### PR TITLE
feat [#144]: idle HUD shows last-dash summary

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleScreen.kt
@@ -77,6 +77,7 @@ fun BubbleScreen(
     val appState by viewModel.appState.collectAsState()
     val sessionMiles by viewModel.sessionMiles.collectAsState()
     val sessionEarnings by viewModel.sessionEarnings.collectAsState()
+    val lastSessionSummary by viewModel.lastSessionSummary.collectAsState()
     var showFullChat by remember { mutableStateOf(false) }
 
     Scaffold(
@@ -106,7 +107,8 @@ fun BubbleScreen(
                         SessionMetricsActions(
                             appState = appState,
                             earnings = sessionEarnings,
-                            miles = sessionMiles
+                            miles = sessionMiles,
+                            lastSessionSummary = lastSessionSummary
                         )
                     }
                 }
@@ -120,6 +122,7 @@ fun BubbleScreen(
                 DashboardView(
                     appState = appState,
                     messages = messages,
+                    lastSessionSummary = lastSessionSummary,
                     onOpenChat = { showFullChat = true }
                 )
             }
@@ -135,6 +138,7 @@ fun BubbleScreen(
 fun DashboardView(
     appState: AppStateV2,
     messages: List<ChatMessage>,
+    lastSessionSummary: SessionSummary?,
     onOpenChat: () -> Unit
 ) {
     Column(
@@ -143,7 +147,7 @@ fun DashboardView(
             .padding(horizontal = 16.dp, vertical = 8.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
-        ModeCard(appState = appState, modifier = Modifier.fillMaxWidth())
+        ModeCard(appState = appState, lastSessionSummary = lastSessionSummary, modifier = Modifier.fillMaxWidth())
         Spacer(modifier = Modifier.weight(1f))
         LatestMessageTicker(messages = messages, onClick = onOpenChat)
     }
@@ -175,33 +179,59 @@ private fun StatusBadgeTitle(appState: AppStateV2) {
 // ---------------------------------------------------------------------------
 
 @Composable
-private fun SessionMetricsActions(appState: AppStateV2, earnings: Double, miles: Double) {
+private fun SessionMetricsActions(
+    appState: AppStateV2,
+    earnings: Double,
+    miles: Double,
+    lastSessionSummary: SessionSummary?
+) {
     val isActive = appState !is AppStateV2.IdleOffline &&
             appState !is AppStateV2.Initializing &&
             appState !is AppStateV2.PostDash
 
-    if (isActive) {
-        Row(
-            modifier = Modifier.padding(end = 12.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Text(
-                text = "$${String.format("%.2f", earnings)}",
-                style = MaterialTheme.typography.titleSmall,
-                fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.onSurface
-            )
-            Text(
-                text = "  ·  ",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f)
-            )
-            Text(
-                text = "${"%.1f".format(miles)} mi",
-                style = MaterialTheme.typography.titleSmall,
-                color = MaterialTheme.colorScheme.onSurface
-            )
+    val displayEarnings: Double?
+    val displayMiles: Double?
+    val dimmed: Boolean
+
+    when {
+        isActive -> {
+            displayEarnings = earnings
+            displayMiles = miles
+            dimmed = false
         }
+        appState is AppStateV2.IdleOffline && lastSessionSummary != null -> {
+            displayEarnings = lastSessionSummary.earnings
+            displayMiles = lastSessionSummary.miles
+            dimmed = true
+        }
+        else -> return
+    }
+
+    Row(
+        modifier = Modifier.padding(end = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        val textColor = if (dimmed)
+            MaterialTheme.colorScheme.onSurface.copy(alpha = 0.45f)
+        else
+            MaterialTheme.colorScheme.onSurface
+
+        Text(
+            text = "$${String.format("%.2f", displayEarnings)}",
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.Bold,
+            color = textColor
+        )
+        Text(
+            text = "  ·  ",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.25f)
+        )
+        Text(
+            text = "${"%.1f".format(displayMiles)} mi",
+            style = MaterialTheme.typography.titleSmall,
+            color = textColor
+        )
     }
 }
 
@@ -231,7 +261,7 @@ private fun statusBadge(appState: AppStateV2): Pair<String, Color> {
 // ---------------------------------------------------------------------------
 
 @Composable
-fun ModeCard(appState: AppStateV2, modifier: Modifier = Modifier) {
+fun ModeCard(appState: AppStateV2, lastSessionSummary: SessionSummary? = null, modifier: Modifier = Modifier) {
     Card(
         modifier = modifier,
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
@@ -240,7 +270,7 @@ fun ModeCard(appState: AppStateV2, modifier: Modifier = Modifier) {
         Box(modifier = Modifier.padding(16.dp)) {
             when (appState) {
                 is AppStateV2.Initializing -> ModeInitializing()
-                is AppStateV2.IdleOffline -> ModeIdle()
+                is AppStateV2.IdleOffline -> ModeIdle(lastSessionSummary)
                 is AppStateV2.AwaitingOffer -> ModeAwaiting(appState)
                 is AppStateV2.OfferPresented -> ModeOffer(appState)
                 is AppStateV2.OnPickup -> ModePickup(appState)
@@ -260,8 +290,27 @@ private fun ModeInitializing() {
 }
 
 @Composable
-private fun ModeIdle() {
-    ModeRow(label = "Status", value = "Offline — not dashing")
+private fun ModeIdle(lastSessionSummary: SessionSummary?) {
+    if (lastSessionSummary != null) {
+        Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Text(
+                text = "Last dash",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+            )
+            Text(
+                text = "$${String.format("%.2f", lastSessionSummary.earnings)}",
+                style = MaterialTheme.typography.headlineMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.primary
+            )
+            ModeRow(label = "Miles", value = "${"%.1f".format(lastSessionSummary.miles)} mi")
+            ModeRow(label = "Duration", value = formatDuration(lastSessionSummary.durationMillis))
+            ModeRow(label = "Acceptance", value = lastSessionSummary.acceptanceRate)
+        }
+    } else {
+        ModeRow(label = "Status", value = "Offline — not dashing")
+    }
 }
 
 @Composable

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleViewModel.kt
@@ -9,12 +9,20 @@ import cloud.trotter.dashbuddy.state.StateManagerV2
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.scan
 import kotlinx.coroutines.flow.stateIn
 import javax.inject.Inject
+
+data class SessionSummary(
+    val earnings: Double,
+    val miles: Double,
+    val durationMillis: Long,
+    val acceptanceRate: String
+)
 
 @HiltViewModel
 class BubbleViewModel @Inject constructor(
@@ -63,5 +71,24 @@ class BubbleViewModel @Inject constructor(
     // Real-time session miles from GPS odometer
     val sessionMiles = odometerRepository.sessionMilesFlow
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 0.0)
+
+    // Snapshot of the last completed dash — populated when PostDash is seen, persists through idle.
+    // Miles are captured at that moment before the odometer resets on the next session.
+    val lastSessionSummary = combine(stateManager.state, odometerRepository.sessionMilesFlow) { state, miles ->
+        state to miles
+    }
+        .scan(null as SessionSummary?) { last, (state, miles) ->
+            if (state is AppStateV2.PostDash) {
+                SessionSummary(
+                    earnings = state.totalEarnings,
+                    miles = miles,
+                    durationMillis = state.durationMillis,
+                    acceptanceRate = state.acceptanceRateForSession
+                )
+            } else {
+                last
+            }
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
 
 }


### PR DESCRIPTION
## Summary

- `SessionSummary` data class (earnings, miles, durationMillis, acceptanceRate)
- `BubbleViewModel.lastSessionSummary`: `StateFlow<SessionSummary?>` — combines state + odometer miles via `scan`, snapshots when `PostDash` is seen so miles are captured before the odometer resets on the next session
- `ModeIdle`: shows last-dash earnings headline, miles, duration, acceptance rate when a summary is available; falls back to "Offline — not dashing" on first launch before any dash completes
- `SessionMetricsActions` (TopAppBar right side): shows last-session earnings/miles when `IdleOffline` with a summary, dimmed to distinguish from a live session; hidden when no summary yet

## MetricsStrip color note

The `secondaryContainer` color issue described in this issue was already resolved when MetricsStrip was promoted into the TopAppBar in PR #179 (#175). No additional color fix needed.

## Test plan

- [ ] Build passes, all tests green
- [ ] After completing a dash → PostDash: TopAppBar shows earnings/miles, ModeCard shows full summary
- [ ] Returning to IdleOffline: summary persists, TopAppBar values dimmed, ModeCard shows last-dash card
- [ ] Fresh install (no prior dash): idle ModeCard shows "Offline" fallback, no metrics in TopAppBar

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)