### PR TITLE
feat: click rule overhaul + Uber screen/notification rules

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -66,6 +66,12 @@ android {
         targetCompatibility = JavaVersion.VERSION_21
     }
 
+    testOptions {
+        unitTests.all {
+            it.jvmArgs("-XX:+EnableDynamicAgentLoading")
+        }
+    }
+
     viewBinding.enable = true
 
     buildFeatures {

--- a/app/src/main/assets/rules/doordash.json
+++ b/app/src/main/assets/rules/doordash.json
@@ -781,6 +781,18 @@
         "flow": "task:dropoff:navigation",
         "modeHint": "online"
       },
+      "reject": [
+        {
+          "exists": {
+            "any": [
+              { "hasText": "Continue" },
+              { "hasText": "Complete Delivery" },
+              { "hasText": "Mark as delivered" },
+              { "hasIdSuffix": "complete_delivery_steps_button" }
+            ]
+          }
+        }
+      ],
       "branches": [
         {
           "target": "NAVIGATION_VIEW_TO_DROP_OFF",
@@ -1345,12 +1357,12 @@
       "shape": "task"
     },
     {
-      "id": "doordash.screen.dropoff_arrival",
+      "id": "doordash.screen.dropoff_pre_arrival_completion",
       "platform_id": "doordash.driver",
       "priority": 74,
       "overrideable": true,
       "state": {
-        "flow": "task:dropoff:arrived",
+        "flow": "task:dropoff:navigation",
         "modeHint": "online"
       },
       "require": {
@@ -1378,6 +1390,9 @@
                 },
                 {
                   "hasText": "Mark as delivered"
+                },
+                {
+                  "hasIdSuffix": "complete_delivery_steps_button"
                 }
               ]
             }
@@ -1387,7 +1402,7 @@
       "parse": {
         "fields": {
           "phase": "DROPOFF",
-          "subFlow": "ARRIVED",
+          "subFlow": "NAVIGATION",
           "customerNameHash": {
             "find": {
               "any": [
@@ -2394,6 +2409,8 @@
       "platform_id": "doordash.driver",
       "priority": 10,
       "overrideable": true,
+      "screenIs": "OFFER_POPUP",
+      "intent": "accept_offer",
       "if": {
         "hasIdSuffix": "accept_button"
       }
@@ -2403,6 +2420,8 @@
       "platform_id": "doordash.driver",
       "priority": 20,
       "overrideable": true,
+      "screenIs": "OFFER_POPUP_CONFIRM_DECLINE",
+      "intent": "decline_offer",
       "if": {
         "hasText": "Decline offer"
       }
@@ -2412,6 +2431,8 @@
       "platform_id": "doordash.driver",
       "priority": 30,
       "overrideable": true,
+      "screenIs": "pickup_arrival",
+      "intent": "arrived_at_store",
       "if": {
         "all": [
           {
@@ -2428,6 +2449,78 @@
             ]
           }
         ]
+      }
+    },
+    {
+      "id": "doordash.click.initial_decline",
+      "platform_id": "doordash.driver",
+      "priority": 15,
+      "overrideable": true,
+      "screenIs": "OFFER_POPUP",
+      "intent": "initial_decline",
+      "if": {
+        "hasIdSuffix": "secondary_action_button_dash_plus"
+      }
+    },
+    {
+      "id": "doordash.click.resume_dash",
+      "platform_id": "doordash.driver",
+      "priority": 40,
+      "overrideable": true,
+      "screenIs": "dash_paused",
+      "intent": "resume_dash",
+      "if": {
+        "hasIdSuffix": "resumeButton"
+      }
+    },
+    {
+      "id": "doordash.click.start_navigation",
+      "platform_id": "doordash.driver",
+      "priority": 50,
+      "overrideable": true,
+      "intent": "start_navigation",
+      "if": {
+        "any": [
+          { "hasIdSuffix": "directions_button" },
+          { "hasIdSuffix": "navigate_button" }
+        ]
+      }
+    },
+    {
+      "id": "doordash.click.complete_delivery",
+      "platform_id": "doordash.driver",
+      "priority": 60,
+      "overrideable": true,
+      "screenIs": "dropoff_pre_arrival_completion",
+      "intent": "complete_delivery",
+      "if": {
+        "any": [
+          { "hasIdSuffix": "complete_delivery_steps_button" },
+          { "hasText": "Complete Delivery" },
+          { "hasText": "Mark as delivered" }
+        ]
+      }
+    },
+    {
+      "id": "doordash.click.submit_photo",
+      "platform_id": "doordash.driver",
+      "priority": 70,
+      "overrideable": true,
+      "screenIs": "dropoff_pre_arrival",
+      "intent": "submit_photo",
+      "if": {
+        "hasIdSuffix": "submit_button"
+      }
+    },
+    {
+      "id": "doordash.click.checkout",
+      "platform_id": "doordash.driver",
+      "priority": 80,
+      "overrideable": true,
+      "screenIs": "pickup_shopping",
+      "intent": "checkout",
+      "if": {
+        "hasIdSuffix": "button_checkout"
       }
     }
   ],

--- a/app/src/main/assets/rules/doordash.json
+++ b/app/src/main/assets/rules/doordash.json
@@ -2572,6 +2572,28 @@
           }
         ]
       }
