### PR TITLE
fix: DashSummaryParser falls back when header_pay ID is absent

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/processing/parsers/DashSummaryParser.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/processing/parsers/DashSummaryParser.kt
@@ -15,11 +15,15 @@ class DashSummaryParser @Inject constructor() : ScreenParser {
 
     private val timePattern = Pattern.compile("(\\d+)\\s*(hr|min)")
     private val offersPattern = Pattern.compile("(\\d+)\\s*out of\\s*(\\d+)", Pattern.CASE_INSENSITIVE)
+    private val currencyPattern = Pattern.compile("^\\$[\\d,]+\\.\\d{2}$")
 
     override fun parse(node: UiNode): ScreenInfo {
         Timber.d("DashSummaryParser: analyzing node tree...")
 
+        // DoorDash removed the header_pay ID in a late-2025 app update; fall back to finding
+        // the first bare currency text node in the tree (the session total is always first).
         val payNode = node.findDescendantById("header_pay")
+            ?: node.findNode { it.text != null && currencyPattern.matcher(it.text!!).matches() }
         val totalEarnings = payNode?.text?.let { UtilityFunctions.parseCurrency(it) }
         Timber.d("Dash Earnings: node='${payNode?.text}' -> parsed=$totalEarnings")
 


### PR DESCRIPTION
## Problem

`DashSummaryParser` looks up the session total by `findDescendantById("header_pay")`. DoorDash removed that view ID in a late-2025 app update — newer snapshots (March 2026 onward) have the earnings as a bare `TextView` with no ID. Result: `totalEarnings` always parsed as `null` after the update.

## Fix

One-line fallback after the ID lookup:
```kotlin
val payNode = node.findDescendantById("header_pay")
    ?: node.findNode { it.text != null && currencyPattern.matcher(it.text!!).matches() }
```

The session total is always the first currency-formatted text node in the tree, so the fallback is unambiguous. Older layouts with the ID still take the fast path.

## Test plan
- [ ] `AllMatchersSuite` passes ✅
- [ ] `DashSummaryRegressionTest` passes ✅
- [ ] Confirm `$55.25` and `$75.66` parse correctly from the March 2026 snapshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)