### PR TITLE
feat [#177]: odometer anchor fields on OnPickup/OnDelivery

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/state/AppStateV2.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/AppStateV2.kt
@@ -74,7 +74,9 @@ sealed class AppStateV2 {
         val pickupDeadline: ParsedTime? = null,   // e.g. "Pick up by 17:39"
         val arrivedAt: Long? = null,              // epoch millis when ARRIVED status first set
         val itemCount: Int? = null,               // number of items to pick up
-        val redCardTotal: Double? = null          // Red Card payment total when applicable
+        val redCardTotal: Double? = null,         // Red Card payment total when applicable
+        val odometerAtEntry: Double? = null,      // odometer snapshot when pickup task began
+        val odometerAtArrival: Double? = null     // odometer snapshot when ARRIVED at store
     ) : AppStateV2()
 
     data class OnDelivery(
@@ -84,7 +86,9 @@ sealed class AppStateV2 {
         val customerNameHash: String? = null,
         val customerAddressHash: String? = null,
         val deliveryDeadline: ParsedTime? = null, // e.g. "Deliver by 8:16 PM"
-        val arrivedAt: Long? = null               // epoch millis when ARRIVED status first detected
+        val arrivedAt: Long? = null,              // epoch millis when ARRIVED status first detected
+        val odometerAtEntry: Double? = null,      // odometer snapshot when delivery task began
+        val odometerAtArrival: Double? = null     // odometer snapshot when ARRIVED at customer
     ) : AppStateV2()
 
     data class PostDelivery(

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/factories/DeliveryStateFactory.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/factories/DeliveryStateFactory.kt
@@ -17,7 +17,8 @@ class DeliveryStateFactory @Inject constructor() {
     fun createEntry(
         oldState: AppStateV2,
         input: ScreenInfo.DropoffDetails,
-        isRecovery: Boolean
+        isRecovery: Boolean,
+        odometerMiles: Double? = null
     ): Transition {
         val storeName = (oldState as? AppStateV2.OnPickup)?.storeName
 
@@ -26,7 +27,8 @@ class DeliveryStateFactory @Inject constructor() {
             storeName = storeName,
             customerNameHash = input.customerNameHash,
             customerAddressHash = input.customerAddressHash,
-            deliveryDeadline = input.deadline
+            deliveryDeadline = input.deadline,
+            odometerAtEntry = odometerMiles
         )
 
         Timber.i("🚗 DELIVERY: en route to customer [${input.customerNameHash?.take(6) ?: "?"}]")

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/factories/PickupStateFactory.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/factories/PickupStateFactory.kt
@@ -18,7 +18,8 @@ class PickupStateFactory @Inject constructor() {
     fun createEntry(
         oldState: AppStateV2,
         input: ScreenInfo.PickupDetails,
-        isRecovery: Boolean
+        isRecovery: Boolean,
+        odometerMiles: Double? = null
     ): Transition {
         val safeStoreName = input.storeName ?: "Unknown"
 
@@ -29,7 +30,8 @@ class PickupStateFactory @Inject constructor() {
             status = input.status,
             pickupDeadline = input.deadline,
             itemCount = input.itemCount,
-            redCardTotal = input.redCardTotal
+            redCardTotal = input.redCardTotal,
+            odometerAtEntry = odometerMiles
         )
 
         Timber.i("🛍️ PICKUP: $safeStoreName [${input.status}]")

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/reducers/AwaitingReducer.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/reducers/AwaitingReducer.kt
@@ -34,7 +34,7 @@ class AwaitingReducer @Inject constructor(
         return when (event) {
             is ScreenUpdateEvent -> {
                 val input = event.screenInfo ?: return null
-                handleScreenUpdate(state, input)
+                handleScreenUpdate(state, input, event.odometer)
             }
             // Awaiting state generally doesn't handle Clicks/Timeouts directly,
             // but the structure is here if you need it later.
@@ -44,7 +44,8 @@ class AwaitingReducer @Inject constructor(
 
     private fun handleScreenUpdate(
         state: AppStateV2.AwaitingOffer,
-        input: ScreenInfo
+        input: ScreenInfo,
+        odometer: Double?
     ): Transition? {
 
         // Helper: Factories now return Transition directly. We just pass it through.
@@ -82,11 +83,11 @@ class AwaitingReducer @Inject constructor(
             )
 
             is ScreenInfo.PickupDetails -> request(
-                pickupStateFactory.createEntry(state, input, isRecovery = false)
+                pickupStateFactory.createEntry(state, input, isRecovery = false, odometerMiles = odometer)
             )
 
             is ScreenInfo.DropoffDetails -> request(
-                deliveryStateFactory.createEntry(state, input, isRecovery = false)
+                deliveryStateFactory.createEntry(state, input, isRecovery = false, odometerMiles = odometer)
             )
 
             is ScreenInfo.DashSummary -> request(

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/reducers/DeliveryReducer.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/reducers/DeliveryReducer.kt
@@ -24,14 +24,18 @@ class DeliveryReducer @Inject constructor(
         return when (event) {
             is ScreenUpdateEvent -> {
                 val input = event.screenInfo ?: return null
-                handleScreenUpdate(state, input)
+                handleScreenUpdate(state, input, event.odometer)
             }
 
             else -> null
         }
     }
 
-    private fun handleScreenUpdate(state: AppStateV2.OnDelivery, input: ScreenInfo): Transition? {
+    private fun handleScreenUpdate(
+        state: AppStateV2.OnDelivery,
+        input: ScreenInfo,
+        odometer: Double?
+    ): Transition? {
         fun request(result: Transition) = result
 
         return when (input) {
@@ -56,7 +60,8 @@ class DeliveryReducer @Inject constructor(
                             arrivedAt = arrivedAt,
                             deliveryDeadline = input.deadline ?: state.deliveryDeadline,
                             customerNameHash = input.customerNameHash ?: state.customerNameHash,
-                            customerAddressHash = input.customerAddressHash ?: state.customerAddressHash
+                            customerAddressHash = input.customerAddressHash ?: state.customerAddressHash,
+                            odometerAtArrival = if (justArrived && state.odometerAtArrival == null) odometer else state.odometerAtArrival
                         ),
                         effects
                     )

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/reducers/OfferReducer.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/reducers/OfferReducer.kt
@@ -34,7 +34,7 @@ class OfferReducer @Inject constructor(
         return when (event) {
             is ScreenUpdateEvent -> {
                 val input = event.screenInfo ?: return null
-                handleScreenUpdate(state, input)
+                handleScreenUpdate(state, input, event.odometer)
             }
 
             is ClickEvent -> handleClick(state, event)
@@ -79,7 +79,8 @@ class OfferReducer @Inject constructor(
 
     private fun handleScreenUpdate(
         state: AppStateV2.OfferPresented,
-        input: ScreenInfo
+        input: ScreenInfo,
+        odometer: Double?
     ): Transition? {
         // Helper to simplify logging + transitioning
         fun request(
@@ -145,7 +146,7 @@ class OfferReducer @Inject constructor(
             is ScreenInfo.PickupDetails -> {
                 val outcome = resolveOutcome(state)
                 request(
-                    pickupStateFactory.createEntry(state, input, isRecovery = false),
+                    pickupStateFactory.createEntry(state, input, isRecovery = false, odometerMiles = odometer),
                     outcome,
                     "Transitioned to Pickup"
                 )

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/reducers/PickupReducer.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/reducers/PickupReducer.kt
@@ -28,7 +28,7 @@ class PickupReducer @Inject constructor(
         return when (event) {
             is ScreenUpdateEvent -> {
                 val input = event.screenInfo ?: return null
-                handleScreenUpdate(state, input)
+                handleScreenUpdate(state, input, event.odometer)
             }
             // Pickup state usually handles internal clicks for "Arrived", etc.
             // You can add `is ClickEvent` here later if needed.
@@ -36,7 +36,11 @@ class PickupReducer @Inject constructor(
         }
     }
 
-    private fun handleScreenUpdate(state: AppStateV2.OnPickup, input: ScreenInfo): Transition? {
+    private fun handleScreenUpdate(
+        state: AppStateV2.OnPickup,
+        input: ScreenInfo,
+        odometer: Double?
+    ): Transition? {
 
         // Helper: Simple forwarder (no wrapping needed)
         fun request(result: Transition) = result
@@ -55,18 +59,16 @@ class PickupReducer @Inject constructor(
 
                 if (hasStoreChanged || hasStatusChanged || hasDeadlineChanged || hasItemCountChanged || hasRedCardChanged) {
                     val nextStoreName = if (hasStoreChanged) newStoreName else state.storeName
-                    val arrivedAt = if (hasStatusChanged && input.status == PickupStatus.ARRIVED) {
-                        System.currentTimeMillis()
-                    } else {
-                        state.arrivedAt
-                    }
+                    val justArrived = hasStatusChanged && input.status == PickupStatus.ARRIVED
+                    val arrivedAt = if (justArrived) System.currentTimeMillis() else state.arrivedAt
                     val nextState = state.copy(
                         storeName = nextStoreName,
                         status = input.status,
                         pickupDeadline = input.deadline ?: state.pickupDeadline,
                         arrivedAt = arrivedAt,
                         itemCount = input.itemCount ?: state.itemCount,
-                        redCardTotal = input.redCardTotal ?: state.redCardTotal
+                        redCardTotal = input.redCardTotal ?: state.redCardTotal,
+                        odometerAtArrival = if (justArrived && state.odometerAtArrival == null) odometer else state.odometerAtArrival
                     )
                     if (hasStatusChanged) Timber.i("🛍️ PICKUP STATUS: ${state.status} → ${input.status} @ $nextStoreName")
                     val effects = mutableListOf<AppEffect>()
@@ -88,7 +90,7 @@ class PickupReducer @Inject constructor(
                     effects.add(AppEffect.UpdateBubble("Pickup: ${nextState.storeName}", persona))
 
                     // Logging Effects
-                    if (hasStatusChanged && input.status == PickupStatus.ARRIVED) {
+                    if (justArrived) {
                         effects.add(AppEffect.PauseOdometer)
                         effects.add(
                             AppEffect.LogEvent(
@@ -123,7 +125,7 @@ class PickupReducer @Inject constructor(
             }
 
             is ScreenInfo.DropoffDetails -> request(
-                deliveryStateFactory.createEntry(state, input, isRecovery = false)
+                deliveryStateFactory.createEntry(state, input, isRecovery = false, odometerMiles = odometer)
             )
 
             is ScreenInfo.WaitingForOffer -> request(

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/reducers/PostDeliveryReducer.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/reducers/PostDeliveryReducer.kt
@@ -38,7 +38,7 @@ class PostDeliveryReducer @Inject constructor(
         return when (event) {
             is ScreenUpdateEvent -> {
                 val input = event.screenInfo ?: return null
-                handleScreenUpdate(state, input)
+                handleScreenUpdate(state, input, event.odometer)
             }
 
             is TimeoutEvent -> handleTimeout(state, event)
@@ -46,9 +46,13 @@ class PostDeliveryReducer @Inject constructor(
         }
     }
 
-    private fun handleScreenUpdate(state: AppStateV2.PostDelivery, input: ScreenInfo): Transition? {
+    private fun handleScreenUpdate(
+        state: AppStateV2.PostDelivery,
+        input: ScreenInfo,
+        odometer: Double?
+    ): Transition? {
         // 1. EXIT LOGIC: User has left the screen.
-        val exitTransition = checkForExit(state, input)
+        val exitTransition = checkForExit(state, input, odometer)
         if (exitTransition != null) {
             return attachFinalRecording(state, exitTransition)
         }
@@ -168,11 +172,15 @@ class PostDeliveryReducer @Inject constructor(
 
     // --- Helpers ---
 
-    private fun checkForExit(state: AppStateV2.PostDelivery, input: ScreenInfo): Transition? {
+    private fun checkForExit(
+        state: AppStateV2.PostDelivery,
+        input: ScreenInfo,
+        odometer: Double?
+    ): Transition? {
         return when (input) {
             is ScreenInfo.WaitingForOffer -> awaitingStateFactory.createEntry(state, input, false)
-            is ScreenInfo.DropoffDetails -> deliveryStateFactory.createEntry(state, input, false)
-            is ScreenInfo.PickupDetails -> pickupStateFactory.createEntry(state, input, false)
+            is ScreenInfo.DropoffDetails -> deliveryStateFactory.createEntry(state, input, false, odometerMiles = odometer)
+            is ScreenInfo.PickupDetails -> pickupStateFactory.createEntry(state, input, false, odometerMiles = odometer)
             is ScreenInfo.Offer -> offerStateFactory.createEntry(state, input, false)
             else -> null
         }


### PR DESCRIPTION
## Summary

- `AppStateV2.OnPickup`: add `odometerAtEntry: Double?` and `odometerAtArrival: Double?`
- `AppStateV2.OnDelivery`: add `odometerAtEntry: Double?` and `odometerAtArrival: Double?`
- `PickupStateFactory` / `DeliveryStateFactory`: new `odometerMiles: Double? = null` parameter populates `odometerAtEntry` on state construction — default null means zero breaking changes to existing callers
- `PickupReducer` / `DeliveryReducer`: extract `event.odometer` and thread it through; set `odometerAtArrival` once on first ARRIVED detection (idempotent guard)
- `OfferReducer`, `AwaitingReducer`, `PostDeliveryReducer`: pass `event.odometer` to pickup/delivery factory calls on all normal transition paths
- Recovery paths (`Reducer.checkAnchors`) continue to pass `null` — graceful degradation, anchor fields stay null on crash-recovery

## Why these fields

These anchor points let the HUD compute per-task nav miles via simple subtraction (`odometerAtArrival - odometerAtEntry`) rather than a separate counter. They also stamp every task in the event log with mileage context for the event sourcing / replay model (#119).

## No injection-point changes

`ScreenFactory` already stamps `event.odometer` at capture time (correct — snapshot at observation, not at processing). No change needed there.

## Test plan

- [ ] Build passes, all unit tests green
- [ ] `OnPickup.odometerAtEntry` populated when offer is accepted (OfferReducer → PickupStateFactory)
- [ ] `OnPickup.odometerAtArrival` populated on first ARRIVED status at store
- [ ] `OnDelivery.odometerAtEntry` populated on pickup-confirmed transition
- [ ] `OnDelivery.odometerAtArrival` populated on first ARRIVED at customer
- [ ] Recovery snap (checkAnchors) leaves anchor fields null without crashing

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)