### PR TITLE
fix [#161]: dropoff navigation with "Heading to" prefix not recognized

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/processing/matchers/DropoffNavigationMatcher.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/processing/matchers/DropoffNavigationMatcher.kt
@@ -17,10 +17,18 @@ class DropoffNavigationMatcher @Inject constructor() : ScreenMatcher {
 
         val titleText = navTitleNode.text ?: ""
 
-        // Fail fast: "Heading to" means pickup, not dropoff.
-        if (titleText.contains("Heading to", ignoreCase = true)) return null
+        // "Deliver to [name]" — definitively a dropoff.
+        if (titleText.contains("Deliver to", ignoreCase = true)) return targetScreen
 
-        // Must say "Deliver to" to be a dropoff.
-        return if (titleText.contains("Deliver to", ignoreCase = true)) targetScreen else null
+        // "Heading to [name]" is shared with pickup navigation. Confirm dropoff via "Deliver by"
+        // in the arrive-by node — pickup navigation says "Pick up by [time]" instead.
+        if (titleText.contains("Heading to", ignoreCase = true)) {
+            val timeNode = node.findNode {
+                it.viewIdResourceName?.endsWith("bottom_sheet_task_arrive_by") == true
+            }
+            if (timeNode?.text?.contains("Deliver by", ignoreCase = true) == true) return targetScreen
+        }
+
+        return null
     }
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/processing/parsers/DropoffNavigationParser.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/processing/parsers/DropoffNavigationParser.kt
@@ -18,8 +18,11 @@ class DropoffNavigationParser @Inject constructor() : ScreenParser {
             it.viewIdResourceName?.endsWith("bottom_sheet_task_title") == true
         }?.text ?: ""
 
-        // "Deliver to John Doe" -> "John Doe"
-        val rawName = titleText.replace("Deliver to ", "", ignoreCase = true).trim()
+        // "Deliver to John Doe" or "Heading to John Doe" -> "John Doe"
+        val rawName = titleText
+            .replace("Deliver to ", "", ignoreCase = true)
+            .replace("Heading to ", "", ignoreCase = true)
+            .trim()
 
         val address1 = node.findNode {
             it.viewIdResourceName?.endsWith("bottom_sheet_address_line_1") == true

--- a/app/src/test/java/cloud/trotter/dashbuddy/pipeline/recognition/matchers/NavigationViewRegressionTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/pipeline/recognition/matchers/NavigationViewRegressionTest.kt
@@ -1,0 +1,48 @@
+package cloud.trotter.dashbuddy.pipeline.recognition.matchers
+
+import cloud.trotter.dashbuddy.domain.model.accessibility.Screen
+import cloud.trotter.dashbuddy.domain.model.accessibility.ScreenInfo
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import cloud.trotter.dashbuddy.pipeline.accessibility.event.type.window.processing.matchers.NavigationViewMatcher
+import cloud.trotter.dashbuddy.test.base.BaseParameterizedTest
+import cloud.trotter.dashbuddy.test.base.SnapshotTestStats
+import cloud.trotter.dashbuddy.test.util.TestResourceLoader
+import org.junit.AfterClass
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+class NavigationViewRegressionTest(filename: String, node: UiNode) :
+    BaseParameterizedTest(filename, node) {
+
+    override val stats = sharedStats
+
+    companion object {
+        private const val FOLDER = "NAVIGATION_VIEW"
+        val sharedStats = SnapshotTestStats(FOLDER)
+
+        @JvmStatic
+        @Parameterized.Parameters(name = "{0}")
+        fun data(): Collection<Array<Any>> {
+            val data = TestResourceLoader.loadForParameterized(FOLDER)
+            sharedStats.reset(data.size)
+            return data
+        }
+
+        @JvmStatic
+        @AfterClass
+        fun tearDown() = sharedStats.printFooter()
+    }
+
+    @Test
+    fun `validate snapshot`() {
+        val matcher = NavigationViewMatcher()
+
+        runTest(matcher) { result ->
+            val info = result as ScreenInfo.Simple
+            assertEquals(Screen.NAVIGATION_VIEW, info.screen)
+        }
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/test/suites/AllMatcherSuite.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/test/suites/AllMatcherSuite.kt
@@ -6,6 +6,7 @@ import cloud.trotter.dashbuddy.pipeline.recognition.matchers.DashSummaryRegressi
 import cloud.trotter.dashbuddy.pipeline.recognition.matchers.DeliverySummaryCollapsedRegressionTest
 import cloud.trotter.dashbuddy.pipeline.recognition.matchers.DeliverySummaryExpandedRegressionTest
 import cloud.trotter.dashbuddy.pipeline.recognition.matchers.DropoffNavigationRegressionTest
+import cloud.trotter.dashbuddy.pipeline.recognition.matchers.NavigationViewRegressionTest
 import cloud.trotter.dashbuddy.pipeline.recognition.matchers.DropoffPreArrivalRegressionTest
 import cloud.trotter.dashbuddy.pipeline.recognition.matchers.IdleMapRegressionTest
 import cloud.trotter.dashbuddy.pipeline.recognition.matchers.LoadingScreenRegressionTest
@@ -55,6 +56,7 @@ import org.junit.runners.Suite
     DashSummaryRegressionTest::class,
 
     // UI / Navigation screens
+    NavigationViewRegressionTest::class,
     ScheduleRegressionTest::class,
     TimelineRegressionTest::class,
 


### PR DESCRIPTION
## Summary

- `DropoffNavigationMatcher` had a `return null` guard on `"Heading to"` with the incorrect assumption that this prefix is pickup-only. Both pickup and dropoff navigation use `"Heading to [name]"` — the correct discriminator is the arrive-by node (`"Deliver by"` = dropoff, `"Pick up by"` = pickup).
- This caused Shop & Deliver orders to classify dropoff navigation as `NAVIGATION_VIEW`, bypassing `DropoffNavigationParser` entirely. `PickupReducer` never received `ScreenInfo.DropoffDetails`, so `OnDelivery` was never entered — sessions ended `OnPickup → AwaitingOffer → PostDelivery` without any delivery state.
- Also updated `DropoffNavigationParser` to strip `"Heading to "` prefix (in addition to `"Deliver to "`) when extracting the customer name hash.
- Added `NavigationViewRegressionTest` (15 snapshots) and registered it in `AllMatchersSuite` — plain navigation view had no regression coverage.

## Test plan

- [x] `AllMatchersSuite` passes (15 NAVIGATION_VIEW snapshots, 15 NAVIGATION_VIEW_TO_DROP_OFF snapshots, full suite)
- [x] `InboxProcessorTest` correctly classifies a real "Heading to / Deliver by" log snapshot as `NAVIGATION_VIEW_TO_DROP_OFF`
- [x] `PickupNavigationMatcher` already guards against `"Deliver by"` in arrive-by — no conflict with the updated dropoff matcher

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)