### PR TITLE
fix: bugs #224 + platform refactor #223 + ReplayMetadata Phase A

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,5 @@ local.properties
 .kotlin/
 
 # Claude Code local session state (commit CLAUDE.md, not this)
-.claude/settings.local.json
+.claude/
 CLAUDE.local.md
-/.claude/worktrees/magical-meninsky-93448f/

--- a/app/src/main/assets/rules.default.json
+++ b/app/src/main/assets/rules.default.json
@@ -446,7 +446,7 @@
                 "read": "text",
                 "transform": "parseCurrency"
               },
-              "doorDashPay": {
+              "appPay": {
                 "find": {
                   "hasTextContaining": "DoorDash pay"
                 },
@@ -499,7 +499,7 @@
             {
               "assert": "sumApproxEquals",
               "fields": [
-                "doorDashPay",
+                "appPay",
                 "customerTips"
               ],
               "target": "totalPay",
@@ -1101,7 +1101,14 @@
             "find": {
               "hasIdSuffix": "user_name"
             },
-            "read": "text"
+            "read": "text",
+            "transform": {
+              "stripPrefixes": [
+                "Pickup from ",
+                "Heading to ",
+                "Pick up at "
+              ]
+            }
           },
           "storeAddress": {
             "join": [
@@ -1229,16 +1236,148 @@
                   "hasText": "Directions"
                 },
                 {
+                  "hasText": "Call"
+                },
+                {
+                  "hasText": "Message"
+                }
+              ]
+            }
+          }
+        ],
+        "not": {
+          "exists": {
+            "any": [
+              {
+                "hasText": "Continue"
+              },
+              {
+                "hasText": "Complete Delivery"
+              },
+              {
+                "hasText": "Mark as delivered"
+              }
+            ]
+          }
+        }
+      },
+      "parse": {
+        "fields": {
+          "phase": "DROPOFF",
+          "subFlow": "NAVIGATION",
+          "customerNameHash": {
+            "find": {
+              "any": [
+                {
+                  "hasTextStartsWith": "Deliver to"
+                },
+                {
+                  "hasTextStartsWith": "Heading to"
+                }
+              ]
+            },
+            "read": "text",
+            "transform": [
+              {
+                "stripPrefixes": [
+                  "Deliver to ",
+                  "Heading to "
+                ]
+              },
+              "trim",
+              "sha256"
+            ]
+          },
+          "customerAddressHash": {
+            "join": [
+              {
+                "find": {
+                  "all": [
+                    {
+                      "hasTextMatchesRegex": "^\\d{1,5}\\s+\\S"
+                    },
+                    {
+                      "hasNoId": true
+                    }
+                  ]
+                },
+                "read": "text"
+              },
+              {
+                "find": {
+                  "all": [
+                    {
+                      "hasTextMatchesRegex": "^\\d{1,5}\\s+\\S"
+                    },
+                    {
+                      "hasNoId": true
+                    }
+                  ]
+                },
+                "navigate": "sibling(1)",
+                "rejectIf": {
+                  "not": {
+                    "hasTextMatchesRegex": "\\d{5}$"
+                  }
+                },
+                "read": "text"
+              }
+            ],
+            "separator": ", ",
+            "transform": "sha256"
+          },
+          "deadlineText": {
+            "find": {
+              "hasTextMatchesRegex": "\\bby\\s+\\d{1,2}:\\d{2}"
+            },
+            "read": "text",
+            "transform": "stripDeadlinePrefix"
+          },
+          "deadlineMillis": {
+            "find": {
+              "hasTextMatchesRegex": "\\bby\\s+\\d{1,2}:\\d{2}"
+            },
+            "read": "text",
+            "transform": "parseDeadline"
+          }
+        }
+      },
+      "shape": "task"
+    },
+    {
+      "id": "doordash.screen.dropoff_arrival",
+      "platform_id": "doordash.driver",
+      "priority": 74,
+      "overrideable": true,
+      "state": {
+        "flow": "task:dropoff:arrived",
+        "modeHint": "online"
+      },
+      "require": {
+        "all": [
+          {
+            "exists": {
+              "any": [
+                {
+                  "hasTextStartsWith": "Deliver to"
+                },
+                {
+                  "hasTextStartsWith": "Heading to"
+                }
+              ]
+            }
+          },
+          {
+            "exists": {
+              "any": [
+                {
                   "hasText": "Continue"
                 },
                 {
                   "hasText": "Complete Delivery"
                 },
                 {
-                  "hasText": "Call"
-                },
-                {
-                  "hasText": "Message"
+                  "hasText": "Mark as delivered"
                 }
               ]
             }
@@ -1248,28 +1387,7 @@
       "parse": {
         "fields": {
           "phase": "DROPOFF",
-          "subFlow": {
-            "conditionalEnum": [
-              {
-                "if": {
-                  "exists": {
-                    "any": [
-                      {
-                        "hasText": "Continue"
-                      },
-                      {
-                        "hasText": "Complete Delivery"
-                      }
-                    ]
-                  }
-                },
-                "then": "ARRIVED"
-              },
-              {
-                "else": "NAVIGATION"
-              }
-            ]
-          },
+          "subFlow": "ARRIVED",
           "customerNameHash": {
             "find": {
               "any": [

--- a/app/src/main/java/cloud/trotter/dashbuddy/di/PipelineModule.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/di/PipelineModule.kt
@@ -2,6 +2,8 @@ package cloud.trotter.dashbuddy.di
 
 import cloud.trotter.dashbuddy.core.data.capture.CaptureBus
 import cloud.trotter.dashbuddy.core.data.capture.DiskCaptureBus
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadataProvider
+import cloud.trotter.dashbuddy.pipeline.ReplayMetadataProviderImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -18,4 +20,7 @@ abstract class PipelineModule {
 
     @Binds @Singleton
     abstract fun bindCaptureBus(impl: DiskCaptureBus): CaptureBus
+
+    @Binds @Singleton
+    abstract fun bindReplayMetadataProvider(impl: ReplayMetadataProviderImpl): ReplayMetadataProvider
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/ReplayMetadataProviderImpl.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/ReplayMetadataProviderImpl.kt
@@ -1,0 +1,27 @@
+package cloud.trotter.dashbuddy.pipeline
+
+import android.os.Build
+import cloud.trotter.dashbuddy.BuildConfig
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadataProvider
+import cloud.trotter.dashbuddy.domain.pipeline.PipelineRegistry
+import cloud.trotter.dashbuddy.domain.pipeline.RuleEngineConstants
+import cloud.trotter.dashbuddy.domain.pipeline.StateMachineContract
+import cloud.trotter.dashbuddy.rules.JsonRuleInterpreter
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ReplayMetadataProviderImpl @Inject constructor(
+    private val interpreter: JsonRuleInterpreter,
+) : ReplayMetadataProvider {
+
+    override fun current(): ReplayMetadata = ReplayMetadata(
+        engineVersion = RuleEngineConstants.VERSION,
+        rulesetFormatVersion = interpreter.loadedFormatVersion,
+        pipelineVersions = PipelineRegistry.pipelines,
+        stateMachineApiVersion = "${StateMachineContract.API_VERSION_MAJOR}.${StateMachineContract.API_VERSION_MINOR}",
+        appVersion = BuildConfig.VERSION_NAME,
+        deviceFingerprint = Build.FINGERPRINT,
+    )
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/ClickSubPipe.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/ClickSubPipe.kt
@@ -5,6 +5,7 @@ import cloud.trotter.dashbuddy.core.data.capture.CaptureBus
 import cloud.trotter.dashbuddy.core.data.capture.EnvelopeBuilder
 import cloud.trotter.dashbuddy.core.data.capture.schema.UiNodeSchema
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.pipeline.accessibility.event.type.view.clicked.ClickClassifier
 import cloud.trotter.dashbuddy.pipeline.accessibility.input.AccessibilitySource
 import cloud.trotter.dashbuddy.pipeline.accessibility.mapper.toUiNode
@@ -27,32 +28,32 @@ class ClickSubPipe @Inject constructor(
 ) {
     companion object {
         const val PIPELINE_ID = "accessibility.click"
-        private const val PLATFORM = "doordash"
     }
 
     fun output(): Flow<Observation.Click> = source.events
         .filter { it.eventType == AccessibilityEvent.TYPE_VIEW_CLICKED }
-        .filter { it.packageName == "com.doordash.driverapp" }
         .mapNotNull { event ->
             val sourceNode = event.source ?: return@mapNotNull null
             val node = sourceNode.toUiNode() ?: return@mapNotNull null
             val obs = classifier.classify(node)
+            val platform = Platform.fromRuleId(obs.ruleId).wire
             Timber.d("Click Event: ${obs.target}")
 
             val capture = EnvelopeBuilder.build(
                 pipelineId = PIPELINE_ID,
                 schema = UiNodeSchema,
-                platform = PLATFORM,
+                platform = platform,
                 ruleId = obs.ruleId,
                 classificationName = obs.target,
                 payload = node,
                 contentHash = node.structuralHash,
+                metadata = obs.metadata,
             )
             val captureId = captureBus.offer(
                 captureId = capture.captureId,
                 source = PIPELINE_ID,
                 classification = obs.target,
-                platform = PLATFORM,
+                platform = platform,
                 envelopeJson = capture.envelopeJson,
                 contentHash = capture.contentHash,
             )

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/WindowSubPipe.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/WindowSubPipe.kt
@@ -4,6 +4,7 @@ import cloud.trotter.dashbuddy.core.data.capture.CaptureBus
 import cloud.trotter.dashbuddy.core.data.capture.EnvelopeBuilder
 import cloud.trotter.dashbuddy.core.data.capture.schema.UiNodeSchema
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.pipeline.accessibility.event.type.window.ScreenDiffer
 import cloud.trotter.dashbuddy.pipeline.accessibility.event.type.window.content_changed.ContentChangedPipeline
 import cloud.trotter.dashbuddy.pipeline.accessibility.event.type.window.processing.ScreenClassifier
@@ -32,7 +33,6 @@ class WindowSubPipe @Inject constructor(
 ) {
     companion object {
         const val PIPELINE_ID = "accessibility.window"
-        private const val PLATFORM = "doordash"
     }
 
     fun output(): Flow<Observation.Screen> = merge(
@@ -47,21 +47,23 @@ class WindowSubPipe @Inject constructor(
         }
         .map { tree ->
             val obs = classifier.classify(tree)
+            val platform = Platform.fromRuleId(obs.ruleId).wire
 
             val capture = EnvelopeBuilder.build(
                 pipelineId = PIPELINE_ID,
                 schema = UiNodeSchema,
-                platform = PLATFORM,
+                platform = platform,
                 ruleId = obs.ruleId,
                 classificationName = obs.target,
                 payload = tree,
                 contentHash = tree.structuralHash,
+                metadata = obs.metadata,
             )
             val captureId = captureBus.offer(
                 captureId = capture.captureId,
                 source = PIPELINE_ID,
                 classification = obs.target,
-                platform = PLATFORM,
+                platform = platform,
                 envelopeJson = capture.envelopeJson,
                 contentHash = capture.contentHash,
             )

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/view/clicked/ClickClassifier.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/view/clicked/ClickClassifier.kt
@@ -1,6 +1,6 @@
 package cloud.trotter.dashbuddy.pipeline.accessibility.event.type.view.clicked
 
-import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadataProvider
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
 import cloud.trotter.dashbuddy.domain.state.ParsedFields
@@ -15,6 +15,7 @@ import javax.inject.Inject
  */
 class ClickClassifier @Inject constructor(
     private val interpreter: JsonRuleInterpreter,
+    private val metadataProvider: ReplayMetadataProvider,
 ) {
 
     fun classify(node: UiNode): Observation.Click {
@@ -26,7 +27,7 @@ class ClickClassifier @Inject constructor(
                     timestamp = System.currentTimeMillis(),
                     captureId = null,
                     ruleId = result.ruleId,
-                    metadata = ReplayMetadata.EMPTY,
+                    metadata = metadataProvider.current(),
                     flow = result.flow,
                     modeHint = result.modeHint,
                     parsed = ParsedFields.ClickFields(intent = result.intent),
@@ -43,7 +44,7 @@ class ClickClassifier @Inject constructor(
             timestamp = System.currentTimeMillis(),
             captureId = null,
             ruleId = null,
-            metadata = ReplayMetadata.EMPTY,
+            metadata = metadataProvider.current(),
             flow = null,
             modeHint = null,
             parsed = ParsedFields.ClickFields(

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/processing/ScreenClassifier.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/window/processing/ScreenClassifier.kt
@@ -1,6 +1,6 @@
 package cloud.trotter.dashbuddy.pipeline.accessibility.event.type.window.processing
 
-import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadataProvider
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
 import cloud.trotter.dashbuddy.domain.pipeline.RequestedAction
@@ -13,6 +13,7 @@ import javax.inject.Singleton
 @Singleton
 class ScreenClassifier @Inject constructor(
     private val interpreter: JsonRuleInterpreter,
+    private val metadataProvider: ReplayMetadataProvider,
 ) {
 
     fun classify(node: UiNode): Observation.Screen {
@@ -54,7 +55,7 @@ class ScreenClassifier @Inject constructor(
             timestamp = System.currentTimeMillis(),
             captureId = null,
             ruleId = ruleId,
-            metadata = ReplayMetadata.EMPTY,
+            metadata = metadataProvider.current(),
             flow = flow,
             modeHint = modeHint,
             parsed = parsed,

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/input/AccessibilityListener.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/accessibility/input/AccessibilityListener.kt
@@ -2,6 +2,7 @@ package cloud.trotter.dashbuddy.pipeline.accessibility.input
 
 import android.accessibilityservice.AccessibilityService
 import android.view.accessibility.AccessibilityEvent
+import cloud.trotter.dashbuddy.domain.state.Platform
 import dagger.hilt.android.AndroidEntryPoint
 import timber.log.Timber
 import javax.inject.Inject
@@ -21,7 +22,7 @@ class AccessibilityListener : AccessibilityService() {
         if (event == null) return
 
         // `set' here for expandability later. i.e. if we decide to do Uber or Grubhub, etc.
-        val validPackages = setOf("com.doordash.driverapp")
+        val validPackages = Platform.watchedPackages()
         if (event.packageName?.toString() !in validPackages) {
             Timber.d("Ignoring event from ${event.packageName}")
             return

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/notification/NotificationClassifier.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/notification/NotificationClassifier.kt
@@ -1,6 +1,6 @@
 package cloud.trotter.dashbuddy.pipeline.notification
 
-import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadataProvider
 import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
 import cloud.trotter.dashbuddy.domain.state.ParsedFields
@@ -15,6 +15,7 @@ import javax.inject.Inject
  */
 class NotificationClassifier @Inject constructor(
     private val interpreter: JsonRuleInterpreter,
+    private val metadataProvider: ReplayMetadataProvider,
 ) {
 
     fun classify(raw: RawNotificationData): Observation.Notification {
@@ -26,7 +27,7 @@ class NotificationClassifier @Inject constructor(
                     timestamp = System.currentTimeMillis(),
                     captureId = null,
                     ruleId = result.ruleId,
-                    metadata = ReplayMetadata.EMPTY,
+                    metadata = metadataProvider.current(),
                     flow = result.flow,
                     modeHint = result.modeHint,
                     parsed = ParsedFields.NotificationFields(
@@ -47,7 +48,7 @@ class NotificationClassifier @Inject constructor(
             timestamp = System.currentTimeMillis(),
             captureId = null,
             ruleId = null,
-            metadata = ReplayMetadata.EMPTY,
+            metadata = metadataProvider.current(),
             flow = null,
             modeHint = null,
             parsed = ParsedFields.NotificationFields(

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/notification/NotificationFilter.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/notification/NotificationFilter.kt
@@ -1,6 +1,7 @@
 package cloud.trotter.dashbuddy.pipeline.notification
 
 import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData
+import cloud.trotter.dashbuddy.domain.state.Platform
 import javax.inject.Inject
 
 /**
@@ -13,5 +14,5 @@ import javax.inject.Inject
 class NotificationFilter @Inject constructor() {
 
     fun isRelevant(raw: RawNotificationData): Boolean =
-        raw.packageName == "com.doordash.driverapp" && raw.isClearable
+        raw.packageName in Platform.watchedPackages() && raw.isClearable
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/notification/NotificationPipeline.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/notification/NotificationPipeline.kt
@@ -4,6 +4,7 @@ import cloud.trotter.dashbuddy.core.data.capture.CaptureBus
 import cloud.trotter.dashbuddy.core.data.capture.EnvelopeBuilder
 import cloud.trotter.dashbuddy.core.data.capture.schema.RawNotificationSchema
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.pipeline.notification.input.NotificationSource
 import cloud.trotter.dashbuddy.pipeline.notification.mapper.toDomain
 import kotlinx.coroutines.flow.Flow
@@ -26,7 +27,6 @@ class NotificationPipeline @Inject constructor(
 ) {
     companion object {
         const val PIPELINE_ID = "notification"
-        private const val PLATFORM = "doordash"
     }
 
     fun output(): Flow<Observation.Notification> = source.events
@@ -34,20 +34,22 @@ class NotificationPipeline @Inject constructor(
         .filter { raw -> filter.isRelevant(raw) }
         .map { raw ->
             val obs = classifier.classify(raw).copy(timestamp = raw.postTime)
+            val platform = Platform.fromRuleId(obs.ruleId).wire
 
             val capture = EnvelopeBuilder.build(
                 pipelineId = PIPELINE_ID,
                 schema = RawNotificationSchema,
-                platform = PLATFORM,
+                platform = platform,
                 ruleId = obs.ruleId,
                 classificationName = obs.target,
                 payload = raw,
+                metadata = obs.metadata,
             )
             val captureId = captureBus.offer(
                 captureId = capture.captureId,
                 source = PIPELINE_ID,
                 classification = obs.target,
-                platform = PLATFORM,
+                platform = platform,
                 envelopeJson = capture.envelopeJson,
                 contentHash = capture.contentHash,
             )

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/notification/input/NotificationListener.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/notification/input/NotificationListener.kt
@@ -4,6 +4,7 @@ import android.service.notification.NotificationListenerService
 import android.service.notification.StatusBarNotification
 //import cloud.trotter.dashbuddy.pipeline.Pipeline
 //import cloud.trotter.dashbuddy.pipeline.features.notification.NotificationInfo
+import cloud.trotter.dashbuddy.domain.state.Platform
 import dagger.hilt.android.AndroidEntryPoint
 import timber.log.Timber
 import javax.inject.Inject
@@ -26,7 +27,7 @@ class NotificationListener : NotificationListenerService() {
 
         // 1. Filter: Only care about specific apps?
         val packageName = sbn.packageName
-        val validPackages = setOf("com.doordash.driverapp")
+        val validPackages = Platform.watchedPackages()
 
         if (packageName !in validPackages) return
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/rules/JsonRuleInterpreter.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/rules/JsonRuleInterpreter.kt
@@ -3,8 +3,10 @@ package cloud.trotter.dashbuddy.rules
 import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.int
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -31,6 +33,8 @@ class JsonRuleInterpreter @Inject constructor(
     var clickRuleset: ClickRuleset? = null
         private set
     var notificationRuleset: NotificationRuleset? = null
+        private set
+    var loadedFormatVersion: Int? = null
         private set
 
     /** Load the bundled default rules from `assets/rules.default.json`. */
@@ -76,6 +80,7 @@ class JsonRuleInterpreter @Inject constructor(
             screenRuleset = ScreenRuleset(screens)
             clickRuleset = ClickRuleset(clicks)
             notificationRuleset = NotificationRuleset(notifications)
+            loadedFormatVersion = root["format_version"]?.jsonPrimitive?.int
 
             Timber.i(
                 "JsonRuleInterpreter: loaded from '$source' " +

--- a/app/src/main/java/cloud/trotter/dashbuddy/rules/ParsedFieldsFactory.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/rules/ParsedFieldsFactory.kt
@@ -107,7 +107,7 @@ object ParsedFieldsFactory {
         return ParsedFields.PostTaskFields(
             activity = f.str("activity"),
             totalPay = f.double("totalPay") ?: 0.0,
-            doorDashPay = f.double("doorDashPay"),
+            appPay = f.double("appPay"),
             customerTips = f.double("customerTips"),
             parsedPay = parsedPay,
             isExpanded = f.bool("isExpanded") ?: false,

--- a/app/src/main/java/cloud/trotter/dashbuddy/rules/TransformRegistry.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/rules/TransformRegistry.kt
@@ -337,7 +337,7 @@ object TransformRegistry {
     /**
      * Assert that the sum of named fields approximately equals a target field.
      * ```json
-     * { "assert": "sumApproxEquals", "fields": ["doorDashPay","customerTips"],
+     * { "assert": "sumApproxEquals", "fields": ["appPay","customerTips"],
      *   "target": "totalPay", "tolerance": 0.02 }
      * ```
      */

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/EffectMap.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/EffectMap.kt
@@ -13,6 +13,7 @@ import cloud.trotter.dashbuddy.domain.state.FlowRegion
 import cloud.trotter.dashbuddy.domain.state.Mode
 import cloud.trotter.dashbuddy.domain.state.ModeConfidence
 import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import cloud.trotter.dashbuddy.domain.state.PendingOffer
 import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.domain.state.PlatformRegion
 import cloud.trotter.dashbuddy.domain.state.TaskPhase
@@ -87,7 +88,7 @@ class EffectMap @Inject constructor() {
             prevOffer.offerHash != nextOffer.offerHash
         ) {
             // Log resolution of old offer
-            val outcome = resolveOfferOutcome(obs)
+            val outcome = resolveOfferOutcome(obs, prevOffer)
             add(logEffect(null, outcome, "Replaced by new offer"))
 
             // Log + evaluate new offer
@@ -101,7 +102,7 @@ class EffectMap @Inject constructor() {
 
         // Offer resolved (accepted/declined/timeout)
         if (prevOffer != null && nextOffer == null) {
-            val outcome = resolveOfferOutcome(obs)
+            val outcome = resolveOfferOutcome(obs, prevOffer)
             val description = when (outcome) {
                 AppEventType.OFFER_ACCEPTED -> "Transitioned to Pickup"
                 AppEventType.OFFER_DECLINED -> "Returned to search"
@@ -311,8 +312,10 @@ class EffectMap @Inject constructor() {
                 prevTask.phase == TaskPhase.PICKUP &&
                 nextTask.phase == TaskPhase.PICKUP
             ) {
-                val storeChanged = nextTask.storeName != prevTask.storeName &&
-                    nextTask.storeName != null && nextTask.storeName != "Unknown"
+                val prevName = prevTask.storeName?.trim()
+                val nextName = nextTask.storeName?.trim()
+                val storeChanged = nextName != prevName &&
+                    nextName != null && nextName != "Unknown"
                 val activityChanged = nextTask.activity != prevTask.activity
 
                 if (storeChanged || activityChanged) {
@@ -367,8 +370,8 @@ class EffectMap @Inject constructor() {
         return buildList {
             val payData = parsed.parsedPay
 
-            // If we got expanded pay data, log it
-            if (payData != null) {
+            // If we got expanded pay data AND it's different from last emission, log it
+            if (payData != null && next.lastPostTaskPayHash != prev.lastPostTaskPayHash) {
                 val receiptText = buildString {
                     append("Saved: ${UtilityFunctions.formatCurrency(payData.total)}")
                     payData.customerTips.forEach { item ->
@@ -477,10 +480,17 @@ class EffectMap @Inject constructor() {
     // HELPERS
     // =========================================================================
 
-    private fun resolveOfferOutcome(obs: Observation): AppEventType {
+    private fun resolveOfferOutcome(obs: Observation, prevOffer: PendingOffer? = null): AppEventType {
+        // 1. Stored click intent on PendingOffer — covers the common case where
+        //    the click was observed first and the resolving obs is a Screen
+        when (prevOffer?.lastClickIntent) {
+            "accept_offer" -> return AppEventType.OFFER_ACCEPTED
+            "decline_offer" -> return AppEventType.OFFER_DECLINED
+        }
+        // 2. Direct click observation — covers the edge case where click and
+        //    flow change arrive in the same observation
         val clickFields = when (obs) {
             is Observation.Click -> obs.parsed as? ParsedFields.ClickFields
-            is Observation.Screen -> null
             else -> null
         }
         return when (clickFields?.intent) {

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/FlowRegionStepper.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/FlowRegionStepper.kt
@@ -108,10 +108,15 @@ class FlowRegionStepper @Inject constructor() {
      * Record accept/decline clicks on the pending offer for outcome resolution.
      */
     private fun handleOfferClick(prev: FlowRegion, obs: Observation.Click): FlowRegion {
-        if (prev.pendingOffer == null || prev.flow != Flow.OfferPresented) return prev
-        // Click fields carry intent: "accept_offer", "decline_offer"
-        // We don't clear pendingOffer here — the flow change does that
-        return prev.copy(lastObservedAt = obs.timestamp)
+        val offer = prev.pendingOffer ?: return prev
+        if (prev.flow != Flow.OfferPresented) return prev
+        val fields = obs.parsed as? ParsedFields.ClickFields
+        // Store intent on PendingOffer so EffectMap can resolve outcome
+        // even when the resolving observation is a Screen (not a Click)
+        return prev.copy(
+            pendingOffer = offer.copy(lastClickIntent = fields?.intent),
+            lastObservedAt = obs.timestamp,
+        )
     }
 
     /**

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/PlatformRegionStepper.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/PlatformRegionStepper.kt
@@ -208,6 +208,21 @@ class PlatformRegionStepper @Inject constructor() {
         // Update session fields from observations
         r = updateSessionFields(r, obs)
 
+        // Accumulate delivery pay when entering PostTask
+        if (prev != Flow.PostTask && next == Flow.PostTask) {
+            val postFields = obs.parsed as? ParsedFields.PostTaskFields
+            if (postFields != null && postFields.totalPay > 0) {
+                r.session?.let { session ->
+                    val accumulated = session.accumulatedDeliveryPay + postFields.totalPay
+                    val best = maxOf(session.runningEarnings, accumulated)
+                    r = r.copy(session = session.copy(
+                        accumulatedDeliveryPay = accumulated,
+                        runningEarnings = best,
+                    ))
+                }
+            }
+        }
+
         // Update ratings if we got a ratings observation
         r = updateRatings(r, obs)
 
@@ -236,6 +251,8 @@ class PlatformRegionStepper @Inject constructor() {
                 }
             }
             is ParsedFields.PostTaskFields -> {
+                val payHash = parsed.parsedPay?.hashCode()
+                r = r.copy(lastPostTaskPayHash = payHash)
                 r.session?.let { session ->
                     val earnings = parsed.sessionEarnings
                     if (earnings != null) {
@@ -434,6 +451,7 @@ class PlatformRegionStepper @Inject constructor() {
         val job = region.activeJob ?: return region
         return region.copy(
             activeJob = null,
+            lastPostTaskPayHash = null,
             // Keep recent tasks — they reference the job by ID
         )
     }

--- a/app/src/test/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/view/clicked/ClickClassifierTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/view/clicked/ClickClassifierTest.kt
@@ -3,6 +3,8 @@ package cloud.trotter.dashbuddy.pipeline.accessibility.event.type.view.clicked
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
 import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadataProvider
 import cloud.trotter.dashbuddy.rules.JsonRuleInterpreter
 import cloud.trotter.dashbuddy.test.util.TestRulesetFactory
 import org.junit.Assert.assertEquals
@@ -15,9 +17,12 @@ import org.mockito.kotlin.mock
 
 class ClickClassifierTest {
 
-    private val classifier = ClickClassifier(mock<JsonRuleInterpreter> {
-        on { clickRuleset } doReturn TestRulesetFactory.clickRuleset
-    })
+    private val classifier = ClickClassifier(
+        mock<JsonRuleInterpreter> {
+            on { clickRuleset } doReturn TestRulesetFactory.clickRuleset
+        },
+        mock<ReplayMetadataProvider> { on { current() } doReturn ReplayMetadata.EMPTY },
+    )
 
     // =========================================================================
     // Helpers

--- a/app/src/test/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/view/clicked/UnknownClickTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/view/clicked/UnknownClickTest.kt
@@ -3,8 +3,11 @@ package cloud.trotter.dashbuddy.pipeline.accessibility.event.type.view.clicked
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
 import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadataProvider
 import cloud.trotter.dashbuddy.rules.JsonRuleInterpreter
 import org.junit.Assert.assertEquals
+import org.mockito.kotlin.doReturn
 import org.junit.Assert.assertNull
 import org.junit.Test
 import org.mockito.kotlin.mock
@@ -17,7 +20,10 @@ import org.mockito.kotlin.mock
  */
 class UnknownClickTest {
 
-    private val classifier = ClickClassifier(mock<JsonRuleInterpreter>())
+    private val classifier = ClickClassifier(
+        mock<JsonRuleInterpreter>(),
+        mock<ReplayMetadataProvider> { on { current() } doReturn ReplayMetadata.EMPTY },
+    )
 
     private fun node(viewId: String? = null, text: String? = null) =
         UiNode(viewIdResourceName = viewId, text = text)

--- a/app/src/test/java/cloud/trotter/dashbuddy/pipeline/notification/NotificationClassifierTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/pipeline/notification/NotificationClassifierTest.kt
@@ -3,6 +3,8 @@ package cloud.trotter.dashbuddy.pipeline.notification
 import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
 import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadataProvider
 import cloud.trotter.dashbuddy.rules.JsonRuleInterpreter
 import cloud.trotter.dashbuddy.test.util.TestRulesetFactory
 import org.junit.Assert.assertEquals
@@ -20,9 +22,12 @@ import org.mockito.kotlin.mock
  */
 class NotificationClassifierTest {
 
-    private val classifier = NotificationClassifier(mock<JsonRuleInterpreter> {
-        on { notificationRuleset } doReturn TestRulesetFactory.notificationRuleset
-    })
+    private val classifier = NotificationClassifier(
+        mock<JsonRuleInterpreter> {
+            on { notificationRuleset } doReturn TestRulesetFactory.notificationRuleset
+        },
+        mock<ReplayMetadataProvider> { on { current() } doReturn ReplayMetadata.EMPTY },
+    )
 
     // =========================================================================
     // Helpers

--- a/app/src/test/java/cloud/trotter/dashbuddy/pipeline/notification/UnknownNotificationClassifierTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/pipeline/notification/UnknownNotificationClassifierTest.kt
@@ -2,10 +2,13 @@ package cloud.trotter.dashbuddy.pipeline.notification
 
 import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData
 import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadataProvider
 import cloud.trotter.dashbuddy.rules.JsonRuleInterpreter
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 
 /**
@@ -17,7 +20,10 @@ import org.mockito.kotlin.mock
  */
 class UnknownNotificationClassifierTest {
 
-    private val classifier = NotificationClassifier(mock<JsonRuleInterpreter>())
+    private val classifier = NotificationClassifier(
+        mock<JsonRuleInterpreter>(),
+        mock<ReplayMetadataProvider> { on { current() } doReturn ReplayMetadata.EMPTY },
+    )
 
     private fun raw(title: String? = null, text: String? = null, bigText: String? = null) =
         RawNotificationData(

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/capture/EnvelopeBuilder.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/capture/EnvelopeBuilder.kt
@@ -1,6 +1,7 @@
 package cloud.trotter.dashbuddy.core.data.capture
 
 import cloud.trotter.dashbuddy.domain.capture.CaptureSchema
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
 import cloud.trotter.dashbuddy.domain.pipeline.PipelineRegistry
 import cloud.trotter.dashbuddy.domain.pipeline.RuleEngineConstants
 import kotlinx.serialization.Serializable
@@ -33,18 +34,22 @@ object EnvelopeBuilder {
         classificationName: String?,
         payload: T,
         contentHash: Int? = null,
-        appVersion: String? = null,
-        rulesetFormatVersion: Int? = null,
+        metadata: ReplayMetadata? = null,
     ): CaptureResult {
         val captureId = UUID.randomUUID().toString()
         val payloadJsonStr = schema.serialize(payload)
         val payloadElement = json.parseToJsonElement(payloadJsonStr)
 
-        val metadata = ReplayMetadataDto(
-            engineVersion = RuleEngineConstants.VERSION,
-            rulesetFormatVersion = rulesetFormatVersion,
-            pipelineVersions = PipelineRegistry.pipelines,
-            appVersion = appVersion,
+        val meta = metadata
+        val metadataDto = ReplayMetadataDto(
+            engineVersion = meta?.engineVersion ?: RuleEngineConstants.VERSION,
+            rulesetFormatVersion = meta?.rulesetFormatVersion,
+            rulesetReleaseTag = meta?.rulesetReleaseTag,
+            rulesetSignature = meta?.rulesetSignature,
+            pipelineVersions = meta?.pipelineVersions ?: PipelineRegistry.pipelines,
+            stateMachineApiVersion = meta?.stateMachineApiVersion,
+            appVersion = meta?.appVersion,
+            deviceFingerprint = meta?.deviceFingerprint,
         )
 
         val envelope = CaptureEnvelopeDto(
@@ -55,7 +60,7 @@ object EnvelopeBuilder {
             platform = platform,
             ruleId = ruleId,
             classificationName = classificationName,
-            metadata = metadata,
+            metadata = metadataDto,
             payload = payloadElement,
         )
 

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/capture/ReplayMetadataProvider.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/capture/ReplayMetadataProvider.kt
@@ -1,0 +1,9 @@
+package cloud.trotter.dashbuddy.domain.capture
+
+/**
+ * Provides live [ReplayMetadata] for the current engine/ruleset/pipeline state.
+ * Interface in `:domain`, implementation in `:app` (needs Android context + BuildConfig).
+ */
+interface ReplayMetadataProvider {
+    fun current(): ReplayMetadata
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/FlowRegion.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/FlowRegion.kt
@@ -33,4 +33,5 @@ data class PendingOffer(
     val presentedAt: Long,
     val evaluation: OfferEvaluation? = null,
     val returnFlow: Flow,
+    val lastClickIntent: String? = null,
 )

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/ParsedFields.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/ParsedFields.kt
@@ -51,7 +51,7 @@ sealed class ParsedFields {
     data class PostTaskFields(
         override val activity: String? = null,
         val totalPay: Double,
-        val doorDashPay: Double? = null,
+        val appPay: Double? = null,
         val customerTips: Double? = null,
         val parsedPay: ParsedPay? = null,
         val isExpanded: Boolean = false,

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/Platform.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/Platform.kt
@@ -8,12 +8,12 @@ package cloud.trotter.dashbuddy.domain.state
  * state machine creates a [PlatformRegion] per platform automatically
  * on first observation.
  */
-enum class Platform(val wire: String) {
-    DoorDash("doordash"),
-    Uber("uber"),
-    Instacart("instacart"),
-    WalmartSpark("walmart_spark"),
-    Unknown("_unknown"),
+enum class Platform(val wire: String, val packageName: String?) {
+    DoorDash("doordash", "com.doordash.driverapp"),
+    Uber("uber", "com.ubercab.driver4"),
+    Instacart("instacart", "com.instacart.shopper"),
+    WalmartSpark("walmart_spark", "com.walmart.spark"),
+    Unknown("_unknown", null),
     ;
 
     companion object {
@@ -26,5 +26,9 @@ enum class Platform(val wire: String) {
         }
 
         fun fromWire(wire: String): Platform? = byWire[wire]
+
+        /** All known package names for OS-level event subscription. */
+        fun watchedPackages(): Set<String> =
+            entries.mapNotNull { it.packageName }.toSet()
     }
 }

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/PlatformRegion.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/PlatformRegion.kt
@@ -22,6 +22,7 @@ data class PlatformRegion(
     val sessionType: SessionType? = null,
     val ratings: RatingsSnapshot? = null,
     val surgeMultiplier: Double? = null,
+    val lastPostTaskPayHash: Int? = null,
     val lastObservedAt: Long = 0,
 )
 

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/Session.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/Session.kt
@@ -10,4 +10,5 @@ data class Session(
     val earningMode: SessionType? = null,
     val runningEarnings: Double = 0.0,
     val runningMiles: Double = 0.0,
+    val accumulatedDeliveryPay: Double = 0.0,
 )


### PR DESCRIPTION
## Summary

- **Phase A ReplayMetadata**: New `ReplayMetadataProvider` interface/impl, injected into all 3 classifiers, metadata flows through observations to `EnvelopeBuilder` — captures now carry real provenance instead of `EMPTY`
- **#223 Platform identity**: `Platform` enum gains `packageName` + `watchedPackages()`, all hardcoded `"com.doordash.driverapp"` / `PLATFORM` constants removed from pipeline, `doorDashPay` → `appPay`
- **Bug 1**: Offer accepted logged as OFFER_TIMEOUT — store `lastClickIntent` on `PendingOffer`, resolution cascade checks stored intent before observation
- **Bug 2**: Post-delivery earnings bubble fires twice — track `lastPostTaskPayHash`, gate emission on hash change
- **Bug 3**: Customer-arrival not detected on dropoff — new `dropoff_arrival` rule (priority 74), tighten `dropoff_pre_arrival` with reject clause
- **Bug 4**: Duplicate "Pickup" bubble — normalize `storeName` with `stripPrefixes` transform + trim comparison
- **Bug 6**: HUD running earnings stuck at $0 — accumulate `totalPay` into `Session.accumulatedDeliveryPay`, `runningEarnings = max(screen-parsed, accumulated)`

Bug 5 (capture file explosion) deferred to separate PR per plan.

Closes #224, closes #223

## Test plan

- [x] `./gradlew :app:build` — clean
- [x] `./gradlew testDebugUnitTest` — all pass
- [ ] `./gradlew testDebugUnitTest --tests "*AllMatchersSuite*"` — regression suite
- [ ] Field test: verify offer accepted resolves correctly, earnings accumulate, dropoff arrival detected, no duplicate bubbles

🤖 Generated with [Claude Code](https://claude.com/claude-code)