### PR TITLE
cleanup [#120]: Add OnDashMapMatcher, mutual fail-fasts across map matchers

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/di/PipelineModule.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/di/PipelineModule.kt
@@ -10,6 +10,7 @@ import cloud.trotter.dashbuddy.pipeline.accessibility.event.type.window.processi
 import cloud.trotter.dashbuddy.pipeline.accessibility.event.type.window.processing.matchers.DropoffPreArrivalMatcher
 import cloud.trotter.dashbuddy.pipeline.accessibility.event.type.window.processing.matchers.IdleMapMatcher
 import cloud.trotter.dashbuddy.pipeline.accessibility.event.type.window.processing.matchers.OfferMatcher
+import cloud.trotter.dashbuddy.pipeline.accessibility.event.type.window.processing.matchers.OnDashMapMatcher
 import cloud.trotter.dashbuddy.pipeline.accessibility.event.type.window.processing.matchers.PickupArrivalMatcher
 import cloud.trotter.dashbuddy.pipeline.accessibility.event.type.window.processing.matchers.PickupNavigationMatcher
 import cloud.trotter.dashbuddy.pipeline.accessibility.event.type.window.processing.matchers.PickupPreArrivalMatcher
@@ -55,6 +56,11 @@ abstract class PipelineModule {
     @IntoSet
     @Singleton
     abstract fun bindOfferMatcher(impl: OfferMatcher): ScreenMatcher
+
+    @Binds
+    @IntoSet
+    @Singleton
+    abstract fun bindOnDashMapMatcher(impl: OnDashMapMatcher): ScreenMatcher
 
     @Binds
     @IntoSet

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/processing/matchers/IdleMapMatcher.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/processing/matchers/IdleMapMatcher.kt
@@ -16,16 +16,25 @@ class IdleMapMatcher @Inject constructor() : ScreenMatcher {
     override fun matches(node: UiNode): ScreenInfo? {
         // --- 1. NEGATIVE MATCHING (Safety Guards) ---
 
-        // Safety Guard 1: "Return to dash"
-        // If this button is visible, we are definitely NOT idle, we are in an active dash
-        // (likely navigating menus).
+        // Safety Guard 1: "Return to dash" — this screen belongs to OnDashMapMatcher.
         val isReturnToDash = node.findNode {
             it.text.equals("Return to dash", ignoreCase = true)
         } != null
 
         if (isReturnToDash) {
-            Timber.v("Match failed: 'Return to dash' button detected (Active Dash).")
-            return ScreenInfo.Simple(Screen.MAIN_MAP_ON_DASH)
+            Timber.v("Match failed: 'Return to dash' button detected (MAIN_MAP_ON_DASH).")
+            return null
+        }
+
+        // Safety Guard 2: "Looking for offers" / "Finding offers" — belongs to WaitingForOfferMatcher.
+        val isWaitingForOffer = node.findNode {
+            it.text?.contains("looking for offers", ignoreCase = true) == true ||
+                    it.text?.contains("finding offers", ignoreCase = true) == true
+        } != null
+
+        if (isWaitingForOffer) {
+            Timber.v("Match failed: Waiting-for-offer UI detected (ON_DASH_MAP_WAITING_FOR_OFFER).")
+            return null
         }
 
         // --- 2. POSITIVE MATCHING (Structural Fingerprint) ---

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/processing/matchers/OnDashMapMatcher.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/processing/matchers/OnDashMapMatcher.kt
@@ -1,0 +1,51 @@
+package cloud.trotter.dashbuddy.pipeline.accessibility.event.type.window.processing.matchers
+
+import cloud.trotter.dashbuddy.domain.model.accessibility.Screen
+import cloud.trotter.dashbuddy.domain.model.accessibility.ScreenInfo
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import cloud.trotter.dashbuddy.pipeline.accessibility.event.type.window.processing.ScreenMatcher
+import timber.log.Timber
+import javax.inject.Inject
+
+class OnDashMapMatcher @Inject constructor() : ScreenMatcher {
+
+    override val targetScreen = Screen.MAIN_MAP_ON_DASH
+    override val priority = 2
+
+    override fun matches(node: UiNode): ScreenInfo? {
+        // --- 1. NEGATIVE MATCHING (Safety Guards) ---
+
+        // Safety Guard 1: Earnings Mode Switcher — this screen belongs to IdleMapMatcher.
+        val hasEarningsSwitcher = node.findNode {
+            it.contentDescription == "Earnings Mode Switcher"
+        } != null
+
+        if (hasEarningsSwitcher) {
+            Timber.v("Match failed: Earnings Mode Switcher detected (MAIN_MAP_IDLE).")
+            return null
+        }
+
+        // Safety Guard 2: "Looking for offers" / "Finding offers" — belongs to WaitingForOfferMatcher.
+        val isWaitingForOffer = node.findNode {
+            it.text?.contains("looking for offers", ignoreCase = true) == true ||
+                    it.text?.contains("finding offers", ignoreCase = true) == true
+        } != null
+
+        if (isWaitingForOffer) {
+            Timber.v("Match failed: Waiting-for-offer UI detected (ON_DASH_MAP_WAITING_FOR_OFFER).")
+            return null
+        }
+
+        // --- 2. POSITIVE MATCHING ---
+
+        // The "Return to dash" button is the definitive signal that the dasher is mid-dash
+        // and has navigated away from the active order screen to the home map.
+        val hasReturnToDash = node.findNode {
+            it.text.equals("Return to dash", ignoreCase = true)
+        } != null
+
+        if (!hasReturnToDash) return null
+
+        return ScreenInfo.Simple(Screen.MAIN_MAP_ON_DASH)
+    }
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/processing/matchers/WaitingForOfferMatcher.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/processing/matchers/WaitingForOfferMatcher.kt
@@ -13,8 +13,23 @@ class WaitingForOfferMatcher @Inject constructor() : ScreenMatcher {
     override val priority = 1
 
     override fun matches(node: UiNode): ScreenInfo? {
-        // --- 1. SAFETY CHECK ---
-        // Ensure we aren't on the "Dash Along The Way" start screen
+        // --- 1. SAFETY CHECKS ---
+
+        // Guard: Earnings Mode Switcher — this screen belongs to IdleMapMatcher.
+        val hasEarningsSwitcher = node.findNode {
+            it.contentDescription == "Earnings Mode Switcher"
+        } != null
+
+        if (hasEarningsSwitcher) return null
+
+        // Guard: "Return to dash" — this screen belongs to OnDashMapMatcher.
+        val hasReturnToDash = node.findNode {
+            it.text.equals("Return to dash", ignoreCase = true)
+        } != null
+
+        if (hasReturnToDash) return null
+
+        // Guard: Ensure we aren't on the "Dash Along The Way" start screen.
         val hasAlongWayText = node.findNode {
             it.text?.contains("look for orders along the way", ignoreCase = true) == true
         } != null

--- a/app/src/test/java/cloud/trotter/dashbuddy/pipeline/recognition/matchers/IdleMapMatcherTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/pipeline/recognition/matchers/IdleMapMatcherTest.kt
@@ -479,15 +479,9 @@ UiNode(, id=no_id, state=null, class=android.widget.FrameLayout)
 
         val result = matcher.matches(root!!)
 
-        // IdleMapMatcher is a "special" matcher that returns MAIN_MAP_ON_DASH when it detects
-        // the "Return to dash" button, rather than null. This is intentional current behavior.
-        // TODO (#89 pipeline refactor): decide whether guard-triggered cross-screen returns
-        //  should stay here or be delegated to a dedicated OnDashMapMatcher.
-        assertNotNull("Should return a screen result (not null) for return to dash", result)
-        assertTrue(
-            "Should return MAIN_MAP_ON_DASH, not IdleMap",
-            result !is ScreenInfo.IdleMap
-        )
+        // IdleMapMatcher must return null for the on-dash map screen.
+        // OnDashMapMatcher is the dedicated handler for MAIN_MAP_ON_DASH.
+        assertNull("Should return null — MAIN_MAP_ON_DASH belongs to OnDashMapMatcher", result)
     }
 
     @Test

--- a/app/src/test/java/cloud/trotter/dashbuddy/pipeline/recognition/matchers/OnDashMapMatcherTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/pipeline/recognition/matchers/OnDashMapMatcherTest.kt
@@ -1,0 +1,152 @@
+package cloud.trotter.dashbuddy.pipeline.recognition.matchers
+
+import cloud.trotter.dashbuddy.domain.model.accessibility.Screen
+import cloud.trotter.dashbuddy.domain.model.accessibility.ScreenInfo
+import cloud.trotter.dashbuddy.pipeline.accessibility.event.type.window.processing.matchers.OnDashMapMatcher
+import cloud.trotter.dashbuddy.test.LogToUiNodeParser
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class OnDashMapMatcherTest {
+
+    private val matcher = OnDashMapMatcher()
+
+    // Dasher is mid-dash and has navigated to the home map screen.
+    // The "Return to dash" button is visible.
+    private val returnToDashLog = """
+UiNode(, id=no_id, state=null, class=android.widget.FrameLayout)
+  UiNode(, id=no_id, state=null, class=android.widget.LinearLayout)
+    UiNode(, id=no_id, state=null, class=android.widget.FrameLayout)
+      UiNode(, id=action_bar_root, state=null, class=android.widget.LinearLayout)
+        UiNode(, id=content, state=null, class=android.widget.FrameLayout)
+          UiNode(, id=overlay_gesture_manager, state=null, class=android.widget.FrameLayout)
+            UiNode(, id=root_constraint_layout, state=null, class=android.view.ViewGroup)
+              UiNode(, id=side_nav_content_container, state=null, class=android.widget.FrameLayout)
+                UiNode(, id=main_fragment, state=null, class=android.widget.FrameLayout)
+                  UiNode(, id=no_id, state=null, class=androidx.compose.ui.platform.ComposeView)
+                    UiNode(, id=no_id, state=null, class=android.view.View)
+                      UiNode(, id=no_id, state=null, class=android.view.View)
+                        UiNode(, id=no_id, state=null, class=androidx.compose.ui.viewinterop.ViewFactoryHolder)
+                          UiNode(, id=no_id, state=null, class=android.widget.FrameLayout)
+                            UiNode(, id=no_id, state=null, class=android.widget.FrameLayout)
+                              UiNode(, id=no_id, state=null, class=android.view.TextureView)
+                              UiNode(, id=no_id, state=null, class=android.widget.FrameLayout)
+                        UiNode(, id=no_id, state=null, class=android.view.View)
+                          UiNode(desc='Side Menu', id=no_id, state=null, class=android.view.View)
+                          UiNode(, id=no_id, state=null, class=android.widget.Button)
+                        UiNode(, id=no_id, state=null, class=android.view.View)
+                          UiNode(, id=no_id, state=null, class=android.widget.Button)
+                        UiNode(, id=no_id, state=null, class=android.view.View)
+                          UiNode(desc='', id=no_id, state=null, class=android.view.View)
+                          UiNode(, id=no_id, state=null, class=android.widget.Button)
+                        UiNode(, id=no_id, state=null, class=android.view.View)
+                          UiNode(text='${'$'}', id=no_id, state=null, class=android.widget.TextView)
+                          UiNode(text='0', id=no_id, state=null, class=android.widget.TextView)
+                          UiNode(text='.', id=no_id, state=null, class=android.widget.TextView)
+                          UiNode(text='0', id=no_id, state=null, class=android.widget.TextView)
+                          UiNode(text='0', id=no_id, state=null, class=android.widget.TextView)
+                          UiNode(text='This week', id=no_id, state=null, class=android.widget.TextView)
+                          UiNode(, id=no_id, state=null, class=android.widget.Button)
+                        UiNode(, id=no_id, state=null, class=android.view.View)
+                          UiNode(, id=no_id, state=null, class=android.widget.ScrollView)
+                        UiNode(, id=no_id, state=null, class=android.view.View)
+                          UiNode(desc='', id=no_id, state=null, class=android.view.View)
+                          UiNode(, id=no_id, state=null, class=android.widget.Button)
+                        UiNode(, id=no_id, state=null, class=android.view.View)
+                          UiNode(desc='Safety tools', id=no_id, state=null, class=android.view.View)
+                          UiNode(, id=no_id, state=null, class=android.widget.Button)
+                        UiNode(, id=no_id, state=null, class=android.view.View)
+                          UiNode(text='Return to dash', id=no_id, state=null, class=android.widget.TextView)
+                          UiNode(, id=no_id, state=null, class=android.widget.Button)
+              UiNode(, id=side_nav_container, state=null, class=android.widget.FrameLayout)
+                UiNode(, id=no_id, state=null, class=android.widget.LinearLayout)
+                  UiNode(, id=side_nav_compose_view, state=null, class=androidx.compose.ui.platform.ComposeView)
+                    UiNode(, id=no_id, state=null, class=android.view.View)
+                      UiNode(, id=no_id, state=null, class=android.view.View)
+                        UiNode(, id=no_id, state=null, class=android.view.View)
+                          UiNode(text='Stephen T', id=no_id, state=null, class=android.widget.TextView)
+              UiNode(, id=side_nav_header_background, state=null, class=androidx.compose.ui.platform.ComposeView)
+                UiNode(, id=no_id, state=null, class=android.view.View)
+""".trimIndent()
+
+    // Idle map — has Earnings Mode Switcher, no "Return to dash".
+    // OnDashMapMatcher must NOT match this.
+    private val idleMapLog = """
+UiNode(, id=no_id, state=null, class=android.widget.FrameLayout)
+  UiNode(, id=no_id, state=null, class=android.widget.LinearLayout)
+    UiNode(, id=no_id, state=null, class=android.widget.FrameLayout)
+      UiNode(, id=action_bar_root, state=null, class=android.widget.LinearLayout)
+        UiNode(, id=content, state=null, class=android.widget.FrameLayout)
+          UiNode(, id=overlay_gesture_manager, state=null, class=android.widget.FrameLayout)
+            UiNode(, id=root_constraint_layout, state=null, class=android.view.ViewGroup)
+              UiNode(, id=side_nav_content_container, state=null, class=android.widget.FrameLayout)
+                UiNode(, id=main_fragment, state=null, class=android.widget.FrameLayout)
+                  UiNode(, id=no_id, state=null, class=androidx.compose.ui.platform.ComposeView)
+                    UiNode(, id=no_id, state=null, class=android.view.View)
+                      UiNode(, id=no_id, state=null, class=android.view.View)
+                        UiNode(, id=no_id, state=null, class=android.view.View)
+                          UiNode(desc='Side Menu', id=no_id, state=null, class=android.view.View)
+                        UiNode(, id=no_id, state=null, class=android.view.View)
+                          UiNode(desc='Earnings Mode Switcher', id=no_id, state=null, class=android.view.View)
+                          UiNode(, id=no_id, state=null, class=android.view.View)
+                            UiNode(desc='Time mode off', id=no_id, state=null, class=android.view.View)
+                            UiNode(desc='Time mode on', id=no_id, state=null, class=android.view.View)
+                        UiNode(, id=no_id, state=null, class=android.view.View)
+                          UiNode(text='Dash', id=no_id, state=null, class=android.widget.TextView)
+""".trimIndent()
+
+    // Waiting for offer — has "Looking for offers" text, no "Return to dash".
+    // OnDashMapMatcher must NOT match this.
+    private val waitingForOfferLog = """
+UiNode(, id=no_id, state=null, class=android.widget.FrameLayout)
+  UiNode(, id=no_id, state=null, class=android.widget.LinearLayout)
+    UiNode(, id=no_id, state=null, class=android.widget.FrameLayout)
+      UiNode(, id=action_bar_root, state=null, class=android.widget.LinearLayout)
+        UiNode(, id=content, state=null, class=android.widget.FrameLayout)
+          UiNode(, id=overlay_gesture_manager, state=null, class=android.widget.FrameLayout)
+            UiNode(, id=root_constraint_layout, state=null, class=android.view.ViewGroup)
+              UiNode(, id=side_nav_content_container, state=null, class=android.widget.FrameLayout)
+                UiNode(, id=main_fragment, state=null, class=android.widget.FrameLayout)
+                  UiNode(, id=no_id, state=null, class=androidx.compose.ui.platform.ComposeView)
+                    UiNode(, id=no_id, state=null, class=android.view.View)
+                      UiNode(, id=no_id, state=null, class=android.view.View)
+                        UiNode(, id=no_id, state=null, class=android.view.View)
+                          UiNode(text='Looking for offers', id=no_id, state=null, class=android.widget.TextView)
+                          UiNode(id=looking_for_order_progress_bar, state=null, class=android.widget.ProgressBar)
+""".trimIndent()
+
+    @Test
+    fun `matches MAIN_MAP_ON_DASH when Return to dash button is present`() {
+        val root = LogToUiNodeParser.parseLog(returnToDashLog)
+        assertNotNull("Failed to parse log", root)
+
+        val result = matcher.matches(root!!)
+
+        assertNotNull("Should match MAIN_MAP_ON_DASH", result)
+        assertTrue(result is ScreenInfo.Simple)
+        assertEquals(Screen.MAIN_MAP_ON_DASH, result!!.screen)
+    }
+
+    @Test
+    fun `does not match idle map (Earnings Mode Switcher present)`() {
+        val root = LogToUiNodeParser.parseLog(idleMapLog)
+        assertNotNull("Failed to parse log", root)
+
+        val result = matcher.matches(root!!)
+
+        assertNull("Should return null — MAIN_MAP_IDLE belongs to IdleMapMatcher", result)
+    }
+
+    @Test
+    fun `does not match waiting for offer screen`() {
+        val root = LogToUiNodeParser.parseLog(waitingForOfferLog)
+        assertNotNull("Failed to parse log", root)
+
+        val result = matcher.matches(root!!)
+
+        assertNull("Should return null — ON_DASH_MAP_WAITING_FOR_OFFER belongs to WaitingForOfferMatcher", result)
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/test/util/TestMatcherFactory.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/test/util/TestMatcherFactory.kt
@@ -11,6 +11,7 @@ import cloud.trotter.dashbuddy.pipeline.accessibility.event.type.window.processi
 import cloud.trotter.dashbuddy.pipeline.accessibility.event.type.window.processing.matchers.DropoffPreArrivalMatcher
 import cloud.trotter.dashbuddy.pipeline.accessibility.event.type.window.processing.matchers.IdleMapMatcher
 import cloud.trotter.dashbuddy.pipeline.accessibility.event.type.window.processing.matchers.OfferMatcher
+import cloud.trotter.dashbuddy.pipeline.accessibility.event.type.window.processing.matchers.OnDashMapMatcher
 import cloud.trotter.dashbuddy.pipeline.accessibility.event.type.window.processing.matchers.PickupArrivalMatcher
 import cloud.trotter.dashbuddy.pipeline.accessibility.event.type.window.processing.matchers.PickupNavigationMatcher
 import cloud.trotter.dashbuddy.pipeline.accessibility.event.type.window.processing.matchers.PickupPreArrivalMatcher
@@ -40,6 +41,7 @@ object TestMatcherFactory {
             DropoffPreArrivalMatcher(),
             IdleMapMatcher(),
             OfferMatcher(),
+            OnDashMapMatcher(),
             PickupArrivalMatcher(),
             PickupNavigationMatcher(),
             PickupPreArrivalMatcher(),


### PR DESCRIPTION
## Summary
- Add `OnDashMapMatcher` (priority 2) to positively identify `MAIN_MAP_ON_DASH` via the "Return to dash" button
- All three map-screen matchers are now fully mutually exclusive via bilateral fail-fasts:
  - `IdleMapMatcher` — fails fast on "Return to dash" (returns `null`, not cross-screen result) and "Looking for offers"/"Finding offers"
  - `OnDashMapMatcher` — fails fast on Earnings Mode Switcher and waiting-for-offer UI
  - `WaitingForOfferMatcher` — fails fast on Earnings Mode Switcher and "Return to dash"
- Register `OnDashMapMatcher` in `PipelineModule` and `TestMatcherFactory`
- Update `IdleMapMatcherTest` to expect `null` for on-dash screen; remove stale TODO
- Add `OnDashMapMatcherTest` with positive match and two fail-fast cases

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)