### PR TITLE
feat [closes #59]: Display session miles in Bubble UI

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleScreen.kt
@@ -92,33 +92,49 @@ fun BubbleScreen(
             if (showFullChat) {
                 FullChatView(messages)
             } else {
-                DashboardView(messages) { showFullChat = true }
+                DashboardView(messages, viewModel) { showFullChat = true }
             }
         }
     }
 }
 
 @Composable
-fun DashboardView(messages: List<ChatMessageEntity>, onOpenChat: () -> Unit) {
+fun DashboardView(
+    messages: List<ChatMessageEntity>,
+    viewModel: BubbleViewModel,
+    onOpenChat: () -> Unit
+) {
+    val miles by viewModel.sessionMiles.collectAsState()
+
     Column(
         modifier = Modifier
             .fillMaxSize()
             .padding(16.dp)
     ) {
 
-        Text("Current Status", style = MaterialTheme.typography.titleMedium)
+        Text("Current Trip", style = MaterialTheme.typography.titleMedium)
         Card(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(vertical = 8.dp)
-                .height(80.dp),
+                .height(100.dp),
             colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer)
         ) {
-            Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+            Column(
+                modifier = Modifier.fillMaxSize(),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
                 Text(
-                    "Waiting for Offer...",
-                    style = MaterialTheme.typography.titleMedium,
+                    text = "%.2f".format(miles),
+                    style = MaterialTheme.typography.headlineLarge,
+                    fontWeight = FontWeight.Bold,
                     color = MaterialTheme.colorScheme.onSecondaryContainer
+                )
+                Text(
+                    text = "SESSION MILES",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.7f)
                 )
             }
         }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleViewModel.kt
@@ -3,19 +3,22 @@ package cloud.trotter.dashbuddy.ui.bubble
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import cloud.trotter.dashbuddy.data.chat.ChatRepository
+import cloud.trotter.dashbuddy.data.location.OdometerRepository
 import cloud.trotter.dashbuddy.domain.chat.ChatPersona
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import javax.inject.Inject
 
 @HiltViewModel
 class BubbleViewModel @Inject constructor(
     private val bubbleManager: BubbleManager,
-    private val chatRepository: ChatRepository
+    private val chatRepository: ChatRepository,
+    odometerRepository: OdometerRepository
 ) : ViewModel() {
 
     // Automatically switches the chat stream when the activeDashId changes
@@ -27,6 +30,11 @@ class BubbleViewModel @Inject constructor(
             flowOf(emptyList()) // Or show system messages if offline
         }
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    // Expose real-time session miles
+    val sessionMiles = odometerRepository.sessionMeters
+        .map { meters -> meters * 0.000621371 }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 0.0)
 
     // Debug helper to test the system
     fun sendTestMessage() {


### PR DESCRIPTION
This commit updates the `DashboardView` within the `BubbleScreen` to display real-time session mileage instead of a static status message.

- **Enhance `BubbleViewModel`**:
    - Injected `OdometerRepository` to access distance data.
    - Introduced `sessionMiles` StateFlow, which converts raw meters from the repository into miles for UI consumption.
- **Update `BubbleScreen` UI**:
    - Modified `DashboardView` to accept `BubbleViewModel` and observe `sessionMiles`.
    - Replaced the "Waiting for Offer..." placeholder with a prominent display of current trip miles.
    - Updated card styling and labels to focus on "Current Trip" metrics.