### PR TITLE
refactor(PostDelivery) [#49]: Improve pay summary automation with UI …

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -79,6 +79,7 @@ dependencies {
     implementation(libs.material)
     implementation(libs.play.services.location)
     implementation(libs.reorderable)
+    implementation(libs.robolectric)
     implementation(libs.timber)
     implementation(platform(libs.androidx.compose.bom))
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/model/UiNode.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/model/UiNode.kt
@@ -69,6 +69,48 @@ data class UiNode(
         return json.encodeToString(this)
     }
 
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as UiNode
+
+        // Compare unique identifiers instead of the recursive tree.
+        // Text comparisons: text, contentDescription, stateDescription
+        if (text != other.text) return false
+        if (contentDescription != other.contentDescription) return false
+        if (stateDescription != other.stateDescription) return false
+        // ID and className
+        if (viewIdResourceName != other.viewIdResourceName) return false
+        if (className != other.className) return false
+        // Flags
+        if (isClickable != other.isClickable) return false
+        if (isEnabled != other.isEnabled) return false
+        if (isChecked != other.isChecked) return false
+        // Bounds
+        if (boundsInScreen != other.boundsInScreen) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        // Hash based on unique identifiers
+        // Texts: text, contentDescription, stateDescription
+        var result = text?.hashCode() ?: 0
+        result = 31 * result + (contentDescription?.hashCode() ?: 0)
+        result = 31 * result + (stateDescription?.hashCode() ?: 0)
+        // ID and className
+        result = 31 * result + (viewIdResourceName?.hashCode() ?: 0)
+        result = 31 * result + (className?.hashCode() ?: 0)
+        // Flags
+        result = 31 * result + isClickable.hashCode()
+        result = 31 * result + isEnabled.hashCode()
+        result = 31 * result + isChecked.hashCode()
+        // Bounds
+        result = 31 * result + boundsInScreen.hashCode()
+        return result
+    }
+
     // ========================================================================
     //  STRICT MATCHERS (Check ONLY this node)
     //  Use these for specific logic or inside the recursive functions.

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/AppStateV2.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/AppStateV2.kt
@@ -5,6 +5,7 @@ import cloud.trotter.dashbuddy.data.event.status.PickupStatus
 import cloud.trotter.dashbuddy.data.pay.ParsedPay
 import cloud.trotter.dashbuddy.pipeline.accessibility.event.type.view.clicked.ClickAction
 import cloud.trotter.dashbuddy.pipeline.accessibility.event.type.window.processing.Screen
+import cloud.trotter.dashbuddy.pipeline.accessibility.model.UiNode
 
 sealed class AppStateV2 {
     abstract val timestamp: Long
@@ -84,7 +85,9 @@ sealed class AppStateV2 {
         val totalPay: Double = 0.0,
         val merchantNames: String = "Delivery",
         val summaryText: String = "Processing...",
-
+        @Transient
+        val latestExpandButton: UiNode? = null,
+        val settleTimerStarted: Boolean = false,
         // Automation State (Closed Loop)
         val clickSent: Boolean = false,
         val clickAttempts: Int = 0

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/DefaultEffectHandler.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/DefaultEffectHandler.kt
@@ -30,6 +30,7 @@ class DefaultEffectHandler @Inject constructor(
     private val bubbleManager: BubbleManager,
     private val offerEvaluator: OfferEvaluator,
     private val screenShotHandler: ScreenShotHandler,
+    private val uiInteractionHandler: UiInteractionHandler,
 ) : EffectHandler {
 
     @RequiresApi(Build.VERSION_CODES.BAKLAVA)
@@ -106,8 +107,7 @@ class DefaultEffectHandler @Inject constructor(
 
             is AppEffect.ClickNode -> {
                 Timber.i("Executing Effect: Clicking Node (${effect.description})")
-                // Robust utility call
-                cloud.trotter.dashbuddy.util.AccNodeUtils.clickNode(effect.node.originalNode)
+                uiInteractionHandler.performClick(effect.node, effect.description)
             }
 
             is AppEffect.Delayed -> {

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/UiInteractionHandler.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/UiInteractionHandler.kt
@@ -1,0 +1,52 @@
+package cloud.trotter.dashbuddy.state.effects
+
+import android.graphics.Rect
+import android.view.accessibility.AccessibilityNodeInfo
+import cloud.trotter.dashbuddy.pipeline.accessibility.input.AccessibilitySource
+import cloud.trotter.dashbuddy.pipeline.accessibility.model.UiNode
+import cloud.trotter.dashbuddy.util.AccNodeUtils
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class UiInteractionHandler @Inject constructor(
+    private val accessibilitySource: AccessibilitySource
+) {
+
+    /**
+     * Takes a pure data template, finds its live native counterpart, and clicks it.
+     */
+    fun performClick(templateNode: UiNode, description: String) {
+        Timber.i("UiInteractionHandler: Attempting surgical strike ($description)")
+
+        // 1. Get the live native root directly from the OS
+        val liveRoot = accessibilitySource.getLiveNativeRoot()
+        if (liveRoot == null) {
+            Timber.w("Failed to click: Live root window is null.")
+            return
+        }
+
+        // 2. Fast Native Search
+        val candidates = mutableListOf<AccessibilityNodeInfo>()
+        if (!templateNode.viewIdResourceName.isNullOrEmpty()) {
+            candidates.addAll(liveRoot.findAccessibilityNodeInfosByViewId(templateNode.viewIdResourceName))
+        } else if (!templateNode.text.isNullOrEmpty()) {
+            candidates.addAll(liveRoot.findAccessibilityNodeInfosByText(templateNode.text))
+        }
+
+        // 3. Exact Match Filter (Use Bounds as the fingerprint)
+        val exactMatch = candidates.find { nativeNode ->
+            val liveBounds = Rect()
+            nativeNode.getBoundsInScreen(liveBounds)
+            liveBounds == templateNode.boundsInScreen
+        }
+
+        // 4. Delegate to your existing utility!
+        if (exactMatch != null) {
+            AccNodeUtils.clickNode(exactMatch)
+        } else {
+            Timber.w("Could not find a live node matching the template for: $description")
+        }
+    }
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/factories/PostDeliveryStateFactory.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/factories/PostDeliveryStateFactory.kt
@@ -41,6 +41,7 @@ class PostDeliveryStateFactory @Inject constructor() {
                     Transition(
                         baseState.copy(
                             totalPay = total,
+                            latestExpandButton = input.expandButton,
                             summaryText = if (total > 0) "Paid: ${
                                 UtilityFunctions.formatCurrency(
                                     total

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/model/TimeoutType.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/model/TimeoutType.kt
@@ -4,12 +4,9 @@ enum class TimeoutType {
     // Global Safety
     DASH_PAUSED_SAFETY,
 
-    // Expanding Reducer
-    EXPAND_STABILITY,
-    EXPAND_CLICK_FAIL,
-
     // Post Delivery Reducer
-    VERIFY_PAY,
+    RETRY_CLICK_TIMEOUT,
+    SETTLE_UI,
 
     // Offer Reducer (Decline Flow)
     DECLINE_POPUP_WAIT,

--- a/app/src/main/java/cloud/trotter/dashbuddy/util/AccNodeUtils.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/util/AccNodeUtils.kt
@@ -3,8 +3,6 @@ package cloud.trotter.dashbuddy.util
 import android.view.accessibility.AccessibilityNodeInfo
 import timber.log.Timber
 
-//import cloud.trotter.dashbuddy.log.Logger as Log
-
 /**
  * A utility object for performing actions on AccessibilityNodeInfo objects.
  */

--- a/app/src/test/java/cloud/trotter/dashbuddy/pipeline/accessibility/model/UiNodeTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/pipeline/accessibility/model/UiNodeTest.kt
@@ -1,0 +1,116 @@
+package cloud.trotter.dashbuddy.pipeline.accessibility.model
+
+import android.graphics.Rect
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class UiNodeTest {
+
+    // A helper to generate a fully-populated base node for testing
+    private fun createBaseNode(): UiNode {
+        return UiNode(
+            text = "Accept",
+            contentDescription = "Accept button",
+            stateDescription = "expanded",
+            viewIdResourceName = "com.doordash:id/accept_btn",
+            className = "android.widget.Button",
+            isClickable = true,
+            isEnabled = true,
+            isChecked = 0,
+            boundsInScreen = Rect(10, 10, 100, 100)
+        )
+    }
+
+    @Test
+    fun `equals does NOT cause StackOverflowError on circular references`() {
+        val parent1 = createBaseNode().copy(viewIdResourceName = "parent")
+        val child1 = createBaseNode().copy(viewIdResourceName = "child")
+        parent1.children.add(child1)
+        child1.parent = parent1 // Circular Reference!
+
+        val parent2 = createBaseNode().copy(viewIdResourceName = "parent")
+        val child2 = createBaseNode().copy(viewIdResourceName = "child")
+        parent2.children.add(child2)
+        child2.parent = parent2 // Circular Reference!
+
+        // THE TEST: If the bug exists, this will crash with StackOverflowError
+        val areEqual = parent1 == parent2
+
+        assertTrue("Nodes with the same core properties should be equal", areEqual)
+    }
+
+    @Test
+    fun `equals returns true for identically populated nodes`() {
+        val node1 = createBaseNode()
+        val node2 = createBaseNode()
+
+        assertEquals("Identical nodes should be equal", node1, node2)
+    }
+
+    @Test
+    fun `equals returns false when any single text property differs`() {
+        val base = createBaseNode()
+
+        assertNotEquals("Should fail on text mismatch", base, base.copy(text = "Decline"))
+        assertNotEquals(
+            "Should fail on desc mismatch",
+            base,
+            base.copy(contentDescription = "Other")
+        )
+        assertNotEquals(
+            "Should fail on state mismatch",
+            base,
+            base.copy(stateDescription = "collapsed")
+        )
+    }
+
+    @Test
+    fun `equals returns false when any single structure property differs`() {
+        val base = createBaseNode()
+
+        assertNotEquals(
+            "Should fail on ID mismatch",
+            base,
+            base.copy(viewIdResourceName = "id/other")
+        )
+        assertNotEquals(
+            "Should fail on class mismatch",
+            base,
+            base.copy(className = "android.widget.TextView")
+        )
+    }
+
+    @Test
+    fun `equals returns false when any single flag property differs`() {
+        val base = createBaseNode()
+
+        assertNotEquals("Should fail on clickable mismatch", base, base.copy(isClickable = false))
+        assertNotEquals("Should fail on enabled mismatch", base, base.copy(isEnabled = false))
+        assertNotEquals("Should fail on checked mismatch", base, base.copy(isChecked = 1))
+    }
+
+    @Test
+    fun `equals returns false when bounds differ`() {
+        val base = createBaseNode()
+        val differentBounds = base.copy(boundsInScreen = Rect(0, 0, 0, 0))
+
+        assertNotEquals("Should fail on bounds mismatch", base, differentBounds)
+    }
+
+    @Test
+    fun `hashCode is consistent for identical nodes`() {
+        val node1 = createBaseNode()
+        val node2 = createBaseNode()
+
+        assertEquals(
+            "HashCodes must match if nodes are logically equal",
+            node1.hashCode(),
+            node2.hashCode()
+        )
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/test/util/SnapshotMatcherGenerator.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/test/util/SnapshotMatcherGenerator.kt
@@ -17,7 +17,7 @@ object SnapshotMatcherGenerator {
             .distinct()
             .take(3) // Pick top 3 IDs
 
-        val texts = candidates.filter { !it.text.isNullOrBlank() && it.text!!.length > 5 }
+        val texts = candidates.filter { !it.text.isNullOrBlank() && it.text.length > 5 }
             .mapNotNull { it.text }
             .distinct()
             .take(2) // Pick top 2 Texts

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,20 +1,20 @@
 [versions]
-agp = "9.0.0"
-activityCompose = "1.12.3"
+agp = "9.0.1"
+activityCompose = "1.12.4"
 androidxFragmentKtx = "1.8.9"
 androidxLifecycle = "2.10.0"
 appcompat = "1.7.1"
 coreKtx = "1.17.0"
-composeBom = "2026.01.01"
+composeBom = "2026.02.00"
 datastore = "1.2.0"
 espressoCore = "3.7.0"
-foundation = "1.10.2"
+foundation = "1.10.3"
 gson = "2.13.2"
-hilt = "2.59"
+hilt = "2.59.2"
 hiltNavigationCompose = "1.3.0"
 junit = "4.13.2"
 junitVersion = "1.3.0"
-kotlin = "2.3.0"
+kotlin = "2.3.10"
 kotlinSerialization = "1.10.0"
 ksp = "2.3.4"
 material = "1.13.0"
@@ -27,6 +27,7 @@ playServicesLocation = "21.3.0"
 preference = "1.2.1"
 reorderable = "3.0.0"
 room = "2.8.4"
+robolectric = "4.16.1"
 timber = "5.0.1"
 
 [libraries]
@@ -67,6 +68,7 @@ mockito-kotlin = { group = "org.mockito.kotlin", name = "mockito-kotlin", versio
 play-services-location = { group = "com.google.android.gms", name = "play-services-location", version.ref = "playServicesLocation" }
 reorderable = { module = "sh.calvin.reorderable:reorderable", version.ref = "reorderable" }
 timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
+robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
…settle timer

This commit refactors the `PostDeliveryReducer` to more reliably automate the process of expanding the delivery summary to parse detailed pay information. The previous logic, which relied on a simple delay and retry mechanism, has been replaced with a more robust, two-stage timer system that accounts for UI animations.

Additionally, this commit introduces a `UiInteractionHandler` to make automated clicks more reliable by re-acquiring a live view of the UI just before acting.

### Key Changes:

-   **refactor: Implement UI Settle and Retry Timers**
    -   Upon detecting the delivery summary screen, a short `UI_SETTLE_DELAY` (500ms) timer is now started. This waits for the "Earnings" card to finish its slide-in animation before attempting any interaction.
    -   After the settle timer fires, the reducer clicks the expand button and starts a longer `RETRY_CLICK_TIMEOUT` (1.5s).
    -   If the pay details are not found before this second timer expires, the entire automation loop is reset, making it resilient to app lag or UI glitches.
    -   Timers (`SETTLE_UI`, `RETRY_CLICK_TIMEOUT`) are now explicitly canceled upon successfully parsing the pay or when exiting the `PostDelivery` state to prevent leaks.

-   **feat: Introduce `UiInteractionHandler` for Reliable Clicks**
    -   A new `UiInteractionHandler` class is introduced to centralize and improve the reliability of automated UI clicks.
    -   Instead of clicking a potentially stale `UiNode` captured during a `ScreenUpdateEvent`, the handler re-fetches the live `AccessibilityNodeInfo` from the `AccessibilitySource` at the moment the click is requested.
    -   It uses the `viewId` and `boundsInScreen` from the original `UiNode` as a "fingerprint" to find the exact, fresh node on the live screen, preventing `StaleObjectException` errors.

-   **fix(UiNode): Prevent StackOverflow in `equals()`**
    -   The `equals()` and `hashCode()` methods of the `UiNode` class have been overridden to compare only core properties (like `text`, `viewIdResourceName`, and `boundsInScreen`).
    -   This prevents a `StackOverflowError` that would occur when comparing nodes with circular parent-child references. Unit tests for `UiNode` have been added to verify this fix.

-   **chore: Dependency Updates**
    -   Several AndroidX and Kotlin libraries have been updated to their latest versions, including Compose BOM, Hilt, and Kotlin itself.
    -   The `robolectric` dependency has been added to support unit testing of Android framework classes like `Rect`.