### PR TITLE
maintenance: Refactor persistent UI snapshot storage with deduplicati…

### DIFF
--- a/app/schemas/cloud.trotter.dashbuddy.data.base.DashBuddyDatabase/3.json
+++ b/app/schemas/cloud.trotter.dashbuddy.data.base.DashBuddyDatabase/3.json
@@ -1,0 +1,211 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "bdf1ea90e53d6b66701fe5f4124852f2",
+    "entities": [
+      {
+        "tableName": "app_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sequenceId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `aggregateId` TEXT, `eventType` TEXT NOT NULL, `eventPayload` TEXT NOT NULL, `occurredAt` INTEGER NOT NULL, `metadata` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "sequenceId",
+            "columnName": "sequenceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "aggregateId",
+            "columnName": "aggregateId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "eventType",
+            "columnName": "eventType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventPayload",
+            "columnName": "eventPayload",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "occurredAt",
+            "columnName": "occurredAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadata",
+            "columnName": "metadata",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "sequenceId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_app_events_aggregateId",
+            "unique": false,
+            "columnNames": [
+              "aggregateId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_app_events_aggregateId` ON `${TABLE_NAME}` (`aggregateId`)"
+          },
+          {
+            "name": "index_app_events_eventType",
+            "unique": false,
+            "columnNames": [
+              "eventType"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_app_events_eventType` ON `${TABLE_NAME}` (`eventType`)"
+          },
+          {
+            "name": "index_app_events_occurredAt",
+            "unique": false,
+            "columnNames": [
+              "occurredAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_app_events_occurredAt` ON `${TABLE_NAME}` (`occurredAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "chat_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `dashId` TEXT, `timestamp` INTEGER NOT NULL, `senderId` TEXT NOT NULL, `senderName` TEXT NOT NULL, `messageText` TEXT NOT NULL, `iconResId` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dashId",
+            "columnName": "dashId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "senderId",
+            "columnName": "senderId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "senderName",
+            "columnName": "senderName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageText",
+            "columnName": "messageText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iconResId",
+            "columnName": "iconResId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_messages_dashId",
+            "unique": false,
+            "columnNames": [
+              "dashId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_messages_dashId` ON `${TABLE_NAME}` (`dashId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `screenType` TEXT NOT NULL, `structuralHash` INTEGER NOT NULL, `contentHash` INTEGER NOT NULL, `filePath` TEXT NOT NULL, `timestamp` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "screenType",
+            "columnName": "screenType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "structuralHash",
+            "columnName": "structuralHash",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentHash",
+            "columnName": "contentHash",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_snapshots_screenType",
+            "unique": false,
+            "columnNames": [
+              "screenType"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_snapshots_screenType` ON `${TABLE_NAME}` (`screenType`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'bdf1ea90e53d6b66701fe5f4124852f2')"
+    ]
+  }
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/data/base/DashBuddyDatabase.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/data/base/DashBuddyDatabase.kt
@@ -9,13 +9,16 @@ import cloud.trotter.dashbuddy.data.chat.ChatDao
 import cloud.trotter.dashbuddy.data.chat.ChatMessageEntity
 import cloud.trotter.dashbuddy.data.event.AppEventDao
 import cloud.trotter.dashbuddy.data.event.AppEventEntity
+import cloud.trotter.dashbuddy.data.log.snapshots.SnapshotDao
+import cloud.trotter.dashbuddy.data.log.snapshots.SnapshotRecord
 
 @Database(
     entities = [
         AppEventEntity::class,
         ChatMessageEntity::class,
+        SnapshotRecord::class,
     ],
-    version = 2,
+    version = 3,
     exportSchema = true
 )
 @TypeConverters(DataTypeConverters::class)
@@ -24,6 +27,7 @@ abstract class DashBuddyDatabase : RoomDatabase() {
     // Abstract methods for each of your DAOs
     abstract fun appEventDao(): AppEventDao
     abstract fun chatDao(): ChatDao
+    abstract fun snapshotDao(): SnapshotDao
 
     companion object {
         @Volatile

--- a/app/src/main/java/cloud/trotter/dashbuddy/data/log/LogRepository.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/data/log/LogRepository.kt
@@ -1,15 +1,12 @@
 package cloud.trotter.dashbuddy.data.log
 
 import android.content.Context
-import cloud.trotter.dashbuddy.data.log.dash.DashLogRepo
 import cloud.trotter.dashbuddy.data.log.debug.DebugLogRepo
-import cloud.trotter.dashbuddy.pipeline.model.UiNode
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
-import timber.log.Timber
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -20,8 +17,7 @@ import javax.inject.Singleton
 @Singleton
 class LogRepository @Inject constructor(
     @param:ApplicationContext private val context: Context,
-    private val debugLogRepo: DebugLogRepo, // For the Bubble UI
-    private val dashLogRepo: DashLogRepo    // For the User Chat
+    private val debugLogRepo: DebugLogRepo // For the Bubble UI
 ) {
     // Run file operations on IO thread to never block the main thread
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
@@ -32,21 +28,12 @@ class LogRepository @Inject constructor(
 
     private val appLogFile by lazy { File(logDir, "app.log") }
 
-    // Dedicated folder just for UI dumps
-    private val snapshotDir by lazy {
-        File(logDir, "snapshots").apply { mkdirs() }
-    }
-
     private val maxLogFileSizeBytes = 2.3 * 1024 * 1024 // 2.3 MB
     private val maxRotatedLogs = 50
     private val rotationPrefix = "app_log_rotated_"
 
     // Format for log rotation: app_log_rotated_20260127_143000.log
     private val logRotationFormat = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US)
-
-    // Format for Snapshots: 20260127_143000_123_OfferScreen.json
-    // We include Milliseconds (SSS) to keep order if multiple snapshots happen quickly
-    private val snapshotFormat = SimpleDateFormat("yyyyMMdd_HHmmss_SSS", Locale.US)
 
     /**
      * Appends a pre-formatted line to the main log file.
@@ -67,30 +54,6 @@ class LogRepository @Inject constructor(
 
             } catch (_: Exception) {
                 // Fail silently to avoid crash loops
-            }
-        }
-    }
-
-    /**
-     * Saves a UI snapshot to the Evidence Locker.
-     * @param node The root UiNode to save.
-     * @param tag The screen type or reason (e.g. "OFFER_EXPANDED", "ERROR_PARSING")
-     */
-    fun saveSnapshot(node: UiNode, tag: String) {
-        scope.launch {
-            try {
-                val timestamp = snapshotFormat.format(Date())
-                // Result: 20260127_143501_555_OFFER_EXPANDED.json
-                val filename = "${timestamp}_${tag}.json"
-                val file = File(snapshotDir, filename)
-
-                // Use the built-in serialization we added to UiNode
-                file.writeText(node.toJson())
-
-                // Log a reference so we know where to find it
-                Timber.tag("LogRepo").i("📸 Saved UI Snapshot: ${file.name}")
-            } catch (e: Exception) {
-                Timber.tag("LogRepo").e(e, "Failed to save UI snapshot")
             }
         }
     }

--- a/app/src/main/java/cloud/trotter/dashbuddy/data/log/snapshots/SnapshotDao.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/data/log/snapshots/SnapshotDao.kt
@@ -1,0 +1,31 @@
+package cloud.trotter.dashbuddy.data.log.snapshots
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.Query
+
+@Dao
+interface SnapshotDao {
+    // 1. The Duplicate Check
+    @Query("SELECT * FROM snapshots WHERE screenType = :type AND structuralHash = :hash LIMIT 1")
+    suspend fun findByHash(type: String, hash: Int): SnapshotRecord?
+
+    // 2. The Rotation Logic (Count)
+    @Query("SELECT COUNT(*) FROM snapshots WHERE screenType = :type")
+    suspend fun getCountByType(type: String): Int
+
+    // 3. Find the "Stalest" one to delete (Oldest timestamp)
+    @Query("SELECT * FROM snapshots WHERE screenType = :type ORDER BY timestamp ASC LIMIT 1")
+    suspend fun getOldestByType(type: String): SnapshotRecord?
+
+    // 4. Update timestamp (to keep frequently seen layouts "fresh" so they don't get deleted)
+    @Query("UPDATE snapshots SET timestamp = :newTime WHERE id = :id")
+    suspend fun updateTimestamp(id: Long, newTime: Long)
+
+    @Insert
+    suspend fun insert(record: SnapshotRecord)
+
+    @Delete
+    suspend fun delete(record: SnapshotRecord)
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/data/log/snapshots/SnapshotRecord.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/data/log/snapshots/SnapshotRecord.kt
@@ -1,0 +1,19 @@
+package cloud.trotter.dashbuddy.data.log.snapshots
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "snapshots")
+data class SnapshotRecord(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+
+    @ColumnInfo(index = true) // Index for fast lookups
+    val screenType: String,   // e.g. "OFFER", "MAP"
+
+    val structuralHash: Int,  // From UiNode
+    val contentHash: Int,     // From UiNode
+
+    val filePath: String,
+    val timestamp: Long
+)

--- a/app/src/main/java/cloud/trotter/dashbuddy/data/log/snapshots/SnapshotRepository.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/data/log/snapshots/SnapshotRepository.kt
@@ -1,0 +1,113 @@
+package cloud.trotter.dashbuddy.data.log.snapshots
+
+import android.content.Context
+import cloud.trotter.dashbuddy.pipeline.model.UiNode
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class SnapshotRepository @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+    private val snapshotDao: SnapshotDao
+) {
+    // 1. Scope: Run on IO thread, SupervisorJob prevents crashes from cancelling the scope
+    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
+    // 2. Base Directory: /storage/.../Android/data/cloud.trotter.dashbuddy/files/snapshots/
+    private val snapshotDir by lazy {
+        File(context.getExternalFilesDir(null) ?: context.filesDir, "snapshots").apply { mkdirs() }
+    }
+
+    // --- Configuration ---
+    private val defaultLimit = 10
+    private val unknownLimit = 50
+
+    /**
+     * Entry point. Checks for uniqueness before saving.
+     */
+    fun saveSnapshot(node: UiNode, screenType: String) {
+        scope.launch {
+            try {
+                val hash = node.structuralHash
+
+                // 1. Deduplication Check
+                val existing = snapshotDao.findByHash(screenType, hash)
+
+                if (existing != null) {
+                    // DUPLICATE: Update timestamp to mark it as "fresh" (recently seen)
+                    snapshotDao.updateTimestamp(existing.id, System.currentTimeMillis())
+                    Timber.d(
+                        "Duplicate snapshot ignored (touched timestamp): $screenType / ${
+                            Integer.toHexString(
+                                hash
+                            )
+                        }"
+                    )
+                    return@launch
+                }
+
+                // 2. New Variation: Enforce Quota (Delete oldest if full)
+                enforceQuota(screenType)
+
+                // 3. Save to Disk and DB
+                writeToDiskAndDb(node, screenType, hash)
+
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to save snapshot for $screenType")
+            }
+        }
+    }
+
+    private suspend fun enforceQuota(screenType: String) {
+        val limit = if (screenType == "UNKNOWN") unknownLimit else defaultLimit
+        val count = snapshotDao.getCountByType(screenType)
+
+        if (count >= limit) {
+            val oldest = snapshotDao.getOldestByType(screenType)
+            if (oldest != null) {
+                // Delete the physical file
+                val file = File(oldest.filePath)
+                if (file.exists()) {
+                    file.delete()
+                }
+                // Delete the DB record
+                snapshotDao.delete(oldest)
+                Timber.d("♻️ Pruned oldest variation for $screenType: ${oldest.filePath}")
+            }
+        }
+    }
+
+    private suspend fun writeToDiskAndDb(node: UiNode, screenType: String, hash: Int) {
+        // Create Subfolder: /snapshots/OFFER/
+        val typeDir = File(snapshotDir, screenType)
+        if (!typeDir.exists()) {
+            typeDir.mkdirs()
+        }
+
+        // Filename: A1B2C3.json
+        val filename = "${Integer.toHexString(hash)}.json"
+        val file = File(typeDir, filename)
+
+        // Write content
+        file.writeText(node.toJson())
+
+        // Save Record
+        val record = SnapshotRecord(
+            screenType = screenType,
+            structuralHash = hash,
+            contentHash = node.contentHash,
+            filePath = file.absolutePath, // <--- Correctly accessible now
+            timestamp = System.currentTimeMillis()
+        )
+        snapshotDao.insert(record)
+
+        Timber.i("📸 Saved NEW Snapshot: $screenType/${file.name}")
+    }
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/data/settings/SettingsRepository.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/data/settings/SettingsRepository.kt
@@ -19,7 +19,10 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.serialization.json.Json
@@ -70,6 +73,20 @@ class SettingsRepository @Inject constructor(
         ScoringRule.MetricRule("hr", true, MetricType.ACTIVE_HOURLY, 22.0f),
         ScoringRule.MetricRule("items", false, MetricType.ITEM_COUNT, 50.0f)
     )
+
+    // --- DEVELOPER SETTINGS ---
+
+    // TODO: SECURITY: Set this to FALSE (or BuildConfig.DEBUG) before releasing to Play Store!
+    // We default to TRUE right now so we can gather data during development.
+    private val _devSnapshotsEnabled = MutableStateFlow(true)
+    val devSnapshotsEnabled: StateFlow<Boolean> = _devSnapshotsEnabled.asStateFlow()
+
+    /** * Temporary helper to toggle it at runtime if needed (e.g. via a hidden debug menu)
+     */
+    fun setDevSnapshotsEnabled(enabled: Boolean) {
+        _devSnapshotsEnabled.value = enabled
+    }
+
 
     // ============================================================================================
     // HOT STREAMS

--- a/app/src/main/java/cloud/trotter/dashbuddy/di/DatabaseModule.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/di/DatabaseModule.kt
@@ -5,6 +5,7 @@ import androidx.room.Room
 import cloud.trotter.dashbuddy.data.base.DashBuddyDatabase
 import cloud.trotter.dashbuddy.data.chat.ChatDao
 import cloud.trotter.dashbuddy.data.event.AppEventDao
+import cloud.trotter.dashbuddy.data.log.snapshots.SnapshotDao
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -36,5 +37,10 @@ object DatabaseModule {
     @Provides
     fun provideChatDao(db: DashBuddyDatabase): ChatDao {
         return db.chatDao()
+    }
+
+    @Provides
+    fun provideSnapshotDao(db: DashBuddyDatabase): SnapshotDao {
+        return db.snapshotDao()
     }
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/processing/StateContextFactory.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/processing/StateContextFactory.kt
@@ -1,7 +1,7 @@
 package cloud.trotter.dashbuddy.pipeline.processing
 
 import cloud.trotter.dashbuddy.data.location.OdometerRepository
-import cloud.trotter.dashbuddy.data.log.LogRepository
+import cloud.trotter.dashbuddy.data.log.snapshots.SnapshotRepository
 import cloud.trotter.dashbuddy.data.settings.SettingsRepository
 import cloud.trotter.dashbuddy.pipeline.model.UiNode
 import cloud.trotter.dashbuddy.pipeline.recognition.ScreenRecognizer
@@ -15,8 +15,8 @@ import javax.inject.Singleton
 class StateContextFactory @Inject constructor(
     private val odometerRepository: OdometerRepository,
     private val screenRecognizer: ScreenRecognizer,
-    private val logRepository: LogRepository,
-    private val settingsRepository: SettingsRepository // <--- Injected
+    private val settingsRepository: SettingsRepository,
+    private val snapshotRepository: SnapshotRepository,
 ) {
 
     fun createFromNotification(info: NotificationInfo): NotificationEvent {
@@ -35,12 +35,12 @@ class StateContextFactory @Inject constructor(
 
         // 2. Evidence Locker (Debug State)
         // Access the cached value directly. No blocking, no statics.
-        val evidenceConfig = settingsRepository.evidenceConfig.value
+        val devConfig = settingsRepository.devSnapshotsEnabled.value
 
-        if (evidenceConfig.masterEnabled) {
+        if (devConfig) {
             // Optional: finer grain control based on screen type
             // e.g. only save if (evidenceConfig.saveOffers && screenInfo.screen == Screen.OFFER)
-            logRepository.saveSnapshot(uiNode, screenInfo.screen.name)
+            snapshotRepository.saveSnapshot(uiNode, screenInfo.screen.name)
         }
 
         // 3. Build Event


### PR DESCRIPTION
…on - closes [#32]

This commit introduces a robust system for capturing and storing UI snapshots for debugging and analysis. Snapshots are now saved to a persistent database, preventing duplicates and managing storage by rotating out old or less frequent variations.

- **feat: Add `snapshots` table to Room database**
    - Bumps the `DashBuddyDatabase` version from 2 to 3.
    - Adds a new `snapshots` table to store metadata about captured UI layouts, including screen type, structural hash, content hash, file path, and timestamp.
    - A new `SnapshotRecord.kt` entity and `SnapshotDao.kt` are created for database interactions.

- **feat: Create `SnapshotRepository` for logic and lifecycle management**
    - Introduces `SnapshotRepository.kt` to manage the snapshotting process.
    - Implements a deduplication strategy: if a snapshot with the same screen type and structural hash already exists, its timestamp is updated instead of creating a new entry.
    - Enforces a storage quota by pruning the oldest snapshot for a given screen type when the limit is reached.
    - Snapshots are saved as `.json` files in an external `snapshots` directory, organized into subfolders by screen type (e.g., `snapshots/OFFER/`).

- **refactor: Integrate snapshotting into the processing pipeline**
    - The `StateContextFactory` is updated to use the new `SnapshotRepository`.
    - The `LogRepository` is simplified by removing the old, file-based snapshot implementation.
    - Adds a `devSnapshotsEnabled` boolean flag in `SettingsRepository` to control the feature at runtime, which is enabled by default for development.