### PR TITLE
feat(#192): JSON rule interpreter — Phase A2

### DIFF
--- a/app/src/main/assets/rules.default.json
+++ b/app/src/main/assets/rules.default.json
@@ -1,0 +1,594 @@
+{
+  "format_version": 1,
+  "platform_id": "doordash.driver",
+  "min_app_version": "0.230.0",
+
+  "screens": [
+
+    {
+      "id": "doordash.screen.sensitive",
+      "platform_id": "doordash.driver",
+      "priority": 0,
+      "overrideable": false,
+      "target": "SENSITIVE",
+      "if": { "allTextContainsAny": [
+        "Bank Account", "Routing Number", "Verify Identity", "Social Security",
+        "Crimson", "Biometric", "Available Balance", "View card details",
+        "Linked accounts", "Debit card", "Account number", "Statements & documents",
+        "Card status", "Lock card", "Emergency contact details", "Withdraw",
+        "Expiry", "Enter the code we sent", "t=completed_view"
+      ]}
+    },
+
+    {
+      "id": "doordash.screen.timeline",
+      "platform_id": "doordash.driver",
+      "priority": 10,
+      "overrideable": true,
+      "target": "TIMELINE_VIEW",
+      "if": { "allTextContainsAll": ["dash ends at", "pause orders"] }
+    },
+
+    {
+      "id": "doordash.screen.offer",
+      "platform_id": "doordash.driver",
+      "priority": 20,
+      "overrideable": true,
+      "branches": [
+        {
+          "target": "OFFER_POPUP_CONFIRM_DECLINE",
+          "if": { "exists": { "hasTextContaining": "sure you want to decline" } }
+        },
+        {
+          "target": "OFFER_POPUP",
+          "guards": [
+            { "exists": { "hasIdSuffix": "progress_bar" } }
+          ],
+          "if": { "all": [
+            { "exists": { "hasText": "Decline" } },
+            { "exists": { "any": [{ "hasText": "Accept" }, { "hasText": "Add to route" }] } }
+          ]}
+        }
+      ]
+    },
+
+    {
+      "id": "doordash.screen.delivery_summary.expanded",
+      "platform_id": "doordash.driver",
+      "priority": 30,
+      "overrideable": true,
+      "target": "DELIVERY_SUMMARY_EXPANDED",
+      "guards": [
+        { "allTextContains": "pause orders" }
+      ],
+      "if": { "all": [
+        { "exists": { "hasIdSuffix": "final_value" } },
+        { "allTextContainsAll": ["this offer", "doordash pay"] }
+      ]}
+    },
+
+    {
+      "id": "doordash.screen.delivery_summary.collapsed",
+      "platform_id": "doordash.driver",
+      "priority": 31,
+      "overrideable": true,
+      "target": "DELIVERY_SUMMARY_COLLAPSED",
+      "guards": [
+        { "allTextContains": "pause orders" }
+      ],
+      "if": { "all": [
+        { "exists": { "hasIdSuffix": "final_value" } },
+        { "any": [
+          { "allTextContains": "this offer" },
+          { "allTextContains": "delivery complete" }
+        ]},
+        { "not": { "allTextContains": "doordash pay" } }
+      ]}
+    },
+
+    {
+      "id": "doordash.screen.app_startup",
+      "platform_id": "doordash.driver",
+      "priority": 40,
+      "overrideable": true,
+      "target": "APP_STARTING_OR_LOADING",
+      "if": { "all": [
+        { "exists": { "all": [
+          { "hasTextCaseSensitive": "Starting\u2026" },
+          { "hasClassNameEndsWith": "TextView" }
+        ]}},
+        { "exists": { "all": [
+          { "hasText": "Cancel" },
+          { "hasClassNameEndsWith": "Button" }
+        ]}}
+      ]}
+    },
+
+    {
+      "id": "doordash.screen.dash_paused",
+      "platform_id": "doordash.driver",
+      "priority": 50,
+      "overrideable": true,
+      "target": "DASH_PAUSED",
+      "if": { "all": [
+        { "exists": { "hasText": "Dash Paused" } },
+        { "exists": { "all": [
+          { "hasIdSuffix": "resumeButton" },
+          { "hasDesc": "Resume dash" }
+        ]}},
+        { "exists": { "hasIdSuffix": "progress_number" } }
+      ]}
+    },
+
+    {
+      "id": "doordash.screen.pickup_navigation",
+      "platform_id": "doordash.driver",
+      "priority": 60,
+      "overrideable": true,
+      "target": "NAVIGATION_VIEW_TO_PICK_UP",
+      "guards": [
+        { "exists": { "all": [
+          { "hasIdSuffix": "bottom_sheet_task_title" },
+          { "hasTextContaining": "Deliver to" }
+        ]}},
+        { "exists": { "all": [
+          { "hasIdSuffix": "bottom_sheet_task_arrive_by" },
+          { "hasTextContaining": "Deliver by" }
+        ]}}
+      ],
+      "if": { "exists": { "hasIdSuffix": "bottom_sheet_task_title" } }
+    },
+
+    {
+      "id": "doordash.screen.dropoff_navigation",
+      "platform_id": "doordash.driver",
+      "priority": 61,
+      "overrideable": true,
+      "branches": [
+        {
+          "target": "NAVIGATION_VIEW_TO_DROP_OFF",
+          "if": { "exists": { "all": [
+            { "hasIdSuffix": "bottom_sheet_task_title" },
+            { "hasTextContaining": "Deliver to" }
+          ]}}
+        },
+        {
+          "target": "NAVIGATION_VIEW_TO_DROP_OFF",
+          "if": { "all": [
+            { "exists": { "all": [
+              { "hasIdSuffix": "bottom_sheet_task_title" },
+              { "hasTextContaining": "Heading to" }
+            ]}},
+            { "exists": { "all": [
+              { "hasIdSuffix": "bottom_sheet_task_arrive_by" },
+              { "hasTextContaining": "Deliver by" }
+            ]}}
+          ]}
+        }
+      ]
+    },
+
+    {
+      "id": "doordash.screen.pickup_arrival",
+      "platform_id": "doordash.driver",
+      "priority": 70,
+      "overrideable": true,
+      "target": "PICKUP_DETAILS_POST_ARRIVAL_PICKUP_SINGLE",
+      "if": { "all": [
+        { "exists": { "all": [
+          { "hasIdSuffix": "customer_name_label" },
+          { "hasTextContaining": "Order for" }
+        ]}},
+        { "exists": { "all": [
+          { "hasIdSuffix": "textView_prism_button_title" },
+          { "any": [
+            { "hasTextContaining": "Confirm" },
+            { "hasTextContaining": "Continue" },
+            { "hasTextContaining": "Start" }
+          ]}
+        ]}}
+      ]}
+    },
+
+    {
+      "id": "doordash.screen.pickup_pre_arrival",
+      "platform_id": "doordash.driver",
+      "priority": 71,
+      "overrideable": true,
+      "target": "PICKUP_DETAILS_PRE_ARRIVAL",
+      "if": { "all": [
+        { "exists": { "all": [
+          { "hasIdSuffix": "user_name_label" },
+          { "hasTextContaining": "Pickup from" }
+        ]}},
+        { "exists": { "all": [
+          { "hasIdSuffix": "textView_prism_button_title" },
+          { "any": [
+            { "hasText": "Directions" },
+            { "hasText": "Arrived at store" }
+          ]}
+        ]}}
+      ]}
+    },
+
+    {
+      "id": "doordash.screen.pickup_shopping",
+      "platform_id": "doordash.driver",
+      "priority": 72,
+      "overrideable": true,
+      "target": "PICKUP_DETAILS_POST_ARRIVAL_SHOP",
+      "if": { "all": [
+        { "exists": { "hasText": "Shop and Deliver" } },
+        { "any": [
+          { "exists": { "hasIdSuffix": "tab_layout" } },
+          { "exists": { "hasTextStartsWith": "To shop" } }
+        ]}
+      ]}
+    },
+
+    {
+      "id": "doordash.screen.dropoff_pre_arrival",
+      "platform_id": "doordash.driver",
+      "priority": 73,
+      "overrideable": true,
+      "target": "DROPOFF_DETAILS_PRE_ARRIVAL",
+      "if": { "all": [
+        { "exists": { "any": [
+          { "hasTextStartsWith": "Deliver to" },
+          { "hasTextStartsWith": "Heading to" }
+        ]}},
+        { "exists": { "any": [
+          { "hasText": "Directions" },
+          { "hasText": "Continue" },
+          { "hasText": "Complete Delivery" },
+          { "hasText": "Call" },
+          { "hasText": "Message" }
+        ]}}
+      ]}
+    },
+
+    {
+      "id": "doordash.screen.schedule",
+      "platform_id": "doordash.driver",
+      "priority": 80,
+      "overrideable": true,
+      "target": "SCHEDULE_VIEW",
+      "if": { "all": [
+        { "exists": { "all": [
+          { "hasText": "Schedule" },
+          { "hasClassName": "android.widget.TextView" }
+        ]}},
+        { "any": [
+          { "exists": { "hasText": "Available" } },
+          { "exists": { "hasText": "Scheduled" } }
+        ]}
+      ]}
+    },
+
+    {
+      "id": "doordash.screen.ratings",
+      "platform_id": "doordash.driver",
+      "priority": 90,
+      "overrideable": true,
+      "target": "RATINGS_VIEW",
+      "if": { "allTextContainsAll": ["ratings", "acceptance rate", "completion rate", "overall"] }
+    },
+
+    {
+      "id": "doordash.screen.safety",
+      "platform_id": "doordash.driver",
+      "priority": 91,
+      "overrideable": true,
+      "target": "SAFETY_VIEW",
+      "if": { "allTextContainsAll": ["safedash", "safety tools", "report safety issue", "share your location"] }
+    },
+
+    {
+      "id": "doordash.screen.chat",
+      "platform_id": "doordash.driver",
+      "priority": 92,
+      "overrideable": true,
+      "target": "CHAT_VIEW",
+      "guards": [
+        { "allTextContains": "folder" }
+      ],
+      "if": { "allTextContainsAll": ["dasher", "messages"] }
+    },
+
+    {
+      "id": "doordash.screen.earnings",
+      "platform_id": "doordash.driver",
+      "priority": 93,
+      "overrideable": true,
+      "target": "EARNINGS_VIEW",
+      "if": { "all": [
+        { "allTextContainsAll": ["earnings", "this week"] },
+        { "allTextContainsAny": ["past weeks", "balance", "crimson"] }
+      ]}
+    },
+
+    {
+      "id": "doordash.screen.help",
+      "platform_id": "doordash.driver",
+      "priority": 94,
+      "overrideable": true,
+      "target": "HELP_VIEW",
+      "if": { "allTextContainsAll": [
+        "doordash dasher", "close webview", "safety resources",
+        "additional resources", "chat with support"
+      ]}
+    },
+
+    {
+      "id": "doordash.screen.navigation_generic",
+      "platform_id": "doordash.driver",
+      "priority": 95,
+      "overrideable": true,
+      "target": "NAVIGATION_VIEW",
+      "guards": [
+        { "allTextContains": "accept" },
+        { "allTextContains": "decline" }
+      ],
+      "if": { "all": [
+        { "allTextContainsAll": ["min", "exit"] },
+        { "allTextContainsAny": ["mi", "ft"] }
+      ]}
+    },
+
+    {
+      "id": "doordash.screen.notifications_view",
+      "platform_id": "doordash.driver",
+      "priority": 96,
+      "overrideable": true,
+      "target": "NOTIFICATIONS_VIEW",
+      "guards": [
+        { "allTextContains": "battery" }
+      ],
+      "if": { "allTextContains": "notifications" }
+    },
+
+    {
+      "id": "doordash.screen.promos",
+      "platform_id": "doordash.driver",
+      "priority": 97,
+      "overrideable": true,
+      "target": "PROMOS_VIEW",
+      "if": { "allTextContainsAll": ["navigate up", "promotions"] }
+    },
+
+    {
+      "id": "doordash.screen.pickup_picked_up",
+      "platform_id": "doordash.driver",
+      "priority": 98,
+      "overrideable": true,
+      "target": "PICKUP_DETAILS_PICKED_UP",
+      "if": { "allTextContainsAll": ["confirm pickup", "loading\u2026"] }
+    },
+
+    {
+      "id": "doordash.screen.pickup_post_arrival_multi",
+      "platform_id": "doordash.driver",
+      "priority": 99,
+      "overrideable": true,
+      "target": "PICKUP_DETAILS_POST_ARRIVAL_PICKUP_MULTI",
+      "guards": [
+        { "allTextContains": "confirm at store" },
+        { "allTextContains": "customer" }
+      ],
+      "if": { "allTextContainsAll": [
+        "pick up", "orders", "you have",
+        "orders to pick up at", "pick up each one to continue"
+      ]}
+    },
+
+    {
+      "id": "doordash.screen.pickup_pre_arrival_multi",
+      "platform_id": "doordash.driver",
+      "priority": 100,
+      "overrideable": true,
+      "target": "PICKUP_DETAILS_PRE_ARRIVAL_PICKUP_MULTI",
+      "if": { "allTextContainsAll": [
+        "confirm at store", "orders", "you have",
+        "orders to pick up at", "pick up each one to continue"
+      ]}
+    },
+
+    {
+      "id": "doordash.screen.pickup_verify",
+      "platform_id": "doordash.driver",
+      "priority": 101,
+      "overrideable": true,
+      "target": "PICKUP_DETAILS_VERIFY_PICKUP",
+      "guards": [
+        { "allTextContains": "pick up by" }
+      ],
+      "if": { "allTextContainsAll": [
+        "verify order", "order for", "confirm pickup", "can't verify order"
+      ]}
+    },
+
+    {
+      "id": "doordash.screen.on_dash_map",
+      "platform_id": "doordash.driver",
+      "priority": 110,
+      "overrideable": true,
+      "target": "MAIN_MAP_ON_DASH",
+      "guards": [
+        { "exists": { "hasDesc": "Earnings Mode Switcher" } },
+        { "exists": { "any": [
+          { "hasTextContaining": "looking for offers" },
+          { "hasTextContaining": "finding offers" }
+        ]}}
+      ],
+      "if": { "exists": { "hasText": "Return to dash" } }
+    },
+
+    {
+      "id": "doordash.screen.dash_along_the_way",
+      "platform_id": "doordash.driver",
+      "priority": 111,
+      "overrideable": true,
+      "target": "ON_DASH_ALONG_THE_WAY",
+      "if": { "all": [
+        { "exists": { "hasIdSuffix": "navigate_button" } },
+        { "any": [
+          { "exists": { "hasIdSuffix": "bottom_view_info_ctd_v2_title" } },
+          { "exists": { "hasIdSuffix": "bottom_view_info_title" } }
+        ]}
+      ]}
+    },
+
+    {
+      "id": "doordash.screen.waiting_for_offer",
+      "platform_id": "doordash.driver",
+      "priority": 120,
+      "overrideable": true,
+      "target": "ON_DASH_MAP_WAITING_FOR_OFFER",
+      "guards": [
+        { "exists": { "hasDesc": "Earnings Mode Switcher" } },
+        { "exists": { "hasText": "Return to dash" } },
+        { "exists": { "hasTextContaining": "look for orders along the way" } }
+      ],
+      "if": { "any": [
+        { "exists": { "hasIdSuffix": "looking_for_order_progress_bar" } },
+        { "exists": { "hasText": "Looking for offers" } },
+        { "all": [
+          { "exists": { "hasTextContaining": "Finding offers" } },
+          { "any": [
+            { "exists": { "hasTextContaining": "Zone offer wait" } },
+            { "exists": { "hasIdSuffix": "running_total_pay" } }
+          ]}
+        ]}
+      ]}
+    },
+
+    {
+      "id": "doordash.screen.set_dash_end_time",
+      "platform_id": "doordash.driver",
+      "priority": 130,
+      "overrideable": true,
+      "target": "SET_DASH_END_TIME",
+      "if": { "all": [
+        { "exists": { "hasIdSuffix": "starting_point_name" } },
+        { "any": [
+          { "exists": { "hasTextContaining": "Select end time" } },
+          { "exists": { "hasIdSuffix": "end_time_description" } }
+        ]}
+      ]}
+    },
+
+    {
+      "id": "doordash.screen.idle_map",
+      "platform_id": "doordash.driver",
+      "priority": 140,
+      "overrideable": true,
+      "target": "MAIN_MAP_IDLE",
+      "guards": [
+        { "exists": { "hasText": "Return to dash" } },
+        { "exists": { "any": [
+          { "hasTextContaining": "looking for offers" },
+          { "hasTextContaining": "finding offers" }
+        ]}}
+      ],
+      "if": { "all": [
+        { "exists": { "hasDesc": "Earnings Mode Switcher" } },
+        { "exists": { "any": [
+          { "hasIdSuffix": "side_nav_compose_view" },
+          { "hasDesc": "Side Menu" }
+        ]}}
+      ]}
+    },
+
+    {
+      "id": "doordash.screen.dash_summary",
+      "platform_id": "doordash.driver",
+      "priority": 150,
+      "overrideable": true,
+      "target": "DASH_SUMMARY_SCREEN",
+      "if": { "all": [
+        { "exists": { "hasText": "Dash summary" } },
+        { "exists": { "all": [
+          { "hasIdSuffix": "textView_prism_button_title" },
+          { "hasText": "Done" }
+        ]}}
+      ]}
+    }
+
+  ],
+
+  "clicks": [
+
+    {
+      "id": "doordash.click.accept_offer",
+      "platform_id": "doordash.driver",
+      "priority": 10,
+      "overrideable": true,
+      "target": "AcceptOffer",
+      "if": { "hasIdSuffix": "accept_button" }
+    },
+
+    {
+      "id": "doordash.click.decline_offer",
+      "platform_id": "doordash.driver",
+      "priority": 20,
+      "overrideable": true,
+      "target": "DeclineOffer",
+      "if": { "hasText": "Decline offer" }
+    },
+
+    {
+      "id": "doordash.click.arrived_at_store",
+      "platform_id": "doordash.driver",
+      "priority": 30,
+      "overrideable": true,
+      "target": "ArrivedAtStore",
+      "if": { "all": [
+        { "hasIdSuffix": "primary_action_button" },
+        { "any": [
+          { "hasText": "Arrived at store" },
+          { "hasText": "Arrived" }
+        ]}
+      ]}
+    }
+
+  ],
+
+  "notifications": [
+
+    {
+      "id": "doordash.notification.additional_tip",
+      "platform_id": "doordash.driver",
+      "priority": 10,
+      "overrideable": true,
+      "target": "AdditionalTip",
+      "if": { "anyFieldMatchesRegex": "added \\$(\\d+\\.\\d{2}) tip on a past (.+?) order delivered at (\\d{1,2}/\\d{1,2}, \\d{1,2}:\\d{2} [AP]M)" },
+      "extract": {
+        "amount":      { "fromGroup": 1, "transform": "parseDouble" },
+        "storeName":   { "fromGroup": 2, "transform": "trim" },
+        "deliveredAt": { "fromGroup": 3, "transform": "trim" }
+      }
+    },
+
+    {
+      "id": "doordash.notification.new_order",
+      "platform_id": "doordash.driver",
+      "priority": 20,
+      "overrideable": true,
+      "target": "NewOrder",
+      "if": { "titleContains": "new order" }
+    },
+
+    {
+      "id": "doordash.notification.scheduled_expired",
+      "platform_id": "doordash.driver",
+      "priority": 30,
+      "overrideable": true,
+      "target": "ScheduledDashExpired",
+      "if": { "all": [
+        { "anyFieldContains": "scheduled" },
+        { "anyFieldContains": "expired" }
+      ]}
+    }
+
+  ]
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/DashBuddyApplication.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/DashBuddyApplication.kt
@@ -15,6 +15,7 @@ import cloud.trotter.dashbuddy.core.data.settings.AppPreferencesRepository
 import cloud.trotter.dashbuddy.core.data.settings.DevSettingsRepository
 import cloud.trotter.dashbuddy.domain.model.event.EventMetadata
 import cloud.trotter.dashbuddy.log.StateAwareTree
+import cloud.trotter.dashbuddy.rules.JsonRuleInterpreter
 import cloud.trotter.dashbuddy.state.StateManagerV2
 import cloud.trotter.dashbuddy.worker.DailyGasPriceWorker
 import dagger.hilt.android.HiltAndroidApp
@@ -44,6 +45,9 @@ class DashBuddyApplication : Application(), Configuration.Provider {
     // Needed for Hilt to inject repositories into WorkManager classes
     @Inject
     lateinit var workerFactory: HiltWorkerFactory
+
+    @Inject
+    lateinit var jsonRuleInterpreter: JsonRuleInterpreter
 
     // Global Context Accessor (Still useful for Utils, but avoid if possible)
     companion object {
@@ -95,11 +99,14 @@ class DashBuddyApplication : Application(), Configuration.Provider {
             )
         )
 
-        // 2. Initialize State
+        // 2. Load JSON rule interpreter (dual-run validation; Kotlin matchers remain authoritative)
+        jsonRuleInterpreter.loadDefaults()
+
+        // 3. Initialize State
         stateManagerV2.initialize()
         Timber.i("StateManagerV2 initialized.")
 
-        // 3. Schedule Background Tasks
+        // 4. Schedule Background Tasks
         scheduleBackgroundWorkers()
 
         Timber.i("DashBuddyApplication initialized.")

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/view/clicked/ClickClassifier.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/view/clicked/ClickClassifier.kt
@@ -1,28 +1,33 @@
 package cloud.trotter.dashbuddy.pipeline.accessibility.event.type.view.clicked
 
+import cloud.trotter.dashbuddy.BuildConfig
 import cloud.trotter.dashbuddy.domain.model.accessibility.ClickInfo
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import cloud.trotter.dashbuddy.rules.JsonRuleInterpreter
 import timber.log.Timber
 import javax.inject.Inject
 
 /**
  * Classifies a clicked [UiNode] into a typed [ClickInfo] subtype.
  *
- * Analogous to [ScreenParser] and [NotificationClassifier] — first match wins.
- * [ClickInfo.Unknown] captures the raw node ID and text so unrecognized clicks
- * can be identified from field logs and promoted to first-class subtypes.
+ * The Kotlin implementation is authoritative. In debug builds the JSON interpreter runs
+ * in parallel and logs any disagreement via [dualRunClick].
  */
-class ClickClassifier @Inject constructor() {
+class ClickClassifier @Inject constructor(
+    private val interpreter: JsonRuleInterpreter,
+) {
 
     fun classify(node: UiNode): ClickInfo {
 
         // Accepting an offer
         if (node.hasId("accept_button")) {
+            dualRunClick(node, ClickInfo.AcceptOffer)
             return ClickInfo.AcceptOffer
         }
 
         // Declining an offer
         if (node.hasText("Decline offer")) {
+            dualRunClick(node, ClickInfo.DeclineOffer)
             return ClickInfo.DeclineOffer
         }
 
@@ -30,13 +35,36 @@ class ClickClassifier @Inject constructor() {
         if (node.hasId("primary_action_button") &&
             (node.hasText("Arrived at store") || node.hasText("Arrived"))
         ) {
+            dualRunClick(node, ClickInfo.ArrivedAtStore)
             return ClickInfo.ArrivedAtStore
         }
 
         // Unknown — log node identity for future classification
         val nodeId = node.viewIdResourceName?.takeIf { it.isNotBlank() && it != "no_id" }
         val nodeText = node.text?.takeIf { it.isNotBlank() }
+        val result = ClickInfo.Unknown(nodeId = nodeId, nodeText = nodeText)
         Timber.d("ClickClassifier: UNKNOWN — id=$nodeId text=$nodeText")
-        return ClickInfo.Unknown(nodeId = nodeId, nodeText = nodeText)
+        dualRunClick(node, result)
+        return result
+    }
+
+    /**
+     * Debug-only: compare Kotlin classification with JSON interpreter result.
+     * JSON interpreter is never authoritative in this phase.
+     */
+    private fun dualRunClick(node: UiNode, kotlinResult: ClickInfo) {
+        if (!BuildConfig.DEBUG) return
+        val ruleset = interpreter.clickRuleset ?: return
+
+        // For Unknown the JSON ruleset returns null (no rule matched) — that aligns correctly.
+        val jsonResult = ruleset.classifyFirst(node)
+        val kotlinType = kotlinResult::class.simpleName
+        val jsonType = jsonResult?.let { it::class.simpleName } ?: "Unknown(no-rule)"
+        if (kotlinType != jsonType) {
+            Timber.w(
+                "MATCHER_DISAGREE [click] kotlin=$kotlinType json=$jsonType " +
+                    "id=${node.viewIdResourceName} text=${node.text}"
+            )
+        }
     }
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/processing/ScreenClassifier.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/processing/ScreenClassifier.kt
@@ -1,8 +1,10 @@
 package cloud.trotter.dashbuddy.pipeline.accessibility.event.type.window.processing
 
+import cloud.trotter.dashbuddy.BuildConfig
 import cloud.trotter.dashbuddy.domain.model.accessibility.Screen
 import cloud.trotter.dashbuddy.domain.model.accessibility.ScreenInfo
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import cloud.trotter.dashbuddy.rules.JsonRuleInterpreter
 import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -10,22 +12,50 @@ import javax.inject.Singleton
 @Singleton
 class ScreenClassifier @Inject constructor(
     injectedMatchers: Set<@JvmSuppressWildcards ScreenMatcher>,
-    injectedParsers: Set<@JvmSuppressWildcards ScreenParser>
+    injectedParsers: Set<@JvmSuppressWildcards ScreenParser>,
+    private val interpreter: JsonRuleInterpreter,
 ) {
 
-    private val allMatchers = injectedMatchers
-        .sortedByDescending { it.priority }
+    private val allMatchers = injectedMatchers.sortedByDescending { it.priority }
 
     private val parserMap: Map<Screen, ScreenParser> =
         injectedParsers.associateBy { it.targetScreen }
 
     fun identify(node: UiNode): ScreenInfo {
+        // --- Kotlin matchers: authoritative ---
         val screen = allMatchers.firstNotNullOfOrNull { it.matches(node) }
             ?: run {
+                dualRunScreen(node, null)
                 Timber.i("🖥️ SCREEN: UNKNOWN")
                 return ScreenInfo.Simple(Screen.UNKNOWN)
             }
+
+        dualRunScreen(node, screen)
+
         Timber.i("🖥️ SCREEN: ${screen.name}")
         return parserMap[screen]?.parse(node) ?: ScreenInfo.Simple(screen)
+    }
+
+    /**
+     * Debug-only: run the JSON interpreter in parallel and log any disagreement.
+     *
+     * NOTE: DELIVERY_SUMMARY_EXPANDED vs DELIVERY_SUMMARY_COLLAPSED disagreements are
+     * expected — the Kotlin matcher always returns EXPANDED and lets the parser correct
+     * it to COLLAPSED, whereas the JSON rules detect this at the matching step. These
+     * disagreements will resolve when parsers are migrated to Phase A3.
+     *
+     * The JSON interpreter is NEVER authoritative in this phase; logs only.
+     */
+    private fun dualRunScreen(node: UiNode, kotlinResult: Screen?) {
+        if (!BuildConfig.DEBUG) return
+        val ruleset = interpreter.screenRuleset ?: return
+
+        val jsonResult = ruleset.matchFirst(node)
+        if (jsonResult != kotlinResult) {
+            Timber.w(
+                "MATCHER_DISAGREE [screen] kotlin=${kotlinResult?.name ?: "UNKNOWN"} " +
+                    "json=${jsonResult?.name ?: "UNKNOWN"}"
+            )
+        }
     }
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/notification/NotificationClassifier.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/notification/NotificationClassifier.kt
@@ -1,7 +1,9 @@
 package cloud.trotter.dashbuddy.pipeline.notification
 
+import cloud.trotter.dashbuddy.BuildConfig
 import cloud.trotter.dashbuddy.domain.model.notification.NotificationInfo
 import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData
+import cloud.trotter.dashbuddy.rules.JsonRuleInterpreter
 import timber.log.Timber
 import java.util.regex.Pattern
 import javax.inject.Inject
@@ -9,9 +11,8 @@ import javax.inject.Inject
 /**
  * Classifies a [RawNotificationData] into a typed [NotificationInfo] subtype.
  *
- * Analogous to [ScreenParser] in the window pipeline — consumes raw data,
- * returns a strongly-typed result so consumers can pattern-match instead of
- * re-scanning text.
+ * The Kotlin implementation is authoritative. In debug builds the JSON interpreter runs
+ * in parallel and logs any disagreement via [dualRunNotification].
  *
  * Classification priority (first match wins):
  *   1. AdditionalTip  — "added $X.XX tip on a past [store] order delivered at …"
@@ -19,7 +20,9 @@ import javax.inject.Inject
  *   3. ScheduledDashExpired — "scheduled" + "expired" in text
  *   4. Unknown        — everything else; raw text preserved for future analysis
  */
-class NotificationClassifier @Inject constructor() {
+class NotificationClassifier @Inject constructor(
+    private val interpreter: JsonRuleInterpreter,
+) {
 
     // e.g. "added $5.00 tip on a past H-E-B order delivered at 4/26, 3:15 PM"
     private val tipPattern: Pattern = Pattern.compile(
@@ -33,10 +36,10 @@ class NotificationClassifier @Inject constructor() {
         // 1. Additional tip
         val tipMatcher = tipPattern.matcher(fullText)
         if (tipMatcher.find()) {
-            val amountStr = tipMatcher.group(1) ?: return unknown(fullText)
-            val storeName = tipMatcher.group(2) ?: return unknown(fullText)
-            val deliveredAt = tipMatcher.group(3) ?: return unknown(fullText)
-            return try {
+            val amountStr = tipMatcher.group(1) ?: return unknown(raw, fullText)
+            val storeName = tipMatcher.group(2) ?: return unknown(raw, fullText)
+            val deliveredAt = tipMatcher.group(3) ?: return unknown(raw, fullText)
+            val result = try {
                 NotificationInfo.AdditionalTip(
                     amount = amountStr.toDouble(),
                     storeName = storeName.trim(),
@@ -44,13 +47,16 @@ class NotificationClassifier @Inject constructor() {
                 )
             } catch (e: NumberFormatException) {
                 Timber.w("NotificationClassifier: could not parse tip amount '$amountStr'")
-                unknown(fullText)
+                unknown(raw, fullText)
             }
+            dualRunNotification(raw, result)
+            return result
         }
 
         // 2. New order
         val title = raw.title.orEmpty()
         if (title.contains("new order", ignoreCase = true)) {
+            dualRunNotification(raw, NotificationInfo.NewOrder)
             return NotificationInfo.NewOrder
         }
 
@@ -58,15 +64,37 @@ class NotificationClassifier @Inject constructor() {
         if (fullText.contains("scheduled", ignoreCase = true) &&
             fullText.contains("expired", ignoreCase = true)
         ) {
+            dualRunNotification(raw, NotificationInfo.ScheduledDashExpired)
             return NotificationInfo.ScheduledDashExpired
         }
 
         // 4. Unknown — preserve raw text for later analysis
-        return unknown(fullText)
+        return unknown(raw, fullText)
     }
 
-    private fun unknown(rawText: String): NotificationInfo.Unknown {
+    private fun unknown(raw: RawNotificationData, rawText: String): NotificationInfo.Unknown {
         Timber.d("NotificationClassifier: UNKNOWN — $rawText")
-        return NotificationInfo.Unknown(rawText)
+        val result = NotificationInfo.Unknown(rawText)
+        dualRunNotification(raw, result)
+        return result
+    }
+
+    /**
+     * Debug-only: compare Kotlin classification with JSON interpreter result.
+     * JSON interpreter is never authoritative in this phase.
+     */
+    private fun dualRunNotification(raw: RawNotificationData, kotlinResult: NotificationInfo) {
+        if (!BuildConfig.DEBUG) return
+        val ruleset = interpreter.notificationRuleset ?: return
+
+        val jsonResult = ruleset.classifyFirst(raw)
+        val kotlinType = kotlinResult::class.simpleName
+        val jsonType = jsonResult?.let { it::class.simpleName } ?: "Unknown(no-rule)"
+        if (kotlinType != jsonType) {
+            Timber.w(
+                "MATCHER_DISAGREE [notification] kotlin=$kotlinType json=$jsonType " +
+                    "text=${raw.toFullString().take(120)}"
+            )
+        }
     }
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/rules/ClickRuleset.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/rules/ClickRuleset.kt
@@ -1,0 +1,28 @@
+package cloud.trotter.dashbuddy.rules
+
+import cloud.trotter.dashbuddy.domain.model.accessibility.ClickInfo
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+
+/**
+ * Immutable, pre-sorted list of compiled click rules.
+ *
+ * Click predicates operate on a single [UiNode] (the tapped element) — no tree traversal.
+ * Rules are sorted ascending by priority (lower = evaluated first).
+ */
+class ClickRuleset(rules: List<CompiledClickRule>) {
+
+    private val sorted: List<CompiledClickRule> = rules.sortedBy { it.priority }
+
+    val ruleCount: Int get() = sorted.size
+
+    /**
+     * Evaluate the sorted rules against [node] and return the first matching [ClickInfo],
+     * or null if no rule matches (caller should fall back to [ClickInfo.Unknown]).
+     */
+    fun classifyFirst(node: UiNode): ClickInfo? {
+        for (rule in sorted) {
+            if (rule.condition(node)) return rule.factory(node)
+        }
+        return null
+    }
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/rules/CompiledRules.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/rules/CompiledRules.kt
@@ -1,0 +1,56 @@
+package cloud.trotter.dashbuddy.rules
+
+import cloud.trotter.dashbuddy.domain.model.accessibility.ClickInfo
+import cloud.trotter.dashbuddy.domain.model.accessibility.Screen
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import cloud.trotter.dashbuddy.domain.model.notification.NotificationInfo
+import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData
+
+/**
+ * A single branch within a [CompiledScreenRule].
+ *
+ * @param target    The [Screen] enum value to return on match.
+ * @param guards    If ANY guard lambda returns true, this branch is skipped.
+ * @param condition The main predicate — must return true for the branch to match.
+ */
+data class CompiledBranch(
+    val target: Screen,
+    val guards: List<(UiNode) -> Boolean>,
+    val condition: (UiNode) -> Boolean,
+)
+
+/**
+ * A compiled screen rule. Single-target rules normalise to a one-element [branches] list.
+ *
+ * Rules are sorted ascending by [priority] (lower = evaluated first).
+ */
+data class CompiledScreenRule(
+    val id: String,
+    val priority: Int,
+    val overrideable: Boolean,
+    val branches: List<CompiledBranch>,
+)
+
+/**
+ * A compiled click rule. Click predicates operate on a single [UiNode] (no tree traversal).
+ *
+ * [factory] is called with the matched node to produce the [ClickInfo] result.
+ */
+data class CompiledClickRule(
+    val id: String,
+    val priority: Int,
+    val overrideable: Boolean,
+    val condition: (UiNode) -> Boolean,
+    val factory: (UiNode) -> ClickInfo,
+)
+
+/**
+ * A compiled notification rule. [classify] handles both matching and extraction in one step,
+ * returning null if the rule does not match.
+ */
+data class CompiledNotificationRule(
+    val id: String,
+    val priority: Int,
+    val overrideable: Boolean,
+    val classify: (RawNotificationData) -> NotificationInfo?,
+)

--- a/app/src/main/java/cloud/trotter/dashbuddy/rules/JsonRuleInterpreter.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/rules/JsonRuleInterpreter.kt
@@ -1,0 +1,88 @@
+package cloud.trotter.dashbuddy.rules
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Singleton that owns the compiled rule rulesets.
+ *
+ * On [loadDefaults], reads `rules.default.json` from app assets, parses it, and compiles
+ * each rule's predicate tree into a JVM lambda via [RuleCompiler]. After this call the
+ * three rulesets are available for use in the pipeline classifiers.
+ *
+ * Security checks applied before parsing:
+ * - File size ≤ [MAX_FILE_BYTES] (1 MB)
+ * - [RuleCompiler.MAX_DEPTH] caps nesting depth during compilation
+ * - [RuleCompiler.MAX_REGEX_LENGTH] caps regex patterns during compilation
+ */
+@Singleton
+class JsonRuleInterpreter @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+
+    var screenRuleset: ScreenRuleset? = null
+        private set
+    var clickRuleset: ClickRuleset? = null
+        private set
+    var notificationRuleset: NotificationRuleset? = null
+        private set
+
+    /** Load the bundled default rules from `assets/rules.default.json`. */
+    fun loadDefaults() {
+        try {
+            val json = context.assets.open(ASSET_NAME).bufferedReader().readText()
+            load(json, source = ASSET_NAME)
+        } catch (e: Exception) {
+            Timber.e(e, "JsonRuleInterpreter: failed to open $ASSET_NAME")
+        }
+    }
+
+    /**
+     * Parse and compile a rules JSON string.
+     * Called by [loadDefaults] and will be called by the CDN fetch path in Phase A3+.
+     */
+    fun load(jsonString: String, source: String = "unknown") {
+        if (jsonString.length > MAX_FILE_BYTES) {
+            Timber.e("JsonRuleInterpreter: $source exceeds size limit (${jsonString.length} bytes)")
+            return
+        }
+
+        try {
+            val root = Json.parseToJsonElement(jsonString).jsonObject
+
+            val screens = root["screens"]?.jsonArray
+                ?.let { RuleCompiler.compileScreenRules(it) }
+                ?: emptyList()
+            val clicks = root["clicks"]?.jsonArray
+                ?.let { RuleCompiler.compileClickRules(it) }
+                ?: emptyList()
+            val notifications = root["notifications"]?.jsonArray
+                ?.let { RuleCompiler.compileNotificationRules(it) }
+                ?: emptyList()
+
+            screenRuleset = ScreenRuleset(screens)
+            clickRuleset = ClickRuleset(clicks)
+            notificationRuleset = NotificationRuleset(notifications)
+
+            Timber.i(
+                "JsonRuleInterpreter: loaded from '$source' " +
+                    "(screens=${screens.size}, clicks=${clicks.size}, notifications=${notifications.size})"
+            )
+        } catch (e: RuleCompileException) {
+            Timber.e(e, "JsonRuleInterpreter: compile error in '$source'")
+        } catch (e: Exception) {
+            Timber.e(e, "JsonRuleInterpreter: parse error in '$source'")
+        }
+    }
+
+    companion object {
+        private const val ASSET_NAME = "rules.default.json"
+        private const val MAX_FILE_BYTES = 1_000_000  // 1 MB
+    }
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/rules/NotificationRuleset.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/rules/NotificationRuleset.kt
@@ -1,0 +1,29 @@
+package cloud.trotter.dashbuddy.rules
+
+import cloud.trotter.dashbuddy.domain.model.notification.NotificationInfo
+import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData
+
+/**
+ * Immutable, pre-sorted list of compiled notification rules.
+ *
+ * Rules are sorted ascending by priority (lower = evaluated first).
+ * Each rule's [CompiledNotificationRule.classify] lambda handles both matching and extraction.
+ */
+class NotificationRuleset(rules: List<CompiledNotificationRule>) {
+
+    private val sorted: List<CompiledNotificationRule> = rules.sortedBy { it.priority }
+
+    val ruleCount: Int get() = sorted.size
+
+    /**
+     * Evaluate the sorted rules against [raw] and return the first matching [NotificationInfo],
+     * or null if no rule matches (caller should fall back to [NotificationInfo.Unknown]).
+     */
+    fun classifyFirst(raw: RawNotificationData): NotificationInfo? {
+        for (rule in sorted) {
+            val result = rule.classify(raw)
+            if (result != null) return result
+        }
+        return null
+    }
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/rules/RuleCompileException.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/rules/RuleCompileException.kt
@@ -1,0 +1,5 @@
+package cloud.trotter.dashbuddy.rules
+
+/** Thrown when a rule JSON cannot be compiled into a valid lambda. */
+class RuleCompileException(message: String, cause: Throwable? = null) :
+    Exception(message, cause)

--- a/app/src/main/java/cloud/trotter/dashbuddy/rules/RuleCompiler.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/rules/RuleCompiler.kt
@@ -1,0 +1,474 @@
+package cloud.trotter.dashbuddy.rules
+
+import cloud.trotter.dashbuddy.domain.model.accessibility.ClickInfo
+import cloud.trotter.dashbuddy.domain.model.accessibility.Screen
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import cloud.trotter.dashbuddy.domain.model.notification.NotificationInfo
+import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Compiles a parsed `rules.json` [JsonElement] tree into typed lambda rulesets.
+ *
+ * The compilation happens once at startup; the resulting lambdas are pure JVM closures
+ * with no further JSON parsing on the hot path.
+ *
+ * Security caps enforced at compile time:
+ * - [MAX_DEPTH] — maximum nesting depth of predicate objects (prevents stack overflows)
+ * - [MAX_REGEX_LENGTH] — maximum characters in any regex pattern (mitigates ReDoS)
+ *
+ * This object knows about [Screen], [ClickInfo], and [NotificationInfo] by design —
+ * the target name → domain type mapping is a fixed table; new subtypes require an app update.
+ */
+object RuleCompiler {
+
+    const val MAX_DEPTH = 20
+    const val MAX_REGEX_LENGTH = 200
+
+    // ==========================================================================
+    //  Screen rules
+    // ==========================================================================
+
+    fun compileScreenRules(array: JsonArray): List<CompiledScreenRule> =
+        array.map { compileScreenRule(it.jsonObject) }
+
+    private fun compileScreenRule(obj: JsonObject): CompiledScreenRule {
+        val id = obj["id"]!!.jsonPrimitive.content
+        val priority = obj["priority"]!!.jsonPrimitive.int
+        val overrideable = obj["overrideable"]?.jsonPrimitive?.booleanOrNull ?: true
+
+        val branches: List<CompiledBranch> = if ("branches" in obj) {
+            obj["branches"]!!.jsonArray.map { compileBranch(it.jsonObject) }
+        } else {
+            listOf(compileBranch(obj))
+        }
+
+        return CompiledScreenRule(id, priority, overrideable, branches)
+    }
+
+    private fun compileBranch(obj: JsonObject): CompiledBranch {
+        val targetName = obj["target"]!!.jsonPrimitive.content
+        val target = try {
+            Screen.valueOf(targetName)
+        } catch (e: IllegalArgumentException) {
+            throw RuleCompileException("Unknown Screen target: '$targetName'", e)
+        }
+        val guards = obj["guards"]?.jsonArray?.map { compileTreePred(it) } ?: emptyList()
+        val condition = compileTreePred(obj["if"]!!)
+        return CompiledBranch(target, guards, condition)
+    }
+
+    // ==========================================================================
+    //  Click rules
+    // ==========================================================================
+
+    fun compileClickRules(array: JsonArray): List<CompiledClickRule> =
+        array.map { compileClickRule(it.jsonObject) }
+
+    private fun compileClickRule(obj: JsonObject): CompiledClickRule {
+        val id = obj["id"]!!.jsonPrimitive.content
+        val priority = obj["priority"]!!.jsonPrimitive.int
+        val overrideable = obj["overrideable"]?.jsonPrimitive?.booleanOrNull ?: true
+        val targetName = obj["target"]!!.jsonPrimitive.content
+        val condition = compileNodePred(obj["if"]!!)
+
+        val factory: (UiNode) -> ClickInfo = when (targetName) {
+            "AcceptOffer" -> { _ -> ClickInfo.AcceptOffer }
+            "DeclineOffer" -> { _ -> ClickInfo.DeclineOffer }
+            "ArrivedAtStore" -> { _ -> ClickInfo.ArrivedAtStore }
+            else -> throw RuleCompileException("Unknown click target: '$targetName'")
+        }
+
+        return CompiledClickRule(id, priority, overrideable, condition, factory)
+    }
+
+    // ==========================================================================
+    //  Notification rules
+    // ==========================================================================
+
+    fun compileNotificationRules(array: JsonArray): List<CompiledNotificationRule> =
+        array.map { compileNotificationRule(it.jsonObject) }
+
+    private fun compileNotificationRule(obj: JsonObject): CompiledNotificationRule {
+        val id = obj["id"]!!.jsonPrimitive.content
+        val priority = obj["priority"]!!.jsonPrimitive.int
+        val overrideable = obj["overrideable"]?.jsonPrimitive?.booleanOrNull ?: true
+        val targetName = obj["target"]!!.jsonPrimitive.content
+        val ifJson = obj["if"]
+        val extract = obj["extract"] as? JsonObject
+
+        val classify: (RawNotificationData) -> NotificationInfo? = when {
+            targetName == "AdditionalTip" && extract != null ->
+                compileAdditionalTipRule(ifJson!!, extract)
+
+            targetName == "NewOrder" -> {
+                val pred = ifJson?.let { compileNotifPred(it) }
+                ;{ raw -> if (pred == null || pred(raw)) NotificationInfo.NewOrder else null }
+            }
+
+            targetName == "ScheduledDashExpired" -> {
+                val pred = ifJson?.let { compileNotifPred(it) }
+                ;{ raw -> if (pred == null || pred(raw)) NotificationInfo.ScheduledDashExpired else null }
+            }
+
+            else -> throw RuleCompileException("Unknown notification target: '$targetName'")
+        }
+
+        return CompiledNotificationRule(id, priority, overrideable, classify)
+    }
+
+    /**
+     * AdditionalTip requires regex group extraction. The `if` block must use
+     * `anyFieldMatchesRegex` so the same regex that matches can also extract groups.
+     */
+    private fun compileAdditionalTipRule(
+        ifJson: JsonElement,
+        @Suppress("UNUSED_PARAMETER") extract: JsonObject,
+    ): (RawNotificationData) -> NotificationInfo? {
+        val ifObj = ifJson.jsonObject
+        val pattern = ifObj["anyFieldMatchesRegex"]?.jsonPrimitive?.content
+            ?: throw RuleCompileException("AdditionalTip rule must use anyFieldMatchesRegex in 'if'")
+        val regex = compileRegex(pattern)
+
+        return { raw ->
+            run {
+                val m = regex.find(raw.toFullString()) ?: return@run null
+                val amount = m.groupValues.getOrNull(1)?.toDoubleOrNull() ?: return@run null
+                val storeName = m.groupValues.getOrNull(2)?.trim() ?: return@run null
+                val deliveredAt = m.groupValues.getOrNull(3)?.trim() ?: return@run null
+                NotificationInfo.AdditionalTip(amount, storeName, deliveredAt)
+            }
+        }
+    }
+
+    // ==========================================================================
+    //  Tree predicate compiler  (operates on full UiNode tree)
+    // ==========================================================================
+
+    /**
+     * Compile a tree-level predicate from a [JsonElement].
+     *
+     * Tree predicates: `exists`, `notExists`, `allTextContains`, `allTextContainsAll`,
+     * `allTextContainsAny`, `all`, `any`, `not`.
+     *
+     * NOTE: All when-branches that end with a lambda literal use a leading `;` to prevent
+     * Kotlin from parsing the lambda as a trailing argument to the preceding expression.
+     */
+    fun compileTreePred(json: JsonElement, depth: Int = 0): (UiNode) -> Boolean {
+        if (depth > MAX_DEPTH)
+            throw RuleCompileException("Predicate nesting exceeds MAX_DEPTH=$MAX_DEPTH")
+
+        val obj = json as? JsonObject
+            ?: throw RuleCompileException("Tree predicate must be a JSON object, got: $json")
+        val key = obj.keys.firstOrNull()
+            ?: throw RuleCompileException("Empty tree predicate object")
+        val value = obj[key]!!
+
+        return when (key) {
+            "exists" -> {
+                val nodePred = compileNodePred(value, depth + 1)
+                ;{ tree -> tree.findNode(nodePred) != null }
+            }
+            "notExists" -> {
+                val nodePred = compileNodePred(value, depth + 1)
+                ;{ tree -> tree.findNode(nodePred) == null }
+            }
+            "allTextContains" -> {
+                val text = (value as? JsonPrimitive)?.content?.lowercase()
+                    ?: throw RuleCompileException("allTextContains requires a string value")
+                ;{ tree -> tree.allText.joinToString(" | ").lowercase().contains(text) }
+            }
+            "allTextContainsAll" -> {
+                val texts = (value as? JsonArray)
+                    ?.map { (it as JsonPrimitive).content.lowercase() }
+                    ?: throw RuleCompileException("allTextContainsAll requires an array")
+                ;{ tree ->
+                    val joined = tree.allText.joinToString(" | ").lowercase()
+                    texts.all { joined.contains(it) }
+                }
+            }
+            "allTextContainsAny" -> {
+                val texts = (value as? JsonArray)
+                    ?.map { (it as JsonPrimitive).content.lowercase() }
+                    ?: throw RuleCompileException("allTextContainsAny requires an array")
+                ;{ tree ->
+                    val joined = tree.allText.joinToString(" | ").lowercase()
+                    texts.any { joined.contains(it) }
+                }
+            }
+            "all" -> {
+                val preds = (value as? JsonArray)
+                    ?.map { compileTreePred(it, depth + 1) }
+                    ?: throw RuleCompileException("all requires an array")
+                ;{ tree -> preds.all { it(tree) } }
+            }
+            "any" -> {
+                val preds = (value as? JsonArray)
+                    ?.map { compileTreePred(it, depth + 1) }
+                    ?: throw RuleCompileException("any requires an array")
+                ;{ tree -> preds.any { it(tree) } }
+            }
+            "not" -> {
+                val pred = compileTreePred(value, depth + 1)
+                ;{ tree -> !pred(tree) }
+            }
+            else -> throw RuleCompileException("Unknown tree predicate key: '$key'")
+        }
+    }
+
+    // ==========================================================================
+    //  Node predicate compiler  (operates on a single UiNode)
+    // ==========================================================================
+
+    /**
+     * Compile a node-level predicate from a [JsonElement].
+     *
+     * Used inside `exists`/`notExists` (tree → node transition), and directly for click rules
+     * (which operate on a single tapped node rather than a full tree).
+     *
+     * NOTE: All when-branches that end with a lambda literal use a leading `;` to prevent
+     * Kotlin from parsing the lambda as a trailing argument to the preceding expression.
+     */
+    fun compileNodePred(json: JsonElement, depth: Int = 0): (UiNode) -> Boolean {
+        if (depth > MAX_DEPTH)
+            throw RuleCompileException("Predicate nesting exceeds MAX_DEPTH=$MAX_DEPTH")
+
+        val obj = json as? JsonObject
+            ?: throw RuleCompileException("Node predicate must be a JSON object, got: $json")
+        val key = obj.keys.firstOrNull()
+            ?: throw RuleCompileException("Empty node predicate object")
+        val value = obj[key]!!
+
+        return when (key) {
+            // --- ID predicates ---
+            "hasIdSuffix" -> {
+                val s = (value as JsonPrimitive).content
+                ;{ node -> node.viewIdResourceName?.endsWith(s, ignoreCase = true) == true }
+            }
+            "hasIdExact" -> {
+                val s = (value as JsonPrimitive).content
+                ;{ node -> node.viewIdResourceName == s }
+            }
+            "hasIdContaining" -> {
+                val s = (value as JsonPrimitive).content
+                ;{ node -> node.viewIdResourceName?.contains(s) == true }
+            }
+            "hasNoId" ->
+                { node -> node.viewIdResourceName.isNullOrBlank() }
+
+            // --- Text predicates ---
+            "hasText" -> {
+                val s = (value as JsonPrimitive).content
+                ;{ node -> node.text?.equals(s, ignoreCase = true) == true }
+            }
+            "hasTextCaseSensitive" -> {
+                val s = (value as JsonPrimitive).content
+                ;{ node -> node.text == s }
+            }
+            "hasTextContaining" -> {
+                val s = (value as JsonPrimitive).content
+                ;{ node -> node.text?.contains(s, ignoreCase = true) == true }
+            }
+            "hasTextStartsWith" -> {
+                val s = (value as JsonPrimitive).content
+                ;{ node -> node.text?.startsWith(s, ignoreCase = true) == true }
+            }
+            "hasTextMatchesRegex" -> {
+                val regex = compileRegex((value as JsonPrimitive).content)
+                ;{ node -> node.text?.let { str -> regex.containsMatchIn(str) } == true }
+            }
+
+            // --- Content description predicates ---
+            "hasDesc" -> {
+                val s = (value as JsonPrimitive).content
+                ;{ node -> node.contentDescription?.equals(s, ignoreCase = true) == true }
+            }
+            "hasDescContaining" -> {
+                val s = (value as JsonPrimitive).content
+                ;{ node -> node.contentDescription?.contains(s, ignoreCase = true) == true }
+            }
+
+            // --- State description predicates ---
+            "hasStateDescription" -> {
+                val s = (value as JsonPrimitive).content
+                ;{ node -> node.stateDescription?.equals(s, ignoreCase = true) == true }
+            }
+            "hasStateDescriptionContaining" -> {
+                val s = (value as JsonPrimitive).content
+                ;{ node -> node.stateDescription?.contains(s, ignoreCase = true) == true }
+            }
+
+            // --- Class name predicates ---
+            "hasClassName" -> {
+                val s = (value as JsonPrimitive).content
+                ;{ node -> node.className == s }
+            }
+            "hasClassNameEndsWith" -> {
+                val s = (value as JsonPrimitive).content
+                ;{ node -> node.className?.endsWith(s, ignoreCase = true) == true }
+            }
+
+            // --- Boolean flag predicates (value is ignored; presence of key is the signal) ---
+            "isClickable" -> { node -> node.isClickable }
+            "isEnabled" -> { node -> node.isEnabled }
+            "isChecked" -> { node -> node.isChecked != 0 }
+            "hasChildren" -> { node -> node.children.isNotEmpty() }
+            "isLeaf" -> { node -> node.children.isEmpty() }
+
+            // --- Logical combinators (node-level: children are also node predicates) ---
+            "all" -> {
+                val preds = (value as? JsonArray)
+                    ?.map { compileNodePred(it, depth + 1) }
+                    ?: throw RuleCompileException("all requires an array")
+                ;{ node -> preds.all { it(node) } }
+            }
+            "any" -> {
+                val preds = (value as? JsonArray)
+                    ?.map { compileNodePred(it, depth + 1) }
+                    ?: throw RuleCompileException("any requires an array")
+                ;{ node -> preds.any { it(node) } }
+            }
+            "not" -> {
+                val pred = compileNodePred(value, depth + 1)
+                ;{ node -> !pred(node) }
+            }
+
+            else -> throw RuleCompileException("Unknown node predicate key: '$key'")
+        }
+    }
+
+    // ==========================================================================
+    //  Notification predicate compiler
+    // ==========================================================================
+
+    /**
+     * Compile a notification-level predicate from a [JsonElement].
+     *
+     * Predicates operate on [RawNotificationData] flat scalar fields.
+     *
+     * NOTE: All when-branches that end with a lambda literal use a leading `;` to prevent
+     * Kotlin from parsing the lambda as a trailing argument to the preceding expression.
+     */
+    fun compileNotifPred(json: JsonElement, depth: Int = 0): (RawNotificationData) -> Boolean {
+        if (depth > MAX_DEPTH)
+            throw RuleCompileException("Predicate nesting exceeds MAX_DEPTH=$MAX_DEPTH")
+
+        val obj = json as? JsonObject
+            ?: throw RuleCompileException("Notification predicate must be a JSON object")
+        val key = obj.keys.firstOrNull()
+            ?: throw RuleCompileException("Empty notification predicate object")
+        val value = obj[key]!!
+
+        return when (key) {
+            "titleEquals" -> {
+                val s = (value as JsonPrimitive).content
+                ;{ raw -> raw.title?.equals(s, ignoreCase = true) == true }
+            }
+            "titleContains" -> {
+                val s = (value as JsonPrimitive).content
+                ;{ raw -> raw.title?.contains(s, ignoreCase = true) == true }
+            }
+            "titleMatchesRegex" -> {
+                val regex = compileRegex((value as JsonPrimitive).content)
+                ;{ raw -> raw.title?.let { str -> regex.containsMatchIn(str) } == true }
+            }
+            "textEquals" -> {
+                val s = (value as JsonPrimitive).content
+                ;{ raw -> raw.text?.equals(s, ignoreCase = true) == true }
+            }
+            "textContains" -> {
+                val s = (value as JsonPrimitive).content
+                ;{ raw -> raw.text?.contains(s, ignoreCase = true) == true }
+            }
+            "textMatchesRegex" -> {
+                val regex = compileRegex((value as JsonPrimitive).content)
+                ;{ raw -> raw.text?.let { str -> regex.containsMatchIn(str) } == true }
+            }
+            "bigTextContains" -> {
+                val s = (value as JsonPrimitive).content
+                ;{ raw -> raw.bigText?.contains(s, ignoreCase = true) == true }
+            }
+            "bigTextMatchesRegex" -> {
+                val regex = compileRegex((value as JsonPrimitive).content)
+                ;{ raw -> raw.bigText?.let { str -> regex.containsMatchIn(str) } == true }
+            }
+            "tickerTextContains" -> {
+                val s = (value as JsonPrimitive).content
+                ;{ raw -> raw.tickerText?.contains(s, ignoreCase = true) == true }
+            }
+            "tickerTextMatchesRegex" -> {
+                val regex = compileRegex((value as JsonPrimitive).content)
+                ;{ raw -> raw.tickerText?.let { str -> regex.containsMatchIn(str) } == true }
+            }
+            "isClearable" ->
+                { raw -> raw.isClearable }
+            "anyFieldContains" -> {
+                val s = (value as JsonPrimitive).content
+                ;{ raw -> raw.toFullString().contains(s, ignoreCase = true) }
+            }
+            "anyFieldContainsAll" -> {
+                val texts = (value as? JsonArray)
+                    ?.map { (it as JsonPrimitive).content }
+                    ?: throw RuleCompileException("anyFieldContainsAll requires an array")
+                ;{ raw ->
+                    val full = raw.toFullString()
+                    texts.all { full.contains(it, ignoreCase = true) }
+                }
+            }
+            "anyFieldContainsAny" -> {
+                val texts = (value as? JsonArray)
+                    ?.map { (it as JsonPrimitive).content }
+                    ?: throw RuleCompileException("anyFieldContainsAny requires an array")
+                ;{ raw ->
+                    val full = raw.toFullString()
+                    texts.any { full.contains(it, ignoreCase = true) }
+                }
+            }
+            "anyFieldMatchesRegex" -> {
+                val regex = compileRegex((value as JsonPrimitive).content)
+                ;{ raw -> regex.containsMatchIn(raw.toFullString()) }
+            }
+            "all" -> {
+                val preds = (value as? JsonArray)
+                    ?.map { compileNotifPred(it, depth + 1) }
+                    ?: throw RuleCompileException("all requires an array")
+                ;{ raw -> preds.all { it(raw) } }
+            }
+            "any" -> {
+                val preds = (value as? JsonArray)
+                    ?.map { compileNotifPred(it, depth + 1) }
+                    ?: throw RuleCompileException("any requires an array")
+                ;{ raw -> preds.any { it(raw) } }
+            }
+            "not" -> {
+                val pred = compileNotifPred(value, depth + 1)
+                ;{ raw -> !pred(raw) }
+            }
+            else -> throw RuleCompileException("Unknown notification predicate key: '$key'")
+        }
+    }
+
+    // ==========================================================================
+    //  Regex helper
+    // ==========================================================================
+
+    private fun compileRegex(pattern: String): Regex {
+        if (pattern.length > MAX_REGEX_LENGTH)
+            throw RuleCompileException(
+                "Regex pattern length ${pattern.length} exceeds MAX_REGEX_LENGTH=$MAX_REGEX_LENGTH"
+            )
+        return try {
+            Regex(pattern, RegexOption.IGNORE_CASE)
+        } catch (e: Exception) {
+            throw RuleCompileException("Invalid regex pattern: '$pattern'", e)
+        }
+    }
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/rules/ScreenRuleset.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/rules/ScreenRuleset.kt
@@ -1,0 +1,32 @@
+package cloud.trotter.dashbuddy.rules
+
+import cloud.trotter.dashbuddy.domain.model.accessibility.Screen
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+
+/**
+ * Immutable, pre-sorted list of compiled screen rules.
+ *
+ * Rules are sorted ascending by [CompiledScreenRule.priority] (lower number = evaluated first).
+ * The first branch whose guards all pass (none fires) and whose condition returns true wins.
+ */
+class ScreenRuleset(rules: List<CompiledScreenRule>) {
+
+    private val sorted: List<CompiledScreenRule> = rules.sortedBy { it.priority }
+
+    val ruleCount: Int get() = sorted.size
+
+    /**
+     * Evaluate the sorted rules against [tree] and return the first matching [Screen],
+     * or null if no rule matches (caller should fall back to [Screen.UNKNOWN]).
+     */
+    fun matchFirst(tree: UiNode): Screen? {
+        for (rule in sorted) {
+            for (branch in rule.branches) {
+                // Any firing guard disqualifies this branch.
+                if (branch.guards.any { it(tree) }) continue
+                if (branch.condition(tree)) return branch.target
+            }
+        }
+        return null
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/view/clicked/AcceptOfferClickTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/view/clicked/AcceptOfferClickTest.kt
@@ -2,16 +2,18 @@ package cloud.trotter.dashbuddy.pipeline.accessibility.event.type.view.clicked
 
 import cloud.trotter.dashbuddy.domain.model.accessibility.ClickInfo
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import cloud.trotter.dashbuddy.rules.JsonRuleInterpreter
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.mockito.kotlin.mock
 
 /**
  * Regression tests for [ClickClassifier] → [ClickInfo.AcceptOffer].
  */
 class AcceptOfferClickTest {
 
-    private val classifier = ClickClassifier()
+    private val classifier = ClickClassifier(mock<JsonRuleInterpreter>())
 
     private fun node(viewId: String? = null, text: String? = null) =
         UiNode(viewIdResourceName = viewId, text = text)

--- a/app/src/test/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/view/clicked/ArrivedAtStoreClickTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/view/clicked/ArrivedAtStoreClickTest.kt
@@ -2,16 +2,18 @@ package cloud.trotter.dashbuddy.pipeline.accessibility.event.type.view.clicked
 
 import cloud.trotter.dashbuddy.domain.model.accessibility.ClickInfo
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import cloud.trotter.dashbuddy.rules.JsonRuleInterpreter
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.mockito.kotlin.mock
 
 /**
  * Regression tests for [ClickClassifier] → [ClickInfo.ArrivedAtStore].
  */
 class ArrivedAtStoreClickTest {
 
-    private val classifier = ClickClassifier()
+    private val classifier = ClickClassifier(mock<JsonRuleInterpreter>())
 
     private fun node(viewId: String? = null, text: String? = null) =
         UiNode(viewIdResourceName = viewId, text = text)

--- a/app/src/test/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/view/clicked/ClickClassifierTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/view/clicked/ClickClassifierTest.kt
@@ -2,15 +2,17 @@ package cloud.trotter.dashbuddy.pipeline.accessibility.event.type.view.clicked
 
 import cloud.trotter.dashbuddy.domain.model.accessibility.ClickInfo
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import cloud.trotter.dashbuddy.rules.JsonRuleInterpreter
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.mockito.kotlin.mock
 
 class ClickClassifierTest {
 
-    private val classifier = ClickClassifier()
+    private val classifier = ClickClassifier(mock<JsonRuleInterpreter>())
 
     // =========================================================================
     // Helpers

--- a/app/src/test/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/view/clicked/DeclineOfferClickTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/view/clicked/DeclineOfferClickTest.kt
@@ -2,16 +2,18 @@ package cloud.trotter.dashbuddy.pipeline.accessibility.event.type.view.clicked
 
 import cloud.trotter.dashbuddy.domain.model.accessibility.ClickInfo
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import cloud.trotter.dashbuddy.rules.JsonRuleInterpreter
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.mockito.kotlin.mock
 
 /**
  * Regression tests for [ClickClassifier] → [ClickInfo.DeclineOffer].
  */
 class DeclineOfferClickTest {
 
-    private val classifier = ClickClassifier()
+    private val classifier = ClickClassifier(mock<JsonRuleInterpreter>())
 
     private fun node(viewId: String? = null, text: String? = null) =
         UiNode(viewIdResourceName = viewId, text = text)

--- a/app/src/test/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/view/clicked/UnknownClickTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/view/clicked/UnknownClickTest.kt
@@ -2,10 +2,12 @@ package cloud.trotter.dashbuddy.pipeline.accessibility.event.type.view.clicked
 
 import cloud.trotter.dashbuddy.domain.model.accessibility.ClickInfo
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import cloud.trotter.dashbuddy.rules.JsonRuleInterpreter
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.mockito.kotlin.mock
 
 /**
  * Regression tests for [ClickClassifier] → [ClickInfo.Unknown].
@@ -15,7 +17,7 @@ import org.junit.Test
  */
 class UnknownClickTest {
 
-    private val classifier = ClickClassifier()
+    private val classifier = ClickClassifier(mock<JsonRuleInterpreter>())
 
     private fun node(viewId: String? = null, text: String? = null) =
         UiNode(viewIdResourceName = viewId, text = text)

--- a/app/src/test/java/cloud/trotter/dashbuddy/pipeline/notification/AdditionalTipClassifierTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/pipeline/notification/AdditionalTipClassifierTest.kt
@@ -2,9 +2,11 @@ package cloud.trotter.dashbuddy.pipeline.notification
 
 import cloud.trotter.dashbuddy.domain.model.notification.NotificationInfo
 import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData
+import cloud.trotter.dashbuddy.rules.JsonRuleInterpreter
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.mockito.kotlin.mock
 
 /**
  * Regression tests for [NotificationClassifier] → [NotificationInfo.AdditionalTip].
@@ -14,7 +16,7 @@ import org.junit.Test
  */
 class AdditionalTipClassifierTest {
 
-    private val classifier = NotificationClassifier()
+    private val classifier = NotificationClassifier(mock<JsonRuleInterpreter>())
 
     private fun raw(bigText: String? = null, text: String? = null, title: String? = null) =
         RawNotificationData(

--- a/app/src/test/java/cloud/trotter/dashbuddy/pipeline/notification/NewOrderClassifierTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/pipeline/notification/NewOrderClassifierTest.kt
@@ -2,16 +2,18 @@ package cloud.trotter.dashbuddy.pipeline.notification
 
 import cloud.trotter.dashbuddy.domain.model.notification.NotificationInfo
 import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData
+import cloud.trotter.dashbuddy.rules.JsonRuleInterpreter
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.mockito.kotlin.mock
 
 /**
  * Regression tests for [NotificationClassifier] → [NotificationInfo.NewOrder].
  */
 class NewOrderClassifierTest {
 
-    private val classifier = NotificationClassifier()
+    private val classifier = NotificationClassifier(mock<JsonRuleInterpreter>())
 
     private fun raw(title: String? = null, text: String? = null) =
         RawNotificationData(

--- a/app/src/test/java/cloud/trotter/dashbuddy/pipeline/notification/NotificationClassifierTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/pipeline/notification/NotificationClassifierTest.kt
@@ -2,9 +2,11 @@ package cloud.trotter.dashbuddy.pipeline.notification
 
 import cloud.trotter.dashbuddy.domain.model.notification.NotificationInfo
 import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData
+import cloud.trotter.dashbuddy.rules.JsonRuleInterpreter
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.mockito.kotlin.mock
 
 /**
  * Unit tests for [NotificationClassifier].
@@ -14,7 +16,7 @@ import org.junit.Test
  */
 class NotificationClassifierTest {
 
-    private val classifier = NotificationClassifier()
+    private val classifier = NotificationClassifier(mock<JsonRuleInterpreter>())
 
     // =========================================================================
     // Helpers

--- a/app/src/test/java/cloud/trotter/dashbuddy/pipeline/notification/ScheduledDashExpiredClassifierTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/pipeline/notification/ScheduledDashExpiredClassifierTest.kt
@@ -2,16 +2,18 @@ package cloud.trotter.dashbuddy.pipeline.notification
 
 import cloud.trotter.dashbuddy.domain.model.notification.NotificationInfo
 import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData
+import cloud.trotter.dashbuddy.rules.JsonRuleInterpreter
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.mockito.kotlin.mock
 
 /**
  * Regression tests for [NotificationClassifier] → [NotificationInfo.ScheduledDashExpired].
  */
 class ScheduledDashExpiredClassifierTest {
 
-    private val classifier = NotificationClassifier()
+    private val classifier = NotificationClassifier(mock<JsonRuleInterpreter>())
 
     private fun raw(title: String? = null, text: String? = null) =
         RawNotificationData(

--- a/app/src/test/java/cloud/trotter/dashbuddy/pipeline/notification/UnknownNotificationClassifierTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/pipeline/notification/UnknownNotificationClassifierTest.kt
@@ -2,9 +2,11 @@ package cloud.trotter.dashbuddy.pipeline.notification
 
 import cloud.trotter.dashbuddy.domain.model.notification.NotificationInfo
 import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData
+import cloud.trotter.dashbuddy.rules.JsonRuleInterpreter
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.mockito.kotlin.mock
 
 /**
  * Regression tests for [NotificationClassifier] → [NotificationInfo.Unknown].
@@ -15,7 +17,7 @@ import org.junit.Test
  */
 class UnknownNotificationClassifierTest {
 
-    private val classifier = NotificationClassifier()
+    private val classifier = NotificationClassifier(mock<JsonRuleInterpreter>())
 
     private fun raw(title: String? = null, text: String? = null, bigText: String? = null) =
         RawNotificationData(

--- a/app/src/test/java/cloud/trotter/dashbuddy/pipeline/recognition/matchers/InboxProcessorTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/pipeline/recognition/matchers/InboxProcessorTest.kt
@@ -9,7 +9,9 @@ import cloud.trotter.dashbuddy.test.util.SnapshotLibrarian
 import cloud.trotter.dashbuddy.test.util.SnapshotScreenDiagnostics
 import cloud.trotter.dashbuddy.test.util.SnapshotSecurityScanner
 import cloud.trotter.dashbuddy.test.util.SnapshotSession
+import cloud.trotter.dashbuddy.rules.JsonRuleInterpreter
 import cloud.trotter.dashbuddy.test.util.TestMatcherFactory
+import org.mockito.kotlin.mock
 import cloud.trotter.dashbuddy.test.util.TestParserFactory
 import cloud.trotter.dashbuddy.test.util.TestResourceLoader
 import org.junit.AfterClass
@@ -36,7 +38,8 @@ class InboxProcessorTest(
         private val recognizer: ScreenClassifier by lazy {
             ScreenClassifier(
                 injectedMatchers = TestMatcherFactory.createAllMatchers(),
-                injectedParsers = TestParserFactory.createAllParsers()
+                injectedParsers = TestParserFactory.createAllParsers(),
+                interpreter = mock<JsonRuleInterpreter>(),
             )
         }
 

--- a/app/src/test/java/cloud/trotter/dashbuddy/pipeline/recognition/matchers/UnknownScreenAnalysisTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/pipeline/recognition/matchers/UnknownScreenAnalysisTest.kt
@@ -4,9 +4,11 @@ import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
 import cloud.trotter.dashbuddy.domain.model.accessibility.Screen
 import cloud.trotter.dashbuddy.pipeline.accessibility.event.type.window.processing.ScreenClassifier
 import cloud.trotter.dashbuddy.domain.model.accessibility.ScreenInfo
+import cloud.trotter.dashbuddy.rules.JsonRuleInterpreter
 import cloud.trotter.dashbuddy.test.util.TestMatcherFactory
 import cloud.trotter.dashbuddy.test.util.TestParserFactory
 import cloud.trotter.dashbuddy.test.util.TestResourceLoader
+import org.mockito.kotlin.mock
 import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -26,7 +28,8 @@ class UnknownScreenAnalysisTest(filename: String, node: UiNode) {
         private val recognizer: ScreenClassifier by lazy {
             ScreenClassifier(
                 injectedMatchers = TestMatcherFactory.createAllMatchers(),
-                injectedParsers = TestParserFactory.createAllParsers()
+                injectedParsers = TestParserFactory.createAllParsers(),
+                interpreter = mock<JsonRuleInterpreter>(),
             )
         }
 

--- a/app/src/test/java/cloud/trotter/dashbuddy/rules/ClickRulesetTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/rules/ClickRulesetTest.kt
@@ -1,0 +1,150 @@
+package cloud.trotter.dashbuddy.rules
+
+import cloud.trotter.dashbuddy.domain.model.accessibility.ClickInfo
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [ClickRuleset.classifyFirst].
+ */
+class ClickRulesetTest {
+
+    private fun node(viewId: String? = null, text: String? = null) =
+        UiNode(viewIdResourceName = viewId, text = text)
+
+    private fun rule(
+        id: String,
+        priority: Int,
+        condition: (UiNode) -> Boolean,
+        factory: (UiNode) -> ClickInfo,
+    ) = CompiledClickRule(
+        id = id, priority = priority, overrideable = true,
+        condition = condition, factory = factory,
+    )
+
+    // =========================================================================
+    // Basic matching
+    // =========================================================================
+
+    @Test
+    fun `classifyFirst returns null when no rules match`() {
+        val ruleset = ClickRuleset(
+            listOf(rule("r1", 10, { it.viewIdResourceName == "accept_button" }, { ClickInfo.AcceptOffer }))
+        )
+        assertNull(ruleset.classifyFirst(node(viewId = "decline_button")))
+    }
+
+    @Test
+    fun `classifyFirst returns factory result for matching rule`() {
+        val ruleset = ClickRuleset(
+            listOf(rule("r1", 10, { it.viewIdResourceName == "accept_button" }, { ClickInfo.AcceptOffer }))
+        )
+        assertEquals(ClickInfo.AcceptOffer, ruleset.classifyFirst(node(viewId = "accept_button")))
+    }
+
+    // =========================================================================
+    // Priority order (ascending: lower number = evaluated first)
+    // =========================================================================
+
+    @Test
+    fun `first matching rule by priority wins`() {
+        val ruleset = ClickRuleset(
+            listOf(
+                rule("r2", 20, { true }, { ClickInfo.DeclineOffer }),
+                rule("r1", 10, { true }, { ClickInfo.AcceptOffer }),
+            )
+        )
+        // Priority 10 rule wins even though it was added second
+        assertEquals(ClickInfo.AcceptOffer, ruleset.classifyFirst(node()))
+    }
+
+    @Test
+    fun `non-matching rule is skipped and next rule is checked`() {
+        val ruleset = ClickRuleset(
+            listOf(
+                rule("r1", 10, { it.viewIdResourceName == "accept_button" }, { ClickInfo.AcceptOffer }),
+                rule("r2", 20, { it.text == "Decline offer" }, { ClickInfo.DeclineOffer }),
+            )
+        )
+        assertEquals(ClickInfo.DeclineOffer, ruleset.classifyFirst(node(text = "Decline offer")))
+    }
+
+    // =========================================================================
+    // Factory receives the matched node
+    // =========================================================================
+
+    @Test
+    fun `factory lambda receives the matched node`() {
+        var capturedNode: UiNode? = null
+        val ruleset = ClickRuleset(
+            listOf(
+                rule("r1", 10, { true }, { n ->
+                    capturedNode = n
+                    ClickInfo.AcceptOffer
+                })
+            )
+        )
+        val input = node(viewId = "accept_button")
+        ruleset.classifyFirst(input)
+        assertEquals(input, capturedNode)
+    }
+
+    // =========================================================================
+    // ruleCount and empty ruleset
+    // =========================================================================
+
+    @Test
+    fun `empty ruleset returns null`() {
+        assertNull(ClickRuleset(emptyList()).classifyFirst(node()))
+    }
+
+    @Test
+    fun `ruleCount reflects number of compiled rules`() {
+        val ruleset = ClickRuleset(
+            listOf(
+                rule("r1", 10, { false }, { ClickInfo.AcceptOffer }),
+                rule("r2", 20, { false }, { ClickInfo.DeclineOffer }),
+            )
+        )
+        assertEquals(2, ruleset.ruleCount)
+    }
+
+    // =========================================================================
+    // Realistic scenario: AcceptOffer → DeclineOffer → ArrivedAtStore priority
+    // =========================================================================
+
+    @Test
+    fun `AcceptOffer rule fires before DeclineOffer when both conditions true`() {
+        val ruleset = ClickRuleset(
+            listOf(
+                rule("accept", 10,
+                    { it.viewIdResourceName?.endsWith("accept_button") == true },
+                    { ClickInfo.AcceptOffer }),
+                rule("decline", 20,
+                    { it.text?.equals("Decline offer", ignoreCase = true) == true },
+                    { ClickInfo.DeclineOffer }),
+            )
+        )
+        // Node has accept_button ID AND "Decline offer" text — AcceptOffer wins on priority
+        assertEquals(
+            ClickInfo.AcceptOffer,
+            ruleset.classifyFirst(node(viewId = "com.example:id/accept_button", text = "Decline offer"))
+        )
+    }
+
+    @Test
+    fun `Unknown click — no rule matches — returns null`() {
+        val ruleset = ClickRuleset(
+            listOf(
+                rule("accept", 10,
+                    { it.viewIdResourceName?.endsWith("accept_button") == true },
+                    { ClickInfo.AcceptOffer }),
+            )
+        )
+        val result = ruleset.classifyFirst(node(viewId = "some_unknown_button", text = "Got it"))
+        assertNull(result)
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/rules/DefaultRulesIntegrationTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/rules/DefaultRulesIntegrationTest.kt
@@ -1,0 +1,154 @@
+package cloud.trotter.dashbuddy.rules
+
+import cloud.trotter.dashbuddy.domain.model.accessibility.ClickInfo
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import cloud.trotter.dashbuddy.domain.model.notification.NotificationInfo
+import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+
+/**
+ * Integration tests that compile the production [rules.default.json] file and run
+ * the resulting rulesets against known inputs.
+ *
+ * These tests load the file directly from source (no Android Context needed),
+ * bypassing [JsonRuleInterpreter] so no dependency injection is required.
+ */
+class DefaultRulesIntegrationTest {
+
+    private lateinit var screenRuleset: ScreenRuleset
+    private lateinit var clickRuleset: ClickRuleset
+    private lateinit var notificationRuleset: NotificationRuleset
+
+    @Before
+    fun loadRules() {
+        val json = File("src/main/assets/rules.default.json").readText()
+        val root = Json.parseToJsonElement(json).jsonObject
+
+        val screens = root["screens"]?.jsonArray
+            ?.let { RuleCompiler.compileScreenRules(it) } ?: emptyList()
+        val clicks = root["clicks"]?.jsonArray
+            ?.let { RuleCompiler.compileClickRules(it) } ?: emptyList()
+        val notifications = root["notifications"]?.jsonArray
+            ?.let { RuleCompiler.compileNotificationRules(it) } ?: emptyList()
+
+        screenRuleset = ScreenRuleset(screens)
+        clickRuleset = ClickRuleset(clicks)
+        notificationRuleset = NotificationRuleset(notifications)
+    }
+
+    // =========================================================================
+    // Sanity — rule counts are non-zero
+    // =========================================================================
+
+    @Test
+    fun `screen ruleset has rules`() {
+        assertTrue("Expected screen rules, got 0", screenRuleset.ruleCount > 0)
+    }
+
+    @Test
+    fun `click ruleset has rules`() {
+        assertTrue("Expected click rules, got 0", clickRuleset.ruleCount > 0)
+    }
+
+    @Test
+    fun `notification ruleset has rules`() {
+        assertTrue("Expected notification rules, got 0", notificationRuleset.ruleCount > 0)
+    }
+
+    // =========================================================================
+    // Click classification — spot checks matching the Kotlin ClickClassifier
+    // =========================================================================
+
+    @Test
+    fun `accept_button id classifies as AcceptOffer`() {
+        val node = UiNode(viewIdResourceName = "com.doordash.driverapp:id/accept_button")
+        assertEquals(ClickInfo.AcceptOffer, clickRuleset.classifyFirst(node))
+    }
+
+    @Test
+    fun `'Decline offer' text classifies as DeclineOffer`() {
+        val node = UiNode(text = "Decline offer")
+        assertEquals(ClickInfo.DeclineOffer, clickRuleset.classifyFirst(node))
+    }
+
+    @Test
+    fun `primary_action_button + Arrived at store classifies as ArrivedAtStore`() {
+        val node = UiNode(
+            viewIdResourceName = "com.doordash.driverapp:id/primary_action_button",
+            text = "Arrived at store",
+        )
+        assertEquals(ClickInfo.ArrivedAtStore, clickRuleset.classifyFirst(node))
+    }
+
+    @Test
+    fun `unrecognized click node returns null`() {
+        val node = UiNode(viewIdResourceName = "com.doordash.driverapp:id/some_unknown_btn")
+        assertNull(clickRuleset.classifyFirst(node))
+    }
+
+    // =========================================================================
+    // Notification classification — spot checks matching the Kotlin classifier
+    // =========================================================================
+
+    @Test
+    fun `New Order title classifies as NewOrder`() {
+        val raw = raw(title = "New Order")
+        assertEquals(NotificationInfo.NewOrder, notificationRuleset.classifyFirst(raw))
+    }
+
+    @Test
+    fun `Scheduled dash expired notification classifies correctly`() {
+        val raw = raw(text = "Your scheduled dash has expired")
+        assertEquals(NotificationInfo.ScheduledDashExpired, notificationRuleset.classifyFirst(raw))
+    }
+
+    @Test
+    fun `AdditionalTip notification extracts fields correctly`() {
+        val raw = raw(bigText = "added \$5.00 tip on a past H-E-B order delivered at 4/26, 3:15 PM")
+        val result = notificationRuleset.classifyFirst(raw)
+        assertNotNull("Expected AdditionalTip result", result)
+        assertTrue("Expected AdditionalTip, got $result", result is NotificationInfo.AdditionalTip)
+        val tip = result as NotificationInfo.AdditionalTip
+        assertEquals(5.00, tip.amount, 0.001)
+        assertEquals("H-E-B", tip.storeName)
+        assertEquals("4/26, 3:15 PM", tip.deliveredAt)
+    }
+
+    @Test
+    fun `unrecognized notification returns null`() {
+        val raw = raw(title = "DoorDash", text = "Something not yet classified")
+        // None of the rules should match — Unknown falls back to the caller
+        assertNull(notificationRuleset.classifyFirst(raw))
+    }
+
+    // =========================================================================
+    // File loading edge cases
+    // =========================================================================
+
+    @Test
+    fun `file compiles without RuleCompileException`() {
+        // @Before would have thrown if compilation failed; reaching here means success
+        assertTrue(screenRuleset.ruleCount > 0)
+        assertTrue(clickRuleset.ruleCount > 0)
+        assertTrue(notificationRuleset.ruleCount > 0)
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private fun raw(title: String? = null, text: String? = null, bigText: String? = null) =
+        RawNotificationData(
+            title = title, text = text, bigText = bigText, tickerText = null,
+            packageName = "com.doordash.driverapp", postTime = 0L, isClearable = true,
+        )
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/rules/NotificationRulesetTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/rules/NotificationRulesetTest.kt
@@ -1,0 +1,132 @@
+package cloud.trotter.dashbuddy.rules
+
+import cloud.trotter.dashbuddy.domain.model.notification.NotificationInfo
+import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [NotificationRuleset.classifyFirst].
+ */
+class NotificationRulesetTest {
+
+    private fun raw(title: String? = null, text: String? = null, bigText: String? = null) =
+        RawNotificationData(
+            title = title, text = text, bigText = bigText, tickerText = null,
+            packageName = "com.doordash.driverapp", postTime = 0L, isClearable = false,
+        )
+
+    private fun rule(
+        id: String,
+        priority: Int,
+        classify: (RawNotificationData) -> NotificationInfo?,
+    ) = CompiledNotificationRule(id = id, priority = priority, overrideable = true, classify = classify)
+
+    // =========================================================================
+    // Basic matching
+    // =========================================================================
+
+    @Test
+    fun `classifyFirst returns null when no rule matches`() {
+        val ruleset = NotificationRuleset(
+            listOf(rule("r1", 10) { raw ->
+                if (raw.title?.contains("New Order") == true) NotificationInfo.NewOrder else null
+            })
+        )
+        assertNull(ruleset.classifyFirst(raw(title = "DoorDash")))
+    }
+
+    @Test
+    fun `classifyFirst returns first non-null classify result`() {
+        val ruleset = NotificationRuleset(
+            listOf(rule("r1", 10) { NotificationInfo.NewOrder })
+        )
+        assertEquals(NotificationInfo.NewOrder, ruleset.classifyFirst(raw()))
+    }
+
+    // =========================================================================
+    // Priority order (ascending: lower number = evaluated first)
+    // =========================================================================
+
+    @Test
+    fun `lower priority rule wins when both match`() {
+        val ruleset = NotificationRuleset(
+            listOf(
+                rule("high-priority", 10) { NotificationInfo.NewOrder },
+                rule("low-priority", 20) { NotificationInfo.ScheduledDashExpired },
+            )
+        )
+        // Priority-10 rule evaluated first → returns NewOrder
+        assertEquals(NotificationInfo.NewOrder, ruleset.classifyFirst(raw()))
+    }
+
+    @Test
+    fun `skips null-returning rules and continues to next`() {
+        val ruleset = NotificationRuleset(
+            listOf(
+                rule("r1", 10) { null },  // always returns null
+                rule("r2", 20) { NotificationInfo.NewOrder },
+            )
+        )
+        assertEquals(NotificationInfo.NewOrder, ruleset.classifyFirst(raw()))
+    }
+
+    @Test
+    fun `rules are evaluated in ascending priority regardless of insertion order`() {
+        val ruleset = NotificationRuleset(
+            listOf(
+                rule("last", 30) { NotificationInfo.ScheduledDashExpired },
+                rule("first", 10) { null },  // always returns null
+                rule("second", 20) { NotificationInfo.NewOrder },
+            )
+        )
+        // Priority 10 returns null, priority 20 returns NewOrder → NewOrder wins
+        assertEquals(NotificationInfo.NewOrder, ruleset.classifyFirst(raw()))
+    }
+
+    // =========================================================================
+    // AdditionalTip with extraction
+    // =========================================================================
+
+    @Test
+    fun `AdditionalTip rule returns extracted tip data`() {
+        val regex = Regex("""added \$(\d+\.\d{2}) tip on a past (.+?) order delivered at (.*)""")
+        val ruleset = NotificationRuleset(
+            listOf(rule("tip", 10) { raw ->
+                val m = regex.find(raw.toFullString()) ?: return@rule null
+                val amount = m.groupValues[1].toDoubleOrNull() ?: return@rule null
+                NotificationInfo.AdditionalTip(amount, m.groupValues[2].trim(), m.groupValues[3].trim())
+            })
+        )
+        val result = ruleset.classifyFirst(
+            raw(bigText = "added \$5.00 tip on a past H-E-B order delivered at 4/26, 3:15 PM")
+        )
+        assertTrue(result is NotificationInfo.AdditionalTip)
+        val tip = result as NotificationInfo.AdditionalTip
+        assertEquals(5.00, tip.amount, 0.001)
+        assertEquals("H-E-B", tip.storeName)
+    }
+
+    // =========================================================================
+    // ruleCount and empty ruleset
+    // =========================================================================
+
+    @Test
+    fun `empty ruleset returns null`() {
+        assertNull(NotificationRuleset(emptyList()).classifyFirst(raw()))
+    }
+
+    @Test
+    fun `ruleCount reflects number of compiled rules`() {
+        val ruleset = NotificationRuleset(
+            listOf(
+                rule("r1", 10) { null },
+                rule("r2", 20) { null },
+                rule("r3", 30) { null },
+            )
+        )
+        assertEquals(3, ruleset.ruleCount)
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/rules/RuleCompilerTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/rules/RuleCompilerTest.kt
@@ -1,0 +1,456 @@
+package cloud.trotter.dashbuddy.rules
+
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [RuleCompiler] predicate compilation.
+ *
+ * Each test compiles a predicate from a JSON snippet and verifies it returns the
+ * expected boolean for specific inputs. No JSON file on disk is loaded — inputs are
+ * constructed inline.
+ */
+class RuleCompilerTest {
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private fun raw(
+        title: String? = null,
+        text: String? = null,
+        bigText: String? = null,
+        tickerText: String? = null,
+    ) = RawNotificationData(
+        title = title, text = text, bigText = bigText, tickerText = tickerText,
+        packageName = "com.doordash.driverapp", postTime = 0L, isClearable = false,
+    )
+
+    private fun node(
+        viewId: String? = null,
+        text: String? = null,
+        contentDescription: String? = null,
+        className: String? = null,
+        isClickable: Boolean = false,
+        isEnabled: Boolean = false,
+        isChecked: Int = 0,
+    ) = UiNode(
+        viewIdResourceName = viewId,
+        text = text,
+        contentDescription = contentDescription,
+        className = className,
+        isClickable = isClickable,
+        isEnabled = isEnabled,
+        isChecked = isChecked,
+    )
+
+    private fun tree(vararg children: UiNode, text: String? = null): UiNode {
+        val root = UiNode(text = text, children = children.toMutableList())
+        root.restoreParents()
+        return root
+    }
+
+    private fun json(vararg pairs: Pair<String, Any>) = JsonObject(
+        pairs.associate { (k, v) ->
+            k to when (v) {
+                is String -> JsonPrimitive(v)
+                is Boolean -> JsonPrimitive(v)
+                is Int -> JsonPrimitive(v)
+                else -> throw IllegalArgumentException("Unsupported type: ${v::class}")
+            }
+        }
+    )
+
+    private fun parseJson(s: String) = Json.parseToJsonElement(s)
+
+    // =========================================================================
+    // compileNodePred — ID predicates
+    // =========================================================================
+
+    @Test
+    fun `hasIdSuffix matches by suffix`() {
+        val pred = RuleCompiler.compileNodePred(json("hasIdSuffix" to "accept_button"))
+        assertTrue(pred(node(viewId = "com.example:id/accept_button")))
+        assertFalse(pred(node(viewId = "com.example:id/decline_button")))
+    }
+
+    @Test
+    fun `hasIdSuffix is case insensitive`() {
+        val pred = RuleCompiler.compileNodePred(json("hasIdSuffix" to "Accept_Button"))
+        assertTrue(pred(node(viewId = "com.example:id/accept_button")))
+    }
+
+    @Test
+    fun `hasIdSuffix returns false for null viewId`() {
+        val pred = RuleCompiler.compileNodePred(json("hasIdSuffix" to "accept_button"))
+        assertFalse(pred(node(viewId = null)))
+    }
+
+    @Test
+    fun `hasIdExact requires exact match`() {
+        val pred = RuleCompiler.compileNodePred(json("hasIdExact" to "com.example:id/btn"))
+        assertTrue(pred(node(viewId = "com.example:id/btn")))
+        assertFalse(pred(node(viewId = "com.example:id/btn_extra")))
+        assertFalse(pred(node(viewId = null)))
+    }
+
+    @Test
+    fun `hasIdContaining matches substring in viewId`() {
+        val pred = RuleCompiler.compileNodePred(json("hasIdContaining" to "action"))
+        assertTrue(pred(node(viewId = "com.example:id/primary_action_button")))
+        assertFalse(pred(node(viewId = "com.example:id/accept_button")))
+    }
+
+    @Test
+    fun `hasNoId matches null or blank viewId`() {
+        val pred = RuleCompiler.compileNodePred(json("hasNoId" to "true"))
+        assertTrue(pred(node(viewId = null)))
+        assertTrue(pred(node(viewId = "")))
+        assertFalse(pred(node(viewId = "some:id/btn")))
+    }
+
+    // =========================================================================
+    // compileNodePred — text predicates
+    // =========================================================================
+
+    @Test
+    fun `hasText matches exact text case-insensitively`() {
+        val pred = RuleCompiler.compileNodePred(json("hasText" to "Accept"))
+        assertTrue(pred(node(text = "Accept")))
+        assertTrue(pred(node(text = "ACCEPT")))
+        assertTrue(pred(node(text = "accept")))
+        // hasText is equals (not contains), so partial match fails
+        assertFalse(pred(node(text = "Accept offer")))
+        assertFalse(pred(node(text = null)))
+    }
+
+    @Test
+    fun `hasTextCaseSensitive is exact and case-sensitive`() {
+        val pred = RuleCompiler.compileNodePred(json("hasTextCaseSensitive" to "Accept"))
+        assertTrue(pred(node(text = "Accept")))
+        assertFalse(pred(node(text = "ACCEPT")))
+        assertFalse(pred(node(text = "accept")))
+    }
+
+    @Test
+    fun `hasTextContaining matches substring case-insensitively`() {
+        val pred = RuleCompiler.compileNodePred(json("hasTextContaining" to "Decline"))
+        assertTrue(pred(node(text = "Decline offer")))
+        assertTrue(pred(node(text = "decline offer")))
+        assertFalse(pred(node(text = "Accept")))
+        assertFalse(pred(node(text = null)))
+    }
+
+    @Test
+    fun `hasTextStartsWith matches prefix case-insensitively`() {
+        val pred = RuleCompiler.compileNodePred(json("hasTextStartsWith" to "Arrived"))
+        assertTrue(pred(node(text = "Arrived at store")))
+        assertTrue(pred(node(text = "arrived")))
+        assertFalse(pred(node(text = "You Arrived")))
+        assertFalse(pred(node(text = null)))
+    }
+
+    @Test
+    fun `hasTextMatchesRegex uses compiled regex`() {
+        val pred = RuleCompiler.compileNodePred(parseJson("""{"hasTextMatchesRegex": "\\d{1,2}/\\d{1,2}"}"""))
+        assertTrue(pred(node(text = "Delivered at 4/26")))
+        assertFalse(pred(node(text = "No date here")))
+        assertFalse(pred(node(text = null)))
+    }
+
+    // =========================================================================
+    // compileNodePred — content description & class predicates
+    // =========================================================================
+
+    @Test
+    fun `hasDesc matches content description case-insensitively`() {
+        val pred = RuleCompiler.compileNodePred(json("hasDesc" to "close"))
+        assertTrue(pred(node(contentDescription = "Close")))
+        assertFalse(pred(node(contentDescription = "Open")))
+    }
+
+    @Test
+    fun `hasClassNameEndsWith matches class suffix`() {
+        val pred = RuleCompiler.compileNodePred(json("hasClassNameEndsWith" to "TextView"))
+        assertTrue(pred(node(className = "android.widget.TextView")))
+        assertFalse(pred(node(className = "android.widget.Button")))
+    }
+
+    // =========================================================================
+    // compileNodePred — boolean flag predicates
+    // =========================================================================
+
+    @Test
+    fun `isClickable passes for clickable nodes`() {
+        val pred = RuleCompiler.compileNodePred(json("isClickable" to true))
+        assertTrue(pred(node(isClickable = true)))
+        assertFalse(pred(node(isClickable = false)))
+    }
+
+    @Test
+    fun `isEnabled passes for enabled nodes`() {
+        val pred = RuleCompiler.compileNodePred(json("isEnabled" to true))
+        assertTrue(pred(node(isEnabled = true)))
+        assertFalse(pred(node(isEnabled = false)))
+    }
+
+    @Test
+    fun `isChecked passes for checked nodes`() {
+        val pred = RuleCompiler.compileNodePred(json("isChecked" to true))
+        assertTrue(pred(node(isChecked = 1)))
+        assertFalse(pred(node(isChecked = 0)))
+    }
+
+    @Test
+    fun `hasChildren passes for nodes with children`() {
+        val pred = RuleCompiler.compileNodePred(json("hasChildren" to true))
+        val withChild = UiNode(children = mutableListOf(UiNode(text = "child")))
+        assertTrue(pred(withChild))
+        assertFalse(pred(node()))
+    }
+
+    @Test
+    fun `isLeaf passes for nodes without children`() {
+        val pred = RuleCompiler.compileNodePred(json("isLeaf" to true))
+        assertTrue(pred(node()))
+        val withChild = UiNode(children = mutableListOf(UiNode(text = "child")))
+        assertFalse(pred(withChild))
+    }
+
+    // =========================================================================
+    // compileNodePred — logical combinators
+    // =========================================================================
+
+    @Test
+    fun `all requires every predicate to pass`() {
+        val pred = RuleCompiler.compileNodePred(
+            parseJson("""{"all": [{"hasText": "Accept"}, {"isClickable": true}]}""")
+        )
+        assertTrue(pred(node(text = "Accept", isClickable = true)))
+        assertFalse(pred(node(text = "Accept", isClickable = false)))
+        assertFalse(pred(node(text = "Other", isClickable = true)))
+    }
+
+    @Test
+    fun `any passes when at least one predicate passes`() {
+        val pred = RuleCompiler.compileNodePred(
+            parseJson("""{"any": [{"hasText": "Accept"}, {"hasText": "Decline"}]}""")
+        )
+        assertTrue(pred(node(text = "Accept")))
+        assertTrue(pred(node(text = "Decline")))
+        assertFalse(pred(node(text = "Other")))
+    }
+
+    @Test
+    fun `not negates the inner predicate`() {
+        val pred = RuleCompiler.compileNodePred(parseJson("""{"not": {"hasText": "Accept"}}"""))
+        assertFalse(pred(node(text = "Accept")))
+        assertTrue(pred(node(text = "Decline")))
+        assertTrue(pred(node(text = null)))
+    }
+
+    // =========================================================================
+    // compileTreePred
+    // =========================================================================
+
+    @Test
+    fun `allTextContains passes when joined tree text contains substring`() {
+        val pred = RuleCompiler.compileTreePred(json("allTextContains" to "accept"))
+        val t = tree(node(text = "Accept"), text = "Other")
+        assertTrue(pred(t))
+    }
+
+    @Test
+    fun `allTextContains fails when substring not in tree`() {
+        val pred = RuleCompiler.compileTreePred(json("allTextContains" to "missing"))
+        assertFalse(pred(tree(node(text = "Accept"))))
+    }
+
+    @Test
+    fun `allTextContainsAll requires all strings in tree text`() {
+        val pred = RuleCompiler.compileTreePred(
+            parseJson("""{"allTextContainsAll": ["accept", "decline"]}""")
+        )
+        val t = tree(node(text = "Accept"), node(text = "Decline"))
+        assertTrue(pred(t))
+        assertFalse(pred(tree(node(text = "Accept"))))
+    }
+
+    @Test
+    fun `allTextContainsAny requires at least one string in tree text`() {
+        val pred = RuleCompiler.compileTreePred(
+            parseJson("""{"allTextContainsAny": ["accept", "confirm"]}""")
+        )
+        assertTrue(pred(tree(node(text = "Accept"))))
+        assertTrue(pred(tree(node(text = "Confirm pickup"))))
+        assertFalse(pred(tree(node(text = "Other"))))
+    }
+
+    @Test
+    fun `exists passes when matching node found in tree`() {
+        val pred = RuleCompiler.compileTreePred(parseJson("""{"exists": {"hasText": "Accept"}}"""))
+        val t = tree(node(text = "Accept"), node(text = "Other"))
+        assertTrue(pred(t))
+    }
+
+    @Test
+    fun `exists fails when no matching node in tree`() {
+        val pred = RuleCompiler.compileTreePred(parseJson("""{"exists": {"hasText": "Accept"}}"""))
+        assertFalse(pred(tree(node(text = "Decline"))))
+    }
+
+    @Test
+    fun `notExists passes when no matching node`() {
+        val pred = RuleCompiler.compileTreePred(parseJson("""{"notExists": {"hasText": "Accept"}}"""))
+        assertTrue(pred(tree(node(text = "Decline"))))
+        assertFalse(pred(tree(node(text = "Accept"))))
+    }
+
+    @Test
+    fun `tree all combinator`() {
+        val pred = RuleCompiler.compileTreePred(
+            parseJson("""{"all": [{"allTextContains": "foo"}, {"allTextContains": "bar"}]}""")
+        )
+        assertTrue(pred(tree(node(text = "foo"), node(text = "bar"))))
+        assertFalse(pred(tree(node(text = "foo"))))
+    }
+
+    @Test
+    fun `tree not combinator`() {
+        val pred = RuleCompiler.compileTreePred(
+            parseJson("""{"not": {"allTextContains": "sensitive"}}""")
+        )
+        assertTrue(pred(tree(node(text = "Normal screen"))))
+        assertFalse(pred(tree(node(text = "sensitive content"))))
+    }
+
+    // =========================================================================
+    // compileNotifPred
+    // =========================================================================
+
+    @Test
+    fun `titleContains matches notification title case-insensitively`() {
+        val pred = RuleCompiler.compileNotifPred(json("titleContains" to "New Order"))
+        assertTrue(pred(raw(title = "New Order")))
+        assertTrue(pred(raw(title = "NEW ORDER AVAILABLE")))
+        assertFalse(pred(raw(title = "DoorDash")))
+        assertFalse(pred(raw(title = null)))
+    }
+
+    @Test
+    fun `textContains matches notification text`() {
+        val pred = RuleCompiler.compileNotifPred(json("textContains" to "expired"))
+        assertTrue(pred(raw(text = "Your scheduled dash has expired")))
+        assertFalse(pred(raw(text = "Your dash is active")))
+    }
+
+    @Test
+    fun `anyFieldMatchesRegex matches against full text`() {
+        val pred = RuleCompiler.compileNotifPred(
+            parseJson("""{"anyFieldMatchesRegex": "added \\$\\d+\\.\\d{2} tip"}""")
+        )
+        assertTrue(pred(raw(bigText = "added \$5.00 tip on a past H-E-B order delivered at 4/26, 3:15 PM")))
+        assertFalse(pred(raw(text = "You received a tip")))
+    }
+
+    @Test
+    fun `anyFieldContainsAll requires all substrings present across all fields`() {
+        val pred = RuleCompiler.compileNotifPred(
+            parseJson("""{"anyFieldContainsAll": ["scheduled", "expired"]}""")
+        )
+        assertTrue(pred(raw(text = "Your scheduled dash has expired")))
+        assertFalse(pred(raw(text = "Your scheduled dash starts soon")))
+        assertFalse(pred(raw(text = "Your promo has expired")))
+    }
+
+    @Test
+    fun `anyFieldContainsAny passes when any substring matches`() {
+        val pred = RuleCompiler.compileNotifPred(
+            parseJson("""{"anyFieldContainsAny": ["new order", "order available"]}""")
+        )
+        assertTrue(pred(raw(title = "New Order")))
+        assertTrue(pred(raw(text = "An order available for pickup")))
+        assertFalse(pred(raw(title = "DoorDash", text = "Something else")))
+    }
+
+    @Test
+    fun `isClearable matches clearable notifications`() {
+        val pred = RuleCompiler.compileNotifPred(json("isClearable" to true))
+        val clearable = RawNotificationData(
+            title = null, text = null, bigText = null, tickerText = null,
+            packageName = "com.doordash.driverapp", postTime = 0L, isClearable = true,
+        )
+        val notClearable = clearable.copy(isClearable = false)
+        assertTrue(pred(clearable))
+        assertFalse(pred(notClearable))
+    }
+
+    @Test
+    fun `notif not combinator negates predicate`() {
+        val pred = RuleCompiler.compileNotifPred(
+            parseJson("""{"not": {"titleContains": "New Order"}}""")
+        )
+        assertFalse(pred(raw(title = "New Order")))
+        assertTrue(pred(raw(title = "DoorDash")))
+    }
+
+    @Test
+    fun `notif all combinator`() {
+        val pred = RuleCompiler.compileNotifPred(
+            parseJson("""{"all": [{"titleContains": "New"}, {"textContains": "order"}]}""")
+        )
+        assertTrue(pred(raw(title = "New Order", text = "An order is available")))
+        assertFalse(pred(raw(title = "New Order", text = "Something else")))
+        assertFalse(pred(raw(title = "DoorDash", text = "An order is available")))
+    }
+
+    // =========================================================================
+    // Security caps
+    // =========================================================================
+
+    @Test(expected = RuleCompileException::class)
+    fun `regex length exceeding MAX_REGEX_LENGTH throws`() {
+        val pattern = "a".repeat(RuleCompiler.MAX_REGEX_LENGTH + 1)
+        RuleCompiler.compileNodePred(parseJson("""{"hasTextMatchesRegex": "$pattern"}"""))
+    }
+
+    @Test(expected = RuleCompileException::class)
+    fun `invalid regex throws RuleCompileException`() {
+        RuleCompiler.compileNodePred(parseJson("""{"hasTextMatchesRegex": "[invalid("}"""))
+    }
+
+    @Test(expected = RuleCompileException::class)
+    fun `unknown node predicate key throws`() {
+        RuleCompiler.compileNodePred(parseJson("""{"unknownKey": "value"}"""))
+    }
+
+    @Test(expected = RuleCompileException::class)
+    fun `unknown tree predicate key throws`() {
+        RuleCompiler.compileTreePred(parseJson("""{"unknownKey": "value"}"""))
+    }
+
+    @Test(expected = RuleCompileException::class)
+    fun `unknown notif predicate key throws`() {
+        RuleCompiler.compileNotifPred(parseJson("""{"unknownKey": "value"}"""))
+    }
+
+    @Test(expected = RuleCompileException::class)
+    fun `node pred depth limit throws`() {
+        var json = """{"hasText": "x"}"""
+        repeat(RuleCompiler.MAX_DEPTH + 2) { json = """{"not": $json}""" }
+        RuleCompiler.compileNodePred(Json.parseToJsonElement(json))
+    }
+
+    @Test(expected = RuleCompileException::class)
+    fun `tree pred depth limit throws`() {
+        var json = """{"allTextContains": "x"}"""
+        repeat(RuleCompiler.MAX_DEPTH + 2) { json = """{"not": $json}""" }
+        RuleCompiler.compileTreePred(Json.parseToJsonElement(json))
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/rules/ScreenRulesetTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/rules/ScreenRulesetTest.kt
@@ -1,0 +1,185 @@
+package cloud.trotter.dashbuddy.rules
+
+import cloud.trotter.dashbuddy.domain.model.accessibility.Screen
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Unit tests for [ScreenRuleset.matchFirst].
+ *
+ * Rules and branches are constructed directly from [CompiledScreenRule] / [CompiledBranch]
+ * data classes — no JSON parsing involved.
+ */
+class ScreenRulesetTest {
+
+    private fun node(text: String? = null, viewId: String? = null) =
+        UiNode(text = text, viewIdResourceName = viewId)
+
+    private fun branch(
+        target: Screen,
+        guards: List<(UiNode) -> Boolean> = emptyList(),
+        condition: (UiNode) -> Boolean,
+    ) = CompiledBranch(target = target, guards = guards, condition = condition)
+
+    private fun rule(
+        id: String,
+        priority: Int,
+        vararg branches: CompiledBranch,
+    ) = CompiledScreenRule(
+        id = id,
+        priority = priority,
+        overrideable = true,
+        branches = branches.toList(),
+    )
+
+    // =========================================================================
+    // Basic matching
+    // =========================================================================
+
+    @Test
+    fun `matchFirst returns null when no rules match`() {
+        val ruleset = ScreenRuleset(
+            listOf(rule("r1", 10, branch(Screen.OFFER_POPUP) { it.text == "Offer" }))
+        )
+        assertNull(ruleset.matchFirst(node(text = "Something else")))
+    }
+
+    @Test
+    fun `matchFirst returns the target of the matching branch`() {
+        val ruleset = ScreenRuleset(
+            listOf(rule("r1", 10, branch(Screen.OFFER_POPUP) { it.text == "Offer" }))
+        )
+        assertEquals(Screen.OFFER_POPUP, ruleset.matchFirst(node(text = "Offer")))
+    }
+
+    // =========================================================================
+    // Priority order (ascending: lower number = evaluated first)
+    // =========================================================================
+
+    @Test
+    fun `matchFirst evaluates rules in ascending priority order`() {
+        val ruleset = ScreenRuleset(
+            listOf(
+                // Priority 20 — would match IDLE_MAP
+                rule("low-priority", 20, branch(Screen.MAIN_MAP_IDLE) { true }),
+                // Priority 10 — evaluated first; matches OFFER
+                rule("high-priority", 10, branch(Screen.OFFER_POPUP) { true }),
+            )
+        )
+        // Priority-10 rule wins even though it was added second
+        assertEquals(Screen.OFFER_POPUP, ruleset.matchFirst(node()))
+    }
+
+    @Test
+    fun `matchFirst skips non-matching rules and continues to next`() {
+        val ruleset = ScreenRuleset(
+            listOf(
+                rule("r1", 10, branch(Screen.OFFER_POPUP) { it.text == "Offer" }),
+                rule("r2", 20, branch(Screen.MAIN_MAP_IDLE) { it.text == "Map" }),
+            )
+        )
+        assertEquals(Screen.MAIN_MAP_IDLE, ruleset.matchFirst(node(text = "Map")))
+    }
+
+    // =========================================================================
+    // Guard logic
+    // =========================================================================
+
+    @Test
+    fun `guard fires — branch is skipped`() {
+        val guardFires: (UiNode) -> Boolean = { true }   // always fires
+        val ruleset = ScreenRuleset(
+            listOf(
+                rule(
+                    "r1", 10,
+                    branch(Screen.OFFER_POPUP, guards = listOf(guardFires)) { true }
+                )
+            )
+        )
+        // Guard fires → branch is skipped → no match → null
+        assertNull(ruleset.matchFirst(node()))
+    }
+
+    @Test
+    fun `guard does not fire — branch is evaluated normally`() {
+        val guardSilent: (UiNode) -> Boolean = { false }  // never fires
+        val ruleset = ScreenRuleset(
+            listOf(
+                rule(
+                    "r1", 10,
+                    branch(Screen.OFFER_POPUP, guards = listOf(guardSilent)) { true }
+                )
+            )
+        )
+        assertEquals(Screen.OFFER_POPUP, ruleset.matchFirst(node()))
+    }
+
+    @Test
+    fun `any firing guard skips the branch even if condition is true`() {
+        val g1: (UiNode) -> Boolean = { false }
+        val g2: (UiNode) -> Boolean = { true }  // this one fires
+        val ruleset = ScreenRuleset(
+            listOf(
+                rule(
+                    "r1", 10,
+                    branch(Screen.OFFER_POPUP, guards = listOf(g1, g2)) { true }
+                )
+            )
+        )
+        assertNull(ruleset.matchFirst(node()))
+    }
+
+    // =========================================================================
+    // Branches within a rule
+    // =========================================================================
+
+    @Test
+    fun `first matching branch in a rule wins`() {
+        val ruleset = ScreenRuleset(
+            listOf(
+                rule(
+                    "branched", 10,
+                    branch(Screen.DELIVERY_SUMMARY_EXPANDED) { it.text == "expanded" },
+                    branch(Screen.DELIVERY_SUMMARY_COLLAPSED) { it.text == "collapsed" },
+                )
+            )
+        )
+        assertEquals(Screen.DELIVERY_SUMMARY_EXPANDED, ruleset.matchFirst(node(text = "expanded")))
+        assertEquals(Screen.DELIVERY_SUMMARY_COLLAPSED, ruleset.matchFirst(node(text = "collapsed")))
+    }
+
+    @Test
+    fun `subsequent rule evaluated when earlier rule has no matching branch`() {
+        val ruleset = ScreenRuleset(
+            listOf(
+                rule("r1", 10, branch(Screen.OFFER_POPUP) { it.text == "Offer" }),
+                rule("r2", 20, branch(Screen.MAIN_MAP_IDLE) { true }),
+            )
+        )
+        // r1 doesn't match "Map", r2 matches everything
+        assertEquals(Screen.MAIN_MAP_IDLE, ruleset.matchFirst(node(text = "Map")))
+    }
+
+    // =========================================================================
+    // ruleCount
+    // =========================================================================
+
+    @Test
+    fun `ruleCount reflects the number of compiled rules`() {
+        val ruleset = ScreenRuleset(
+            listOf(
+                rule("r1", 10, branch(Screen.OFFER_POPUP) { true }),
+                rule("r2", 20, branch(Screen.MAIN_MAP_IDLE) { true }),
+                rule("r3", 30, branch(Screen.DASH_PAUSED) { true }),
+            )
+        )
+        assertEquals(3, ruleset.ruleCount)
+    }
+
+    @Test
+    fun `empty ruleset returns null`() {
+        assertNull(ScreenRuleset(emptyList()).matchFirst(node()))
+    }
+}

--- a/core/database/src/test/java/cloud/trotter/dashbuddy/core/database/log/mapper/MapperEnforcementTest.kt
+++ b/core/database/src/test/java/cloud/trotter/dashbuddy/core/database/log/mapper/MapperEnforcementTest.kt
@@ -15,6 +15,7 @@ class MapperEnforcementTest {
             "allText",          // lazy property
             "structuralHash",   // lazy property
             "contentHash",      // lazy property
+            "hasViewId",        // computed interpreter helper (not stored)
         )
         // Get all property names from the Domain model
         val domainProps =

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/accessibility/UiNode.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/accessibility/UiNode.kt
@@ -183,6 +183,43 @@ data class UiNode(
     }
 
     // ========================================================================
+    //  INTERPRETER HELPERS
+    //  Used by the JSON rule interpreter (RuleCompiler). Internalise patterns
+    //  that appear across many Kotlin matchers so the DSL stays simple.
+    // ========================================================================
+
+    /** Walk [n] levels up the parent chain. Null if tree is shallower than [n]. */
+    fun ancestor(n: Int): UiNode? {
+        var current: UiNode? = this
+        repeat(n) { current = current?.parent }
+        return current
+    }
+
+    /**
+     * Return the sibling at (this node's index in parent's children + [offset]).
+     * Null if there is no parent or the computed index is out of bounds.
+     */
+    fun sibling(offset: Int): UiNode? {
+        val siblings = parent?.children ?: return null
+        val idx = siblings.indexOf(this) + offset
+        return siblings.getOrNull(idx)
+    }
+
+    /**
+     * Find [label] in this node's [allText] DFS list and return the entry at label+[offset].
+     * [allText] is lazy — computed once and cached — so repeated calls are free.
+     * Returns null if [label] is not found or the offset index is out of bounds.
+     */
+    fun textAfterLabel(label: String, offset: Int = 1): String? {
+        val idx = allText.indexOfFirst { it.equals(label, ignoreCase = true) }
+        return if (idx >= 0) allText.getOrNull(idx + offset) else null
+    }
+
+    /** True when [viewIdResourceName] is non-null and non-blank. */
+    val hasViewId: Boolean
+        get() = !viewIdResourceName.isNullOrBlank()
+
+    // ========================================================================
     //  DATA COLLECTION (Lazy)
     // ========================================================================
 


### PR DESCRIPTION
## Summary

- Implements `RuleCompiler` — compiles JSON predicate trees to JVM lambdas at startup (compile-once, lambda-hot-path evaluation)
- Adds `ScreenRuleset`, `ClickRuleset`, `NotificationRuleset` — immutable, pre-sorted rule containers
- Ships `rules.default.json` with full production rule coverage (28 screen, 3 click, 3 notification rules)
- Wires `JsonRuleInterpreter` (@Singleton) into all three classifiers; in DEBUG both Kotlin and JSON paths run and log `MATCHER_DISAGREE` on divergence — Kotlin remains authoritative in Phase A2
- Adds `UiNode` interpreter helpers: `ancestor()`, `sibling()`, `textAfterLabel()`, `hasViewId`
- 5 new test files (`RuleCompilerTest`, `ScreenRulesetTest`, `ClickRulesetTest`, `NotificationRulesetTest`, `DefaultRulesIntegrationTest`); 12 existing tests updated for new constructor signatures

Closes #209. Advances #192 (Phase A2 complete).

## Test plan

- [ ] `./gradlew testDebugUnitTest --tests "cloud.trotter.dashbuddy.rules.*"` — all new rule tests pass
- [ ] `./gradlew testDebugUnitTest --tests "*AllMatchersSuite*"` — full regression suite clean
- [ ] Install on device, start a dash — confirm no crash on startup (`loadDefaults()` in Application)
- [ ] In DEBUG build, confirm `MATCHER_DISAGREE` logs appear only when Kotlin/JSON genuinely disagree, not on every event

🤖 Generated with [Claude Code](https://claude.ai/claude-code)