### PR TITLE
fix: field bugs from 2026-04-25 dashing session (#185–196)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/processing/matchers/WaitingForOfferMatcher.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/processing/matchers/WaitingForOfferMatcher.kt
@@ -29,10 +29,22 @@ class WaitingForOfferMatcher @Inject constructor() : ScreenMatcher {
         } != null
         if (hasProgressBar || hasLegacyTitle) return targetScreen
 
-        // New layout: "Finding offers" text.
-        val isNewLayout = node.findNode {
+        // New layout: "Finding offers" text MUST be accompanied by a positive zone/pay signal.
+        // A bare "Finding offers" on a map interstitial flash is NOT sufficient — require
+        // either "Zone offer wait" (zone wait estimate is visible) or the session pay node.
+        val hasFindingOffers = node.findNode {
             it.text?.contains("Finding offers", ignoreCase = true) == true
         } != null
-        return if (isNewLayout) targetScreen else null
+
+        if (!hasFindingOffers) return null
+
+        val hasZoneWaitSignal = node.findNode {
+            it.text?.contains("Zone offer wait", ignoreCase = true) == true
+        } != null
+        val hasSessionPay = node.findNode {
+            it.viewIdResourceName?.endsWith("running_total_pay") == true
+        } != null
+
+        return if (hasZoneWaitSignal || hasSessionPay) targetScreen else null
     }
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/processing/parsers/DashAlongTheWayParser.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/processing/parsers/DashAlongTheWayParser.kt
@@ -4,6 +4,7 @@ import cloud.trotter.dashbuddy.domain.model.accessibility.Screen
 import cloud.trotter.dashbuddy.domain.model.accessibility.ScreenInfo
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
 import cloud.trotter.dashbuddy.pipeline.accessibility.event.type.window.processing.ScreenParser
+import cloud.trotter.dashbuddy.util.UtilityFunctions
 import javax.inject.Inject
 
 class DashAlongTheWayParser @Inject constructor() : ScreenParser {
@@ -16,11 +17,15 @@ class DashAlongTheWayParser @Inject constructor() : ScreenParser {
             it.viewIdResourceName?.endsWith("bottom_view_info_title") == true
         }?.text
 
+        // Parse the deadline time from "Spot saved until HH:mm (N mins)" → epoch millis.
+        val spotSaveDeadline = spotSaveText?.let { UtilityFunctions.parseDeadlineMillis(it) }
+
         return ScreenInfo.WaitingForOffer(
             screen = targetScreen,
             dashPay = null,
-            waitTimeEstimate = spotSaveText,
-            isHeadingBackToZone = false
+            waitTimeEstimate = null,
+            isHeadingBackToZone = false,
+            spotSaveDeadline = spotSaveDeadline
         )
     }
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/processing/parsers/DropoffNavigationParser.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/processing/parsers/DropoffNavigationParser.kt
@@ -39,7 +39,9 @@ class DropoffNavigationParser @Inject constructor() : ScreenParser {
         val deadlineText = node.findNode {
             it.viewIdResourceName?.endsWith("bottom_sheet_task_arrive_by") == true
         }?.text
-        val deadline = deadlineText?.let { ParsedTime(it, UtilityFunctions.parseDeadlineMillis(it)) }
+        val deadline = deadlineText?.let {
+            ParsedTime(UtilityFunctions.stripDeadlinePrefix(it), UtilityFunctions.parseDeadlineMillis(it))
+        }
 
         Timber.d("DropoffNav: raw customer='$rawName', raw address='$rawAddress', deadline='$deadlineText'")
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/processing/parsers/DropoffPreArrivalParser.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/processing/parsers/DropoffPreArrivalParser.kt
@@ -33,7 +33,9 @@ class DropoffPreArrivalParser @Inject constructor() : ScreenParser {
             it.text?.startsWith("by ", ignoreCase = true) == true &&
                 it.text?.contains(Regex("\\d{1,2}:\\d{2}")) == true
         }?.text
-        val deadline = deadlineText?.let { ParsedTime(it, UtilityFunctions.parseDeadlineMillis(it)) }
+        val deadline = deadlineText?.let {
+            ParsedTime(UtilityFunctions.stripDeadlinePrefix(it), UtilityFunctions.parseDeadlineMillis(it))
+        }
 
         // Address: two consecutive ID-less text nodes — first matches a street number pattern,
         // second ends with a 5-digit zip code. Not always present on this screen.

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/processing/parsers/PickupArrivalParser.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/processing/parsers/PickupArrivalParser.kt
@@ -36,7 +36,9 @@ class PickupArrivalParser @Inject constructor() : ScreenParser {
         val deadlineText = node.findNode {
             it.text?.startsWith("Pick up by", ignoreCase = true) == true
         }?.text
-        val deadline = deadlineText?.let { ParsedTime(it, UtilityFunctions.parseDeadlineMillis(it)) }
+        val deadline = deadlineText?.let {
+            ParsedTime(UtilityFunctions.stripDeadlinePrefix(it), UtilityFunctions.parseDeadlineMillis(it))
+        }
 
         // "5 items" — parse leading integer.
         val itemCount = node.findNode {

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/processing/parsers/PickupNavigationParser.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/processing/parsers/PickupNavigationParser.kt
@@ -35,7 +35,9 @@ class PickupNavigationParser @Inject constructor() : ScreenParser {
         val deadlineText = node.findNode {
             it.viewIdResourceName?.endsWith("bottom_sheet_task_arrive_by") == true
         }?.text
-        val deadline = deadlineText?.let { ParsedTime(it, UtilityFunctions.parseDeadlineMillis(it)) }
+        val deadline = deadlineText?.let {
+            ParsedTime(UtilityFunctions.stripDeadlinePrefix(it), UtilityFunctions.parseDeadlineMillis(it))
+        }
 
         return ScreenInfo.PickupDetails(
             screen = targetScreen,

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/processing/parsers/PickupPreArrivalParser.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/processing/parsers/PickupPreArrivalParser.kt
@@ -36,7 +36,9 @@ class PickupPreArrivalParser @Inject constructor() : ScreenParser {
         val deadlineText = node.findNode {
             it.text?.startsWith("Pick up by", ignoreCase = true) == true
         }?.text
-        val deadline = deadlineText?.let { ParsedTime(it, UtilityFunctions.parseDeadlineMillis(it)) }
+        val deadline = deadlineText?.let {
+            ParsedTime(UtilityFunctions.stripDeadlinePrefix(it), UtilityFunctions.parseDeadlineMillis(it))
+        }
 
         // "4 items" — parse leading integer.
         val itemCount = node.findNode {

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/processing/parsers/PickupShoppingParser.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/processing/parsers/PickupShoppingParser.kt
@@ -11,11 +11,26 @@ class PickupShoppingParser @Inject constructor() : ScreenParser {
 
     override val targetScreen = Screen.PICKUP_DETAILS_POST_ARRIVAL_SHOP
 
+    // Matches "To shop (N)" tab label — live count of remaining items to scan.
+    private val toShopRegex = Regex("To shop \\((\\d+)\\)", RegexOption.IGNORE_CASE)
+
     override fun parse(node: UiNode): ScreenInfo {
+        // "To shop (N)" tab in the tab_layout shows remaining item count in real time.
+        val itemCount = node.findNode {
+            it.viewIdResourceName?.endsWith("tab_layout") == true ||
+                it.text?.let { t -> toShopRegex.containsMatchIn(t) } == true
+        }?.let { tabNode ->
+            // May be the tab_layout container — look for the "To shop (N)" text among its descendants.
+            val matchNode = if (toShopRegex.containsMatchIn(tabNode.text.orEmpty())) tabNode
+            else tabNode.findNode { toShopRegex.containsMatchIn(it.text.orEmpty()) }
+            matchNode?.text?.let { t -> toShopRegex.find(t)?.groupValues?.get(1)?.toIntOrNull() }
+        }
+
         // Store name is not available on this screen; handler uses sticky logic from prior state.
         return ScreenInfo.PickupDetails(
             screen = targetScreen,
             storeName = null,
+            itemCount = itemCount,
             status = PickupStatus.SHOPPING
         )
     }

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/processing/parsers/TimelineViewParser.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/processing/parsers/TimelineViewParser.kt
@@ -33,7 +33,9 @@ class TimelineViewParser @Inject constructor() : ScreenParser {
 
         // --- Dash end time ---
         val endsAtText = allTexts.firstOrNull { it.startsWith("Dash ends at", ignoreCase = true) }
-        val endsAt = endsAtText?.let { ParsedTime(it, UtilityFunctions.parseDeadlineMillis(it)) }
+        val endsAt = endsAtText?.let {
+            ParsedTime(UtilityFunctions.stripDeadlinePrefix(it), UtilityFunctions.parseDeadlineMillis(it))
+        }
 
         // --- Task chain ---
         // Each task is a pair of consecutive text nodes:
@@ -62,7 +64,9 @@ class TimelineViewParser @Inject constructor() : ScreenParser {
             val rawDeadline = deadlineNode?.text
             val deadlineParts = rawDeadline?.split(" • ", limit = 2)
             val deadlineText = deadlineParts?.getOrNull(0)?.trim()
-            val deadline = deadlineText?.let { ParsedTime(it, UtilityFunctions.parseDeadlineMillis(it)) }
+            val deadline = deadlineText?.let {
+                ParsedTime(UtilityFunctions.stripDeadlinePrefix(it), UtilityFunctions.parseDeadlineMillis(it))
+            }
             val storeHint = deadlineParts?.getOrNull(1)?.trim()
 
             val isCurrent = taskNode.findNode {

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/processing/parsers/WaitingForOfferParser.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/processing/parsers/WaitingForOfferParser.kt
@@ -19,11 +19,28 @@ class WaitingForOfferParser @Inject constructor() : ScreenParser {
         } != null
 
         if (isNewLayout) {
-            Timber.d("WaitingForOfferParser: new layout (pay/wait unavailable)")
+            // "Zone offer wait" label is followed by a sibling text node with the estimate, e.g. "1-3 min".
+            val zoneWaitNode = node.findNode {
+                it.text?.contains("Zone offer wait", ignoreCase = true) == true
+            }
+            val waitTimeEstimate = if (zoneWaitNode != null) {
+                // Walk up to parent, then find the next text sibling after the label node.
+                val parent = zoneWaitNode.parent
+                if (parent != null) {
+                    val siblings = parent.children
+                    val labelIdx = siblings.indexOf(zoneWaitNode)
+                    siblings.getOrNull(labelIdx + 1)?.text?.takeIf { it.isNotBlank() }
+                } else null
+            } else null
+
+            val payNode = node.findNode { it.viewIdResourceName?.endsWith("running_total_pay") == true }
+            val currentPay = UtilityFunctions.parseCurrency(payNode?.text)
+
+            Timber.d("WaitingForOfferParser: new layout — wait='$waitTimeEstimate', pay=$currentPay")
             return ScreenInfo.WaitingForOffer(
                 screen = targetScreen,
-                dashPay = null,
-                waitTimeEstimate = null,
+                dashPay = currentPay,
+                waitTimeEstimate = waitTimeEstimate,
                 isHeadingBackToZone = false
             )
         }

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/reducers/AwaitingReducer.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/reducers/AwaitingReducer.kt
@@ -54,11 +54,15 @@ class AwaitingReducer @Inject constructor(
         return when (input) {
             // Internal Update
             is ScreenInfo.WaitingForOffer -> {
-                if (state.currentSessionPay != input.dashPay || state.waitTimeEstimate != input.waitTimeEstimate) {
+                if (state.currentSessionPay != input.dashPay ||
+                    state.waitTimeEstimate != input.waitTimeEstimate ||
+                    state.spotSaveDeadline != input.spotSaveDeadline
+                ) {
                     Transition(
                         state.copy(
                             currentSessionPay = input.dashPay,
-                            waitTimeEstimate = input.waitTimeEstimate
+                            waitTimeEstimate = input.waitTimeEstimate,
+                            spotSaveDeadline = input.spotSaveDeadline
                         )
                     )
                 } else Transition(state)

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/reducers/PickupReducer.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/reducers/PickupReducer.kt
@@ -59,7 +59,12 @@ class PickupReducer @Inject constructor(
 
                 if (hasStoreChanged || hasStatusChanged || hasDeadlineChanged || hasItemCountChanged || hasRedCardChanged) {
                     val nextStoreName = if (hasStoreChanged) newStoreName else state.storeName
-                    val justArrived = hasStatusChanged && input.status == PickupStatus.ARRIVED
+                    // Treat a direct NAVIGATING→SHOPPING transition (Shop & Deliver) the same as ARRIVED:
+                    // set arrivedAt and odometerAtArrival if not already set.
+                    val justArrived = hasStatusChanged && (
+                        input.status == PickupStatus.ARRIVED ||
+                        (input.status == PickupStatus.SHOPPING && state.arrivedAt == null)
+                    )
                     val arrivedAt = if (justArrived) System.currentTimeMillis() else state.arrivedAt
                     val nextState = state.copy(
                         storeName = nextStoreName,
@@ -73,21 +78,21 @@ class PickupReducer @Inject constructor(
                     if (hasStatusChanged) Timber.i("🛍️ PICKUP STATUS: ${state.status} → ${input.status} @ $nextStoreName")
                     val effects = mutableListOf<AppEffect>()
 
-                    // Persona Selection
-                    val persona = when (input.status) {
-                        PickupStatus.NAVIGATING -> ChatPersona.Navigator
-                        PickupStatus.ARRIVED -> ChatPersona.Merchant(nextStoreName)
-                        PickupStatus.CONFIRMED -> ChatPersona.Customer(
-                            // input.customerNameHash is not in PickupDetails anymore in some versions,
-                            // check your ScreenInfo definition. Assuming it exists:
-                            input.customerNameHash?.take(6) ?: "Customer"
-                        )
-
-                        PickupStatus.SHOPPING -> ChatPersona.Shopper
-                        else -> ChatPersona.Dispatcher
+                    // Only post a chat message when the status or store actually changes — not on
+                    // silent data refreshes (deadline, item count, red card total).
+                    if (hasStatusChanged || hasStoreChanged) {
+                        // Persona Selection
+                        val persona = when (input.status) {
+                            PickupStatus.NAVIGATING -> ChatPersona.Navigator
+                            PickupStatus.ARRIVED -> ChatPersona.Merchant(nextStoreName)
+                            PickupStatus.CONFIRMED -> ChatPersona.Customer(
+                                input.customerNameHash?.take(6) ?: "Customer"
+                            )
+                            PickupStatus.SHOPPING -> ChatPersona.Shopper
+                            else -> ChatPersona.Dispatcher
+                        }
+                        effects.add(AppEffect.UpdateBubble("Pickup: ${nextState.storeName}", persona))
                     }
-
-                    effects.add(AppEffect.UpdateBubble("Pickup: ${nextState.storeName}", persona))
 
                     // Logging Effects
                     if (justArrived) {

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleScreen.kt
@@ -315,6 +315,8 @@ private fun ModeIdle(lastSessionSummary: SessionSummary?) {
 
 @Composable
 private fun ModeAwaiting(state: AppStateV2.AwaitingOffer) {
+    val now by rememberNow()
+
     Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
         ModePrimaryText("Waiting for orders")
         if (state.isHeadingBackToZone) {
@@ -322,6 +324,14 @@ private fun ModeAwaiting(state: AppStateV2.AwaitingOffer) {
         }
         state.waitTimeEstimate?.let {
             ModeRow(label = "Est. wait", value = it)
+        }
+        state.spotSaveDeadline?.let { deadline ->
+            val remaining = deadline - now
+            if (remaining > 0) {
+                ModeRow(label = "Spot saved", value = formatDuration(remaining))
+            } else {
+                ModeRow(label = "Spot saved", value = "Expired")
+            }
         }
     }
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/util/UtilityFunctions.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/util/UtilityFunctions.kt
@@ -49,6 +49,30 @@ object UtilityFunctions {
     }
 
     /**
+     * Strips known deadline prefixes from a raw node text string, returning just the time portion.
+     * Examples:
+     *   "Pick up by 17:39"   → "17:39"
+     *   "Deliver by 8:16 PM" → "8:16 PM"
+     *   "by 6:10 PM"         → "6:10 PM"
+     *   "Dash ends at 15:00" → "15:00"
+     *   "17:39"              → "17:39"  (no-op if no known prefix)
+     */
+    fun stripDeadlinePrefix(text: String): String {
+        val prefixes = listOf(
+            "Pick up by ",
+            "Deliver by ",
+            "Dash ends at ",
+            "by "
+        )
+        for (prefix in prefixes) {
+            if (text.startsWith(prefix, ignoreCase = true)) {
+                return text.substring(prefix.length).trim()
+            }
+        }
+        return text.trim()
+    }
+
+    /**
      * Extracts a time value from a deadline string and converts it to epoch millis.
      * Handles formats like "Pick up by 17:39", "Deliver by 8:16 PM", "by 6:10 PM",
      * "Dash ends at 15:00", etc. Returns null if no parseable time is found.

--- a/app/src/test/java/cloud/trotter/dashbuddy/pipeline/recognition/matchers/DashAlongTheWayMatcherTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/pipeline/recognition/matchers/DashAlongTheWayMatcherTest.kt
@@ -92,6 +92,7 @@ UiNode(, id=no_id, state=null, class=android.widget.FrameLayout)
 
         assertFalse("Along the way is forward navigation, not heading back", result.isHeadingBackToZone)
         assertNull("Pay not available on this screen", result.dashPay)
-        assertEquals("Spot save timer extracted from bottom_view_info_title", "Spot saved until 3:00 PM", result.waitTimeEstimate)
+        assertNull("Spot save text moves to spotSaveDeadline, not waitTimeEstimate", result.waitTimeEstimate)
+        assertNotNull("Spot save deadline parsed from bottom_view_info_title", result.spotSaveDeadline)
     }
 }

--- a/app/src/test/java/cloud/trotter/dashbuddy/pipeline/recognition/matchers/WaitingForOfferMatcherTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/pipeline/recognition/matchers/WaitingForOfferMatcherTest.kt
@@ -41,8 +41,17 @@ UiNode(, id=no_id, state=null, class=android.widget.FrameLayout)
   UiNode(text='${'$'}7.25', id=running_total_pay, state=null, class=android.widget.TextView)
 """.trimIndent()
 
-    // New layout: "Finding offers" text
+    // New layout: "Finding offers" heading + "Zone offer wait" signal (required for match)
     private val newLayoutWaitingLog = """
+UiNode(, id=no_id, state=null, class=android.widget.FrameLayout)
+  UiNode(text='Finding offers', id=no_id, state=null, class=android.widget.TextView)
+  UiNode(, id=no_id, state=null, class=android.widget.LinearLayout)
+    UiNode(text='Zone offer wait', id=no_id, state=null, class=android.widget.TextView)
+    UiNode(text='1-3 min', id=no_id, state=null, class=android.widget.TextView)
+""".trimIndent()
+
+    // Interstitial map flash: "Finding offers" text but no zone-wait or pay signal — should NOT match
+    private val interstitialFlashLog = """
 UiNode(, id=no_id, state=null, class=android.widget.FrameLayout)
   UiNode(text='Finding offers', id=no_id, state=null, class=android.widget.TextView)
   UiNode(, id=no_id, state=null, class=android.widget.ProgressBar)
@@ -109,6 +118,14 @@ UiNode(, id=no_id, state=null, class=android.widget.FrameLayout)
         assertNull(matcher.matches(root!!))
     }
 
+    @Test
+    fun `returns null for interstitial map flash (Finding offers without zone signal)`() {
+        val root = LogToUiNodeParser.parseLog(interstitialFlashLog)
+        assertNotNull("Failed to parse log", root)
+
+        assertNull("Map interstitial without zone-wait signal should not match", matcher.matches(root!!))
+    }
+
     // --- PARSING TESTS ---
 
     @Test
@@ -130,11 +147,11 @@ UiNode(, id=no_id, state=null, class=android.widget.FrameLayout)
     }
 
     @Test
-    fun `new layout returns null for volatile fields`() {
+    fun `new layout extracts zone wait estimate and no session pay`() {
         val root = LogToUiNodeParser.parseLog(newLayoutWaitingLog)!!
         val result = parser.parse(root) as ScreenInfo.WaitingForOffer
 
         assertNull("Pay volatile in new layout", result.dashPay)
-        assertNull("Wait time not extracted in new layout", result.waitTimeEstimate)
+        assertEquals("Zone wait time extracted from sibling", "1-3 min", result.waitTimeEstimate)
     }
 }

--- a/app/src/test/resources/snapshots/ON_DASH_ALONG_THE_WAY/2026-04-25_18-52-07__ON_DASH_ALONG_THE_WAY__28f8873e.json
+++ b/app/src/test/resources/snapshots/ON_DASH_ALONG_THE_WAY/2026-04-25_18-52-07__ON_DASH_ALONG_THE_WAY__28f8873e.json
@@ -1,20 +1,24 @@
 {
-    "timestamp": 1776762477297,
+    "timestamp": 1777161127492,
     "breadcrumbs": [
-        "APP_STARTING_OR_LOADING",
+        "DASH_SUMMARY_SCREEN",
         "UNKNOWN",
         "MAIN_MAP_IDLE",
         "UNKNOWN",
-        "SET_DASH_END_TIME",
+        "ON_DASH_ALONG_THE_WAY",
+        "UNKNOWN",
+        "OFFER_POPUP",
+        "UNKNOWN",
+        "OFFER_POPUP_CONFIRM_DECLINE",
         "ON_DASH_ALONG_THE_WAY"
     ],
     "root": {
         "class": "android.widget.FrameLayout",
         "isEnabled": true,
         "bounds": {
-            "left": 35,
+            "left": -213,
             "top": 0,
-            "right": 1115,
+            "right": 866,
             "bottom": 2400
         },
         "children": [
@@ -22,9 +26,9 @@
                 "class": "android.widget.LinearLayout",
                 "isEnabled": true,
                 "bounds": {
-                    "left": 156,
+                    "left": -213,
                     "top": 0,
-                    "right": 1236,
+                    "right": 866,
                     "bottom": 2347
                 },
                 "children": [
@@ -32,9 +36,9 @@
                         "class": "android.widget.FrameLayout",
                         "isEnabled": true,
                         "bounds": {
-                            "left": 156,
+                            "left": -213,
                             "top": 136,
-                            "right": 1236,
+                            "right": 866,
                             "bottom": 2347
                         },
                         "children": [
@@ -43,9 +47,9 @@
                                 "class": "android.widget.LinearLayout",
                                 "isEnabled": true,
                                 "bounds": {
-                                    "left": 156,
+                                    "left": -213,
                                     "top": 136,
-                                    "right": 1236,
+                                    "right": 866,
                                     "bottom": 2347
                                 },
                                 "children": [
@@ -54,9 +58,9 @@
                                         "class": "android.widget.FrameLayout",
                                         "isEnabled": true,
                                         "bounds": {
-                                            "left": 156,
+                                            "left": -213,
                                             "top": 136,
-                                            "right": 1236,
+                                            "right": 866,
                                             "bottom": 2347
                                         },
                                         "children": [
@@ -65,9 +69,9 @@
                                                 "class": "android.view.ViewGroup",
                                                 "isEnabled": true,
                                                 "bounds": {
-                                                    "left": 156,
+                                                    "left": -213,
                                                     "top": 136,
-                                                    "right": 1236,
+                                                    "right": 866,
                                                     "bottom": 2347
                                                 },
                                                 "children": [
@@ -76,9 +80,9 @@
                                                         "class": "android.widget.LinearLayout",
                                                         "isEnabled": true,
                                                         "bounds": {
-                                                            "left": 156,
+                                                            "left": -213,
                                                             "top": 136,
-                                                            "right": 1236,
+                                                            "right": 866,
                                                             "bottom": 278
                                                         },
                                                         "children": [
@@ -87,9 +91,9 @@
                                                                 "class": "android.view.ViewGroup",
                                                                 "isEnabled": true,
                                                                 "bounds": {
-                                                                    "left": 156,
+                                                                    "left": -213,
                                                                     "top": 136,
-                                                                    "right": 1236,
+                                                                    "right": 866,
                                                                     "bottom": 278
                                                                 },
                                                                 "children": [
@@ -99,9 +103,9 @@
                                                                         "isClickable": true,
                                                                         "isEnabled": true,
                                                                         "bounds": {
-                                                                            "left": 156,
+                                                                            "left": -213,
                                                                             "top": 144,
-                                                                            "right": 281,
+                                                                            "right": -88,
                                                                             "bottom": 269
                                                                         }
                                                                     },
@@ -110,9 +114,9 @@
                                                                         "class": "android.widget.TextView",
                                                                         "isEnabled": true,
                                                                         "bounds": {
-                                                                            "left": 289,
+                                                                            "left": -80,
                                                                             "top": 182,
-                                                                            "right": 619,
+                                                                            "right": 249,
                                                                             "bottom": 232
                                                                         }
                                                                     },
@@ -120,26 +124,11 @@
                                                                         "class": "androidx.appcompat.widget.LinearLayoutCompat",
                                                                         "isEnabled": true,
                                                                         "bounds": {
-                                                                            "left": 1129,
+                                                                            "left": 866,
                                                                             "top": 144,
-                                                                            "right": 1236,
+                                                                            "right": 866,
                                                                             "bottom": 269
-                                                                        },
-                                                                        "children": [
-                                                                            {
-                                                                                "desc": "Safety",
-                                                                                "id": "com.doordash.driverapp:id/action_dasher_safety",
-                                                                                "class": "android.widget.Button",
-                                                                                "isClickable": true,
-                                                                                "isEnabled": true,
-                                                                                "bounds": {
-                                                                                    "left": 1129,
-                                                                                    "top": 153,
-                                                                                    "right": 1236,
-                                                                                    "bottom": 260
-                                                                                }
-                                                                            }
-                                                                        ]
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -149,9 +138,9 @@
                                                         "class": "android.widget.FrameLayout",
                                                         "isEnabled": true,
                                                         "bounds": {
-                                                            "left": 156,
+                                                            "left": -213,
                                                             "top": 278,
-                                                            "right": 1236,
+                                                            "right": 866,
                                                             "bottom": 2347
                                                         },
                                                         "children": [
@@ -160,9 +149,9 @@
                                                                 "class": "android.widget.FrameLayout",
                                                                 "isEnabled": true,
                                                                 "bounds": {
-                                                                    "left": 156,
+                                                                    "left": -213,
                                                                     "top": 278,
-                                                                    "right": 1236,
+                                                                    "right": 866,
                                                                     "bottom": 2347
                                                                 },
                                                                 "children": [
@@ -171,9 +160,9 @@
                                                                         "class": "android.view.ViewGroup",
                                                                         "isEnabled": true,
                                                                         "bounds": {
-                                                                            "left": 156,
+                                                                            "left": -213,
                                                                             "top": 278,
-                                                                            "right": 1236,
+                                                                            "right": 866,
                                                                             "bottom": 2347
                                                                         },
                                                                         "children": [
@@ -182,9 +171,9 @@
                                                                                 "class": "android.widget.FrameLayout",
                                                                                 "isEnabled": true,
                                                                                 "bounds": {
-                                                                                    "left": 156,
+                                                                                    "left": -213,
                                                                                     "top": 278,
-                                                                                    "right": 1236,
+                                                                                    "right": 866,
                                                                                     "bottom": 1959
                                                                                 },
                                                                                 "children": [
@@ -192,9 +181,9 @@
                                                                                         "class": "android.widget.FrameLayout",
                                                                                         "isEnabled": true,
                                                                                         "bounds": {
-                                                                                            "left": 156,
+                                                                                            "left": -213,
                                                                                             "top": 278,
-                                                                                            "right": 1236,
+                                                                                            "right": 866,
                                                                                             "bottom": 1959
                                                                                         },
                                                                                         "children": [
@@ -202,9 +191,9 @@
                                                                                                 "class": "android.view.TextureView",
                                                                                                 "isEnabled": true,
                                                                                                 "bounds": {
-                                                                                                    "left": 156,
+                                                                                                    "left": -213,
                                                                                                     "top": 278,
-                                                                                                    "right": 1236,
+                                                                                                    "right": 866,
                                                                                                     "bottom": 1959
                                                                                                 }
                                                                                             },
@@ -212,9 +201,9 @@
                                                                                                 "class": "android.widget.FrameLayout",
                                                                                                 "isEnabled": true,
                                                                                                 "bounds": {
-                                                                                                    "left": 156,
+                                                                                                    "left": -213,
                                                                                                     "top": 278,
-                                                                                                    "right": 1236,
+                                                                                                    "right": 866,
                                                                                                     "bottom": 1959
                                                                                                 }
                                                                                             },
@@ -222,9 +211,9 @@
                                                                                                 "class": "android.widget.ImageView",
                                                                                                 "isEnabled": true,
                                                                                                 "bounds": {
-                                                                                                    "left": 161,
+                                                                                                    "left": -208,
                                                                                                     "top": 1907,
-                                                                                                    "right": 350,
+                                                                                                    "right": -19,
                                                                                                     "bottom": 1954
                                                                                                 }
                                                                                             },
@@ -233,9 +222,9 @@
                                                                                                 "isClickable": true,
                                                                                                 "isEnabled": true,
                                                                                                 "bounds": {
-                                                                                                    "left": 356,
+                                                                                                    "left": -13,
                                                                                                     "top": 1907,
-                                                                                                    "right": 403,
+                                                                                                    "right": 33,
                                                                                                     "bottom": 1954
                                                                                                 }
                                                                                             }
@@ -249,9 +238,9 @@
                                                                                 "isClickable": true,
                                                                                 "isEnabled": true,
                                                                                 "bounds": {
-                                                                                    "left": 1111,
+                                                                                    "left": 741,
                                                                                     "top": 1789,
-                                                                                    "right": 1200,
+                                                                                    "right": 830,
                                                                                     "bottom": 1878
                                                                                 },
                                                                                 "children": [
@@ -260,9 +249,9 @@
                                                                                         "class": "android.widget.ImageView",
                                                                                         "isEnabled": true,
                                                                                         "bounds": {
-                                                                                            "left": 1133,
+                                                                                            "left": 763,
                                                                                             "top": 1811,
-                                                                                            "right": 1178,
+                                                                                            "right": 808,
                                                                                             "bottom": 1856
                                                                                         }
                                                                                     }
@@ -273,9 +262,9 @@
                                                                                 "class": "android.widget.LinearLayout",
                                                                                 "isEnabled": true,
                                                                                 "bounds": {
-                                                                                    "left": 156,
+                                                                                    "left": -213,
                                                                                     "top": 1914,
-                                                                                    "right": 1236,
+                                                                                    "right": 866,
                                                                                     "bottom": 2347
                                                                                 },
                                                                                 "children": [
@@ -285,9 +274,9 @@
                                                                                         "class": "android.widget.TextView",
                                                                                         "isEnabled": true,
                                                                                         "bounds": {
-                                                                                            "left": 156,
+                                                                                            "left": -213,
                                                                                             "top": 1950,
-                                                                                            "right": 1236,
+                                                                                            "right": 866,
                                                                                             "bottom": 1992
                                                                                         }
                                                                                     },
@@ -296,9 +285,9 @@
                                                                                         "class": "android.view.View",
                                                                                         "isEnabled": true,
                                                                                         "bounds": {
-                                                                                            "left": 156,
+                                                                                            "left": -213,
                                                                                             "top": 2010,
-                                                                                            "right": 1236,
+                                                                                            "right": 866,
                                                                                             "bottom": 2012
                                                                                         }
                                                                                     },
@@ -307,9 +296,9 @@
                                                                                         "class": "android.widget.TextView",
                                                                                         "isEnabled": true,
                                                                                         "bounds": {
-                                                                                            "left": 156,
+                                                                                            "left": -213,
                                                                                             "top": 2048,
-                                                                                            "right": 228,
+                                                                                            "right": -141,
                                                                                             "bottom": 2100
                                                                                         }
                                                                                     },
@@ -318,9 +307,9 @@
                                                                                         "class": "android.widget.TextView",
                                                                                         "isEnabled": true,
                                                                                         "bounds": {
-                                                                                            "left": 156,
+                                                                                            "left": -213,
                                                                                             "top": 2109,
-                                                                                            "right": 228,
+                                                                                            "right": -141,
                                                                                             "bottom": 2151
                                                                                         }
                                                                                     },
@@ -331,9 +320,9 @@
                                                                                         "isClickable": true,
                                                                                         "isEnabled": true,
                                                                                         "bounds": {
-                                                                                            "left": 192,
+                                                                                            "left": -177,
                                                                                             "top": 2204,
-                                                                                            "right": 1200,
+                                                                                            "right": 830,
                                                                                             "bottom": 2311
                                                                                         },
                                                                                         "children": [
@@ -342,10 +331,22 @@
                                                                                                 "class": "android.widget.ImageView",
                                                                                                 "isEnabled": true,
                                                                                                 "bounds": {
-                                                                                                    "left": 107,
+                                                                                                    "left": -141,
                                                                                                     "top": 2231,
-                                                                                                    "right": 178,
+                                                                                                    "right": -70,
                                                                                                     "bottom": 2284
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "Navigate",
+                                                                                                "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 235,
+                                                                                                    "top": 2225,
+                                                                                                    "right": 418,
+                                                                                                    "bottom": 2291
                                                                                                 }
                                                                                             }
                                                                                         ]

--- a/app/src/test/resources/snapshots/ON_DASH_ALONG_THE_WAY/2026-04-25_18-52-32__ON_DASH_ALONG_THE_WAY__5132f708.json
+++ b/app/src/test/resources/snapshots/ON_DASH_ALONG_THE_WAY/2026-04-25_18-52-32__ON_DASH_ALONG_THE_WAY__5132f708.json
@@ -1,22 +1,24 @@
 {
-    "timestamp": 1776762477542,
+    "timestamp": 1777161152669,
     "breadcrumbs": [
-        "APP_STARTING_OR_LOADING",
         "UNKNOWN",
-        "MAIN_MAP_IDLE",
+        "OFFER_POPUP",
         "UNKNOWN",
-        "SET_DASH_END_TIME",
+        "OFFER_POPUP_CONFIRM_DECLINE",
         "ON_DASH_ALONG_THE_WAY",
         "UNKNOWN",
+        "OFFER_POPUP",
+        "UNKNOWN",
+        "OFFER_POPUP_CONFIRM_DECLINE",
         "ON_DASH_ALONG_THE_WAY"
     ],
     "root": {
         "class": "android.widget.FrameLayout",
         "isEnabled": true,
         "bounds": {
-            "left": 0,
+            "left": -213,
             "top": 0,
-            "right": 1080,
+            "right": 866,
             "bottom": 2400
         },
         "children": [
@@ -34,9 +36,9 @@
                         "class": "android.widget.FrameLayout",
                         "isEnabled": true,
                         "bounds": {
-                            "left": 0,
+                            "left": -92,
                             "top": 136,
-                            "right": 1080,
+                            "right": 987,
                             "bottom": 2347
                         },
                         "children": [
@@ -56,9 +58,9 @@
                                         "class": "android.widget.FrameLayout",
                                         "isEnabled": true,
                                         "bounds": {
-                                            "left": 0,
+                                            "left": -92,
                                             "top": 136,
-                                            "right": 1080,
+                                            "right": 987,
                                             "bottom": 2347
                                         },
                                         "children": [
@@ -67,9 +69,9 @@
                                                 "class": "android.view.ViewGroup",
                                                 "isEnabled": true,
                                                 "bounds": {
-                                                    "left": 0,
+                                                    "left": -92,
                                                     "top": 136,
-                                                    "right": 1080,
+                                                    "right": 987,
                                                     "bottom": 2347
                                                 },
                                                 "children": [
@@ -78,9 +80,9 @@
                                                         "class": "android.widget.LinearLayout",
                                                         "isEnabled": true,
                                                         "bounds": {
-                                                            "left": 0,
+                                                            "left": -92,
                                                             "top": 136,
-                                                            "right": 1080,
+                                                            "right": 987,
                                                             "bottom": 278
                                                         },
                                                         "children": [
@@ -96,49 +98,49 @@
                                                                 },
                                                                 "children": [
                                                                     {
-                                                                        "text": "Looking for offers",
-                                                                        "class": "android.widget.TextView",
-                                                                        "isEnabled": true,
-                                                                        "bounds": {
-                                                                            "left": 0,
-                                                                            "top": 136,
-                                                                            "right": 0,
-                                                                            "bottom": 136
-                                                                        }
-                                                                    },
-                                                                    {
                                                                         "desc": "Current dash",
                                                                         "class": "android.widget.ImageButton",
                                                                         "isClickable": true,
                                                                         "isEnabled": true,
                                                                         "bounds": {
-                                                                            "left": 0,
+                                                                            "left": -92,
                                                                             "top": 144,
-                                                                            "right": 125,
+                                                                            "right": 32,
                                                                             "bottom": 269
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "text": "Looking for offers",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 40,
+                                                                            "top": 182,
+                                                                            "right": 370,
+                                                                            "bottom": 232
                                                                         }
                                                                     },
                                                                     {
                                                                         "class": "androidx.appcompat.widget.LinearLayoutCompat",
                                                                         "isEnabled": true,
                                                                         "bounds": {
-                                                                            "left": 1080,
+                                                                            "left": 973,
                                                                             "top": 144,
                                                                             "right": 1080,
                                                                             "bottom": 269
                                                                         },
                                                                         "children": [
                                                                             {
-                                                                                "desc": "Safety",
-                                                                                "id": "com.doordash.driverapp:id/action_dasher_safety",
+                                                                                "desc": "Help",
+                                                                                "id": "com.doordash.driverapp:id/action_self_help",
                                                                                 "class": "android.widget.Button",
                                                                                 "isClickable": true,
                                                                                 "isEnabled": true,
                                                                                 "bounds": {
-                                                                                    "left": 1080,
-                                                                                    "top": 144,
+                                                                                    "left": 973,
+                                                                                    "top": 153,
                                                                                     "right": 1080,
-                                                                                    "bottom": 144
+                                                                                    "bottom": 260
                                                                                 }
                                                                             }
                                                                         ]
@@ -162,9 +164,9 @@
                                                                 "class": "android.widget.FrameLayout",
                                                                 "isEnabled": true,
                                                                 "bounds": {
-                                                                    "left": 0,
+                                                                    "left": -5,
                                                                     "top": 278,
-                                                                    "right": 1080,
+                                                                    "right": 1074,
                                                                     "bottom": 2347
                                                                 },
                                                                 "children": [
@@ -173,105 +175,75 @@
                                                                         "class": "android.view.ViewGroup",
                                                                         "isEnabled": true,
                                                                         "bounds": {
-                                                                            "left": 0,
+                                                                            "left": -5,
                                                                             "top": 278,
-                                                                            "right": 0,
-                                                                            "bottom": 278
+                                                                            "right": 1074,
+                                                                            "bottom": 2347
                                                                         },
                                                                         "children": [
                                                                             {
-                                                                                "id": "com.doordash.driverapp:id/bottom_spot_info_and_navigate_layout",
-                                                                                "class": "android.widget.LinearLayout",
+                                                                                "id": "com.doordash.driverapp:id/map_container",
+                                                                                "class": "android.widget.FrameLayout",
                                                                                 "isEnabled": true,
                                                                                 "bounds": {
                                                                                     "left": 0,
                                                                                     "top": 278,
-                                                                                    "right": 0,
-                                                                                    "bottom": 278
+                                                                                    "right": 1080,
+                                                                                    "bottom": 1959
                                                                                 },
                                                                                 "children": [
                                                                                     {
-                                                                                        "desc": "Navigate",
-                                                                                        "id": "com.doordash.driverapp:id/navigate_button",
-                                                                                        "class": "android.widget.Button",
-                                                                                        "isClickable": true,
+                                                                                        "class": "android.widget.FrameLayout",
                                                                                         "isEnabled": true,
                                                                                         "bounds": {
-                                                                                            "left": 0,
+                                                                                            "left": -5,
                                                                                             "top": 278,
-                                                                                            "right": 0,
-                                                                                            "bottom": 278
+                                                                                            "right": 1074,
+                                                                                            "bottom": 1959
                                                                                         },
                                                                                         "children": [
                                                                                             {
-                                                                                                "text": "Navigate",
-                                                                                                "id": "com.doordash.driverapp:id/textView_prism_button_title",
-                                                                                                "class": "android.widget.TextView",
+                                                                                                "class": "android.view.TextureView",
                                                                                                 "isEnabled": true,
                                                                                                 "bounds": {
                                                                                                     "left": 0,
                                                                                                     "top": 278,
-                                                                                                    "right": 0,
-                                                                                                    "bottom": 278
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 1959
                                                                                                 }
                                                                                             },
                                                                                             {
-                                                                                                "id": "com.doordash.driverapp:id/imageView_prism_button_start_icon",
-                                                                                                "class": "android.widget.ImageView",
+                                                                                                "class": "android.widget.FrameLayout",
                                                                                                 "isEnabled": true,
                                                                                                 "bounds": {
                                                                                                     "left": 0,
                                                                                                     "top": 278,
-                                                                                                    "right": 0,
-                                                                                                    "bottom": 278
+                                                                                                    "right": 1079,
+                                                                                                    "bottom": 1959
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 5,
+                                                                                                    "top": 1907,
+                                                                                                    "right": 194,
+                                                                                                    "bottom": 1954
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isClickable": true,
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 200,
+                                                                                                    "top": 1907,
+                                                                                                    "right": 247,
+                                                                                                    "bottom": 1954
                                                                                                 }
                                                                                             }
                                                                                         ]
-                                                                                    },
-                                                                                    {
-                                                                                        "id": "com.doordash.driverapp:id/bottom_view_info_subtitle",
-                                                                                        "class": "android.widget.TextView",
-                                                                                        "isEnabled": true,
-                                                                                        "bounds": {
-                                                                                            "left": 0,
-                                                                                            "top": 278,
-                                                                                            "right": 0,
-                                                                                            "bottom": 278
-                                                                                        }
-                                                                                    },
-                                                                                    {
-                                                                                        "id": "com.doordash.driverapp:id/bottom_view_info_title",
-                                                                                        "class": "android.widget.TextView",
-                                                                                        "isEnabled": true,
-                                                                                        "bounds": {
-                                                                                            "left": 0,
-                                                                                            "top": 278,
-                                                                                            "right": 0,
-                                                                                            "bottom": 278
-                                                                                        }
-                                                                                    },
-                                                                                    {
-                                                                                        "id": "com.doordash.driverapp:id/ctd_v2_title_divider",
-                                                                                        "class": "android.view.View",
-                                                                                        "isEnabled": true,
-                                                                                        "bounds": {
-                                                                                            "left": 0,
-                                                                                            "top": 278,
-                                                                                            "right": 0,
-                                                                                            "bottom": 278
-                                                                                        }
-                                                                                    },
-                                                                                    {
-                                                                                        "text": "We'll look for orders along the way",
-                                                                                        "id": "com.doordash.driverapp:id/bottom_view_info_ctd_v2_title",
-                                                                                        "class": "android.widget.TextView",
-                                                                                        "isEnabled": true,
-                                                                                        "bounds": {
-                                                                                            "left": 0,
-                                                                                            "top": 278,
-                                                                                            "right": 0,
-                                                                                            "bottom": 278
-                                                                                        }
                                                                                     }
                                                                                 ]
                                                                             },
@@ -281,10 +253,10 @@
                                                                                 "isClickable": true,
                                                                                 "isEnabled": true,
                                                                                 "bounds": {
-                                                                                    "left": 0,
-                                                                                    "top": 278,
-                                                                                    "right": 0,
-                                                                                    "bottom": 278
+                                                                                    "left": 955,
+                                                                                    "top": 1789,
+                                                                                    "right": 1044,
+                                                                                    "bottom": 1878
                                                                                 },
                                                                                 "children": [
                                                                                     {
@@ -292,74 +264,104 @@
                                                                                         "class": "android.widget.ImageView",
                                                                                         "isEnabled": true,
                                                                                         "bounds": {
-                                                                                            "left": 1133,
-                                                                                            "top": 1834,
-                                                                                            "right": 1178,
-                                                                                            "bottom": 1879
+                                                                                            "left": 977,
+                                                                                            "top": 1811,
+                                                                                            "right": 1022,
+                                                                                            "bottom": 1856
                                                                                         }
                                                                                     }
                                                                                 ]
                                                                             },
                                                                             {
-                                                                                "id": "com.doordash.driverapp:id/map_container",
-                                                                                "class": "android.widget.FrameLayout",
+                                                                                "id": "com.doordash.driverapp:id/bottom_spot_info_and_navigate_layout",
+                                                                                "class": "android.widget.LinearLayout",
                                                                                 "isEnabled": true,
                                                                                 "bounds": {
-                                                                                    "left": 62,
-                                                                                    "top": 296,
-                                                                                    "right": 1142,
-                                                                                    "bottom": 1977
+                                                                                    "left": 0,
+                                                                                    "top": 1914,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2347
                                                                                 },
                                                                                 "children": [
                                                                                     {
-                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "text": "We'll look for orders along the way",
+                                                                                        "id": "com.doordash.driverapp:id/bottom_view_info_ctd_v2_title",
+                                                                                        "class": "android.widget.TextView",
                                                                                         "isEnabled": true,
                                                                                         "bounds": {
-                                                                                            "left": 62,
-                                                                                            "top": 296,
-                                                                                            "right": 1142,
-                                                                                            "bottom": 1977
+                                                                                            "left": 0,
+                                                                                            "top": 1950,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 1992
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/ctd_v2_title_divider",
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 2010,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2012
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/bottom_view_info_title",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 2048,
+                                                                                            "right": 72,
+                                                                                            "bottom": 2100
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/bottom_view_info_subtitle",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 2109,
+                                                                                            "right": 72,
+                                                                                            "bottom": 2151
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "desc": "Navigate",
+                                                                                        "id": "com.doordash.driverapp:id/navigate_button",
+                                                                                        "class": "android.widget.Button",
+                                                                                        "isClickable": true,
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 36,
+                                                                                            "top": 2204,
+                                                                                            "right": 1044,
+                                                                                            "bottom": 2311
                                                                                         },
                                                                                         "children": [
                                                                                             {
-                                                                                                "class": "android.view.TextureView",
-                                                                                                "isEnabled": true,
-                                                                                                "bounds": {
-                                                                                                    "left": 35,
-                                                                                                    "top": 292,
-                                                                                                    "right": 1115,
-                                                                                                    "bottom": 1973
-                                                                                                }
-                                                                                            },
-                                                                                            {
-                                                                                                "class": "android.widget.FrameLayout",
-                                                                                                "isEnabled": true,
-                                                                                                "bounds": {
-                                                                                                    "left": 35,
-                                                                                                    "top": 292,
-                                                                                                    "right": 1115,
-                                                                                                    "bottom": 1973
-                                                                                                }
-                                                                                            },
-                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/imageView_prism_button_start_icon",
                                                                                                 "class": "android.widget.ImageView",
                                                                                                 "isEnabled": true,
                                                                                                 "bounds": {
-                                                                                                    "left": 40,
-                                                                                                    "top": 1873,
-                                                                                                    "right": 229,
-                                                                                                    "bottom": 1920
+                                                                                                    "left": 72,
+                                                                                                    "top": 2231,
+                                                                                                    "right": 143,
+                                                                                                    "bottom": 2284
                                                                                                 }
                                                                                             },
                                                                                             {
-                                                                                                "class": "android.widget.ImageView",
-                                                                                                "isClickable": true,
+                                                                                                "text": "Navigate",
+                                                                                                "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                                "class": "android.widget.TextView",
                                                                                                 "isEnabled": true,
                                                                                                 "bounds": {
-                                                                                                    "left": 235,
-                                                                                                    "top": 1873,
-                                                                                                    "right": 282,
-                                                                                                    "bottom": 1920
+                                                                                                    "left": 449,
+                                                                                                    "top": 2225,
+                                                                                                    "right": 632,
+                                                                                                    "bottom": 2291
                                                                                                 }
                                                                                             }
                                                                                         ]

--- a/app/src/test/resources/snapshots/ON_DASH_ALONG_THE_WAY/2026-04-25_18-52-54__ON_DASH_ALONG_THE_WAY__3959444a.json
+++ b/app/src/test/resources/snapshots/ON_DASH_ALONG_THE_WAY/2026-04-25_18-52-54__ON_DASH_ALONG_THE_WAY__3959444a.json
@@ -1,13 +1,14 @@
 {
-    "timestamp": 1776614323511,
+    "timestamp": 1777161174067,
     "breadcrumbs": [
-        "MAIN_MAP_IDLE",
         "UNKNOWN",
-        "MAIN_MAP_IDLE",
+        "OFFER_POPUP_CONFIRM_DECLINE",
+        "ON_DASH_ALONG_THE_WAY",
         "UNKNOWN",
-        "MAIN_MAP_IDLE",
+        "OFFER_POPUP",
         "UNKNOWN",
-        "MAIN_MAP_IDLE",
+        "OFFER_POPUP_CONFIRM_DECLINE",
+        "ON_DASH_ALONG_THE_WAY",
         "UNKNOWN",
         "ON_DASH_ALONG_THE_WAY"
     ],
@@ -15,9 +16,9 @@
         "class": "android.widget.FrameLayout",
         "isEnabled": true,
         "bounds": {
-            "left": 0,
+            "left": 28,
             "top": 0,
-            "right": 1080,
+            "right": 1108,
             "bottom": 2400
         },
         "children": [
@@ -25,9 +26,9 @@
                 "class": "android.widget.LinearLayout",
                 "isEnabled": true,
                 "bounds": {
-                    "left": 0,
+                    "left": 28,
                     "top": 0,
-                    "right": 1080,
+                    "right": 1108,
                     "bottom": 2347
                 },
                 "children": [
@@ -35,9 +36,9 @@
                         "class": "android.widget.FrameLayout",
                         "isEnabled": true,
                         "bounds": {
-                            "left": 0,
+                            "left": 28,
                             "top": 136,
-                            "right": 1080,
+                            "right": 1108,
                             "bottom": 2347
                         },
                         "children": [
@@ -46,9 +47,9 @@
                                 "class": "android.widget.LinearLayout",
                                 "isEnabled": true,
                                 "bounds": {
-                                    "left": 0,
+                                    "left": 28,
                                     "top": 136,
-                                    "right": 1080,
+                                    "right": 1108,
                                     "bottom": 2347
                                 },
                                 "children": [
@@ -57,9 +58,9 @@
                                         "class": "android.widget.FrameLayout",
                                         "isEnabled": true,
                                         "bounds": {
-                                            "left": 0,
+                                            "left": 28,
                                             "top": 136,
-                                            "right": 1080,
+                                            "right": 1108,
                                             "bottom": 2347
                                         },
                                         "children": [
@@ -68,9 +69,9 @@
                                                 "class": "android.view.ViewGroup",
                                                 "isEnabled": true,
                                                 "bounds": {
-                                                    "left": 0,
+                                                    "left": 28,
                                                     "top": 136,
-                                                    "right": 1080,
+                                                    "right": 1108,
                                                     "bottom": 2347
                                                 },
                                                 "children": [
@@ -79,9 +80,9 @@
                                                         "class": "android.widget.LinearLayout",
                                                         "isEnabled": true,
                                                         "bounds": {
-                                                            "left": 0,
+                                                            "left": 28,
                                                             "top": 136,
-                                                            "right": 1080,
+                                                            "right": 1108,
                                                             "bottom": 278
                                                         },
                                                         "children": [
@@ -90,9 +91,9 @@
                                                                 "class": "android.view.ViewGroup",
                                                                 "isEnabled": true,
                                                                 "bounds": {
-                                                                    "left": 0,
+                                                                    "left": 28,
                                                                     "top": 136,
-                                                                    "right": 1080,
+                                                                    "right": 1108,
                                                                     "bottom": 278
                                                                 },
                                                                 "children": [
@@ -102,41 +103,30 @@
                                                                         "isClickable": true,
                                                                         "isEnabled": true,
                                                                         "bounds": {
-                                                                            "left": 0,
+                                                                            "left": 28,
                                                                             "top": 144,
-                                                                            "right": 125,
+                                                                            "right": 153,
                                                                             "bottom": 269
                                                                         }
                                                                     },
                                                                     {
-                                                                        "text": "Navigate to zone",
+                                                                        "text": "Looking for offers",
                                                                         "class": "android.widget.TextView",
                                                                         "isEnabled": true,
                                                                         "bounds": {
-                                                                            "left": 133,
-                                                                            "top": 163,
-                                                                            "right": 448,
-                                                                            "bottom": 213
-                                                                        }
-                                                                    },
-                                                                    {
-                                                                        "text": "TX: Northwest San Antonio",
-                                                                        "class": "android.widget.TextView",
-                                                                        "isEnabled": true,
-                                                                        "bounds": {
-                                                                            "left": 133,
-                                                                            "top": 213,
-                                                                            "right": 514,
-                                                                            "bottom": 251
+                                                                            "left": 161,
+                                                                            "top": 182,
+                                                                            "right": 491,
+                                                                            "bottom": 232
                                                                         }
                                                                     },
                                                                     {
                                                                         "class": "androidx.appcompat.widget.LinearLayoutCompat",
                                                                         "isEnabled": true,
                                                                         "bounds": {
-                                                                            "left": 866,
+                                                                            "left": 1001,
                                                                             "top": 144,
-                                                                            "right": 1080,
+                                                                            "right": 1108,
                                                                             "bottom": 269
                                                                         },
                                                                         "children": [
@@ -147,22 +137,9 @@
                                                                                 "isClickable": true,
                                                                                 "isEnabled": true,
                                                                                 "bounds": {
-                                                                                    "left": 866,
+                                                                                    "left": 1001,
                                                                                     "top": 153,
-                                                                                    "right": 973,
-                                                                                    "bottom": 260
-                                                                                }
-                                                                            },
-                                                                            {
-                                                                                "desc": "Help",
-                                                                                "id": "com.doordash.driverapp:id/action_self_help",
-                                                                                "class": "android.widget.Button",
-                                                                                "isClickable": true,
-                                                                                "isEnabled": true,
-                                                                                "bounds": {
-                                                                                    "left": 973,
-                                                                                    "top": 153,
-                                                                                    "right": 1080,
+                                                                                    "right": 1108,
                                                                                     "bottom": 260
                                                                                 }
                                                                             }
@@ -176,9 +153,9 @@
                                                         "class": "android.widget.FrameLayout",
                                                         "isEnabled": true,
                                                         "bounds": {
-                                                            "left": 0,
+                                                            "left": 28,
                                                             "top": 278,
-                                                            "right": 1080,
+                                                            "right": 1108,
                                                             "bottom": 2347
                                                         },
                                                         "children": [
@@ -187,9 +164,9 @@
                                                                 "class": "android.widget.FrameLayout",
                                                                 "isEnabled": true,
                                                                 "bounds": {
-                                                                    "left": 0,
+                                                                    "left": 28,
                                                                     "top": 278,
-                                                                    "right": 1080,
+                                                                    "right": 1108,
                                                                     "bottom": 2347
                                                                 },
                                                                 "children": [
@@ -198,9 +175,9 @@
                                                                         "class": "android.view.ViewGroup",
                                                                         "isEnabled": true,
                                                                         "bounds": {
-                                                                            "left": 0,
+                                                                            "left": 28,
                                                                             "top": 278,
-                                                                            "right": 1080,
+                                                                            "right": 1108,
                                                                             "bottom": 2347
                                                                         },
                                                                         "children": [
@@ -209,9 +186,9 @@
                                                                                 "class": "android.widget.FrameLayout",
                                                                                 "isEnabled": true,
                                                                                 "bounds": {
-                                                                                    "left": 0,
+                                                                                    "left": 28,
                                                                                     "top": 278,
-                                                                                    "right": 1080,
+                                                                                    "right": 1108,
                                                                                     "bottom": 1959
                                                                                 },
                                                                                 "children": [
@@ -219,9 +196,9 @@
                                                                                         "class": "android.widget.FrameLayout",
                                                                                         "isEnabled": true,
                                                                                         "bounds": {
-                                                                                            "left": 0,
+                                                                                            "left": 28,
                                                                                             "top": 278,
-                                                                                            "right": 1080,
+                                                                                            "right": 1108,
                                                                                             "bottom": 1959
                                                                                         },
                                                                                         "children": [
@@ -229,9 +206,9 @@
                                                                                                 "class": "android.view.TextureView",
                                                                                                 "isEnabled": true,
                                                                                                 "bounds": {
-                                                                                                    "left": 0,
+                                                                                                    "left": 28,
                                                                                                     "top": 278,
-                                                                                                    "right": 1080,
+                                                                                                    "right": 1108,
                                                                                                     "bottom": 1959
                                                                                                 }
                                                                                             },
@@ -239,9 +216,9 @@
                                                                                                 "class": "android.widget.FrameLayout",
                                                                                                 "isEnabled": true,
                                                                                                 "bounds": {
-                                                                                                    "left": 0,
+                                                                                                    "left": 28,
                                                                                                     "top": 278,
-                                                                                                    "right": 1080,
+                                                                                                    "right": 1108,
                                                                                                     "bottom": 1959
                                                                                                 }
                                                                                             },
@@ -249,10 +226,10 @@
                                                                                                 "class": "android.widget.ImageView",
                                                                                                 "isEnabled": true,
                                                                                                 "bounds": {
-                                                                                                    "left": 5,
-                                                                                                    "top": 1859,
-                                                                                                    "right": 194,
-                                                                                                    "bottom": 1906
+                                                                                                    "left": 33,
+                                                                                                    "top": 1907,
+                                                                                                    "right": 222,
+                                                                                                    "bottom": 1954
                                                                                                 }
                                                                                             },
                                                                                             {
@@ -260,10 +237,10 @@
                                                                                                 "isClickable": true,
                                                                                                 "isEnabled": true,
                                                                                                 "bounds": {
-                                                                                                    "left": 200,
-                                                                                                    "top": 1859,
-                                                                                                    "right": 247,
-                                                                                                    "bottom": 1906
+                                                                                                    "left": 228,
+                                                                                                    "top": 1907,
+                                                                                                    "right": 275,
+                                                                                                    "bottom": 1954
                                                                                                 }
                                                                                             }
                                                                                         ]
@@ -276,9 +253,9 @@
                                                                                 "isClickable": true,
                                                                                 "isEnabled": true,
                                                                                 "bounds": {
-                                                                                    "left": 955,
+                                                                                    "left": 983,
                                                                                     "top": 1789,
-                                                                                    "right": 1044,
+                                                                                    "right": 1072,
                                                                                     "bottom": 1878
                                                                                 },
                                                                                 "children": [
@@ -287,9 +264,9 @@
                                                                                         "class": "android.widget.ImageView",
                                                                                         "isEnabled": true,
                                                                                         "bounds": {
-                                                                                            "left": 977,
+                                                                                            "left": 1005,
                                                                                             "top": 1811,
-                                                                                            "right": 1022,
+                                                                                            "right": 1050,
                                                                                             "bottom": 1856
                                                                                         }
                                                                                     }
@@ -300,9 +277,9 @@
                                                                                 "class": "android.widget.LinearLayout",
                                                                                 "isEnabled": true,
                                                                                 "bounds": {
-                                                                                    "left": 0,
+                                                                                    "left": 28,
                                                                                     "top": 1914,
-                                                                                    "right": 1080,
+                                                                                    "right": 1108,
                                                                                     "bottom": 2347
                                                                                 },
                                                                                 "children": [
@@ -312,9 +289,9 @@
                                                                                         "class": "android.widget.TextView",
                                                                                         "isEnabled": true,
                                                                                         "bounds": {
-                                                                                            "left": 0,
+                                                                                            "left": 28,
                                                                                             "top": 1950,
-                                                                                            "right": 1080,
+                                                                                            "right": 1108,
                                                                                             "bottom": 1992
                                                                                         }
                                                                                     },
@@ -323,33 +300,31 @@
                                                                                         "class": "android.view.View",
                                                                                         "isEnabled": true,
                                                                                         "bounds": {
-                                                                                            "left": 0,
+                                                                                            "left": 28,
                                                                                             "top": 2010,
-                                                                                            "right": 1080,
+                                                                                            "right": 1108,
                                                                                             "bottom": 2012
                                                                                         }
                                                                                     },
                                                                                     {
-                                                                                        "text": "Spot saved until 11:34 (35 mins)",
                                                                                         "id": "com.doordash.driverapp:id/bottom_view_info_title",
                                                                                         "class": "android.widget.TextView",
                                                                                         "isEnabled": true,
                                                                                         "bounds": {
-                                                                                            "left": 0,
+                                                                                            "left": 28,
                                                                                             "top": 2048,
-                                                                                            "right": 684,
+                                                                                            "right": 100,
                                                                                             "bottom": 2100
                                                                                         }
                                                                                     },
                                                                                     {
-                                                                                        "text": "Traffic conditions are considered in the travel time.",
                                                                                         "id": "com.doordash.driverapp:id/bottom_view_info_subtitle",
                                                                                         "class": "android.widget.TextView",
                                                                                         "isEnabled": true,
                                                                                         "bounds": {
-                                                                                            "left": 0,
+                                                                                            "left": 28,
                                                                                             "top": 2109,
-                                                                                            "right": 894,
+                                                                                            "right": 100,
                                                                                             "bottom": 2151
                                                                                         }
                                                                                     },
@@ -360,9 +335,9 @@
                                                                                         "isClickable": true,
                                                                                         "isEnabled": true,
                                                                                         "bounds": {
-                                                                                            "left": 36,
+                                                                                            "left": 64,
                                                                                             "top": 2204,
-                                                                                            "right": 1044,
+                                                                                            "right": 1072,
                                                                                             "bottom": 2311
                                                                                         },
                                                                                         "children": [
@@ -371,9 +346,9 @@
                                                                                                 "class": "android.widget.ImageView",
                                                                                                 "isEnabled": true,
                                                                                                 "bounds": {
-                                                                                                    "left": 72,
+                                                                                                    "left": 100,
                                                                                                     "top": 2231,
-                                                                                                    "right": 143,
+                                                                                                    "right": 171,
                                                                                                     "bottom": 2284
                                                                                                 }
                                                                                             },
@@ -383,9 +358,9 @@
                                                                                                 "class": "android.widget.TextView",
                                                                                                 "isEnabled": true,
                                                                                                 "bounds": {
-                                                                                                    "left": 449,
+                                                                                                    "left": 477,
                                                                                                     "top": 2225,
-                                                                                                    "right": 632,
+                                                                                                    "right": 660,
                                                                                                     "bottom": 2291
                                                                                                 }
                                                                                             }

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/accessibility/ScreenInfo.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/accessibility/ScreenInfo.kt
@@ -39,8 +39,9 @@ sealed class ScreenInfo {
     data class WaitingForOffer(
         override val screen: Screen,
         val dashPay: Double?,             // e.g. 7.50 (if visible)
-        val waitTimeEstimate: String?,    // e.g. "1-4 min" or "Spot saved until 15:57 (43 mins)"
-        val isHeadingBackToZone: Boolean  // true if "Heading back to zone" text is present
+        val waitTimeEstimate: String?,    // e.g. "1-4 min" (zone wait estimate from new layout)
+        val isHeadingBackToZone: Boolean, // true if "Heading back to zone" text is present
+        val spotSaveDeadline: Long? = null // epoch millis of "Spot saved until HH:mm"; null if not present
     ) : ScreenInfo()
 
     /** Contains the parsed offer details from an Offer Popup screen. */


### PR DESCRIPTION
## Summary

Seven bugs observed in the field during a real dashing session, fixed in one branch.

- **#185** `DashAlongTheWayParser`: spot-save text was going into `waitTimeEstimate` (showed as "Est. wait: Spot saved until…"). Now parsed as epoch millis in new `spotSaveDeadline` field; `ModeAwaiting` shows a live countdown.
- **#186** `WaitingForOfferParser`: new "Finding offers" layout now extracts "Zone offer wait" + adjacent sibling text node for the zone wait estimate; session pay also captured.
- **#187** Deadline prefix stripping: `UtilityFunctions.stripDeadlinePrefix()` added; all six deadline-producing parsers now store just the time in `ParsedTime.text` ("17:39" not "Pick up by 17:39"), fixing the doubled label in the HUD. Also fixes `arrivedAt` not being set on NAVIGATING→SHOPPING transitions (Shop & Deliver), so the wait timer no longer shows "0s".
- **#188** `PickupReducer`: `UpdateBubble` now fires only on status/store changes — not on silent data refreshes (deadline, items, redCard), stopping chat re-posts on every screen oscillation during Shop & Deliver.
- **#191** `PickupShoppingParser`: parses live item count from "To shop (N)" tab label via regex.
- **#195** 24h/12h deadline parsing: covered by the prefix-stripping fix + existing `parseTimeTextToMillis` (already handles both formats).
- **#196** `WaitingForOfferMatcher`: tightened new-layout match to require "Zone offer wait" (or session pay) alongside "Finding offers". Bare "Finding offers" on a map interstitial flash during active pickup now falls through to UNKNOWN. Verified against 8 field snapshots — every genuine new-layout waiting screen has "Zone offer wait"; zero have "Finding offers" alone.

## Test plan

- [x] All unit tests pass (`testDebugUnitTest`)
- [x] `AllMatchersSuite` regression passes
- [x] `InboxProcessorTest` sorted 34 new field snapshots (new-layout WaitingForOffer, DashAlongTheWay with spot-save, PickupShop) correctly
- [x] New "interstitial flash" guard test added to `WaitingForOfferMatcherTest`
- [x] `DashAlongTheWayMatcherTest` updated to assert `spotSaveDeadline != null` instead of old `waitTimeEstimate` text
- [ ] Build to device and dash to verify HUD display

Closes #185, #186, #187, #188, #191, #195, #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)