### PR TITLE
fix [#176]: detect delivery ARRIVED, set arrivedAt, resume odometer on PostDelivery

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/state/AppStateV2.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/AppStateV2.kt
@@ -83,7 +83,8 @@ sealed class AppStateV2 {
         val storeName: String? = null,            // carried from OnPickup
         val customerNameHash: String? = null,
         val customerAddressHash: String? = null,
-        val deliveryDeadline: ParsedTime? = null  // e.g. "Deliver by 8:16 PM"
+        val deliveryDeadline: ParsedTime? = null, // e.g. "Deliver by 8:16 PM"
+        val arrivedAt: Long? = null               // epoch millis when ARRIVED status first detected
     ) : AppStateV2()
 
     data class PostDelivery(

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/factories/PostDeliveryStateFactory.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/factories/PostDeliveryStateFactory.kt
@@ -2,6 +2,7 @@ package cloud.trotter.dashbuddy.state.factories
 
 import cloud.trotter.dashbuddy.domain.model.pay.ParsedPay
 import cloud.trotter.dashbuddy.domain.model.accessibility.ScreenInfo
+import cloud.trotter.dashbuddy.state.AppEffect
 import cloud.trotter.dashbuddy.state.AppStateV2
 import cloud.trotter.dashbuddy.state.model.Transition
 import cloud.trotter.dashbuddy.util.UtilityFunctions
@@ -21,6 +22,10 @@ class PostDeliveryStateFactory @Inject constructor() {
             dashId = oldState.dashId
         )
 
+        // Always resume — idempotent safety net. The dasher is done at the door regardless
+        // of whether we detected arrival earlier (hand-to-me deliveries skip post-arrival screens).
+        val baseEffects = listOf(AppEffect.ResumeOdometer)
+
         // Pre-populate if we have data immediately
         return when (input) {
             is ScreenInfo.DeliverySummary -> {
@@ -33,26 +38,25 @@ class PostDeliveryStateFactory @Inject constructor() {
                             totalPay = pay.total,
                             merchantNames = merchants,
                             summaryText = "Paid: ${UtilityFunctions.formatCurrency(pay.total)}"
-                        )
+                        ),
+                        baseEffects
                     )
                 } else {
-                    // We only have the header total
                     val total = input.totalPay
                     Transition(
                         baseState.copy(
                             totalPay = total,
                             latestExpandButton = input.expandButton,
                             summaryText = if (total > 0) "Paid: ${
-                                UtilityFunctions.formatCurrency(
-                                    total
-                                )
+                                UtilityFunctions.formatCurrency(total)
                             }" else "Processing..."
-                        )
+                        ),
+                        baseEffects
                     )
                 }
             }
 
-            else -> Transition(baseState)
+            else -> Transition(baseState, baseEffects)
         }
     }
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/reducers/DeliveryReducer.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/reducers/DeliveryReducer.kt
@@ -1,8 +1,10 @@
 package cloud.trotter.dashbuddy.state.reducers
 
 import cloud.trotter.dashbuddy.domain.model.accessibility.ScreenInfo
+import cloud.trotter.dashbuddy.domain.model.order.DropoffStatus
 import cloud.trotter.dashbuddy.domain.model.state.ScreenUpdateEvent
 import cloud.trotter.dashbuddy.domain.model.state.StateEvent
+import cloud.trotter.dashbuddy.state.AppEffect
 import cloud.trotter.dashbuddy.state.AppStateV2
 import cloud.trotter.dashbuddy.state.factories.AwaitingStateFactory
 import cloud.trotter.dashbuddy.state.factories.DashPausedStateFactory
@@ -34,17 +36,29 @@ class DeliveryReducer @Inject constructor(
 
         return when (input) {
             is ScreenInfo.DropoffDetails -> {
-                // Internal update: enrich fields as more data becomes available
+                val effects = mutableListOf<AppEffect>()
+
+                // Arrival detection: GPS-confirmed arrival shows "Continue" or "Complete Delivery"
+                // buttons on the dropoff screen. Capture the timestamp once and pause the odometer.
+                val justArrived = input.status == DropoffStatus.ARRIVED && state.arrivedAt == null
+                if (justArrived) {
+                    effects.add(AppEffect.PauseOdometer)
+                }
+
+                val arrivedAt = if (justArrived) System.currentTimeMillis() else state.arrivedAt
                 val deadlineChanged = input.deadline != null && input.deadline != state.deliveryDeadline
                 val customerChanged = input.customerNameHash != null && input.customerNameHash != state.customerNameHash
                 val addressChanged = input.customerAddressHash != null && input.customerAddressHash != state.customerAddressHash
-                if (deadlineChanged || customerChanged || addressChanged) {
+
+                if (justArrived || deadlineChanged || customerChanged || addressChanged) {
                     Transition(
                         state.copy(
+                            arrivedAt = arrivedAt,
                             deliveryDeadline = input.deadline ?: state.deliveryDeadline,
                             customerNameHash = input.customerNameHash ?: state.customerNameHash,
                             customerAddressHash = input.customerAddressHash ?: state.customerAddressHash
-                        )
+                        ),
+                        effects
                     )
                 } else {
                     Transition(state)


### PR DESCRIPTION
## Summary

- `AppStateV2.OnDelivery`: add `arrivedAt: Long?` field (parallel to `OnPickup.arrivedAt`)
- `DeliveryReducer`: detect `DropoffStatus.ARRIVED` on first occurrence, set `arrivedAt`, emit `PauseOdometer`
- `PostDeliveryStateFactory`: emit `ResumeOdometer` unconditionally on all entry paths — safety net for hand-to-me deliveries that skip post-arrival screens

## Why unconditional resume in PostDelivery

Many deliveries (hand-to-me, no ID check, no photo required) skip all post-arrival screens entirely. The dasher completes the delivery at the door and lands directly in PostDelivery without the reducer ever seeing `DropoffStatus.ARRIVED`. Emitting `ResumeOdometer` unconditionally on every PostDelivery entry ensures GPS resumes regardless of which path was taken. The effect is idempotent — `startTracking()` no-ops if already running.

## Test plan

- [ ] Normal delivery: NAVIGATING → ARRIVED (odometer pauses) → PostDelivery (odometer resumes)
- [ ] Hand-to-me delivery: no ARRIVED detection → PostDelivery still resumes odometer
- [ ] Crash recovery: PostDelivery entry always resumes odometer
- [ ] Build passes, all unit tests green

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)