### PR TITLE
ci [#113]: Run unit tests across all modules in PR check

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -37,7 +37,7 @@ jobs:
         run: ./gradlew :app:assembleDebug
 
       - name: Run unit tests
-        run: ./gradlew :app:testDebugUnitTest
+        run: ./gradlew testDebugUnitTest
 
       - name: Upload debug APK
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

- Changes `./gradlew :app:testDebugUnitTest` → `./gradlew testDebugUnitTest` in `pr-check.yml`
- Gradle will now run `testDebugUnitTest` in every subproject that defines it, so `:core:data`, `:core:database`, and `:core:network` tests are no longer silently skipped on every PR

Closes #113

## Test plan
- [ ] CI PR check runs and passes all module tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)