### PR TITLE
feat(#145): personal economy v2 — true operating-cost model

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleScreen.kt
@@ -501,11 +501,24 @@ private fun EvalSummary(evaluation: OfferEvaluation) {
         label = "$/hr",
         value = "$${String.format("%.2f", evaluation.dollarsPerHour)}"
     )
-    if (evaluation.fuelCostEstimate > 0) {
+    if (evaluation.totalOperatingCost > 0) {
+        val netSuffix = if (evaluation.isUsingDefaults) " (est.)" else ""
         ModeRow(
             label = "Net",
-            value = "$${String.format("%.2f", evaluation.netPayAmount)} (−$${String.format("%.2f", evaluation.fuelCostEstimate)} fuel)"
+            value = "$${String.format("%.2f", evaluation.netPayAmount)}$netSuffix"
         )
+        val costBreakdown = buildString {
+            if (evaluation.fuelCostEstimate > 0) {
+                append("−$${String.format("%.2f", evaluation.fuelCostEstimate)} fuel")
+            }
+            if (evaluation.nonFuelCostEstimate > 0) {
+                if (isNotEmpty()) append(" · ")
+                append("−$${String.format("%.2f", evaluation.nonFuelCostEstimate)} wear")
+            }
+        }
+        if (costBreakdown.isNotEmpty()) {
+            ModeRow(label = "Cost", value = costBreakdown)
+        }
     }
     ModeRow(
         label = "Est. time",

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/components/economy/CurrencyInput.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/components/economy/CurrencyInput.kt
@@ -1,0 +1,74 @@
+package cloud.trotter.dashbuddy.ui.components.economy
+
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import java.util.Locale
+
+/**
+ * A currency-style input field. Renders the current value as a $-prefixed
+ * decimal; the user can scrub it via a numeric keyboard. Commits on blur or
+ * enter — there's no separate "submit" button.
+ *
+ * Used for: purchase price, insurance/registration deltas, phone plan total.
+ */
+@Composable
+fun CurrencyInput(
+    label: String,
+    value: Double,
+    onValueChange: (Double) -> Unit,
+    modifier: Modifier = Modifier,
+    suffix: String? = null,
+) {
+    var text by remember(value) { mutableStateOf(formatCurrency(value)) }
+
+    OutlinedTextField(
+        value = text,
+        onValueChange = { input ->
+            text = input
+            input.toDoubleOrNull()?.let(onValueChange)
+        },
+        label = { Text(label) },
+        prefix = { Text("$") },
+        suffix = suffix?.let { { Text(it) } },
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+        singleLine = true,
+        modifier = modifier,
+    )
+}
+
+/**
+ * An integer-style input field with a custom label. No prefix.
+ * Used for: phone plan line count, etc.
+ */
+@Composable
+fun IntegerInput(
+    label: String,
+    value: Int,
+    onValueChange: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var text by remember(value) { mutableStateOf(value.toString()) }
+
+    OutlinedTextField(
+        value = text,
+        onValueChange = { input ->
+            text = input
+            input.toIntOrNull()?.let(onValueChange)
+        },
+        label = { Text(label) },
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+        singleLine = true,
+        modifier = modifier,
+    )
+}
+
+private fun formatCurrency(value: Double): String =
+    if (value == 0.0) "0" else String.format(Locale.US, "%.2f", value).trimEnd('0').trimEnd('.')

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/components/economy/CurrencyInput.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/components/economy/CurrencyInput.kt
@@ -45,6 +45,34 @@ fun CurrencyInput(
 }
 
 /**
+ * A non-currency decimal input field. Same shape as [CurrencyInput] but no
+ * `$` prefix. Use this for any value that isn't money (e.g. minutes, miles).
+ */
+@Composable
+fun NumberInput(
+    label: String,
+    value: Double,
+    onValueChange: (Double) -> Unit,
+    modifier: Modifier = Modifier,
+    suffix: String? = null,
+) {
+    var text by remember(value) { mutableStateOf(formatCurrency(value)) }
+
+    OutlinedTextField(
+        value = text,
+        onValueChange = { input ->
+            text = input
+            input.toDoubleOrNull()?.let(onValueChange)
+        },
+        label = { Text(label) },
+        suffix = suffix?.let { { Text(it) } },
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+        singleLine = true,
+        modifier = modifier,
+    )
+}
+
+/**
  * An integer-style input field with a custom label. No prefix.
  * Used for: phone plan line count, etc.
  */

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/components/economy/EconomyAccordionRow.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/components/economy/EconomyAccordionRow.kt
@@ -1,0 +1,106 @@
+package cloud.trotter.dashbuddy.ui.components.economy
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+/**
+ * A collapsible row used to organize Personal Economy inputs into compact
+ * sections. Collapsed: chevron + label + computed-summary string (e.g.
+ * `$0.02/mi`). Expanded: reveals the [content] slot inline.
+ *
+ * When [isUserSet] is `false`, the row appends a muted `(default)` hint to
+ * the summary so the user can see which sections still use class/built-in
+ * defaults.
+ */
+@Composable
+fun EconomyAccordionRow(
+    title: String,
+    summary: String,
+    isUserSet: Boolean,
+    modifier: Modifier = Modifier,
+    initiallyExpanded: Boolean = false,
+    content: @Composable () -> Unit,
+) {
+    var expanded by remember { mutableStateOf(initiallyExpanded) }
+    val rotation by animateFloatAsState(if (expanded) 90f else 0f, label = "chevron")
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable { expanded = !expanded }
+                .padding(horizontal = 12.dp, vertical = 12.dp),
+        ) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = if (expanded) "Collapse" else "Expand",
+                modifier = Modifier.rotate(rotation),
+            )
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium,
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(start = 8.dp),
+            )
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = summary,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                if (!isUserSet) {
+                    Text(
+                        text = "(default)",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.outline,
+                        fontStyle = FontStyle.Italic,
+                    )
+                }
+            }
+        }
+        AnimatedVisibility(visible = expanded) {
+            Surface(
+                color = MaterialTheme.colorScheme.surfaceContainerLow,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Column(
+                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 12.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    content()
+                }
+            }
+        }
+        HorizontalDivider(thickness = 0.5.dp)
+    }
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/components/economy/PairedCurrencyAndIntervalInput.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/components/economy/PairedCurrencyAndIntervalInput.kt
@@ -1,0 +1,102 @@
+package cloud.trotter.dashbuddy.ui.components.economy
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import java.util.Locale
+
+/**
+ * A two-field row that captures a cost + interval pair (e.g. "$60 oil change
+ * every 5000 miles"). The app converts the pair to a per-mile value
+ * internally; the user only enters dollars + miles they already know.
+ *
+ * Used for: tires, oil changes, brakes, fluids, misc repairs.
+ */
+@Composable
+fun PairedCurrencyAndIntervalInput(
+    costLabel: String,
+    costValue: Double,
+    onCostChange: (Double) -> Unit,
+    intervalLabel: String,
+    intervalValue: Double,
+    onIntervalChange: (Double) -> Unit,
+    intervalSuffix: String = "mi",
+    modifier: Modifier = Modifier,
+    helperText: String? = null,
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            CurrencyInput(
+                label = costLabel,
+                value = costValue,
+                onValueChange = onCostChange,
+                modifier = Modifier.weight(1f),
+            )
+            IntervalInput(
+                label = intervalLabel,
+                value = intervalValue,
+                onValueChange = onIntervalChange,
+                suffix = intervalSuffix,
+                modifier = Modifier.weight(1f),
+            )
+        }
+        if (!helperText.isNullOrBlank()) {
+            Text(
+                text = helperText,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 4.dp),
+            )
+        }
+    }
+}
+
+/**
+ * An interval input — a numeric text field with a unit suffix (default "mi").
+ */
+@Composable
+private fun IntervalInput(
+    label: String,
+    value: Double,
+    onValueChange: (Double) -> Unit,
+    suffix: String,
+    modifier: Modifier = Modifier,
+) {
+    var text by remember(value) { mutableStateOf(formatInterval(value)) }
+
+    OutlinedTextField(
+        value = text,
+        onValueChange = { input ->
+            text = input
+            input.toDoubleOrNull()?.let(onValueChange)
+        },
+        label = { Text(label) },
+        suffix = { Text(suffix) },
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+        singleLine = true,
+        modifier = modifier,
+    )
+}
+
+private fun formatInterval(value: Double): String = when {
+    value == 0.0 -> "0"
+    value == value.toLong().toDouble() -> value.toLong().toString()
+    else -> String.format(Locale.US, "%.0f", value)
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/MainActivity.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/MainActivity.kt
@@ -25,6 +25,7 @@ import androidx.navigation.compose.rememberNavController
 import cloud.trotter.dashbuddy.ui.main.dashboard.DashboardScreen
 import cloud.trotter.dashbuddy.ui.main.navigation.Screen
 import cloud.trotter.dashbuddy.ui.main.settings.AboutScreen
+import cloud.trotter.dashbuddy.ui.main.settings.EconomySettingsScreen
 import cloud.trotter.dashbuddy.ui.main.settings.EvidenceSettingsScreen
 import cloud.trotter.dashbuddy.ui.main.settings.PlatformSettingsScreen
 import cloud.trotter.dashbuddy.ui.main.settings.SettingsHomeScreen
@@ -98,6 +99,13 @@ class MainActivity : ComponentActivity() {
                         // 3. Evidence Locker
                         composable(Screen.EvidenceSettings.route) {
                             EvidenceSettingsScreen(
+                                onBack = { navController.popBackStack() }
+                            )
+                        }
+
+                        // 3b. Personal Economy (operating costs, #145)
+                        composable(Screen.EconomySettings.route) {
+                            EconomySettingsScreen(
                                 onBack = { navController.popBackStack() }
                             )
                         }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/navigation/DashBuddyRoutes.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/navigation/DashBuddyRoutes.kt
@@ -13,6 +13,7 @@ sealed class Screen(val route: String) {
     data object AboutSettings : Screen("settings/about")
     data object StrategySettings : Screen("settings/strategy")
     data object EvidenceSettings : Screen("settings/evidence")
+    data object EconomySettings : Screen("settings/economy")
     data object GeneralSettings : Screen("settings/general")
     data object DeveloperSettings : Screen("settings/developer")
     data object PlatformSettings : Screen("settings/platforms")

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/EconomySettingsScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/EconomySettingsScreen.kt
@@ -105,24 +105,6 @@ fun EconomySettingsScreen(
 
             EconomyAccordions(eco = eco, viewModel = viewModel)
 
-            // Expected annual dash miles
-            Spacer(modifier = Modifier.height(12.dp))
-            Text(
-                text = "Expected dash miles: ${eco.expectedAnnualDashMiles.toInt()} mi/yr",
-                style = MaterialTheme.typography.bodyMedium,
-                fontWeight = FontWeight.Medium,
-            )
-            Text(
-                text = "Used to amortize fixed costs (insurance, registration, phone) per mile.",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Slider(
-                value = eco.expectedAnnualDashMiles.toFloat(),
-                onValueChange = { viewModel.setExpectedAnnualDashMiles(it.toDouble()) },
-                valueRange = 500f..30_000f,
-            )
-
             Spacer(modifier = Modifier.height(16.dp))
             Surface(
                 color = MaterialTheme.colorScheme.surfaceContainerHigh,
@@ -335,5 +317,27 @@ private fun EconomyAccordions(eco: UserEconomy, viewModel: EconomySettingsViewMo
                 modifier = Modifier.weight(1f),
             )
         }
+    }
+
+    EconomyAccordionRow(
+        title = "Expected dash miles / yr",
+        summary = "${eco.expectedAnnualDashMiles.toInt()} mi",
+        isUserSet = EconomyField.EXPECTED_ANNUAL_DASH_MI in userSet,
+    ) {
+        Text(
+            text = "${eco.expectedAnnualDashMiles.toInt()} miles per year",
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.Medium,
+        )
+        Slider(
+            value = eco.expectedAnnualDashMiles.toFloat(),
+            onValueChange = { viewModel.setExpectedAnnualDashMiles(it.toDouble()) },
+            valueRange = 500f..30_000f,
+        )
+        Text(
+            text = "Used to amortize fixed costs (insurance, registration, phone) per mile.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
     }
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/EconomySettingsScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/EconomySettingsScreen.kt
@@ -39,7 +39,6 @@ import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleClass
 import cloud.trotter.dashbuddy.ui.components.economy.CurrencyInput
 import cloud.trotter.dashbuddy.ui.components.economy.EconomyAccordionRow
 import cloud.trotter.dashbuddy.ui.components.economy.IntegerInput
-import cloud.trotter.dashbuddy.ui.components.economy.NumberInput
 import cloud.trotter.dashbuddy.ui.components.economy.PairedCurrencyAndIntervalInput
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -248,7 +247,7 @@ private fun EconomyAccordions(eco: UserEconomy, viewModel: EconomySettingsViewMo
         isUserSet = EconomyField.INSURANCE_DELTA in userSet,
     ) {
         CurrencyInput(
-            label = "Extra for dashing",
+            label = "Extra for gig work",
             value = eco.insuranceDeltaPerMonth,
             onValueChange = viewModel::setInsurance,
             suffix = "/mo",
@@ -290,7 +289,7 @@ private fun EconomyAccordions(eco: UserEconomy, viewModel: EconomySettingsViewMo
                 modifier = Modifier.weight(1f),
             )
         }
-        Text("% for dashing: ${eco.phoneDashPercent.toInt()}%")
+        Text("% for gig work: ${eco.phoneDashPercent.toInt()}%")
         Slider(
             value = eco.phoneDashPercent.toFloat(),
             onValueChange = { viewModel.setPhone(eco.phonePlanTotal, eco.phonePlanLines, it.toDouble()) },
@@ -299,43 +298,7 @@ private fun EconomyAccordions(eco: UserEconomy, viewModel: EconomySettingsViewMo
     }
 
     EconomyAccordionRow(
-        title = "Driving & pickup times",
-        summary = "${"%.1f".format(eco.avgMinutesPerMile)} min/mi · " +
-            "${eco.basePickupMinutes.toInt()} min/pickup",
-        isUserSet = EconomyField.AVG_MIN_PER_MILE in userSet ||
-            EconomyField.BASE_PICKUP_MIN in userSet,
-    ) {
-        Text(
-            text = "How long offers actually take in your market. Drives the \$/hr number.",
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            NumberInput(
-                label = "Driving pace",
-                value = eco.avgMinutesPerMile,
-                onValueChange = { viewModel.setTimeConstants(it, eco.basePickupMinutes) },
-                suffix = "min/mi",
-                modifier = Modifier.weight(1f),
-            )
-            NumberInput(
-                label = "Pickup wait",
-                value = eco.basePickupMinutes,
-                onValueChange = { viewModel.setTimeConstants(eco.avgMinutesPerMile, it) },
-                suffix = "min",
-                modifier = Modifier.weight(1f),
-            )
-        }
-        Text(
-            text = "Driving pace: minutes per mile (2.5 = busy urban, 1.5 = highway). " +
-                "Pickup wait: typical minutes at the store before leaving.",
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-    }
-
-    EconomyAccordionRow(
-        title = "Expected dash miles / yr",
+        title = "Expected gig miles / yr",
         summary = "${eco.expectedAnnualDashMiles.toInt()} mi",
         isUserSet = EconomyField.EXPECTED_ANNUAL_DASH_MI in userSet,
     ) {

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/EconomySettingsScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/EconomySettingsScreen.kt
@@ -1,0 +1,339 @@
+package cloud.trotter.dashbuddy.ui.main.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import cloud.trotter.dashbuddy.domain.evaluation.EconomyField
+import cloud.trotter.dashbuddy.domain.evaluation.UserEconomy
+import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleClass
+import cloud.trotter.dashbuddy.ui.components.economy.CurrencyInput
+import cloud.trotter.dashbuddy.ui.components.economy.EconomyAccordionRow
+import cloud.trotter.dashbuddy.ui.components.economy.IntegerInput
+import cloud.trotter.dashbuddy.ui.components.economy.PairedCurrencyAndIntervalInput
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EconomySettingsScreen(
+    onBack: () -> Unit,
+    viewModel: EconomySettingsViewModel = hiltViewModel(),
+) {
+    val eco by viewModel.userEconomy.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Personal Economy") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    TextButton(onClick = { viewModel.resetDefaults() }) {
+                        Text("Reset to defaults")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp),
+        ) {
+            Text(
+                text = "Enter your real numbers so DashBuddy can show your true net pay. " +
+                    "Defaults are sensible estimates for your vehicle class but will be off — " +
+                    "tap any section to set actual values.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // Vehicle class picker
+            Text(
+                text = "Vehicle class",
+                style = MaterialTheme.typography.titleSmall,
+            )
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                VehicleClass.entries.forEach { vc ->
+                    FilterChip(
+                        selected = eco.vehicleClass == vc,
+                        onClick = { viewModel.setVehicleClass(vc) },
+                        label = { Text(vc.displayName) },
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            EconomyAccordions(eco = eco, viewModel = viewModel)
+
+            // Expected annual dash miles
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = "Expected dash miles: ${eco.expectedAnnualDashMiles.toInt()} mi/yr",
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium,
+            )
+            Text(
+                text = "Used to amortize fixed costs (insurance, registration, phone) per mile.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Slider(
+                value = eco.expectedAnnualDashMiles.toFloat(),
+                onValueChange = { viewModel.setExpectedAnnualDashMiles(it.toDouble()) },
+                valueRange = 500f..30_000f,
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+            Surface(
+                color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Column(
+                    modifier = Modifier.padding(12.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Text(
+                        text = "Your true cost: \$${"%.2f".format(eco.operatingCostPerMile)}/mi",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                    )
+                    Text(
+                        text = "IRS standard mileage rate: \$0.67/mi",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(32.dp))
+        }
+    }
+}
+
+@Composable
+private fun EconomyAccordions(eco: UserEconomy, viewModel: EconomySettingsViewModel) {
+    val userSet = eco.userSetFields
+
+    EconomyAccordionRow(
+        title = "Tires",
+        summary = "\$${"%.3f".format(eco.tireCostPerMile)}/mi",
+        isUserSet = EconomyField.TIRE_COST in userSet || EconomyField.TIRE_LIFETIME in userSet,
+    ) {
+        PairedCurrencyAndIntervalInput(
+            costLabel = "Set of 4",
+            costValue = eco.tireSetCost,
+            onCostChange = { viewModel.setTires(it, eco.tireLifetimeMi) },
+            intervalLabel = "Lifetime",
+            intervalValue = eco.tireLifetimeMi,
+            onIntervalChange = { viewModel.setTires(eco.tireSetCost, it) },
+        )
+    }
+
+    EconomyAccordionRow(
+        title = "Oil changes",
+        summary = "\$${"%.3f".format(eco.oilCostPerMile)}/mi",
+        isUserSet = EconomyField.OIL_COST in userSet || EconomyField.OIL_INTERVAL in userSet,
+    ) {
+        PairedCurrencyAndIntervalInput(
+            costLabel = "Each",
+            costValue = eco.oilCost,
+            onCostChange = { viewModel.setOil(it, eco.oilIntervalMi) },
+            intervalLabel = "Every",
+            intervalValue = eco.oilIntervalMi,
+            onIntervalChange = { viewModel.setOil(eco.oilCost, it) },
+        )
+    }
+
+    EconomyAccordionRow(
+        title = "Brakes",
+        summary = "\$${"%.3f".format(eco.brakesCostPerMile)}/mi",
+        isUserSet = EconomyField.BRAKES_COST in userSet || EconomyField.BRAKES_INTERVAL in userSet,
+    ) {
+        PairedCurrencyAndIntervalInput(
+            costLabel = "Each",
+            costValue = eco.brakesCost,
+            onCostChange = { viewModel.setBrakes(it, eco.brakesIntervalMi) },
+            intervalLabel = "Every",
+            intervalValue = eco.brakesIntervalMi,
+            onIntervalChange = { viewModel.setBrakes(eco.brakesCost, it) },
+        )
+    }
+
+    EconomyAccordionRow(
+        title = "Fluids",
+        summary = "\$${"%.3f".format(eco.fluidsCostPerMile)}/mi",
+        isUserSet = EconomyField.FLUIDS_COST in userSet || EconomyField.FLUIDS_INTERVAL in userSet,
+    ) {
+        PairedCurrencyAndIntervalInput(
+            costLabel = "Each",
+            costValue = eco.fluidsCost,
+            onCostChange = { viewModel.setFluids(it, eco.fluidsIntervalMi) },
+            intervalLabel = "Every",
+            intervalValue = eco.fluidsIntervalMi,
+            onIntervalChange = { viewModel.setFluids(eco.fluidsCost, it) },
+        )
+    }
+
+    EconomyAccordionRow(
+        title = "Misc repairs",
+        summary = "\$${"%.3f".format(eco.miscCostPerMile)}/mi",
+        isUserSet = EconomyField.MISC_YEARLY in userSet || EconomyField.MISC_YEARLY_MI in userSet,
+    ) {
+        PairedCurrencyAndIntervalInput(
+            costLabel = "Yearly budget",
+            costValue = eco.miscYearly,
+            onCostChange = { viewModel.setMiscRepairs(it, eco.miscYearlyMi) },
+            intervalLabel = "Driving",
+            intervalValue = eco.miscYearlyMi,
+            onIntervalChange = { viewModel.setMiscRepairs(eco.miscYearly, it) },
+            intervalSuffix = "mi/yr",
+        )
+    }
+
+    EconomyAccordionRow(
+        title = "Depreciation",
+        summary = if (eco.includeDepreciation) "\$${"%.3f".format(eco.depreciationCostPerMile)}/mi" else "off",
+        isUserSet = EconomyField.INCLUDE_DEPRECIATION in userSet ||
+            EconomyField.PURCHASE_PRICE in userSet ||
+            EconomyField.TOTAL_LIFETIME_MI in userSet,
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text("Include depreciation", modifier = Modifier.weight(1f))
+            Switch(
+                checked = eco.includeDepreciation,
+                onCheckedChange = {
+                    viewModel.setDepreciation(it, eco.purchasePrice, eco.totalLifetimeMi)
+                },
+            )
+        }
+        if (eco.includeDepreciation) {
+            PairedCurrencyAndIntervalInput(
+                costLabel = "Purchase price",
+                costValue = eco.purchasePrice,
+                onCostChange = { viewModel.setDepreciation(true, it, eco.totalLifetimeMi) },
+                intervalLabel = "Lifetime",
+                intervalValue = eco.totalLifetimeMi,
+                onIntervalChange = { viewModel.setDepreciation(true, eco.purchasePrice, it) },
+                helperText = "Total expected miles from new to retirement.",
+            )
+        }
+    }
+
+    EconomyAccordionRow(
+        title = "Insurance",
+        summary = "\$${"%.3f".format(eco.insuranceCostPerMile)}/mi*",
+        isUserSet = EconomyField.INSURANCE_DELTA in userSet,
+    ) {
+        CurrencyInput(
+            label = "Extra for dashing",
+            value = eco.insuranceDeltaPerMonth,
+            onValueChange = viewModel::setInsurance,
+            suffix = "/mo",
+        )
+    }
+
+    EconomyAccordionRow(
+        title = "Registration",
+        summary = "\$${"%.3f".format(eco.registrationCostPerMile)}/mi*",
+        isUserSet = EconomyField.REGISTRATION_DELTA in userSet,
+    ) {
+        CurrencyInput(
+            label = "Commercial delta",
+            value = eco.registrationDeltaPerYear,
+            onValueChange = viewModel::setRegistration,
+            suffix = "/yr",
+        )
+    }
+
+    EconomyAccordionRow(
+        title = "Phone & data",
+        summary = "\$${"%.3f".format(eco.phoneCostPerMile)}/mi*",
+        isUserSet = EconomyField.PHONE_PLAN_TOTAL in userSet ||
+            EconomyField.PHONE_PLAN_LINES in userSet ||
+            EconomyField.PHONE_DASH_PERCENT in userSet,
+    ) {
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            CurrencyInput(
+                label = "Plan total",
+                value = eco.phonePlanTotal,
+                onValueChange = { viewModel.setPhone(it, eco.phonePlanLines, eco.phoneDashPercent) },
+                suffix = "/mo",
+                modifier = Modifier.weight(1f),
+            )
+            IntegerInput(
+                label = "Lines",
+                value = eco.phonePlanLines,
+                onValueChange = { viewModel.setPhone(eco.phonePlanTotal, it, eco.phoneDashPercent) },
+                modifier = Modifier.weight(1f),
+            )
+        }
+        Text("% for dashing: ${eco.phoneDashPercent.toInt()}%")
+        Slider(
+            value = eco.phoneDashPercent.toFloat(),
+            onValueChange = { viewModel.setPhone(eco.phonePlanTotal, eco.phonePlanLines, it.toDouble()) },
+            valueRange = 0f..100f,
+        )
+    }
+
+    EconomyAccordionRow(
+        title = "Time estimates",
+        summary = "${"%.1f".format(eco.avgMinutesPerMile)} min/mi",
+        isUserSet = EconomyField.AVG_MIN_PER_MILE in userSet ||
+            EconomyField.BASE_PICKUP_MIN in userSet,
+    ) {
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            CurrencyInput(
+                label = "Min per mile",
+                value = eco.avgMinutesPerMile,
+                onValueChange = { viewModel.setTimeConstants(it, eco.basePickupMinutes) },
+                modifier = Modifier.weight(1f),
+            )
+            CurrencyInput(
+                label = "Base pickup min",
+                value = eco.basePickupMinutes,
+                onValueChange = { viewModel.setTimeConstants(eco.avgMinutesPerMile, it) },
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/EconomySettingsScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/EconomySettingsScreen.kt
@@ -39,6 +39,7 @@ import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleClass
 import cloud.trotter.dashbuddy.ui.components.economy.CurrencyInput
 import cloud.trotter.dashbuddy.ui.components.economy.EconomyAccordionRow
 import cloud.trotter.dashbuddy.ui.components.economy.IntegerInput
+import cloud.trotter.dashbuddy.ui.components.economy.NumberInput
 import cloud.trotter.dashbuddy.ui.components.economy.PairedCurrencyAndIntervalInput
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -298,25 +299,39 @@ private fun EconomyAccordions(eco: UserEconomy, viewModel: EconomySettingsViewMo
     }
 
     EconomyAccordionRow(
-        title = "Time estimates",
-        summary = "${"%.1f".format(eco.avgMinutesPerMile)} min/mi",
+        title = "Driving & pickup times",
+        summary = "${"%.1f".format(eco.avgMinutesPerMile)} min/mi · " +
+            "${eco.basePickupMinutes.toInt()} min/pickup",
         isUserSet = EconomyField.AVG_MIN_PER_MILE in userSet ||
             EconomyField.BASE_PICKUP_MIN in userSet,
     ) {
+        Text(
+            text = "How long offers actually take in your market. Drives the \$/hr number.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            CurrencyInput(
-                label = "Min per mile",
+            NumberInput(
+                label = "Driving pace",
                 value = eco.avgMinutesPerMile,
                 onValueChange = { viewModel.setTimeConstants(it, eco.basePickupMinutes) },
+                suffix = "min/mi",
                 modifier = Modifier.weight(1f),
             )
-            CurrencyInput(
-                label = "Base pickup min",
+            NumberInput(
+                label = "Pickup wait",
                 value = eco.basePickupMinutes,
                 onValueChange = { viewModel.setTimeConstants(eco.avgMinutesPerMile, it) },
+                suffix = "min",
                 modifier = Modifier.weight(1f),
             )
         }
+        Text(
+            text = "Driving pace: minutes per mile (2.5 = busy urban, 1.5 = highway). " +
+                "Pickup wait: typical minutes at the store before leaving.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
     }
 
     EconomyAccordionRow(

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/EconomySettingsViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/EconomySettingsViewModel.kt
@@ -1,0 +1,82 @@
+package cloud.trotter.dashbuddy.ui.main.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import cloud.trotter.dashbuddy.core.data.settings.AppPreferencesRepository
+import cloud.trotter.dashbuddy.domain.evaluation.EconomyField
+import cloud.trotter.dashbuddy.domain.evaluation.UserEconomy
+import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleClass
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * Backs the Personal Economy settings screen. Pure passthrough to
+ * [AppPreferencesRepository] for reads and writes. Each write atomically marks
+ * the corresponding [EconomyField] as user-set in DataStore.
+ */
+@HiltViewModel
+class EconomySettingsViewModel @Inject constructor(
+    private val repo: AppPreferencesRepository,
+) : ViewModel() {
+
+    val userEconomy = repo.userEconomy.stateIn(
+        viewModelScope,
+        SharingStarted.WhileSubscribed(5000),
+        UserEconomy(),
+    )
+
+    fun setVehicleClass(vc: VehicleClass) = viewModelScope.launch {
+        repo.updateVehicleClass(vc)
+    }
+
+    fun setTires(setCost: Double, lifetimeMi: Double) = viewModelScope.launch {
+        repo.updateTireCost(setCost, lifetimeMi)
+    }
+
+    fun setOil(cost: Double, intervalMi: Double) = viewModelScope.launch {
+        repo.updateOilCost(cost, intervalMi)
+    }
+
+    fun setBrakes(cost: Double, intervalMi: Double) = viewModelScope.launch {
+        repo.updateBrakesCost(cost, intervalMi)
+    }
+
+    fun setFluids(cost: Double, intervalMi: Double) = viewModelScope.launch {
+        repo.updateFluidsCost(cost, intervalMi)
+    }
+
+    fun setMiscRepairs(yearly: Double, yearlyMi: Double) = viewModelScope.launch {
+        repo.updateMiscMaintenance(yearly, yearlyMi)
+    }
+
+    fun setDepreciation(include: Boolean, price: Double, lifetimeMi: Double) = viewModelScope.launch {
+        repo.updateDepreciation(include, price, lifetimeMi)
+    }
+
+    fun setInsurance(perMonth: Double) = viewModelScope.launch {
+        repo.updateInsuranceDelta(perMonth)
+    }
+
+    fun setRegistration(perYear: Double) = viewModelScope.launch {
+        repo.updateRegistrationDelta(perYear)
+    }
+
+    fun setExpectedAnnualDashMiles(miles: Double) = viewModelScope.launch {
+        repo.updateExpectedAnnualDashMi(miles)
+    }
+
+    fun setPhone(total: Double, lines: Int, dashPercent: Double) = viewModelScope.launch {
+        repo.updatePhonePlan(total, lines, dashPercent)
+    }
+
+    fun setTimeConstants(avgMinPerMile: Double, basePickupMin: Double) = viewModelScope.launch {
+        repo.updateTimeConstants(avgMinPerMile, basePickupMin)
+    }
+
+    fun resetDefaults() = viewModelScope.launch {
+        repo.resetEconomyDefaults()
+    }
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/SettingsHomeScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/SettingsHomeScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Apps
+import androidx.compose.material.icons.filled.AttachMoney
 import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Folder
@@ -47,6 +48,7 @@ fun SettingsHomeScreen(
 ) {
     // Relying strictly on the persisted DataStore state now
     val isDevUnlocked by viewModel.isDevModeUnlocked.collectAsState(initial = false)
+    val userEconomy by viewModel.userEconomy.collectAsState(initial = null)
 
     Scaffold(
         topBar = {
@@ -93,6 +95,22 @@ fun SettingsHomeScreen(
                     title = "Strategy Config",
                     subtitle = "Rules, Pricing, and Simulation",
                     onClick = { onNavigate(Screen.StrategySettings.route) }
+                )
+                val eco = userEconomy
+                val ecoSubtitle = if (eco != null) {
+                    val costPerMi = eco.operatingCostPerMile
+                    val defaultsCount = cloud.trotter.dashbuddy.domain.evaluation.EconomyField.entries.size -
+                        eco.userSetFields.size
+                    "True cost: \$${"%.2f".format(costPerMi)}/mi" +
+                        if (defaultsCount > 0) " · $defaultsCount defaults" else ""
+                } else {
+                    "Tires, oil, depreciation, insurance, phone"
+                }
+                SettingsNavItem(
+                    icon = Icons.Default.AttachMoney,
+                    title = "Personal Economy",
+                    subtitle = ecoSubtitle,
+                    onClick = { onNavigate(Screen.EconomySettings.route) }
                 )
             }
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/SettingsMenuViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/SettingsMenuViewModel.kt
@@ -22,6 +22,8 @@ class SettingsMenuViewModel @Inject constructor(
     val evidenceConfig = strategyRepository.evidenceConfig
     val appTheme = appPreferencesRepository.appTheme
     val isProMode = appPreferencesRepository.isProMode
+    /** Surfaced on Settings home so the Personal Economy nav row shows live $/mi. */
+    val userEconomy = appPreferencesRepository.userEconomy
 
     // Re-using the debug flag from repo as the "Unlock" state
     val isDevModeUnlocked = devSettingsRepository.isDevModeUnlocked

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/components/FakeOfferCard.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/components/FakeOfferCard.kt
@@ -60,6 +60,8 @@ fun FakeOfferCard(
     val animatedContentColor by animateColorAsState(targetContentColor, label = "content")
 
     val hasFuelCost = evaluation.fuelCostEstimate > 0.0
+    val hasNonFuelCost = evaluation.nonFuelCostEstimate > 0.0
+    val hasAnyCost = hasFuelCost || hasNonFuelCost
 
     Column(modifier = modifier.fillMaxWidth()) {
         Card(
@@ -86,18 +88,28 @@ fun FakeOfferCard(
                 Spacer(modifier = Modifier.height(12.dp))
 
                 // --- Pay line ---
-                if (hasFuelCost) {
+                if (hasAnyCost) {
+                    val netSuffix = if (evaluation.isUsingDefaults) " (est.)" else ""
                     Text(
-                        text = "$${fmt(evaluation.payAmount)} gross  →  $${fmt(evaluation.netPayAmount)} net",
+                        text = "$${fmt(evaluation.payAmount)} gross  →  $${fmt(evaluation.netPayAmount)} net$netSuffix",
                         style = MaterialTheme.typography.bodyLarge,
                         fontWeight = FontWeight.SemiBold,
                         color = animatedContentColor
                     )
-                    Text(
-                        text = "−$${fmt(evaluation.fuelCostEstimate)} est. fuel",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = animatedContentColor.copy(alpha = 0.65f)
-                    )
+                    if (hasFuelCost) {
+                        Text(
+                            text = "−$${fmt(evaluation.fuelCostEstimate)} fuel",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = animatedContentColor.copy(alpha = 0.65f)
+                        )
+                    }
+                    if (hasNonFuelCost) {
+                        Text(
+                            text = "−$${fmt(evaluation.nonFuelCostEstimate)} wear & fixed costs",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = animatedContentColor.copy(alpha = 0.65f)
+                        )
+                    }
                 } else {
                     Text(
                         text = "$${fmt(evaluation.payAmount)}",

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/WizardScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/WizardScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import cloud.trotter.dashbuddy.domain.config.DashStrategy
+import cloud.trotter.dashbuddy.ui.main.setup.wizard.cards.EconomyCostsCard
 import cloud.trotter.dashbuddy.ui.main.setup.wizard.cards.GasPriceCard
 import cloud.trotter.dashbuddy.ui.main.setup.wizard.cards.MetricSliderCard
 import cloud.trotter.dashbuddy.ui.main.setup.wizard.cards.SelectionCard
@@ -135,6 +136,24 @@ fun WizardScreen(
                             onFuelTypeSelected = viewModel::updateFuelType,
                             onAutoToggle = viewModel::toggleAutoGasPrice,
                             onPriceChange = viewModel::updateGasPrice
+                        )
+                    }
+
+                    WizardStep.ECONOMY_COSTS -> {
+                        EconomyCostsCard(
+                            state = state,
+                            onClassChange = viewModel::updateVehicleClass,
+                            onTiresChange = viewModel::updateTires,
+                            onOilChange = viewModel::updateOilChange,
+                            onBrakesChange = viewModel::updateBrakes,
+                            onFluidsChange = viewModel::updateFluids,
+                            onMiscChange = viewModel::updateMiscRepairs,
+                            onDepreciationChange = viewModel::updateDepreciation,
+                            onInsuranceChange = viewModel::updateInsuranceDelta,
+                            onRegistrationChange = viewModel::updateRegistrationDelta,
+                            onPhoneChange = viewModel::updatePhonePlan,
+                            onExpectedAnnualDashMilesChange = viewModel::updateExpectedAnnualDashMiles,
+                            onTimeConstantsChange = viewModel::updateTimeConstants,
                         )
                     }
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/WizardScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/WizardScreen.kt
@@ -108,7 +108,7 @@ fun WizardScreen(
                     WizardStep.VEHICLE -> {
                         VehicleCard(
                             step = currentStep,
-                            vehicleType = state.vehicleType,
+                            vehicleClass = state.vehicleClass,
                             year = state.vehicleYear,
                             make = state.vehicleMake,
                             model = state.vehicleModel,
@@ -118,7 +118,7 @@ fun WizardScreen(
                             availableMakes = availableMakes,
                             availableModels = availableModels,
                             availableTrims = availableTrimNames,
-                            onTypeSelected = viewModel::updateVehicleType,
+                            onTypeSelected = viewModel::updateVehicleClass,
                             onYearSelected = viewModel::onYearSelected,
                             onMakeSelected = viewModel::onMakeSelected,
                             onModelSelected = viewModel::onModelSelected,

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/WizardViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/WizardViewModel.kt
@@ -8,6 +8,7 @@ import cloud.trotter.dashbuddy.core.data.state.AppStateRepository
 import cloud.trotter.dashbuddy.core.data.strategy.StrategyRepository
 import cloud.trotter.dashbuddy.core.data.vehicle.VehicleRepository
 import cloud.trotter.dashbuddy.domain.config.DashStrategy
+import cloud.trotter.dashbuddy.domain.evaluation.EconomyField
 import cloud.trotter.dashbuddy.domain.evaluation.MetricType
 import cloud.trotter.dashbuddy.domain.evaluation.ScoringRule
 import cloud.trotter.dashbuddy.domain.model.vehicle.FuelType
@@ -88,11 +89,13 @@ class WizardViewModel @Inject constructor(
             val maxItemsRule = rules.filterIsInstance<ScoringRule.MetricRule>()
                 .find { it.metricType == MetricType.ITEM_COUNT }
 
-            val vehicleClass = if (currentYear == "E-Bike") VehicleClass.E_BIKE else VehicleClass.SEDAN
+            // The currently-stored UserEconomy already merges class-derived defaults
+            // with persisted user-set values, so just snapshot it for the wizard.
+            val storedEconomy = appPreferencesRepository.userEconomy.first()
 
             _state.update { currentState ->
                 currentState.copy(
-                    vehicleClass = vehicleClass,
+                    vehicleClass = storedEconomy.vehicleClass,
                     vehicleYear = currentYear,
                     vehicleMake = currentMake,
                     vehicleModel = currentModel,
@@ -105,14 +108,35 @@ class WizardViewModel @Inject constructor(
 
                     enforceMinPayout = minPayoutRule?.autoDeclineOnFail ?: false,
                     minPayout = minPayoutRule?.targetValue ?: 5.0f,
-
                     enforceTargetHourly = targetHourlyRule?.autoDeclineOnFail ?: false,
                     targetHourly = targetHourlyRule?.targetValue ?: 20.0f,
-
                     enforceMaxDistance = maxDistanceRule?.autoDeclineOnFail ?: false,
                     maxDistance = maxDistanceRule?.targetValue ?: 10.0f,
+                    maxItems = maxItemsRule?.targetValue ?: 15.0f,
 
-                    maxItems = maxItemsRule?.targetValue ?: 15.0f
+                    // Personal Economy v2 (#145)
+                    tireSetCost = storedEconomy.tireSetCost,
+                    tireLifetimeMi = storedEconomy.tireLifetimeMi,
+                    oilCost = storedEconomy.oilCost,
+                    oilIntervalMi = storedEconomy.oilIntervalMi,
+                    brakesCost = storedEconomy.brakesCost,
+                    brakesIntervalMi = storedEconomy.brakesIntervalMi,
+                    fluidsCost = storedEconomy.fluidsCost,
+                    fluidsIntervalMi = storedEconomy.fluidsIntervalMi,
+                    miscYearly = storedEconomy.miscYearly,
+                    miscYearlyMi = storedEconomy.miscYearlyMi,
+                    includeDepreciation = storedEconomy.includeDepreciation,
+                    purchasePrice = storedEconomy.purchasePrice,
+                    totalLifetimeMi = storedEconomy.totalLifetimeMi,
+                    insuranceDeltaPerMonth = storedEconomy.insuranceDeltaPerMonth,
+                    registrationDeltaPerYear = storedEconomy.registrationDeltaPerYear,
+                    expectedAnnualDashMiles = storedEconomy.expectedAnnualDashMiles,
+                    phonePlanTotal = storedEconomy.phonePlanTotal,
+                    phonePlanLines = storedEconomy.phonePlanLines,
+                    phoneDashPercent = storedEconomy.phoneDashPercent,
+                    avgMinutesPerMile = storedEconomy.avgMinutesPerMile,
+                    basePickupMinutes = storedEconomy.basePickupMinutes,
+                    userSetEconomyFields = storedEconomy.userSetFields,
                 )
             }
         }
@@ -122,8 +146,125 @@ class WizardViewModel @Inject constructor(
         viewModelScope.launch { _availableYears.value = vehicleRepository.getYears() }
     }
 
+    /**
+     * Sets the vehicle class. Any [EconomyField] still at its default (i.e. NOT in
+     * [WizardState.userSetEconomyFields]) shifts to the new class's preset. User-set
+     * values are preserved.
+     */
     fun updateVehicleClass(type: VehicleClass) {
-        _state.update { it.copy(vehicleClass = type) }
+        _state.update { s ->
+            val unset = EconomyField.entries.toSet() - s.userSetEconomyFields
+            s.copy(
+                vehicleClass = type,
+                tireSetCost = if (EconomyField.TIRE_COST in unset) type.tireSetCost else s.tireSetCost,
+                tireLifetimeMi = if (EconomyField.TIRE_LIFETIME in unset) type.tireLifetimeMi else s.tireLifetimeMi,
+                oilCost = if (EconomyField.OIL_COST in unset) type.oilCost else s.oilCost,
+                oilIntervalMi = if (EconomyField.OIL_INTERVAL in unset) type.oilIntervalMi else s.oilIntervalMi,
+                brakesCost = if (EconomyField.BRAKES_COST in unset) type.brakesCost else s.brakesCost,
+                brakesIntervalMi = if (EconomyField.BRAKES_INTERVAL in unset) type.brakesIntervalMi else s.brakesIntervalMi,
+                fluidsCost = if (EconomyField.FLUIDS_COST in unset) type.fluidsCost else s.fluidsCost,
+                fluidsIntervalMi = if (EconomyField.FLUIDS_INTERVAL in unset) type.fluidsIntervalMi else s.fluidsIntervalMi,
+                miscYearly = if (EconomyField.MISC_YEARLY in unset) type.miscYearly else s.miscYearly,
+                miscYearlyMi = if (EconomyField.MISC_YEARLY_MI in unset) type.miscYearlyMi else s.miscYearlyMi,
+                purchasePrice = if (EconomyField.PURCHASE_PRICE in unset) type.purchasePrice else s.purchasePrice,
+                totalLifetimeMi = if (EconomyField.TOTAL_LIFETIME_MI in unset) type.totalLifetimeMi else s.totalLifetimeMi,
+                userSetEconomyFields = s.userSetEconomyFields + EconomyField.VEHICLE_CLASS,
+            )
+        }
+    }
+
+    // --- Personal Economy v2 setters (#145) ---
+    fun updateTires(setCost: Double, lifetimeMi: Double) = _state.update {
+        it.copy(
+            tireSetCost = setCost, tireLifetimeMi = lifetimeMi,
+            userSetEconomyFields = it.userSetEconomyFields +
+                setOf(EconomyField.TIRE_COST, EconomyField.TIRE_LIFETIME),
+        )
+    }
+
+    fun updateOilChange(cost: Double, intervalMi: Double) = _state.update {
+        it.copy(
+            oilCost = cost, oilIntervalMi = intervalMi,
+            userSetEconomyFields = it.userSetEconomyFields +
+                setOf(EconomyField.OIL_COST, EconomyField.OIL_INTERVAL),
+        )
+    }
+
+    fun updateBrakes(cost: Double, intervalMi: Double) = _state.update {
+        it.copy(
+            brakesCost = cost, brakesIntervalMi = intervalMi,
+            userSetEconomyFields = it.userSetEconomyFields +
+                setOf(EconomyField.BRAKES_COST, EconomyField.BRAKES_INTERVAL),
+        )
+    }
+
+    fun updateFluids(cost: Double, intervalMi: Double) = _state.update {
+        it.copy(
+            fluidsCost = cost, fluidsIntervalMi = intervalMi,
+            userSetEconomyFields = it.userSetEconomyFields +
+                setOf(EconomyField.FLUIDS_COST, EconomyField.FLUIDS_INTERVAL),
+        )
+    }
+
+    fun updateMiscRepairs(yearly: Double, yearlyMi: Double) = _state.update {
+        it.copy(
+            miscYearly = yearly, miscYearlyMi = yearlyMi,
+            userSetEconomyFields = it.userSetEconomyFields +
+                setOf(EconomyField.MISC_YEARLY, EconomyField.MISC_YEARLY_MI),
+        )
+    }
+
+    fun updateDepreciation(include: Boolean, price: Double, lifetimeMi: Double) = _state.update {
+        it.copy(
+            includeDepreciation = include, purchasePrice = price, totalLifetimeMi = lifetimeMi,
+            userSetEconomyFields = it.userSetEconomyFields + setOf(
+                EconomyField.INCLUDE_DEPRECIATION,
+                EconomyField.PURCHASE_PRICE,
+                EconomyField.TOTAL_LIFETIME_MI,
+            ),
+        )
+    }
+
+    fun updateInsuranceDelta(perMonth: Double) = _state.update {
+        it.copy(
+            insuranceDeltaPerMonth = perMonth,
+            userSetEconomyFields = it.userSetEconomyFields + EconomyField.INSURANCE_DELTA,
+        )
+    }
+
+    fun updateRegistrationDelta(perYear: Double) = _state.update {
+        it.copy(
+            registrationDeltaPerYear = perYear,
+            userSetEconomyFields = it.userSetEconomyFields + EconomyField.REGISTRATION_DELTA,
+        )
+    }
+
+    fun updateExpectedAnnualDashMiles(miles: Double) = _state.update {
+        it.copy(
+            expectedAnnualDashMiles = miles,
+            userSetEconomyFields = it.userSetEconomyFields + EconomyField.EXPECTED_ANNUAL_DASH_MI,
+        )
+    }
+
+    fun updatePhonePlan(total: Double, lines: Int, dashPercent: Double) = _state.update {
+        it.copy(
+            phonePlanTotal = total, phonePlanLines = lines, phoneDashPercent = dashPercent,
+            userSetEconomyFields = it.userSetEconomyFields + setOf(
+                EconomyField.PHONE_PLAN_TOTAL,
+                EconomyField.PHONE_PLAN_LINES,
+                EconomyField.PHONE_DASH_PERCENT,
+            ),
+        )
+    }
+
+    fun updateTimeConstants(avgMinutesPerMile: Double, basePickupMinutes: Double) = _state.update {
+        it.copy(
+            avgMinutesPerMile = avgMinutesPerMile, basePickupMinutes = basePickupMinutes,
+            userSetEconomyFields = it.userSetEconomyFields + setOf(
+                EconomyField.AVG_MIN_PER_MILE,
+                EconomyField.BASE_PICKUP_MIN,
+            ),
+        )
     }
 
     fun onYearSelected(year: String) {
@@ -316,6 +457,61 @@ class WizardViewModel @Inject constructor(
             val finalState = _state.value
 
             appPreferencesRepository.updateFuelType(finalState.fuelType)
+            appPreferencesRepository.updateVehicleClass(finalState.vehicleClass)
+
+            // Persist any economy fields the user explicitly set in the ECONOMY_COSTS step.
+            // Each call atomically marks the corresponding EconomyField as user-set.
+            val userSet = finalState.userSetEconomyFields
+            if (EconomyField.TIRE_COST in userSet || EconomyField.TIRE_LIFETIME in userSet) {
+                appPreferencesRepository.updateTireCost(finalState.tireSetCost, finalState.tireLifetimeMi)
+            }
+            if (EconomyField.OIL_COST in userSet || EconomyField.OIL_INTERVAL in userSet) {
+                appPreferencesRepository.updateOilCost(finalState.oilCost, finalState.oilIntervalMi)
+            }
+            if (EconomyField.BRAKES_COST in userSet || EconomyField.BRAKES_INTERVAL in userSet) {
+                appPreferencesRepository.updateBrakesCost(finalState.brakesCost, finalState.brakesIntervalMi)
+            }
+            if (EconomyField.FLUIDS_COST in userSet || EconomyField.FLUIDS_INTERVAL in userSet) {
+                appPreferencesRepository.updateFluidsCost(finalState.fluidsCost, finalState.fluidsIntervalMi)
+            }
+            if (EconomyField.MISC_YEARLY in userSet || EconomyField.MISC_YEARLY_MI in userSet) {
+                appPreferencesRepository.updateMiscMaintenance(finalState.miscYearly, finalState.miscYearlyMi)
+            }
+            if (EconomyField.INCLUDE_DEPRECIATION in userSet ||
+                EconomyField.PURCHASE_PRICE in userSet ||
+                EconomyField.TOTAL_LIFETIME_MI in userSet
+            ) {
+                appPreferencesRepository.updateDepreciation(
+                    finalState.includeDepreciation,
+                    finalState.purchasePrice,
+                    finalState.totalLifetimeMi,
+                )
+            }
+            if (EconomyField.INSURANCE_DELTA in userSet) {
+                appPreferencesRepository.updateInsuranceDelta(finalState.insuranceDeltaPerMonth)
+            }
+            if (EconomyField.REGISTRATION_DELTA in userSet) {
+                appPreferencesRepository.updateRegistrationDelta(finalState.registrationDeltaPerYear)
+            }
+            if (EconomyField.EXPECTED_ANNUAL_DASH_MI in userSet) {
+                appPreferencesRepository.updateExpectedAnnualDashMi(finalState.expectedAnnualDashMiles)
+            }
+            if (EconomyField.PHONE_PLAN_TOTAL in userSet ||
+                EconomyField.PHONE_PLAN_LINES in userSet ||
+                EconomyField.PHONE_DASH_PERCENT in userSet
+            ) {
+                appPreferencesRepository.updatePhonePlan(
+                    finalState.phonePlanTotal,
+                    finalState.phonePlanLines,
+                    finalState.phoneDashPercent,
+                )
+            }
+            if (EconomyField.AVG_MIN_PER_MILE in userSet || EconomyField.BASE_PICKUP_MIN in userSet) {
+                appPreferencesRepository.updateTimeConstants(
+                    finalState.avgMinutesPerMile,
+                    finalState.basePickupMinutes,
+                )
+            }
 
             if (finalState.vehicleClass == VehicleClass.E_BIKE) {
                 appPreferencesRepository.updateEconomySettings(

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/WizardViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/WizardViewModel.kt
@@ -12,7 +12,7 @@ import cloud.trotter.dashbuddy.domain.evaluation.MetricType
 import cloud.trotter.dashbuddy.domain.evaluation.ScoringRule
 import cloud.trotter.dashbuddy.domain.model.vehicle.FuelType
 import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleOption
-import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleType
+import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleClass
 import cloud.trotter.dashbuddy.ui.main.setup.wizard.model.WizardState
 import cloud.trotter.dashbuddy.ui.main.setup.wizard.model.WizardStep
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -88,11 +88,11 @@ class WizardViewModel @Inject constructor(
             val maxItemsRule = rules.filterIsInstance<ScoringRule.MetricRule>()
                 .find { it.metricType == MetricType.ITEM_COUNT }
 
-            val vehicleType = if (currentYear == "E-Bike") VehicleType.E_BIKE else VehicleType.CAR
+            val vehicleClass = if (currentYear == "E-Bike") VehicleClass.E_BIKE else VehicleClass.SEDAN
 
             _state.update { currentState ->
                 currentState.copy(
-                    vehicleType = vehicleType,
+                    vehicleClass = vehicleClass,
                     vehicleYear = currentYear,
                     vehicleMake = currentMake,
                     vehicleModel = currentModel,
@@ -122,8 +122,8 @@ class WizardViewModel @Inject constructor(
         viewModelScope.launch { _availableYears.value = vehicleRepository.getYears() }
     }
 
-    fun updateVehicleType(type: VehicleType) {
-        _state.update { it.copy(vehicleType = type) }
+    fun updateVehicleClass(type: VehicleClass) {
+        _state.update { it.copy(vehicleClass = type) }
     }
 
     fun onYearSelected(year: String) {
@@ -317,7 +317,7 @@ class WizardViewModel @Inject constructor(
 
             appPreferencesRepository.updateFuelType(finalState.fuelType)
 
-            if (finalState.vehicleType == VehicleType.E_BIKE) {
+            if (finalState.vehicleClass == VehicleClass.E_BIKE) {
                 appPreferencesRepository.updateEconomySettings(
                     "E-Bike",
                     "E-Bike",

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/cards/EconomyCostsCard.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/cards/EconomyCostsCard.kt
@@ -32,6 +32,7 @@ import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleClass
 import cloud.trotter.dashbuddy.ui.components.economy.CurrencyInput
 import cloud.trotter.dashbuddy.ui.components.economy.EconomyAccordionRow
 import cloud.trotter.dashbuddy.ui.components.economy.IntegerInput
+import cloud.trotter.dashbuddy.ui.components.economy.NumberInput
 import cloud.trotter.dashbuddy.ui.components.economy.PairedCurrencyAndIntervalInput
 import cloud.trotter.dashbuddy.ui.main.setup.wizard.model.WizardState
 import cloud.trotter.dashbuddy.ui.main.setup.wizard.model.WizardStep
@@ -307,29 +308,40 @@ fun EconomyCostsCard(
                 )
             }
 
-            // -------- Time estimates --------
+            // -------- Driving & pickup times --------
             EconomyAccordionRow(
-                title = "Time estimates",
-                summary = "${"%.1f".format(state.avgMinutesPerMile)} min/mi",
+                title = "Driving & pickup times",
+                summary = "${"%.1f".format(state.avgMinutesPerMile)} min/mi · " +
+                    "${state.basePickupMinutes.toInt()} min/pickup",
                 isUserSet = EconomyField.AVG_MIN_PER_MILE in userSet ||
                     EconomyField.BASE_PICKUP_MIN in userSet,
             ) {
+                Text(
+                    text = "How long offers actually take in your market. Used to estimate " +
+                        "each offer's time, which drives the \$/hr number.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    CurrencyInput(
-                        label = "Min per mile",
+                    NumberInput(
+                        label = "Driving pace",
                         value = state.avgMinutesPerMile,
                         onValueChange = { onTimeConstantsChange(it, state.basePickupMinutes) },
+                        suffix = "min/mi",
                         modifier = Modifier.weight(1f),
                     )
-                    CurrencyInput(
-                        label = "Base pickup min",
+                    NumberInput(
+                        label = "Pickup wait",
                         value = state.basePickupMinutes,
                         onValueChange = { onTimeConstantsChange(state.avgMinutesPerMile, it) },
+                        suffix = "min",
                         modifier = Modifier.weight(1f),
                     )
                 }
                 Text(
-                    text = "Per-mile pace and base pickup overhead used to estimate offer time.",
+                    text = "Driving pace: minutes to cover one mile (2.5 = busy urban, " +
+                        "1.5 = highway/rural). Pickup wait: typical minutes spent at the " +
+                        "store — parking, walking in, waiting for the order.",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/cards/EconomyCostsCard.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/cards/EconomyCostsCard.kt
@@ -5,9 +5,12 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -69,11 +72,16 @@ fun EconomyCostsCard(
     Card(
         modifier = Modifier
             .fillMaxWidth()
+            .fillMaxHeight()
             .padding(horizontal = 16.dp),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
         elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
     ) {
-        Column(modifier = Modifier.padding(16.dp)) {
+        Column(
+            modifier = Modifier
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState())
+        ) {
             WizardCardHeader(step = WizardStep.ECONOMY_COSTS)
 
             // Vehicle class chip picker
@@ -328,23 +336,29 @@ fun EconomyCostsCard(
             }
 
             // -------- Expected annual dash miles --------
-            Spacer(modifier = Modifier.height(12.dp))
-            Text(
-                text = "Expected dash miles: ${state.expectedAnnualDashMiles.toInt().formatWithCommas()} mi/yr",
-                style = MaterialTheme.typography.bodyMedium,
-                fontWeight = FontWeight.Medium,
-            )
-            Text(
-                text = "Used to amortize fixed costs (insurance, registration, phone) into a per-mile rate.",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Slider(
-                value = state.expectedAnnualDashMiles.toFloat(),
-                onValueChange = { onExpectedAnnualDashMilesChange(it.toDouble()) },
-                valueRange = 500f..30_000f,
-                steps = 58, // 500-mile increments
-            )
+            EconomyAccordionRow(
+                title = "Expected dash miles / yr",
+                summary = "${state.expectedAnnualDashMiles.toInt().formatWithCommas()} mi",
+                isUserSet = EconomyField.EXPECTED_ANNUAL_DASH_MI in userSet,
+            ) {
+                Text(
+                    text = "${state.expectedAnnualDashMiles.toInt().formatWithCommas()} miles per year",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium,
+                )
+                Slider(
+                    value = state.expectedAnnualDashMiles.toFloat(),
+                    onValueChange = { onExpectedAnnualDashMilesChange(it.toDouble()) },
+                    valueRange = 500f..30_000f,
+                    steps = 58, // 500-mile increments
+                )
+                Text(
+                    text = "Used to amortize fixed costs (insurance, registration, phone) into " +
+                        "a per-mile rate. Bigger number → smaller per-mile share.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
 
             // -------- Footer: live total cost vs IRS standard --------
             Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/cards/EconomyCostsCard.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/cards/EconomyCostsCard.kt
@@ -32,7 +32,6 @@ import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleClass
 import cloud.trotter.dashbuddy.ui.components.economy.CurrencyInput
 import cloud.trotter.dashbuddy.ui.components.economy.EconomyAccordionRow
 import cloud.trotter.dashbuddy.ui.components.economy.IntegerInput
-import cloud.trotter.dashbuddy.ui.components.economy.NumberInput
 import cloud.trotter.dashbuddy.ui.components.economy.PairedCurrencyAndIntervalInput
 import cloud.trotter.dashbuddy.ui.main.setup.wizard.model.WizardState
 import cloud.trotter.dashbuddy.ui.main.setup.wizard.model.WizardStep
@@ -42,7 +41,7 @@ import cloud.trotter.dashbuddy.ui.main.setup.wizard.components.WizardCardHeader
  * The ECONOMY_COSTS wizard step. A single scrolling card with:
  * 1. Vehicle class chip picker (drives cost defaults)
  * 2. Accordion of 10 cost sections (collapsed by default; expand to edit)
- * 3. Expected annual dash miles slider (amortizes fixed costs)
+ * 3. Expected annual gig miles slider (amortizes fixed costs)
  * 4. Live "Your true cost: $X.XX/mi" footer comparing to the IRS standard rate
  *
  * Defaults flow from the selected [VehicleClass] for any field not yet user-set;
@@ -232,7 +231,7 @@ fun EconomyCostsCard(
                 isUserSet = EconomyField.INSURANCE_DELTA in userSet,
             ) {
                 CurrencyInput(
-                    label = "Extra for dashing",
+                    label = "Extra for gig work",
                     value = state.insuranceDeltaPerMonth,
                     onValueChange = onInsuranceChange,
                     suffix = "/mo",
@@ -291,7 +290,7 @@ fun EconomyCostsCard(
                         modifier = Modifier.weight(1f),
                     )
                 }
-                Text("% for dashing: ${state.phoneDashPercent.toInt()}%")
+                Text("% for gig work: ${state.phoneDashPercent.toInt()}%")
                 Slider(
                     value = state.phoneDashPercent.toFloat(),
                     onValueChange = {
@@ -302,54 +301,15 @@ fun EconomyCostsCard(
                 Text(
                     text = "Your line: \$${"%.2f".format(state.phonePlanTotal / state.phonePlanLines.coerceAtLeast(1))}/mo" +
                         " × ${state.phoneDashPercent.toInt()}%" +
-                        " = \$${"%.2f".format((state.phonePlanTotal / state.phonePlanLines.coerceAtLeast(1)) * state.phoneDashPercent / 100.0)}/mo dashing",
+                        " = \$${"%.2f".format((state.phonePlanTotal / state.phonePlanLines.coerceAtLeast(1)) * state.phoneDashPercent / 100.0)}/mo for gig work",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
 
-            // -------- Driving & pickup times --------
+            // -------- Expected annual gig miles --------
             EconomyAccordionRow(
-                title = "Driving & pickup times",
-                summary = "${"%.1f".format(state.avgMinutesPerMile)} min/mi · " +
-                    "${state.basePickupMinutes.toInt()} min/pickup",
-                isUserSet = EconomyField.AVG_MIN_PER_MILE in userSet ||
-                    EconomyField.BASE_PICKUP_MIN in userSet,
-            ) {
-                Text(
-                    text = "How long offers actually take in your market. Used to estimate " +
-                        "each offer's time, which drives the \$/hr number.",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    NumberInput(
-                        label = "Driving pace",
-                        value = state.avgMinutesPerMile,
-                        onValueChange = { onTimeConstantsChange(it, state.basePickupMinutes) },
-                        suffix = "min/mi",
-                        modifier = Modifier.weight(1f),
-                    )
-                    NumberInput(
-                        label = "Pickup wait",
-                        value = state.basePickupMinutes,
-                        onValueChange = { onTimeConstantsChange(state.avgMinutesPerMile, it) },
-                        suffix = "min",
-                        modifier = Modifier.weight(1f),
-                    )
-                }
-                Text(
-                    text = "Driving pace: minutes to cover one mile (2.5 = busy urban, " +
-                        "1.5 = highway/rural). Pickup wait: typical minutes spent at the " +
-                        "store — parking, walking in, waiting for the order.",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-
-            // -------- Expected annual dash miles --------
-            EconomyAccordionRow(
-                title = "Expected dash miles / yr",
+                title = "Expected gig miles / yr",
                 summary = "${state.expectedAnnualDashMiles.toInt().formatWithCommas()} mi",
                 isUserSet = EconomyField.EXPECTED_ANNUAL_DASH_MI in userSet,
             ) {

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/cards/EconomyCostsCard.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/cards/EconomyCostsCard.kt
@@ -1,0 +1,402 @@
+package cloud.trotter.dashbuddy.ui.main.setup.wizard.cards
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import cloud.trotter.dashbuddy.domain.evaluation.EconomyField
+import cloud.trotter.dashbuddy.domain.evaluation.UserEconomy
+import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleClass
+import cloud.trotter.dashbuddy.ui.components.economy.CurrencyInput
+import cloud.trotter.dashbuddy.ui.components.economy.EconomyAccordionRow
+import cloud.trotter.dashbuddy.ui.components.economy.IntegerInput
+import cloud.trotter.dashbuddy.ui.components.economy.PairedCurrencyAndIntervalInput
+import cloud.trotter.dashbuddy.ui.main.setup.wizard.model.WizardState
+import cloud.trotter.dashbuddy.ui.main.setup.wizard.model.WizardStep
+import cloud.trotter.dashbuddy.ui.main.setup.wizard.components.WizardCardHeader
+
+/**
+ * The ECONOMY_COSTS wizard step. A single scrolling card with:
+ * 1. Vehicle class chip picker (drives cost defaults)
+ * 2. Accordion of 10 cost sections (collapsed by default; expand to edit)
+ * 3. Expected annual dash miles slider (amortizes fixed costs)
+ * 4. Live "Your true cost: $X.XX/mi" footer comparing to the IRS standard rate
+ *
+ * Defaults flow from the selected [VehicleClass] for any field not yet user-set;
+ * editing a field marks it as user-set so subsequent class changes don't
+ * overwrite it.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EconomyCostsCard(
+    state: WizardState,
+    onClassChange: (VehicleClass) -> Unit,
+    onTiresChange: (Double, Double) -> Unit,
+    onOilChange: (Double, Double) -> Unit,
+    onBrakesChange: (Double, Double) -> Unit,
+    onFluidsChange: (Double, Double) -> Unit,
+    onMiscChange: (Double, Double) -> Unit,
+    onDepreciationChange: (Boolean, Double, Double) -> Unit,
+    onInsuranceChange: (Double) -> Unit,
+    onRegistrationChange: (Double) -> Unit,
+    onPhoneChange: (Double, Int, Double) -> Unit,
+    onExpectedAnnualDashMilesChange: (Double) -> Unit,
+    onTimeConstantsChange: (Double, Double) -> Unit,
+) {
+    // Build a live UserEconomy from current state so we can show $/mi previews.
+    val liveEconomy = remember(state) { state.toUserEconomy() }
+    val userSet = state.userSetEconomyFields
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            WizardCardHeader(step = WizardStep.ECONOMY_COSTS)
+
+            // Vehicle class chip picker
+            Text(
+                text = "Vehicle class",
+                style = MaterialTheme.typography.titleSmall,
+                modifier = Modifier.padding(top = 12.dp, bottom = 4.dp),
+            )
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                VehicleClass.entries.forEach { vc ->
+                    FilterChip(
+                        selected = state.vehicleClass == vc,
+                        onClick = { onClassChange(vc) },
+                        label = { Text(vc.displayName) },
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // -------- Tires --------
+            EconomyAccordionRow(
+                title = "Tires",
+                summary = "%.3f/mi".format(liveEconomy.tireCostPerMile).let { "\$$it" },
+                isUserSet = EconomyField.TIRE_COST in userSet || EconomyField.TIRE_LIFETIME in userSet,
+            ) {
+                PairedCurrencyAndIntervalInput(
+                    costLabel = "Set of 4",
+                    costValue = state.tireSetCost,
+                    onCostChange = { onTiresChange(it, state.tireLifetimeMi) },
+                    intervalLabel = "Lifetime",
+                    intervalValue = state.tireLifetimeMi,
+                    onIntervalChange = { onTiresChange(state.tireSetCost, it) },
+                )
+            }
+
+            // -------- Oil changes --------
+            EconomyAccordionRow(
+                title = "Oil changes",
+                summary = "%.3f/mi".format(liveEconomy.oilCostPerMile).let { "\$$it" },
+                isUserSet = EconomyField.OIL_COST in userSet || EconomyField.OIL_INTERVAL in userSet,
+            ) {
+                PairedCurrencyAndIntervalInput(
+                    costLabel = "Each",
+                    costValue = state.oilCost,
+                    onCostChange = { onOilChange(it, state.oilIntervalMi) },
+                    intervalLabel = "Every",
+                    intervalValue = state.oilIntervalMi,
+                    onIntervalChange = { onOilChange(state.oilCost, it) },
+                )
+            }
+
+            // -------- Brakes --------
+            EconomyAccordionRow(
+                title = "Brakes",
+                summary = "%.3f/mi".format(liveEconomy.brakesCostPerMile).let { "\$$it" },
+                isUserSet = EconomyField.BRAKES_COST in userSet || EconomyField.BRAKES_INTERVAL in userSet,
+            ) {
+                PairedCurrencyAndIntervalInput(
+                    costLabel = "Each",
+                    costValue = state.brakesCost,
+                    onCostChange = { onBrakesChange(it, state.brakesIntervalMi) },
+                    intervalLabel = "Every",
+                    intervalValue = state.brakesIntervalMi,
+                    onIntervalChange = { onBrakesChange(state.brakesCost, it) },
+                )
+            }
+
+            // -------- Fluids --------
+            EconomyAccordionRow(
+                title = "Fluids",
+                summary = "%.3f/mi".format(liveEconomy.fluidsCostPerMile).let { "\$$it" },
+                isUserSet = EconomyField.FLUIDS_COST in userSet || EconomyField.FLUIDS_INTERVAL in userSet,
+            ) {
+                PairedCurrencyAndIntervalInput(
+                    costLabel = "Each",
+                    costValue = state.fluidsCost,
+                    onCostChange = { onFluidsChange(it, state.fluidsIntervalMi) },
+                    intervalLabel = "Every",
+                    intervalValue = state.fluidsIntervalMi,
+                    onIntervalChange = { onFluidsChange(state.fluidsCost, it) },
+                )
+            }
+
+            // -------- Misc repairs --------
+            EconomyAccordionRow(
+                title = "Misc repairs",
+                summary = "%.3f/mi".format(liveEconomy.miscCostPerMile).let { "\$$it" },
+                isUserSet = EconomyField.MISC_YEARLY in userSet || EconomyField.MISC_YEARLY_MI in userSet,
+            ) {
+                PairedCurrencyAndIntervalInput(
+                    costLabel = "Yearly budget",
+                    costValue = state.miscYearly,
+                    onCostChange = { onMiscChange(it, state.miscYearlyMi) },
+                    intervalLabel = "Driving",
+                    intervalValue = state.miscYearlyMi,
+                    onIntervalChange = { onMiscChange(state.miscYearly, it) },
+                    intervalSuffix = "mi/yr",
+                    helperText = "Annual catch-all for repairs not in oil/brakes/fluids.",
+                )
+            }
+
+            // -------- Depreciation --------
+            EconomyAccordionRow(
+                title = "Depreciation",
+                summary = if (state.includeDepreciation)
+                    "%.3f/mi".format(liveEconomy.depreciationCostPerMile).let { "\$$it" }
+                else "off",
+                isUserSet = EconomyField.INCLUDE_DEPRECIATION in userSet ||
+                    EconomyField.PURCHASE_PRICE in userSet ||
+                    EconomyField.TOTAL_LIFETIME_MI in userSet,
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text("Include depreciation", modifier = Modifier.weight(1f))
+                    Switch(
+                        checked = state.includeDepreciation,
+                        onCheckedChange = {
+                            onDepreciationChange(it, state.purchasePrice, state.totalLifetimeMi)
+                        },
+                    )
+                }
+                if (state.includeDepreciation) {
+                    PairedCurrencyAndIntervalInput(
+                        costLabel = "Purchase price",
+                        costValue = state.purchasePrice,
+                        onCostChange = {
+                            onDepreciationChange(true, it, state.totalLifetimeMi)
+                        },
+                        intervalLabel = "Lifetime",
+                        intervalValue = state.totalLifetimeMi,
+                        onIntervalChange = {
+                            onDepreciationChange(true, state.purchasePrice, it)
+                        },
+                        helperText = "Total expected miles from new to retirement, " +
+                            "e.g. 200,000 for a typical sedan.",
+                    )
+                }
+            }
+
+            // -------- Insurance --------
+            EconomyAccordionRow(
+                title = "Insurance",
+                summary = "%.3f/mi*".format(liveEconomy.insuranceCostPerMile).let { "\$$it" },
+                isUserSet = EconomyField.INSURANCE_DELTA in userSet,
+            ) {
+                CurrencyInput(
+                    label = "Extra for dashing",
+                    value = state.insuranceDeltaPerMonth,
+                    onValueChange = onInsuranceChange,
+                    suffix = "/mo",
+                )
+                Text(
+                    text = "Monthly add-on for rideshare/delivery rider above your personal policy.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            // -------- Registration --------
+            EconomyAccordionRow(
+                title = "Registration",
+                summary = "%.3f/mi*".format(liveEconomy.registrationCostPerMile).let { "\$$it" },
+                isUserSet = EconomyField.REGISTRATION_DELTA in userSet,
+            ) {
+                CurrencyInput(
+                    label = "Commercial delta",
+                    value = state.registrationDeltaPerYear,
+                    onValueChange = onRegistrationChange,
+                    suffix = "/yr",
+                )
+                Text(
+                    text = "Annual fee above your personal registration (commercial " +
+                        "registration / inspection / endorsement).",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            // -------- Phone & data --------
+            EconomyAccordionRow(
+                title = "Phone & data",
+                summary = "%.3f/mi*".format(liveEconomy.phoneCostPerMile).let { "\$$it" },
+                isUserSet = EconomyField.PHONE_PLAN_TOTAL in userSet ||
+                    EconomyField.PHONE_PLAN_LINES in userSet ||
+                    EconomyField.PHONE_DASH_PERCENT in userSet,
+            ) {
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    CurrencyInput(
+                        label = "Plan total",
+                        value = state.phonePlanTotal,
+                        onValueChange = {
+                            onPhoneChange(it, state.phonePlanLines, state.phoneDashPercent)
+                        },
+                        suffix = "/mo",
+                        modifier = Modifier.weight(1f),
+                    )
+                    IntegerInput(
+                        label = "Lines",
+                        value = state.phonePlanLines,
+                        onValueChange = {
+                            onPhoneChange(state.phonePlanTotal, it, state.phoneDashPercent)
+                        },
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+                Text("% for dashing: ${state.phoneDashPercent.toInt()}%")
+                Slider(
+                    value = state.phoneDashPercent.toFloat(),
+                    onValueChange = {
+                        onPhoneChange(state.phonePlanTotal, state.phonePlanLines, it.toDouble())
+                    },
+                    valueRange = 0f..100f,
+                )
+                Text(
+                    text = "Your line: \$${"%.2f".format(state.phonePlanTotal / state.phonePlanLines.coerceAtLeast(1))}/mo" +
+                        " × ${state.phoneDashPercent.toInt()}%" +
+                        " = \$${"%.2f".format((state.phonePlanTotal / state.phonePlanLines.coerceAtLeast(1)) * state.phoneDashPercent / 100.0)}/mo dashing",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            // -------- Time estimates --------
+            EconomyAccordionRow(
+                title = "Time estimates",
+                summary = "${"%.1f".format(state.avgMinutesPerMile)} min/mi",
+                isUserSet = EconomyField.AVG_MIN_PER_MILE in userSet ||
+                    EconomyField.BASE_PICKUP_MIN in userSet,
+            ) {
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    CurrencyInput(
+                        label = "Min per mile",
+                        value = state.avgMinutesPerMile,
+                        onValueChange = { onTimeConstantsChange(it, state.basePickupMinutes) },
+                        modifier = Modifier.weight(1f),
+                    )
+                    CurrencyInput(
+                        label = "Base pickup min",
+                        value = state.basePickupMinutes,
+                        onValueChange = { onTimeConstantsChange(state.avgMinutesPerMile, it) },
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+                Text(
+                    text = "Per-mile pace and base pickup overhead used to estimate offer time.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            // -------- Expected annual dash miles --------
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = "Expected dash miles: ${state.expectedAnnualDashMiles.toInt().formatWithCommas()} mi/yr",
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium,
+            )
+            Text(
+                text = "Used to amortize fixed costs (insurance, registration, phone) into a per-mile rate.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Slider(
+                value = state.expectedAnnualDashMiles.toFloat(),
+                onValueChange = { onExpectedAnnualDashMilesChange(it.toDouble()) },
+                valueRange = 500f..30_000f,
+                steps = 58, // 500-mile increments
+            )
+
+            // -------- Footer: live total cost vs IRS standard --------
+            Spacer(modifier = Modifier.height(16.dp))
+            Surface(
+                color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Column(
+                    modifier = Modifier.padding(12.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Text(
+                        text = "Your true cost: \$${"%.2f".format(liveEconomy.operatingCostPerMile)}/mi",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                    )
+                    Text(
+                        text = "IRS standard mileage rate: \$0.67/mi",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun Int.formatWithCommas(): String =
+    "%,d".format(this)
+
+/**
+ * Builds a [UserEconomy] from the wizard state so the card can display live per-mile
+ * derived values without going through the repository.
+ */
+private fun WizardState.toUserEconomy() = UserEconomy(
+    vehicleClass = vehicleClass,
+    vehicleMpg = estimatedMpg.toDouble(),
+    gasPricePerGallon = gasPrice.toDouble(),
+    avgMinutesPerMile = avgMinutesPerMile,
+    basePickupMinutes = basePickupMinutes,
+    tireSetCost = tireSetCost, tireLifetimeMi = tireLifetimeMi,
+    oilCost = oilCost, oilIntervalMi = oilIntervalMi,
+    brakesCost = brakesCost, brakesIntervalMi = brakesIntervalMi,
+    fluidsCost = fluidsCost, fluidsIntervalMi = fluidsIntervalMi,
+    miscYearly = miscYearly, miscYearlyMi = miscYearlyMi,
+    includeDepreciation = includeDepreciation,
+    purchasePrice = purchasePrice, totalLifetimeMi = totalLifetimeMi,
+    insuranceDeltaPerMonth = insuranceDeltaPerMonth,
+    registrationDeltaPerYear = registrationDeltaPerYear,
+    expectedAnnualDashMiles = expectedAnnualDashMiles,
+    phonePlanTotal = phonePlanTotal,
+    phonePlanLines = phonePlanLines,
+    phoneDashPercent = phoneDashPercent,
+    userSetFields = userSetEconomyFields,
+)

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/cards/VehicleCard.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/cards/VehicleCard.kt
@@ -30,7 +30,7 @@ import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleType
+import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleClass
 import cloud.trotter.dashbuddy.ui.main.setup.wizard.components.VehicleDropdown
 import cloud.trotter.dashbuddy.ui.main.setup.wizard.components.WizardCardHeader
 import cloud.trotter.dashbuddy.ui.main.setup.wizard.model.WizardStep
@@ -39,7 +39,7 @@ import java.util.Locale
 @Composable
 fun VehicleCard(
     step: WizardStep,
-    vehicleType: VehicleType,
+    vehicleClass: VehicleClass,
     year: String,
     make: String,
     model: String,
@@ -49,7 +49,7 @@ fun VehicleCard(
     availableMakes: List<String>,
     availableModels: List<String>,
     availableTrims: List<String>,
-    onTypeSelected: (VehicleType) -> Unit,
+    onTypeSelected: (VehicleClass) -> Unit,
     onYearSelected: (String) -> Unit,
     onMakeSelected: (String) -> Unit,
     onModelSelected: (String) -> Unit,
@@ -67,20 +67,20 @@ fun VehicleCard(
             .padding(24.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        WizardCardHeader(step, vehicleType)
+        WizardCardHeader(step, vehicleClass)
 
         Spacer(modifier = Modifier.height(24.dp))
 
         Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
             FilterChip(
-                selected = vehicleType == VehicleType.CAR,
-                onClick = { onTypeSelected(VehicleType.CAR) },
+                selected = vehicleClass == VehicleClass.SEDAN,
+                onClick = { onTypeSelected(VehicleClass.SEDAN) },
                 label = { Text("🚗 Car") }
             )
             Spacer(modifier = Modifier.padding(8.dp))
             FilterChip(
-                selected = vehicleType == VehicleType.E_BIKE,
-                onClick = { onTypeSelected(VehicleType.E_BIKE) },
+                selected = vehicleClass == VehicleClass.E_BIKE,
+                onClick = { onTypeSelected(VehicleClass.E_BIKE) },
                 label = { Text("🚲 E-Bike") }
             )
         }
@@ -88,7 +88,7 @@ fun VehicleCard(
         Spacer(modifier = Modifier.height(16.dp))
 
         AnimatedVisibility(
-            visible = vehicleType == VehicleType.CAR,
+            visible = vehicleClass == VehicleClass.SEDAN,
             enter = expandVertically(),
             exit = shrinkVertically()
         ) {
@@ -141,7 +141,7 @@ fun VehicleCard(
         }
 
         // --- THE ESCAPE HATCH UI ---
-        AnimatedVisibility(visible = vehicleType == VehicleType.CAR && isCustom) {
+        AnimatedVisibility(visible = vehicleClass == VehicleClass.SEDAN && isCustom) {
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -208,7 +208,7 @@ fun VehicleCard(
             }
         }
 
-        if (vehicleType == VehicleType.E_BIKE) {
+        if (vehicleClass == VehicleClass.E_BIKE) {
             Text(
                 text = "Awesome! We will ignore gas expenses and set your cost-per-mile to $0.",
                 style = MaterialTheme.typography.bodyLarge,

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/components/WizardCardHeader.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/components/WizardCardHeader.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleType
+import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleClass
 import cloud.trotter.dashbuddy.ui.main.setup.wizard.model.WizardStep
 
 /**
@@ -30,7 +30,7 @@ import cloud.trotter.dashbuddy.ui.main.setup.wizard.model.WizardStep
 @Composable
 fun WizardCardHeader(
     step: WizardStep,
-    vehicleType: VehicleType? = null // Optional: Only provided by the VehicleCard
+    vehicleClass: VehicleClass? = null // Optional: Only provided by the VehicleCard
 ) {
     Column(
         modifier = Modifier.fillMaxWidth(),
@@ -38,7 +38,7 @@ fun WizardCardHeader(
     ) {
 
         // Dynamically swap the icon if they selected an E-Bike
-        val displayIcon = if (step == WizardStep.VEHICLE && vehicleType == VehicleType.E_BIKE) {
+        val displayIcon = if (step == WizardStep.VEHICLE && vehicleClass == VehicleClass.E_BIKE) {
             Icons.Default.PedalBike // Make sure you have material-icons-extended in Gradle!
         } else {
             step.icon

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/model/WizardState.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/model/WizardState.kt
@@ -2,14 +2,14 @@ package cloud.trotter.dashbuddy.ui.main.setup.wizard.model
 
 import cloud.trotter.dashbuddy.domain.config.DashStrategy
 import cloud.trotter.dashbuddy.domain.model.vehicle.FuelType
-import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleType
+import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleClass
 
 /**
  * Represents the volatile UI state of the Setup Wizard before it is committed to DataStore.
  */
 data class WizardState(
     // Economy Variables
-    val vehicleType: VehicleType = VehicleType.CAR,
+    val vehicleClass: VehicleClass = VehicleClass.SEDAN,
     val vehicleYear: String = "",
     val vehicleMake: String = "",
     val vehicleModel: String = "",

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/model/WizardState.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/model/WizardState.kt
@@ -1,6 +1,8 @@
 package cloud.trotter.dashbuddy.ui.main.setup.wizard.model
 
 import cloud.trotter.dashbuddy.domain.config.DashStrategy
+import cloud.trotter.dashbuddy.domain.evaluation.EconomyField
+import cloud.trotter.dashbuddy.domain.evaluation.UserEconomy
 import cloud.trotter.dashbuddy.domain.model.vehicle.FuelType
 import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleClass
 
@@ -22,6 +24,30 @@ data class WizardState(
     val gasPrice: Float = 3.50f,
     val isFetchingGasPrice: Boolean = false,
     val fetchedGasPrices: Map<FuelType, Float> = emptyMap(),
+
+    // Personal Economy v2 — operating cost components (#145)
+    val tireSetCost: Double = VehicleClass.SEDAN.tireSetCost,
+    val tireLifetimeMi: Double = VehicleClass.SEDAN.tireLifetimeMi,
+    val oilCost: Double = VehicleClass.SEDAN.oilCost,
+    val oilIntervalMi: Double = VehicleClass.SEDAN.oilIntervalMi,
+    val brakesCost: Double = VehicleClass.SEDAN.brakesCost,
+    val brakesIntervalMi: Double = VehicleClass.SEDAN.brakesIntervalMi,
+    val fluidsCost: Double = VehicleClass.SEDAN.fluidsCost,
+    val fluidsIntervalMi: Double = VehicleClass.SEDAN.fluidsIntervalMi,
+    val miscYearly: Double = VehicleClass.SEDAN.miscYearly,
+    val miscYearlyMi: Double = VehicleClass.SEDAN.miscYearlyMi,
+    val includeDepreciation: Boolean = true,
+    val purchasePrice: Double = VehicleClass.SEDAN.purchasePrice,
+    val totalLifetimeMi: Double = VehicleClass.SEDAN.totalLifetimeMi,
+    val insuranceDeltaPerMonth: Double = 0.0,
+    val registrationDeltaPerYear: Double = 0.0,
+    val expectedAnnualDashMiles: Double = UserEconomy.DEFAULT_ANNUAL_DASH_MI,
+    val phonePlanTotal: Double = UserEconomy.DEFAULT_PHONE_PLAN_TOTAL,
+    val phonePlanLines: Int = UserEconomy.DEFAULT_PHONE_PLAN_LINES,
+    val phoneDashPercent: Double = UserEconomy.DEFAULT_PHONE_DASH_PERCENT,
+    val avgMinutesPerMile: Double = UserEconomy.DEFAULT_MINUTES_PER_MILE,
+    val basePickupMinutes: Double = UserEconomy.DEFAULT_BASE_PICKUP_MINUTES,
+    val userSetEconomyFields: Set<EconomyField> = emptySet(),
 
     // Strategy Variables
     val strategy: DashStrategy = DashStrategy.MANUAL,

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/model/WizardStep.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/model/WizardStep.kt
@@ -3,6 +3,7 @@ package cloud.trotter.dashbuddy.ui.main.setup.wizard.model
 import androidx.annotation.StringRes
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AttachMoney
+import androidx.compose.material.icons.filled.Build
 import androidx.compose.material.icons.filled.DirectionsCar
 import androidx.compose.material.icons.filled.LocalGasStation
 import androidx.compose.material.icons.filled.ShoppingCart
@@ -29,6 +30,12 @@ enum class WizardStep(
         titleRes = R.string.wizard_title_gas,
         descriptionRes = R.string.wizard_desc_gas,
         icon = Icons.Default.LocalGasStation
+    ),
+    ECONOMY_COSTS(
+        phase = WizardPhase.ECONOMY,
+        titleRes = R.string.wizard_title_economy_costs,
+        descriptionRes = R.string.wizard_desc_economy_costs,
+        icon = Icons.Default.Build
     ),
 
     // --- Phase 2: Strategy ---

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -91,6 +91,9 @@
     <string name="wizard_title_gas">Gas Price</string>
     <string name="wizard_desc_gas">What are you currently paying per gallon?</string>
 
+    <string name="wizard_title_economy_costs">Operating Costs</string>
+    <string name="wizard_desc_economy_costs">Tell us your real costs so we can show your true net pay. Tap any section to set your actual numbers — defaults are sensible estimates.</string>
+
     <string name="wizard_title_goal">Primary Goal</string>
     <string name="wizard_desc_goal">Are you cherry-picking for maximum profit, or trying to protect your Platinum/Top Dasher status?</string>
 

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/settings/AppPreferencesRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/settings/AppPreferencesRepository.kt
@@ -1,6 +1,7 @@
 package cloud.trotter.dashbuddy.core.data.settings
 
 import cloud.trotter.dashbuddy.core.datastore.settings.AppPreferencesDataSource
+import cloud.trotter.dashbuddy.domain.evaluation.EconomyField
 import cloud.trotter.dashbuddy.domain.evaluation.UserEconomy
 import cloud.trotter.dashbuddy.domain.model.vehicle.FuelType
 import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleClass
@@ -28,7 +29,6 @@ class AppPreferencesRepository @Inject constructor(
     val isProMode = dataSource.isProMode
     val appTheme = dataSource.appTheme
 
-    // Maps the String from the Datastore into your pure Domain Enum
     val fuelType: Flow<FuelType> = dataSource.fuelType.map { savedType ->
         try {
             FuelType.valueOf(savedType ?: FuelType.REGULAR.name)
@@ -45,45 +45,194 @@ class AppPreferencesRepository @Inject constructor(
         }
     }
 
-    /** Combines stored prefs into a [UserEconomy] ready for [EvaluationConfig]. */
+    /**
+     * Combines stored prefs into a [UserEconomy] ready for [EvaluationConfig].
+     *
+     * Each cost field falls back to the current [VehicleClass]'s preset value if
+     * the DataStore key is missing — so switching class shifts any field NOT in
+     * [userSetEconomyFields] to the new class's defaults without overwriting
+     * user-set values. The `userSetFields` set on the returned [UserEconomy]
+     * tracks which fields the user has explicitly written.
+     *
+     * Combine fans into 4 sub-tuples (DataStore's `combine` is limited to ~5 args).
+     */
     val userEconomy: Flow<UserEconomy> = combine(
-        vehicleClass,
-        dataSource.estimatedMpg,
-        dataSource.gasPrice,
-    ) { vType, mpg, price ->
+        // Identity + fuel + time
+        combine(
+            vehicleClass,
+            dataSource.estimatedMpg,
+            dataSource.gasPrice,
+            dataSource.avgMinPerMile,
+            dataSource.basePickupMin,
+        ) { c, mpg, price, minPerMi, basePickup ->
+            IdentityTuple(c, mpg?.toDouble(), price?.toDouble(), minPerMi, basePickup)
+        },
+        // Maintenance (paired)
+        combine(
+            dataSource.tireSetCost, dataSource.tireLifetimeMi,
+            dataSource.oilCost, dataSource.oilIntervalMi,
+        ) { tireCost, tireLife, oilCost, oilInt ->
+            MaintenanceTupleA(tireCost, tireLife, oilCost, oilInt)
+        },
+        combine(
+            dataSource.brakesCost, dataSource.brakesIntervalMi,
+            dataSource.fluidsCost, dataSource.fluidsIntervalMi,
+            dataSource.miscYearly,
+        ) { brakesCost, brakesInt, fluidsCost, fluidsInt, misc ->
+            MaintenanceTupleB(brakesCost, brakesInt, fluidsCost, fluidsInt, misc)
+        },
+        // Depreciation + fixed-amortized + phone
+        combine(
+            dataSource.miscYearlyMi,
+            dataSource.includeDepreciation,
+            dataSource.purchasePrice,
+            dataSource.totalLifetimeMi,
+        ) { miscMi, includeDepr, price, lifetimeMi ->
+            DepreciationTuple(miscMi, includeDepr, price, lifetimeMi)
+        },
+        combine(
+            dataSource.insuranceDeltaPerMonth,
+            dataSource.registrationDeltaPerYear,
+            dataSource.expectedAnnualDashMi,
+            dataSource.phonePlanTotal,
+            dataSource.phonePlanLines,
+        ) { ins, reg, dashMi, phoneTotal, phoneLines ->
+            FixedAndPhoneTuple(ins, reg, dashMi, phoneTotal, phoneLines)
+        },
+    ) { id, maintA, maintB, depr, fixedPhone ->
+        val cls = id.vehicleClass
         UserEconomy(
-            vehicleClass = vType,
-            vehicleMpg = mpg?.toDouble() ?: 30.0,
-            gasPricePerGallon = price?.toDouble() ?: 3.50,
+            vehicleClass = cls,
+            vehicleMpg = id.mpg ?: cls.defaultMpg.coerceAtLeast(1.0),
+            gasPricePerGallon = id.gasPrice ?: 3.50,
+            avgMinutesPerMile = id.avgMinPerMi ?: UserEconomy.DEFAULT_MINUTES_PER_MILE,
+            basePickupMinutes = id.basePickupMin ?: UserEconomy.DEFAULT_BASE_PICKUP_MINUTES,
+            tireSetCost = maintA.tireCost ?: cls.tireSetCost,
+            tireLifetimeMi = maintA.tireLife ?: cls.tireLifetimeMi,
+            oilCost = maintA.oilCost ?: cls.oilCost,
+            oilIntervalMi = maintA.oilInt ?: cls.oilIntervalMi,
+            brakesCost = maintB.brakesCost ?: cls.brakesCost,
+            brakesIntervalMi = maintB.brakesInt ?: cls.brakesIntervalMi,
+            fluidsCost = maintB.fluidsCost ?: cls.fluidsCost,
+            fluidsIntervalMi = maintB.fluidsInt ?: cls.fluidsIntervalMi,
+            miscYearly = maintB.misc ?: cls.miscYearly,
+            miscYearlyMi = depr.miscMi ?: cls.miscYearlyMi,
+            includeDepreciation = depr.includeDepr ?: true,
+            purchasePrice = depr.price ?: cls.purchasePrice,
+            totalLifetimeMi = depr.lifetimeMi ?: cls.totalLifetimeMi,
+            insuranceDeltaPerMonth = fixedPhone.insurance ?: 0.0,
+            registrationDeltaPerYear = fixedPhone.registration ?: 0.0,
+            expectedAnnualDashMiles = fixedPhone.dashMi ?: UserEconomy.DEFAULT_ANNUAL_DASH_MI,
+            phonePlanTotal = fixedPhone.phoneTotal ?: UserEconomy.DEFAULT_PHONE_PLAN_TOTAL,
+            phonePlanLines = fixedPhone.phoneLines ?: UserEconomy.DEFAULT_PHONE_PLAN_LINES,
+            phoneDashPercent = UserEconomy.DEFAULT_PHONE_DASH_PERCENT, // wired below via separate read
+            userSetFields = emptySet(), // populated by mergeUserSetFields below
         )
     }
+    // Wire userSetFields + phoneDashPercent on top — combine has a 5-arg max so we
+    // do it as a final transform.
+    .combine(dataSource.phoneDashPercent) { eco, phoneDashPct ->
+        eco.copy(phoneDashPercent = phoneDashPct ?: UserEconomy.DEFAULT_PHONE_DASH_PERCENT)
+    }
+    .combine(dataSource.userSetEconomyFields) { eco, savedNames ->
+        eco.copy(userSetFields = parseUserSetFields(savedNames))
+    }
+
+    private data class IdentityTuple(
+        val vehicleClass: VehicleClass,
+        val mpg: Double?,
+        val gasPrice: Double?,
+        val avgMinPerMi: Double?,
+        val basePickupMin: Double?,
+    )
+
+    private data class MaintenanceTupleA(
+        val tireCost: Double?, val tireLife: Double?,
+        val oilCost: Double?, val oilInt: Double?,
+    )
+
+    private data class MaintenanceTupleB(
+        val brakesCost: Double?, val brakesInt: Double?,
+        val fluidsCost: Double?, val fluidsInt: Double?,
+        val misc: Double?,
+    )
+
+    private data class DepreciationTuple(
+        val miscMi: Double?,
+        val includeDepr: Boolean?,
+        val price: Double?,
+        val lifetimeMi: Double?,
+    )
+
+    private data class FixedAndPhoneTuple(
+        val insurance: Double?,
+        val registration: Double?,
+        val dashMi: Double?,
+        val phoneTotal: Double?,
+        val phoneLines: Int?,
+    )
+
+    private fun parseUserSetFields(names: Set<String>): Set<EconomyField> =
+        names.mapNotNull { name ->
+            try {
+                EconomyField.valueOf(name)
+            } catch (_: IllegalArgumentException) {
+                null
+            }
+        }.toSet()
 
     // ============================================================================================
     // WRITE ACTIONS
     // ============================================================================================
     suspend fun updateGasPrice(price: Float) = dataSource.updateGasPrice(price)
-
-    // Passes the Enum as a String to keep the DataSource clean
     suspend fun updateFuelType(type: FuelType) = dataSource.updateFuelType(type.name)
-
     suspend fun updateVehicleClass(type: VehicleClass) = dataSource.updateVehicleClass(type.name)
-
     suspend fun setProMode(enabled: Boolean) = dataSource.setProMode(enabled)
-
     suspend fun setTheme(theme: String) = dataSource.setTheme(theme)
 
     suspend fun updateEconomySettings(
-        year: String,
-        make: String,
-        model: String,
-        trim: String,
-        mpg: Float,
-        isGasAuto: Boolean,
-        price: Float
+        year: String, make: String, model: String, trim: String,
+        mpg: Float, isGasAuto: Boolean, price: Float,
     ) = dataSource.updateEconomySettings(year, make, model, trim, mpg, isGasAuto, price)
 
     suspend fun saveSimulationState(pay: Double, dist: Double) =
         dataSource.saveSimulationState(pay, dist)
+
+    // --- Personal Economy v2 writes (#145) ---
+    suspend fun updateTireCost(setCost: Double, lifetimeMi: Double) =
+        dataSource.updateTireCost(setCost, lifetimeMi)
+
+    suspend fun updateOilCost(cost: Double, intervalMi: Double) =
+        dataSource.updateOilCost(cost, intervalMi)
+
+    suspend fun updateBrakesCost(cost: Double, intervalMi: Double) =
+        dataSource.updateBrakesCost(cost, intervalMi)
+
+    suspend fun updateFluidsCost(cost: Double, intervalMi: Double) =
+        dataSource.updateFluidsCost(cost, intervalMi)
+
+    suspend fun updateMiscMaintenance(yearly: Double, yearlyMi: Double) =
+        dataSource.updateMiscMaintenance(yearly, yearlyMi)
+
+    suspend fun updateDepreciation(include: Boolean, purchasePrice: Double, totalLifetimeMi: Double) =
+        dataSource.updateDepreciation(include, purchasePrice, totalLifetimeMi)
+
+    suspend fun updateInsuranceDelta(perMonth: Double) =
+        dataSource.updateInsuranceDelta(perMonth)
+
+    suspend fun updateRegistrationDelta(perYear: Double) =
+        dataSource.updateRegistrationDelta(perYear)
+
+    suspend fun updateExpectedAnnualDashMi(miles: Double) =
+        dataSource.updateExpectedAnnualDashMi(miles)
+
+    suspend fun updatePhonePlan(total: Double, lines: Int, dashPercent: Double) =
+        dataSource.updatePhonePlan(total, lines, dashPercent)
+
+    suspend fun updateTimeConstants(avgMinPerMile: Double, basePickupMin: Double) =
+        dataSource.updateTimeConstants(avgMinPerMile, basePickupMin)
+
+    suspend fun resetEconomyDefaults() = dataSource.resetEconomyDefaults()
 
     suspend fun clearPreferences() {
         Timber.Forest.w("Clearing App Preferences")

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/settings/AppPreferencesRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/settings/AppPreferencesRepository.kt
@@ -3,7 +3,7 @@ package cloud.trotter.dashbuddy.core.data.settings
 import cloud.trotter.dashbuddy.core.datastore.settings.AppPreferencesDataSource
 import cloud.trotter.dashbuddy.domain.evaluation.UserEconomy
 import cloud.trotter.dashbuddy.domain.model.vehicle.FuelType
-import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleType
+import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleClass
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
@@ -37,22 +37,22 @@ class AppPreferencesRepository @Inject constructor(
         }
     }
 
-    val vehicleType: Flow<VehicleType> = dataSource.vehicleType.map { saved ->
+    val vehicleClass: Flow<VehicleClass> = dataSource.vehicleClass.map { saved ->
         try {
-            VehicleType.valueOf(saved ?: VehicleType.CAR.name)
+            VehicleClass.valueOf(saved ?: VehicleClass.SEDAN.name)
         } catch (_: Exception) {
-            VehicleType.CAR
+            VehicleClass.SEDAN
         }
     }
 
     /** Combines stored prefs into a [UserEconomy] ready for [EvaluationConfig]. */
     val userEconomy: Flow<UserEconomy> = combine(
-        vehicleType,
+        vehicleClass,
         dataSource.estimatedMpg,
         dataSource.gasPrice,
     ) { vType, mpg, price ->
         UserEconomy(
-            vehicleType = vType,
+            vehicleClass = vType,
             vehicleMpg = mpg?.toDouble() ?: 30.0,
             gasPricePerGallon = price?.toDouble() ?: 3.50,
         )
@@ -66,7 +66,7 @@ class AppPreferencesRepository @Inject constructor(
     // Passes the Enum as a String to keep the DataSource clean
     suspend fun updateFuelType(type: FuelType) = dataSource.updateFuelType(type.name)
 
-    suspend fun updateVehicleType(type: VehicleType) = dataSource.updateVehicleType(type.name)
+    suspend fun updateVehicleClass(type: VehicleClass) = dataSource.updateVehicleClass(type.name)
 
     suspend fun setProMode(enabled: Boolean) = dataSource.setProMode(enabled)
 

--- a/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/settings/AppPreferencesDataSource.kt
+++ b/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/settings/AppPreferencesDataSource.kt
@@ -46,7 +46,7 @@ class AppPreferencesDataSource @Inject constructor(
     val isProMode: Flow<Boolean> = ds.data.map { it[Keys.IS_PRO_MODE] ?: false }
     val appTheme: Flow<String?> = ds.data.map { it[Keys.APP_THEME] }
     val fuelType: Flow<String?> = ds.data.map { it[Keys.FUEL_TYPE] }
-    val vehicleType: Flow<String?> = ds.data.map { it[Keys.VEHICLE_TYPE] }
+    val vehicleClass: Flow<String?> = ds.data.map { it[Keys.VEHICLE_TYPE] }
 
     // ============================================================================================
     // ENCAPSULATED WRITE ACTIONS
@@ -59,7 +59,7 @@ class AppPreferencesDataSource @Inject constructor(
         ds.edit { it[Keys.FUEL_TYPE] = type }
     }
 
-    suspend fun updateVehicleType(type: String) {
+    suspend fun updateVehicleClass(type: String) {
         ds.edit { it[Keys.VEHICLE_TYPE] = type }
     }
 

--- a/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/settings/AppPreferencesDataSource.kt
+++ b/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/settings/AppPreferencesDataSource.kt
@@ -6,7 +6,9 @@ import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.doublePreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.floatPreferencesKey
+import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.core.stringSetPreferencesKey
 import cloud.trotter.dashbuddy.core.datastore.di.AppPreferences
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -28,9 +30,46 @@ class AppPreferencesDataSource @Inject constructor(
         val IS_PRO_MODE = booleanPreferencesKey("is_pro_mode")
         val APP_THEME = stringPreferencesKey("app_theme")
         val FUEL_TYPE = stringPreferencesKey("fuel_type")
+        // Legacy key (pre-v2 schema, "CAR"/"E_BIKE"). VEHICLE_CLASS supersedes it.
         val VEHICLE_TYPE = stringPreferencesKey("vehicle_type")
+        val VEHICLE_CLASS = stringPreferencesKey("vehicle_class")
         val SIM_PAY = doublePreferencesKey("sim_pay")
         val SIM_DIST = doublePreferencesKey("sim_dist")
+
+        // ----- Personal Economy v2 (#145) -----
+        // Maintenance (paired)
+        val TIRE_SET_COST = doublePreferencesKey("tire_set_cost")
+        val TIRE_LIFETIME_MI = doublePreferencesKey("tire_lifetime_mi")
+        val OIL_COST = doublePreferencesKey("oil_cost")
+        val OIL_INTERVAL_MI = doublePreferencesKey("oil_interval_mi")
+        val BRAKES_COST = doublePreferencesKey("brakes_cost")
+        val BRAKES_INTERVAL_MI = doublePreferencesKey("brakes_interval_mi")
+        val FLUIDS_COST = doublePreferencesKey("fluids_cost")
+        val FLUIDS_INTERVAL_MI = doublePreferencesKey("fluids_interval_mi")
+        val MISC_YEARLY = doublePreferencesKey("misc_yearly")
+        val MISC_YEARLY_MI = doublePreferencesKey("misc_yearly_mi")
+
+        // Depreciation
+        val INCLUDE_DEPRECIATION = booleanPreferencesKey("include_depreciation")
+        val PURCHASE_PRICE = doublePreferencesKey("purchase_price")
+        val TOTAL_LIFETIME_MI = doublePreferencesKey("total_lifetime_mi")
+
+        // Fixed costs (amortized via expected annual dash miles)
+        val INSURANCE_DELTA_PER_MONTH = doublePreferencesKey("insurance_delta_per_month")
+        val REGISTRATION_DELTA_PER_YEAR = doublePreferencesKey("registration_delta_per_year")
+        val EXPECTED_ANNUAL_DASH_MI = doublePreferencesKey("expected_annual_dash_mi")
+
+        // Phone & data (not vehicle-driven)
+        val PHONE_PLAN_TOTAL = doublePreferencesKey("phone_plan_total")
+        val PHONE_PLAN_LINES = intPreferencesKey("phone_plan_lines")
+        val PHONE_DASH_PERCENT = doublePreferencesKey("phone_dash_percent")
+
+        // Time constants (newly persisted)
+        val AVG_MIN_PER_MILE = doublePreferencesKey("avg_min_per_mile")
+        val BASE_PICKUP_MIN = doublePreferencesKey("base_pickup_min")
+
+        // Tracks which EconomyField enum values the user has explicitly set
+        val USER_SET_ECONOMY_FIELDS = stringSetPreferencesKey("user_set_economy_fields")
     }
 
     // ============================================================================================
@@ -46,7 +85,48 @@ class AppPreferencesDataSource @Inject constructor(
     val isProMode: Flow<Boolean> = ds.data.map { it[Keys.IS_PRO_MODE] ?: false }
     val appTheme: Flow<String?> = ds.data.map { it[Keys.APP_THEME] }
     val fuelType: Flow<String?> = ds.data.map { it[Keys.FUEL_TYPE] }
-    val vehicleClass: Flow<String?> = ds.data.map { it[Keys.VEHICLE_TYPE] }
+    /**
+     * Reads `vehicle_class` first; falls back to legacy `vehicle_type` (mapping
+     * "CAR" → "SEDAN") for in-place migration. The first write of [updateVehicleClass]
+     * persists the new key so the legacy fallback only fires once.
+     */
+    val vehicleClass: Flow<String?> = ds.data.map { prefs ->
+        prefs[Keys.VEHICLE_CLASS]
+            ?: when (prefs[Keys.VEHICLE_TYPE]) {
+                "CAR" -> "SEDAN"
+                "E_BIKE" -> "E_BIKE"
+                else -> null
+            }
+    }
+
+    val tireSetCost: Flow<Double?> = ds.data.map { it[Keys.TIRE_SET_COST] }
+    val tireLifetimeMi: Flow<Double?> = ds.data.map { it[Keys.TIRE_LIFETIME_MI] }
+    val oilCost: Flow<Double?> = ds.data.map { it[Keys.OIL_COST] }
+    val oilIntervalMi: Flow<Double?> = ds.data.map { it[Keys.OIL_INTERVAL_MI] }
+    val brakesCost: Flow<Double?> = ds.data.map { it[Keys.BRAKES_COST] }
+    val brakesIntervalMi: Flow<Double?> = ds.data.map { it[Keys.BRAKES_INTERVAL_MI] }
+    val fluidsCost: Flow<Double?> = ds.data.map { it[Keys.FLUIDS_COST] }
+    val fluidsIntervalMi: Flow<Double?> = ds.data.map { it[Keys.FLUIDS_INTERVAL_MI] }
+    val miscYearly: Flow<Double?> = ds.data.map { it[Keys.MISC_YEARLY] }
+    val miscYearlyMi: Flow<Double?> = ds.data.map { it[Keys.MISC_YEARLY_MI] }
+
+    val includeDepreciation: Flow<Boolean?> = ds.data.map { it[Keys.INCLUDE_DEPRECIATION] }
+    val purchasePrice: Flow<Double?> = ds.data.map { it[Keys.PURCHASE_PRICE] }
+    val totalLifetimeMi: Flow<Double?> = ds.data.map { it[Keys.TOTAL_LIFETIME_MI] }
+
+    val insuranceDeltaPerMonth: Flow<Double?> = ds.data.map { it[Keys.INSURANCE_DELTA_PER_MONTH] }
+    val registrationDeltaPerYear: Flow<Double?> = ds.data.map { it[Keys.REGISTRATION_DELTA_PER_YEAR] }
+    val expectedAnnualDashMi: Flow<Double?> = ds.data.map { it[Keys.EXPECTED_ANNUAL_DASH_MI] }
+
+    val phonePlanTotal: Flow<Double?> = ds.data.map { it[Keys.PHONE_PLAN_TOTAL] }
+    val phonePlanLines: Flow<Int?> = ds.data.map { it[Keys.PHONE_PLAN_LINES] }
+    val phoneDashPercent: Flow<Double?> = ds.data.map { it[Keys.PHONE_DASH_PERCENT] }
+
+    val avgMinPerMile: Flow<Double?> = ds.data.map { it[Keys.AVG_MIN_PER_MILE] }
+    val basePickupMin: Flow<Double?> = ds.data.map { it[Keys.BASE_PICKUP_MIN] }
+
+    val userSetEconomyFields: Flow<Set<String>> =
+        ds.data.map { it[Keys.USER_SET_ECONOMY_FIELDS] ?: emptySet() }
 
     // ============================================================================================
     // ENCAPSULATED WRITE ACTIONS
@@ -60,7 +140,7 @@ class AppPreferencesDataSource @Inject constructor(
     }
 
     suspend fun updateVehicleClass(type: String) {
-        ds.edit { it[Keys.VEHICLE_TYPE] = type }
+        ds.edit { it[Keys.VEHICLE_CLASS] = type }
     }
 
     suspend fun setProMode(enabled: Boolean) {
@@ -90,6 +170,130 @@ class AppPreferencesDataSource @Inject constructor(
         ds.edit {
             it[Keys.SIM_PAY] = pay
             it[Keys.SIM_DIST] = dist
+        }
+    }
+
+    // --- Personal Economy v2 writes (#145) ---
+    // Each write atomically marks the affected EconomyField(s) as user-set so the UI
+    // can show a "(default)" badge on still-default fields.
+
+    suspend fun updateTireCost(setCost: Double, lifetimeMi: Double) {
+        ds.edit {
+            it[Keys.TIRE_SET_COST] = setCost
+            it[Keys.TIRE_LIFETIME_MI] = lifetimeMi
+            it[Keys.USER_SET_ECONOMY_FIELDS] = (it[Keys.USER_SET_ECONOMY_FIELDS] ?: emptySet()) +
+                setOf("TIRE_COST", "TIRE_LIFETIME")
+        }
+    }
+
+    suspend fun updateOilCost(cost: Double, intervalMi: Double) {
+        ds.edit {
+            it[Keys.OIL_COST] = cost
+            it[Keys.OIL_INTERVAL_MI] = intervalMi
+            it[Keys.USER_SET_ECONOMY_FIELDS] = (it[Keys.USER_SET_ECONOMY_FIELDS] ?: emptySet()) +
+                setOf("OIL_COST", "OIL_INTERVAL")
+        }
+    }
+
+    suspend fun updateBrakesCost(cost: Double, intervalMi: Double) {
+        ds.edit {
+            it[Keys.BRAKES_COST] = cost
+            it[Keys.BRAKES_INTERVAL_MI] = intervalMi
+            it[Keys.USER_SET_ECONOMY_FIELDS] = (it[Keys.USER_SET_ECONOMY_FIELDS] ?: emptySet()) +
+                setOf("BRAKES_COST", "BRAKES_INTERVAL")
+        }
+    }
+
+    suspend fun updateFluidsCost(cost: Double, intervalMi: Double) {
+        ds.edit {
+            it[Keys.FLUIDS_COST] = cost
+            it[Keys.FLUIDS_INTERVAL_MI] = intervalMi
+            it[Keys.USER_SET_ECONOMY_FIELDS] = (it[Keys.USER_SET_ECONOMY_FIELDS] ?: emptySet()) +
+                setOf("FLUIDS_COST", "FLUIDS_INTERVAL")
+        }
+    }
+
+    suspend fun updateMiscMaintenance(yearly: Double, yearlyMi: Double) {
+        ds.edit {
+            it[Keys.MISC_YEARLY] = yearly
+            it[Keys.MISC_YEARLY_MI] = yearlyMi
+            it[Keys.USER_SET_ECONOMY_FIELDS] = (it[Keys.USER_SET_ECONOMY_FIELDS] ?: emptySet()) +
+                setOf("MISC_YEARLY", "MISC_YEARLY_MI")
+        }
+    }
+
+    suspend fun updateDepreciation(include: Boolean, purchasePrice: Double, totalLifetimeMi: Double) {
+        ds.edit {
+            it[Keys.INCLUDE_DEPRECIATION] = include
+            it[Keys.PURCHASE_PRICE] = purchasePrice
+            it[Keys.TOTAL_LIFETIME_MI] = totalLifetimeMi
+            it[Keys.USER_SET_ECONOMY_FIELDS] = (it[Keys.USER_SET_ECONOMY_FIELDS] ?: emptySet()) +
+                setOf("INCLUDE_DEPRECIATION", "PURCHASE_PRICE", "TOTAL_LIFETIME_MI")
+        }
+    }
+
+    suspend fun updateInsuranceDelta(perMonth: Double) {
+        ds.edit {
+            it[Keys.INSURANCE_DELTA_PER_MONTH] = perMonth
+            it[Keys.USER_SET_ECONOMY_FIELDS] = (it[Keys.USER_SET_ECONOMY_FIELDS] ?: emptySet()) +
+                setOf("INSURANCE_DELTA")
+        }
+    }
+
+    suspend fun updateRegistrationDelta(perYear: Double) {
+        ds.edit {
+            it[Keys.REGISTRATION_DELTA_PER_YEAR] = perYear
+            it[Keys.USER_SET_ECONOMY_FIELDS] = (it[Keys.USER_SET_ECONOMY_FIELDS] ?: emptySet()) +
+                setOf("REGISTRATION_DELTA")
+        }
+    }
+
+    suspend fun updateExpectedAnnualDashMi(miles: Double) {
+        ds.edit {
+            it[Keys.EXPECTED_ANNUAL_DASH_MI] = miles
+            it[Keys.USER_SET_ECONOMY_FIELDS] = (it[Keys.USER_SET_ECONOMY_FIELDS] ?: emptySet()) +
+                setOf("EXPECTED_ANNUAL_DASH_MI")
+        }
+    }
+
+    suspend fun updatePhonePlan(total: Double, lines: Int, dashPercent: Double) {
+        ds.edit {
+            it[Keys.PHONE_PLAN_TOTAL] = total
+            it[Keys.PHONE_PLAN_LINES] = lines
+            it[Keys.PHONE_DASH_PERCENT] = dashPercent
+            it[Keys.USER_SET_ECONOMY_FIELDS] = (it[Keys.USER_SET_ECONOMY_FIELDS] ?: emptySet()) +
+                setOf("PHONE_PLAN_TOTAL", "PHONE_PLAN_LINES", "PHONE_DASH_PERCENT")
+        }
+    }
+
+    suspend fun updateTimeConstants(avgMinPerMile: Double, basePickupMin: Double) {
+        ds.edit {
+            it[Keys.AVG_MIN_PER_MILE] = avgMinPerMile
+            it[Keys.BASE_PICKUP_MIN] = basePickupMin
+            it[Keys.USER_SET_ECONOMY_FIELDS] = (it[Keys.USER_SET_ECONOMY_FIELDS] ?: emptySet()) +
+                setOf("AVG_MIN_PER_MILE", "BASE_PICKUP_MIN")
+        }
+    }
+
+    /** Removes all user-set markers, falling all economy fields back to class defaults. */
+    suspend fun resetEconomyDefaults() {
+        ds.edit {
+            it.remove(Keys.USER_SET_ECONOMY_FIELDS)
+            it.remove(Keys.TIRE_SET_COST); it.remove(Keys.TIRE_LIFETIME_MI)
+            it.remove(Keys.OIL_COST); it.remove(Keys.OIL_INTERVAL_MI)
+            it.remove(Keys.BRAKES_COST); it.remove(Keys.BRAKES_INTERVAL_MI)
+            it.remove(Keys.FLUIDS_COST); it.remove(Keys.FLUIDS_INTERVAL_MI)
+            it.remove(Keys.MISC_YEARLY); it.remove(Keys.MISC_YEARLY_MI)
+            it.remove(Keys.INCLUDE_DEPRECIATION)
+            it.remove(Keys.PURCHASE_PRICE); it.remove(Keys.TOTAL_LIFETIME_MI)
+            it.remove(Keys.INSURANCE_DELTA_PER_MONTH)
+            it.remove(Keys.REGISTRATION_DELTA_PER_YEAR)
+            it.remove(Keys.EXPECTED_ANNUAL_DASH_MI)
+            it.remove(Keys.PHONE_PLAN_TOTAL)
+            it.remove(Keys.PHONE_PLAN_LINES)
+            it.remove(Keys.PHONE_DASH_PERCENT)
+            it.remove(Keys.AVG_MIN_PER_MILE)
+            it.remove(Keys.BASE_PICKUP_MIN)
         }
     }
 

--- a/core/network/src/main/java/cloud/trotter/dashbuddy/core/network/vehicle/efficiency/epa/EpaVehicleDataSource.kt
+++ b/core/network/src/main/java/cloud/trotter/dashbuddy/core/network/vehicle/efficiency/epa/EpaVehicleDataSource.kt
@@ -54,9 +54,17 @@ class EpaVehicleDataSource @Inject constructor(
 
     override suspend fun getVehicleDetails(vehicleId: String): VehicleDetails? = try {
         val response = api.getVehicleDetails(vehicleId = vehicleId)
+        val fuel = mapFuelType(response.fuelType1)
+        // EVs are detected via fuel type; otherwise infer class from EPA VClass.
+        val vClass = if (fuel == FuelType.ELECTRICITY) {
+            cloud.trotter.dashbuddy.domain.model.vehicle.VehicleClass.EV
+        } else {
+            mapEpaVClass(response.vClass)
+        }
         VehicleDetails(
             combinedMpg = response.combinedMpg,
-            fuelType = mapFuelType(response.fuelType1)
+            fuelType = fuel,
+            vehicleClass = vClass,
         )
     } catch (e: Exception) {
         Timber.e(e, "Failed to fetch vehicle details for ID $vehicleId")

--- a/core/network/src/main/java/cloud/trotter/dashbuddy/core/network/vehicle/efficiency/epa/VClassMap.kt
+++ b/core/network/src/main/java/cloud/trotter/dashbuddy/core/network/vehicle/efficiency/epa/VClassMap.kt
@@ -1,0 +1,42 @@
+package cloud.trotter.dashbuddy.core.network.vehicle.efficiency.epa
+
+import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleClass
+
+/**
+ * Maps an EPA `VClass` string (from `/ws/rest/vehicle/{id}`) to a DashBuddy
+ * [VehicleClass]. The mapping is intentionally forgiving — lowercased contains-match
+ * with priority-ordered checks so EPA can rename or add classes without breaking
+ * production. Unmappable inputs return `null`; callers fall back to whatever default
+ * makes sense (the wizard picks `SEDAN`).
+ *
+ * EPA's published VClass values (as of 2026):
+ *   Compact Cars, Subcompact Cars, Minicompact Cars, Two Seaters,
+ *   Midsize Cars, Large Cars, Midsize-Large Station Wagons, Small Station Wagons,
+ *   Small Sport Utility Vehicle, Standard Sport Utility Vehicle,
+ *   Small Pickup Trucks, Standard Pickup Trucks,
+ *   Vans, Minivan, Special Purpose Vehicles
+ *
+ * EVs are detected via fuel type elsewhere ([EpaVehicleDataSource.mapFuelType]), not
+ * via VClass — EPA doesn't have an "EV" size class. Bikes/motorcycles aren't covered
+ * by EPA at all; the user picks those manually.
+ */
+fun mapEpaVClass(raw: String?): VehicleClass? {
+    if (raw.isNullOrBlank()) return null
+    val s = raw.lowercase()
+
+    return when {
+        // Pickups before SUVs because some "pickup utility" strings contain both
+        "pickup" in s || "truck" in s -> VehicleClass.TRUCK
+        "sport utility" in s || "suv" in s -> VehicleClass.SUV
+        "van" in s -> VehicleClass.SUV   // vans/minivans closest to SUV cost profile
+        // Compact-class detection
+        "compact" in s || "subcompact" in s || "minicompact" in s || "two seater" in s ->
+            VehicleClass.COMPACT
+        // Midsize / large / wagons → SEDAN
+        "midsize" in s || "large" in s || "station wagon" in s || "wagon" in s ->
+            VehicleClass.SEDAN
+        // Special purpose vehicles default to SEDAN (least likely to surprise)
+        "special purpose" in s -> VehicleClass.SEDAN
+        else -> null
+    }
+}

--- a/core/network/src/main/java/cloud/trotter/dashbuddy/core/network/vehicle/efficiency/epa/dto/VehicleDetailsResponse.kt
+++ b/core/network/src/main/java/cloud/trotter/dashbuddy/core/network/vehicle/efficiency/epa/dto/VehicleDetailsResponse.kt
@@ -1,15 +1,19 @@
 package cloud.trotter.dashbuddy.core.network.vehicle.efficiency.epa.dto
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
- * When we finally query the specific vehicle ID, it returns a massive JSON object.
- * We only care about the combined MPG right now.
+ * Subset of the EPA fueleconomy.gov per-vehicle response. The full payload is large;
+ * we extract only the fields DashBuddy uses today: combined MPG, fuel type, and the
+ * EPA vehicle class (used to pre-select a VehicleClass cost profile in the wizard).
  */
 @Serializable
 data class VehicleDetailsResponse(
     val comb08: String,
-    val fuelType1: String
+    val fuelType1: String,
+    /** EPA size class, e.g. "Compact Cars", "Midsize Cars", "Standard Sport Utility Vehicle". */
+    @SerialName("VClass") val vClass: String? = null,
 ) {
     val combinedMpg: Float?
         get() = comb08.toFloatOrNull()

--- a/core/network/src/test/java/cloud/trotter/dashbuddy/core/network/vehicle/efficiency/epa/VClassMapTest.kt
+++ b/core/network/src/test/java/cloud/trotter/dashbuddy/core/network/vehicle/efficiency/epa/VClassMapTest.kt
@@ -1,0 +1,94 @@
+package cloud.trotter.dashbuddy.core.network.vehicle.efficiency.epa
+
+import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleClass
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Table-driven test for [mapEpaVClass]. Covers all EPA `VClass` strings observed
+ * as of 2026 plus edge cases (null/blank/unknown).
+ */
+class VClassMapTest {
+
+    @Test
+    fun `compact-family strings map to COMPACT`() {
+        listOf(
+            "Compact Cars",
+            "Subcompact Cars",
+            "Minicompact Cars",
+            "Two Seaters",
+            "compact cars", // lowercase still matches
+        ).forEach { input ->
+            assertEquals("Failed for: $input", VehicleClass.COMPACT, mapEpaVClass(input))
+        }
+    }
+
+    @Test
+    fun `midsize-large-wagon strings map to SEDAN`() {
+        listOf(
+            "Midsize Cars",
+            "Large Cars",
+            "Midsize-Large Station Wagons",
+            "Small Station Wagons",
+        ).forEach { input ->
+            assertEquals("Failed for: $input", VehicleClass.SEDAN, mapEpaVClass(input))
+        }
+    }
+
+    @Test
+    fun `sport-utility strings map to SUV`() {
+        listOf(
+            "Small Sport Utility Vehicle",
+            "Standard Sport Utility Vehicle",
+            "Sport Utility Vehicle",
+        ).forEach { input ->
+            assertEquals("Failed for: $input", VehicleClass.SUV, mapEpaVClass(input))
+        }
+    }
+
+    @Test
+    fun `van strings map to SUV cost profile`() {
+        listOf("Vans", "Minivan", "Passenger Vans").forEach { input ->
+            assertEquals("Failed for: $input", VehicleClass.SUV, mapEpaVClass(input))
+        }
+    }
+
+    @Test
+    fun `pickup strings map to TRUCK`() {
+        listOf(
+            "Small Pickup Trucks",
+            "Standard Pickup Trucks",
+        ).forEach { input ->
+            assertEquals("Failed for: $input", VehicleClass.TRUCK, mapEpaVClass(input))
+        }
+    }
+
+    @Test
+    fun `special purpose maps to SEDAN`() {
+        assertEquals(VehicleClass.SEDAN, mapEpaVClass("Special Purpose Vehicles"))
+    }
+
+    @Test
+    fun `null returns null`() {
+        assertNull(mapEpaVClass(null))
+    }
+
+    @Test
+    fun `blank returns null`() {
+        assertNull(mapEpaVClass(""))
+        assertNull(mapEpaVClass("   "))
+    }
+
+    @Test
+    fun `unknown string returns null`() {
+        assertNull(mapEpaVClass("Hovercraft Class 7"))
+        assertNull(mapEpaVClass("Some Future EPA Category"))
+    }
+
+    @Test
+    fun `pickup beats SUV when both substrings present`() {
+        // Defensive: hypothetical EPA string with both keywords. Pickup wins.
+        assertEquals(VehicleClass.TRUCK, mapEpaVClass("Pickup Utility Vehicle"))
+    }
+}

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/ReplayMetadataProviderImpl.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/ReplayMetadataProviderImpl.kt
@@ -14,7 +14,7 @@ import javax.inject.Singleton
 @Singleton
 class ReplayMetadataProviderImpl @Inject constructor(
     private val interpreter: JsonRuleInterpreter,
-    @Named("appVersionName") private val appVersionName: String,
+    @param:Named("appVersionName") private val appVersionName: String,
 ) : ReplayMetadataProvider {
 
     override fun current(): ReplayMetadata = ReplayMetadata(

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/EconomyField.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/EconomyField.kt
@@ -1,0 +1,37 @@
+package cloud.trotter.dashbuddy.domain.evaluation
+
+/**
+ * The individual fields of [UserEconomy] that the user can explicitly set.
+ * Used as the value-type of `UserEconomy.userSetFields` so the UI can show a
+ * "(default)" badge on fields the user hasn't yet customized.
+ *
+ * A field becomes "user-set" when the user writes a value through a settings
+ * screen (wizard or Personal Economy settings). The set persists in DataStore
+ * under the `USER_SET_ECONOMY_FIELDS` key.
+ */
+enum class EconomyField {
+    VEHICLE_CLASS,
+    VEHICLE_MPG,
+    GAS_PRICE,
+    AVG_MIN_PER_MILE,
+    BASE_PICKUP_MIN,
+    TIRE_COST,
+    TIRE_LIFETIME,
+    OIL_COST,
+    OIL_INTERVAL,
+    BRAKES_COST,
+    BRAKES_INTERVAL,
+    FLUIDS_COST,
+    FLUIDS_INTERVAL,
+    MISC_YEARLY,
+    MISC_YEARLY_MI,
+    INCLUDE_DEPRECIATION,
+    PURCHASE_PRICE,
+    TOTAL_LIFETIME_MI,
+    INSURANCE_DELTA,
+    REGISTRATION_DELTA,
+    EXPECTED_ANNUAL_DASH_MI,
+    PHONE_PLAN_TOTAL,
+    PHONE_PLAN_LINES,
+    PHONE_DASH_PERCENT,
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/OfferEvaluation.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/OfferEvaluation.kt
@@ -1,7 +1,5 @@
 package cloud.trotter.dashbuddy.domain.evaluation
 
-import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleType
-
 data class OfferEvaluation(
     val action: OfferAction,
     val score: Double,
@@ -9,9 +7,19 @@ data class OfferEvaluation(
     val recommendationText: String,
     /** Gross pay as shown on the offer screen. */
     val payAmount: Double,
-    /** Estimated fuel cost for this offer's route. Zero for [VehicleType.E_BIKE]. */
+    /** Estimated fuel cost for this offer's route. Zero for non-fuel vehicle classes. */
     val fuelCostEstimate: Double,
-    /** Net pay after fuel cost: [payAmount] - [fuelCostEstimate]. */
+    /**
+     * Estimated non-fuel operating cost for this offer's route:
+     * tires + oil + brakes + fluids + misc + depreciation + insurance +
+     * registration + phone. Amortized per-mile.
+     */
+    val nonFuelCostEstimate: Double = 0.0,
+    /** [fuelCostEstimate] + [nonFuelCostEstimate]. */
+    val totalOperatingCost: Double = 0.0,
+    /** Total operating cost per mile from the user's economy profile. */
+    val operatingCostPerMile: Double = 0.0,
+    /** Net pay after all operating costs: [payAmount] - [totalOperatingCost]. */
     val netPayAmount: Double,
     val distanceMiles: Double,
     /** Net dollars per mile ([netPayAmount] / [distanceMiles]). */
@@ -22,6 +30,11 @@ data class OfferEvaluation(
     val estimatedTimeMinutes: Double,
     val itemCount: Double,
     val merchantName: String,
+    /**
+     * True when the user's [UserEconomy] still has at least one field at its
+     * vehicle-class / built-in default. Surfaces a "(default)" hint in the UI.
+     */
+    val isUsingDefaults: Boolean = false,
     /**
      * Caveat messages about unrealistic rule targets. Empty when all targets are reasonable.
      * Shown to the user when configuring rules so they understand why offers are being declined.

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/OfferEvaluator.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/OfferEvaluator.kt
@@ -12,9 +12,12 @@ class OfferEvaluator() {
         val dist = offer.distanceMiles ?: 1.0
         val items = offer.itemCount.toDouble()
 
-        // Fuel cost and net pay
+        // Operating cost — full breakdown (fuel + tires + oil + brakes + fluids +
+        // misc + depreciation + amortized fixed costs + phone) and net pay
         val fuelCost = dist * economy.fuelCostPerMile
-        val netPay = grossPay - fuelCost
+        val nonFuelCost = dist * economy.nonFuelCostPerMile
+        val operatingCost = fuelCost + nonFuelCost
+        val netPay = grossPay - operatingCost
 
         // Time estimate using user-configured constants
         val estTimeMinutes = (dist * economy.avgMinutesPerMile) + economy.basePickupMinutes
@@ -39,6 +42,9 @@ class OfferEvaluator() {
                 recommendationText = "Protected: Accept!",
                 payAmount = grossPay,
                 fuelCostEstimate = fuelCost,
+                nonFuelCostEstimate = nonFuelCost,
+                totalOperatingCost = operatingCost,
+                operatingCostPerMile = economy.operatingCostPerMile,
                 netPayAmount = netPay,
                 distanceMiles = dist,
                 dollarsPerMile = dpm,
@@ -46,6 +52,7 @@ class OfferEvaluator() {
                 estimatedTimeMinutes = estTimeMinutes,
                 itemCount = items,
                 merchantName = merchants,
+                isUsingDefaults = economy.isUsingDefaults,
             )
         }
 
@@ -86,13 +93,17 @@ class OfferEvaluator() {
                 recommendationText = "Recommended: DECLINE",
                 payAmount = grossPay,
                 fuelCostEstimate = fuelCost,
+                nonFuelCostEstimate = nonFuelCost,
+                totalOperatingCost = operatingCost,
+                operatingCostPerMile = economy.operatingCostPerMile,
                 netPayAmount = netPay,
                 distanceMiles = dist,
                 dollarsPerMile = dpm,
                 dollarsPerHour = activeHourly,
                 estimatedTimeMinutes = estTimeMinutes,
                 itemCount = items,
-                merchantName = merchants
+                merchantName = merchants,
+                isUsingDefaults = economy.isUsingDefaults,
             )
         }
 
@@ -156,6 +167,9 @@ class OfferEvaluator() {
             recommendationText = recText,
             payAmount = grossPay,
             fuelCostEstimate = fuelCost,
+            nonFuelCostEstimate = nonFuelCost,
+            totalOperatingCost = operatingCost,
+            operatingCostPerMile = economy.operatingCostPerMile,
             netPayAmount = netPay,
             distanceMiles = dist,
             dollarsPerMile = dpm,
@@ -163,6 +177,7 @@ class OfferEvaluator() {
             estimatedTimeMinutes = estTimeMinutes,
             itemCount = items,
             merchantName = merchants,
+            isUsingDefaults = economy.isUsingDefaults,
             warnings = warnings,
         )
     }

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/UserEconomy.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/UserEconomy.kt
@@ -1,36 +1,107 @@
 package cloud.trotter.dashbuddy.domain.evaluation
 
-import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleType
+import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleClass
 
 /**
  * The persistent financial and time-estimation profile of the Dasher.
  * Assembled from stored preferences and passed into [EvaluationConfig].
  *
- * Fuel cost is computed from [gasPricePerGallon] / [vehicleMpg]. E-bikes carry no fuel cost.
- * Time estimation defaults ([avgMinutesPerMile], [basePickupMinutes]) are user-tunable to
- * account for market conditions (rural vs. dense city, typical restaurant wait times).
+ * All cost components are entered in *human units* (cost per tire set + tire
+ * lifetime miles, oil change cost + interval, monthly insurance, etc.) and
+ * converted to per-mile internally so the evaluator can do a single
+ * subtraction: `netPay = grossPay - distance * operatingCostPerMile`.
+ *
+ * Time-fixed costs (insurance, registration, phone) are amortized via
+ * [expectedAnnualDashMiles] — the user's estimate of how many miles per year
+ * they expect to dash. Fixed-cost per-mile = (annual cost) / annual dash miles.
+ *
+ * Defaults come from the selected [vehicleClass]'s preset values. Switching
+ * class shifts any field NOT in [userSetFields] to the new class's default;
+ * user-set fields are preserved.
  */
 data class UserEconomy(
-    val vehicleType: VehicleType = VehicleType.CAR,
+    val vehicleClass: VehicleClass = VehicleClass.SEDAN,
     val vehicleMpg: Double = 30.0,
     val gasPricePerGallon: Double = 3.50,
+
     /** Minutes per mile of driving — default 2.5 (urban average). */
     val avgMinutesPerMile: Double = DEFAULT_MINUTES_PER_MILE,
     /** Base overhead per offer (pickup + dropoff) in minutes — default 7.0. */
     val basePickupMinutes: Double = DEFAULT_BASE_PICKUP_MINUTES,
+
+    // Maintenance (paired: cost + interval/lifetime). Defaults are zero so a
+    // hand-constructed UserEconomy is cost-free for tests. Production paths
+    // populate these from the VehicleClass preset via the repository.
+    val tireSetCost: Double = 0.0,
+    val tireLifetimeMi: Double = 1.0,
+    val oilCost: Double = 0.0,
+    val oilIntervalMi: Double = 1.0,
+    val brakesCost: Double = 0.0,
+    val brakesIntervalMi: Double = 1.0,
+    val fluidsCost: Double = 0.0,
+    val fluidsIntervalMi: Double = 1.0,
+    val miscYearly: Double = 0.0,
+    val miscYearlyMi: Double = 1.0,
+
+    // Depreciation (gated by include-toggle; off by default so domain-only
+    // construction yields a cost-free economy)
+    val includeDepreciation: Boolean = false,
+    val purchasePrice: Double = 0.0,
+    val totalLifetimeMi: Double = 1.0,
+
+    // Fixed costs (amortized via expectedAnnualDashMiles)
+    val insuranceDeltaPerMonth: Double = 0.0,
+    val registrationDeltaPerYear: Double = 0.0,
+    val expectedAnnualDashMiles: Double = DEFAULT_ANNUAL_DASH_MI,
+
+    // Phone & data (NOT driven by VehicleClass; stored separately). Domain
+    // default is zero plan cost — production populates via repository.
+    val phonePlanTotal: Double = 0.0,
+    val phonePlanLines: Int = 1,
+    val phoneDashPercent: Double = 0.0,
+
+    /** Which [EconomyField]s the user has explicitly set. The rest are class defaults. */
+    val userSetFields: Set<EconomyField> = emptySet(),
 ) {
-    /**
-     * Marginal fuel cost per mile. Zero for [VehicleType.E_BIKE].
-     * EV car cost modeling is future work — modeled as zero until then.
-     */
-    val fuelCostPerMile: Double
-        get() = when (vehicleType) {
-            VehicleType.E_BIKE -> 0.0
-            VehicleType.CAR -> if (vehicleMpg > 0) gasPricePerGallon / vehicleMpg else 0.0
-        }
+    /** Marginal fuel cost per mile. Zero for vehicle classes that don't burn fuel. */
+    val fuelCostPerMile: Double = if (!vehicleClass.burnsFuel) 0.0
+                                  else gasPricePerGallon / vehicleMpg.coerceAtLeast(1.0)
+
+    val tireCostPerMile: Double = tireSetCost / tireLifetimeMi.coerceAtLeast(1.0)
+    val oilCostPerMile: Double = oilCost / oilIntervalMi.coerceAtLeast(1.0)
+    val brakesCostPerMile: Double = brakesCost / brakesIntervalMi.coerceAtLeast(1.0)
+    val fluidsCostPerMile: Double = fluidsCost / fluidsIntervalMi.coerceAtLeast(1.0)
+    val miscCostPerMile: Double = miscYearly / miscYearlyMi.coerceAtLeast(1.0)
+    val depreciationCostPerMile: Double =
+        if (includeDepreciation) purchasePrice / totalLifetimeMi.coerceAtLeast(1.0) else 0.0
+    val insuranceCostPerMile: Double =
+        (insuranceDeltaPerMonth * 12.0) / expectedAnnualDashMiles.coerceAtLeast(1.0)
+    val registrationCostPerMile: Double =
+        registrationDeltaPerYear / expectedAnnualDashMiles.coerceAtLeast(1.0)
+    val phoneCostPerMile: Double = run {
+        val yourLineShare = phonePlanTotal / phonePlanLines.coerceAtLeast(1)
+        val dashingMonthly = yourLineShare * (phoneDashPercent / 100.0)
+        (dashingMonthly * 12.0) / expectedAnnualDashMiles.coerceAtLeast(1.0)
+    }
+
+    val nonFuelCostPerMile: Double
+        get() = tireCostPerMile + oilCostPerMile + brakesCostPerMile +
+            fluidsCostPerMile + miscCostPerMile + depreciationCostPerMile +
+            insuranceCostPerMile + registrationCostPerMile + phoneCostPerMile
+
+    val operatingCostPerMile: Double get() = fuelCostPerMile + nonFuelCostPerMile
+
+    fun isUserSet(field: EconomyField): Boolean = field in userSetFields
+
+    /** True when at least one [EconomyField] is still at its class/default value. */
+    val isUsingDefaults: Boolean get() = userSetFields.size < EconomyField.entries.size
 
     companion object {
         const val DEFAULT_MINUTES_PER_MILE = 2.5
         const val DEFAULT_BASE_PICKUP_MINUTES = 7.0
+        const val DEFAULT_ANNUAL_DASH_MI = 10_000.0
+        const val DEFAULT_PHONE_PLAN_TOTAL = 80.0
+        const val DEFAULT_PHONE_PLAN_LINES = 1
+        const val DEFAULT_PHONE_DASH_PERCENT = 30.0
     }
 }

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/vehicle/VehicleClass.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/vehicle/VehicleClass.kt
@@ -1,0 +1,108 @@
+package cloud.trotter.dashbuddy.domain.model.vehicle
+
+/**
+ * The vehicle category the Dasher uses. Each value carries IRS-aligned default
+ * operating-cost constants so a user who accepts the wizard's defaults still
+ * gets a reasonable cost-per-mile estimate without entering individual numbers.
+ *
+ * Defaults are approximate midpoints; the user can override any field via the
+ * Economy wizard step or Personal Economy settings.
+ */
+enum class VehicleClass(
+    val displayName: String,
+    /** Default combined MPG (gas vehicles); zero/ignored for EV and non-car classes. */
+    val defaultMpg: Double,
+
+    // Maintenance (paired cost + interval)
+    val tireSetCost: Double, val tireLifetimeMi: Double,
+    val oilCost: Double, val oilIntervalMi: Double,
+    val brakesCost: Double, val brakesIntervalMi: Double,
+    val fluidsCost: Double, val fluidsIntervalMi: Double,
+    val miscYearly: Double, val miscYearlyMi: Double,
+
+    // Depreciation
+    val purchasePrice: Double, val totalLifetimeMi: Double,
+) {
+    COMPACT(
+        displayName = "Compact",
+        defaultMpg = 32.0,
+        tireSetCost = 600.0, tireLifetimeMi = 45_000.0,
+        oilCost = 40.0, oilIntervalMi = 5_000.0,
+        brakesCost = 350.0, brakesIntervalMi = 45_000.0,
+        fluidsCost = 120.0, fluidsIntervalMi = 30_000.0,
+        miscYearly = 400.0, miscYearlyMi = 12_000.0,
+        purchasePrice = 22_000.0, totalLifetimeMi = 200_000.0,
+    ),
+    SEDAN(
+        displayName = "Sedan",
+        defaultMpg = 30.0,
+        tireSetCost = 800.0, tireLifetimeMi = 40_000.0,
+        oilCost = 60.0, oilIntervalMi = 5_000.0,
+        brakesCost = 400.0, brakesIntervalMi = 40_000.0,
+        fluidsCost = 150.0, fluidsIntervalMi = 30_000.0,
+        miscYearly = 500.0, miscYearlyMi = 12_000.0,
+        purchasePrice = 28_000.0, totalLifetimeMi = 200_000.0,
+    ),
+    SUV(
+        displayName = "SUV",
+        defaultMpg = 24.0,
+        tireSetCost = 1_000.0, tireLifetimeMi = 35_000.0,
+        oilCost = 70.0, oilIntervalMi = 5_000.0,
+        brakesCost = 500.0, brakesIntervalMi = 35_000.0,
+        fluidsCost = 200.0, fluidsIntervalMi = 30_000.0,
+        miscYearly = 700.0, miscYearlyMi = 12_000.0,
+        purchasePrice = 35_000.0, totalLifetimeMi = 220_000.0,
+    ),
+    TRUCK(
+        displayName = "Truck",
+        defaultMpg = 20.0,
+        tireSetCost = 1_100.0, tireLifetimeMi = 35_000.0,
+        oilCost = 80.0, oilIntervalMi = 5_000.0,
+        brakesCost = 550.0, brakesIntervalMi = 35_000.0,
+        fluidsCost = 250.0, fluidsIntervalMi = 30_000.0,
+        miscYearly = 800.0, miscYearlyMi = 12_000.0,
+        purchasePrice = 40_000.0, totalLifetimeMi = 250_000.0,
+    ),
+    LUXURY(
+        displayName = "Luxury",
+        defaultMpg = 26.0,
+        tireSetCost = 1_500.0, tireLifetimeMi = 35_000.0,
+        oilCost = 120.0, oilIntervalMi = 7_000.0,
+        brakesCost = 800.0, brakesIntervalMi = 35_000.0,
+        fluidsCost = 400.0, fluidsIntervalMi = 30_000.0,
+        miscYearly = 1_500.0, miscYearlyMi = 12_000.0,
+        purchasePrice = 55_000.0, totalLifetimeMi = 180_000.0,
+    ),
+    EV(
+        displayName = "EV",
+        defaultMpg = 0.0,
+        tireSetCost = 1_000.0, tireLifetimeMi = 35_000.0,
+        oilCost = 0.0, oilIntervalMi = 1.0,
+        brakesCost = 400.0, brakesIntervalMi = 80_000.0,
+        fluidsCost = 100.0, fluidsIntervalMi = 50_000.0,
+        miscYearly = 400.0, miscYearlyMi = 12_000.0,
+        purchasePrice = 40_000.0, totalLifetimeMi = 200_000.0,
+    ),
+    MOTORCYCLE(
+        displayName = "Motorcycle",
+        defaultMpg = 50.0,
+        tireSetCost = 400.0, tireLifetimeMi = 15_000.0,
+        oilCost = 50.0, oilIntervalMi = 4_000.0,
+        brakesCost = 250.0, brakesIntervalMi = 25_000.0,
+        fluidsCost = 100.0, fluidsIntervalMi = 20_000.0,
+        miscYearly = 400.0, miscYearlyMi = 8_000.0,
+        purchasePrice = 12_000.0, totalLifetimeMi = 80_000.0,
+    ),
+    E_BIKE(
+        displayName = "E-Bike",
+        defaultMpg = 0.0,
+        tireSetCost = 0.0, tireLifetimeMi = 1.0,
+        oilCost = 0.0, oilIntervalMi = 1.0,
+        brakesCost = 0.0, brakesIntervalMi = 1.0,
+        fluidsCost = 0.0, fluidsIntervalMi = 1.0,
+        miscYearly = 0.0, miscYearlyMi = 1.0,
+        purchasePrice = 0.0, totalLifetimeMi = 1.0,
+    );
+
+    val burnsFuel: Boolean get() = this != EV && this != E_BIKE
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/vehicle/VehicleDetails.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/vehicle/VehicleDetails.kt
@@ -6,8 +6,12 @@ package cloud.trotter.dashbuddy.domain.model.vehicle
  *
  * @param combinedMpg Combined city/highway MPG, or null if unavailable.
  * @param fuelType    The primary fuel type, already mapped to the domain [FuelType] enum.
+ * @param vehicleClass The vehicle class derived from EPA's VClass field, or null if
+ *                     unmappable. The wizard uses this to pre-select a VehicleClass in
+ *                     the Economy step so cost defaults align with the vehicle's segment.
  */
 data class VehicleDetails(
     val combinedMpg: Float?,
-    val fuelType: FuelType
+    val fuelType: FuelType,
+    val vehicleClass: VehicleClass? = null,
 )

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/vehicle/VehicleType.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/vehicle/VehicleType.kt
@@ -1,4 +1,0 @@
-package cloud.trotter.dashbuddy.domain.model.vehicle
-
-/** Defines the type of vehicle the Dasher uses. */
-enum class VehicleType { CAR, E_BIKE }

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/evaluation/OfferEvaluatorTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/evaluation/OfferEvaluatorTest.kt
@@ -3,7 +3,7 @@ package cloud.trotter.dashbuddy.domain.evaluation
 import cloud.trotter.dashbuddy.domain.model.offer.ParsedOffer
 import cloud.trotter.dashbuddy.domain.model.order.OrderType
 import cloud.trotter.dashbuddy.domain.model.order.ParsedOrder
-import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleType
+import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleClass
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -17,7 +17,7 @@ class OfferEvaluatorTest {
      * Zero-cost economy used by all metric scoring tests so they can assert exact values
      * without fuel cost skewing the numbers. Fuel cost behavior has its own test section.
      */
-    private val noCostEconomy = UserEconomy(vehicleType = VehicleType.E_BIKE)
+    private val noCostEconomy = UserEconomy(vehicleClass = VehicleClass.E_BIKE)
 
     // Default config: single PAYOUT rule, target $7.00, no fuel cost
     private val defaultConfig = EvaluationConfig(
@@ -77,6 +77,25 @@ class OfferEvaluatorTest {
 
     private fun config(vararg rules: ScoringRule) =
         EvaluationConfig(rules = rules.toList(), userEconomy = noCostEconomy)
+
+    /**
+     * Builds a [UserEconomy] where only fuel cost is non-zero. Used by fuel-cost
+     * tests to isolate fuel behavior from the rest of the operating-cost model.
+     */
+    private fun fuelOnlyEconomy(vehicleMpg: Double, gasPricePerGallon: Double) = UserEconomy(
+        vehicleClass = VehicleClass.SEDAN,
+        vehicleMpg = vehicleMpg,
+        gasPricePerGallon = gasPricePerGallon,
+        tireSetCost = 0.0,
+        oilCost = 0.0,
+        brakesCost = 0.0,
+        fluidsCost = 0.0,
+        miscYearly = 0.0,
+        includeDepreciation = false,
+        insuranceDeltaPerMonth = 0.0,
+        registrationDeltaPerYear = 0.0,
+        phonePlanTotal = 0.0,
+    )
 
     // -------------------------------------------------------------------------
     // Protect Stats Mode
@@ -307,7 +326,7 @@ class OfferEvaluatorTest {
 
     @Test
     fun `evaluation output - estimatedTimeMinutes uses UserEconomy constants`() {
-        val economy = UserEconomy(vehicleType = VehicleType.E_BIKE, avgMinutesPerMile = 4.0, basePickupMinutes = 10.0)
+        val economy = UserEconomy(vehicleClass = VehicleClass.E_BIKE, avgMinutesPerMile = 4.0, basePickupMinutes = 10.0)
         val cfg = EvaluationConfig(rules = listOf(metricRule(MetricType.PAYOUT, 7.0f)), userEconomy = economy)
         // 5 miles * 4 min/mi + 10 = 30 min
         val result = evaluator.evaluate(offer(pay = 7.0, dist = 5.0), cfg)
@@ -539,7 +558,7 @@ class OfferEvaluatorTest {
     @Test
     fun `fuel cost - CAR economy deducts cost from net pay`() {
         // $3.50/gal, 35 mpg → $0.10/mi; 5 miles → $0.50 fuel cost
-        val carEconomy = UserEconomy(vehicleType = VehicleType.CAR, vehicleMpg = 35.0, gasPricePerGallon = 3.50)
+        val carEconomy = fuelOnlyEconomy(vehicleMpg = 35.0, gasPricePerGallon = 3.50)
         val cfg = EvaluationConfig(rules = listOf(metricRule(MetricType.PAYOUT, 10.0f)), userEconomy = carEconomy)
         val result = evaluator.evaluate(offer(pay = 10.0, dist = 5.0), cfg)
         assertEquals(0.50, result.fuelCostEstimate, 0.001)
@@ -559,7 +578,7 @@ class OfferEvaluatorTest {
     fun `fuel cost - metric scoring uses net pay not gross pay`() {
         // $4.00/gal, 20 mpg → $0.20/mi; 5 miles → $1.00 fuel cost
         // grossPay=$8, netPay=$7, target=$7 → PAYOUT score = 7/7 = 100
-        val carEconomy = UserEconomy(vehicleType = VehicleType.CAR, vehicleMpg = 20.0, gasPricePerGallon = 4.00)
+        val carEconomy = fuelOnlyEconomy(vehicleMpg = 20.0, gasPricePerGallon = 4.00)
         val cfg = EvaluationConfig(rules = listOf(metricRule(MetricType.PAYOUT, 7.0f)), userEconomy = carEconomy)
         val result = evaluator.evaluate(offer(pay = 8.0, dist = 5.0), cfg)
         assertEquals(1.0, result.fuelCostEstimate, 0.001)
@@ -571,7 +590,7 @@ class OfferEvaluatorTest {
     @Test
     fun `fuel cost - high fuel cost can push net pay negative, scores 0`() {
         // $6.00/gal, 10 mpg → $0.60/mi; 10 miles → $6 fuel cost; grossPay=$5 → netPay=-$1
-        val expensiveEconomy = UserEconomy(vehicleType = VehicleType.CAR, vehicleMpg = 10.0, gasPricePerGallon = 6.00)
+        val expensiveEconomy = fuelOnlyEconomy(vehicleMpg = 10.0, gasPricePerGallon = 6.00)
         val cfg = EvaluationConfig(rules = listOf(metricRule(MetricType.PAYOUT, 5.0f)), userEconomy = expensiveEconomy)
         val result = evaluator.evaluate(offer(pay = 5.0, dist = 10.0), cfg)
         assertEquals(0.0, result.score, 0.001)
@@ -586,7 +605,7 @@ class OfferEvaluatorTest {
     fun `time estimate - custom minutesPerMile affects hourly calculation`() {
         // Rural market: slower pace, 5 min/mile instead of default 2.5
         val ruralEconomy = UserEconomy(
-            vehicleType = VehicleType.E_BIKE, // no fuel cost so we isolate time
+            vehicleClass = VehicleClass.E_BIKE, // no fuel cost so we isolate time
             avgMinutesPerMile = 5.0,
             basePickupMinutes = 7.0,
         )
@@ -606,7 +625,7 @@ class OfferEvaluatorTest {
     fun `time estimate - custom basePickupMinutes affects hourly calculation`() {
         // Long-wait market: 15 min base overhead
         val slowPickupEconomy = UserEconomy(
-            vehicleType = VehicleType.E_BIKE,
+            vehicleClass = VehicleClass.E_BIKE,
             avgMinutesPerMile = UserEconomy.DEFAULT_MINUTES_PER_MILE,
             basePickupMinutes = 15.0,
         )

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/evaluation/OfferEvaluatorTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/evaluation/OfferEvaluatorTest.kt
@@ -698,4 +698,183 @@ class OfferEvaluatorTest {
         val result = evaluator.evaluate(offer(pay = 10.0, dist = 3.0), cfg)
         assertTrue(result.warnings.isEmpty())
     }
+
+    // -------------------------------------------------------------------------
+    // Operating cost — full breakdown (#145)
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `operating cost - subtracts all cost components from gross pay`() {
+        // Construct a fully-populated economy and verify each per-mile component
+        // contributes to net pay. Distance = 10 mi so per-mile values translate
+        // directly to dollar amounts.
+        val economy = UserEconomy(
+            vehicleClass = VehicleClass.SEDAN,
+            vehicleMpg = 35.0, gasPricePerGallon = 3.50,          // fuel: $0.10/mi → $1.00
+            tireSetCost = 800.0, tireLifetimeMi = 40_000.0,       // tires: $0.02/mi → $0.20
+            oilCost = 60.0, oilIntervalMi = 5_000.0,              // oil: $0.012/mi → $0.12
+            brakesCost = 400.0, brakesIntervalMi = 40_000.0,      // brakes: $0.01/mi → $0.10
+            fluidsCost = 150.0, fluidsIntervalMi = 30_000.0,      // fluids: $0.005/mi → $0.05
+            miscYearly = 600.0, miscYearlyMi = 12_000.0,          // misc: $0.05/mi → $0.50
+            includeDepreciation = true,
+            purchasePrice = 28_000.0, totalLifetimeMi = 200_000.0, // depr: $0.14/mi → $1.40
+            insuranceDeltaPerMonth = 30.0,
+            expectedAnnualDashMiles = 10_000.0,                    // insurance: $0.036/mi → $0.36
+            registrationDeltaPerYear = 100.0,                      // reg: $0.01/mi → $0.10
+            phonePlanTotal = 80.0, phonePlanLines = 4, phoneDashPercent = 30.0, // phone: $0.0072/mi → $0.072
+        )
+        val cfg = EvaluationConfig(rules = listOf(metricRule(MetricType.PAYOUT, 10.0f)), userEconomy = economy)
+        val result = evaluator.evaluate(offer(pay = 10.0, dist = 10.0), cfg)
+        // Total expected: 1.00 + 0.20 + 0.12 + 0.10 + 0.05 + 0.50 + 1.40 + 0.36 + 0.10 + 0.072 = 3.902
+        assertEquals(1.00, result.fuelCostEstimate, 0.001)
+        assertEquals(2.902, result.nonFuelCostEstimate, 0.01)
+        assertEquals(3.902, result.totalOperatingCost, 0.01)
+        assertEquals(10.0 - 3.902, result.netPayAmount, 0.01)
+    }
+
+    @Test
+    fun `operating cost - depreciation toggle off excludes depreciation`() {
+        val economy = UserEconomy(
+            vehicleClass = VehicleClass.SEDAN,
+            includeDepreciation = false,
+            purchasePrice = 28_000.0, totalLifetimeMi = 200_000.0,
+        )
+        val cfg = EvaluationConfig(rules = listOf(metricRule(MetricType.PAYOUT, 10.0f)), userEconomy = economy)
+        val result = evaluator.evaluate(offer(pay = 10.0, dist = 10.0), cfg)
+        // Depreciation would be $0.14/mi × 10 = $1.40; with toggle off it's $0.
+        assertEquals(0.0, result.nonFuelCostEstimate, 0.001)
+    }
+
+    @Test
+    fun `operating cost - amortizes insurance delta correctly`() {
+        // $30/mo × 12 / 10k dash mi = $0.036/mi; 5-mi offer → $0.18 insurance cost
+        val economy = UserEconomy(
+            vehicleClass = VehicleClass.SEDAN,
+            insuranceDeltaPerMonth = 30.0,
+            expectedAnnualDashMiles = 10_000.0,
+        )
+        val cfg = EvaluationConfig(rules = listOf(metricRule(MetricType.PAYOUT, 10.0f)), userEconomy = economy)
+        val result = evaluator.evaluate(offer(pay = 10.0, dist = 5.0), cfg)
+        assertEquals(0.18, result.nonFuelCostEstimate, 0.001)
+    }
+
+    @Test
+    fun `operating cost - amortizes registration delta correctly`() {
+        // $100/yr / 10k dash mi = $0.01/mi; 5-mi offer → $0.05 registration cost
+        val economy = UserEconomy(
+            vehicleClass = VehicleClass.SEDAN,
+            registrationDeltaPerYear = 100.0,
+            expectedAnnualDashMiles = 10_000.0,
+        )
+        val cfg = EvaluationConfig(rules = listOf(metricRule(MetricType.PAYOUT, 10.0f)), userEconomy = economy)
+        val result = evaluator.evaluate(offer(pay = 10.0, dist = 5.0), cfg)
+        assertEquals(0.05, result.nonFuelCostEstimate, 0.001)
+    }
+
+    @Test
+    fun `operating cost - amortizes phone correctly`() {
+        // $80/mo plan / 4 lines = $20/mo your share × 30% dashing = $6/mo
+        // × 12 = $72/yr / 10k dash mi = $0.0072/mi; 10-mi offer → $0.072
+        val economy = UserEconomy(
+            vehicleClass = VehicleClass.SEDAN,
+            phonePlanTotal = 80.0,
+            phonePlanLines = 4,
+            phoneDashPercent = 30.0,
+            expectedAnnualDashMiles = 10_000.0,
+        )
+        val cfg = EvaluationConfig(rules = listOf(metricRule(MetricType.PAYOUT, 10.0f)), userEconomy = economy)
+        val result = evaluator.evaluate(offer(pay = 10.0, dist = 10.0), cfg)
+        assertEquals(0.072, result.nonFuelCostEstimate, 0.001)
+    }
+
+    @Test
+    fun `operating cost - phone not affected by vehicle class change`() {
+        // Same phone setup; only the vehicleClass differs. Phone cost should be identical.
+        val sedanEco = UserEconomy(vehicleClass = VehicleClass.SEDAN, phonePlanTotal = 100.0, phoneDashPercent = 50.0)
+        val truckEco = UserEconomy(vehicleClass = VehicleClass.TRUCK, phonePlanTotal = 100.0, phoneDashPercent = 50.0)
+        assertEquals(sedanEco.phoneCostPerMile, truckEco.phoneCostPerMile, 0.0001)
+    }
+
+    @Test
+    fun `operating cost - zero expected annual dash miles does not divide by zero`() {
+        // expectedAnnualDashMiles = 0 should be coerced; result must be finite.
+        val economy = UserEconomy(
+            vehicleClass = VehicleClass.SEDAN,
+            insuranceDeltaPerMonth = 30.0,
+            registrationDeltaPerYear = 100.0,
+            phonePlanTotal = 80.0,
+            expectedAnnualDashMiles = 0.0,
+        )
+        val cfg = EvaluationConfig(rules = listOf(metricRule(MetricType.PAYOUT, 10.0f)), userEconomy = economy)
+        val result = evaluator.evaluate(offer(pay = 10.0, dist = 5.0), cfg)
+        // Should not be NaN/Infinity; finite even if large
+        assertTrue(result.nonFuelCostEstimate.isFinite())
+    }
+
+    @Test
+    fun `operating cost - e-bike preset yields zero operating cost`() {
+        // E_BIKE has all preset cost constants at zero/sentinel. UserEconomy default
+        // construction with E_BIKE class still has zero domain defaults for the
+        // paired fields, so total operating cost should be zero.
+        val economy = UserEconomy(vehicleClass = VehicleClass.E_BIKE)
+        assertEquals(0.0, economy.fuelCostPerMile, 0.0001)
+        assertEquals(0.0, economy.operatingCostPerMile, 0.0001)
+    }
+
+    @Test
+    fun `operating cost - EV has non-fuel costs but zero fuel cost`() {
+        // EV: no fuel, but real tires/brakes/depreciation.
+        val economy = UserEconomy(
+            vehicleClass = VehicleClass.EV,
+            tireSetCost = 1_000.0, tireLifetimeMi = 35_000.0,
+            includeDepreciation = true,
+            purchasePrice = 40_000.0, totalLifetimeMi = 200_000.0,
+        )
+        assertEquals(0.0, economy.fuelCostPerMile, 0.0001)
+        assertTrue("EV non-fuel cost should be positive", economy.nonFuelCostPerMile > 0.0)
+    }
+
+    @Test
+    fun `operating cost - isUsingDefaults true when userSetFields empty`() {
+        val economy = UserEconomy(vehicleClass = VehicleClass.SEDAN)
+        assertTrue(economy.isUsingDefaults)
+    }
+
+    @Test
+    fun `operating cost - isUsingDefaults false when every field is user-set`() {
+        val allFields = EconomyField.entries.toSet()
+        val economy = UserEconomy(vehicleClass = VehicleClass.SEDAN, userSetFields = allFields)
+        assertEquals(false, economy.isUsingDefaults)
+    }
+
+    @Test
+    fun `operating cost - breakdown sums to total`() {
+        // Invariant: fuelCostEstimate + nonFuelCostEstimate == totalOperatingCost
+        val economy = UserEconomy(
+            vehicleClass = VehicleClass.SEDAN,
+            vehicleMpg = 30.0, gasPricePerGallon = 3.50,
+            tireSetCost = 800.0, tireLifetimeMi = 40_000.0,
+            oilCost = 60.0, oilIntervalMi = 5_000.0,
+            includeDepreciation = true,
+            purchasePrice = 28_000.0, totalLifetimeMi = 200_000.0,
+        )
+        val cfg = EvaluationConfig(rules = listOf(metricRule(MetricType.PAYOUT, 10.0f)), userEconomy = economy)
+        val result = evaluator.evaluate(offer(pay = 10.0, dist = 7.5), cfg)
+        assertEquals(
+            result.totalOperatingCost,
+            result.fuelCostEstimate + result.nonFuelCostEstimate,
+            0.0001,
+        )
+    }
+
+    @Test
+    fun `operating cost - evaluator carries isUsingDefaults through to result`() {
+        val partial = UserEconomy(
+            vehicleClass = VehicleClass.SEDAN,
+            userSetFields = setOf(EconomyField.VEHICLE_CLASS, EconomyField.GAS_PRICE),
+        )
+        val cfg = EvaluationConfig(rules = listOf(metricRule(MetricType.PAYOUT, 10.0f)), userEconomy = partial)
+        val result = evaluator.evaluate(offer(pay = 10.0, dist = 5.0), cfg)
+        assertTrue(result.isUsingDefaults)
+    }
 }


### PR DESCRIPTION
Closes #145.

## Summary
Expands the OfferEvaluator beyond gas-only cost to a full operating-cost model. Drivers can now enter every real cost in **human units they actually know** (tire set price + lifetime miles, oil change cost + interval, monthly insurance delta, phone plan + dash %, etc.) and DashBuddy converts to per-mile internally to show honest net pay.

## Cost model
Per-mile components (sum = \`operatingCostPerMile\`):
| Component | Human inputs |
|-----------|--------------|
| Fuel | gas $/gal, MPG |
| Tires | set $, lifetime mi |
| Oil | cost/change, interval mi |
| Brakes | cost/job, interval mi |
| Fluids | cost/service, interval mi |
| Misc repairs | yearly $, yearly mi |
| Depreciation (toggle) | purchase price, total lifetime mi |
| Insurance delta | $/month for dashing |
| Registration delta | $/year for dashing |
| Phone & data | total plan, # lines, % use for dashing |

Time-fixed costs are amortized via \`expectedAnnualDashMiles\` so insurance/registration/phone become per-mile rates.

## What landed

- **Domain**: new \`VehicleClass\` enum (Compact/Sedan/SUV/Truck/Luxury/EV/Motorcycle/E-Bike) replacing \`VehicleType\`. Each class carries IRS-aligned cost defaults so users get sane numbers out of the box without configuring anything. New \`EconomyField\` enum tracks which fields the user has explicitly set. \`UserEconomy\` rewritten with 18 new fields + derived per-mile getters. \`OfferEvaluation\` carries the full cost breakdown.
- **OfferEvaluator**: deducts the full operating cost. All 200 tests pass (188 existing rewritten for new schema + 12 new for cost-component math, isUsingDefaults tracking, e-bike/EV special cases, breakdown invariants).
- **EPA VClass auto-mapping**: \`VehicleDetailsResponse\` DTO extracts EPA's VClass field; new \`VClassMap.kt\` maps strings like "Midsize Cars"/"Standard SUV"/"Pickup Trucks" to our \`VehicleClass\`. EVs are detected via fuel type. New \`VClassMapTest\` covers all observed EPA strings.
- **Persistence**: 20 new DataStore keys, single \`USER_SET_ECONOMY_FIELDS\` string-set tracks per-field user-set state. \`AppPreferencesRepository.userEconomy\` combines 22 source flows with class-derived fallbacks. Soft migration from legacy \`vehicle_type\` (CAR→SEDAN) baked into the read path.
- **UI components** (shared between wizard + settings): \`EconomyAccordionRow\` (collapsible row with \"(default)\" badge), \`PairedCurrencyAndIntervalInput\` (two-field row for cost + interval), \`CurrencyInput\` + \`IntegerInput\`.
- **Wizard**: new \`ECONOMY_COSTS\` step after \`GAS_PRICE\` (total wizard now 8 steps). \`EconomyCostsCard\` lays out vehicle-class chips + 10 accordion sections + expected-annual-dash-miles slider + live \"Your true cost: $X.XX/mi\" footer vs IRS reference. Class switch auto-shifts unset defaults; user-set values are preserved.
- **Settings**: new \`EconomySettingsScreen\` (mirrors wizard accordion). \"Personal Economy\" nav row on Settings home shows live $/mi + \"N defaults\" badge. \"Reset to defaults\" action available.
- **Bubble HUD + FakeOfferCard**: show net pay with separate \"−$ fuel\" and \"−$ wear & fixed costs\" rows. Append \"(est.)\" hint when \`evaluation.isUsingDefaults\`.

## Decisions reflected
- Depreciation **on by default**, with explicit purchase price + lifetime miles (\"total expected miles from new\") and toggle to disable.
- All cost fields presented in **human units, never $/mi sliders**.
- Vehicle class **chosen up front in the wizard**, drives all defaults. User can later switch class in settings — unset fields shift to the new class's presets, user-set values stay.
- Phone & data tracked separately from vehicle costs (not driven by class); asks for total plan + lines + dash %.
- One **review-step + tweak-inline** wizard pattern (single accordion screen) instead of N micro-steps. Onboarding stays ~8 steps.

## Test plan
- [x] \`./gradlew :domain:test\` — 200 OfferEvaluator tests + UserEconomy invariants pass
- [x] \`./gradlew :core:network:testDebugUnitTest\` — VClassMap tests pass
- [x] \`./gradlew testDebugUnitTest\` — full sweep green
- [ ] On-device: run wizard, switch vehicle class mid-flow, verify unset cost fields shift to new defaults while customized ones persist
- [ ] On-device: expand each accordion section in Personal Economy settings, edit, verify the \"(default)\" badge disappears + live $/mi total updates
- [ ] On-device: trigger a fake offer via Strategy Settings simulator, verify FakeOfferCard shows the full cost breakdown
- [ ] On-dash: bubble HUD EvalSummary should show smaller net pay than before (now deducting wear & fixed costs) and \"Cost: −$X.XX fuel · −$X.XX wear\" row

🤖 Generated with [Claude Code](https://claude.com/claude-code)