+    },
+    {
+      "id": "doordash.notification.demand_nudge",
+      "platform_id": "doordash.driver",
+      "priority": 50,
+      "overrideable": true,
+      "if": {
+        "titleContains": "Dash now"
+      },
+      "intent": "demand_nudge",
+      "shape": "notification"
+    },
+    {
+      "id": "doordash.notification.peak_pay_promo",
+      "platform_id": "doordash.driver",
+      "priority": 60,
+      "overrideable": true,
+      "if": {
+        "titleContains": "Incentives Update"
+      },
+      "intent": "peak_pay_promo",
+      "shape": "notification"
     }
   ]
 }

--- a/app/src/main/assets/rules/uber.json
+++ b/app/src/main/assets/rules/uber.json
@@ -39,7 +39,7 @@
           "parse": {
             "fields": {
               "payAmount": {
-                "find": { "hasTextMatchesRegex": "^\\$\\d" },
+                "find": { "hasTextMatchesRegex": "\\$\\d" },
                 "read": "text",
                 "transform": "parseCurrency"
               },
@@ -61,12 +61,17 @@
                         { "hasClassName": "android.widget.TextView" },
                         { "not": { "any": [
                           { "hasTextMatchesRegex": "^\\$" },
+                          { "hasTextMatchesRegex": "^\\+" },
                           { "hasTextContaining": "min" },
                           { "hasText": "Accept" },
                           { "hasText": "Match" },
                           { "hasText": "Delivery" },
                           { "hasTextContaining": "Exclusive" },
                           { "hasTextContaining": "Guaranteed" },
+                          { "hasTextContaining": "Includes" },
+                          { "hasTextContaining": "Add a" },
+                          { "hasTextContaining": "Shop &" },
+                          { "hasTextMatchesRegex": "^\\d+ items?" },
                           { "hasTextContaining": ", " }
                         ]}}
                       ]
@@ -92,6 +97,182 @@
         "exists": {
           "hasIdSuffix": "rootSplashBackground"
         }
+      }
+    },
+    {
+      "id": "uber.screen.pickup_verification",
+      "platform_id": "uber.driver",
+      "priority": 50,
+      "overrideable": true,
+      "state": {
+        "flow": "task:pickup:arrived",
+        "modeHint": "online"
+      },
+      "branches": [
+        {
+          "target": "pickup_verification_info",
+          "require": {
+            "all": [
+              { "exists": { "hasIdSuffix": "on_job_view" } },
+              { "exists": { "hasText": "Pickup verification" } }
+            ]
+          }
+        },
+        {
+          "target": "pickup_verification_pin",
+          "require": {
+            "all": [
+              { "exists": { "hasIdSuffix": "on_job_view" } },
+              { "exists": { "hasTextContaining": "Enter Uber Eats order number" } }
+            ]
+          }
+        },
+        {
+          "target": "pickup_verification_items",
+          "require": {
+            "all": [
+              { "exists": { "hasIdSuffix": "on_job_view" } },
+              { "exists": { "hasText": "Verify order" } },
+              { "exists": {
+                  "any": [
+                    { "hasText": "Order verified" },
+                    { "hasText": "Issue with order" }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "id": "uber.screen.customer_chat",
+      "platform_id": "uber.driver",
+      "priority": 55,
+      "overrideable": true,
+      "state": {
+        "modeHint": "online"
+      },
+      "require": {
+        "all": [
+          { "exists": { "hasIdSuffix": "on_job_view" } },
+          { "exists": { "hasIdSuffix": "ub__intercom_coordinator_layout" } }
+        ]
+      }
+    },
+    {
+      "id": "uber.screen.photo_capture",
+      "platform_id": "uber.driver",
+      "priority": 60,
+      "overrideable": true,
+      "state": {
+        "flow": "task:dropoff:arrived",
+        "modeHint": "online"
+      },
+      "require": {
+        "all": [
+          { "exists": { "hasIdSuffix": "on_job_view" } },
+          { "exists": { "hasIdSuffix": "ub__carbon_facecamera_root_view" } }
+        ]
+      }
+    },
+    {
+      "id": "uber.screen.delivery_confirmation",
+      "platform_id": "uber.driver",
+      "priority": 65,
+      "overrideable": true,
+      "state": {
+        "flow": "task:dropoff:arrived",
+        "modeHint": "online"
+      },
+      "require": {
+        "all": [
+          { "exists": { "hasIdSuffix": "on_job_view" } },
+          { "exists": { "hasIdSuffix": "earner_trip_image_capture_taskbar_container" } }
+        ]
+      }
+    },
+    {
+      "id": "uber.screen.shop_and_pay",
+      "platform_id": "uber.driver",
+      "priority": 68,
+      "overrideable": true,
+      "state": {
+        "flow": "task:pickup:arrived",
+        "modeHint": "online"
+      },
+      "branches": [
+        {
+          "target": "shop_and_pay_list",
+          "require": {
+            "all": [
+              { "exists": { "hasIdSuffix": "on_job_view" } },
+              { "exists": { "hasTextContaining": "Shop priority items" } }
+            ]
+          }
+        },
+        {
+          "target": "shop_and_pay_checkout",
+          "require": {
+            "all": [
+              { "exists": { "hasIdSuffix": "on_job_view" } },
+              { "exists": { "hasTextContaining": "shopping bags" } }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "id": "uber.screen.post_trip",
+      "platform_id": "uber.driver",
+      "priority": 75,
+      "overrideable": true,
+      "state": {
+        "flow": "post:task",
+        "modeHint": "online"
+      },
+      "require": {
+        "all": [
+          { "exists": { "hasIdSuffix": "on_job_view" } },
+          { "exists": { "hasTextContaining": "more customers order again" } }
+        ]
+      }
+    },
+    {
+      "id": "uber.screen.earnings_activity",
+      "platform_id": "uber.driver",
+      "priority": 78,
+      "overrideable": true,
+      "require": {
+        "all": [
+          { "exists": { "hasText": "Earnings Activity" } },
+          { "exists": { "hasIdSuffix": "recycler_view" } }
+        ]
+      }
+    },
+    {
+      "id": "uber.screen.session_summary",
+      "platform_id": "uber.driver",
+      "priority": 80,
+      "overrideable": true,
+      "state": {
+        "flow": "session:ended",
+        "modeHint": "offline"
+      },
+      "require": {
+        "exists": { "hasTextContaining": "Session summary" }
+      }
+    },
+    {
+      "id": "uber.screen.active_trip",
+      "platform_id": "uber.driver",
+      "priority": 100,
+      "overrideable": true,
+      "state": {
+        "modeHint": "online"
+      },
+      "require": {
+        "exists": { "hasIdSuffix": "on_job_view" }
       }
     },
     {
@@ -161,6 +342,12 @@
               { "exists": { "hasIdSuffix": "ub__system_banner_text" } }
             ]
           }
+        },
+        {
+          "target": "home_dashboard",
+          "require": {
+            "exists": { "hasIdSuffix": "glide_bottom_nav_home" }
+          }
         }
       ]
     }
@@ -214,6 +401,61 @@
     }
   ],
   "notifications": [
+    {
+      "id": "uber.notification.trip_en_route_pickup",
+      "platform_id": "uber.driver",
+      "priority": 3,
+      "overrideable": true,
+      "if": {
+        "titleMatchesRegex": "^Going to (?!\\d)"
+      },
+      "intent": "trip_en_route_pickup",
+      "shape": "notification"
+    },
+    {
+      "id": "uber.notification.trip_arrived_pickup",
+      "platform_id": "uber.driver",
+      "priority": 4,
+      "overrideable": true,
+      "if": {
+        "titleContains": "Arrived at "
+      },
+      "intent": "trip_arrived_pickup",
+      "shape": "notification"
+    },
+    {
+      "id": "uber.notification.trip_en_route_dropoff",
+      "platform_id": "uber.driver",
+      "priority": 5,
+      "overrideable": true,
+      "if": {
+        "titleMatchesRegex": "^Going to \\d"
+      },
+      "intent": "trip_en_route_dropoff",
+      "shape": "notification"
+    },
+    {
+      "id": "uber.notification.trip_at_dropoff",
+      "platform_id": "uber.driver",
+      "priority": 6,
+      "overrideable": true,
+      "if": {
+        "titleMatchesRegex": "(Leave the order at|Meet at door for)"
+      },
+      "intent": "trip_at_dropoff",
+      "shape": "notification"
+    },
+    {
+      "id": "uber.notification.tip_received",
+      "platform_id": "uber.driver",
+      "priority": 8,
+      "overrideable": true,
+      "if": {
+        "titleMatchesRegex": "received a \\$\\d"
+      },
+      "intent": "tip_received",
+      "shape": "notification"
+    },
     {
       "id": "uber.notification.online_status",
       "platform_id": "uber.driver",

--- a/app/src/main/assets/rules/uber.json
+++ b/app/src/main/assets/rules/uber.json
@@ -172,7 +172,7 @@
       "priority": 5,
       "overrideable": true,
       "screenIs": "OFFER",
-      "intent": "accept",
+      "intent": "accept_offer",
       "if": {
         "any": [
           { "hasText": "Accept" },
@@ -185,6 +185,7 @@
       "platform_id": "uber.driver",
       "priority": 10,
       "overrideable": true,
+      "intent": "go_online",
       "if": {
         "hasIdSuffix": "go_online_button"
       }
@@ -195,10 +196,58 @@
       "priority": 20,
       "overrideable": true,
       "screenIs": "home_dashboard",
+      "intent": "go_offline",
       "if": {
         "hasIdSuffix": "carbon_action_button"
       }
+    },
+    {
+      "id": "uber.click.open_inbox",
+      "platform_id": "uber.driver",
+      "priority": 30,
+      "overrideable": true,
+      "screenIs": "home_dashboard",
+      "intent": "open_inbox",
+      "if": {
+        "hasIdSuffix": "glide_bottom_nav_inbox"
+      }
     }
   ],
-  "notifications": []
+  "notifications": [
+    {
+      "id": "uber.notification.online_status",
+      "platform_id": "uber.driver",
+      "priority": 10,
+      "overrideable": true,
+      "if": {
+        "titleContains": "currently online"
+      },
+      "shape": "noise"
+    },
+    {
+      "id": "uber.notification.quest_promo",
+      "platform_id": "uber.driver",
+      "priority": 20,
+      "overrideable": true,
+      "if": {
+        "titleContains": "Quest awaits"
+      },
+      "intent": "quest_promo",
+      "shape": "notification"
+    },
+    {
+      "id": "uber.notification.quest_deadline",
+      "platform_id": "uber.driver",
+      "priority": 30,
+      "overrideable": true,
+      "if": {
+        "all": [
+          { "titleContains": "Last chance" },
+          { "anyFieldContains": "Quest" }
+        ]
+      },
+      "intent": "quest_deadline",
+      "shape": "notification"
+    }
+  ]
 }

--- a/app/src/test/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/view/clicked/ClickClassifierTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/view/clicked/ClickClassifierTest.kt
@@ -40,8 +40,14 @@ class ClickClassifierTest {
         contentDescription = contentDescription,
     )
 
-    private fun classifyClick(node: UiNode): Observation.Click =
-        classifier.classify(PipelineEvent.Click(System.currentTimeMillis(), node)) as Observation.Click
+    private fun classifyClick(node: UiNode, screenTarget: String? = null): Observation.Click {
+        // Set screen context so rules with screenIs constraints can match
+        ObservationClassifier::class.java.getDeclaredField("lastScreenTarget").apply {
+            isAccessible = true
+            set(classifier, screenTarget)
+        }
+        return classifier.classify(PipelineEvent.Click(System.currentTimeMillis(), node)) as Observation.Click
+    }
 
     private fun Observation.Click.intent(): String =
         (parsed as ParsedFields.ClickFields).intent
@@ -55,13 +61,13 @@ class ClickClassifierTest {
 
     @Test
     fun `classifies accept_button as AcceptOffer`() {
-        val result = classifyClick(node(viewId = "accept_button"))
+        val result = classifyClick(node(viewId = "accept_button"), "OFFER_POPUP")
         assertEquals("accept_offer", result.intent())
     }
 
     @Test
     fun `AcceptOffer takes priority over text when both present`() {
-        val result = classifyClick(node(viewId = "accept_button", text = "Decline offer"))
+        val result = classifyClick(node(viewId = "accept_button", text = "Decline offer"), "OFFER_POPUP")
         assertEquals("accept_offer", result.intent())
     }
 
@@ -71,13 +77,13 @@ class ClickClassifierTest {
 
     @Test
     fun `classifies 'Decline offer' text as DeclineOffer`() {
-        val result = classifyClick(node(text = "Decline offer"))
+        val result = classifyClick(node(text = "Decline offer"), "OFFER_POPUP_CONFIRM_DECLINE")
         assertEquals("decline_offer", result.intent())
     }
 
     @Test
     fun `DeclineOffer matches case-insensitively`() {
-        val result = classifyClick(node(text = "decline offer"))
+        val result = classifyClick(node(text = "decline offer"), "OFFER_POPUP_CONFIRM_DECLINE")
         assertEquals("decline_offer", result.intent())
     }
 
@@ -88,7 +94,7 @@ class ClickClassifierTest {
     @Test
     fun `classifies primary_action_button + 'Arrived at store' text as ArrivedAtStore`() {
         val result = classifyClick(
-            node(viewId = "primary_action_button", text = "Arrived at store")
+            node(viewId = "primary_action_button", text = "Arrived at store"), "pickup_arrival"
         )
         assertEquals("arrived_at_store", result.intent())
     }
@@ -96,7 +102,7 @@ class ClickClassifierTest {
     @Test
     fun `classifies primary_action_button + 'Arrived' text as ArrivedAtStore`() {
         val result = classifyClick(
-            node(viewId = "primary_action_button", text = "Arrived")
+            node(viewId = "primary_action_button", text = "Arrived"), "pickup_arrival"
         )
         assertEquals("arrived_at_store", result.intent())
     }

--- a/app/src/test/java/cloud/trotter/dashbuddy/rules/DefaultRulesIntegrationTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/rules/DefaultRulesIntegrationTest.kt
@@ -78,13 +78,13 @@ class DefaultRulesIntegrationTest {
     @Test
     fun `accept_button id classifies as accept_offer`() {
         val node = UiNode(viewIdResourceName = "com.doordash.driverapp:id/accept_button")
-        assertEquals("accept_offer", clickRuleset.classifyFirst(node)?.intent)
+        assertEquals("accept_offer", clickRuleset.classifyFirst(node, screenTarget = "OFFER_POPUP")?.intent)
     }
 
     @Test
     fun `'Decline offer' text classifies as decline_offer`() {
         val node = UiNode(text = "Decline offer")
-        assertEquals("decline_offer", clickRuleset.classifyFirst(node)?.intent)
+        assertEquals("decline_offer", clickRuleset.classifyFirst(node, screenTarget = "OFFER_POPUP_CONFIRM_DECLINE")?.intent)
     }
 
     @Test
@@ -93,7 +93,7 @@ class DefaultRulesIntegrationTest {
             viewIdResourceName = "com.doordash.driverapp:id/primary_action_button",
             text = "Arrived at store",
         )
-        assertEquals("arrived_at_store", clickRuleset.classifyFirst(node)?.intent)
+        assertEquals("arrived_at_store", clickRuleset.classifyFirst(node, screenTarget = "pickup_arrival")?.intent)
     }
 
     @Test

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -1,0 +1,238 @@
+# DashBuddy Field Testing Log
+
+Running log of observations made while actively dashing in the field, captured
+in real time during sessions. Each session is its own entry, **newest first**.
+
+This is a freeform capture log — a mix of bugs, open questions, meta
+observations about platform UI/UX, design proposals, and verification TODOs
+that were noticed during a session. The intent is to preserve raw context
+*before* it gets distilled into focused work items. Items here are not yet
+triaged; the developer triages to the project board manually using the
+Android Studio plugin or `gh` CLI.
+
+## Format
+
+Each session entry has:
+
+- **Date** — YYYY-MM-DD
+- **Platform(s) tested** — DoorDash, Uber, etc.
+- **Branch under test** — the git branch the build came from
+- **Field conditions** — anything that affects interpretation (offers
+  accepted vs declined, weather, multi-app testing, etc.)
+- **Observations** — grouped by kind:
+  - **Bugs** — reproducible defects
+  - **Field UX context** — what the platform's UI actually looks like in
+    the wild; helps explain why a matcher behaves the way it does
+  - **Open questions / investigations** — things to look at back at the desk
+  - **Meta / architecture** — broader concerns that aren't single-bug shaped
+  - **Research / design** — speculative or strategic proposals
+  - **Verification TODOs** — items the session itself produced ground-truth
+    for, but which need cross-referencing against captured data
+
+Item numbers are **session-local** (reset each session) and intended for
+cross-referencing within a single session entry, not across sessions.
+
+---
+
+## 2026-05-09 — Uber session
+
+- **Platform tested:** Uber Driver
+- **Branch under test:** `feature/click-rule-overhaul` (commit `90200bc`)
+- **Field conditions:** developer dashed on Uber; accepted every offer
+  received during the session.
+
+### Bugs
+
+#### 1. Uber: bubble stays "offline" after going online
+
+- **Repro:** Tap "Go online" in Uber Driver.
+- **Observed:** Bubble shows offline state. A "started dashing" notification
+  appears (note: that notification's UI copy is stale — hasn't been updated
+  for the multi-platform world — but that's a separate cosmetic concern).
+- **Expected:** Bubble enters online/dashing state.
+- **Likely cause:** `uber.click.go_online` intent
+  (`app/src/main/assets/rules/uber.json:184-190`) fires the rule, but no
+  handler in `state/EffectMap.kt` reacts to `go_online`. DoorDash's
+  start-of-session path produces `AppEffect.StartDash`
+  (`state/EffectMap.kt:184`); there's no Uber-equivalent wiring.
+- **Proposed fix:** unify the intent vocabulary across platforms — rename
+  DoorDash's start-dash click intent to `go_online` (or whatever shared
+  term fits), rename `AppEffect.StartDash` → `StartSession` (or similar
+  platform-neutral term), and remove DoorDash-specific language elsewhere
+  in the state machine. Single intent, single handler, both platforms route
+  through it.
+
+#### 2. Uber: online/offline screen recognition flaps
+
+- **Observed:** Immediately after going online, the screen matcher appears
+  to oscillate between online and offline classifications.
+- **Likely contributor to #1** — even with the intent wired up, a flapping
+  classifier may immediately clobber the new state.
+- **Field UX context (helps explain):** Uber has *two* surfaces from which
+  a driver can go online or offline:
+  - The **dashboard** (post-splash home screen) has a "start Ubering"
+    button.
+  - Tapping the map widget opens the **full map screen**, which has its own
+    "Go" button.
+  - Going offline is symmetrical: end from the map, or back out to the
+    dashboard and end from there.
+  - So "online" and "offline" each have **two valid screens** with different
+    layouts. A matcher keying on a single UI element only present on one
+    surface will flip when the user moves between them.
+- **Hypothesis:** the current matcher is too strict — keying on a single UI
+  telltale that's only present on one of the two surfaces.
+- **Action:** capture all four screens (online-dashboard, online-map,
+  offline-dashboard, offline-map), find a robust common signal per state,
+  relax/rework the matcher.
+
+#### 3. Uber offer TTS reads raw text; offer shape not standardized across platforms
+
+- **Repro:** Receive an Uber offer with TTS announcement enabled.
+- **Observed:** TTS reads minutes-as-miles (a field-mapping bug in the
+  Uber parser), then continues reading the raw screen string — so the user
+  hears the parsed-wrong value *and* the real miles trailing in the verbatim
+  text.
+- **Expected:** TTS speaks a constructed message built from parsed fields,
+  not raw screen text.
+- **Underlying problem — offer parse fields aren't normalized between
+  platforms:**
+  - Uber gives **duration in minutes** directly.
+  - DoorDash gives a **deadline timestamp** (due time).
+  - TTS / UI should work off a single canonical offer shape, computing
+    whichever representation is needed (duration ↔ due time) rather than
+    reading screen text verbatim.
+- **Proposed fix:** canonical parsed offer schema; TTS announcement built
+  from fields, never from raw strings.
+
+#### 4. Uber offer overlay not captured by pipeline
+
+- **Repro:** Receive an offer in Uber while in the field.
+- **Observed:** Offer was not evaluated — no parsed data, no bubble update.
+- **Hypothesis:** Uber renders some offers as a full-screen notification or
+  system-overlay window rather than a normal app window; the current
+  accessibility pipeline doesn't catch overlay-style surfaces.
+- **Investigation TODO (back at desk):**
+  - Check whether *any* data was captured for the missed offer.
+  - If the `WindowChanged` pipeline still exists, see if it picked up
+    anything. If not, this becomes a case for keeping/restoring it.
+
+#### 6. Uber: persistent "currently online" notification dropped as noise
+
+- **Current behavior:** `uber.notification.online_status`
+  (`app/src/main/assets/rules/uber.json:218-225`) is classified
+  `shape: "noise"` and dropped entirely. Match condition is
+  `titleContains: "currently online"`.
+- **Field observation — the body carries live flow state:** while on a
+  delivery, the body reads things like "picking up from [store]" during
+  the pickup leg, and "going to [customer address]" during the dropoff
+  leg. The notification body reflects **which leg of the offer is active**.
+- **Field observation — the actions also carry signal:** the active
+  notification exposes action buttons that change with leg (e.g., a
+  "Contact customer" button is present during dropoff). These are a
+  structured, leg-correlated signal.
+- **Why it matters:** given Uber's flowy UI (#5) and overlay-style offers
+  (#4), this notification may be the most reliable continuous source of
+  "what is the driver actually doing right now" on Uber.
+- **Broader parser concern:** verify the notification parser is extracting
+  **everything** Android exposes — title, text, sub-text, big-text,
+  actions/buttons, action labels, action intents — not just title + body.
+- **Proposed fix:** re-shape `uber.notification.online_status` from noise
+  to parsed; expand parser to surface action buttons; route the parsed
+  result as a flow-region/leg signal in the state machine. Likely tightly
+  coupled to #1, #2, #5.
+
+### Open questions / investigations
+
+#### 7. How does Uber's slide-to-confirm surface in accessibility?
+
+Uber uses slide-to-confirm widgets for advancing pickups and dropoffs (and
+the "Go" button to start dashing may be similar). Three common
+implementations:
+
+1. **Slider/SeekBar-backed** — fires `ACTION_SET_PROGRESS` and emits
+   `TYPE_VIEW_SCROLLED` accessibility events; we can detect "reached end."
+2. **Custom view that dispatches a click on completion** — surfaces as a
+   normal click event; a regular click rule keyed on the slider's node id
+   catches it.
+3. **Pure gesture-only surface with no accessibility action** — hardest;
+   we'd have to infer from the screen transition that follows the slide.
+
+Most production apps go with #1 or #2 because TalkBack users need it to
+work. Worth confirming by capturing accessibility events while completing
+a slide back at the desk.
+
+**Field addition:** slide-to-confirm appears to be the standard
+"advance to next leg" affordance on Uber pickups and dropoffs (likely
+absent on shop-and-deliver — needs verification). This is the
+**leg-transition signal** equivalent to DoorDash's "Arrived at store" /
+"Complete delivery" buttons. Capturing it well is high-priority.
+
+#### 9. Uber "match" screen — multiple concurrent offers
+
+- **Observed:** Uber has a screen called the **match screen** that can
+  display more than one offer at a time. Saw it in the field with multiple
+  offers visible.
+- **DoorDash analog:** none — DoorDash offers are presented one at a time.
+- **Implication:** the offer evaluator and `OfferMatcher` may need to
+  handle a list of offers, not a single-offer assumption.
+- **Action:** capture this screen at the desk; design parser + evaluator to
+  support N≥1 offers.
+
+### Meta / architecture
+
+#### 5. Uber UI is "flowy" — recognition strategy needs to differ from DoorDash
+
+- DoorDash screens are discrete and separable; Uber screens blend into each
+  other (shared chrome, persistent map background, transient sheets and
+  overlays).
+- Recognizing a screen on Uber is less about "exact tree match" and more
+  about "what set of affordances is currently visible."
+- **Action:** document the recognition strategy difference somewhere.
+  Options considered:
+  - This log entry (current home — fine for now).
+  - A separate architecture issue.
+  - `CLAUDE.md` addition.
+  - **Per-rules-file README** — one alongside each `assets/rules/*.json`
+    explaining how captures were used to identify screens, what fields were
+    extracted, and any platform-specific quirks. (Probably the most
+    maintainable; keeps platform-specific reasoning next to the rules it
+    governs.)
+
+### Research / design
+
+#### 8. ZIP-derived zones as a first-class signal
+
+- **Question:** is the platform-provided zone name even worth scraping, or
+  is it an "extra" at best?
+- **Problem with platform zones:** unreliable boundary semantics — dashing
+  *in* zone X doesn't mean the pickup or dropoff is *in* zone X. A driver
+  can leave the zone mid-offer (e.g., dashing in zone X but the offer's
+  pickup is just outside, or the dropoff is several zones away).
+- **Proposal:** extract the **ZIP code** from the customer dropoff address
+  (and possibly pickup) and treat that as the canonical geo-signal. Hash
+  the rest of the address as today, but keep the ZIP as a structured field.
+- **Why it matters on both sides:**
+  - **Academic federation:** "do tips correlate with ZIP demographics?" is
+    a meaningful query and needs ZIP, not platform-zone.
+  - **Driver side:** lets a dasher correlate earnings/tips by ZIP
+    independent of platform zone definitions, which can change.
+- **Open implementation questions:**
+  - Pre-hash extraction (extract ZIP, then hash the rest) — needs the
+    address parser to handle US format reliably.
+  - ZIP → demographic classification — likely already exists (Census tract
+    / USPS); confirm before reinventing.
+  - Pickup-side ZIP useful too? Probably yes for restaurant-density /
+    market context.
+
+### Verification TODOs
+
+#### 10. Accept-button capture consistency for this Uber session
+
+- **Field condition:** developer accepted **every** offer in this session.
+- **Action at desk:** cross-reference accept-button click events / sessions
+  against the actual offers received during the session window. Any missing
+  accepts indicate either matcher gaps, click-classifier gaps, or pipeline
+  drops. Good ground-truth opportunity.
+- **Related:** while doing this, also verify capture consistency of any
+  pickup-confirm and dropoff-complete slide events from #7 — if those
+  surface as click events, they should be present alongside the accepts.


### PR DESCRIPTION
## Summary

- **Click rule overhaul**: All click rules now declare `intent` explicitly and use `screenIs` constraints to prevent misclassification across screen contexts. New DoorDash click rules for delivery flow (confirm pickup, complete steps, photo confirmation). Tests updated with `screenTarget` parameter support.
- **Uber screen rules**: 9 new screen rules (pickup verification, customer chat, photo capture, delivery confirmation, shop & pay, post-trip, earnings activity, session summary, active trip catch-all) covering ~208 previously-UNKNOWN captures. Home dashboard broadened with fallback branch. Offer parser fixes for add-on pay amounts and store name exclusions.
- **Uber notification lifecycle**: 5 new notification rules classifying the ongoing "currently online" notification by trip leg (en route pickup, arrived pickup, en route dropoff, at dropoff, tip received). Store vs address disambiguation via `(?!\d)` lookahead.
- **DoorDash notifications**: 2 new rules for demand nudge and peak pay promo.
- **Build fix**: Mockito JDK 21 dynamic agent loading warning resolved.
- **Field testing log**: Detailed observations from May 9 Uber session.

## Test plan

- [x] `DefaultRulesIntegrationTest` passes — all rules compile, spot checks pass
- [x] `ClickClassifierTest` passes with `screenTarget` parameter
- [ ] CI/CD green
- [ ] Field verification on next Uber session

🤖 Generated with [Claude Code](https://claude.com/claude-code)