### PR TITLE
ci: support [skip ci] in PR body to bypass PR check

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.body, '[skip ci]') }}
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 


### PR DESCRIPTION
## Summary
- Add `if: !contains(github.event.pull_request.body, '[skip ci]')` condition to the `build-and-test` job
- Placing `[skip ci]` anywhere in a PR description will now skip the CI pipeline
- Useful for doc-only PRs (e.g. CLAUDE.md updates) that don't affect the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)