### PR TITLE
fix: Set and clear accessibility service instance

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/inputs/AccessibilityListener.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/inputs/AccessibilityListener.kt
@@ -47,6 +47,7 @@ class AccessibilityListener : AccessibilityService() {
 
     override fun onDestroy() {
         super.onDestroy()
+        _instance = null
         Logger.d(tag, "Accessibility service destroyed")
     }
 
@@ -54,13 +55,7 @@ class AccessibilityListener : AccessibilityService() {
     override fun onServiceConnected() {
         super.onServiceConnected()
 
-        // REMOVED: Manual AccessibilityServiceInfo configuration.
-        // We now rely entirely on accessibility_service_config.xml.
-        // This ensures flags like flagReportViewIds are not overwritten.
-
-//        eventHandler.initializeStateManager()
-//        eventHandler.setServiceInstance(this)
-
+        _instance = this
         Logger.d(tag, "Accessibility service connected")
     }
 


### PR DESCRIPTION
Set the static instance of the accessibility service in `onServiceConnected` and clear it in `onDestroy`. This change also removes outdated code and comments related to manual service configuration.

This fixes screenshot issues; because the screenshot function grabs the AccessibilityListener instance from here, it was failing because we never set the instance.