### PR TITLE
refactor: harden rule compiler, unify DSL, add shape contracts

### DIFF
--- a/app/src/main/assets/rules/doordash.json
+++ b/app/src/main/assets/rules/doordash.json
@@ -22,7 +22,9 @@
           "Emergency contact details"
         ]
       },
-      "shape": "sensitive"
+      "parse": {
+        "as": "sensitive"
+      }
     },
     {
       "id": "doordash.screen.timeline",
@@ -34,6 +36,7 @@
         ]
       },
       "parse": {
+        "as": "timeline",
         "fields": {
           "sessionEarnings": {
             "textAfterLabel": "This dash",
@@ -199,8 +202,7 @@
             }
           }
         }
-      },
-      "shape": "timeline"
+      }
     },
     {
       "id": "doordash.screen.offer_popup_confirm_decline",
@@ -251,6 +253,7 @@
         }
       ],
       "parse": {
+        "as": "offer",
         "fields": {
           "payAmount": {
             "coalesce": [
@@ -387,7 +390,6 @@
           }
         }
       },
-      "shape": "offer",
       "effects": [
         {
           "screenshot": {
@@ -435,6 +437,7 @@
         }
       ],
       "parse": {
+        "as": "post_task",
         "fields": {
           "totalPay": {
             "find": {
@@ -492,7 +495,6 @@
           }
         }
       },
-      "shape": "post_task",
       "validate": [
         {
           "assert": "sumApproxEquals",
@@ -525,6 +527,7 @@
         }
       ],
       "parse": {
+        "as": "post_task",
         "fields": {
           "totalPay": {
             "find": {
@@ -561,7 +564,6 @@
           }
         }
       },
-      "shape": "post_task",
       "bind": {
         "expandButton": {
           "find": {
@@ -656,6 +658,7 @@
         ]
       },
       "parse": {
+        "as": "paused",
         "fields": {
           "remainingText": {
             "find": {
@@ -673,8 +676,7 @@
             "fallback": 2100000
           }
         }
-      },
-      "shape": "paused"
+      }
     },
     {
       "id": "doordash.screen.pickup_navigation",
@@ -715,6 +717,7 @@
         }
       },
       "parse": {
+        "as": "task",
         "fields": {
           "phase": "PICKUP",
           "subFlow": "NAVIGATION",
@@ -762,8 +765,7 @@
             "transform": "parseDeadline"
           }
         }
-      },
-      "shape": "task"
+      }
     },
     {
       "id": "doordash.screen.dropoff_navigation",
@@ -838,8 +840,8 @@
           }
         }
       ],
-      "shape": "task",
       "parse": {
+        "as": "task",
         "fields": {
           "phase": "DROPOFF",
           "subFlow": "NAVIGATION",
@@ -940,6 +942,7 @@
         ]
       },
       "parse": {
+        "as": "task",
         "fields": {
           "phase": "PICKUP",
           "subFlow": "ARRIVED",
@@ -998,8 +1001,7 @@
             "literal": true
           }
         }
-      },
-      "shape": "task"
+      }
     },
     {
       "id": "doordash.screen.pickup_pre_arrival",
@@ -1044,6 +1046,7 @@
         ]
       },
       "parse": {
+        "as": "task",
         "fields": {
           "phase": "PICKUP",
           "subFlow": "NAVIGATION",
@@ -1099,8 +1102,7 @@
             "transform": "parseLeadingInt"
           }
         }
-      },
-      "shape": "task"
+      }
     },
     {
       "id": "doordash.screen.pickup_shopping",
@@ -1133,6 +1135,7 @@
         ]
       },
       "parse": {
+        "as": "task",
         "fields": {
           "activity": "shopping",
           "phase": "PICKUP",
@@ -1151,8 +1154,7 @@
             }
           }
         }
-      },
-      "shape": "task"
+      }
     },
     {
       "id": "doordash.screen.dropoff_pre_arrival",
@@ -1193,6 +1195,7 @@
         ]
       },
       "parse": {
+        "as": "task",
         "fields": {
           "phase": "DROPOFF",
           "subFlow": "NAVIGATION",
@@ -1272,8 +1275,7 @@
             "transform": "parseDeadline"
           }
         }
-      },
-      "shape": "task"
+      }
     },
     {
       "id": "doordash.screen.dropoff_pre_arrival_completion",
@@ -1317,6 +1319,7 @@
         ]
       },
       "parse": {
+        "as": "task",
         "fields": {
           "phase": "DROPOFF",
           "subFlow": "NAVIGATION",
@@ -1396,8 +1399,7 @@
             "transform": "parseDeadline"
           }
         }
-      },
-      "shape": "task"
+      }
     },
     {
       "id": "doordash.screen.schedule",
@@ -1445,6 +1447,7 @@
         ]
       },
       "parse": {
+        "as": "ratings",
         "fields": {
           "acceptanceRate": {
             "siblingOf": {
@@ -1603,8 +1606,7 @@
             "transform": "toInt"
           }
         }
-      },
-      "shape": "ratings"
+      }
     },
     {
       "id": "doordash.screen.safety",
@@ -1857,6 +1859,7 @@
         ]
       },
       "parse": {
+        "as": "idle",
         "fields": {
           "isHeadingBackToZone": {
             "literal": false
@@ -1883,8 +1886,7 @@
             "transform": "parseDeadline"
           }
         }
-      },
-      "shape": "idle"
+      }
     },
     {
       "id": "doordash.screen.waiting_for_offer",
@@ -1948,6 +1950,7 @@
         ]
       },
       "parse": {
+        "as": "idle",
         "fields": {
           "sessionPay": {
             "find": {
@@ -1985,8 +1988,7 @@
             }
           }
         }
-      },
-      "shape": "idle"
+      }
     },
     {
       "id": "doordash.screen.set_dash_end_time",
@@ -2018,6 +2020,7 @@
         ]
       },
       "parse": {
+        "as": "idle",
         "fields": {
           "zoneName": {
             "find": {
@@ -2026,8 +2029,7 @@
             "read": "text"
           }
         }
-      },
-      "shape": "idle"
+      }
     },
     {
       "id": "doordash.screen.idle_map",
@@ -2077,6 +2079,7 @@
         ]
       },
       "parse": {
+        "as": "idle",
         "fields": {
           "sessionType": {
             "conditionalEnum": [
@@ -2099,8 +2102,7 @@
             ]
           }
         }
-      },
-      "shape": "idle"
+      }
     },
     {
       "id": "doordash.screen.dash_summary",
@@ -2131,6 +2133,7 @@
         ]
       },
       "parse": {
+        "as": "session_ended",
         "fields": {
           "totalEarnings": {
             "coalesce": [
@@ -2235,8 +2238,7 @@
           "tolerance": 0.02,
           "onFail": "dropParsed"
         }
-      ],
-      "shape": "session_ended"
+      ]
     },
     {
       "id": "doordash.screen.sensitive.catchall",
@@ -2254,7 +2256,9 @@
           "t=completed_view"
         ]
       },
-      "shape": "sensitive"
+      "parse": {
+        "as": "sensitive"
+      }
     }
   ],
   "clicks": [
@@ -2375,11 +2379,11 @@
       "id": "doordash.notification.additional_tip",
       "priority": 10,
       "intent": "additional_tip",
-      "shape": "notification",
       "require": {
         "anyFieldMatchesRegex": "added \\$(\\d+\\.\\d{2}) tip on a past (.+?) order delivered at (\\d{1,2}/\\d{1,2}, \\d{1,2}:\\d{2} [AP]M)"
       },
       "parse": {
+        "as": "notification",
         "fields": {
           "amount": {
             "from": "fullString",
@@ -2454,7 +2458,9 @@
         "titleContains": "Dash now"
       },
       "intent": "demand_nudge",
-      "shape": "notification",
+      "parse": {
+        "as": "notification"
+      },
       "effects": [
         {
           "log": {
@@ -2471,7 +2477,9 @@
         "titleContains": "Incentives Update"
       },
       "intent": "peak_pay_promo",
-      "shape": "notification",
+      "parse": {
+        "as": "notification"
+      },
       "effects": [
         {
           "log": {

--- a/app/src/main/assets/rules/doordash.json
+++ b/app/src/main/assets/rules/doordash.json
@@ -204,7 +204,7 @@
     },
     {
       "id": "doordash.screen.offer_popup_confirm_decline",
-      "priority": 20,
+      "priority": 19,
       "state": {
         "flow": "offer:presented",
         "modeHint": "online"
@@ -508,7 +508,7 @@
     },
     {
       "id": "doordash.screen.delivery_summary_collapsed",
-      "priority": 30,
+      "priority": 31,
       "state": {
         "flow": "post:task",
         "modeHint": "online"

--- a/app/src/main/assets/rules/doordash.json
+++ b/app/src/main/assets/rules/doordash.json
@@ -2400,14 +2400,30 @@
             "transform": "trim"
           }
         }
-      }
+      },
+      "effects": [
+        {
+          "log": {
+            "type": "NOTIFICATION_RECEIVED",
+            "payload": "TIP_ADDED: ${amount} {storeName}"
+          }
+        }
+      ]
     },
     {
       "id": "doordash.notification.new_order",
       "priority": 20,
       "require": {
         "titleContains": "new order"
-      }
+      },
+      "effects": [
+        {
+          "log": {
+            "type": "NOTIFICATION_RECEIVED",
+            "payload": "NEW_ORDER"
+          }
+        }
+      ]
     },
     {
       "id": "doordash.notification.scheduled_dash_expired",
@@ -2421,7 +2437,15 @@
             "anyFieldContains": "expired"
           }
         ]
-      }
+      },
+      "effects": [
+        {
+          "log": {
+            "type": "NOTIFICATION_RECEIVED",
+            "payload": "SCHEDULED_DASH_EXPIRED"
+          }
+        }
+      ]
     },
     {
       "id": "doordash.notification.demand_nudge",
@@ -2430,7 +2454,15 @@
         "titleContains": "Dash now"
       },
       "intent": "demand_nudge",
-      "shape": "notification"
+      "shape": "notification",
+      "effects": [
+        {
+          "log": {
+            "type": "NOTIFICATION_RECEIVED",
+            "payload": "DEMAND_NUDGE"
+          }
+        }
+      ]
     },
     {
       "id": "doordash.notification.peak_pay_promo",
@@ -2439,7 +2471,15 @@
         "titleContains": "Incentives Update"
       },
       "intent": "peak_pay_promo",
