### PR TITLE
refactor(state) [#41]: Standardize reducer inputs to handle generic S…

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/state/reducers/IdleReducer.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/reducers/IdleReducer.kt
@@ -2,6 +2,8 @@ package cloud.trotter.dashbuddy.state.reducers
 
 import cloud.trotter.dashbuddy.pipeline.accessibility.event.type.window.processing.ScreenInfo
 import cloud.trotter.dashbuddy.state.AppStateV2
+import cloud.trotter.dashbuddy.state.event.ScreenUpdateEvent
+import cloud.trotter.dashbuddy.state.event.StateEvent
 import cloud.trotter.dashbuddy.state.factories.AwaitingStateFactory
 import cloud.trotter.dashbuddy.state.model.Transition
 import javax.inject.Inject
@@ -12,13 +14,28 @@ class IdleReducer @Inject constructor(
     private val awaitingStateFactory: AwaitingStateFactory
 ) {
 
+    // --- NEW CONTRACT: Handle ANY StateEvent ---
     fun reduce(
+        state: AppStateV2.IdleOffline,
+        event: StateEvent
+    ): Transition? {
+        return when (event) {
+            is ScreenUpdateEvent -> {
+                val input = event.screenInfo ?: return null
+                handleScreenUpdate(state, input)
+            }
+            // Idle state usually doesn't handle Clicks or Timeouts directly yet
+            else -> null
+        }
+    }
+
+    private fun handleScreenUpdate(
         state: AppStateV2.IdleOffline,
         input: ScreenInfo
     ): Transition? {
         return when (input) {
             is ScreenInfo.IdleMap -> {
-                // Internal Update - No transition needed
+                // Internal Update - No transition needed, just update data if changed
                 if (state.lastKnownZone != input.zoneName || state.dashType != input.dashType) {
                     Transition(
                         state.copy(

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/reducers/InitializingReducer.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/reducers/InitializingReducer.kt
@@ -2,6 +2,8 @@ package cloud.trotter.dashbuddy.state.reducers
 
 import cloud.trotter.dashbuddy.pipeline.accessibility.event.type.window.processing.ScreenInfo
 import cloud.trotter.dashbuddy.state.AppStateV2
+import cloud.trotter.dashbuddy.state.event.ScreenUpdateEvent
+import cloud.trotter.dashbuddy.state.event.StateEvent
 import cloud.trotter.dashbuddy.state.factories.AwaitingStateFactory
 import cloud.trotter.dashbuddy.state.factories.IdleStateFactory
 import cloud.trotter.dashbuddy.state.model.Transition
@@ -13,7 +15,23 @@ class InitializingReducer @Inject constructor(
     private val idleStateFactory: IdleStateFactory,
     private val awaitingStateFactory: AwaitingStateFactory,
 ) {
-    fun reduce(state: AppStateV2.Initializing, input: ScreenInfo): Transition? {
+
+    // --- NEW CONTRACT: Handle ANY StateEvent ---
+    fun reduce(state: AppStateV2.Initializing, event: StateEvent): Transition? {
+        return when (event) {
+            is ScreenUpdateEvent -> {
+                val input = event.screenInfo ?: return null
+                handleScreenUpdate(state, input)
+            }
+            // Initializing doesn't usually handle clicks/timeouts
+            else -> null
+        }
+    }
+
+    private fun handleScreenUpdate(
+        state: AppStateV2.Initializing,
+        input: ScreenInfo
+    ): Transition? {
         fun request(result: Transition) = result
 
         return when (input) {

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/reducers/PickupReducer.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/reducers/PickupReducer.kt
@@ -6,6 +6,8 @@ import cloud.trotter.dashbuddy.domain.chat.ChatPersona
 import cloud.trotter.dashbuddy.pipeline.accessibility.event.type.window.processing.ScreenInfo
 import cloud.trotter.dashbuddy.state.AppEffect
 import cloud.trotter.dashbuddy.state.AppStateV2
+import cloud.trotter.dashbuddy.state.event.ScreenUpdateEvent
+import cloud.trotter.dashbuddy.state.event.StateEvent
 import cloud.trotter.dashbuddy.state.factories.AwaitingStateFactory
 import cloud.trotter.dashbuddy.state.factories.DeliveryStateFactory
 import cloud.trotter.dashbuddy.state.factories.OfferStateFactory
@@ -20,7 +22,20 @@ class PickupReducer @Inject constructor(
     private val offerStateFactory: OfferStateFactory,
 ) {
 
-    fun reduce(state: AppStateV2.OnPickup, input: ScreenInfo): Transition? {
+    // --- NEW CONTRACT: Handle ANY StateEvent ---
+    fun reduce(state: AppStateV2.OnPickup, event: StateEvent): Transition? {
+        return when (event) {
+            is ScreenUpdateEvent -> {
+                val input = event.screenInfo ?: return null
+                handleScreenUpdate(state, input)
+            }
+            // Pickup state usually handles internal clicks for "Arrived", etc.
+            // You can add `is ClickEvent` here later if needed.
+            else -> null
+        }
+    }
+
+    private fun handleScreenUpdate(state: AppStateV2.OnPickup, input: ScreenInfo): Transition? {
 
         // Helper: Simple forwarder (no wrapping needed)
         fun request(result: Transition) = result
@@ -28,28 +43,34 @@ class PickupReducer @Inject constructor(
         return when (input) {
             is ScreenInfo.PickupDetails -> {
                 // Internal Logic: Check for meaningful updates (Status change / Store Name resolution)
+                // Note: 'input.storeName' might be null if not found, fallback to existing state
                 val newStoreName = input.storeName ?: state.storeName
+
                 val hasStoreChanged = newStoreName != state.storeName && newStoreName != "Unknown"
                 val hasStatusChanged = input.status != state.status
 
                 if (hasStoreChanged || hasStatusChanged) {
-                    val storeName = if (hasStoreChanged) newStoreName else state.storeName
-                    val nextState = state.copy(storeName = storeName, status = input.status)
+                    val nextStoreName = if (hasStoreChanged) newStoreName else state.storeName
+                    val nextState = state.copy(storeName = nextStoreName, status = input.status)
                     val effects = mutableListOf<AppEffect>()
 
-                    // Internal Effects
+                    // Persona Selection
                     val persona = when (input.status) {
                         PickupStatus.NAVIGATING -> ChatPersona.Navigator
-                        PickupStatus.ARRIVED -> ChatPersona.Merchant(storeName)
+                        PickupStatus.ARRIVED -> ChatPersona.Merchant(nextStoreName)
                         PickupStatus.CONFIRMED -> ChatPersona.Customer(
+                            // input.customerNameHash is not in PickupDetails anymore in some versions,
+                            // check your ScreenInfo definition. Assuming it exists:
                             input.customerNameHash?.take(6) ?: "Customer"
                         )
 
                         PickupStatus.SHOPPING -> ChatPersona.Shopper
                         else -> ChatPersona.Dispatcher
                     }
+
                     effects.add(AppEffect.UpdateBubble("Pickup: ${nextState.storeName}", persona))
 
+                    // Logging Effects
                     if (hasStatusChanged && input.status == PickupStatus.ARRIVED) {
                         effects.add(
                             AppEffect.LogEvent(
@@ -64,7 +85,8 @@ class PickupReducer @Inject constructor(
                         effects.add(
                             AppEffect.LogEvent(
                                 ReducerUtils.createEvent(
-                                    state.dashId, AppEventType.PICKUP_NAV_STARTED,
+                                    state.dashId,
+                                    AppEventType.PICKUP_NAV_STARTED, // Or PICKUP_STATUS_UPDATE per our discussion
                                     mapOf(
                                         "message" to "Store Name Updated",
                                         "previous" to state.storeName,

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/reducers/SummaryReducer.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/reducers/SummaryReducer.kt
@@ -2,6 +2,8 @@ package cloud.trotter.dashbuddy.state.reducers
 
 import cloud.trotter.dashbuddy.pipeline.accessibility.event.type.window.processing.ScreenInfo
 import cloud.trotter.dashbuddy.state.AppStateV2
+import cloud.trotter.dashbuddy.state.event.ScreenUpdateEvent
+import cloud.trotter.dashbuddy.state.event.StateEvent
 import cloud.trotter.dashbuddy.state.factories.IdleStateFactory
 import cloud.trotter.dashbuddy.state.model.Transition
 import javax.inject.Inject
@@ -11,14 +13,28 @@ import javax.inject.Singleton
 class SummaryReducer @Inject constructor(
     private val idleStateFactory: IdleStateFactory,
 ) {
-    fun reduce(state: AppStateV2.PostDash, input: ScreenInfo): Transition? {
+
+    // --- NEW CONTRACT: Handle ANY StateEvent ---
+    fun reduce(state: AppStateV2.PostDash, event: StateEvent): Transition? {
+        return when (event) {
+            is ScreenUpdateEvent -> {
+                val input = event.screenInfo ?: return null
+                handleScreenUpdate(state, input)
+            }
+
+            else -> null
+        }
+    }
+
+    private fun handleScreenUpdate(state: AppStateV2.PostDash, input: ScreenInfo): Transition? {
         return when (input) {
             is ScreenInfo.IdleMap -> {
-                // Just return the factory result directly
+                // Return the factory result directly
                 idleStateFactory.createEntry(state, input, isRecovery = false)
             }
 
             is ScreenInfo.DashSummary -> Transition(state)
+
             else -> null
         }
     }


### PR DESCRIPTION
…tateEvents

This commit refactors all state reducers (`OfferReducer`, `PostDeliveryReducer`, etc.) to adopt a unified input contract. Instead of handling specific event types like `ScreenInfo` or `TimeoutEvent` in separate functions, each reducer now implements a single `reduce(state, event: StateEvent)` function.

This change centralizes event handling logic within each reducer, making them responsible for routing different `StateEvent` subtypes (e.g., `ScreenUpdateEvent`, `ClickEvent`, `TimeoutEvent`) to the appropriate internal handler.

### Key Changes:

- **Unified Reducer Contract:**
    - All reducers now accept a generic `StateEvent` and use a `when` block to delegate to specific private handlers like `handleScreenUpdate`, `handleClick`, or `handleTimeout`.
    - This removes the need for multiple public entry points (e.g., `onTimeout`, `onClick`) and simplifies the top-level `Reducer` orchestrator.

- **Simplified `Reducer.kt` Orchestrator:**
    - The main `Reducer.kt` class is now a simple router. It no longer contains complex `when` blocks to delegate specific event types to different reducer methods.
    - It now just passes the incoming `StateEvent` directly to the `reduce` method of the current state's corresponding reducer.

- **Refactored Reducer Logic:**
    - **`OfferReducer`**: The `onClick` logic is now integrated into `reduce` as a `handleClick` private function.
    - **`PostDeliveryReducer`**: The `onTimeout` logic is merged into `reduce` as a `handleTimeout` private function.
    - **`DashPausedReducer`**: The `onTimeout` logic is similarly moved into `reduce`.
    - All other reducers (`Awaiting`, `Delivery`, `Idle`, `Initializing`, `Pickup`, `Summary`) are updated to wrap their existing `ScreenInfo`-based logic within a new `handleScreenUpdate` function, which is called when a `ScreenUpdateEvent` is received.

- **Unified `DeliverySummary` Handling:**
    - Several reducers (`AwaitingReducer`, `DeliveryReducer`, `OfferReducer`, `DashPausedReducer`) are updated to transition based on the unified `ScreenInfo.DeliverySummary` screen, removing references to the deprecated `DeliveryCompleted` and `DeliverySummaryCollapsed` types.