### PR TITLE
feature [#173]: plumb ScreenInfo enrichment fields into AppStateV2

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/state/AppStateV2.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/AppStateV2.kt
@@ -1,11 +1,13 @@
 package cloud.trotter.dashbuddy.state
 
 import cloud.trotter.dashbuddy.domain.model.accessibility.ClickAction
+import cloud.trotter.dashbuddy.domain.model.accessibility.ParsedTime
 import cloud.trotter.dashbuddy.domain.model.accessibility.Screen
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
 import cloud.trotter.dashbuddy.domain.model.dash.DashType
 import cloud.trotter.dashbuddy.domain.model.order.PickupStatus
 import cloud.trotter.dashbuddy.domain.model.pay.ParsedPay
+import cloud.trotter.dashbuddy.domain.model.ratings.RatingsSnapshot
 
 sealed class AppStateV2 {
     abstract val timestamp: Long
@@ -22,7 +24,8 @@ sealed class AppStateV2 {
         override val timestamp: Long = System.currentTimeMillis(),
         override val dashId: String? = null,
         val lastKnownZone: String? = null,
-        val dashType: DashType? = null
+        val dashType: DashType? = null,
+        val latestRatings: RatingsSnapshot? = null
     ) : AppStateV2()
 
     data class PostDash(
@@ -45,7 +48,8 @@ sealed class AppStateV2 {
         // Live data from the "Looking..." screen
         val currentSessionPay: Double? = null,
         val waitTimeEstimate: String? = null,
-        val isHeadingBackToZone: Boolean = false
+        val isHeadingBackToZone: Boolean = false,
+        val spotSaveDeadline: Long? = null  // epoch millis; populated after #137 parser lands
     ) : AppStateV2()
 
     data class OfferPresented(
@@ -66,14 +70,20 @@ sealed class AppStateV2 {
         val customerNameHash: String? = null,
         val status: PickupStatus = PickupStatus.UNKNOWN,
         val arrivalConfirmed: Boolean = false,
-        val orders: List<String> = emptyList()
+        val orders: List<String> = emptyList(),
+        val pickupDeadline: ParsedTime? = null,   // e.g. "Pick up by 17:39"
+        val arrivedAt: Long? = null,              // epoch millis when ARRIVED status first set
+        val itemCount: Int? = null,               // number of items to pick up
+        val redCardTotal: Double? = null          // Red Card payment total when applicable
     ) : AppStateV2()
 
     data class OnDelivery(
         override val timestamp: Long = System.currentTimeMillis(),
         override val dashId: String?,
+        val storeName: String? = null,            // carried from OnPickup
         val customerNameHash: String? = null,
-        val customerAddressHash: String? = null
+        val customerAddressHash: String? = null,
+        val deliveryDeadline: ParsedTime? = null  // e.g. "Deliver by 8:16 PM"
     ) : AppStateV2()
 
     data class PostDelivery(

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/factories/DeliveryStateFactory.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/factories/DeliveryStateFactory.kt
@@ -19,10 +19,14 @@ class DeliveryStateFactory @Inject constructor() {
         input: ScreenInfo.DropoffDetails,
         isRecovery: Boolean
     ): Transition {
+        val storeName = (oldState as? AppStateV2.OnPickup)?.storeName
+
         val newState = AppStateV2.OnDelivery(
             dashId = oldState.dashId,
-            customerNameHash = null,
-            customerAddressHash = null
+            storeName = storeName,
+            customerNameHash = input.customerNameHash,
+            customerAddressHash = input.customerAddressHash,
+            deliveryDeadline = input.deadline
         )
 
         Timber.i("🚗 DELIVERY: en route to customer [${input.customerNameHash?.take(6) ?: "?"}]")

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/factories/IdleStateFactory.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/factories/IdleStateFactory.kt
@@ -18,9 +18,12 @@ class IdleStateFactory @Inject constructor() {
         input: ScreenInfo.IdleMap,
         isRecovery: Boolean
     ): Transition {
+        val previousRatings = (oldState as? AppStateV2.IdleOffline)?.latestRatings
+
         val newState = AppStateV2.IdleOffline(
             lastKnownZone = input.zoneName,
-            dashType = input.dashType
+            dashType = input.dashType,
+            latestRatings = previousRatings
         )
 
         val endingDash = oldState.dashId != null

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/factories/PickupStateFactory.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/factories/PickupStateFactory.kt
@@ -26,7 +26,10 @@ class PickupStateFactory @Inject constructor() {
             dashId = oldState.dashId,
             storeName = safeStoreName,
             customerNameHash = input.customerNameHash,
-            status = input.status
+            status = input.status,
+            pickupDeadline = input.deadline,
+            itemCount = input.itemCount,
+            redCardTotal = input.redCardTotal
         )
 
         Timber.i("🛍️ PICKUP: $safeStoreName [${input.status}]")

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/reducers/DeliveryReducer.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/reducers/DeliveryReducer.kt
@@ -34,8 +34,21 @@ class DeliveryReducer @Inject constructor(
 
         return when (input) {
             is ScreenInfo.DropoffDetails -> {
-                // Internal update (e.g. Navigation instructions changing)
-                Transition(state)
+                // Internal update: enrich fields as more data becomes available
+                val deadlineChanged = input.deadline != null && input.deadline != state.deliveryDeadline
+                val customerChanged = input.customerNameHash != null && input.customerNameHash != state.customerNameHash
+                val addressChanged = input.customerAddressHash != null && input.customerAddressHash != state.customerAddressHash
+                if (deadlineChanged || customerChanged || addressChanged) {
+                    Transition(
+                        state.copy(
+                            deliveryDeadline = input.deadline ?: state.deliveryDeadline,
+                            customerNameHash = input.customerNameHash ?: state.customerNameHash,
+                            customerAddressHash = input.customerAddressHash ?: state.customerAddressHash
+                        )
+                    )
+                } else {
+                    Transition(state)
+                }
             }
 
             is ScreenInfo.WaitingForOffer -> request(

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/reducers/IdleReducer.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/reducers/IdleReducer.kt
@@ -1,6 +1,7 @@
 package cloud.trotter.dashbuddy.state.reducers
 
 import cloud.trotter.dashbuddy.domain.model.accessibility.ScreenInfo
+import cloud.trotter.dashbuddy.domain.model.ratings.RatingsSnapshot
 import cloud.trotter.dashbuddy.domain.model.state.ScreenUpdateEvent
 import cloud.trotter.dashbuddy.domain.model.state.StateEvent
 import cloud.trotter.dashbuddy.state.AppStateV2
@@ -51,6 +52,24 @@ class IdleReducer @Inject constructor(
             is ScreenInfo.WaitingForOffer -> {
                 // Just return the transition package from the factory
                 awaitingStateFactory.createEntry(state, input, isRecovery = false)
+            }
+
+            is ScreenInfo.Ratings -> {
+                val snapshot = RatingsSnapshot(
+                    acceptanceRate = input.acceptanceRate,
+                    completionRate = input.completionRate,
+                    onTimeRate = input.onTimeRate,
+                    customerRating = input.customerRating,
+                    deliveriesLast30Days = input.deliveriesLast30Days,
+                    lifetimeDeliveries = input.lifetimeDeliveries,
+                    originalItemsFoundRate = input.originalItemsFoundRate,
+                    totalItemsFoundRate = input.totalItemsFoundRate,
+                    substitutionIssuesRate = input.substitutionIssuesRate,
+                    itemsWithQualityIssuesRate = input.itemsWithQualityIssuesRate,
+                    itemsWrongOrMissingRate = input.itemsWrongOrMissingRate,
+                    lifetimeShoppingOrders = input.lifetimeShoppingOrders,
+                )
+                Transition(state.copy(latestRatings = snapshot))
             }
 
             else -> null

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/reducers/PickupReducer.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/reducers/PickupReducer.kt
@@ -49,10 +49,25 @@ class PickupReducer @Inject constructor(
 
                 val hasStoreChanged = newStoreName != state.storeName && newStoreName != "Unknown"
                 val hasStatusChanged = input.status != state.status
+                val hasDeadlineChanged = input.deadline != state.pickupDeadline
+                val hasItemCountChanged = input.itemCount != state.itemCount
+                val hasRedCardChanged = input.redCardTotal != state.redCardTotal
 
-                if (hasStoreChanged || hasStatusChanged) {
+                if (hasStoreChanged || hasStatusChanged || hasDeadlineChanged || hasItemCountChanged || hasRedCardChanged) {
                     val nextStoreName = if (hasStoreChanged) newStoreName else state.storeName
-                    val nextState = state.copy(storeName = nextStoreName, status = input.status)
+                    val arrivedAt = if (hasStatusChanged && input.status == PickupStatus.ARRIVED) {
+                        System.currentTimeMillis()
+                    } else {
+                        state.arrivedAt
+                    }
+                    val nextState = state.copy(
+                        storeName = nextStoreName,
+                        status = input.status,
+                        pickupDeadline = input.deadline ?: state.pickupDeadline,
+                        arrivedAt = arrivedAt,
+                        itemCount = input.itemCount ?: state.itemCount,
+                        redCardTotal = input.redCardTotal ?: state.redCardTotal
+                    )
                     if (hasStatusChanged) Timber.i("🛍️ PICKUP STATUS: ${state.status} → ${input.status} @ $nextStoreName")
                     val effects = mutableListOf<AppEffect>()
 

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/ratings/RatingsSnapshot.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/ratings/RatingsSnapshot.kt
@@ -1,0 +1,22 @@
+package cloud.trotter.dashbuddy.domain.model.ratings
+
+/**
+ * A point-in-time snapshot of the dasher's performance metrics, captured when the Ratings
+ * screen is observed. Stored on [AppStateV2.IdleOffline] so the bubble HUD can display it
+ * on the idle card without re-observing the ratings screen.
+ */
+data class RatingsSnapshot(
+    val capturedAt: Long = System.currentTimeMillis(),
+    val acceptanceRate: Double? = null,
+    val completionRate: Double? = null,
+    val onTimeRate: Double? = null,
+    val customerRating: Double? = null,
+    val deliveriesLast30Days: Int? = null,
+    val lifetimeDeliveries: Int? = null,
+    val originalItemsFoundRate: Double? = null,
+    val totalItemsFoundRate: Double? = null,
+    val substitutionIssuesRate: Double? = null,
+    val itemsWithQualityIssuesRate: Double? = null,
+    val itemsWrongOrMissingRate: Double? = null,
+    val lifetimeShoppingOrders: Int? = null,
+)


### PR DESCRIPTION
## Summary

- `OnPickup`: adds `pickupDeadline`, `arrivedAt` (set on first ARRIVED status transition), `itemCount`, `redCardTotal` — all sourced from `ScreenInfo.PickupDetails`
- `OnDelivery`: adds `storeName` (carried from `OnPickup`), `deliveryDeadline` from `ScreenInfo.DropoffDetails`; `customerNameHash` / `customerAddressHash` now populated at entry and enriched on internal updates
- `AwaitingOffer`: adds `spotSaveDeadline: Long?` placeholder field — will be populated after #137 parser lands
- `IdleOffline`: adds `latestRatings: RatingsSnapshot?` — updated from `ScreenInfo.Ratings` in `IdleReducer`, carried across `IdleOffline` re-entries via `IdleStateFactory`
- New `RatingsSnapshot` domain model (`domain/model/ratings/`) holds the captured performance metrics snapshot

## Test plan
- [x] Build passes
- [x] Unit tests pass (`testDebugUnitTest`)
- [ ] Manual: verify bubble HUD shows storeName/deadline on delivery card (blocked by #169 UI work)

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)