### PR TITLE
docs: update test commands to run across all modules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,14 +9,14 @@ repository.
 # Build the app
 ./gradlew :app:build
 
-# Run all unit tests
-./gradlew :app:testDebugUnitTest
+# Run all unit tests (across all modules)
+./gradlew testDebugUnitTest
 
 # Run the full regression suite (before any PR)
-./gradlew :app:testDebugUnitTest --tests "*AllMatchersSuite*"
+./gradlew testDebugUnitTest --tests "*AllMatchersSuite*"
 
 # Run a specific regression test
-./gradlew :app:testDebugUnitTest --tests "*DashPausedRegressionTest*"
+./gradlew testDebugUnitTest --tests "*DashPausedRegressionTest*"
 
 # Run instrumented tests (requires connected device/emulator)
 ./gradlew :app:connectedAndroidTest


### PR DESCRIPTION
## Summary
- Remove `:app:` prefix from unit test commands in CLAUDE.md
- Commands now match the CI/CD pipeline (`testDebugUnitTest` runs all modules)

[skip ci]

🤖 Generated with [Claude Code](https://claude.com/claude-code)