### PR TITLE
refactor(#204): click pipeline — typed ClickInfo sealed class + package filter + tests

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/view/clicked/ClickClassifier.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/view/clicked/ClickClassifier.kt
@@ -1,32 +1,42 @@
 package cloud.trotter.dashbuddy.pipeline.accessibility.event.type.view.clicked
 
-import cloud.trotter.dashbuddy.domain.model.accessibility.ClickAction
+import cloud.trotter.dashbuddy.domain.model.accessibility.ClickInfo
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import timber.log.Timber
 import javax.inject.Inject
 
+/**
+ * Classifies a clicked [UiNode] into a typed [ClickInfo] subtype.
+ *
+ * Analogous to [ScreenParser] and [NotificationClassifier] — first match wins.
+ * [ClickInfo.Unknown] captures the raw node ID and text so unrecognized clicks
+ * can be identified from field logs and promoted to first-class subtypes.
+ */
 class ClickClassifier @Inject constructor() {
 
-    fun classify(node: UiNode): ClickAction {
+    fun classify(node: UiNode): ClickInfo {
 
-        // --- Accepting an offer
+        // Accepting an offer
         if (node.hasId("accept_button")) {
-            return ClickAction.ACCEPT_OFFER
+            return ClickInfo.AcceptOffer
         }
 
-        // --- Declining an offer
+        // Declining an offer
         if (node.hasText("Decline offer")) {
-            return ClickAction.DECLINE_OFFER
+            return ClickInfo.DeclineOffer
         }
 
-        if (node.hasId("primary_action_button") && (
-                    node.hasText("Arrived at store") ||
-                            node.hasText("Arrived")
-                    )
+        // Arrived at store (pickup navigation)
+        if (node.hasId("primary_action_button") &&
+            (node.hasText("Arrived at store") || node.hasText("Arrived"))
         ) {
-            return ClickAction.ARRIVED_AT_STORE
+            return ClickInfo.ArrivedAtStore
         }
 
-        // --- IGNORE EVERYTHING ELSE ---
-        return ClickAction.UNKNOWN
+        // Unknown — log node identity for future classification
+        val nodeId = node.viewIdResourceName?.takeIf { it.isNotBlank() && it != "no_id" }
+        val nodeText = node.text?.takeIf { it.isNotBlank() }
+        Timber.d("ClickClassifier: UNKNOWN — id=$nodeId text=$nodeText")
+        return ClickInfo.Unknown(nodeId = nodeId, nodeText = nodeText)
     }
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/view/clicked/ClickFactory.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/view/clicked/ClickFactory.kt
@@ -1,7 +1,7 @@
 package cloud.trotter.dashbuddy.pipeline.accessibility.event.type.view.clicked
 
 import cloud.trotter.dashbuddy.core.data.log.ClickLogRepository
-import cloud.trotter.dashbuddy.domain.model.accessibility.ClickAction
+import cloud.trotter.dashbuddy.domain.model.accessibility.ClickInfo
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
 import cloud.trotter.dashbuddy.domain.model.state.ClickEvent
 import timber.log.Timber
@@ -10,13 +10,13 @@ import javax.inject.Inject
 class ClickFactory @Inject constructor(
     private val clickLogRepository: ClickLogRepository
 ) {
-    fun create(node: UiNode, action: ClickAction): ClickEvent {
+    fun create(node: UiNode, info: ClickInfo): ClickEvent {
         val event = ClickEvent(
             timestamp = System.currentTimeMillis(),
-            action = action,
-            sourceNode = node
+            info = info,
+            sourceNode = node,
         )
-        Timber.d("Click Event Created: $action")
+        Timber.d("Click Event Created: $info")
         clickLogRepository.log(event)
         return event
     }

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/view/clicked/ClickedPipeline.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/view/clicked/ClickedPipeline.kt
@@ -12,18 +12,15 @@ import javax.inject.Inject
 class ClickedPipeline @Inject constructor(
     private val source: AccessibilitySource,
     private val classifier: ClickClassifier,
-    private val factory: ClickFactory
+    private val factory: ClickFactory,
 ) {
     fun output(): Flow<StateEvent> = source.events
         .filter { it.eventType == AccessibilityEvent.TYPE_VIEW_CLICKED }
+        .filter { it.packageName == "com.doordash.driverapp" }  // drop non-DD clicks
         .mapNotNull { event ->
             val sourceNode = event.source ?: return@mapNotNull null
             val node = sourceNode.toUiNode() ?: return@mapNotNull null
-
-            // Enrich
-            val action = classifier.classify(node)
-
-            // Produce
-            factory.create(node, action)
+            val info = classifier.classify(node)
+            factory.create(node, info)
         }
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/AppStateV2.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/AppStateV2.kt
@@ -1,6 +1,6 @@
 package cloud.trotter.dashbuddy.state
 
-import cloud.trotter.dashbuddy.domain.model.accessibility.ClickAction
+import cloud.trotter.dashbuddy.domain.model.accessibility.ClickInfo
 import cloud.trotter.dashbuddy.domain.model.accessibility.ParsedTime
 import cloud.trotter.dashbuddy.domain.model.accessibility.Screen
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
@@ -60,7 +60,7 @@ sealed class AppStateV2 {
         val amount: Double?,
         val currentOfferHash: String,
         val currentScreen: Screen,
-        val clickInfo: Pair<Screen, ClickAction>? = null
+        val clickInfo: Pair<Screen, ClickInfo>? = null
     ) : AppStateV2()
 
     data class OnPickup(

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/reducers/OfferReducer.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/reducers/OfferReducer.kt
@@ -1,6 +1,6 @@
 package cloud.trotter.dashbuddy.state.reducers
 
-import cloud.trotter.dashbuddy.domain.model.accessibility.ClickAction
+import cloud.trotter.dashbuddy.domain.model.accessibility.ClickInfo
 import cloud.trotter.dashbuddy.domain.model.accessibility.Screen
 import cloud.trotter.dashbuddy.domain.model.accessibility.ScreenInfo
 import cloud.trotter.dashbuddy.domain.model.chat.ChatPersona
@@ -54,16 +54,16 @@ class OfferReducer @Inject constructor(
 
     private fun handleClick(state: AppStateV2.OfferPresented, event: ClickEvent): Transition {
         // 1. Update State (So resolveOutcome works later when the screen changes)
-        val newClickInfo = state.currentScreen to event.action
+        val newClickInfo = state.currentScreen to event.info
 
         // 2. Immediate Feedback (Optimistic UI)
-        val bubbleEffect = when (event.action) {
-            ClickAction.ACCEPT_OFFER -> AppEffect.UpdateBubble(
+        val bubbleEffect = when (event.info) {
+            is ClickInfo.AcceptOffer -> AppEffect.UpdateBubble(
                 "Offer Accepted",
                 persona = ChatPersona.Dispatcher
             )
 
-            ClickAction.DECLINE_OFFER -> AppEffect.UpdateBubble(
+            is ClickInfo.DeclineOffer -> AppEffect.UpdateBubble(
                 "Offer Declined",
                 persona = ChatPersona.Dispatcher
             )
@@ -191,8 +191,8 @@ class OfferReducer @Inject constructor(
         val action = state.clickInfo?.second
 
         return when (action) {
-            ClickAction.ACCEPT_OFFER -> AppEventType.OFFER_ACCEPTED
-            ClickAction.DECLINE_OFFER -> AppEventType.OFFER_DECLINED
+            is ClickInfo.AcceptOffer -> AppEventType.OFFER_ACCEPTED
+            is ClickInfo.DeclineOffer -> AppEventType.OFFER_DECLINED
             else -> AppEventType.OFFER_TIMEOUT
         }
     }

--- a/app/src/test/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/view/clicked/ClickClassifierTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/view/clicked/ClickClassifierTest.kt
@@ -1,0 +1,137 @@
+package cloud.trotter.dashbuddy.pipeline.accessibility.event.type.view.clicked
+
+import cloud.trotter.dashbuddy.domain.model.accessibility.ClickInfo
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ClickClassifierTest {
+
+    private val classifier = ClickClassifier()
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private fun node(
+        viewId: String? = null,
+        text: String? = null,
+        contentDescription: String? = null,
+    ) = UiNode(
+        viewIdResourceName = viewId,
+        text = text,
+        contentDescription = contentDescription,
+    )
+
+    // =========================================================================
+    // AcceptOffer
+    // =========================================================================
+
+    @Test
+    fun `classifies accept_button as AcceptOffer`() {
+        val result = classifier.classify(node(viewId = "accept_button"))
+        assertEquals(ClickInfo.AcceptOffer, result)
+    }
+
+    @Test
+    fun `AcceptOffer takes priority over text when both present`() {
+        val result = classifier.classify(node(viewId = "accept_button", text = "Decline offer"))
+        assertEquals(ClickInfo.AcceptOffer, result)
+    }
+
+    // =========================================================================
+    // DeclineOffer
+    // =========================================================================
+
+    @Test
+    fun `classifies 'Decline offer' text as DeclineOffer`() {
+        val result = classifier.classify(node(text = "Decline offer"))
+        assertEquals(ClickInfo.DeclineOffer, result)
+    }
+
+    @Test
+    fun `DeclineOffer matches case-insensitively`() {
+        // hasText uses ignoreCase = true internally
+        val result = classifier.classify(node(text = "decline offer"))
+        assertEquals(ClickInfo.DeclineOffer, result)
+    }
+
+    // =========================================================================
+    // ArrivedAtStore
+    // =========================================================================
+
+    @Test
+    fun `classifies primary_action_button + 'Arrived at store' text as ArrivedAtStore`() {
+        val result = classifier.classify(
+            node(viewId = "primary_action_button", text = "Arrived at store")
+        )
+        assertEquals(ClickInfo.ArrivedAtStore, result)
+    }
+
+    @Test
+    fun `classifies primary_action_button + 'Arrived' text as ArrivedAtStore`() {
+        val result = classifier.classify(
+            node(viewId = "primary_action_button", text = "Arrived")
+        )
+        assertEquals(ClickInfo.ArrivedAtStore, result)
+    }
+
+    @Test
+    fun `primary_action_button without Arrived text is Unknown`() {
+        val result = classifier.classify(
+            node(viewId = "primary_action_button", text = "Confirm pickup")
+        )
+        assertTrue(result is ClickInfo.Unknown)
+    }
+
+    @Test
+    fun `Arrived text without primary_action_button is Unknown`() {
+        val result = classifier.classify(
+            node(viewId = "some_other_button", text = "Arrived")
+        )
+        assertTrue(result is ClickInfo.Unknown)
+    }
+
+    // =========================================================================
+    // Unknown
+    // =========================================================================
+
+    @Test
+    fun `returns Unknown for unrecognized node`() {
+        val result = classifier.classify(node(viewId = "some_button", text = "Some action"))
+        assertTrue(result is ClickInfo.Unknown)
+    }
+
+    @Test
+    fun `Unknown preserves nodeId for analysis`() {
+        val result = classifier.classify(node(viewId = "confirm_delivery_button"))
+        val unknown = result as ClickInfo.Unknown
+        assertEquals("confirm_delivery_button", unknown.nodeId)
+    }
+
+    @Test
+    fun `Unknown preserves nodeText for analysis`() {
+        val result = classifier.classify(node(viewId = "primary_action_button", text = "Complete delivery"))
+        val unknown = result as ClickInfo.Unknown
+        assertEquals("Complete delivery", unknown.nodeText)
+    }
+
+    @Test
+    fun `Unknown with null viewId and null text has null fields`() {
+        val result = classifier.classify(node())
+        val unknown = result as ClickInfo.Unknown
+        assertNull(unknown.nodeId)
+        assertNull(unknown.nodeText)
+    }
+
+    @Test
+    fun `Unknown strips no_id placeholder from nodeId`() {
+        val result = classifier.classify(node(viewId = "no_id", text = "Got it"))
+        val unknown = result as ClickInfo.Unknown
+        assertNull(unknown.nodeId)
+        assertNotNull(unknown.nodeText)
+    }
+}

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/log/ClickLogRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/log/ClickLogRepository.kt
@@ -70,7 +70,7 @@ class ClickLogRepository @Inject constructor(
         val entryDto = ClickLogEntryDto(
             timestamp = event.timestamp,
             dateReadable = prettyTimeFormat.format(now),
-            action = event.action.name, // Convert Enum to String
+            action = event.info::class.simpleName ?: "Unknown",
             targetId = event.sourceNode.viewIdResourceName,
             targetText = event.sourceNode.text,
             sourceNode = event.sourceNode.toDto() // Map the domain node to UiNodeDto

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/accessibility/ClickAction.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/accessibility/ClickAction.kt
@@ -1,8 +1,0 @@
-package cloud.trotter.dashbuddy.domain.model.accessibility
-
-enum class ClickAction {
-    ACCEPT_OFFER,
-    DECLINE_OFFER,
-    ARRIVED_AT_STORE,
-    UNKNOWN
-}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/accessibility/ClickInfo.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/accessibility/ClickInfo.kt
@@ -1,0 +1,31 @@
+package cloud.trotter.dashbuddy.domain.model.accessibility
+
+/**
+ * Typed result of click classification — analogous to [ScreenInfo] and [NotificationInfo].
+ *
+ * [ClickClassifier] maps a clicked [UiNode] to one of these subtypes. Consumers
+ * (reducers, effect handlers) pattern-match instead of re-checking view IDs or text.
+ *
+ * Unknown clicks carry the raw node ID and text so new patterns can be identified
+ * from field logs and promoted to first-class subtypes.
+ */
+sealed class ClickInfo {
+
+    /** Dasher tapped the accept button on an offer popup. */
+    data object AcceptOffer : ClickInfo()
+
+    /** Dasher tapped the decline button on an offer popup. */
+    data object DeclineOffer : ClickInfo()
+
+    /** Dasher tapped "Arrived at store" on the pickup navigation screen. */
+    data object ArrivedAtStore : ClickInfo()
+
+    /**
+     * Click could not be matched to a known action.
+     * Raw node identifiers are preserved so new click patterns can be classified later.
+     */
+    data class Unknown(
+        val nodeId: String?,
+        val nodeText: String?,
+    ) : ClickInfo()
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/log/clicks/ClickLogEntry.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/log/clicks/ClickLogEntry.kt
@@ -1,12 +1,12 @@
 package cloud.trotter.dashbuddy.domain.model.log.clicks
 
-import cloud.trotter.dashbuddy.domain.model.accessibility.ClickAction
+import cloud.trotter.dashbuddy.domain.model.accessibility.ClickInfo
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
 
 data class ClickLogEntry(
     val timestamp: Long,
     val dateReadable: String, // "12:30:05"
-    val action: ClickAction,
+    val action: ClickInfo,
     val targetId: String?,
     val targetText: String?,
     // We store the specific button node for deep debugging

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/state/ClickEvent.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/state/ClickEvent.kt
@@ -1,10 +1,10 @@
 package cloud.trotter.dashbuddy.domain.model.state
 
-import cloud.trotter.dashbuddy.domain.model.accessibility.ClickAction
+import cloud.trotter.dashbuddy.domain.model.accessibility.ClickInfo
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
 
 data class ClickEvent(
     override val timestamp: Long,
-    val action: ClickAction,
-    val sourceNode: UiNode
+    val info: ClickInfo,
+    val sourceNode: UiNode,
 ) : StateEvent


### PR DESCRIPTION
## Summary

- `ClickAction` enum replaced by `ClickInfo` sealed class (`AcceptOffer`, `DeclineOffer`, `ArrivedAtStore`, `Unknown`) — same pattern as `ScreenInfo` and `NotificationInfo`
- `Unknown` captures raw `nodeId` and `nodeText` so unrecognized clicks accumulate in field logs and can be promoted to first-class subtypes
- `ClickedPipeline` now filters non-DoorDash package events before classification
- `OfferReducer` and `AppStateV2.OfferPresented` updated to pattern-match on `ClickInfo` subtypes
- `ClickLogRepository` derives action string from `info::class.simpleName` — no enum dependency

Closes #204.

## Test plan

- [x] `ClickClassifierTest` — 13 tests covering all subtypes, edge cases, Unknown field capture
- [x] `AllMatchersSuite` regression — green
- [ ] Field verify: accept/decline offer and arrived-at-store actions still drive state machine correctly after next dash session

🤖 Generated with [Claude Code](https://claude.com/claude-code)