### PR TITLE
refactor: ruleset cleanup — strip dead weight, derive targets, DSL improvements

### DIFF
--- a/app/src/main/assets/rules/doordash.json
+++ b/app/src/main/assets/rules/doordash.json
@@ -1,21 +1,9 @@
 {
   "format_version": 2,
-  "engine_version": "1.0.0",
   "platform_id": "doordash.driver",
-  "min_app_version": "0.230.0",
-  "pipelines": {
-    "accessibility.window": 1,
-    "accessibility.click": 1,
-    "notification": 1
-  },
-  "state_machine": {
-    "api_version_major": 1,
-    "api_version_minor": 0
-  },
   "screens": [
     {
       "id": "doordash.screen.sensitive.known",
-      "platform_id": "doordash.driver",
       "priority": 0,
       "overrideable": false,
       "require": {
@@ -37,9 +25,7 @@
     },
     {
       "id": "doordash.screen.timeline",
-      "platform_id": "doordash.driver",
       "priority": 10,
-      "overrideable": true,
       "require": {
         "allTextContainsAll": [
           "dash ends at",
@@ -156,7 +142,7 @@
                 "navigate": "sibling(1)",
                 "read": "text",
                 "transform": {
-                  "extractBefore": " \u00ef\u00bf\u00bd "
+                  "extractBefore": " ï¿½ "
                 }
               },
               "deadlineMillis": {
@@ -177,7 +163,7 @@
                 "read": "text",
                 "transform": [
                   {
-                    "extractBefore": " \u00ef\u00bf\u00bd "
+                    "extractBefore": " ï¿½ "
                   },
                   "parseDeadline"
                 ]
@@ -199,7 +185,7 @@
                 "navigate": "sibling(1)",
                 "read": "text",
                 "transform": {
-                  "extractAfter": " \u00ef\u00bf\u00bd "
+                  "extractAfter": " ï¿½ "
                 }
               },
               "isCurrent": {
@@ -216,405 +202,404 @@
       "shape": "timeline"
     },
     {
-      "id": "doordash.screen.offer",
-      "platform_id": "doordash.driver",
+      "id": "doordash.screen.offer_popup_confirm_decline",
       "priority": 20,
-      "overrideable": true,
       "state": {
         "flow": "offer:presented",
         "modeHint": "online"
       },
-      "branches": [
-        {
-          "target": "OFFER_POPUP_CONFIRM_DECLINE",
-          "require": {
+      "require": {
+        "exists": {
+          "hasTextContaining": "sure you want to decline"
+        }
+      }
+    },
+    {
+      "id": "doordash.screen.offer_popup",
+      "priority": 20,
+      "state": {
+        "flow": "offer:presented",
+        "modeHint": "online"
+      },
+      "require": {
+        "all": [
+          {
             "exists": {
-              "hasTextContaining": "sure you want to decline"
+              "hasText": "Decline"
+            }
+          },
+          {
+            "exists": {
+              "any": [
+                {
+                  "hasText": "Accept"
+                },
+                {
+                  "hasText": "Add to route"
+                }
+              ]
             }
           }
-        },
+        ]
+      },
+      "reject": [
         {
-          "target": "OFFER_POPUP",
-          "reject": [
-            {
-              "exists": {
-                "hasIdSuffix": "progress_bar"
-              }
-            }
-          ],
-          "require": {
-            "all": [
+          "exists": {
+            "hasIdSuffix": "progress_bar"
+          }
+        }
+      ],
+      "parse": {
+        "fields": {
+          "payAmount": {
+            "coalesce": [
               {
-                "exists": {
-                  "hasText": "Decline"
-                }
-              },
-              {
-                "exists": {
-                  "any": [
+                "find": {
+                  "all": [
                     {
-                      "hasText": "Accept"
+                      "hasIdSuffix": "text_field"
                     },
                     {
-                      "hasText": "Add to route"
+                      "hasTextContaining": "$"
                     }
                   ]
-                }
+                },
+                "read": "text",
+                "transform": "parseCurrency"
+              },
+              {
+                "find": {
+                  "hasTextContaining": "$"
+                },
+                "read": "text",
+                "transform": "parseCurrency"
               }
             ]
           },
-          "parse": {
-            "fields": {
-              "payAmount": {
-                "coalesce": [
-                  {
-                    "find": {
-                      "all": [
-                        {
-                          "hasIdSuffix": "text_field"
-                        },
-                        {
-                          "hasTextContaining": "$"
-                        }
-                      ]
-                    },
-                    "read": "text",
-                    "transform": "parseCurrency"
-                  },
-                  {
-                    "find": {
-                      "hasTextContaining": "$"
-                    },
-                    "read": "text",
-                    "transform": "parseCurrency"
+          "distance": {
+            "find": {
+              "hasTextMatchesRegex": "\\d[\\d.]*\\s*(mi|ft)"
+            },
+            "read": "text",
+            "transform": "parseDistance"
+          },
+          "deliveryTimeText": {
+            "find": {
+              "hasTextStartsWith": "Deliver by"
+            },
+            "read": "text",
+            "transform": {
+              "stripPrefix": "Deliver by "
+            }
+          },
+          "deliveryTime": {
+            "find": {
+              "hasTextStartsWith": "Deliver by"
+            },
+            "read": "text",
+            "transform": "parseDeadline"
+          },
+          "orders": {
+            "each": {
+              "all": [
+                {
+                  "hasIdSuffix": "display_name"
+                },
+                {
+                  "not": {
+                    "hasText": "Customer dropoff"
                   }
-                ]
-              },
-              "distance": {
-                "find": {
-                  "hasTextMatchesRegex": "\\d[\\d.]*\\s*(mi|ft)"
                 },
-                "read": "text",
-                "transform": "parseDistance"
-              },
-              "deliveryTimeText": {
-                "find": {
-                  "hasTextStartsWith": "Deliver by"
-                },
-                "read": "text",
-                "transform": {
-                  "stripPrefix": "Deliver by "
+                {
+                  "not": {
+                    "hasText": "Business handoff"
+                  }
                 }
-              },
-              "deliveryTime": {
+              ]
+            },
+            "scope": "ancestor(2)",
+            "extract": {
+              "storeName": {
                 "find": {
-                  "hasTextStartsWith": "Deliver by"
+                  "hasIdSuffix": "display_name"
                 },
-                "read": "text",
-                "transform": "parseDeadline"
+                "read": "text"
               },
-              "orders": {
-                "each": {
-                  "all": [
-                    {
-                      "hasIdSuffix": "display_name"
-                    },
-                    {
-                      "not": {
-                        "hasText": "Customer dropoff"
-                      }
-                    },
-                    {
-                      "not": {
-                        "hasText": "Business handoff"
-                      }
-                    }
-                  ]
-                },
-                "scope": "ancestor(2)",
-                "extract": {
-                  "storeName": {
-                    "find": {
-                      "hasIdSuffix": "display_name"
-                    },
-                    "read": "text"
-                  },
-                  "orderType": {
-                    "conditionalEnum": [
-                      {
-                        "if": {
-                          "exists": {
-                            "all": [
-                              {
-                                "hasIdSuffix": "work_unit_type"
-                              },
-                              {
-                                "hasTextContaining": "Shop for items"
-                              }
-                            ]
-                          }
-                        },
-                        "then": "SHOP_FOR_ITEMS"
-                      },
-                      {
-                        "else": "PICKUP"
-                      }
-                    ]
-                  },
-                  "itemCount": {
-                    "find": {
-                      "hasIdSuffix": "display_name_secondary"
-                    },
-                    "read": "text",
-                    "transform": "parseItemCount"
-                  },
-                  "isRedCard": {
-                    "presence": {
+              "orderType": {
+                "conditionalEnum": [
+                  {
+                    "if": {
                       "exists": {
                         "all": [
                           {
-                            "hasIdSuffix": "tag"
+                            "hasIdSuffix": "work_unit_type"
                           },
                           {
-                            "hasTextContaining": "Red Card"
+                            "hasTextContaining": "Shop for items"
                           }
                         ]
                       }
-                    }
+                    },
+                    "then": "SHOP_FOR_ITEMS"
                   },
-                  "isLargeOrder": {
-                    "presence": {
-                      "exists": {
-                        "hasTextContaining": "Large Order"
+                  {
+                    "else": "PICKUP"
+                  }
+                ]
+              },
+              "itemCount": {
+                "find": {
+                  "hasIdSuffix": "display_name_secondary"
+                },
+                "read": "text",
+                "transform": "parseItemCount"
+              },
+              "isRedCard": {
+                "presence": {
+                  "exists": {
+                    "all": [
+                      {
+                        "hasIdSuffix": "tag"
+                      },
+                      {
+                        "hasTextContaining": "Red Card"
                       }
-                    }
-                  },
-                  "hasAlcohol": {
-                    "presence": {
-                      "exists": {
-                        "hasTextContaining": "alcohol"
-                      }
-                    }
+                    ]
+                  }
+                }
+              },
+              "isLargeOrder": {
+                "presence": {
+                  "exists": {
+                    "hasTextContaining": "Large Order"
+                  }
+                }
+              },
+              "hasAlcohol": {
+                "presence": {
+                  "exists": {
+                    "hasTextContaining": "alcohol"
                   }
                 }
               }
             }
+          }
+        }
+      },
+      "shape": "offer",
+      "effects": [
+        {
+          "screenshot": {
+            "prefix": "Offer - {storeName}"
           },
-          "shape": "offer",
-          "effects": [
-            {
-              "screenshot": { "prefix": "Offer - {storeName}" },
-              "dedupeKey": "offer-ss-{offerHash}",
-              "throttleMs": 60000
-            },
-            {
-              "log": { "type": "OFFER_RECEIVED", "payload": "pay={payAmount} dist={distance}" },
-              "dedupeKey": "offer-log-{offerHash}",
-              "throttleMs": 60000
-            }
-          ]
+          "dedupeKey": "offer-ss-{offerHash}",
+          "throttleMs": 60000
+        },
+        {
+          "log": {
+            "type": "OFFER_RECEIVED",
+            "payload": "pay={payAmount} dist={distance}"
+          },
+          "dedupeKey": "offer-log-{offerHash}",
+          "throttleMs": 60000
         }
       ]
     },
     {
-      "id": "doordash.screen.delivery_summary",
-      "platform_id": "doordash.driver",
+      "id": "doordash.screen.delivery_summary_expanded",
       "priority": 30,
-      "overrideable": true,
       "state": {
         "flow": "post:task",
         "modeHint": "online"
       },
-      "branches": [
-        {
-          "target": "DELIVERY_SUMMARY_EXPANDED",
-          "reject": [
-            {
-              "allTextContains": "pause orders"
-            }
-          ],
-          "require": {
-            "all": [
-              {
-                "allTextContainsAny": [
-                  "this offer",
-                  "delivery complete"
-                ]
-              },
-              {
-                "allTextContainsAll": [
-                  "doordash pay",
-                  "customer tips"
-                ]
-              }
-            ]
-          },
-          "parse": {
-            "fields": {
-              "totalPay": {
-                "find": {
-                  "hasIdSuffix": "final_value"
-                },
-                "read": "text",
-                "transform": "parseCurrency"
-              },
-              "appPay": {
-                "find": {
-                  "hasTextContaining": "DoorDash pay"
-                },
-                "navigate": "sibling(1)",
-                "read": "text",
-                "transform": "parseCurrency"
-              },
-              "customerTips": {
-                "find": {
-                  "hasTextContaining": "Customer tips"
-                },
-                "navigate": "sibling(1)",
-                "read": "text",
-                "transform": "parseCurrency"
-              },
-              "payLineItems": {
-                "each": {
-                  "hasIdSuffix": "pay_line_item_title"
-                },
-                "scope": "ancestor(1)",
-                "extract": {
-                  "type": {
-                    "find": {
-                      "hasIdSuffix": "pay_line_item_title"
-                    },
-                    "read": "text"
-                  },
-                  "amount": {
-                    "find": {
-                      "hasIdSuffix": "pay_line_item_value"
-                    },
-                    "read": "text",
-                    "transform": "parseCurrency"
-                  }
-                }
-              },
-              "isExpanded": {
-                "literal": true
-              },
-              "sessionEarnings": {
-                "find": {
-                  "hasIdSuffix": "earnings_ticker"
-                },
-                "read": "allText",
-                "transform": "parseCurrency"
-              }
-            }
-          },
-          "validate": [
-            {
-              "assert": "sumApproxEquals",
-              "fields": [
-                "appPay",
-                "customerTips"
-              ],
-              "target": "totalPay",
-              "tolerance": 0.02,
-              "onFail": "skip"
-            }
-          ],
-          "shape": "post_task"
-        },
-        {
-          "target": "DELIVERY_SUMMARY_COLLAPSED",
-          "bind": {
-            "expandButton": {
-              "find": {
-                "any": [
-                  {
-                    "hasIdSuffix": "expandable_view"
-                  },
-                  {
-                    "hasIdSuffix": "expandable_layout"
-                  }
-                ]
-              },
-              "optional": true
-            }
-          },
-          "reject": [
-            {
-              "allTextContains": "pause orders"
-            }
-          ],
-          "require": {
+      "require": {
+        "all": [
+          {
             "allTextContainsAny": [
               "this offer",
               "delivery complete"
             ]
           },
-          "parse": {
-            "fields": {
-              "totalPay": {
+          {
+            "allTextContainsAll": [
+              "doordash pay",
+              "customer tips"
+            ]
+          }
+        ]
+      },
+      "reject": [
+        {
+          "allTextContains": "pause orders"
+        }
+      ],
+      "parse": {
+        "fields": {
+          "totalPay": {
+            "find": {
+              "hasIdSuffix": "final_value"
+            },
+            "read": "text",
+            "transform": "parseCurrency"
+          },
+          "appPay": {
+            "find": {
+              "hasTextContaining": "DoorDash pay"
+            },
+            "navigate": "sibling(1)",
+            "read": "text",
+            "transform": "parseCurrency"
+          },
+          "customerTips": {
+            "find": {
+              "hasTextContaining": "Customer tips"
+            },
+            "navigate": "sibling(1)",
+            "read": "text",
+            "transform": "parseCurrency"
+          },
+          "payLineItems": {
+            "each": {
+              "hasIdSuffix": "pay_line_item_title"
+            },
+            "scope": "ancestor(1)",
+            "extract": {
+              "type": {
                 "find": {
-                  "hasIdSuffix": "final_value"
+                  "hasIdSuffix": "pay_line_item_title"
+                },
+                "read": "text"
+              },
+              "amount": {
+                "find": {
+                  "hasIdSuffix": "pay_line_item_value"
                 },
                 "read": "text",
-                "transform": "parseCurrency"
-              },
-              "isExpanded": {
-                "literal": false
-              },
-              "expandButtonId": {
-                "coalesce": [
-                  {
-                    "find": {
-                      "hasIdSuffix": "expandable_view"
-                    },
-                    "read": "viewIdResourceName"
-                  },
-                  {
-                    "find": {
-                      "hasIdSuffix": "expandable_layout"
-                    },
-                    "read": "viewIdResourceName"
-                  }
-                ]
-              },
-              "sessionEarnings": {
-                "find": {
-                  "hasIdSuffix": "earnings_ticker"
-                },
-                "read": "allText",
                 "transform": "parseCurrency"
               }
             }
           },
-          "effects": [
-            {
-              "click": "$expandButton",
-              "onlyIf": {
-                "fieldEquals": {
-                  "field": "isExpanded",
-                  "value": false
-                }
-              },
-              "dedupeKey": "expand_pay_breakdown",
-              "throttleMs": 1000
-            }
+          "isExpanded": {
+            "literal": true
+          },
+          "sessionEarnings": {
+            "find": {
+              "hasIdSuffix": "earnings_ticker"
+            },
+            "read": "allText",
+            "transform": "parseCurrency"
+          }
+        }
+      },
+      "shape": "post_task",
+      "validate": [
+        {
+          "assert": "sumApproxEquals",
+          "fields": [
+            "appPay",
+            "customerTips"
           ],
-          "shape": "post_task"
+          "target": "totalPay",
+          "tolerance": 0.02,
+          "onFail": "skip"
+        }
+      ]
+    },
+    {
+      "id": "doordash.screen.delivery_summary_collapsed",
+      "priority": 30,
+      "state": {
+        "flow": "post:task",
+        "modeHint": "online"
+      },
+      "require": {
+        "allTextContainsAny": [
+          "this offer",
+          "delivery complete"
+        ]
+      },
+      "reject": [
+        {
+          "allTextContains": "pause orders"
+        }
+      ],
+      "parse": {
+        "fields": {
+          "totalPay": {
+            "find": {
+              "hasIdSuffix": "final_value"
+            },
+            "read": "text",
+            "transform": "parseCurrency"
+          },
+          "isExpanded": {
+            "literal": false
+          },
+          "expandButtonId": {
+            "coalesce": [
+              {
+                "find": {
+                  "hasIdSuffix": "expandable_view"
+                },
+                "read": "viewIdResourceName"
+              },
+              {
+                "find": {
+                  "hasIdSuffix": "expandable_layout"
+                },
+                "read": "viewIdResourceName"
+              }
+            ]
+          },
+          "sessionEarnings": {
+            "find": {
+              "hasIdSuffix": "earnings_ticker"
+            },
+            "read": "allText",
+            "transform": "parseCurrency"
+          }
+        }
+      },
+      "shape": "post_task",
+      "bind": {
+        "expandButton": {
+          "find": {
+            "any": [
+              {
+                "hasIdSuffix": "expandable_view"
+              },
+              {
+                "hasIdSuffix": "expandable_layout"
+              }
+            ]
+          },
+          "optional": true
+        }
+      },
+      "effects": [
+        {
+          "click": "$expandButton",
+          "onlyIf": {
+            "fieldEquals": {
+              "field": "isExpanded",
+              "value": false
+            }
+          },
+          "dedupeKey": "expand_pay_breakdown",
+          "throttleMs": 1000
         }
       ]
     },
     {
       "id": "doordash.screen.app_startup",
-      "platform_id": "doordash.driver",
       "priority": 40,
-      "overrideable": true,
       "require": {
         "all": [
           {
             "exists": {
               "all": [
                 {
-                  "hasTextCaseSensitive": "Starting\u00ef\u00bf\u00bd"
+                  "hasTextCaseSensitive": "Startingï¿½"
                 },
                 {
                   "hasClassNameEndsWith": "TextView"
@@ -639,9 +624,7 @@
     },
     {
       "id": "doordash.screen.dash_paused",
-      "platform_id": "doordash.driver",
       "priority": 50,
-      "overrideable": true,
       "state": {
         "modeHint": "paused"
       },
@@ -694,9 +677,7 @@
     },
     {
       "id": "doordash.screen.pickup_navigation",
-      "platform_id": "doordash.driver",
       "priority": 60,
-      "overrideable": true,
       "state": {
         "flow": "task:pickup:navigation",
         "modeHint": "online"
@@ -785,9 +766,7 @@
     },
     {
       "id": "doordash.screen.dropoff_navigation",
-      "platform_id": "doordash.driver",
       "priority": 61,
-      "overrideable": true,
       "state": {
         "flow": "task:dropoff:navigation",
         "modeHint": "online"
@@ -796,17 +775,24 @@
         {
           "exists": {
             "any": [
-              { "hasText": "Continue" },
-              { "hasText": "Complete Delivery" },
-              { "hasText": "Mark as delivered" },
-              { "hasIdSuffix": "complete_delivery_steps_button" }
+              {
+                "hasText": "Continue"
+              },
+              {
+                "hasText": "Complete Delivery"
+              },
+              {
+                "hasText": "Mark as delivered"
+              },
+              {
+                "hasIdSuffix": "complete_delivery_steps_button"
+              }
             ]
           }
         }
       ],
       "branches": [
         {
-          "target": "NAVIGATION_VIEW_TO_DROP_OFF",
           "require": {
             "exists": {
               "all": [
@@ -818,65 +804,9 @@
                 }
               ]
             }
-          },
-          "parse": {
-            "fields": {
-              "phase": "DROPOFF",
-              "subFlow": "NAVIGATION",
-              "customerNameHash": {
-                "find": {
-                  "hasIdSuffix": "bottom_sheet_task_title"
-                },
-                "read": "text",
-                "transform": [
-                  {
-                    "stripPrefixes": [
-                      "Deliver to ",
-                      "Heading to "
-                    ]
-                  },
-                  "trim",
-                  "sha256"
-                ]
-              },
-              "customerAddressHash": {
-                "join": [
-                  {
-                    "find": {
-                      "hasIdSuffix": "bottom_sheet_address_line_1"
-                    },
-                    "read": "text"
-                  },
-                  {
-                    "find": {
-                      "hasIdSuffix": "bottom_sheet_address_line_2"
-                    },
-                    "read": "text"
-                  }
-                ],
-                "separator": ", ",
-                "transform": "sha256"
-              },
-              "deadlineText": {
-                "find": {
-                  "hasIdSuffix": "bottom_sheet_task_arrive_by"
-                },
-                "read": "text",
-                "transform": "stripDeadlinePrefix"
-              },
-              "deadlineMillis": {
-                "find": {
-                  "hasIdSuffix": "bottom_sheet_task_arrive_by"
-                },
-                "read": "text",
-                "transform": "parseDeadline"
-              }
-            }
-          },
-          "shape": "task"
+          }
         },
         {
-          "target": "NAVIGATION_VIEW_TO_DROP_OFF",
           "require": {
             "all": [
               {
@@ -904,70 +834,68 @@
                 }
               }
             ]
-          },
-          "parse": {
-            "fields": {
-              "phase": "DROPOFF",
-              "subFlow": "NAVIGATION",
-              "customerNameHash": {
-                "find": {
-                  "hasIdSuffix": "bottom_sheet_task_title"
-                },
-                "read": "text",
-                "transform": [
-                  {
-                    "stripPrefixes": [
-                      "Deliver to ",
-                      "Heading to "
-                    ]
-                  },
-                  "trim",
-                  "sha256"
+          }
+        }
+      ],
+      "shape": "task",
+      "parse": {
+        "fields": {
+          "phase": "DROPOFF",
+          "subFlow": "NAVIGATION",
+          "customerNameHash": {
+            "find": {
+              "hasIdSuffix": "bottom_sheet_task_title"
+            },
+            "read": "text",
+            "transform": [
+              {
+                "stripPrefixes": [
+                  "Deliver to ",
+                  "Heading to "
                 ]
               },
-              "customerAddressHash": {
-                "join": [
-                  {
-                    "find": {
-                      "hasIdSuffix": "bottom_sheet_address_line_1"
-                    },
-                    "read": "text"
-                  },
-                  {
-                    "find": {
-                      "hasIdSuffix": "bottom_sheet_address_line_2"
-                    },
-                    "read": "text"
-                  }
-                ],
-                "separator": ", ",
-                "transform": "sha256"
-              },
-              "deadlineText": {
-                "find": {
-                  "hasIdSuffix": "bottom_sheet_task_arrive_by"
-                },
-                "read": "text",
-                "transform": "stripDeadlinePrefix"
-              },
-              "deadlineMillis": {
-                "find": {
-                  "hasIdSuffix": "bottom_sheet_task_arrive_by"
-                },
-                "read": "text",
-                "transform": "parseDeadline"
-              }
-            }
+              "trim",
+              "sha256"
+            ]
           },
-          "shape": "task"
+          "customerAddressHash": {
+            "join": [
+              {
+                "find": {
+                  "hasIdSuffix": "bottom_sheet_address_line_1"
+                },
+                "read": "text"
+              },
+              {
+                "find": {
+                  "hasIdSuffix": "bottom_sheet_address_line_2"
+                },
+                "read": "text"
+              }
+            ],
+            "separator": ", ",
+            "transform": "sha256"
+          },
+          "deadlineText": {
+            "find": {
+              "hasIdSuffix": "bottom_sheet_task_arrive_by"
+            },
+            "read": "text",
+            "transform": "stripDeadlinePrefix"
+          },
+          "deadlineMillis": {
+            "find": {
+              "hasIdSuffix": "bottom_sheet_task_arrive_by"
+            },
+            "read": "text",
+            "transform": "parseDeadline"
+          }
         }
-      ]
+      }
     },
     {
       "id": "doordash.screen.pickup_arrival",
-      "platform_id": "doordash.driver",
       "priority": 70,
-      "overrideable": true,
       "state": {
         "flow": "task:pickup:arrived",
         "modeHint": "online"
@@ -1074,9 +1002,7 @@
     },
     {
       "id": "doordash.screen.pickup_pre_arrival",
-      "platform_id": "doordash.driver",
       "priority": 71,
-      "overrideable": true,
       "state": {
         "flow": "task:pickup:navigation",
         "modeHint": "online"
@@ -1177,9 +1103,7 @@
     },
     {
       "id": "doordash.screen.pickup_shopping",
-      "platform_id": "doordash.driver",
       "priority": 72,
-      "overrideable": true,
       "state": {
         "flow": "task:pickup:arrived",
         "modeHint": "online"
@@ -1231,9 +1155,7 @@
     },
     {
       "id": "doordash.screen.dropoff_pre_arrival",
-      "platform_id": "doordash.driver",
       "priority": 73,
-      "overrideable": true,
       "state": {
         "flow": "task:dropoff:navigation",
         "modeHint": "online"
@@ -1369,9 +1291,7 @@
     },
     {
       "id": "doordash.screen.dropoff_pre_arrival_completion",
-      "platform_id": "doordash.driver",
       "priority": 74,
-      "overrideable": true,
       "state": {
         "flow": "task:dropoff:navigation",
         "modeHint": "online"
@@ -1495,9 +1415,7 @@
     },
     {
       "id": "doordash.screen.schedule",
-      "platform_id": "doordash.driver",
       "priority": 80,
-      "overrideable": true,
       "require": {
         "all": [
           {
@@ -1531,9 +1449,7 @@
     },
     {
       "id": "doordash.screen.ratings",
-      "platform_id": "doordash.driver",
       "priority": 90,
-      "overrideable": true,
       "require": {
         "allTextContainsAll": [
           "ratings",
@@ -1545,7 +1461,7 @@
       "parse": {
         "fields": {
           "acceptanceRate": {
-            "find": {
+            "siblingOf": {
               "all": [
                 {
                   "hasIdSuffix": "textView_title"
@@ -1555,12 +1471,10 @@
                 }
               ]
             },
-            "navigate": "sibling(1)",
-            "read": "text",
             "transform": "parsePercent"
           },
           "completionRate": {
-            "find": {
+            "siblingOf": {
               "all": [
                 {
                   "hasIdSuffix": "textView_title"
@@ -1570,12 +1484,10 @@
                 }
               ]
             },
-            "navigate": "sibling(1)",
-            "read": "text",
             "transform": "parsePercent"
           },
           "onTimeRate": {
-            "find": {
+            "siblingOf": {
               "all": [
                 {
                   "hasIdSuffix": "textView_title"
@@ -1585,12 +1497,10 @@
                 }
               ]
             },
-            "navigate": "sibling(1)",
-            "read": "text",
             "transform": "parsePercent"
           },
           "customerRating": {
-            "find": {
+            "siblingOf": {
               "all": [
                 {
                   "hasIdSuffix": "textView_title"
@@ -1600,12 +1510,10 @@
                 }
               ]
             },
-            "navigate": "sibling(1)",
-            "read": "text",
             "transform": "toDouble"
           },
           "deliveriesLast30Days": {
-            "find": {
+            "siblingOf": {
               "all": [
                 {
                   "hasIdSuffix": "textView_title"
@@ -1615,12 +1523,10 @@
                 }
               ]
             },
-            "navigate": "sibling(1)",
-            "read": "text",
             "transform": "toInt"
           },
           "lifetimeDeliveries": {
-            "find": {
+            "siblingOf": {
               "all": [
                 {
                   "hasIdSuffix": "textView_title"
@@ -1630,12 +1536,10 @@
                 }
               ]
             },
-            "navigate": "sibling(1)",
-            "read": "text",
             "transform": "toInt"
           },
           "originalItemsFoundRate": {
-            "find": {
+            "siblingOf": {
               "all": [
                 {
                   "hasIdSuffix": "textView_title"
@@ -1645,12 +1549,10 @@
                 }
               ]
             },
-            "navigate": "sibling(1)",
-            "read": "text",
             "transform": "parsePercent"
           },
           "totalItemsFoundRate": {
-            "find": {
+            "siblingOf": {
               "all": [
                 {
                   "hasIdSuffix": "textView_title"
@@ -1660,12 +1562,10 @@
                 }
               ]
             },
-            "navigate": "sibling(1)",
-            "read": "text",
             "transform": "parsePercent"
           },
           "substitutionIssuesRate": {
-            "find": {
+            "siblingOf": {
               "all": [
                 {
                   "hasIdSuffix": "textView_title"
@@ -1675,12 +1575,10 @@
                 }
               ]
             },
-            "navigate": "sibling(1)",
-            "read": "text",
             "transform": "parsePercent"
           },
           "itemsWithQualityIssuesRate": {
-            "find": {
+            "siblingOf": {
               "all": [
                 {
                   "hasIdSuffix": "textView_title"
@@ -1690,12 +1588,10 @@
                 }
               ]
             },
-            "navigate": "sibling(1)",
-            "read": "text",
             "transform": "parsePercent"
           },
           "itemsWrongOrMissingRate": {
-            "find": {
+            "siblingOf": {
               "all": [
                 {
                   "hasIdSuffix": "textView_title"
@@ -1705,12 +1601,10 @@
                 }
               ]
             },
-            "navigate": "sibling(1)",
-            "read": "text",
             "transform": "parsePercent"
           },
           "lifetimeShoppingOrders": {
-            "find": {
+            "siblingOf": {
               "all": [
                 {
                   "hasIdSuffix": "textView_title"
@@ -1720,8 +1614,6 @@
                 }
               ]
             },
-            "navigate": "sibling(1)",
-            "read": "text",
             "transform": "toInt"
           }
         }
@@ -1730,9 +1622,7 @@
     },
     {
       "id": "doordash.screen.safety",
-      "platform_id": "doordash.driver",
       "priority": 91,
-      "overrideable": true,
       "require": {
         "allTextContainsAll": [
           "safedash",
@@ -1744,9 +1634,7 @@
     },
     {
       "id": "doordash.screen.chat",
-      "platform_id": "doordash.driver",
       "priority": 92,
-      "overrideable": true,
       "reject": [
         {
           "allTextContains": "folder"
@@ -1761,9 +1649,7 @@
     },
     {
       "id": "doordash.screen.earnings",
-      "platform_id": "doordash.driver",
       "priority": 93,
-      "overrideable": true,
       "require": {
         "all": [
           {
@@ -1784,9 +1670,7 @@
     },
     {
       "id": "doordash.screen.help",
-      "platform_id": "doordash.driver",
       "priority": 94,
-      "overrideable": true,
       "require": {
         "allTextContainsAll": [
           "doordash dasher",
@@ -1799,9 +1683,7 @@
     },
     {
       "id": "doordash.screen.navigation_generic",
-      "platform_id": "doordash.driver",
       "priority": 95,
-      "overrideable": true,
       "reject": [
         {
           "allTextContains": "accept"
@@ -1829,9 +1711,7 @@
     },
     {
       "id": "doordash.screen.notifications_view",
-      "platform_id": "doordash.driver",
       "priority": 96,
-      "overrideable": true,
       "reject": [
         {
           "allTextContains": "battery"
@@ -1843,9 +1723,7 @@
     },
     {
       "id": "doordash.screen.promos",
-      "platform_id": "doordash.driver",
       "priority": 97,
-      "overrideable": true,
       "require": {
         "allTextContainsAll": [
           "navigate up",
@@ -1855,9 +1733,7 @@
     },
     {
       "id": "doordash.screen.pickup_picked_up",
-      "platform_id": "doordash.driver",
       "priority": 98,
-      "overrideable": true,
       "state": {
         "flow": "task:pickup:arrived",
         "modeHint": "online"
@@ -1865,15 +1741,13 @@
       "require": {
         "allTextContainsAll": [
           "confirm pickup",
-          "loading\u00ef\u00bf\u00bd"
+          "loadingï¿½"
         ]
       }
     },
     {
       "id": "doordash.screen.pickup_post_arrival_multi",
-      "platform_id": "doordash.driver",
       "priority": 99,
-      "overrideable": true,
       "state": {
         "flow": "task:pickup:arrived",
         "modeHint": "online"
@@ -1898,9 +1772,7 @@
     },
     {
       "id": "doordash.screen.pickup_pre_arrival_multi",
-      "platform_id": "doordash.driver",
       "priority": 100,
-      "overrideable": true,
       "state": {
         "flow": "task:pickup:navigation",
         "modeHint": "online"
@@ -1917,9 +1789,7 @@
     },
     {
       "id": "doordash.screen.pickup_verify",
-      "platform_id": "doordash.driver",
       "priority": 101,
-      "overrideable": true,
       "state": {
         "flow": "task:pickup:arrived",
         "modeHint": "online"
@@ -1940,9 +1810,7 @@
     },
     {
       "id": "doordash.screen.on_dash_map",
-      "platform_id": "doordash.driver",
       "priority": 110,
-      "overrideable": true,
       "state": {
         "flow": "idle",
         "modeHint": "online"
@@ -1974,9 +1842,7 @@
     },
     {
       "id": "doordash.screen.dash_along_the_way",
-      "platform_id": "doordash.driver",
       "priority": 111,
-      "overrideable": true,
       "state": {
         "flow": "idle",
         "modeHint": "online"
@@ -2036,9 +1902,7 @@
     },
     {
       "id": "doordash.screen.waiting_for_offer",
-      "platform_id": "doordash.driver",
       "priority": 120,
-      "overrideable": true,
       "state": {
         "flow": "idle",
         "modeHint": "online"
@@ -2140,9 +2004,7 @@
     },
     {
       "id": "doordash.screen.set_dash_end_time",
-      "platform_id": "doordash.driver",
       "priority": 130,
-      "overrideable": true,
       "state": {
         "flow": "idle"
       },
@@ -2183,9 +2045,7 @@
     },
     {
       "id": "doordash.screen.idle_map",
-      "platform_id": "doordash.driver",
       "priority": 140,
-      "overrideable": true,
       "state": {
         "flow": "idle",
         "modeHint": "offline"
@@ -2258,9 +2118,7 @@
     },
     {
       "id": "doordash.screen.dash_summary",
-      "platform_id": "doordash.driver",
       "priority": 150,
-      "overrideable": true,
       "state": {
         "flow": "session:ended",
         "modeHint": "offline"
@@ -2396,7 +2254,6 @@
     },
     {
       "id": "doordash.screen.sensitive.catchall",
-      "platform_id": "doordash.driver",
       "priority": 999,
       "overrideable": false,
       "require": {
@@ -2417,10 +2274,8 @@
   "clicks": [
     {
       "id": "doordash.click.accept_offer",
-      "platform_id": "doordash.driver",
       "priority": 10,
-      "overrideable": true,
-      "screenIs": "OFFER_POPUP",
+      "screenIs": "offer_popup",
       "intent": "accept_offer",
       "if": {
         "hasIdSuffix": "accept_button"
@@ -2428,10 +2283,8 @@
     },
     {
       "id": "doordash.click.decline_offer",
-      "platform_id": "doordash.driver",
       "priority": 20,
-      "overrideable": true,
-      "screenIs": "OFFER_POPUP_CONFIRM_DECLINE",
+      "screenIs": "offer_popup_confirm_decline",
       "intent": "decline_offer",
       "if": {
         "hasText": "Decline offer"
@@ -2439,9 +2292,7 @@
     },
     {
       "id": "doordash.click.arrived_at_store",
-      "platform_id": "doordash.driver",
       "priority": 30,
-      "overrideable": true,
       "screenIs": "pickup_arrival",
       "intent": "arrived_at_store",
       "if": {
@@ -2464,10 +2315,8 @@
     },
     {
       "id": "doordash.click.initial_decline",
-      "platform_id": "doordash.driver",
       "priority": 15,
-      "overrideable": true,
-      "screenIs": "OFFER_POPUP",
+      "screenIs": "offer_popup",
       "intent": "initial_decline",
       "if": {
         "hasIdSuffix": "secondary_action_button_dash_plus"
@@ -2475,9 +2324,7 @@
     },
     {
       "id": "doordash.click.resume_dash",
-      "platform_id": "doordash.driver",
       "priority": 40,
-      "overrideable": true,
       "screenIs": "dash_paused",
       "intent": "resume_dash",
       "if": {
@@ -2486,37 +2333,41 @@
     },
     {
       "id": "doordash.click.start_navigation",
-      "platform_id": "doordash.driver",
       "priority": 50,
-      "overrideable": true,
       "intent": "start_navigation",
       "if": {
         "any": [
-          { "hasIdSuffix": "directions_button" },
-          { "hasIdSuffix": "navigate_button" }
+          {
+            "hasIdSuffix": "directions_button"
+          },
+          {
+            "hasIdSuffix": "navigate_button"
+          }
         ]
       }
     },
     {
       "id": "doordash.click.complete_delivery",
-      "platform_id": "doordash.driver",
       "priority": 60,
-      "overrideable": true,
       "screenIs": "dropoff_pre_arrival_completion",
       "intent": "complete_delivery",
       "if": {
         "any": [
-          { "hasIdSuffix": "complete_delivery_steps_button" },
-          { "hasText": "Complete Delivery" },
-          { "hasText": "Mark as delivered" }
+          {
+            "hasIdSuffix": "complete_delivery_steps_button"
+          },
+          {
+            "hasText": "Complete Delivery"
+          },
+          {
+            "hasText": "Mark as delivered"
+          }
         ]
       }
     },
     {
       "id": "doordash.click.submit_photo",
-      "platform_id": "doordash.driver",
       "priority": 70,
-      "overrideable": true,
       "screenIs": "dropoff_pre_arrival",
       "intent": "submit_photo",
       "if": {
@@ -2525,9 +2376,7 @@
     },
     {
       "id": "doordash.click.checkout",
-      "platform_id": "doordash.driver",
       "priority": 80,
-      "overrideable": true,
       "screenIs": "pickup_shopping",
       "intent": "checkout",
       "if": {
@@ -2538,9 +2387,7 @@
   "notifications": [
     {
       "id": "doordash.notification.additional_tip",
-      "platform_id": "doordash.driver",
       "priority": 10,
-      "overrideable": true,
       "if": {
         "anyFieldMatchesRegex": "added \\$(\\d+\\.\\d{2}) tip on a past (.+?) order delivered at (\\d{1,2}/\\d{1,2}, \\d{1,2}:\\d{2} [AP]M)"
       },
@@ -2561,18 +2408,14 @@
     },
     {
       "id": "doordash.notification.new_order",
-      "platform_id": "doordash.driver",
       "priority": 20,
-      "overrideable": true,
       "if": {
         "titleContains": "new order"
       }
     },
     {
       "id": "doordash.notification.scheduled_dash_expired",
-      "platform_id": "doordash.driver",
       "priority": 30,
-      "overrideable": true,
       "if": {
         "all": [
           {
@@ -2586,9 +2429,7 @@
     },
     {
       "id": "doordash.notification.demand_nudge",
-      "platform_id": "doordash.driver",
       "priority": 50,
-      "overrideable": true,
       "if": {
         "titleContains": "Dash now"
       },
@@ -2597,9 +2438,7 @@
     },
     {
       "id": "doordash.notification.peak_pay_promo",
-      "platform_id": "doordash.driver",
       "priority": 60,
-      "overrideable": true,
       "if": {
         "titleContains": "Incentives Update"
       },

--- a/app/src/main/assets/rules/uber.json
+++ b/app/src/main/assets/rules/uber.json
@@ -1,36 +1,38 @@
 {
   "format_version": 2,
-  "engine_version": "1.0.0",
   "platform_id": "uber.driver",
-  "min_app_version": "0.230.0",
-  "pipelines": {
-    "accessibility.window": { "version": 1 },
-    "accessibility.click": { "version": 1 },
-    "notification": { "version": 1, "allowOngoing": true }
-  },
-  "state_machine": {
-    "api_version_major": 1,
-    "api_version_minor": 0
-  },
   "screens": [
     {
       "id": "uber.screen.offer",
-      "platform_id": "uber.driver",
       "priority": 15,
-      "overrideable": true,
       "branches": [
         {
-          "target": "OFFER",
-          "state": { "flow": "offer:presented", "modeHint": "online" },
+          "state": {
+            "flow": "offer:presented",
+            "modeHint": "online"
+          },
           "shape": "offer",
           "require": {
             "all": [
-              { "exists": { "hasIdSuffix": "primary_touch_area" } },
-              { "exists": { "hasTextMatchesRegex": "\\$\\d+\\.\\d{2}" } },
-              { "exists": {
+              {
+                "exists": {
+                  "hasIdSuffix": "primary_touch_area"
+                }
+              },
+              {
+                "exists": {
+                  "hasTextMatchesRegex": "\\$\\d+\\.\\d{2}"
+                }
+              },
+              {
+                "exists": {
                   "any": [
-                    { "hasText": "Accept" },
-                    { "hasText": "Match" }
+                    {
+                      "hasText": "Accept"
+                    },
+                    {
+                      "hasText": "Match"
+                    }
                   ]
                 }
               }
@@ -39,42 +41,82 @@
           "parse": {
             "fields": {
               "payAmount": {
-                "find": { "hasTextMatchesRegex": "\\$\\d" },
+                "find": {
+                  "hasTextMatchesRegex": "\\$\\d"
+                },
                 "read": "text",
                 "transform": "parseCurrency"
               },
               "distance": {
-                "find": { "hasTextMatchesRegex": "\\d[\\d.]*\\s*mi" },
+                "find": {
+                  "hasTextMatchesRegex": "\\d[\\d.]*\\s*mi"
+                },
                 "read": "text",
                 "transform": "parseDistance"
               },
               "timeToCompleteMinutes": {
-                "find": { "hasTextMatchesRegex": "\\d+\\s*min" },
+                "find": {
+                  "hasTextMatchesRegex": "\\d+\\s*min"
+                },
                 "read": "text",
                 "transform": "parseLeadingInt"
               },
               "orders": {
-                "each": { "hasClassNameEndsWith": "CardView" },
+                "each": {
+                  "hasClassNameEndsWith": "CardView"
+                },
                 "extract": {
                   "storeName": {
                     "find": {
                       "all": [
-                        { "hasClassName": "android.widget.TextView" },
-                        { "not": { "any": [
-                          { "hasTextMatchesRegex": "^\\$" },
-                          { "hasTextMatchesRegex": "^\\+" },
-                          { "hasTextContaining": "min" },
-                          { "hasText": "Accept" },
-                          { "hasText": "Match" },
-                          { "hasText": "Delivery" },
-                          { "hasTextContaining": "Exclusive" },
-                          { "hasTextContaining": "Guaranteed" },
-                          { "hasTextContaining": "Includes" },
-                          { "hasTextContaining": "Add a" },
-                          { "hasTextContaining": "Shop &" },
-                          { "hasTextMatchesRegex": "^\\d+ items?" },
-                          { "hasTextContaining": ", " }
-                        ]}}
+                        {
+                          "hasClassName": "android.widget.TextView"
+                        },
+                        {
+                          "not": {
+                            "any": [
+                              {
+                                "hasTextMatchesRegex": "^\\$"
+                              },
+                              {
+                                "hasTextMatchesRegex": "^\\+"
+                              },
+                              {
+                                "hasTextContaining": "min"
+                              },
+                              {
+                                "hasText": "Accept"
+                              },
+                              {
+                                "hasText": "Match"
+                              },
+                              {
+                                "hasText": "Delivery"
+                              },
+                              {
+                                "hasTextContaining": "Exclusive"
+                              },
+                              {
+                                "hasTextContaining": "Guaranteed"
+                              },
+                              {
+                                "hasTextContaining": "Includes"
+                              },
+                              {
+                                "hasTextContaining": "Add a"
+                              },
+                              {
+                                "hasTextContaining": "Shop &"
+                              },
+                              {
+                                "hasTextMatchesRegex": "^\\d+ items?"
+                              },
+                              {
+                                "hasTextContaining": ", "
+                              }
+                            ]
+                          }
+                        }
                       ]
                     },
                     "read": "text"
@@ -88,12 +130,17 @@
           },
           "effects": [
             {
-              "screenshot": { "prefix": "Offer - {storeName}" },
+              "screenshot": {
+                "prefix": "Offer - {storeName}"
+              },
               "dedupeKey": "offer-ss-{offerHash}",
               "throttleMs": 60000
             },
             {
-              "log": { "type": "OFFER_RECEIVED", "payload": "pay={payAmount} dist={distance}" },
+              "log": {
+                "type": "OFFER_RECEIVED",
+                "payload": "pay={payAmount} dist={distance}"
+              },
               "dedupeKey": "offer-log-{offerHash}",
               "throttleMs": 60000
             }
@@ -103,9 +150,7 @@
     },
     {
       "id": "uber.screen.splash",
-      "platform_id": "uber.driver",
       "priority": 40,
-      "overrideable": true,
       "require": {
         "exists": {
           "hasIdSuffix": "rootSplashBackground"
@@ -113,186 +158,260 @@
       }
     },
     {
-      "id": "uber.screen.pickup_verification",
-      "platform_id": "uber.driver",
+      "id": "uber.screen.pickup_verification_info",
       "priority": 50,
-      "overrideable": true,
       "state": {
         "flow": "task:pickup:arrived",
         "modeHint": "online"
       },
-      "branches": [
-        {
-          "target": "pickup_verification_info",
-          "require": {
-            "all": [
-              { "exists": { "hasIdSuffix": "on_job_view" } },
-              { "exists": { "hasText": "Pickup verification" } }
-            ]
+      "require": {
+        "all": [
+          {
+            "exists": {
+              "hasIdSuffix": "on_job_view"
+            }
+          },
+          {
+            "exists": {
+              "hasText": "Pickup verification"
+            }
           }
-        },
-        {
-          "target": "pickup_verification_pin",
-          "require": {
-            "all": [
-              { "exists": { "hasIdSuffix": "on_job_view" } },
-              { "exists": { "hasTextContaining": "Enter Uber Eats order number" } }
-            ]
+        ]
+      }
+    },
+    {
+      "id": "uber.screen.pickup_verification_pin",
+      "priority": 50,
+      "state": {
+        "flow": "task:pickup:arrived",
+        "modeHint": "online"
+      },
+      "require": {
+        "all": [
+          {
+            "exists": {
+              "hasIdSuffix": "on_job_view"
+            }
+          },
+          {
+            "exists": {
+              "hasTextContaining": "Enter Uber Eats order number"
+            }
           }
-        },
-        {
-          "target": "pickup_verification_items",
-          "require": {
-            "all": [
-              { "exists": { "hasIdSuffix": "on_job_view" } },
-              { "exists": { "hasText": "Verify order" } },
-              { "exists": {
-                  "any": [
-                    { "hasText": "Order verified" },
-                    { "hasText": "Issue with order" }
-                  ]
+        ]
+      }
+    },
+    {
+      "id": "uber.screen.pickup_verification_items",
+      "priority": 50,
+      "state": {
+        "flow": "task:pickup:arrived",
+        "modeHint": "online"
+      },
+      "require": {
+        "all": [
+          {
+            "exists": {
+              "hasIdSuffix": "on_job_view"
+            }
+          },
+          {
+            "exists": {
+              "hasText": "Verify order"
+            }
+          },
+          {
+            "exists": {
+              "any": [
+                {
+                  "hasText": "Order verified"
+                },
+                {
+                  "hasText": "Issue with order"
                 }
-              }
-            ]
+              ]
+            }
           }
-        }
-      ]
+        ]
+      }
     },
     {
       "id": "uber.screen.customer_chat",
-      "platform_id": "uber.driver",
       "priority": 55,
-      "overrideable": true,
       "state": {
         "modeHint": "online"
       },
       "require": {
         "all": [
-          { "exists": { "hasIdSuffix": "on_job_view" } },
-          { "exists": { "hasIdSuffix": "ub__intercom_coordinator_layout" } }
+          {
+            "exists": {
+              "hasIdSuffix": "on_job_view"
+            }
+          },
+          {
+            "exists": {
+              "hasIdSuffix": "ub__intercom_coordinator_layout"
+            }
+          }
         ]
       }
     },
     {
       "id": "uber.screen.photo_capture",
-      "platform_id": "uber.driver",
       "priority": 60,
-      "overrideable": true,
       "state": {
         "flow": "task:dropoff:arrived",
         "modeHint": "online"
       },
       "require": {
         "all": [
-          { "exists": { "hasIdSuffix": "on_job_view" } },
-          { "exists": { "hasIdSuffix": "ub__carbon_facecamera_root_view" } }
+          {
+            "exists": {
+              "hasIdSuffix": "on_job_view"
+            }
+          },
+          {
+            "exists": {
+              "hasIdSuffix": "ub__carbon_facecamera_root_view"
+            }
+          }
         ]
       }
     },
     {
       "id": "uber.screen.delivery_confirmation",
-      "platform_id": "uber.driver",
       "priority": 65,
-      "overrideable": true,
       "state": {
         "flow": "task:dropoff:arrived",
         "modeHint": "online"
       },
       "require": {
         "all": [
-          { "exists": { "hasIdSuffix": "on_job_view" } },
-          { "exists": { "hasIdSuffix": "earner_trip_image_capture_taskbar_container" } }
+          {
+            "exists": {
+              "hasIdSuffix": "on_job_view"
+            }
+          },
+          {
+            "exists": {
+              "hasIdSuffix": "earner_trip_image_capture_taskbar_container"
+            }
+          }
         ]
       }
     },
     {
-      "id": "uber.screen.shop_and_pay",
-      "platform_id": "uber.driver",
+      "id": "uber.screen.shop_and_pay_list",
       "priority": 68,
-      "overrideable": true,
       "state": {
         "flow": "task:pickup:arrived",
         "modeHint": "online"
       },
-      "branches": [
-        {
-          "target": "shop_and_pay_list",
-          "require": {
-            "all": [
-              { "exists": { "hasIdSuffix": "on_job_view" } },
-              { "exists": { "hasTextContaining": "Shop priority items" } }
-            ]
+      "require": {
+        "all": [
+          {
+            "exists": {
+              "hasIdSuffix": "on_job_view"
+            }
+          },
+          {
+            "exists": {
+              "hasTextContaining": "Shop priority items"
+            }
           }
-        },
-        {
-          "target": "shop_and_pay_checkout",
-          "require": {
-            "all": [
-              { "exists": { "hasIdSuffix": "on_job_view" } },
-              { "exists": { "hasTextContaining": "shopping bags" } }
-            ]
+        ]
+      }
+    },
+    {
+      "id": "uber.screen.shop_and_pay_checkout",
+      "priority": 68,
+      "state": {
+        "flow": "task:pickup:arrived",
+        "modeHint": "online"
+      },
+      "require": {
+        "all": [
+          {
+            "exists": {
+              "hasIdSuffix": "on_job_view"
+            }
+          },
+          {
+            "exists": {
+              "hasTextContaining": "shopping bags"
+            }
           }
-        }
-      ]
+        ]
+      }
     },
     {
       "id": "uber.screen.post_trip",
-      "platform_id": "uber.driver",
       "priority": 75,
-      "overrideable": true,
       "state": {
         "flow": "post:task",
         "modeHint": "online"
       },
       "require": {
         "all": [
-          { "exists": { "hasIdSuffix": "on_job_view" } },
-          { "exists": { "hasTextContaining": "more customers order again" } }
+          {
+            "exists": {
+              "hasIdSuffix": "on_job_view"
+            }
+          },
+          {
+            "exists": {
+              "hasTextContaining": "more customers order again"
+            }
+          }
         ]
       }
     },
     {
       "id": "uber.screen.earnings_activity",
-      "platform_id": "uber.driver",
       "priority": 78,
-      "overrideable": true,
       "require": {
         "all": [
-          { "exists": { "hasText": "Earnings Activity" } },
-          { "exists": { "hasIdSuffix": "recycler_view" } }
+          {
+            "exists": {
+              "hasText": "Earnings Activity"
+            }
+          },
+          {
+            "exists": {
+              "hasIdSuffix": "recycler_view"
+            }
+          }
         ]
       }
     },
     {
       "id": "uber.screen.session_summary",
-      "platform_id": "uber.driver",
       "priority": 80,
-      "overrideable": true,
       "state": {
         "flow": "session:ended",
         "modeHint": "offline"
       },
       "require": {
-        "exists": { "hasTextContaining": "Session summary" }
+        "exists": {
+          "hasTextContaining": "Session summary"
+        }
       }
     },
     {
       "id": "uber.screen.active_trip",
-      "platform_id": "uber.driver",
       "priority": 100,
-      "overrideable": true,
       "state": {
         "modeHint": "online"
       },
       "require": {
-        "exists": { "hasIdSuffix": "on_job_view" }
+        "exists": {
+          "hasIdSuffix": "on_job_view"
+        }
       }
     },
     {
       "id": "uber.screen.awaiting_offer",
-      "platform_id": "uber.driver",
       "priority": 110,
-      "overrideable": true,
       "state": {
         "flow": "idle",
         "modeHint": "online"
@@ -307,8 +426,12 @@
           {
             "exists": {
               "any": [
-                { "hasTextContaining": "Finding trips" },
-                { "hasText": "You're online" }
+                {
+                  "hasTextContaining": "Finding trips"
+                },
+                {
+                  "hasText": "You're online"
+                }
               ]
             }
           }
@@ -317,9 +440,7 @@
     },
     {
       "id": "uber.screen.idle_map",
-      "platform_id": "uber.driver",
       "priority": 130,
-      "overrideable": true,
       "state": {
         "flow": "idle",
         "modeHint": "offline"
@@ -332,34 +453,53 @@
     },
     {
       "id": "uber.screen.home_dashboard",
-      "platform_id": "uber.driver",
       "priority": 140,
-      "overrideable": true,
       "branches": [
         {
-          "target": "home_dashboard",
-          "state": { "flow": "idle", "modeHint": "offline" },
+          "state": {
+            "flow": "idle",
+            "modeHint": "offline"
+          },
           "require": {
             "all": [
-              { "exists": { "hasIdSuffix": "glide_bottom_nav_home" } },
-              { "exists": { "hasIdSuffix": "go_online_button" } }
+              {
+                "exists": {
+                  "hasIdSuffix": "glide_bottom_nav_home"
+                }
+              },
+              {
+                "exists": {
+                  "hasIdSuffix": "go_online_button"
+                }
+              }
             ]
           }
         },
         {
-          "target": "home_dashboard",
-          "state": { "flow": "idle", "modeHint": "online" },
+          "state": {
+            "flow": "idle",
+            "modeHint": "online"
+          },
           "require": {
             "all": [
-              { "exists": { "hasIdSuffix": "glide_bottom_nav_home" } },
-              { "exists": { "hasIdSuffix": "ub__system_banner_text" } }
+              {
+                "exists": {
+                  "hasIdSuffix": "glide_bottom_nav_home"
+                }
+              },
+              {
+                "exists": {
+                  "hasIdSuffix": "ub__system_banner_text"
+                }
+              }
             ]
           }
         },
         {
-          "target": "home_dashboard",
           "require": {
-            "exists": { "hasIdSuffix": "glide_bottom_nav_home" }
+            "exists": {
+              "hasIdSuffix": "glide_bottom_nav_home"
+            }
           }
         }
       ]
@@ -368,25 +508,30 @@
   "clicks": [
     {
       "id": "uber.click.accept_offer",
-      "platform_id": "uber.driver",
       "priority": 5,
-      "overrideable": true,
-      "screenIs": "OFFER",
-      "state": { "flow": "task:pickup:navigation", "modeHint": "online" },
+      "screenIs": "offer",
+      "state": {
+        "flow": "task:pickup:navigation",
+        "modeHint": "online"
+      },
       "intent": "accept_offer",
       "if": {
         "any": [
-          { "hasText": "Accept" },
-          { "hasText": "Match" }
+          {
+            "hasText": "Accept"
+          },
+          {
+            "hasText": "Match"
+          }
         ]
       }
     },
     {
       "id": "uber.click.go_online",
-      "platform_id": "uber.driver",
       "priority": 10,
-      "overrideable": true,
-      "state": { "modeHint": "online" },
+      "state": {
+        "modeHint": "online"
+      },
       "intent": "go_online",
       "if": {
         "hasIdSuffix": "go_online_button"
@@ -394,11 +539,12 @@
     },
     {
       "id": "uber.click.go_offline",
-      "platform_id": "uber.driver",
       "priority": 20,
-      "overrideable": true,
       "screenIs": "home_dashboard",
-      "state": { "flow": "session:ended", "modeHint": "offline" },
+      "state": {
+        "flow": "session:ended",
+        "modeHint": "offline"
+      },
       "intent": "go_offline",
       "if": {
         "hasIdSuffix": "carbon_action_button"
@@ -406,40 +552,48 @@
     },
     {
       "id": "uber.click.order_verified",
-      "platform_id": "uber.driver",
       "priority": 15,
-      "overrideable": true,
       "screenIs": "pickup_verification_items",
-      "state": { "flow": "task:dropoff:navigation", "modeHint": "online" },
+      "state": {
+        "flow": "task:dropoff:navigation",
+        "modeHint": "online"
+      },
       "intent": "order_verified",
       "if": {
         "all": [
-          { "hasText": "Order verified" },
-          { "hasClassName": "android.widget.Button" }
+          {
+            "hasText": "Order verified"
+          },
+          {
+            "hasClassName": "android.widget.Button"
+          }
         ]
       }
     },
     {
       "id": "uber.click.issue_with_order",
-      "platform_id": "uber.driver",
       "priority": 16,
-      "overrideable": true,
       "screenIs": "pickup_verification_items",
       "intent": "issue_with_order",
       "if": {
         "all": [
-          { "hasText": "Issue with order" },
-          { "hasClassName": "android.widget.Button" }
+          {
+            "hasText": "Issue with order"
+          },
+          {
+            "hasClassName": "android.widget.Button"
+          }
         ]
       }
     },
     {
       "id": "uber.click.delivered",
-      "platform_id": "uber.driver",
       "priority": 20,
-      "overrideable": true,
       "screenIs": "delivery_confirmation",
-      "state": { "flow": "post:task", "modeHint": "online" },
+      "state": {
+        "flow": "post:task",
+        "modeHint": "online"
+      },
       "intent": "delivered",
       "if": {
         "hasIdSuffix": "task_button_button"
@@ -447,9 +601,7 @@
     },
     {
       "id": "uber.click.open_inbox",
-      "platform_id": "uber.driver",
       "priority": 30,
-      "overrideable": true,
       "screenIs": "home_dashboard",
       "intent": "open_inbox",
       "if": {
@@ -460,9 +612,7 @@
   "notifications": [
     {
       "id": "uber.notification.trip_en_route_pickup",
-      "platform_id": "uber.driver",
       "priority": 3,
-      "overrideable": true,
       "if": {
         "titleMatchesRegex": "^Going to (?!\\d)"
       },
@@ -471,9 +621,7 @@
     },
     {
       "id": "uber.notification.trip_arrived_pickup",
-      "platform_id": "uber.driver",
       "priority": 4,
-      "overrideable": true,
       "if": {
         "titleContains": "Arrived at "
       },
@@ -482,9 +630,7 @@
     },
     {
       "id": "uber.notification.trip_en_route_dropoff",
-      "platform_id": "uber.driver",
       "priority": 5,
-      "overrideable": true,
       "if": {
         "titleMatchesRegex": "^Going to \\d"
       },
@@ -493,9 +639,7 @@
     },
     {
       "id": "uber.notification.trip_at_dropoff",
-      "platform_id": "uber.driver",
       "priority": 6,
-      "overrideable": true,
       "if": {
         "titleMatchesRegex": "(Leave the order at|Meet at door for)"
       },
@@ -504,9 +648,7 @@
     },
     {
       "id": "uber.notification.tip_received",
-      "platform_id": "uber.driver",
       "priority": 8,
-      "overrideable": true,
       "if": {
         "titleMatchesRegex": "received a \\$\\d"
       },
@@ -515,9 +657,7 @@
     },
     {
       "id": "uber.notification.online_status",
-      "platform_id": "uber.driver",
       "priority": 10,
-      "overrideable": true,
       "if": {
         "titleContains": "currently online"
       },
@@ -525,9 +665,7 @@
     },
     {
       "id": "uber.notification.quest_promo",
-      "platform_id": "uber.driver",
       "priority": 20,
-      "overrideable": true,
       "if": {
         "titleContains": "Quest awaits"
       },
@@ -536,13 +674,15 @@
     },
     {
       "id": "uber.notification.quest_deadline",
-      "platform_id": "uber.driver",
       "priority": 30,
-      "overrideable": true,
       "if": {
         "all": [
-          { "titleContains": "Last chance" },
-          { "anyFieldContains": "Quest" }
+          {
+            "titleContains": "Last chance"
+          },
+          {
+            "anyFieldContains": "Quest"
+          }
         ]
       },
       "intent": "quest_deadline",

--- a/app/src/main/java/cloud/trotter/dashbuddy/pipeline/notification/NotificationFilter.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/pipeline/notification/NotificationFilter.kt
@@ -3,23 +3,20 @@ package cloud.trotter.dashbuddy.pipeline.notification
 import cloud.trotter.dashbuddy.core.data.settings.PlatformPreferencesRepository
 import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData
 import cloud.trotter.dashbuddy.domain.state.Platform
-import cloud.trotter.dashbuddy.rules.JsonRuleInterpreter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * Package + clearability pre-filter. Gates notifications before they reach the rule engine.
+ * Package pre-filter. Gates notifications before they reach the rule engine.
  *
- * By default, ongoing (non-clearable) notifications are dropped to avoid noise from
- * persistent foreground-service notifications. Platforms can opt in to ongoing notifications
- * by declaring `"allowOngoing": true` in their pipeline config header.
+ * All notifications from watched packages pass through — unwanted ongoing
+ * notifications are handled downstream via `"shape": "noise"` rules.
  */
 @Singleton
 class NotificationFilter @Inject constructor(
     private val platformPreferences: PlatformPreferencesRepository,
-    private val interpreter: JsonRuleInterpreter,
 ) {
     /** Cached enabled packages — refreshed lazily. */
     @Volatile
@@ -33,21 +30,12 @@ class NotificationFilter @Inject constructor(
             cachedPackages = runBlocking { platformPreferences.enabledPackages.first() }
             initialized = true
         }
-        if (raw.packageName !in cachedPackages) return false
-
-        // If not clearable, check if the platform opts in to ongoing notifications
-        if (!raw.isClearable && !allowsOngoing(raw.packageName)) return false
-        return true
+        return raw.packageName in cachedPackages
     }
 
     /** Called by the pipeline to update the cached set when preferences change. */
     fun updateEnabledPackages(packages: Set<String>) {
         cachedPackages = packages
         initialized = true
-    }
-
-    private fun allowsOngoing(packageName: String): Boolean {
-        val platform = Platform.fromPackage(packageName)
-        return interpreter.getPipelineConfig(platform.wire, "notification")?.allowOngoing == true
     }
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/rules/JsonRuleInterpreter.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/rules/JsonRuleInterpreter.kt
@@ -3,9 +3,6 @@ package cloud.trotter.dashbuddy.rules
 import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.int
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
@@ -40,13 +37,6 @@ class JsonRuleInterpreter @Inject constructor(
     var loadedFormatVersion: Int? = null
         private set
 
-    /** Per-platform pipeline configs parsed from ruleset headers. Key = platform wire name. */
-    private val _pipelineConfigs = mutableMapOf<String, Map<String, PipelineConfig>>()
-
-    /** Get pipeline config for a specific platform and pipeline. */
-    fun getPipelineConfig(platformWire: String, pipelineId: String): PipelineConfig? =
-        _pipelineConfigs[platformWire]?.get(pipelineId)
-
     /** Load all bundled rule files from `assets/rules/`. */
     fun loadDefaults() {
         try {
@@ -62,7 +52,6 @@ class JsonRuleInterpreter @Inject constructor(
             val allScreens = mutableListOf<CompiledScreenRule>()
             val allClicks = mutableListOf<CompiledClickRule>()
             val allNotifications = mutableListOf<CompiledNotificationRule>()
-            _pipelineConfigs.clear()
 
             for (fileName in files) {
                 val path = "$RULES_DIR/$fileName"
@@ -71,9 +60,6 @@ class JsonRuleInterpreter @Inject constructor(
                 allScreens += result.screens
                 allClicks += result.clicks
                 allNotifications += result.notifications
-                if (result.platformWire != null && result.pipelineConfigs.isNotEmpty()) {
-                    _pipelineConfigs[result.platformWire] = result.pipelineConfigs
-                }
             }
 
             screenRuleset = ScreenRuleset(allScreens)
@@ -124,17 +110,12 @@ class JsonRuleInterpreter @Inject constructor(
 
             loadedFormatVersion = root["format_version"]?.jsonPrimitive?.int
 
-            // Extract platform wire and pipeline configs
-            val platformId = root["platform_id"]?.jsonPrimitive?.content
-            val platformWire = platformId?.substringBefore('.')
-            val pipelineConfigs = parsePipelineConfigs(root["pipelines"]?.jsonObject)
-
             Timber.i(
                 "JsonRuleInterpreter: compiled '$source' " +
                     "(screens=${screens.size}, clicks=${clicks.size}, notifications=${notifications.size})"
             )
 
-            CompiledRuleBundle(screens, clicks, notifications, platformWire, pipelineConfigs)
+            CompiledRuleBundle(screens, clicks, notifications)
         } catch (e: RuleCompileException) {
             Timber.e(e, "JsonRuleInterpreter: compile error in '$source'")
             null
@@ -160,32 +141,7 @@ class JsonRuleInterpreter @Inject constructor(
         val screens: List<CompiledScreenRule>,
         val clicks: List<CompiledClickRule>,
         val notifications: List<CompiledNotificationRule>,
-        val platformWire: String? = null,
-        val pipelineConfigs: Map<String, PipelineConfig> = emptyMap(),
     )
-
-    /** Per-pipeline configuration declared in a ruleset header. */
-    data class PipelineConfig(
-        val version: Int,
-        val allowOngoing: Boolean = false,
-    )
-
-    private fun parsePipelineConfigs(pipelinesObj: JsonObject?): Map<String, PipelineConfig> {
-        if (pipelinesObj == null) return emptyMap()
-        val configs = mutableMapOf<String, PipelineConfig>()
-        for ((pipelineId, elem) in pipelinesObj) {
-            val config = when (elem) {
-                is JsonPrimitive -> PipelineConfig(version = elem.int)
-                is JsonObject -> PipelineConfig(
-                    version = elem["version"]?.jsonPrimitive?.int ?: 0,
-                    allowOngoing = elem["allowOngoing"]?.jsonPrimitive?.booleanOrNull ?: false,
-                )
-                else -> PipelineConfig(version = 0)
-            }
-            configs[pipelineId] = config
-        }
-        return configs
-    }
 
     companion object {
         private const val RULES_DIR = "rules"

--- a/app/src/main/java/cloud/trotter/dashbuddy/rules/RuleCompiler.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/rules/RuleCompiler.kt
@@ -79,13 +79,21 @@ object RuleCompiler {
         val priority = obj["priority"]!!.jsonPrimitive.int
         val overrideable = obj["overrideable"]?.jsonPrimitive?.booleanOrNull ?: true
 
-        // Rule-level bindings (shared across branches)
-        val ruleBindings = obj["bind"]?.jsonObject?.let { compileBindBlock(it) } ?: emptyList()
+        // Rule-level bindings (shared across branches, overridden if branch declares its own)
+        val ruleBindObj = obj["bind"]?.jsonObject
+        val ruleBindings = ruleBindObj?.let { compileBindBlock(it) } ?: emptyList()
 
         val (ruleFlow, ruleModeHint) = parseStateBlock(obj["state"] as? JsonObject, id)
 
+        // Rule-level parse/shape (inherited by branches unless branch overrides)
+        val ruleParseObj = obj["parse"]?.jsonObject
+        val ruleShape = obj["shape"]?.jsonPrimitive?.content
+
         val branches: List<CompiledBranch> = if ("branches" in obj) {
-            obj["branches"]!!.jsonArray.map { compileBranch(it.jsonObject, ruleFlow, ruleModeHint) }
+            obj["branches"]!!.jsonArray.map {
+                compileBranch(it.jsonObject, ruleFlow, ruleModeHint, ruleId = id,
+                    ruleParseBlock = ruleParseObj, ruleParseShape = ruleShape, ruleBindObj = ruleBindObj)
+            }
         } else {
             listOf(compileBranch(obj, ruleFlow, ruleModeHint, ruleId = id))
         }
@@ -98,16 +106,19 @@ object RuleCompiler {
         ruleFlow: Flow? = null,
         ruleModeHint: Mode? = null,
         ruleId: String? = null,
+        ruleParseBlock: JsonObject? = null,
+        ruleParseShape: String? = null,
+        ruleBindObj: JsonObject? = null,
     ): CompiledBranch {
-        val targetName = obj["target"]?.jsonPrimitive?.content
-            ?: ruleId?.let { deriveTargetFromId(it) }
-            ?: throw RuleCompileException("Branch has no 'target' field and no rule id to derive from")
+        val targetName = ruleId?.let { deriveTargetFromId(it) }
+            ?: throw RuleCompileException("Branch has no rule id to derive target from")
 
         // Branch-level state overrides rule-level defaults
         val (branchFlow, branchModeHint) = parseStateBlock(obj["state"] as? JsonObject, "$targetName-branch")
 
-        // Branch-level bindings
-        val bindings = obj["bind"]?.jsonObject?.let { compileBindBlock(it) } ?: emptyList()
+        // Branch-level bindings override rule-level (no merging)
+        val effectiveBindObj = obj["bind"]?.jsonObject ?: ruleBindObj
+        val bindings = effectiveBindObj?.let { compileBindBlock(it) } ?: emptyList()
 
         // --- Phase 2: Reject ---
         // v2: "reject:" array of tree preds
@@ -128,10 +139,11 @@ object RuleCompiler {
         val requireCheck: (UiNode, Bindings) -> Boolean = { tree, _ -> requirePred(tree) }
 
         // --- Phase 4: Parse ---
-        // Shape is declared at branch level (preferred) or inside parse block (legacy)
-        val parseBlock = obj["parse"]?.jsonObject
+        // Branch-level parse overrides rule-level (no merging)
+        val parseBlock = obj["parse"]?.jsonObject ?: ruleParseBlock
         val parseShape = obj["shape"]?.jsonPrimitive?.content
             ?: parseBlock?.get("shape")?.jsonPrimitive?.content
+            ?: ruleParseShape
         val parser: (UiNode, Bindings) -> Map<String, Any?> = if (parseBlock != null) {
             compileParseBlock(parseBlock)
         } else {
@@ -254,6 +266,7 @@ object RuleCompiler {
             "each" in obj -> compileEach(obj, fromName)
             "join" in obj -> compileJoin(obj)
             "coalesce" in obj -> compileCoalesce(obj)
+            "siblingOf" in obj -> compileSiblingOf(obj, fromName)
             "read" in obj && fromName != null -> compileReadFromBinding(obj, fromName)
             else -> throw RuleCompileException("Unknown parse expression keys: ${obj.keys}")
         }
@@ -315,6 +328,44 @@ object RuleCompiler {
 
             // Fallback
             transformed ?: fallbackVal?.let { resolveLiteral(it) }
+        }
+    }
+
+    /**
+     * `siblingOf:` — shorthand for find→sibling→read→transform.
+     *
+     * ```json
+     * "fieldName": {
+     *   "siblingOf": { "all": [{"hasIdSuffix": "title"}, {"hasTextContaining": "Label"}] },
+     *   "offset": 1,
+     *   "read": "text",
+     *   "transform": "parsePercent"
+     * }
+     * ```
+     *
+     * Defaults: offset=1, read="text". Equivalent to:
+     * ```json
+     * { "find": <predicate>, "navigate": "sibling(1)", "read": "text", "transform": ... }
+     * ```
+     */
+    private fun compileSiblingOf(obj: JsonObject, fromName: String?): (UiNode, Bindings) -> Any? {
+        val findPred = compileNodePred(obj["siblingOf"]!!)
+        val offset = obj["offset"]?.jsonPrimitive?.intOrNull ?: 1
+        val readProp = obj["read"]?.jsonPrimitive?.content ?: "text"
+        val transformSpec = obj["transform"]
+
+        return { tree, bindings ->
+            val startNode = if (fromName != null) bindings[fromName] ?: tree else tree
+            val labelNode = startNode.findNode(findPred)
+            val siblingNode = labelNode?.sibling(offset)
+
+            val rawValue = if (siblingNode != null) {
+                readProperty(siblingNode, readProp)
+            } else null
+
+            if (rawValue != null && transformSpec != null) {
+                TransformRegistry.applyAny(transformSpec, rawValue)
+            } else rawValue
         }
     }
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/rules/RulesetLoader.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/rules/RulesetLoader.kt
@@ -1,16 +1,12 @@
 package cloud.trotter.dashbuddy.rules
 
 import cloud.trotter.dashbuddy.domain.pipeline.RuleEngineConstants
-import cloud.trotter.dashbuddy.domain.pipeline.StateMachineContract
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.int
-import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
-import timber.log.Timber
 
 /**
- * Seven-step compatibility check per ADR-0003.
+ * Compatibility check per ADR-0003.
  *
  * Validates a parsed ruleset JSON root before it reaches [RuleCompiler].
  * If any check fails, the entire bundle is rejected and the caller falls
@@ -36,38 +32,7 @@ object RulesetLoader {
             return "missing or blank platform_id"
         }
 
-        // Step 3: pipeline version compatibility (if declared)
-        // Supports both bare int ("notification": 1) and object ("notification": {"version": 1, ...})
-        val pipelinesObj = root["pipelines"]?.jsonObject
-        if (pipelinesObj != null) {
-            for ((pipelineId, versionElem) in pipelinesObj) {
-                val declared = when (versionElem) {
-                    is JsonPrimitive -> versionElem.int
-                    is JsonObject -> versionElem["version"]?.jsonPrimitive?.int ?: 0
-                    else -> 0
-                }
-                val supported = cloud.trotter.dashbuddy.domain.pipeline.PipelineRegistry
-                    .pipelines[pipelineId]
-                if (supported == null) {
-                    Timber.w("RulesetLoader: unknown pipeline '$pipelineId' in $source (ignored)")
-                    continue
-                }
-                if (declared > supported) {
-                    return "pipeline '$pipelineId' version $declared exceeds supported $supported"
-                }
-            }
-        }
-
-        // Step 4: state_machine version compatibility (if declared)
-        val smObj = root["state_machine"]?.jsonObject
-        if (smObj != null) {
-            val majorDeclared = smObj["api_version_major"]?.jsonPrimitive?.int ?: 0
-            if (majorDeclared > StateMachineContract.API_VERSION_MAJOR) {
-                return "state_machine major version $majorDeclared exceeds supported ${StateMachineContract.API_VERSION_MAJOR}"
-            }
-        }
-
-        // Steps 5-7: flow/mode vocabulary validation is deferred to
+        // Steps 3+: flow/mode vocabulary validation is deferred to
         // RuleCompiler.parseStateBlock which rejects unknown values at
         // compile time per-rule.
 

--- a/app/src/test/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/view/clicked/ClickClassifierTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/pipeline/accessibility/event/type/view/clicked/ClickClassifierTest.kt
@@ -61,13 +61,13 @@ class ClickClassifierTest {
 
     @Test
     fun `classifies accept_button as AcceptOffer`() {
-        val result = classifyClick(node(viewId = "accept_button"), "OFFER_POPUP")
+        val result = classifyClick(node(viewId = "accept_button"), "offer_popup")
         assertEquals("accept_offer", result.intent())
     }
 
     @Test
     fun `AcceptOffer takes priority over text when both present`() {
-        val result = classifyClick(node(viewId = "accept_button", text = "Decline offer"), "OFFER_POPUP")
+        val result = classifyClick(node(viewId = "accept_button", text = "Decline offer"), "offer_popup")
         assertEquals("accept_offer", result.intent())
     }
 
@@ -77,13 +77,13 @@ class ClickClassifierTest {
 
     @Test
     fun `classifies 'Decline offer' text as DeclineOffer`() {
-        val result = classifyClick(node(text = "Decline offer"), "OFFER_POPUP_CONFIRM_DECLINE")
+        val result = classifyClick(node(text = "Decline offer"), "offer_popup_confirm_decline")
         assertEquals("decline_offer", result.intent())
     }
 
     @Test
     fun `DeclineOffer matches case-insensitively`() {
-        val result = classifyClick(node(text = "decline offer"), "OFFER_POPUP_CONFIRM_DECLINE")
+        val result = classifyClick(node(text = "decline offer"), "offer_popup_confirm_decline")
         assertEquals("decline_offer", result.intent())
     }
 

--- a/app/src/test/java/cloud/trotter/dashbuddy/rules/DefaultRulesIntegrationTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/rules/DefaultRulesIntegrationTest.kt
@@ -78,13 +78,13 @@ class DefaultRulesIntegrationTest {
     @Test
     fun `accept_button id classifies as accept_offer`() {
         val node = UiNode(viewIdResourceName = "com.doordash.driverapp:id/accept_button")
-        assertEquals("accept_offer", clickRuleset.classifyFirst(node, screenTarget = "OFFER_POPUP")?.intent)
+        assertEquals("accept_offer", clickRuleset.classifyFirst(node, screenTarget = "offer_popup")?.intent)
     }
 
     @Test
     fun `'Decline offer' text classifies as decline_offer`() {
         val node = UiNode(text = "Decline offer")
-        assertEquals("decline_offer", clickRuleset.classifyFirst(node, screenTarget = "OFFER_POPUP_CONFIRM_DECLINE")?.intent)
+        assertEquals("decline_offer", clickRuleset.classifyFirst(node, screenTarget = "offer_popup_confirm_decline")?.intent)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Remove per-rule `platform_id` (89), redundant `overrideable: true` (74), `state_machine`, `pipelines`, `engine_version`, `min_app_version` from both rulesets
- Remove `allowOngoing` notification filtering and `PipelineConfig` plumbing entirely — unwanted ongoing notifications handled via `shape: noise` rules
- Target always derived from rule ID via `deriveTargetFromId()` — `target` keyword removed from JSON format
- Split 4 multi-target branched rules into 9 separate rules (offer, delivery summary, pickup verification, shop & pay)
- Rule-level `parse`/`shape`/`bind` inheritance for branches (branch overrides, no merge)
- New `siblingOf` parse expression shorthand (ratings rule: 12 fields simplified)
- `RulesetLoader` simplified to `format_version` + `platform_id` validation only

## Test plan

- [x] `./gradlew testDebugUnitTest` — all 612 tests pass
- [x] `AllMatchersSuite` snapshot regression — pass
- [x] `DefaultRulesIntegrationTest` — pass
- [x] Grep verification: no `target`, `platform_id` in rules, no `overrideable: true`, no `state_machine`/`pipelines`
- [x] No references to `PipelineConfig`, `allowsOngoing`, `allowOngoing` in app source

🤖 Generated with [Claude Code](https://claude.com/claude-code)