### PR TITLE
feat [#79, #80]: Surface net pay/fuel cost in UI and expose caveat warnings in playground

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,33 @@ Tests are data-driven using captured UI hierarchy JSON files under
 - **Testing:** JUnit 4, Mockito-Kotlin 6.3.0, Robolectric 4.16.1
 - **Logging:** Timber 5.0.1
 
+## Git Workflow
+
+**Always create a branch** before starting work on any issue or set of issues. Never commit
+feature/fix work directly to `master`.
+
+Branch naming: `<type>/<issue-number(s)>-<short-description>`, e.g. `feature/110-bubble-offer-mode` or `fix/42-crash-on-startup`. Common types:
+
+| Type | Use for |
+|---|---|
+| `feature/` | New functionality |
+| `fix/` | Bug fixes |
+| `refactor/` | Code restructuring, no behavior change |
+| `chore/` | Housekeeping, dependency bumps, config |
+| `test/` | Adding or fixing tests |
+| `ci/` | CI/CD pipeline changes |
+| `docs/` | Documentation only |
+
+Include all relevant issue numbers when a branch covers multiple issues, e.g. `feature/79-80-offer-bubble-net-pay`.
+
+**Always merge PRs with `--merge`** (a true merge commit), never `--squash`. Squash loses
+per-commit history and makes it harder to bisect or attribute changes.
+
+```bash
+GH="/c/Program Files/GitHub CLI/gh.exe"
+"$GH" pr merge <NUMBER> --merge
+```
+
 ## GitHub Issues — Labels & Project
 
 **Always** add every new issue to the DashBuddy Roadmap project. See `CLAUDE.local.md` for the

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/formatters/OfferFormatters.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/formatters/OfferFormatters.kt
@@ -58,5 +58,9 @@ fun OfferEvaluation.toAnnotatedString(): AnnotatedString {
         }
 
         append(" | Score: ${this@toAnnotatedString.score.toInt()}")
+
+        if (this@toAnnotatedString.fuelCostEstimate > 0.0) {
+            append(" | Net: $%.2f".format(this@toAnnotatedString.netPayAmount))
+        }
     }
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/components/FakeOfferCard.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/components/FakeOfferCard.kt
@@ -11,13 +11,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.AttachMoney
-import androidx.compose.material.icons.filled.DirectionsCar
-import androidx.compose.material.icons.filled.Timer
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.Icon
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -25,12 +21,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
 import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
