### PR TITLE
fix [#151]: window pipeline captures rootInActiveWindow instead of event.source

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/ScreenDiffer.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/ScreenDiffer.kt
@@ -8,27 +8,20 @@ import javax.inject.Singleton
 class ScreenDiffer @Inject constructor() {
 
     private var lastStructure: Int? = null
-    private var lastContent: Int? = null
 
     /**
-     * Returns TRUE if the screen is different from the last check.
+     * Returns TRUE if the screen structure has changed since the last check.
+     * Only compares [UiNode.structuralHash] (className + viewIdResourceName hierarchy) —
+     * text/content changes within a stable layout do not constitute a new screen.
      */
     fun hasChanged(node: UiNode): Boolean {
-        // Accessing the properties triggers the lazy computation automatically
         val newStructure = node.structuralHash
-        val newContent = node.contentHash
-
-        if (newStructure == lastStructure && newContent == lastContent) {
-            return false // Screen is identical
-        }
-
+        if (newStructure == lastStructure) return false
         lastStructure = newStructure
-        lastContent = newContent
         return true
     }
 
     fun reset() {
         lastStructure = null
-        lastContent = null
     }
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/content_changed/ContentChangedPipeline.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/content_changed/ContentChangedPipeline.kt
@@ -3,7 +3,6 @@ package cloud.trotter.dashbuddy.pipeline.accessibility.event.type.window.content
 import android.view.accessibility.AccessibilityEvent
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
 import cloud.trotter.dashbuddy.pipeline.accessibility.input.AccessibilitySource
-import cloud.trotter.dashbuddy.pipeline.accessibility.mapper.toUiNode
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filter
@@ -21,7 +20,7 @@ class ContentChangedPipeline @Inject constructor(
         .onEach { Timber.v("🌊 FLOOD: Content Change from ${it.className}") }
         .debounceWithTimeout(150L, 300L)
         .onEach { Timber.d("💧 DRIP: Survivor! ${it.className}") }
-        .mapNotNull { event ->
-            event.source.toUiNode()
+        .mapNotNull { _ ->
+            source.getCurrentRootNode()
         }
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/content_changed/ContentChangedPipeline.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/content_changed/ContentChangedPipeline.kt
@@ -19,7 +19,7 @@ class ContentChangedPipeline @Inject constructor(
         .filter { it.eventType == AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED }
         .onEach { Timber.v("🌊 FLOOD: Content Change from ${it.className}") }
         .debounceWithTimeout(150L, 300L)
-        .onEach { Timber.d("💧 DRIP: Survivor! ${it.className}") }
+        .onEach { Timber.d("💧 DRIP: triggered by ${it.className}, capturing root...") }
         .mapNotNull { _ ->
             source.getCurrentRootNode()
         }

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/state_changed/StateChangedPipeline.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/state_changed/StateChangedPipeline.kt
@@ -3,7 +3,6 @@ package cloud.trotter.dashbuddy.pipeline.accessibility.event.type.window.state_c
 import android.view.accessibility.AccessibilityEvent
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
 import cloud.trotter.dashbuddy.pipeline.accessibility.input.AccessibilitySource
-import cloud.trotter.dashbuddy.pipeline.accessibility.mapper.toUiNode
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.mapNotNull
@@ -14,7 +13,7 @@ class StateChangedPipeline @Inject constructor(
 ) {
     fun output(): Flow<UiNode> = source.events
         .filter { it.eventType == AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED }
-        .mapNotNull { event ->
-            event.source.toUiNode()
+        .mapNotNull { _ ->
+            source.getCurrentRootNode()
         }
 }


### PR DESCRIPTION
## Problem

Both `ContentChangedPipeline` and `StateChangedPipeline` were passing `event.source` — a partial subtree rooted at the widget that triggered the event — downstream for screen matching. This produced a different structural hash on every event (FrameLayout, View, TextView, etc.), causing `ScreenDiffer` deduplication to fail and flooding the matcher chain with UNKNOWN events on stable screens.

Additionally, `ScreenDiffer.hasChanged()` gated on both `structuralHash` AND `contentHash`, so any text change (GPS label, map tile, ETA countdown) on a structurally stable screen still passed through as a new screen event.

## Changes

- **`ContentChangedPipeline`** — post-debounce mapping now calls `source.getCurrentRootNode()` (which wraps `service.rootInActiveWindow`) instead of converting `event.source`
- **`StateChangedPipeline`** — same fix; `event.source` replaced with `source.getCurrentRootNode()`
- **`ScreenDiffer`** — removed `lastContent` field; `hasChanged()` now gates on `structuralHash` only. Text/content changes within a stable layout do not constitute a new screen.
- Log message in `ContentChangedPipeline` updated to clarify the event triggers the DRIP but the captured node is the window root

## Validation

- `AllMatchersSuite` passes
- Device tested: main map idle screen now recognized on first DRIP, duplicate suppression working correctly, clean state transitions

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)