### PR TITLE
chore [#121]: Remove incorrect @RequiresApi(BAKLAVA) propagation from pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,9 @@ Tests are data-driven using captured UI hierarchy JSON files under
 
 ## Git Workflow
 
+**Before creating a branch**, mark the issue(s) as **In Progress** in the GitHub project board.
+See `CLAUDE.local.md` for the command to update the project Status field.
+
 **Always create a branch** before starting work on any issue or set of issues. Never commit
 feature/fix work directly to `master`.
 
@@ -146,6 +149,18 @@ GH="/c/Program Files/GitHub CLI/gh.exe"
 "$GH" pr merge <NUMBER> --merge
 ```
 
+## Session Orientation
+
+At the start of a session or before picking up new work:
+
+1. **Check open issues and their blocking relationships** — don't just look at what's open, look at
+   what's blocking what.
+2. **Prioritize blockers first** — if issue A is blocking issues B, C, and D, resolve A before
+   starting B, C, or D.
+3. **Determine logical next steps** from the milestone/phase ordering, then check those candidates
+   for unresolved blockers before committing to a direction.
+4. **Update `memory/project_state.md`** if the current state has drifted from what's recorded.
+
 ## GitHub Issues — Labels & Project
 
 **Always** add every new issue to the DashBuddy Roadmap project. See `CLAUDE.local.md` for the
@@ -168,6 +183,14 @@ project number, owner, and `gh` CLI path used to do this.
 
 Apply multiple labels when appropriate (e.g. `refactor` + `architecture`, `testing` +
 `offer-engine`).
+
+## GitHub Issues — Blocking Relationships
+
+When one issue is pre-work for or directly blocks another, **always set the blocking relationship**
+so the dependency is visible in the GitHub UI. Use the `addBlockedBy` GraphQL mutation — see
+`CLAUDE.local.md` for the exact command.
+
+Convention: if you say "pre-work for #X" or "blocked by #Y" in an issue description, make it real.
 
 ## Device Setup Note
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/DashBuddyApplication.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/DashBuddyApplication.kt
@@ -2,8 +2,6 @@ package cloud.trotter.dashbuddy
 
 import android.app.Application
 import android.content.Context
-import android.os.Build
-import androidx.annotation.RequiresApi
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
 import androidx.work.Constraints
@@ -73,7 +71,6 @@ class DashBuddyApplication : Application(), Configuration.Provider {
         }
     }
 
-    @RequiresApi(Build.VERSION_CODES.BAKLAVA)
     override fun onCreate() {
         super.onCreate()
         instance = this

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/PipelineV2.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/PipelineV2.kt
@@ -1,7 +1,5 @@
 package cloud.trotter.dashbuddy.pipeline
 
-import android.os.Build
-import androidx.annotation.RequiresApi
 import cloud.trotter.dashbuddy.pipeline.accessibility.AccessibilityPipeline
 import cloud.trotter.dashbuddy.pipeline.notification.NotificationPipeline
 import cloud.trotter.dashbuddy.domain.model.state.StateEvent
@@ -17,7 +15,6 @@ class PipelineV2 @Inject constructor(
     accessibilityPipeline: AccessibilityPipeline,
     notificationPipeline: NotificationPipeline
 ) {
-    @RequiresApi(Build.VERSION_CODES.BAKLAVA)
     val events: Flow<StateEvent> = merge(
         accessibilityPipeline.output(),
         notificationPipeline.output()

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/AccessibilityPipeline.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/AccessibilityPipeline.kt
@@ -1,7 +1,5 @@
 package cloud.trotter.dashbuddy.pipeline.accessibility
 
-import android.os.Build
-import androidx.annotation.RequiresApi
 import cloud.trotter.dashbuddy.domain.model.state.StateEvent
 import cloud.trotter.dashbuddy.pipeline.accessibility.event.type.view.ViewPipeline
 import cloud.trotter.dashbuddy.pipeline.accessibility.event.type.window.WindowPipeline
@@ -13,7 +11,6 @@ class AccessibilityPipeline @Inject constructor(
     private val viewPipeline: ViewPipeline,
     private val windowPipeline: WindowPipeline
 ) {
-    @RequiresApi(Build.VERSION_CODES.BAKLAVA)
     fun output(): Flow<StateEvent> = merge(
         viewPipeline.output(),
         windowPipeline.output()

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/view/ViewPipeline.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/view/ViewPipeline.kt
@@ -1,7 +1,5 @@
 package cloud.trotter.dashbuddy.pipeline.accessibility.event.type.view
 
-import android.os.Build
-import androidx.annotation.RequiresApi
 import cloud.trotter.dashbuddy.pipeline.accessibility.event.type.view.clicked.ClickedPipeline
 import cloud.trotter.dashbuddy.domain.model.state.StateEvent
 import kotlinx.coroutines.flow.Flow
@@ -12,7 +10,6 @@ class ViewPipeline @Inject constructor(
     // Future: private val viewLongClickedPipeline: ViewLongClickedPipeline     // maybe?
     // Future: private val viewScrolledPipeline: ViewScrolledPipeline           // maybe?
 ) {
-    @RequiresApi(Build.VERSION_CODES.BAKLAVA)
     fun output(): Flow<StateEvent> = clickedPipeline.output()
     // Future: .mergeWith(viewLongClickedPipeline.output())                     // maybe?
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/view/clicked/ClickedPipeline.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/view/clicked/ClickedPipeline.kt
@@ -1,8 +1,6 @@
 package cloud.trotter.dashbuddy.pipeline.accessibility.event.type.view.clicked
 
-import android.os.Build
 import android.view.accessibility.AccessibilityEvent
-import androidx.annotation.RequiresApi
 import cloud.trotter.dashbuddy.domain.model.state.StateEvent
 import cloud.trotter.dashbuddy.pipeline.accessibility.input.AccessibilitySource
 import cloud.trotter.dashbuddy.pipeline.accessibility.mapper.toUiNode
@@ -16,7 +14,6 @@ class ClickedPipeline @Inject constructor(
     private val classifier: ClickClassifier,
     private val factory: ClickFactory
 ) {
-    @RequiresApi(Build.VERSION_CODES.BAKLAVA)
     fun output(): Flow<StateEvent> = source.events
         .filter { it.eventType == AccessibilityEvent.TYPE_VIEW_CLICKED }
         .mapNotNull { event ->

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/WindowPipeline.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/WindowPipeline.kt
@@ -1,7 +1,5 @@
 package cloud.trotter.dashbuddy.pipeline.accessibility.event.type.window
 
-import android.os.Build
-import androidx.annotation.RequiresApi
 import cloud.trotter.dashbuddy.pipeline.accessibility.event.type.window.content_changed.ContentChangedPipeline
 import cloud.trotter.dashbuddy.pipeline.accessibility.event.type.window.state_changed.StateChangedPipeline
 import cloud.trotter.dashbuddy.domain.model.state.StateEvent
@@ -17,7 +15,6 @@ class WindowPipeline @Inject constructor(
     private val factory: ScreenFactory,
     private val differ: ScreenDiffer,
 ) {
-    @RequiresApi(Build.VERSION_CODES.BAKLAVA)
     fun output(): Flow<StateEvent> = merge(
         contentChangedPipeline.output(),
         stateChangedPipeline.output()

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/content_changed/ContentChangedPipeline.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/content_changed/ContentChangedPipeline.kt
@@ -1,8 +1,6 @@
 package cloud.trotter.dashbuddy.pipeline.accessibility.event.type.window.content_changed
 
-import android.os.Build
 import android.view.accessibility.AccessibilityEvent
-import androidx.annotation.RequiresApi
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
 import cloud.trotter.dashbuddy.pipeline.accessibility.input.AccessibilitySource
 import cloud.trotter.dashbuddy.pipeline.accessibility.mapper.toUiNode
@@ -18,7 +16,6 @@ import javax.inject.Inject
 class ContentChangedPipeline @Inject constructor(
     private val source: AccessibilitySource
 ) {
-    @RequiresApi(Build.VERSION_CODES.BAKLAVA)
     fun output(): Flow<UiNode> = source.events
         .filter { it.eventType == AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED }
         .onEach { Timber.v("🌊 FLOOD: Content Change from ${it.className}") }

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/processing/matchers/OfferMatcher.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/processing/matchers/OfferMatcher.kt
@@ -1,7 +1,5 @@
 package cloud.trotter.dashbuddy.pipeline.accessibility.event.type.window.processing.matchers
 
-import android.os.Build
-import androidx.annotation.RequiresApi
 import cloud.trotter.dashbuddy.domain.model.accessibility.Screen
 import cloud.trotter.dashbuddy.domain.model.accessibility.ScreenInfo
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
@@ -20,7 +18,6 @@ class OfferMatcher @Inject constructor() : ScreenMatcher {
     override val targetScreen = Screen.OFFER_POPUP
     override val priority = 20
 
-    @RequiresApi(Build.VERSION_CODES.BAKLAVA)
     override fun matches(node: UiNode): ScreenInfo? {
         // --- 1. FAIL FAST CHECKS ---
         if (node.findNode { it.viewIdResourceName?.endsWith("progress_bar") == true } != null) return null

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/state_changed/StateChangedPipeline.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/state_changed/StateChangedPipeline.kt
@@ -1,8 +1,6 @@
 package cloud.trotter.dashbuddy.pipeline.accessibility.event.type.window.state_changed
 
-import android.os.Build
 import android.view.accessibility.AccessibilityEvent
-import androidx.annotation.RequiresApi
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
 import cloud.trotter.dashbuddy.pipeline.accessibility.input.AccessibilitySource
 import cloud.trotter.dashbuddy.pipeline.accessibility.mapper.toUiNode
@@ -14,7 +12,6 @@ import javax.inject.Inject
 class StateChangedPipeline @Inject constructor(
     private val source: AccessibilitySource
 ) {
-    @RequiresApi(Build.VERSION_CODES.BAKLAVA)
     fun output(): Flow<UiNode> = source.events
         .filter { it.eventType == AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED }
         .mapNotNull { event ->

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/input/AccessibilityListener.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/input/AccessibilityListener.kt
@@ -1,9 +1,7 @@
 package cloud.trotter.dashbuddy.pipeline.accessibility.input
 
 import android.accessibilityservice.AccessibilityService
-import android.os.Build
 import android.view.accessibility.AccessibilityEvent
-import androidx.annotation.RequiresApi
 import dagger.hilt.android.AndroidEntryPoint
 import timber.log.Timber
 import javax.inject.Inject
@@ -19,7 +17,6 @@ class AccessibilityListener : AccessibilityService() {
         Timber.d("Accessibility service created")
     }
 
-    @RequiresApi(Build.VERSION_CODES.BAKLAVA)
     override fun onAccessibilityEvent(event: AccessibilityEvent?) {
         if (event == null) return
 
@@ -43,7 +40,6 @@ class AccessibilityListener : AccessibilityService() {
         Timber.d("Accessibility service destroyed")
     }
 
-    @RequiresApi(Build.VERSION_CODES.BAKLAVA)
     override fun onServiceConnected() {
         super.onServiceConnected()
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/input/AccessibilitySource.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/input/AccessibilitySource.kt
@@ -1,10 +1,8 @@
 package cloud.trotter.dashbuddy.pipeline.accessibility.input
 
 import android.accessibilityservice.AccessibilityService
-import android.os.Build
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
-import androidx.annotation.RequiresApi
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
 import cloud.trotter.dashbuddy.pipeline.accessibility.mapper.toUiNode
 import kotlinx.coroutines.channels.BufferOverflow
@@ -49,7 +47,6 @@ class AccessibilitySource @Inject constructor() {
      * Fetches the current Root Node directly from the system.
      * * SAFE to call from background threads.
      */
-    @RequiresApi(Build.VERSION_CODES.BAKLAVA)
     fun getCurrentRootNode(): UiNode? {
         val root = getLiveNativeRoot() ?: return null
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/mapper/AccessibilityNodeMapper.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/mapper/AccessibilityNodeMapper.kt
@@ -3,10 +3,8 @@ package cloud.trotter.dashbuddy.pipeline.accessibility.mapper
 import android.graphics.Rect
 import android.os.Build
 import android.view.accessibility.AccessibilityNodeInfo
-import androidx.annotation.RequiresApi
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
 
-@RequiresApi(Build.VERSION_CODES.BAKLAVA)
 fun AccessibilityNodeInfo?.toUiNode(parentUiNode: UiNode? = null): UiNode? {
     if (this == null) return null
 
@@ -16,7 +14,9 @@ fun AccessibilityNodeInfo?.toUiNode(parentUiNode: UiNode? = null): UiNode? {
     val currentUiNode = UiNode(
         text = this.text?.toString(),
         contentDescription = this.contentDescription?.toString(),
-        stateDescription = this.stateDescription?.toString(),
+        stateDescription = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            this.stateDescription?.toString()
+        } else null,
         viewIdResourceName = this.viewIdResourceName,
         className = this.className?.toString(),
         isClickable = this.isClickable,

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/notification/input/NotificationListener.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/notification/input/NotificationListener.kt
@@ -1,9 +1,7 @@
 package cloud.trotter.dashbuddy.pipeline.notification.input
 
-import android.os.Build
 import android.service.notification.NotificationListenerService
 import android.service.notification.StatusBarNotification
-import androidx.annotation.RequiresApi
 //import cloud.trotter.dashbuddy.pipeline.Pipeline
 //import cloud.trotter.dashbuddy.pipeline.features.notification.NotificationInfo
 import dagger.hilt.android.AndroidEntryPoint
@@ -23,7 +21,6 @@ class NotificationListener : NotificationListenerService() {
         Timber.i("Notification Listener Connected!")
     }
 
-    @RequiresApi(Build.VERSION_CODES.BAKLAVA)
     override fun onNotificationPosted(sbn: StatusBarNotification?) {
         if (sbn == null) return
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/StateManagerV2.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/StateManagerV2.kt
@@ -1,7 +1,5 @@
 package cloud.trotter.dashbuddy.state
 
-import android.os.Build
-import androidx.annotation.RequiresApi
 import cloud.trotter.dashbuddy.core.data.state.StateRecoveryRepository
 import cloud.trotter.dashbuddy.pipeline.PipelineV2
 import cloud.trotter.dashbuddy.state.effects.SideEffectEngine
@@ -56,7 +54,6 @@ class StateManagerV2 @Inject constructor(
     private val _state = MutableStateFlow<AppStateV2>(AppStateV2.Initializing)
     val state = _state.asStateFlow()
 
-    @RequiresApi(Build.VERSION_CODES.BAKLAVA)
     fun initialize() {
         Timber.i("Initializing V2 State Machine...")
         restoreState()
@@ -67,7 +64,6 @@ class StateManagerV2 @Inject constructor(
         uiInputChannel.trySend(stateEvent)
     }
 
-    @RequiresApi(Build.VERSION_CODES.BAKLAVA)
     private fun startProcessor() {
         scope.launch {
             Timber.d("🔌 Connecting All Event Streams...")
@@ -89,7 +85,6 @@ class StateManagerV2 @Inject constructor(
         }
     }
 
-    @RequiresApi(Build.VERSION_CODES.BAKLAVA)
     private fun processEvent(stateEvent: StateEvent) {
         val currentState = _state.value
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
@@ -1,7 +1,5 @@
 package cloud.trotter.dashbuddy.state.effects
 
-import android.os.Build
-import androidx.annotation.RequiresApi
 import cloud.trotter.dashbuddy.core.data.event.AppEventRepo
 import cloud.trotter.dashbuddy.core.data.strategy.StrategyRepository
 import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
@@ -53,14 +51,12 @@ class SideEffectEngine @Inject constructor(
      * Entry point: The StateManager pushes an effect here.
      * We execute it in the provided scope.
      */
-    @RequiresApi(Build.VERSION_CODES.BAKLAVA)
     fun process(effect: AppEffect, scope: CoroutineScope) {
         scope.launch(Dispatchers.Default) {
             execute(effect, scope)
         }
     }
 
-    @RequiresApi(Build.VERSION_CODES.BAKLAVA)
     private suspend fun execute(effect: AppEffect, scope: CoroutineScope) {
         when (effect) {
             // --- FIRE & FORGET (UI / IO) ---


### PR DESCRIPTION
## Summary

- Root cause: `AccessibilityNodeMapper` was annotated `@RequiresApi(BAKLAVA)` (API 36) at the class level. The only field that actually has an API requirement is `stateDescription`, which is API 30 (`R`), not 36.
- Replaced the class-level annotation with an inline `if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R)` guard on `stateDescription` only.
- Removed the now-unnecessary `@RequiresApi(BAKLAVA)` annotation and dead `Build`/`RequiresApi` imports from 14 downstream files: the full pipeline chain (`ContentChangedPipeline`, `StateChangedPipeline`, `WindowPipeline`, `ViewPipeline`, `ClickedPipeline`, `AccessibilityPipeline`, `AccessibilitySource`, `AccessibilityListener`, `NotificationListener`, `PipelineV2`) and the consumers (`StateManagerV2`, `SideEffectEngine`, `DashBuddyApplication`).
- Also removes the previously-committed `@RequiresApi` from `OfferMatcher`.
- Updates `CLAUDE.md` with session orientation workflow, issue blocking relationship convention, and project status field workflow.

## Test plan
- [x] `./gradlew :app:compileDebugKotlin` — BUILD SUCCESSFUL
- [x] `./gradlew :app:testDebugUnitTest --tests "*AllMatchersSuite*"` — all tests pass

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)