-      "shape": "notification"
+      "shape": "notification",
+      "effects": [
+        {
+          "log": {
+            "type": "NOTIFICATION_RECEIVED",
+            "payload": "PEAK_PAY_PROMO"
+          }
+        }
+      ]
     }
   ]
 }

--- a/app/src/main/assets/rules/doordash.json
+++ b/app/src/main/assets/rules/doordash.json
@@ -2263,7 +2263,7 @@
       "priority": 10,
       "screenIs": "offer_popup",
       "intent": "accept_offer",
-      "if": {
+      "require": {
         "hasIdSuffix": "accept_button"
       }
     },
@@ -2272,7 +2272,7 @@
       "priority": 20,
       "screenIs": "offer_popup_confirm_decline",
       "intent": "decline_offer",
-      "if": {
+      "require": {
         "hasText": "Decline offer"
       }
     },
@@ -2281,7 +2281,7 @@
       "priority": 30,
       "screenIs": "pickup_arrival",
       "intent": "arrived_at_store",
-      "if": {
+      "require": {
         "all": [
           {
             "hasIdSuffix": "primary_action_button"
@@ -2304,7 +2304,7 @@
       "priority": 15,
       "screenIs": "offer_popup",
       "intent": "initial_decline",
-      "if": {
+      "require": {
         "hasIdSuffix": "secondary_action_button_dash_plus"
       }
     },
@@ -2313,7 +2313,7 @@
       "priority": 40,
       "screenIs": "dash_paused",
       "intent": "resume_dash",
-      "if": {
+      "require": {
         "hasIdSuffix": "resumeButton"
       }
     },
@@ -2321,7 +2321,7 @@
       "id": "doordash.click.start_navigation",
       "priority": 50,
       "intent": "start_navigation",
-      "if": {
+      "require": {
         "any": [
           {
             "hasIdSuffix": "directions_button"
@@ -2337,7 +2337,7 @@
       "priority": 60,
       "screenIs": "dropoff_pre_arrival_completion",
       "intent": "complete_delivery",
-      "if": {
+      "require": {
         "any": [
           {
             "hasIdSuffix": "complete_delivery_steps_button"
@@ -2356,7 +2356,7 @@
       "priority": 70,
       "screenIs": "dropoff_pre_arrival",
       "intent": "submit_photo",
-      "if": {
+      "require": {
         "hasIdSuffix": "submit_button"
       }
     },
@@ -2365,7 +2365,7 @@
       "priority": 80,
       "screenIs": "pickup_shopping",
       "intent": "checkout",
-      "if": {
+      "require": {
         "hasIdSuffix": "button_checkout"
       }
     }
@@ -2376,7 +2376,7 @@
       "priority": 10,
       "intent": "additional_tip",
       "shape": "notification",
-      "if": {
+      "require": {
         "anyFieldMatchesRegex": "added \\$(\\d+\\.\\d{2}) tip on a past (.+?) order delivered at (\\d{1,2}/\\d{1,2}, \\d{1,2}:\\d{2} [AP]M)"
       },
       "parse": {
@@ -2405,14 +2405,14 @@
     {
       "id": "doordash.notification.new_order",
       "priority": 20,
-      "if": {
+      "require": {
         "titleContains": "new order"
       }
     },
     {
       "id": "doordash.notification.scheduled_dash_expired",
       "priority": 30,
-      "if": {
+      "require": {
         "all": [
           {
             "anyFieldContains": "scheduled"
@@ -2426,7 +2426,7 @@
     {
       "id": "doordash.notification.demand_nudge",
       "priority": 50,
-      "if": {
+      "require": {
         "titleContains": "Dash now"
       },
       "intent": "demand_nudge",
@@ -2435,7 +2435,7 @@
     {
       "id": "doordash.notification.peak_pay_promo",
       "priority": 60,
-      "if": {
+      "require": {
         "titleContains": "Incentives Update"
       },
       "intent": "peak_pay_promo",

--- a/app/src/main/assets/rules/uber.json
+++ b/app/src/main/assets/rules/uber.json
@@ -12,7 +12,6 @@
             "flow": "offer:presented",
             "modeHint": "online"
           },
-          "shape": "offer",
           "require": {
             "all": [
               {
@@ -40,6 +39,7 @@
             ]
           },
           "parse": {
+            "as": "offer",
             "fields": {
               "payAmount": {
                 "find": {
@@ -599,7 +599,7 @@
         "titleMatchesRegex": "^Going to (?!\\d)"
       },
       "intent": "trip_en_route_pickup",
-      "shape": "notification",
+      "parse": { "as": "notification" },
       "effects": [
         {
           "log": {
@@ -616,7 +616,7 @@
         "titleContains": "Arrived at "
       },
       "intent": "trip_arrived_pickup",
-      "shape": "notification",
+      "parse": { "as": "notification" },
       "effects": [
         {
           "log": {
@@ -633,7 +633,7 @@
         "titleMatchesRegex": "^Going to \\d"
       },
       "intent": "trip_en_route_dropoff",
-      "shape": "notification",
+      "parse": { "as": "notification" },
       "effects": [
         {
           "log": {
@@ -650,7 +650,7 @@
         "titleMatchesRegex": "(Leave the order at|Meet at door for)"
       },
       "intent": "trip_at_dropoff",
-      "shape": "notification",
+      "parse": { "as": "notification" },
       "effects": [
         {
           "log": {
@@ -667,7 +667,7 @@
         "titleMatchesRegex": "received a \\$\\d"
       },
       "intent": "tip_received",
-      "shape": "notification",
+      "parse": { "as": "notification" },
       "effects": [
         {
           "log": {
@@ -683,7 +683,7 @@
       "require": {
         "titleContains": "currently online"
       },
-      "shape": "noise"
+      "parse": { "as": "noise" }
     },
     {
       "id": "uber.notification.quest_promo",
@@ -692,7 +692,7 @@
         "titleContains": "Quest awaits"
       },
       "intent": "quest_promo",
-      "shape": "notification",
+      "parse": { "as": "notification" },
       "effects": [
         {
           "log": {
@@ -716,7 +716,7 @@
         ]
       },
       "intent": "quest_deadline",
-      "shape": "notification",
+      "parse": { "as": "notification" },
       "effects": [
         {
           "log": {

--- a/app/src/main/assets/rules/uber.json
+++ b/app/src/main/assets/rules/uber.json
@@ -182,7 +182,7 @@
     },
     {
       "id": "uber.screen.pickup_verification_pin",
-      "priority": 50,
+      "priority": 51,
       "state": {
         "flow": "task:pickup:arrived",
         "modeHint": "online"
@@ -204,7 +204,7 @@
     },
     {
       "id": "uber.screen.pickup_verification_items",
-      "priority": 50,
+      "priority": 52,
       "state": {
         "flow": "task:pickup:arrived",
         "modeHint": "online"
@@ -325,7 +325,7 @@
     },
     {
       "id": "uber.screen.shop_and_pay_checkout",
-      "priority": 68,
+      "priority": 69,
       "state": {
         "flow": "task:pickup:arrived",
         "modeHint": "online"
@@ -540,7 +540,7 @@
     },
     {
       "id": "uber.click.go_offline",
-      "priority": 20,
+      "priority": 21,
       "screenIs": "home_dashboard",
       "state": {
         "flow": "session:ended",

--- a/app/src/main/assets/rules/uber.json
+++ b/app/src/main/assets/rules/uber.json
@@ -511,12 +511,8 @@
       "id": "uber.click.accept_offer",
       "priority": 5,
       "screenIs": "offer",
-      "state": {
-        "flow": "task:pickup:navigation",
-        "modeHint": "online"
-      },
       "intent": "accept_offer",
-      "if": {
+      "require": {
         "any": [
           {
             "hasText": "Accept"
@@ -530,11 +526,8 @@
     {
       "id": "uber.click.go_online",
       "priority": 10,
-      "state": {
-        "modeHint": "online"
-      },
       "intent": "go_online",
-      "if": {
+      "require": {
         "hasIdSuffix": "go_online_button"
       }
     },
@@ -542,12 +535,8 @@
       "id": "uber.click.go_offline",
       "priority": 21,
       "screenIs": "home_dashboard",
-      "state": {
-        "flow": "session:ended",
-        "modeHint": "offline"
-      },
       "intent": "go_offline",
-      "if": {
+      "require": {
         "hasIdSuffix": "carbon_action_button"
       }
     },
@@ -555,12 +544,8 @@
       "id": "uber.click.order_verified",
       "priority": 15,
       "screenIs": "pickup_verification_items",
-      "state": {
-        "flow": "task:dropoff:navigation",
-        "modeHint": "online"
-      },
       "intent": "order_verified",
-      "if": {
+      "require": {
         "all": [
           {
             "hasText": "Order verified"
@@ -576,7 +561,7 @@
       "priority": 16,
       "screenIs": "pickup_verification_items",
       "intent": "issue_with_order",
-      "if": {
+      "require": {
         "all": [
           {
             "hasText": "Issue with order"
@@ -591,12 +576,8 @@
       "id": "uber.click.delivered",
       "priority": 20,
       "screenIs": "delivery_confirmation",
-      "state": {
-        "flow": "post:task",
-        "modeHint": "online"
-      },
       "intent": "delivered",
-      "if": {
+      "require": {
         "hasIdSuffix": "task_button_button"
       }
     },
@@ -605,7 +586,7 @@
       "priority": 30,
       "screenIs": "home_dashboard",
       "intent": "open_inbox",
-      "if": {
+      "require": {
         "hasIdSuffix": "glide_bottom_nav_inbox"
       }
     }
@@ -614,7 +595,7 @@
     {
       "id": "uber.notification.trip_en_route_pickup",
       "priority": 3,
-      "if": {
+      "require": {
         "titleMatchesRegex": "^Going to (?!\\d)"
       },
       "intent": "trip_en_route_pickup",
@@ -623,7 +604,7 @@
     {
       "id": "uber.notification.trip_arrived_pickup",
       "priority": 4,
-      "if": {
+      "require": {
         "titleContains": "Arrived at "
       },
       "intent": "trip_arrived_pickup",
@@ -632,7 +613,7 @@
     {
       "id": "uber.notification.trip_en_route_dropoff",
       "priority": 5,
-      "if": {
+      "require": {
         "titleMatchesRegex": "^Going to \\d"
       },
       "intent": "trip_en_route_dropoff",
@@ -641,7 +622,7 @@
     {
       "id": "uber.notification.trip_at_dropoff",
       "priority": 6,
-      "if": {
+      "require": {
         "titleMatchesRegex": "(Leave the order at|Meet at door for)"
       },
       "intent": "trip_at_dropoff",
@@ -650,7 +631,7 @@
     {
       "id": "uber.notification.tip_received",
       "priority": 8,
-      "if": {
+      "require": {
         "titleMatchesRegex": "received a \\$\\d"
       },
       "intent": "tip_received",
@@ -659,7 +640,7 @@
     {
       "id": "uber.notification.online_status",
       "priority": 10,
-      "if": {
+      "require": {
         "titleContains": "currently online"
       },
       "shape": "noise"
@@ -667,7 +648,7 @@
     {
       "id": "uber.notification.quest_promo",
       "priority": 20,
-      "if": {
+      "require": {
         "titleContains": "Quest awaits"
       },
       "intent": "quest_promo",
@@ -676,7 +657,7 @@
     {
       "id": "uber.notification.quest_deadline",
       "priority": 30,
-      "if": {
+      "require": {
         "all": [
           {
             "titleContains": "Last chance"

--- a/app/src/main/assets/rules/uber.json
+++ b/app/src/main/assets/rules/uber.json
@@ -599,7 +599,15 @@
         "titleMatchesRegex": "^Going to (?!\\d)"
       },
       "intent": "trip_en_route_pickup",
-      "shape": "notification"
+      "shape": "notification",
+      "effects": [
+        {
+          "log": {
+            "type": "NOTIFICATION_RECEIVED",
+            "payload": "TRIP_EN_ROUTE_PICKUP"
+          }
+        }
+      ]
     },
     {
       "id": "uber.notification.trip_arrived_pickup",
@@ -608,7 +616,15 @@
         "titleContains": "Arrived at "
       },
       "intent": "trip_arrived_pickup",
-      "shape": "notification"
+      "shape": "notification",
+      "effects": [
+        {
+          "log": {
+            "type": "NOTIFICATION_RECEIVED",
+            "payload": "TRIP_ARRIVED_PICKUP"
+          }
+        }
+      ]
     },
     {
       "id": "uber.notification.trip_en_route_dropoff",
@@ -617,7 +633,15 @@
         "titleMatchesRegex": "^Going to \\d"
       },
       "intent": "trip_en_route_dropoff",
-      "shape": "notification"
+      "shape": "notification",
+      "effects": [
+        {
+          "log": {
+            "type": "NOTIFICATION_RECEIVED",
+            "payload": "TRIP_EN_ROUTE_DROPOFF"
+          }
+        }
+      ]
     },
     {
       "id": "uber.notification.trip_at_dropoff",
@@ -626,7 +650,15 @@
         "titleMatchesRegex": "(Leave the order at|Meet at door for)"
       },
       "intent": "trip_at_dropoff",
-      "shape": "notification"
+      "shape": "notification",
+      "effects": [
+        {
+          "log": {
+            "type": "NOTIFICATION_RECEIVED",
+            "payload": "TRIP_AT_DROPOFF"
+          }
+        }
+      ]
     },
     {
       "id": "uber.notification.tip_received",
@@ -635,7 +667,15 @@
         "titleMatchesRegex": "received a \\$\\d"
       },
       "intent": "tip_received",
-      "shape": "notification"
+      "shape": "notification",
+      "effects": [
+        {
+          "log": {
+            "type": "NOTIFICATION_RECEIVED",
+            "payload": "TIP_RECEIVED: {rawText}"
+          }
+        }
+      ]
     },
     {
       "id": "uber.notification.online_status",
@@ -652,7 +692,15 @@
         "titleContains": "Quest awaits"
       },
       "intent": "quest_promo",
-      "shape": "notification"
+      "shape": "notification",
+      "effects": [
+        {
+          "log": {
+            "type": "NOTIFICATION_RECEIVED",
+            "payload": "QUEST_PROMO"
+          }
+        }
+      ]
     },
     {
       "id": "uber.notification.quest_deadline",
@@ -668,7 +716,15 @@
         ]
       },
       "intent": "quest_deadline",
-      "shape": "notification"
+      "shape": "notification",
+      "effects": [
+        {
+          "log": {
+            "type": "NOTIFICATION_RECEIVED",
+            "payload": "QUEST_DEADLINE"
+          }
+        }
+      ]
     }
   ]
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/rules/JsonRuleInterpreter.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/rules/JsonRuleInterpreter.kt
@@ -54,11 +54,27 @@ class JsonRuleInterpreter @Inject constructor(
             val allScreens = mutableListOf<CompiledRule<UiNode>>()
             val allClicks = mutableListOf<CompiledRule<UiNode>>()
             val allNotifications = mutableListOf<CompiledRule<RawNotificationData>>()
+            val seenRuleIds = mutableMapOf<String, String>() // ruleId → first source path
 
             for (fileName in files) {
                 val path = "$RULES_DIR/$fileName"
                 val json = context.assets.open(path).bufferedReader().readText()
                 val result = loadSingle(json, source = path) ?: continue
+
+                // Collision detection (C3): warn if any rule ID appears in multiple files
+                val newIds = result.screens.map { it.id } +
+                    result.clicks.map { it.id } +
+                    result.notifications.map { it.id }
+                for (id in newIds) {
+                    val existingSource = seenRuleIds.put(id, path)
+                    if (existingSource != null) {
+                        Timber.w(
+                            "JsonRuleInterpreter: rule ID '%s' declared in both '%s' and '%s'",
+                            id, existingSource, path,
+                        )
+                    }
+                }
+
                 allScreens += result.screens
                 allClicks += result.clicks
                 allNotifications += result.notifications

--- a/app/src/main/java/cloud/trotter/dashbuddy/rules/ParsedFieldsFactory.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/rules/ParsedFieldsFactory.kt
@@ -35,17 +35,39 @@ object ParsedFieldsFactory {
     )
 
     /**
+     * "At least one of" constraints per shape. Each entry is a set of field names
+     * where at least one must be present. Platforms may use different field names
+     * for the same concept (e.g. DoorDash: deliveryTimeText, Uber: timeToCompleteMinutes).
+     */
+    val REQUIRED_ONE_OF_BY_SHAPE: Map<String, List<Set<String>>> = mapOf(
+        "offer" to listOf(setOf("deliveryTimeText", "timeToCompleteMinutes")),
+    )
+
+    /**
      * Validate that a parse block declares all required fields for its shape.
      * @throws RuleCompileException if required fields are missing.
      */
     fun validateShapeFields(shape: String, declaredFields: Set<String>, ruleId: String) {
-        val required = REQUIRED_FIELDS_BY_SHAPE[shape] ?: return
-        val missing = required - declaredFields
-        if (missing.isNotEmpty()) {
-            throw RuleCompileException(
-                "Rule '$ruleId' declares shape '$shape' but parse block is missing required " +
-                    "fields: ${missing.joinToString(", ") { "'$it'" }}",
-            )
+        val required = REQUIRED_FIELDS_BY_SHAPE[shape]
+        if (required != null) {
+            val missing = required - declaredFields
+            if (missing.isNotEmpty()) {
+                throw RuleCompileException(
+                    "Rule '$ruleId' declares shape '$shape' but parse block is missing required " +
+                        "fields: ${missing.joinToString(", ") { "'$it'" }}",
+                )
+            }
+        }
+        val oneOfGroups = REQUIRED_ONE_OF_BY_SHAPE[shape]
+        if (oneOfGroups != null) {
+            for (group in oneOfGroups) {
+                if (group.none { it in declaredFields }) {
+                    throw RuleCompileException(
+                        "Rule '$ruleId' declares shape '$shape' but parse block must include " +
+                            "at least one of: ${group.joinToString(", ") { "'$it'" }}",
+                    )
+                }
+            }
         }
     }
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/rules/ParsedFieldsFactory.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/rules/ParsedFieldsFactory.kt
@@ -23,6 +23,30 @@ import timber.log.Timber
  */
 object ParsedFieldsFactory {
 
+    /**
+     * Required parse fields per shape. The rule compiler verifies at load time
+     * that any parse block declaring a shape includes these field names.
+     * Shapes not listed here have no required fields.
+     */
+    val REQUIRED_FIELDS_BY_SHAPE: Map<String, Set<String>> = mapOf(
+        "offer" to setOf("payAmount"),
+    )
+
+    /**
+     * Validate that a parse block declares all required fields for its shape.
+     * @throws RuleCompileException if required fields are missing.
+     */
+    fun validateShapeFields(shape: String, declaredFields: Set<String>, ruleId: String) {
+        val required = REQUIRED_FIELDS_BY_SHAPE[shape] ?: return
+        val missing = required - declaredFields
+        if (missing.isNotEmpty()) {
+            throw RuleCompileException(
+                "Rule '$ruleId' declares shape '$shape' but parse block is missing required " +
+                    "fields: ${missing.joinToString(", ") { "'$it'" }}",
+            )
+        }
+    }
+
     fun create(shape: String?, fields: Map<String, Any?>): ParsedFields {
         if (shape == null) return ParsedFields.None
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/rules/ParsedFieldsFactory.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/rules/ParsedFieldsFactory.kt
@@ -128,8 +128,8 @@ object ParsedFieldsFactory {
 
     private fun buildPaused(f: Map<String, Any?>) = ParsedFields.PausedFields(
         activity = f.str("activity"),
-        remainingText = f.str("remainingText") ?: "35:00",
-        remainingMillis = f.long("remainingMillis") ?: (35 * 60 * 1000L),
+        remainingText = f.str("remainingText"),
+        remainingMillis = f.long("remainingMillis"),
     )
 
     private fun buildTimeline(f: Map<String, Any?>): ParsedFields.TimelineFields {

--- a/app/src/main/java/cloud/trotter/dashbuddy/rules/ParsedFieldsFactory.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/rules/ParsedFieldsFactory.kt
@@ -29,7 +29,9 @@ object ParsedFieldsFactory {
      * Shapes not listed here have no required fields.
      */
     val REQUIRED_FIELDS_BY_SHAPE: Map<String, Set<String>> = mapOf(
-        "offer" to setOf("payAmount"),
+        "offer" to setOf("payAmount", "distance"),
+        "post_task" to setOf("totalPay"),
+        "session_ended" to setOf("totalEarnings"),
     )
 
     /**

--- a/app/src/main/java/cloud/trotter/dashbuddy/rules/RuleCompiler.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/rules/RuleCompiler.kt
@@ -104,14 +104,14 @@ object RuleCompiler {
 
         val (ruleFlow, ruleModeHint) = parseStateBlock(obj["state"] as? JsonObject, id)
 
-        // Rule-level parse/shape (inherited by branches unless overridden)
+        // Rule-level parse (inherited by branches unless overridden)
         val ruleParseObj = obj["parse"]?.jsonObject
-        val ruleShape = obj["shape"]?.jsonPrimitive?.content
+        val ruleParseAs = ruleParseObj?.get("as")?.jsonPrimitive?.content
 
         val branches: List<CompiledBranch<TInput>> = if ("branches" in obj) {
             obj["branches"]!!.jsonArray.map {
                 compileBranch(it.jsonObject, context, ruleFlow, ruleModeHint, ruleId = id,
-                    ruleParseBlock = ruleParseObj, ruleParseShape = ruleShape, ruleBindObj = ruleBindObj)
+                    ruleParseBlock = ruleParseObj, ruleParseAs = ruleParseAs, ruleBindObj = ruleBindObj)
             }
         } else {
             listOf(compileBranch(obj, context, ruleFlow, ruleModeHint, ruleId = id))
@@ -128,7 +128,7 @@ object RuleCompiler {
         ruleModeHint: Mode? = null,
         ruleId: String? = null,
         ruleParseBlock: JsonObject? = null,
-        ruleParseShape: String? = null,
+        ruleParseAs: String? = null,
         ruleBindObj: JsonObject? = null,
     ): CompiledBranch<TInput> {
         val targetName = ruleId?.let { deriveTargetFromId(it) }
@@ -162,14 +162,12 @@ object RuleCompiler {
 
         // --- Phase 4: Parse ---
         val parseBlock = obj["parse"]?.jsonObject ?: ruleParseBlock
-        val parseShape = obj["shape"]?.jsonPrimitive?.content
-            ?: parseBlock?.get("shape")?.jsonPrimitive?.content
-            ?: ruleParseShape
+        val parseAs = parseBlock?.get("as")?.jsonPrimitive?.content ?: ruleParseAs
 
         // --- Shape contract validation (M3) ---
-        if (parseShape != null) {
+        if (parseAs != null) {
             val declaredFields = parseBlock?.get("fields")?.jsonObject?.keys ?: emptySet()
-            ParsedFieldsFactory.validateShapeFields(parseShape, declaredFields, ruleId)
+            ParsedFieldsFactory.validateShapeFields(parseAs, declaredFields, ruleId)
         }
 
         val parser: (TInput, Bindings) -> Map<String, Any?> = when (context) {
@@ -225,7 +223,7 @@ object RuleCompiler {
             validators = validators,
             effects = effects,
             bindings = bindings,
-            shape = parseShape,
+            shape = parseAs,
             intent = intent,
             flow = branchFlow ?: ruleFlow,
             modeHint = branchModeHint ?: ruleModeHint,

--- a/app/src/main/java/cloud/trotter/dashbuddy/rules/RuleCompiler.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/rules/RuleCompiler.kt
@@ -74,8 +74,21 @@ object RuleCompiler {
      * Compile a JSON array of rule objects into typed [CompiledRule] instances.
      * The [context] determines predicate vocabulary and parse input source.
      */
-    fun <TInput> compileRules(array: JsonArray, context: RuleContext): List<CompiledRule<TInput>> =
-        array.map { compileRule(it.jsonObject, context) }
+    fun <TInput> compileRules(array: JsonArray, context: RuleContext): List<CompiledRule<TInput>> {
+        val rules = array.map { compileRule<TInput>(it.jsonObject, context) }
+        // Enforce unique priorities within the same rule type
+        val seen = mutableMapOf<Int, String>()
+        for (rule in rules) {
+            val existing = seen.put(rule.priority, rule.id)
+            if (existing != null) {
+                throw RuleCompileException(
+                    "Duplicate priority ${rule.priority} in ${context.name.lowercase()} rules: " +
+                        "'$existing' and '${rule.id}'. Priorities must be unique per rule type.",
+                )
+            }
+        }
+        return rules
+    }
 
     @Suppress("UNCHECKED_CAST")
     private fun <TInput> compileRule(obj: JsonObject, context: RuleContext): CompiledRule<TInput> {
@@ -349,6 +362,9 @@ object RuleCompiler {
         val transformSpec = obj["transform"]
         val fallbackVal = obj["fallback"]
 
+        // Validate transform specs at compile time (fail fast on typos)
+        transformSpec?.let { TransformRegistry.validateTransformSpec(it) }
+
         return { raw ->
             val sourceText = readNotificationField(raw, fromField)
 
@@ -396,6 +412,9 @@ object RuleCompiler {
 
         val obj = spec as? JsonObject
             ?: throw RuleCompileException("Parse expression must be an object or string literal")
+
+        // Validate transform specs at compile time (fail fast on typos)
+        obj["transform"]?.let { TransformRegistry.validateTransformSpec(it) }
 
         val fromName = obj["from"]?.jsonPrimitive?.content?.removePrefix("$")
 
@@ -522,7 +541,7 @@ object RuleCompiler {
             "allTextContains" in presenceSpec -> {
                 val text = presenceSpec["allTextContains"]!!.jsonPrimitive.content.lowercase()
                 val fn: (UiNode) -> Boolean = { tree ->
-                    tree.allText.joinToString(" | ").lowercase().contains(text)
+                    tree.allText.joinToString("\u001F").lowercase().contains(text)
                 }
                 fn
             }
@@ -807,14 +826,14 @@ object RuleCompiler {
             "allTextContains" -> {
                 val text = (value as? JsonPrimitive)?.content?.lowercase()
                     ?: throw RuleCompileException("allTextContains requires a string value")
-                ;{ tree -> tree.allText.joinToString(" | ").lowercase().contains(text) }
+                ;{ tree -> tree.allText.joinToString("\u001F").lowercase().contains(text) }
             }
             "allTextContainsAll" -> {
                 val texts = (value as? JsonArray)
                     ?.map { (it as JsonPrimitive).content.lowercase() }
                     ?: throw RuleCompileException("allTextContainsAll requires an array")
                 ;{ tree ->
-                    val joined = tree.allText.joinToString(" | ").lowercase()
+                    val joined = tree.allText.joinToString("\u001F").lowercase()
                     texts.all { joined.contains(it) }
                 }
             }
@@ -823,7 +842,7 @@ object RuleCompiler {
                     ?.map { (it as JsonPrimitive).content.lowercase() }
                     ?: throw RuleCompileException("allTextContainsAny requires an array")
                 ;{ tree ->
-                    val joined = tree.allText.joinToString(" | ").lowercase()
+                    val joined = tree.allText.joinToString("\u001F").lowercase()
                     texts.any { joined.contains(it) }
                 }
             }
@@ -1144,7 +1163,7 @@ object RuleCompiler {
         else -> json.toString()
     }
 
-    private fun compileRegex(pattern: String): Regex {
+    internal fun compileRegex(pattern: String): Regex {
         if (pattern.length > MAX_REGEX_LENGTH)
             throw RuleCompileException(
                 "Regex pattern length ${pattern.length} exceeds MAX_REGEX_LENGTH=$MAX_REGEX_LENGTH",

--- a/app/src/main/java/cloud/trotter/dashbuddy/rules/RuleCompiler.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/rules/RuleCompiler.kt
@@ -166,6 +166,12 @@ object RuleCompiler {
             ?: parseBlock?.get("shape")?.jsonPrimitive?.content
             ?: ruleParseShape
 
+        // --- Shape contract validation (M3) ---
+        if (parseShape != null) {
+            val declaredFields = parseBlock?.get("fields")?.jsonObject?.keys ?: emptySet()
+            ParsedFieldsFactory.validateShapeFields(parseShape, declaredFields, ruleId)
+        }
+
         val parser: (TInput, Bindings) -> Map<String, Any?> = when (context) {
             RuleContext.SCREEN -> {
                 if (parseBlock != null) {

--- a/app/src/main/java/cloud/trotter/dashbuddy/rules/RuleCompiler.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/rules/RuleCompiler.kt
@@ -140,9 +140,7 @@ object RuleCompiler {
         )
 
         // Intent (explicit or derived)
-        val intent = obj["intent"]?.jsonPrimitive?.content
-            ?: obj["target"]?.jsonPrimitive?.content?.let { camelToSnake(it) }
-            ?: targetName
+        val intent = obj["intent"]?.jsonPrimitive?.content ?: targetName
 
         // --- Bindings (screen rules only) ---
         val effectiveBindObj = if (context == RuleContext.SCREEN) {
@@ -151,13 +149,13 @@ object RuleCompiler {
         val bindings = effectiveBindObj?.let { compileBindBlock(it) } ?: emptyList()
 
         // --- Phase 2: Reject ---
-        val rejectJson = obj["reject"] ?: obj["guards"]
+        val rejectJson = obj["reject"]
         val rejectChecks: List<(TInput) -> Boolean> = rejectJson?.jsonArray?.map { rejectEntry ->
             compilePredicate(rejectEntry, context)
         } ?: emptyList()
 
         // --- Phase 3: Require ---
-        val requireJson = obj["require"] ?: obj["if"]
+        val requireJson = obj["require"]
         val predicate: ((TInput) -> Boolean)? = requireJson?.let {
             compilePredicate(it, context)
         }
@@ -203,7 +201,7 @@ object RuleCompiler {
         } ?: emptyList()
 
         // --- Effects ---
-        val effectsArray = obj["effects"]?.jsonArray ?: obj["actions"]?.jsonArray
+        val effectsArray = obj["effects"]?.jsonArray
         val effects = effectsArray?.map { compileEffectEntry(it.jsonObject) } ?: emptyList()
 
         // --- Transition overrides (screen rules) ---
@@ -786,10 +784,6 @@ object RuleCompiler {
     // ==========================================================================
     //  Helpers
     // ==========================================================================
-
-    /** Convert CamelCase to snake_case. "AcceptOffer" → "accept_offer" */
-    private fun camelToSnake(s: String): String =
-        s.replace(Regex("([a-z])([A-Z])"), "$1_$2").lowercase()
 
     /**
      * Derive a classification name from a rule ID by stripping the platform prefix.

--- a/app/src/main/java/cloud/trotter/dashbuddy/rules/TransformRegistry.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/rules/TransformRegistry.kt
@@ -123,7 +123,7 @@ object TransformRegistry {
                 val pattern = obj["pattern"]!!.jsonPrimitive.content
                 val group = obj["group"]?.jsonPrimitive?.intOrNull ?: 0
                 val thenTransform = obj["then"]
-                val regex = Regex(pattern, RegexOption.IGNORE_CASE)
+                val regex = RuleCompiler.compileRegex(pattern)
                 val match = regex.find(value) ?: return null
                 val extracted = match.groupValues.getOrNull(group) ?: return null
                 if (thenTransform != null) {
@@ -173,18 +173,55 @@ object TransformRegistry {
         }
     }
 
+    // ========================================================================
+    //  Compile-time validation
+    // ========================================================================
+
+    private val knownPlainTransforms = setOf(
+        "parseCurrency", "parseDistance", "parseItemCount", "parseDeadline",
+        "parseTime", "parseDuration", "parseHrMin", "parseLeadingInt",
+        "parsePercent", "sha256", "trim", "lower", "upper", "toDouble", "toInt",
+        "stripDeadlinePrefix",
+    )
+
+    private val knownParameterizedTransforms = setOf(
+        "stripPrefix", "stripSuffix", "stripPrefixes",
+        "extractBefore", "extractAfter",
+        "replace", "split", "regex",
+    )
+
     /**
-     * Validate at compile time that all transform and assertion names are known.
+     * Validate at compile time that a plain transform name is known.
      * Call during rule loading to fail fast on typos.
      */
     fun validateTransformName(name: String) {
-        val known = setOf(
-            "parseCurrency", "parseDistance", "parseItemCount", "parseDeadline",
-            "parseTime", "parseDuration", "parseHrMin", "parseLeadingInt",
-            "parsePercent", "sha256", "trim", "lower", "upper", "toDouble", "toInt",
-            "stripDeadlinePrefix",
-        )
-        if (name !in known) throw RuleCompileException("Unknown transform: '$name'")
+        if (name !in knownPlainTransforms)
+            throw RuleCompileException("Unknown transform: '$name'")
+    }
+
+    /**
+     * Validate a transform spec at compile time: plain string, parameterized
+     * object, or chain array. Recursively validates all nested transforms
+     * (e.g. `regex.then`). Throws [RuleCompileException] on unknown names.
+     */
+    fun validateTransformSpec(spec: JsonElement) {
+        when (spec) {
+            is JsonPrimitive -> validateTransformName(spec.content)
+            is JsonObject -> {
+                val key = spec.keys.firstOrNull()
+                    ?: throw RuleCompileException("Empty transform spec")
+                if (key !in knownParameterizedTransforms)
+                    throw RuleCompileException("Unknown parameterized transform: '$key'")
+                // Validate nested 'then' in regex transforms
+                if (key == "regex") {
+                    val regexObj = spec[key]?.jsonObject
+                    val pattern = regexObj?.get("pattern")?.jsonPrimitive?.content
+                    if (pattern != null) RuleCompiler.compileRegex(pattern)
+                    regexObj?.get("then")?.let { validateTransformSpec(it) }
+                }
+            }
+            is JsonArray -> spec.forEach { validateTransformSpec(it) }
+        }
     }
 
     fun validateAssertionName(name: String) {

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/AppEffect.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/AppEffect.kt
@@ -70,8 +70,8 @@ sealed class AppEffect {
         val effects: List<AppEffect>
     ) : AppEffect()
 
-    data class StartDash(val dashId: String, val platformName: String = "DoorDash") : AppEffect() {
-        override val effectKey: String get() = "start_dash:$dashId"
+    data class StartSession(val sessionId: String, val platformName: String) : AppEffect() {
+        override val effectKey: String get() = "start_session:$sessionId"
     }
-    data class EndDash(val platformName: String? = null) : AppEffect()
+    data class EndSession(val platformName: String? = null) : AppEffect()
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/EffectMap.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/EffectMap.kt
@@ -158,7 +158,7 @@ class EffectMap @Inject constructor() {
             addAll(diffMode(p, next, obs))
             addAll(diffTask(p, next, prevFlow, nextFlow, obs))
             addAll(diffPostTask(p, next, nextFlow, obs))
-            addAll(diffNotification(obs, next.session?.sessionId))
+            addAll(diffNotification(obs))
 
             // Delivery completed: leaving PostTask for a non-PostTask flow
             if (prevFlow.flow == Flow.PostTask && nextFlow.flow != Flow.PostTask) {
@@ -450,13 +450,17 @@ class EffectMap @Inject constructor() {
      * Handle notification-driven effects. These are global interceptors
      * that apply regardless of state.
      */
-    private fun diffNotification(obs: Observation, sessionId: String?): List<AppEffect> {
+    /**
+     * Intent-specific notification processing that can't be expressed as
+     * a JSON effect. Logging and other simple effects are now declared in
+     * the rule JSON and handled by [diffRuleEffects].
+     */
+    private fun diffNotification(obs: Observation): List<AppEffect> {
         if (obs !is Observation.Notification) return emptyList()
         val fields = obs.parsed as? ParsedFields.NotificationFields ?: return emptyList()
 
         return buildList {
             when (fields.intent) {
-                // DoorDash
                 "additional_tip" -> {
                     val amount = fields.amount
                     val storeName = fields.storeName
@@ -470,48 +474,6 @@ class EffectMap @Inject constructor() {
                             )
                         )
                     }
-                    add(logEffect(sessionId, AppEventType.NOTIFICATION_RECEIVED, "TIP_ADDED: \$$amount $storeName"))
-                }
-                "new_order" -> {
-                    add(logEffect(sessionId, AppEventType.NOTIFICATION_RECEIVED, "NEW_ORDER"))
-                }
-                "scheduled_dash_expired" -> {
-                    add(logEffect(sessionId, AppEventType.NOTIFICATION_RECEIVED, "SCHEDULED_DASH_EXPIRED"))
-                }
-                "demand_nudge" -> {
-                    add(logEffect(null, AppEventType.NOTIFICATION_RECEIVED, "DEMAND_NUDGE"))
-                }
-                "peak_pay_promo" -> {
-                    add(logEffect(null, AppEventType.NOTIFICATION_RECEIVED, "PEAK_PAY_PROMO"))
-                }
-
-                // Uber trip leg notifications
-                "trip_en_route_pickup" -> {
-                    add(logEffect(sessionId, AppEventType.NOTIFICATION_RECEIVED, "TRIP_EN_ROUTE_PICKUP"))
-                }
-                "trip_arrived_pickup" -> {
-                    add(logEffect(sessionId, AppEventType.NOTIFICATION_RECEIVED, "TRIP_ARRIVED_PICKUP"))
-                }
-                "trip_en_route_dropoff" -> {
-                    add(logEffect(sessionId, AppEventType.NOTIFICATION_RECEIVED, "TRIP_EN_ROUTE_DROPOFF"))
-                }
-                "trip_at_dropoff" -> {
-                    add(logEffect(sessionId, AppEventType.NOTIFICATION_RECEIVED, "TRIP_AT_DROPOFF"))
-                }
-                "tip_received" -> {
-                    add(logEffect(sessionId, AppEventType.NOTIFICATION_RECEIVED, "TIP_RECEIVED: ${fields.rawText}"))
-                }
-
-                // Uber promo notifications
-                "quest_promo" -> {
-                    add(logEffect(sessionId, AppEventType.NOTIFICATION_RECEIVED, "QUEST_PROMO"))
-                }
-                "quest_deadline" -> {
-                    add(logEffect(sessionId, AppEventType.NOTIFICATION_RECEIVED, "QUEST_DEADLINE"))
-                }
-
-                else -> {
-                    add(logEffect(sessionId, AppEventType.NOTIFICATION_RECEIVED, "UNHANDLED: ${fields.intent} — ${fields.rawText}"))
                 }
             }
         }

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/EffectMap.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/EffectMap.kt
@@ -202,7 +202,7 @@ class EffectMap @Inject constructor() {
                         )
                         add(logEffect(nextSession.sessionId, AppEventType.DASH_START, payload))
                         add(AppEffect.StartOdometer)
-                        add(AppEffect.StartDash(nextSession.sessionId, next.platform.name))
+                        add(AppEffect.StartSession(nextSession.sessionId, next.platform.name))
                     }
 
                     // Cancel pause safety timer if resuming from paused
@@ -241,7 +241,7 @@ class EffectMap @Inject constructor() {
                             add(logEffect(sessionId, AppEventType.DASH_STOP, "Return to Map"))
                             add(AppEffect.StopOdometer)
                         }
-                        add(AppEffect.EndDash(platform))
+                        add(AppEffect.EndSession(platform))
                     }
 
                     // Cancel pause safety timer

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
@@ -132,8 +132,8 @@ class SideEffectEngine @Inject constructor(
 
             is AppEffect.SpeakOffer -> ttsEffectHandler.speakOffer(effect.parsedOffer, effect.platformName)
 
-            is AppEffect.StartDash -> bubbleManager.startDash(effect.dashId, effect.platformName)
-            is AppEffect.EndDash -> bubbleManager.endDash(effect.platformName)
+            is AppEffect.StartSession -> bubbleManager.startSession(effect.sessionId, effect.platformName)
+            is AppEffect.EndSession -> bubbleManager.endSession(effect.platformName)
             is AppEffect.StartOdometer -> odometerEffectHandler.startUp()
             is AppEffect.StopOdometer -> odometerEffectHandler.shutDown()
             is AppEffect.PauseOdometer -> odometerEffectHandler.pause()
@@ -283,14 +283,14 @@ class SideEffectEngine @Inject constructor(
     }
 
     private fun sessionStartFromArgs(args: Map<String, String>) {
-        val platformName = args["platformName"] ?: "DoorDash"
-        val dashId = "session-${System.currentTimeMillis()}"
-        bubbleManager.startDash(dashId, platformName)
+        val platformName = args["platformName"] ?: "Unknown"
+        val sessionId = "session-${System.currentTimeMillis()}"
+        bubbleManager.startSession(sessionId, platformName)
     }
 
     private fun sessionEndFromArgs(args: Map<String, String>) {
         val platformName = args["platformName"]
-        bubbleManager.endDash(platformName)
+        bubbleManager.endSession(platformName)
     }
 
     private suspend fun scheduleTimeoutFromArgs(scope: CoroutineScope, args: Map<String, String>) {
@@ -357,8 +357,8 @@ class SideEffectEngine @Inject constructor(
         is AppEffect.StopOdometer,
         is AppEffect.PauseOdometer,
         is AppEffect.ResumeOdometer,
-        is AppEffect.StartDash,
-        is AppEffect.EndDash,
+        is AppEffect.StartSession,
+        is AppEffect.EndSession,
         is AppEffect.ProcessTipNotification,
         is AppEffect.SpeakOffer,
         -> true

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManager.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManager.kt
@@ -48,16 +48,23 @@ class BubbleManager @Inject constructor(
         pushDynamicShortcut()
     }
 
-    fun startDash(dashId: String, platformName: String = "DoorDash") {
-        _activeDashId.value = dashId
-        val verb = if (platformName.equals("uber", ignoreCase = true)) "Ubering" else "Dashing"
+    fun startSession(sessionId: String, platformName: String) {
+        _activeDashId.value = sessionId
+        val verb = sessionVerb(platformName)
         postMessage("Started $verb!", ChatPersona.Dispatcher)
     }
 
-    fun endDash(platformName: String? = null) {
+    fun endSession(platformName: String? = null) {
         _activeDashId.value = null
-        val verb = if (platformName.equals("uber", ignoreCase = true)) "Ubering" else "Dashing"
+        val verb = sessionVerb(platformName)
         postMessage("Done $verb!", ChatPersona.Dispatcher)
+    }
+
+    private fun sessionVerb(platformName: String?): String = when {
+        platformName.equals("uber", ignoreCase = true) -> "Ubering"
+        platformName.equals("doordash", ignoreCase = true) -> "Dashing"
+        platformName != null -> "driving for $platformName"
+        else -> "driving"
     }
 
     fun postMessage(

--- a/app/src/test/java/cloud/trotter/dashbuddy/rules/RuleCompilerTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/rules/RuleCompilerTest.kt
@@ -642,17 +642,51 @@ class RuleCompilerTest {
     // =========================================================================
 
     @Test(expected = RuleCompileException::class)
-    fun `offer shape without payAmount throws RuleCompileException`() {
+    fun `offer without payAmount throws RuleCompileException`() {
         ParsedFieldsFactory.validateShapeFields(
             "offer", setOf("distance", "timeToCompleteMinutes"), "test.rule",
         )
     }
 
+    @Test(expected = RuleCompileException::class)
+    fun `offer without distance throws RuleCompileException`() {
+        ParsedFieldsFactory.validateShapeFields(
+            "offer", setOf("payAmount", "timeToCompleteMinutes"), "test.rule",
+        )
+    }
+
     @Test
-    fun `offer shape with payAmount passes validation`() {
-        // Should not throw
+    fun `offer with payAmount and distance passes validation`() {
         ParsedFieldsFactory.validateShapeFields(
             "offer", setOf("payAmount", "distance"), "test.rule",
+        )
+    }
+
+    @Test(expected = RuleCompileException::class)
+    fun `post_task without totalPay throws RuleCompileException`() {
+        ParsedFieldsFactory.validateShapeFields(
+            "post_task", setOf("appPay", "customerTips"), "test.rule",
+        )
+    }
+
+    @Test
+    fun `post_task with totalPay passes validation`() {
+        ParsedFieldsFactory.validateShapeFields(
+            "post_task", setOf("totalPay"), "test.rule",
+        )
+    }
+
+    @Test(expected = RuleCompileException::class)
+    fun `session_ended without totalEarnings throws RuleCompileException`() {
+        ParsedFieldsFactory.validateShapeFields(
+            "session_ended", setOf("sessionDurationMillis"), "test.rule",
+        )
+    }
+
+    @Test
+    fun `session_ended with totalEarnings passes validation`() {
+        ParsedFieldsFactory.validateShapeFields(
+            "session_ended", setOf("totalEarnings"), "test.rule",
         )
     }
 
@@ -687,7 +721,7 @@ class RuleCompilerTest {
     }
 
     @Test
-    fun `compileRules accepts offer shape rule with payAmount`() {
+    fun `compileRules accepts offer shape rule with required fields`() {
         val ruleJson = """[{
             "id": "test.screen.good_offer",
             "priority": 10,
@@ -695,7 +729,8 @@ class RuleCompilerTest {
             "parse": {
                 "as": "offer",
                 "fields": {
-                    "payAmount": { "find": { "hasTextMatchesRegex": "\\$\\d" }, "read": "text" }
+                    "payAmount": { "find": { "hasTextMatchesRegex": "\\$\\d" }, "read": "text" },
+                    "distance": { "find": { "hasTextMatchesRegex": "\\d.*mi" }, "read": "text" }
                 }
             }
         }]"""

--- a/app/src/test/java/cloud/trotter/dashbuddy/rules/RuleCompilerTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/rules/RuleCompilerTest.kt
@@ -655,10 +655,24 @@ class RuleCompilerTest {
         )
     }
 
-    @Test
-    fun `offer with payAmount and distance passes validation`() {
+    @Test(expected = RuleCompileException::class)
+    fun `offer without time field throws RuleCompileException`() {
         ParsedFieldsFactory.validateShapeFields(
             "offer", setOf("payAmount", "distance"), "test.rule",
+        )
+    }
+
+    @Test
+    fun `offer with deliveryTimeText passes validation`() {
+        ParsedFieldsFactory.validateShapeFields(
+            "offer", setOf("payAmount", "distance", "deliveryTimeText"), "test.rule",
+        )
+    }
+
+    @Test
+    fun `offer with timeToCompleteMinutes passes validation`() {
+        ParsedFieldsFactory.validateShapeFields(
+            "offer", setOf("payAmount", "distance", "timeToCompleteMinutes"), "test.rule",
         )
     }
 
@@ -730,7 +744,8 @@ class RuleCompilerTest {
                 "as": "offer",
                 "fields": {
                     "payAmount": { "find": { "hasTextMatchesRegex": "\\$\\d" }, "read": "text" },
-                    "distance": { "find": { "hasTextMatchesRegex": "\\d.*mi" }, "read": "text" }
+                    "distance": { "find": { "hasTextMatchesRegex": "\\d.*mi" }, "read": "text" },
+                    "deliveryTimeText": { "find": { "hasTextMatchesRegex": "\\d+:\\d+" }, "read": "text" }
                 }
             }
         }]"""

--- a/app/src/test/java/cloud/trotter/dashbuddy/rules/RuleCompilerTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/rules/RuleCompilerTest.kt
@@ -673,9 +673,9 @@ class RuleCompilerTest {
         val ruleJson = """[{
             "id": "test.screen.bad_offer",
             "priority": 10,
-            "shape": "offer",
             "require": { "exists": { "hasText": "Accept" } },
             "parse": {
+                "as": "offer",
                 "fields": {
                     "distance": { "find": { "hasText": "5 mi" }, "read": "text" }
                 }
@@ -691,9 +691,9 @@ class RuleCompilerTest {
         val ruleJson = """[{
             "id": "test.screen.good_offer",
             "priority": 10,
-            "shape": "offer",
             "require": { "exists": { "hasText": "Accept" } },
             "parse": {
+                "as": "offer",
                 "fields": {
                     "payAmount": { "find": { "hasTextMatchesRegex": "\\$\\d" }, "read": "text" }
                 }

--- a/app/src/test/java/cloud/trotter/dashbuddy/rules/RuleCompilerTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/rules/RuleCompilerTest.kt
@@ -5,6 +5,7 @@ import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -634,6 +635,74 @@ class RuleCompilerTest {
             parseJson("""{}""").jsonObject
         )
         assertTrue(overrides.isEmpty())
+    }
+
+    // =========================================================================
+    // Shape contract validation (M3)
+    // =========================================================================
+
+    @Test(expected = RuleCompileException::class)
+    fun `offer shape without payAmount throws RuleCompileException`() {
+        ParsedFieldsFactory.validateShapeFields(
+            "offer", setOf("distance", "timeToCompleteMinutes"), "test.rule",
+        )
+    }
+
+    @Test
+    fun `offer shape with payAmount passes validation`() {
+        // Should not throw
+        ParsedFieldsFactory.validateShapeFields(
+            "offer", setOf("payAmount", "distance"), "test.rule",
+        )
+    }
+
+    @Test
+    fun `shape with no required fields passes validation`() {
+        ParsedFieldsFactory.validateShapeFields("idle", setOf("anything"), "test.rule")
+        ParsedFieldsFactory.validateShapeFields("task", emptySet(), "test.rule")
+        ParsedFieldsFactory.validateShapeFields("noise", emptySet(), "test.rule")
+    }
+
+    @Test
+    fun `unknown shape passes validation`() {
+        ParsedFieldsFactory.validateShapeFields("future_shape", emptySet(), "test.rule")
+    }
+
+    @Test(expected = RuleCompileException::class)
+    fun `compileRules rejects offer shape rule missing payAmount`() {
+        val ruleJson = """[{
+            "id": "test.screen.bad_offer",
+            "priority": 10,
+            "shape": "offer",
+            "require": { "exists": { "hasText": "Accept" } },
+            "parse": {
+                "fields": {
+                    "distance": { "find": { "hasText": "5 mi" }, "read": "text" }
+                }
+            }
+        }]"""
+        RuleCompiler.compileRules<UiNode>(
+            Json.parseToJsonElement(ruleJson).jsonArray, RuleContext.SCREEN,
+        )
+    }
+
+    @Test
+    fun `compileRules accepts offer shape rule with payAmount`() {
+        val ruleJson = """[{
+            "id": "test.screen.good_offer",
+            "priority": 10,
+            "shape": "offer",
+            "require": { "exists": { "hasText": "Accept" } },
+            "parse": {
+                "fields": {
+                    "payAmount": { "find": { "hasTextMatchesRegex": "\\$\\d" }, "read": "text" }
+                }
+            }
+        }]"""
+        val rules = RuleCompiler.compileRules<UiNode>(
+            Json.parseToJsonElement(ruleJson).jsonArray, RuleContext.SCREEN,
+        )
+        assertEquals(1, rules.size)
     }
 
     // =========================================================================

--- a/app/src/test/java/cloud/trotter/dashbuddy/state/EffectMapTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/state/EffectMapTest.kt
@@ -247,7 +247,7 @@ class EffectMapTest {
     // =========================================================================
 
     @Test
-    fun `session start emits DASH_START, StartOdometer, StartDash`() {
+    fun `session start emits DASH_START, StartOdometer, StartSession`() {
         val (platform, _) = stateWithPlatform(mode = Mode.Offline, sessionId = null)
         val prev = AppState(regions = Regions(
             platforms = mapOf(platform to PlatformRegion(platform, mode = Mode.Offline)),
@@ -262,11 +262,11 @@ class EffectMapTest {
 
         assertTrue("Should emit DASH_START", effects.logEventTypes().contains(AppEventType.DASH_START))
         assertTrue("Should emit StartOdometer", effects.any { it is AppEffect.StartOdometer })
-        assertTrue("Should emit StartDash", effects.any { it is AppEffect.StartDash })
+        assertTrue("Should emit StartSession", effects.any { it is AppEffect.StartSession })
     }
 
     @Test
-    fun `session end emits DASH_STOP, StopOdometer, EndDash`() {
+    fun `session end emits DASH_STOP, StopOdometer, EndSession`() {
         val (platform, onlineRegion) = stateWithPlatform(mode = Mode.Online, sessionId = "sess-1")
         val prev = AppState(regions = Regions(
             platforms = mapOf(platform to onlineRegion),
@@ -283,7 +283,7 @@ class EffectMapTest {
 
         assertTrue("Should emit DASH_STOP", effects.logEventTypes().contains(AppEventType.DASH_STOP))
         assertTrue("Should emit StopOdometer", effects.any { it is AppEffect.StopOdometer })
-        assertTrue("Should emit EndDash", effects.any { it is AppEffect.EndDash })
+        assertTrue("Should emit EndSession", effects.any { it is AppEffect.EndSession })
     }
 
     @Test
@@ -527,8 +527,8 @@ class EffectMapTest {
 
         assertTrue("No StartOdometer", effects.none { it is AppEffect.StartOdometer })
         assertTrue("No StopOdometer", effects.none { it is AppEffect.StopOdometer })
-        assertTrue("No StartDash", effects.none { it is AppEffect.StartDash })
-        assertTrue("No EndDash", effects.none { it is AppEffect.EndDash })
+        assertTrue("No StartSession", effects.none { it is AppEffect.StartSession })
+        assertTrue("No EndSession", effects.none { it is AppEffect.EndSession })
     }
 
     // =========================================================================
@@ -586,7 +586,7 @@ class EffectMapTest {
 
         // Default effects should NOT be present
         assertTrue("No StartOdometer", effects.none { it is AppEffect.StartOdometer })
-        assertTrue("No StartDash", effects.none { it is AppEffect.StartDash })
+        assertTrue("No StartSession", effects.none { it is AppEffect.StartSession })
     }
 
     @Test
@@ -643,7 +643,7 @@ class EffectMapTest {
 
         // Defaults suppressed
         assertTrue("No StopOdometer", effects.none { it is AppEffect.StopOdometer })
-        assertTrue("No EndDash", effects.none { it is AppEffect.EndDash })
+        assertTrue("No EndSession", effects.none { it is AppEffect.EndSession })
     }
 
     @Test
@@ -770,7 +770,7 @@ class EffectMapTest {
 
         // Defaults should fire since MODE_TO_ONLINE has no override
         assertTrue("Should emit StartOdometer", effects.any { it is AppEffect.StartOdometer })
-        assertTrue("Should emit StartDash", effects.any { it is AppEffect.StartDash })
+        assertTrue("Should emit StartSession", effects.any { it is AppEffect.StartSession })
         assertTrue("Should emit DASH_START", effects.logEventTypes().contains(AppEventType.DASH_START))
     }
 }

--- a/app/src/test/java/cloud/trotter/dashbuddy/state/EffectMapTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/state/EffectMapTest.kt
@@ -478,7 +478,7 @@ class EffectMapTest {
     // =========================================================================
 
     @Test
-    fun `additional_tip notification emits ProcessTipNotification and LogEvent`() {
+    fun `additional_tip notification emits ProcessTipNotification`() {
         val (platform, onlineRegion) = stateWithPlatform()
         val state = AppState(regions = Regions(platforms = mapOf(platform to onlineRegion)))
 
@@ -490,16 +490,18 @@ class EffectMapTest {
         ))
 
         assertTrue("Should emit ProcessTipNotification", effects.any { it is AppEffect.ProcessTipNotification })
-        assertTrue("Should emit NOTIFICATION_RECEIVED", effects.logEventTypes().contains(AppEventType.NOTIFICATION_RECEIVED))
     }
 
     @Test
-    fun `new_order notification emits LogEvent`() {
+    fun `new_order notification does not crash`() {
+        // Log effects are now rule-declared (JSON) and dispatched via diffRuleEffects.
+        // This test verifies the observation is processed without errors.
         val (platform, onlineRegion) = stateWithPlatform()
         val state = AppState(regions = Regions(platforms = mapOf(platform to onlineRegion)))
 
         val effects = effectMap.diff(state, state, notificationObs(intent = "new_order"))
-        assertTrue(effects.logEventTypes().contains(AppEventType.NOTIFICATION_RECEIVED))
+        // No hardcoded log effects — logging comes from rule-declared effects
+        assertTrue("Should produce no hardcoded effects for new_order", effects.isEmpty())
     }
 
     // =========================================================================

--- a/docs/rules.schema.json
+++ b/docs/rules.schema.json
@@ -64,7 +64,6 @@
           "default": true
         },
         "state": { "$ref": "#/$defs/stateBlock" },
-        "shape": { "$ref": "#/$defs/shapeEnum" },
         "bind": { "$ref": "#/$defs/bindBlock" },
         "reject": {
           "type": "array",
@@ -102,7 +101,6 @@
       "required": ["require"],
       "properties": {
         "state": { "$ref": "#/$defs/stateBlock" },
-        "shape": { "$ref": "#/$defs/shapeEnum" },
         "bind": { "$ref": "#/$defs/bindBlock" },
         "reject": {
           "type": "array",
@@ -127,7 +125,6 @@
       "description": "A single branch within a multi-branch click rule.",
       "required": ["require"],
       "properties": {
-        "shape": { "$ref": "#/$defs/shapeEnum" },
         "screenIs": {
           "type": "string",
           "description": "Only match when the active screen target equals this value."
@@ -161,7 +158,6 @@
       "required": ["require"],
       "properties": {
         "state": { "$ref": "#/$defs/stateBlock" },
-        "shape": { "$ref": "#/$defs/shapeEnum" },
         "intent": {
           "type": "string",
           "description": "Output intent string for this branch."
@@ -215,7 +211,6 @@
           "type": "string",
           "description": "Output intent string. Auto-derived from rule ID if omitted."
         },
-        "shape": { "$ref": "#/$defs/shapeEnum" },
         "bind": { "$ref": "#/$defs/bindBlock" },
         "reject": {
           "type": "array",
@@ -268,7 +263,6 @@
           "description": "CI/CD gate: when false, the split-repo pipeline requires human review before shipping changes to this rule. Not enforced at runtime. Default: true.",
           "default": true
         },
-        "shape": { "$ref": "#/$defs/shapeEnum" },
         "intent": {
           "type": "string",
           "description": "Output intent string. Auto-derived from rule ID if omitted."
@@ -340,28 +334,62 @@
 
     "parseBlock": {
       "type": "object",
-      "description": "Phase 4: Field extraction specification.",
+      "description": "Phase 4: Output type and field extraction specification.",
       "properties": {
-        "shape": { "$ref": "#/$defs/shapeEnum" },
+        "as": {
+          "$ref": "#/$defs/asEnum",
+          "description": "Output type. Determines which ParsedFields subtype is produced from the extracted fields."
+        },
         "fields": {
           "type": "object",
           "description": "Named fields to extract. Each value is a parse expression.",
           "additionalProperties": { "$ref": "#/$defs/parseExpression" }
         }
-      }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "as": { "const": "offer" } },
+            "required": ["as"]
+          },
+          "then": {
+            "required": ["fields"],
+            "properties": {
+              "fields": { "required": ["payAmount"] }
+            }
+          }
+        }
+      ]
     },
 
     "notificationParseBlock": {
       "type": "object",
       "description": "Parse block for notification rules. Extracts fields from notification string properties using regex.",
       "properties": {
-        "shape": { "$ref": "#/$defs/shapeEnum" },
+        "as": {
+          "$ref": "#/$defs/asEnum",
+          "description": "Output type. Determines which ParsedFields subtype is produced from the extracted fields."
+        },
         "fields": {
           "type": "object",
           "description": "Named fields to extract. Each value is a notification parse expression.",
           "additionalProperties": { "$ref": "#/$defs/notificationParseExpression" }
         }
-      }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "as": { "const": "offer" } },
+            "required": ["as"]
+          },
+          "then": {
+            "required": ["fields"],
+            "properties": {
+              "fields": { "required": ["payAmount"] }
+            }
+          }
+        }
+      ]
     },
 
     "notificationParseExpression": {
@@ -1529,9 +1557,9 @@
       ]
     },
 
-    "shapeEnum": {
+    "asEnum": {
       "type": "string",
-      "description": "Output shape type determining which ParsedFields subtype is produced.",
+      "description": "Output type determining which ParsedFields subtype is produced.",
       "enum": [
         "sensitive",
         "noise",

--- a/docs/rules.schema.json
+++ b/docs/rules.schema.json
@@ -355,7 +355,13 @@
           "then": {
             "required": ["fields"],
             "properties": {
-              "fields": { "required": ["payAmount", "distance"] }
+              "fields": {
+                "required": ["payAmount", "distance"],
+                "anyOf": [
+                  { "required": ["deliveryTimeText"] },
+                  { "required": ["timeToCompleteMinutes"] }
+                ]
+              }
             }
           }
         },
@@ -409,7 +415,13 @@
           "then": {
             "required": ["fields"],
             "properties": {
-              "fields": { "required": ["payAmount", "distance"] }
+              "fields": {
+                "required": ["payAmount", "distance"],
+                "anyOf": [
+                  { "required": ["deliveryTimeText"] },
+                  { "required": ["timeToCompleteMinutes"] }
+                ]
+              }
             }
           }
         },

--- a/docs/rules.schema.json
+++ b/docs/rules.schema.json
@@ -17,7 +17,7 @@
     },
     "platform_id": {
       "type": "string",
-      "description": "Platform identifier (e.g. 'doordash.driver', 'uber.driver').",
+      "description": "Provenance metadata identifying this rule file's source platform (e.g. 'doordash.driver', 'uber.driver'). Runtime filtering uses Platform.wire derived from rule IDs, not this field.",
       "pattern": "^[a-z][a-z0-9_]*\\.[a-z][a-z0-9_]*$"
     },
     "screens": {
@@ -54,9 +54,13 @@
           "description": "Evaluation order. Lower = evaluated first.",
           "minimum": 0
         },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of what this rule matches. Ignored by the compiler."
+        },
         "overrideable": {
           "type": "boolean",
-          "description": "Whether this rule can be overridden by platform updates. Default: true.",
+          "description": "CI/CD gate: when false, the split-repo pipeline requires human review before shipping changes to this rule. Not enforced at runtime. Default: true.",
           "default": true
         },
         "state": { "$ref": "#/$defs/stateBlock" },
@@ -194,8 +198,13 @@
           "type": "integer",
           "minimum": 0
         },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of what this rule matches. Ignored by the compiler."
+        },
         "overrideable": {
           "type": "boolean",
+          "description": "CI/CD gate: when false, the split-repo pipeline requires human review before shipping changes to this rule. Not enforced at runtime. Default: true.",
           "default": true
         },
         "screenIs": {
@@ -250,8 +259,13 @@
           "type": "integer",
           "minimum": 0
         },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of what this rule matches. Ignored by the compiler."
+        },
         "overrideable": {
           "type": "boolean",
+          "description": "CI/CD gate: when false, the split-repo pipeline requires human review before shipping changes to this rule. Not enforced at runtime. Default: true.",
           "default": true
         },
         "shape": { "$ref": "#/$defs/shapeEnum" },

--- a/docs/rules.schema.json
+++ b/docs/rules.schema.json
@@ -67,18 +67,9 @@
           "description": "Phase 2: Fail-fast negative checks. Any match skips this rule/branch.",
           "items": { "$ref": "#/$defs/treePredicate" }
         },
-        "guards": {
-          "type": "array",
-          "description": "v1 compat alias for 'reject'.",
-          "items": { "$ref": "#/$defs/treePredicate" }
-        },
         "require": {
           "$ref": "#/$defs/treePredicate",
           "description": "Phase 3: Positive match condition. Must pass for the rule to match."
-        },
-        "if": {
-          "$ref": "#/$defs/treePredicate",
-          "description": "v1 compat alias for 'require'."
         },
         "parse": { "$ref": "#/$defs/parseBlock" },
         "validate": {
@@ -89,11 +80,6 @@
         "effects": {
           "type": "array",
           "description": "Side effects to execute on successful match.",
-          "items": { "$ref": "#/$defs/effectEntry" }
-        },
-        "actions": {
-          "type": "array",
-          "description": "Legacy alias for 'effects'.",
           "items": { "$ref": "#/$defs/effectEntry" }
         },
         "transitionOverrides": { "$ref": "#/$defs/transitionOverrides" },
@@ -108,11 +94,8 @@
 
     "branchObject": {
       "type": "object",
-      "description": "A single branch within a multi-branch screen rule. Must have 'require' or 'if'.",
-      "anyOf": [
-        { "required": ["require"] },
-        { "required": ["if"] }
-      ],
+      "description": "A single branch within a multi-branch screen rule. Must have 'require'.",
+      "required": ["require"],
       "properties": {
         "state": { "$ref": "#/$defs/stateBlock" },
         "shape": { "$ref": "#/$defs/shapeEnum" },
@@ -121,22 +104,13 @@
           "type": "array",
           "items": { "$ref": "#/$defs/treePredicate" }
         },
-        "guards": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/treePredicate" }
-        },
         "require": { "$ref": "#/$defs/treePredicate" },
-        "if": { "$ref": "#/$defs/treePredicate" },
         "parse": { "$ref": "#/$defs/parseBlock" },
         "validate": {
           "type": "array",
           "items": { "$ref": "#/$defs/validateEntry" }
         },
         "effects": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/effectEntry" }
-        },
-        "actions": {
           "type": "array",
           "items": { "$ref": "#/$defs/effectEntry" }
         },
@@ -147,12 +121,8 @@
     "clickBranchObject": {
       "type": "object",
       "description": "A single branch within a multi-branch click rule.",
-      "anyOf": [
-        { "required": ["require"] },
-        { "required": ["if"] }
-      ],
+      "required": ["require"],
       "properties": {
-        "state": { "$ref": "#/$defs/stateBlock" },
         "shape": { "$ref": "#/$defs/shapeEnum" },
         "screenIs": {
           "type": "string",
@@ -168,17 +138,12 @@
           "items": { "$ref": "#/$defs/nodePredicate" }
         },
         "require": { "$ref": "#/$defs/nodePredicate" },
-        "if": { "$ref": "#/$defs/nodePredicate" },
         "parse": { "$ref": "#/$defs/parseBlock" },
         "validate": {
           "type": "array",
           "items": { "$ref": "#/$defs/validateEntry" }
         },
         "effects": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/effectEntry" }
-        },
-        "actions": {
           "type": "array",
           "items": { "$ref": "#/$defs/effectEntry" }
         },
@@ -189,10 +154,7 @@
     "notificationBranchObject": {
       "type": "object",
       "description": "A single branch within a multi-branch notification rule.",
-      "anyOf": [
-        { "required": ["require"] },
-        { "required": ["if"] }
-      ],
+      "required": ["require"],
       "properties": {
         "state": { "$ref": "#/$defs/stateBlock" },
         "shape": { "$ref": "#/$defs/shapeEnum" },
@@ -205,17 +167,12 @@
           "items": { "$ref": "#/$defs/notificationPredicate" }
         },
         "require": { "$ref": "#/$defs/notificationPredicate" },
-        "if": { "$ref": "#/$defs/notificationPredicate" },
         "parse": { "$ref": "#/$defs/notificationParseBlock" },
         "validate": {
           "type": "array",
           "items": { "$ref": "#/$defs/validateEntry" }
         },
         "effects": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/effectEntry" }
-        },
-        "actions": {
           "type": "array",
           "items": { "$ref": "#/$defs/effectEntry" }
         },
@@ -249,11 +206,6 @@
           "type": "string",
           "description": "Output intent string. Auto-derived from rule ID if omitted."
         },
-        "target": {
-          "type": "string",
-          "description": "v1 compat: CamelCase target converted to snake_case intent."
-        },
-        "state": { "$ref": "#/$defs/stateBlock" },
         "shape": { "$ref": "#/$defs/shapeEnum" },
         "bind": { "$ref": "#/$defs/bindBlock" },
         "reject": {
@@ -265,10 +217,6 @@
           "$ref": "#/$defs/nodePredicate",
           "description": "Positive match condition. Must pass for the rule to match."
         },
-        "if": {
-          "$ref": "#/$defs/nodePredicate",
-          "description": "Alias for 'require'."
-        },
         "parse": { "$ref": "#/$defs/parseBlock" },
         "validate": {
           "type": "array",
@@ -276,11 +224,6 @@
         },
         "effects": {
           "type": "array",
-          "items": { "$ref": "#/$defs/effectEntry" }
-        },
-        "actions": {
-          "type": "array",
-          "description": "Legacy alias for 'effects'.",
           "items": { "$ref": "#/$defs/effectEntry" }
         },
         "transitionOverrides": { "$ref": "#/$defs/transitionOverrides" },
@@ -316,10 +259,6 @@
           "type": "string",
           "description": "Output intent string. Auto-derived from rule ID if omitted."
         },
-        "target": {
-          "type": "string",
-          "description": "v1 compat alias for 'intent'."
-        },
         "state": { "$ref": "#/$defs/stateBlock" },
         "reject": {
           "type": "array",
@@ -330,10 +269,6 @@
           "$ref": "#/$defs/notificationPredicate",
           "description": "Positive match condition. Must pass for the rule to match."
         },
-        "if": {
-          "$ref": "#/$defs/notificationPredicate",
-          "description": "Alias for 'require'."
-        },
         "parse": { "$ref": "#/$defs/notificationParseBlock" },
         "validate": {
           "type": "array",
@@ -341,11 +276,6 @@
         },
         "effects": {
           "type": "array",
-          "items": { "$ref": "#/$defs/effectEntry" }
-        },
-        "actions": {
-          "type": "array",
-          "description": "Legacy alias for 'effects'.",
           "items": { "$ref": "#/$defs/effectEntry" }
         },
         "transitionOverrides": { "$ref": "#/$defs/transitionOverrides" },

--- a/docs/rules.schema.json
+++ b/docs/rules.schema.json
@@ -355,7 +355,31 @@
           "then": {
             "required": ["fields"],
             "properties": {
-              "fields": { "required": ["payAmount"] }
+              "fields": { "required": ["payAmount", "distance"] }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": { "as": { "const": "post_task" } },
+            "required": ["as"]
+          },
+          "then": {
+            "required": ["fields"],
+            "properties": {
+              "fields": { "required": ["totalPay"] }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": { "as": { "const": "session_ended" } },
+            "required": ["as"]
+          },
+          "then": {
+            "required": ["fields"],
+            "properties": {
+              "fields": { "required": ["totalEarnings"] }
             }
           }
         }
@@ -385,7 +409,31 @@
           "then": {
             "required": ["fields"],
             "properties": {
-              "fields": { "required": ["payAmount"] }
+              "fields": { "required": ["payAmount", "distance"] }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": { "as": { "const": "post_task" } },
+            "required": ["as"]
+          },
+          "then": {
+            "required": ["fields"],
+            "properties": {
+              "fields": { "required": ["totalPay"] }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": { "as": { "const": "session_ended" } },
+            "required": ["as"]
+          },
+          "then": {
+            "required": ["fields"],
+            "properties": {
+              "fields": { "required": ["totalEarnings"] }
             }
           }
         }

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/ParsedFields.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/ParsedFields.kt
@@ -106,8 +106,8 @@ sealed class ParsedFields {
 
     data class PausedFields(
         override val activity: String? = null,
-        val remainingText: String,
-        val remainingMillis: Long,
+        val remainingText: String? = null,
+        val remainingMillis: Long? = null,
     ) : ParsedFields() {
         // Paused is a single state — identity is just "paused".
         override fun dedupeHash(): Int = "paused".hashCode()


### PR DESCRIPTION
## Summary

- **Compiler hardening**: regex bypass prevention, transform validation, priority uniqueness enforcement, allText separator injection, rule ID collision detection across files
- **DSL cleanup**: remove v1 aliases (`match`/`matchAll`/`matchAny`), remove `state` from click rules, rename `shape`→`as` (moved inside `parse` block)
- **Platform-generic naming**: `StartDash`→`StartSession`, remove DoorDash-specific defaults from shared code
- **Notification effects**: migrate hardcoded notification switch into JSON rule `effects` blocks
- **Shape contracts**: compile-time + JSON Schema validation that offer rules declare `payAmount`, `distance`, and at least one time field; `post_task` declares `totalPay`; `session_ended` declares `totalEarnings`
- **Schema `if/then` contracts**: IDE validation via JSON Schema conditional blocks, including `anyOf` for platform-divergent fields (DoorDash `deliveryTimeText` vs Uber `timeToCompleteMinutes`)

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` — all unit tests pass
- [x] `RuleCompilerTest` — 15+ new tests covering regex bypass, bad transforms, priority collisions, shape contracts, one-of validation
- [x] `EffectMapTest` — updated for notification effect migration
- [x] Rule files compile cleanly with no `"shape"` keys remaining outside `parse` blocks
- [ ] `AllMatchersSuite` full regression pass
- [ ] IDE schema validation: open a rule file, remove a required field from an offer parse block → IDE shows error

🤖 Generated with [Claude Code](https://claude.com/claude-code)