### PR TITLE
fix [#167, #168]: DropoffPreArrival blind spot + session earnings reset

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/processing/matchers/DropoffPreArrivalMatcher.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/processing/matchers/DropoffPreArrivalMatcher.kt
@@ -11,12 +11,14 @@ class DropoffPreArrivalMatcher @Inject constructor() : ScreenMatcher {
     override val priority = 8
 
     override fun matches(node: UiNode): Screen? {
-        // Identity: "Deliver to..." header node.
-        val hasDeliverToNode = node.findNode {
-            it.text?.startsWith("Deliver to", ignoreCase = true) == true
-        } != null
+        // Identity: "Deliver to..." or "Heading to..." header node.
+        // Shop & Deliver uses "Heading to [customer]" on the pre-arrival screen.
+        val titleNode = node.findNode {
+            it.text?.startsWith("Deliver to", ignoreCase = true) == true ||
+                it.text?.startsWith("Heading to", ignoreCase = true) == true
+        } ?: return null
 
-        if (!hasDeliverToNode) return null
+        val isDeliverTo = titleNode.text?.startsWith("Deliver to", ignoreCase = true) == true
 
         // Must have action or contact buttons to confirm this is the delivery details screen.
         val hasActionButtons = node.findNode {
@@ -29,6 +31,16 @@ class DropoffPreArrivalMatcher @Inject constructor() : ScreenMatcher {
         val hasContactButtons = node.findNode {
             it.text.equals("Call", true) || it.text.equals("Message", true)
         } != null
+
+        // "Heading to" + "Directions" alone is ambiguous — pickup navigation screens also show
+        // this combination. Require delivery-specific buttons (Call/Message/Continue/Complete)
+        // to confirm it's a customer-facing pre-arrival screen, not a store navigation screen.
+        if (!isDeliverTo && !hasContactButtons) {
+            val hasDeliverySpecificAction = node.findNode {
+                it.text.equals("Continue", true) || it.text.equals("Complete Delivery", true)
+            } != null
+            if (!hasDeliverySpecificAction) return null
+        }
 
         return if (hasActionButtons || hasContactButtons) targetScreen else null
     }

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/processing/parsers/DropoffPreArrivalParser.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/processing/parsers/DropoffPreArrivalParser.kt
@@ -16,10 +16,14 @@ class DropoffPreArrivalParser @Inject constructor() : ScreenParser {
 
     override fun parse(node: UiNode): ScreenInfo {
         val deliverToNode = node.findNode {
-            it.text?.startsWith("Deliver to", ignoreCase = true) == true
+            it.text?.startsWith("Deliver to", ignoreCase = true) == true ||
+                it.text?.startsWith("Heading to", ignoreCase = true) == true
         }
         val rawTitle = deliverToNode?.text ?: ""
-        val rawCustomerName = rawTitle.replace("Deliver to", "", ignoreCase = true).trim()
+        val rawCustomerName = rawTitle
+            .replace("Deliver to", "", ignoreCase = true)
+            .replace("Heading to", "", ignoreCase = true)
+            .trim()
         val customerHash = if (rawCustomerName.isNotBlank()) {
             UtilityFunctions.generateSha256(rawCustomerName)
         } else null

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleViewModel.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.scan
 import kotlinx.coroutines.flow.stateIn
 import javax.inject.Inject
@@ -31,15 +32,23 @@ class BubbleViewModel @Inject constructor(
     // Session earnings: carries the last known value forward through states that don't have it
     // (e.g. OnDelivery and OnPickup don't carry a pay field, but we still want to show
     // the running session total from the most recent AwaitingOffer or PostDelivery)
+    // Session earnings: carries the last known value forward through states that don't expose pay.
+    // Resets to 0.0 when dashId changes (new dash started) — same signal as odometer.resetSession().
+    // Preserves through PostDash and IdleOffline so a SessionSummary snapshot can read both
+    // earnings and miles before the new dash wipes them.
     val sessionEarnings = stateManager.state
-        .scan(0.0) { lastKnown, state ->
-            when (state) {
-                is AppStateV2.AwaitingOffer -> state.currentSessionPay ?: lastKnown
-                is AppStateV2.PostDelivery -> if (state.totalPay > 0) state.totalPay else lastKnown
-                is AppStateV2.PostDash -> state.totalEarnings
+        .scan(Pair<String?, Double>(null, 0.0)) { (lastDashId, lastKnown), state ->
+            val isNewDash = state.dashId != null && state.dashId != lastDashId && lastDashId != null
+            val earnings = when {
+                isNewDash -> 0.0
+                state is AppStateV2.AwaitingOffer -> state.currentSessionPay ?: lastKnown
+                state is AppStateV2.PostDelivery  -> if (state.totalPay > 0) state.totalPay else lastKnown
+                state is AppStateV2.PostDash      -> state.totalEarnings
                 else -> lastKnown
             }
+            Pair(state.dashId ?: lastDashId, earnings)
         }
+        .map { it.second }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 0.0)
 
     // Messages scoped to the active dash session

--- a/app/src/test/java/cloud/trotter/dashbuddy/pipeline/recognition/matchers/DropoffPreArrivalMatcherTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/pipeline/recognition/matchers/DropoffPreArrivalMatcherTest.kt
@@ -57,10 +57,19 @@ UiNode(, id=no_id, state=null, class=android.widget.FrameLayout)
   UiNode(text='Deliver to Morgan K', id=no_id, state=null, class=android.widget.TextView)
 """.trimIndent()
 
-    // No "Deliver to" header at all — should NOT match
+    // "Heading to [store]" + "Directions" only — pickup navigation, should NOT match
     private val unrelatedLog = """
 UiNode(, id=no_id, state=null, class=android.widget.FrameLayout)
   UiNode(text='Heading to Subway', id=no_id, state=null, class=android.widget.TextView)
+  UiNode(text='Directions', id=no_id, state=null, class=android.widget.TextView)
+""".trimIndent()
+
+    // "Heading to [customer]" + contact buttons — Shop & Deliver delivery, should match
+    private val headingToCustomerLog = """
+UiNode(, id=no_id, state=null, class=android.widget.FrameLayout)
+  UiNode(text='Heading to Alex P', id=no_id, state=null, class=android.widget.TextView)
+  UiNode(text='Call', id=no_id, state=null, class=android.widget.TextView)
+  UiNode(text='Message', id=no_id, state=null, class=android.widget.TextView)
   UiNode(text='Directions', id=no_id, state=null, class=android.widget.TextView)
 """.trimIndent()
 
@@ -103,11 +112,19 @@ UiNode(, id=no_id, state=null, class=android.widget.FrameLayout)
     }
 
     @Test
-    fun `returns null for unrelated screen without Deliver to header`() {
+    fun `returns null for Heading to store with Directions only (pickup navigation)`() {
         val root = LogToUiNodeParser.parseLog(unrelatedLog)
         assertNotNull("Failed to parse log", root)
 
-        assertNull("Missing Deliver to header should not match", matcher.matches(root!!))
+        assertNull("Heading to store + Directions only should not match pre-arrival", matcher.matches(root!!))
+    }
+
+    @Test
+    fun `matches Heading to customer with contact buttons (Shop and Deliver delivery)`() {
+        val root = LogToUiNodeParser.parseLog(headingToCustomerLog)
+        assertNotNull("Failed to parse log", root)
+
+        assertEquals(Screen.DROPOFF_DETAILS_PRE_ARRIVAL, matcher.matches(root!!))
     }
 
     // --- PARSING TESTS ---


### PR DESCRIPTION
## Summary

- **#167**: `DropoffPreArrivalMatcher` and parser accept `"Heading to [name]"` in addition to `"Deliver to [name]"` — same blind spot fixed in #166 for the navigation matcher. For `"Heading to"`, delivery-specific buttons (Call/Message/Continue/Complete Delivery) are required to reject pickup navigation screens, which also show `"Heading to [store]" + "Directions"`.
- **#168**: `sessionEarnings` in `BubbleViewModel` now resets to `0.0` when `dashId` changes (new dash started) rather than on `IdleOffline`. Mirrors the odometer's `resetSession()` signal so both earnings and miles are preserved through `PostDash` → `IdleOffline` for the future `SessionSummary` snapshot (#144).

## Test plan

- [ ] All existing `DropoffPreArrivalMatcherTest` cases pass with updated names
- [ ] New test: `"Heading to [customer]"` + contact buttons matches `DROPOFF_DETAILS_PRE_ARRIVAL`
- [ ] New test: `"Heading to [store]"` + `"Directions"` only does NOT match
- [ ] `AllMatchersSuite` green
- [ ] `sessionEarnings` shows `$0.00` at start of second dash, not previous dash total

Closes #167
Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)