-import cloud.trotter.dashbuddy.ui.formatters.toAnnotatedString
+import java.util.Locale
 
 @Composable
 fun FakeOfferCard(
@@ -39,16 +34,13 @@ fun FakeOfferCard(
 ) {
     val isDark = isSystemInDarkTheme()
 
-    // 1. Logic: In Dark Mode, keep background dark (Surface). In Light Mode, use Pastels.
     val targetContainerColor = if (isDark) {
-        // Dark Mode: Stay dark, maybe slightly tinted
         when (evaluation.action) {
-            OfferAction.ACCEPT -> Color(0xFF1B5E20).copy(alpha = 0.3f) // Very dark green tint
-            OfferAction.DECLINE -> Color(0xFFB71C1C).copy(alpha = 0.3f) // Very dark red tint
+            OfferAction.ACCEPT -> Color(0xFF1B5E20).copy(alpha = 0.3f)
+            OfferAction.DECLINE -> Color(0xFFB71C1C).copy(alpha = 0.3f)
             else -> MaterialTheme.colorScheme.surfaceVariant
         }
     } else {
-        // Light Mode: Use Pastels
         when (evaluation.action) {
             OfferAction.ACCEPT -> Color(0xFFE8F5E9)
             OfferAction.DECLINE -> Color(0xFFFFEBEE)
@@ -56,14 +48,8 @@ fun FakeOfferCard(
         }
     }
 
-    // 2. Logic: Text colors need to pop against the chosen background
-    val targetContentColor = if (isDark) {
-        Color.White // Always white in dark mode
-    } else {
-        Color.Black // Always black in light mode
-    }
+    val targetContentColor = if (isDark) Color.White else Color.Black
 
-    // 3. Logic: Borders carry the heavy lifting in Dark Mode
     val borderColor = when (evaluation.action) {
         OfferAction.ACCEPT -> if (isDark) Color(0xFF4CAF50) else Color(0xFF2E7D32)
         OfferAction.DECLINE -> if (isDark) Color(0xFFEF5350) else Color(0xFFC62828)
@@ -73,56 +59,131 @@ fun FakeOfferCard(
     val animatedContainerColor by animateColorAsState(targetContainerColor, label = "container")
     val animatedContentColor by animateColorAsState(targetContentColor, label = "content")
 
-    Card(
-        modifier = modifier
-            .fillMaxWidth()
-            .border(2.dp, borderColor, RoundedCornerShape(12.dp)),
-        colors = CardDefaults.cardColors(
-            containerColor = animatedContainerColor,
-            contentColor = animatedContentColor
-        )
-    ) {
-        Column(
-            modifier = Modifier.padding(16.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
+    val hasFuelCost = evaluation.fuelCostEstimate > 0.0
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .border(2.dp, borderColor, RoundedCornerShape(12.dp)),
+            colors = CardDefaults.cardColors(
+                containerColor = animatedContainerColor,
+                contentColor = animatedContentColor
+            )
         ) {
-            Text(
-                text = evaluation.toAnnotatedString(),
-                style = MaterialTheme.typography.titleLarge,
-                fontWeight = FontWeight.Bold
-            )
-
-            Spacer(modifier = Modifier.height(16.dp))
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceEvenly
+            Column(
+                modifier = Modifier.padding(16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                MetricBadge(Icons.Default.AttachMoney, "Pay", animatedContentColor)
-                MetricBadge(Icons.Default.DirectionsCar, "Dist", animatedContentColor)
-                MetricBadge(Icons.Default.Timer, "Time", animatedContentColor)
+                // --- Recommendation + Score ---
+                Text(
+                    text = "${evaluation.recommendationText}  ·  ${evaluation.score.toInt()}pts",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = borderColor
+                )
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                // --- Pay line ---
+                if (hasFuelCost) {
+                    Text(
+                        text = "$${fmt(evaluation.payAmount)} gross  →  $${fmt(evaluation.netPayAmount)} net",
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = FontWeight.SemiBold,
+                        color = animatedContentColor
+                    )
+                    Text(
+                        text = "−$${fmt(evaluation.fuelCostEstimate)} est. fuel",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = animatedContentColor.copy(alpha = 0.65f)
+                    )
+                } else {
+                    Text(
+                        text = "$${fmt(evaluation.payAmount)}",
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = FontWeight.SemiBold,
+                        color = animatedContentColor
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(12.dp))
+                HorizontalDivider(color = animatedContentColor.copy(alpha = 0.15f))
+                Spacer(modifier = Modifier.height(12.dp))
+
+                // --- Metric row: $/mi | $/hr | items ---
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceEvenly
+                ) {
+                    MetricCell(
+                        label = "\$/mi",
+                        value = "$${fmt(evaluation.dollarsPerMile)}",
+                        color = animatedContentColor
+                    )
+                    MetricCell(
+                        label = "\$/hr",
+                        value = "$${fmt(evaluation.dollarsPerHour)}",
+                        color = animatedContentColor
+                    )
+                    MetricCell(
+                        label = "items",
+                        value = evaluation.itemCount.toInt().toString(),
+                        color = animatedContentColor
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                // --- Detail row: distance | time ---
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceEvenly
+                ) {
+                    MetricCell(
+                        label = "miles",
+                        value = fmt(evaluation.distanceMiles),
+                        color = animatedContentColor
+                    )
+                    MetricCell(
+                        label = "est. time",
+                        value = "~${evaluation.estimatedTimeMinutes.toInt()} min",
+                        color = animatedContentColor
+                    )
+                }
             }
+        }
 
-            Spacer(modifier = Modifier.height(12.dp))
-
-            Text(
-                text = when (evaluation.action) {
-                    OfferAction.ACCEPT -> "AUTO ACCEPT"
-                    OfferAction.DECLINE -> "AUTO DECLINE"
-                    else -> "MANUAL REVIEW"
-                },
-                style = MaterialTheme.typography.labelLarge,
-                fontWeight = FontWeight.Black,
-                color = if (isDark) borderColor else Color.Black.copy(alpha = 0.7f)
-            )
+        // --- Warnings (#80) ---
+        if (evaluation.warnings.isNotEmpty()) {
+            Spacer(modifier = Modifier.height(8.dp))
+            evaluation.warnings.forEach { warning ->
+                Text(
+                    text = "\u26a0\ufe0f $warning",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.padding(horizontal = 4.dp, vertical = 2.dp)
+                )
+            }
         }
     }
 }
 
 @Composable
-fun MetricBadge(icon: ImageVector, label: String, tint: Color) {
+private fun MetricCell(label: String, value: String, color: Color) {
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        Icon(icon, contentDescription = null, tint = tint)
-        Text(text = label, style = MaterialTheme.typography.bodySmall, color = tint)
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.Bold,
+            color = color
+        )
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = color.copy(alpha = 0.65f)
+        )
     }
 }
+
+private fun fmt(value: Double): String = String.format(Locale.getDefault(), "%.2f", value)

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/OfferEvaluation.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/OfferEvaluation.kt
@@ -18,6 +18,8 @@ data class OfferEvaluation(
     val dollarsPerMile: Double,
     /** Net implied hourly rate. */
     val dollarsPerHour: Double,
+    /** Estimated time for this offer in minutes, based on [UserEconomy] constants. */
+    val estimatedTimeMinutes: Double,
     val itemCount: Double,
     val merchantName: String,
     /**

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/OfferEvaluator.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/OfferEvaluator.kt
@@ -17,7 +17,8 @@ class OfferEvaluator() {
         val netPay = grossPay - fuelCost
 
         // Time estimate using user-configured constants
-        val estTimeHours = ((dist * economy.avgMinutesPerMile) + economy.basePickupMinutes) / 60.0
+        val estTimeMinutes = (dist * economy.avgMinutesPerMile) + economy.basePickupMinutes
+        val estTimeHours = estTimeMinutes / 60.0
 
         // Metrics operate on net pay
         val dpm = if (dist > 0) netPay / dist else 0.0
@@ -42,6 +43,7 @@ class OfferEvaluator() {
                 distanceMiles = dist,
                 dollarsPerMile = dpm,
                 dollarsPerHour = activeHourly,
+                estimatedTimeMinutes = estTimeMinutes,
                 itemCount = items,
                 merchantName = merchants,
             )
@@ -61,6 +63,7 @@ class OfferEvaluator() {
                 distanceMiles = 0.0,
                 dollarsPerMile = 0.0,
                 dollarsPerHour = 0.0,
+                estimatedTimeMinutes = 0.0,
                 itemCount = 0.0,
                 merchantName = "UNKNOWN"
             )
@@ -87,6 +90,7 @@ class OfferEvaluator() {
                 distanceMiles = dist,
                 dollarsPerMile = dpm,
                 dollarsPerHour = activeHourly,
+                estimatedTimeMinutes = estTimeMinutes,
                 itemCount = items,
                 merchantName = merchants
             )
@@ -156,6 +160,7 @@ class OfferEvaluator() {
             distanceMiles = dist,
             dollarsPerMile = dpm,
             dollarsPerHour = activeHourly,
+            estimatedTimeMinutes = estTimeMinutes,
             itemCount = items,
             merchantName = merchants,
             warnings = warnings,

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/evaluation/OfferEvaluatorTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/evaluation/OfferEvaluatorTest.kt
@@ -301,6 +301,17 @@ class OfferEvaluatorTest {
         assertEquals(3.0, result.distanceMiles, 0.0001)
         assertEquals(7.0 / 3.0, result.dollarsPerMile, 0.01)
         assertEquals("Taco Bell", result.merchantName)
+        // 3 miles * 2.5 min/mi + 7 base = 14.5 min
+        assertEquals(14.5, result.estimatedTimeMinutes, 0.0001)
+    }
+
+    @Test
+    fun `evaluation output - estimatedTimeMinutes uses UserEconomy constants`() {
+        val economy = UserEconomy(vehicleType = VehicleType.E_BIKE, avgMinutesPerMile = 4.0, basePickupMinutes = 10.0)
+        val cfg = EvaluationConfig(rules = listOf(metricRule(MetricType.PAYOUT, 7.0f)), userEconomy = economy)
+        // 5 miles * 4 min/mi + 10 = 30 min
+        val result = evaluator.evaluate(offer(pay = 7.0, dist = 5.0), cfg)
+        assertEquals(30.0, result.estimatedTimeMinutes, 0.0001)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- **#79** — `OfferEvaluation` gains `estimatedTimeMinutes`; `FakeOfferCard` fully rewritten to show all real metrics: gross→net pay with fuel breakdown (CAR only), \$/mi, \$/hr, items, distance, and est. time
- **#80** — Caveat warnings from `OfferEvaluation.warnings` now rendered below the playground card in Strategy Settings ("The Lab"), satisfying the settings-side warning requirement
- `toAnnotatedString()` appends net pay when fuel cost is non-zero (bubble/notification formatters)
- Two new `OfferEvaluatorTest` cases covering `estimatedTimeMinutes` calculation

## Test plan

- [x] `:domain:test --tests "*OfferEvaluatorTest*"` passes (including 2 new cases)
- [x] `:app:testDebugUnitTest --tests "*AllMatchersSuite*"` passes (full regression suite)
- [ ] Visual: open Strategy Settings → The Lab, adjust pay/dist sliders — card shows gross, net, fuel line, $/mi, $/hr, items, distance, est. time
- [ ] Visual: set a $/mile rule target > $2.00 — warning appears below the card in red
- [ ] Visual: E-bike vehicle type — no fuel line shown, only gross pay

Closes #79, #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)