### PR TITLE
feat(#257): bubble HUD flow-card stack + AppEvent payload enrichment

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleScreen.kt
@@ -61,6 +61,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
 import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
+import cloud.trotter.dashbuddy.domain.model.cards.CardStack
 import cloud.trotter.dashbuddy.domain.model.chat.ChatMessage
 import cloud.trotter.dashbuddy.domain.model.chat.ChatPersona
 import cloud.trotter.dashbuddy.domain.state.Flow
@@ -68,7 +69,9 @@ import cloud.trotter.dashbuddy.domain.state.FlowRegion
 import cloud.trotter.dashbuddy.domain.state.Mode
 import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.domain.state.PlatformRegion
+import cloud.trotter.dashbuddy.ui.bubble.cards.FlowCardItem
 import cloud.trotter.dashbuddy.ui.formatters.getIconResId
+import androidx.compose.runtime.mutableStateMapOf
 import java.util.Date
 import java.util.concurrent.TimeUnit
 
@@ -84,7 +87,7 @@ fun BubbleScreen(
     val sessionMiles by viewModel.sessionMiles.collectAsState()
     val sessionEarnings by viewModel.sessionEarnings.collectAsState()
     val lastSessionSummary by viewModel.lastSessionSummary.collectAsState()
-    val lastAcceptedOfferPay by viewModel.lastAcceptedOfferPay.collectAsState()
+    val cardStack by viewModel.cardStack.collectAsState()
     var showFullChat by remember { mutableStateOf(false) }
 
     val flow = appState.regions.flow
@@ -133,14 +136,10 @@ fun BubbleScreen(
                 FullChatView(messages)
             } else {
                 DashboardView(
+                    cardStack = cardStack,
                     region = focusedRegion,
-                    flow = flow,
-                    focusedPlatform = focusedPlatform,
                     messages = messages,
                     lastSessionSummary = lastSessionSummary,
-                    sessionEarnings = sessionEarnings,
-                    sessionMiles = sessionMiles,
-                    lastAcceptedOfferPay = lastAcceptedOfferPay,
                     onOpenChat = { showFullChat = true }
                 )
             }
@@ -154,32 +153,83 @@ fun BubbleScreen(
 
 @Composable
 fun DashboardView(
+    cardStack: CardStack,
     region: PlatformRegion?,
-    flow: FlowRegion,
-    focusedPlatform: Platform?,
     messages: List<ChatMessage>,
     lastSessionSummary: SessionSummary?,
-    sessionEarnings: Double,
-    sessionMiles: Double,
-    lastAcceptedOfferPay: Double?,
     onOpenChat: () -> Unit
 ) {
+    val expandedIds = remember { mutableStateMapOf<String, Boolean>() }
+    val listState = rememberLazyListState()
+
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(horizontal = 16.dp, vertical = 8.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp)
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        ModeCard(
-            region = region,
-            flow = flow,
-            lastSessionSummary = lastSessionSummary,
-            sessionEarnings = sessionEarnings,
-            sessionMiles = sessionMiles,
-            lastAcceptedOfferPay = lastAcceptedOfferPay,
-            modifier = Modifier.fillMaxWidth()
-        )
-        Spacer(modifier = Modifier.weight(1f))
+        when {
+            cardStack.isEmpty && (region == null || region.mode == Mode.Offline) -> {
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+                    elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
+                ) {
+                    Box(modifier = Modifier.padding(16.dp)) {
+                        ModeIdle(lastSessionSummary)
+                    }
+                }
+                Spacer(modifier = Modifier.weight(1f))
+            }
+            cardStack.isEmpty -> {
+                Text(
+                    text = "Waiting for activity…",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.weight(1f))
+            }
+            else -> {
+                // reverseLayout = true pins the active card to the bottom of
+                // the viewport and grows the history upward. Items are
+                // declared in reverse chronological order (active first,
+                // then completed newest→oldest) so that visually:
+                //   top    = oldest completed card
+                //   middle = newer completed cards
+                //   bottom = active (live) card
+                // No autoscroll required — Compose naturally keeps the
+                // first-declared item (the active card) at the bottom.
+                LazyColumn(
+                    modifier = Modifier.weight(1f),
+                    state = listState,
+                    reverseLayout = true,
+                    verticalArrangement = Arrangement.spacedBy(6.dp),
+                ) {
+                    cardStack.active?.let { live ->
+                        item(key = "live:${live.id}") {
+                            FlowCardItem(
+                                snapshot = live,
+                                isActive = true,
+                                expanded = true,
+                                onToggleExpand = { /* active always expanded */ },
+                            )
+                        }
+                    }
+                    items(
+                        items = cardStack.completed.asReversed(),
+                        key = { it.id },
+                    ) { snap ->
+                        val expanded = expandedIds[snap.id] == true
+                        FlowCardItem(
+                            snapshot = snap,
+                            isActive = false,
+                            expanded = expanded,
+                            onToggleExpand = { expandedIds[snap.id] = !expanded },
+                        )
+                    }
+                }
+            }
+        }
         LatestMessageTicker(messages = messages, onClick = onOpenChat)
     }
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleViewModel.kt
@@ -3,7 +3,9 @@ package cloud.trotter.dashbuddy.ui.bubble
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import cloud.trotter.dashbuddy.core.data.chat.ChatRepository
+import cloud.trotter.dashbuddy.core.data.event.AppEventRepo
 import cloud.trotter.dashbuddy.core.data.location.OdometerRepository
+import cloud.trotter.dashbuddy.domain.model.cards.CardStack
 import cloud.trotter.dashbuddy.domain.state.AppState
 import cloud.trotter.dashbuddy.domain.state.Flow
 import cloud.trotter.dashbuddy.domain.state.FlowRegion
@@ -11,6 +13,8 @@ import cloud.trotter.dashbuddy.domain.state.Mode
 import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.domain.state.PlatformRegion
 import cloud.trotter.dashbuddy.core.state.StateManagerV2
+import cloud.trotter.dashbuddy.ui.bubble.cards.FlowCardMapper
+import cloud.trotter.dashbuddy.ui.bubble.cards.LiveCardBuilder
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.SharingStarted
@@ -34,7 +38,8 @@ class BubbleViewModel @Inject constructor(
     private val bubbleManager: BubbleManager,
     private val chatRepository: ChatRepository,
     odometerRepository: OdometerRepository,
-    stateManager: StateManagerV2
+    stateManager: StateManagerV2,
+    appEventRepo: AppEventRepo,
 ) : ViewModel() {
 
     // Current app state — drives the mode card in the HUD
@@ -105,6 +110,33 @@ class BubbleViewModel @Inject constructor(
             flowOf(emptyList())
         }
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    // Dash whose event log feeds the card stack — the current active dash
+    // when one is running, otherwise the most-recently-completed one so the
+    // post-dash review stays visible until the next DASH_START.
+    private val displayedDashId = bubbleManager.activeDashId
+        .scan(null as String?) { last, current -> current ?: last }
+
+    /**
+     * Bubble HUD flow-card stack (#257). Completed cards are folded from
+     * the AppEvent log scoped to [displayedDashId]; the live card is built
+     * from current [appState]. A new dash clears the stack via DASH_START's
+     * fold logic, so the user can review the previous dash's cards until
+     * they go Online again.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val cardStack = combine(
+        stateManager.state,
+        displayedDashId.flatMapLatest { dashId ->
+            if (dashId != null) appEventRepo.getEventsForDash(dashId)
+            else flowOf(emptyList())
+        },
+    ) { state, events ->
+        CardStack(
+            completed = FlowCardMapper.fold(events),
+            active = LiveCardBuilder.build(state),
+        )
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), CardStack.Empty)
 
     // Real-time session miles from GPS odometer
     val sessionMiles = odometerRepository.sessionMilesFlow

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardItem.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardItem.kt
@@ -1,0 +1,560 @@
+package cloud.trotter.dashbuddy.ui.bubble.cards
+
+import android.text.format.DateFormat
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import cloud.trotter.dashbuddy.domain.model.cards.FlowCardSnapshot
+import cloud.trotter.dashbuddy.domain.model.event.AppEventType
+import kotlinx.coroutines.delay
+import java.util.Date
+import java.util.concurrent.TimeUnit
+
+/**
+ * A single flow-phase card in the bubble HUD stack (#257).
+ *
+ * Visual structure:
+ * - Header: phase chip + summary line (always visible) + chevron when frozen.
+ * - Body: minimal — one hero value, one secondary line, one tertiary line.
+ *   Active cards (`isActive == true`) are always expanded and use the 1Hz
+ *   `rememberNow()` ticker for countdowns. Frozen cards default collapsed
+ *   and expand on tap, rendering statically from the snapshot.
+ */
+@Composable
+fun FlowCardItem(
+    snapshot: FlowCardSnapshot,
+    isActive: Boolean,
+    expanded: Boolean,
+    onToggleExpand: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val effectiveExpanded = isActive || expanded
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = if (isActive) MaterialTheme.colorScheme.surface
+            else MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f),
+        ),
+        elevation = CardDefaults.cardElevation(
+            defaultElevation = if (isActive) 3.dp else 1.dp,
+        ),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .let { if (!isActive) it.clickable { onToggleExpand() } else it }
+                .padding(horizontal = 14.dp, vertical = 10.dp),
+            verticalArrangement = Arrangement.spacedBy(if (effectiveExpanded) 10.dp else 4.dp),
+        ) {
+            CardHeader(snapshot = snapshot, isActive = isActive, expanded = effectiveExpanded)
+            if (effectiveExpanded) {
+                CardBody(snapshot = snapshot, isActive = isActive)
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Header (always visible)
+// ---------------------------------------------------------------------------
+
+@Composable
+private fun CardHeader(
+    snapshot: FlowCardSnapshot,
+    isActive: Boolean,
+    expanded: Boolean,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        PhaseChip(snapshot, isActive)
+        Text(
+            text = cardSummary(snapshot, isActive),
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = if (isActive) FontWeight.SemiBold else FontWeight.Normal,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.weight(1f),
+            maxLines = 1,
+        )
+        // Trailing status chip — shown in the header so collapsed cards
+        // surface the outcome at a glance.
+        if (snapshot is FlowCardSnapshot.Offer) {
+            snapshot.outcome?.let { OutcomeChip(it) }
+        }
+        if (!isActive) {
+            Icon(
+                imageVector = if (expanded) Icons.Default.KeyboardArrowDown
+                else Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = if (expanded) "Collapse" else "Expand",
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(18.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun PhaseChip(snapshot: FlowCardSnapshot, isActive: Boolean) {
+    val (label, color) = when (snapshot) {
+        is FlowCardSnapshot.Awaiting -> "AWAIT" to MaterialTheme.colorScheme.tertiary
+        is FlowCardSnapshot.Offer -> "OFFER" to MaterialTheme.colorScheme.primary
+        is FlowCardSnapshot.Pickup -> "PICKUP" to MaterialTheme.colorScheme.secondary
+        is FlowCardSnapshot.Delivery -> "DROP" to MaterialTheme.colorScheme.secondary
+        is FlowCardSnapshot.PostTask -> "PAID" to MaterialTheme.colorScheme.primary
+    }
+    Surface(
+        shape = RoundedCornerShape(4.dp),
+        color = color.copy(alpha = if (isActive) 0.22f else 0.14f),
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = color,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Summary (one-line, always visible in header)
+// ---------------------------------------------------------------------------
+
+@Composable
+private fun cardSummary(snapshot: FlowCardSnapshot, isActive: Boolean): String = when (snapshot) {
+    is FlowCardSnapshot.Awaiting -> awaitingSummary(snapshot, isActive)
+    is FlowCardSnapshot.Offer -> offerSummary(snapshot)
+    is FlowCardSnapshot.Pickup -> pickupSummary(snapshot, isActive)
+    is FlowCardSnapshot.Delivery -> deliverySummary(snapshot, isActive)
+    is FlowCardSnapshot.PostTask -> postTaskSummary(snapshot)
+}
+
+@Composable
+private fun awaitingSummary(snap: FlowCardSnapshot.Awaiting, isActive: Boolean): String {
+    val now = if (isActive) rememberNow().value else (snap.phaseEndedAt ?: snap.phaseStartedAt)
+    val elapsed = now - snap.phaseStartedAt
+    return if (isActive) "Waiting · ${formatDuration(elapsed)}" else "Waited ${formatDuration(elapsed)}"
+}
+
+private fun offerSummary(snap: FlowCardSnapshot.Offer): String {
+    val store = snap.storeNames.firstOrNull()?.takeIf { it.isNotBlank() } ?: "Offer"
+    val pay = snap.payAmount?.let { " · $%.2f".format(it) } ?: ""
+    // Outcome is rendered as a trailing chip in the header — see
+    // CardHeader — so we omit it from the summary text.
+    return "$store$pay"
+}
+
+@Composable
+private fun pickupSummary(snap: FlowCardSnapshot.Pickup, isActive: Boolean): String {
+    val store = snap.storeName
+    val arrivedAt = snap.arrivedAt
+    return when {
+        isActive -> store
+        arrivedAt != null -> "$store · arrived ${formatTime(arrivedAt)}"
+        else -> store
+    }
+}
+
+@Composable
+private fun deliverySummary(snap: FlowCardSnapshot.Delivery, isActive: Boolean): String {
+    val customer = snap.customerHash?.take(6) ?: "Customer"
+    val arrivedAt = snap.arrivedAt
+    return when {
+        isActive -> customer
+        arrivedAt != null -> "$customer · delivered ${formatTime(arrivedAt)}"
+        else -> customer
+    }
+}
+
+private fun postTaskSummary(snap: FlowCardSnapshot.PostTask): String {
+    val store = snap.storeName?.let { "$it · " } ?: ""
+    return "$store$%.2f".format(snap.totalPay)
+}
+
+// ---------------------------------------------------------------------------
+// Body (expanded content) — minimal density per phase
+// ---------------------------------------------------------------------------
+
+@Composable
+private fun CardBody(snapshot: FlowCardSnapshot, isActive: Boolean) {
+    when (snapshot) {
+        is FlowCardSnapshot.Awaiting -> AwaitingBody(snapshot, isActive)
+        is FlowCardSnapshot.Offer -> OfferBody(snapshot, isActive)
+        is FlowCardSnapshot.Pickup -> PickupBody(snapshot, isActive)
+        is FlowCardSnapshot.Delivery -> DeliveryBody(snapshot, isActive)
+        is FlowCardSnapshot.PostTask -> PostTaskBody(snapshot)
+    }
+}
+
+@Composable
+private fun AwaitingBody(snap: FlowCardSnapshot.Awaiting, isActive: Boolean) {
+    val now = if (isActive) rememberNow().value else (snap.phaseEndedAt ?: snap.phaseStartedAt)
+    val elapsed = now - snap.phaseStartedAt
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        HeroBig(if (isActive) formatDuration(elapsed) else formatDuration(elapsed))
+        Caption(
+            if (isActive) "since last offer"
+            else "before next offer"
+        )
+    }
+}
+
+/**
+ * Offer body: hero is **Net $/hr** (the "is this worth my time" number).
+ * Subtitle = net pay · miles. Third row = store · score chip.
+ */
+@Composable
+private fun OfferBody(snap: FlowCardSnapshot.Offer, isActive: Boolean) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        val hourly = snap.dollarsPerHour
+        if (hourly != null) {
+            HeroBig("$%.2f/hr".format(hourly))
+        } else if (snap.payAmount != null) {
+            HeroBig("$%.2f".format(snap.payAmount))
+        }
+        val net = snap.netPayAmount ?: snap.payAmount
+        val miles = snap.distanceMiles
+        val secondary = buildString {
+            if (net != null) append("Net $%.2f".format(net))
+            if (miles != null) {
+                if (isNotEmpty()) append(" · ")
+                append("%.1f mi".format(miles))
+            }
+            snap.dollarsPerMile?.let {
+                if (isNotEmpty()) append(" · ")
+                append("$%.2f/mi".format(it))
+            }
+        }
+        if (secondary.isNotBlank()) Caption(secondary)
+        val storeText = snap.storeNames.joinToString(" & ").ifBlank { null }
+        val tertiary = buildString {
+            storeText?.let { append(it) }
+            if (snap.itemCount > 1) {
+                if (isNotEmpty()) append(" · ")
+                append("${snap.itemCount} items")
+            }
+        }
+        if (tertiary.isNotBlank()) Caption(tertiary)
+
+        // Score chip — outcome chip lives in the header so collapsed
+        // cards surface accept/decline at a glance.
+        val score = snap.evaluationScore
+        val action = snap.evaluationAction
+        score?.let {
+            Row(modifier = Modifier.padding(top = 4.dp)) {
+                ScoreChip(it.toInt(), action)
+            }
+        }
+    }
+}
+
+/**
+ * Pickup body: hero is the **countdown to pickup-by deadline**, colored
+ * green/amber/red. When no deadline is parsed, falls back to elapsed time.
+ * Frozen cards show a "+Xm ahead" / "Xm late" delta vs the deadline plus
+ * arrival info.
+ */
+@Composable
+private fun PickupBody(snap: FlowCardSnapshot.Pickup, isActive: Boolean) {
+    DeadlineBody(
+        phaseStartedAt = snap.phaseStartedAt,
+        arrivedAt = snap.arrivedAt,
+        deadlineMillis = snap.deadlineMillis,
+        phaseEndedAt = snap.phaseEndedAt,
+        isActive = isActive,
+        primary = snap.storeName,
+        confirmedAt = snap.confirmedAt,
+        itemCount = snap.itemCount,
+        deadlineLabel = "till pickup-by",
+    )
+}
+
+/**
+ * Delivery body: same shape as Pickup but with deliver-by deadline and
+ * customer hash instead of store name.
+ */
+@Composable
+private fun DeliveryBody(snap: FlowCardSnapshot.Delivery, isActive: Boolean) {
+    DeadlineBody(
+        phaseStartedAt = snap.phaseStartedAt,
+        arrivedAt = snap.arrivedAt,
+        deadlineMillis = snap.deadlineMillis,
+        phaseEndedAt = snap.phaseEndedAt,
+        isActive = isActive,
+        primary = snap.customerHash?.take(6) ?: "Customer",
+        confirmedAt = null,
+        itemCount = null,
+        deadlineLabel = "till deliver-by",
+    )
+}
+
+/**
+ * Shared body for Pickup + Delivery — both have a deadline + arrival
+ * lifecycle. Hero is countdown-to-deadline while active; "+Xm ahead" /
+ * "Xm late" once frozen.
+ */
+@Composable
+private fun DeadlineBody(
+    phaseStartedAt: Long,
+    arrivedAt: Long?,
+    deadlineMillis: Long?,
+    phaseEndedAt: Long?,
+    isActive: Boolean,
+    primary: String,
+    confirmedAt: Long?,
+    itemCount: Int?,
+    deadlineLabel: String,
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        val now = if (isActive) rememberNow().value else (phaseEndedAt ?: phaseStartedAt)
+
+        if (deadlineMillis != null) {
+            val remaining = deadlineMillis - now
+            val color = deadlineColor(remaining)
+            if (isActive) {
+                HeroBig(text = formatCountdown(remaining), color = color)
+                Caption(deadlineLabel)
+            } else {
+                val arrivalRemaining = arrivedAt?.let { deadlineMillis - it }
+                if (arrivalRemaining != null) {
+                    val deltaLabel = if (arrivalRemaining >= 0)
+                        "+${formatCountdown(arrivalRemaining)} ahead"
+                    else
+                        "${formatCountdown(-arrivalRemaining)} late"
+                    HeroBig(text = deltaLabel, color = deadlineColor(arrivalRemaining))
+                    Caption("vs $deadlineLabel")
+                } else {
+                    HeroBig("—")
+                    Caption(deadlineLabel)
+                }
+            }
+        } else if (isActive) {
+            // No deadline parsed — fall back to elapsed time
+            HeroBig(formatDuration(now - phaseStartedAt))
+            Caption(if (arrivedAt == null) "en route" else "at stop")
+        }
+
+        // Tertiary row — store/customer + arrival time + items
+        val tertiary = buildString {
+            append(primary)
+            arrivedAt?.let {
+                append(" · arrived ${formatTime(it)}")
+            }
+            confirmedAt?.let {
+                append(" · picked up ${formatTime(it)}")
+            }
+            itemCount?.let {
+                if (it > 0) append(" · ${it}i")
+            }
+        }
+        Caption(tertiary)
+    }
+}
+
+/**
+ * PostTask body: receipt-style. Hero is total pay. Below: per-item
+ * breakdown (base + tip) shown compactly.
+ */
+@Composable
+private fun PostTaskBody(snap: FlowCardSnapshot.PostTask) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        HeroBig("$%.2f".format(snap.totalPay))
+        Caption("delivery total")
+        snap.parsedPay?.let { pay ->
+            Column(
+                modifier = Modifier.padding(top = 6.dp),
+                verticalArrangement = Arrangement.spacedBy(2.dp),
+            ) {
+                pay.appPayComponents.forEach { item ->
+                    BreakdownRow(item.type, "$%.2f".format(item.amount))
+                }
+                pay.customerTips.forEach { tip ->
+                    BreakdownRow("tip · ${tip.type}", "$%.2f".format(tip.amount))
+                }
+            }
+        }
+        snap.sessionEarningsAtCompletion?.let {
+            Caption("session $%.2f".format(it))
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Primitives
+// ---------------------------------------------------------------------------
+
+@Composable
+private fun HeroBig(text: String, color: Color = MaterialTheme.colorScheme.onSurface) {
+    Text(
+        text = text,
+        fontSize = 30.sp,
+        fontWeight = FontWeight.ExtraBold,
+        color = color,
+        maxLines = 1,
+    )
+}
+
+@Composable
+private fun Caption(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        maxLines = 1,
+    )
+}
+
+@Composable
+private fun BreakdownRow(label: String, value: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(label, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Text(value, style = MaterialTheme.typography.bodySmall, fontWeight = FontWeight.Medium, color = MaterialTheme.colorScheme.onSurface)
+    }
+}
+
+@Composable
+private fun ScoreChip(score: Int, action: String?) {
+    val color = when {
+        score >= 70 -> Color(0xFF2E7D32)
+        score <= 30 -> Color(0xFFC62828)
+        else -> Color(0xFFF9A825)
+    }
+    Surface(
+        shape = RoundedCornerShape(4.dp),
+        color = color.copy(alpha = 0.16f),
+    ) {
+        Text(
+            text = if (action != null) "$score · $action" else score.toString(),
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.Bold,
+            color = color,
+            modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
+        )
+    }
+}
+
+@Composable
+private fun OutcomeChip(outcome: AppEventType) {
+    val (text, color) = when (outcome) {
+        AppEventType.OFFER_ACCEPTED -> "Accepted" to Color(0xFF2E7D32)
+        AppEventType.OFFER_DECLINED -> "Declined" to Color(0xFFC62828)
+        AppEventType.OFFER_TIMEOUT -> "Timed out" to Color(0xFF6D6D6D)
+        else -> outcome.name to MaterialTheme.colorScheme.onSurfaceVariant
+    }
+    Surface(
+        shape = RoundedCornerShape(4.dp),
+        color = color.copy(alpha = 0.16f),
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.Bold,
+            color = color,
+            modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
+        )
+    }
+}
+
+@Composable
+private fun deadlineColor(remainingMs: Long): Color {
+    val mins = remainingMs / 60_000L
+    return when {
+        remainingMs < 0 -> Color(0xFFC62828)              // past — red
+        mins < 5 -> Color(0xFFC62828)                     // <5m — red
+        mins < 10 -> Color(0xFFF9A825)                    // 5-10m — amber
+        else -> Color(0xFF2E7D32)                          // >10m — green
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Time helpers
+// ---------------------------------------------------------------------------
+
+/** 1Hz tick; scoped to this composable. See CLAUDE.md ▸ Reactive UI Principles. */
+@Composable
+internal fun rememberNow(tickMs: Long = 1000L): State<Long> =
+    produceState(initialValue = System.currentTimeMillis()) {
+        while (true) {
+            delay(tickMs)
+            value = System.currentTimeMillis()
+        }
+    }
+
+@Composable
+internal fun rememberFormattedTime(): (Long) -> String {
+    val ctx = LocalContext.current
+    val use24 = DateFormat.is24HourFormat(ctx)
+    val pattern = if (use24) "HH:mm" else "h:mm a"
+    return { millis -> DateFormat.format(pattern, Date(millis)).toString() }
+}
+
+@Composable
+private fun formatTime(millis: Long): String = rememberFormattedTime().invoke(millis)
+
+internal fun formatDuration(millis: Long): String {
+    val safe = millis.coerceAtLeast(0)
+    val hours = TimeUnit.MILLISECONDS.toHours(safe)
+    val minutes = TimeUnit.MILLISECONDS.toMinutes(safe) % 60
+    val seconds = TimeUnit.MILLISECONDS.toSeconds(safe) % 60
+    return when {
+        hours > 0 -> "%dh %dm".format(hours, minutes)
+        minutes > 0 -> "%dm %ds".format(minutes, seconds)
+        else -> "%ds".format(seconds)
+    }
+}
+
+/** "m:ss" style countdown for the deadline hero. Handles negatives by
+ *  returning the absolute magnitude — callers add the "ahead/late" label. */
+internal fun formatCountdown(millis: Long): String {
+    val safe = kotlin.math.abs(millis)
+    val totalMinutes = TimeUnit.MILLISECONDS.toMinutes(safe)
+    val seconds = TimeUnit.MILLISECONDS.toSeconds(safe) % 60
+    return "%d:%02d".format(totalMinutes, seconds)
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardMapper.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardMapper.kt
@@ -1,0 +1,276 @@
+package cloud.trotter.dashbuddy.ui.bubble.cards
+
+import cloud.trotter.dashbuddy.core.database.event.AppEventEntity
+import cloud.trotter.dashbuddy.domain.model.cards.FlowCardSnapshot
+import cloud.trotter.dashbuddy.domain.model.event.AppEventType
+import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.OfferPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.OfferReceivedPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.PickupPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStartPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStopPayload
+import com.google.gson.Gson
+import com.google.gson.JsonSyntaxException
+import timber.log.Timber
+
+/**
+ * Pure fold from the AppEvent log to the completed-card list for the bubble
+ * HUD flow-card stack (#257). One linear pass over the events; closing
+ * events (e.g. `OFFER_ACCEPTED`) carry their full phase context via the
+ * rich payload classes wired in `EffectMap.kt`, so the fold itself does
+ * not need to join other entities.
+ *
+ * The active (live) card is NOT produced here — it's built directly from
+ * the current `AppState` by [BubbleViewModel]. This fold only produces
+ * the completed cards above the active one.
+ */
+object FlowCardMapper {
+
+    private val gson = Gson()
+
+    fun fold(events: List<AppEventEntity>): List<FlowCardSnapshot> {
+        val completed = mutableListOf<FlowCardSnapshot>()
+
+        // Open card accumulators — one slot per kind. For v1 we assume a
+        // single delivery in flight at a time; stacked-order support is
+        // tracked separately.
+        var openAwaiting: FlowCardSnapshot.Awaiting? = null
+        var openPickup: FlowCardSnapshot.Pickup? = null
+        var openDelivery: FlowCardSnapshot.Delivery? = null
+        var lastDeliveryArrivedAt: Long? = null
+
+        for (event in events) {
+            when (event.eventType) {
+                AppEventType.DASH_START -> {
+                    // Reset stack — flush any half-open cards, start fresh
+                    completed.clear()
+                    openAwaiting = null
+                    openPickup = null
+                    openDelivery = null
+                    lastDeliveryArrivedAt = null
+
+                    val payload = decode(event, SessionStartPayload::class.java)
+                    openAwaiting = FlowCardSnapshot.Awaiting(
+                        id = "awaiting:${payload?.sessionId ?: event.aggregateId}:${event.occurredAt}",
+                        phaseStartedAt = payload?.startedAt ?: event.occurredAt,
+                        sessionId = payload?.sessionId ?: event.aggregateId,
+                    )
+                }
+
+                AppEventType.OFFER_RECEIVED -> {
+                    // Close the Awaiting card at the moment the offer hit
+                    // the screen. The Offer card itself is built from the
+                    // closing OFFER_ACCEPTED/DECLINED/TIMEOUT event since
+                    // that's where the rich evaluation lands. Prefer the
+                    // payload's presentedAt; fall back to event occurredAt
+                    // for legacy rows where the payload is empty/missing.
+                    val payload = decode(event, OfferReceivedPayload::class.java)
+                    val endedAt = payload?.presentedAt?.takeIf { it > 0 } ?: event.occurredAt
+                    openAwaiting?.let {
+                        completed.add(it.copy(phaseEndedAt = endedAt))
+                        openAwaiting = null
+                    }
+                }
+
+                AppEventType.OFFER_ACCEPTED,
+                AppEventType.OFFER_DECLINED,
+                AppEventType.OFFER_TIMEOUT -> {
+                    val payload = decode(event, OfferPayload::class.java) ?: continue
+                    // Defensive close of Awaiting using the offer's presentedAt.
+                    // The rule-declared OFFER_RECEIVED log effect currently
+                    // doesn't persist to the DB (it only goes to Timber), so
+                    // Awaiting would otherwise hang open until DASH_STOP.
+                    openAwaiting?.let {
+                        completed.add(it.copy(phaseEndedAt = payload.presentedAt))
+                        openAwaiting = null
+                    }
+                    val storeNames = payload.parsedOffer.orders
+                        .map { it.storeName }
+                        .distinct()
+                    completed.add(
+                        FlowCardSnapshot.Offer(
+                            phaseStartedAt = payload.presentedAt,
+                            phaseEndedAt = payload.decidedAt,
+                            offerHash = payload.offerHash,
+                            payAmount = payload.parsedOffer.payAmount,
+                            distanceMiles = payload.parsedOffer.distanceMiles,
+                            itemCount = payload.parsedOffer.itemCount,
+                            storeNames = storeNames,
+                            evaluationScore = payload.evaluation?.score,
+                            evaluationAction = payload.evaluation?.action?.name,
+                            netPayAmount = payload.evaluation?.netPayAmount,
+                            dollarsPerMile = payload.evaluation?.dollarsPerMile,
+                            dollarsPerHour = payload.evaluation?.dollarsPerHour,
+                            outcome = payload.outcome,
+                        )
+                    )
+                }
+
+                AppEventType.PICKUP_NAV_STARTED -> {
+                    val payload = decode(event, PickupPayload::class.java) ?: continue
+                    // If a pickup is already open and matches this taskId, this
+                    // is a follow-up (e.g. store-name resolution) — update.
+                    // Otherwise close any stale one and open a new card.
+                    val current = openPickup
+                    if (current?.taskId == payload.taskId) {
+                        openPickup = current.copy(
+                            storeName = payload.storeName,
+                            itemCount = payload.itemCount ?: current.itemCount,
+                            deadlineMillis = payload.deadlineMillis ?: current.deadlineMillis,
+                            activity = payload.activity ?: current.activity,
+                        )
+                    } else {
+                        openPickup?.let { completed.add(it.copy(phaseEndedAt = event.occurredAt)) }
+                        openPickup = FlowCardSnapshot.Pickup(
+                            phaseStartedAt = payload.phaseStartedAt,
+                            taskId = payload.taskId,
+                            jobId = payload.jobId,
+                            storeName = payload.storeName,
+                            deadlineMillis = payload.deadlineMillis,
+                            itemCount = payload.itemCount,
+                            activity = payload.activity,
+                        )
+                    }
+                }
+
+                AppEventType.PICKUP_ARRIVED -> {
+                    val payload = decode(event, PickupPayload::class.java) ?: continue
+                    val current = openPickup
+                    openPickup = if (current?.taskId == payload.taskId) {
+                        current.copy(
+                            arrivedAt = payload.arrivedAt ?: event.occurredAt,
+                            storeName = payload.storeName.takeIf { it.isNotBlank() } ?: current.storeName,
+                        )
+                    } else {
+                        // No open pickup (probably a recovered session) — synthesize.
+                        FlowCardSnapshot.Pickup(
+                            phaseStartedAt = payload.phaseStartedAt,
+                            taskId = payload.taskId,
+                            jobId = payload.jobId,
+                            storeName = payload.storeName,
+                            arrivedAt = payload.arrivedAt ?: event.occurredAt,
+                            deadlineMillis = payload.deadlineMillis,
+                            itemCount = payload.itemCount,
+                            activity = payload.activity,
+                        )
+                    }
+                }
+
+                AppEventType.PICKUP_CONFIRMED -> {
+                    val payload = decode(event, PickupPayload::class.java) ?: continue
+                    val current = openPickup
+                    val closed = if (current?.taskId == payload.taskId) {
+                        current.copy(
+                            confirmedAt = payload.confirmedAt ?: event.occurredAt,
+                            phaseEndedAt = payload.confirmedAt ?: event.occurredAt,
+                        )
+                    } else {
+                        FlowCardSnapshot.Pickup(
+                            phaseStartedAt = payload.phaseStartedAt,
+                            phaseEndedAt = payload.confirmedAt ?: event.occurredAt,
+                            taskId = payload.taskId,
+                            jobId = payload.jobId,
+                            storeName = payload.storeName,
+                            arrivedAt = payload.arrivedAt,
+                            confirmedAt = payload.confirmedAt ?: event.occurredAt,
+                            deadlineMillis = payload.deadlineMillis,
+                            itemCount = payload.itemCount,
+                            activity = payload.activity,
+                        )
+                    }
+                    completed.add(closed)
+                    openPickup = null
+                }
+
+                AppEventType.DELIVERY_NAV_STARTED -> {
+                    val payload = decode(event, DeliveryPayload::class.java) ?: continue
+                    // Idempotent — if already open with same taskId, leave it
+                    if (openDelivery?.taskId != payload.taskId) {
+                        openDelivery?.let { completed.add(it.copy(phaseEndedAt = event.occurredAt)) }
+                        openDelivery = FlowCardSnapshot.Delivery(
+                            phaseStartedAt = payload.phaseStartedAt,
+                            taskId = payload.taskId,
+                            jobId = payload.jobId,
+                            storeName = payload.storeName,
+                            customerHash = payload.customerHash,
+                            deadlineMillis = payload.deadlineMillis,
+                        )
+                    }
+                }
+
+                AppEventType.DELIVERY_ARRIVED -> {
+                    val payload = decode(event, DeliveryPayload::class.java) ?: continue
+                    val current = openDelivery
+                    val closed = if (current?.taskId == payload.taskId) {
+                        current.copy(
+                            arrivedAt = payload.arrivedAt ?: event.occurredAt,
+                            phaseEndedAt = payload.arrivedAt ?: event.occurredAt,
+                        )
+                    } else {
+                        FlowCardSnapshot.Delivery(
+                            phaseStartedAt = payload.phaseStartedAt,
+                            phaseEndedAt = payload.arrivedAt ?: event.occurredAt,
+                            taskId = payload.taskId,
+                            jobId = payload.jobId,
+                            storeName = payload.storeName,
+                            customerHash = payload.customerHash,
+                            arrivedAt = payload.arrivedAt ?: event.occurredAt,
+                            deadlineMillis = payload.deadlineMillis,
+                        )
+                    }
+                    completed.add(closed)
+                    openDelivery = null
+                    lastDeliveryArrivedAt = payload.arrivedAt ?: event.occurredAt
+                }
+
+                AppEventType.DELIVERY_COMPLETED -> {
+                    val payload = decode(event, DeliveryPayload::class.java) ?: continue
+                    // PostTask card spans from delivery arrival (start of the
+                    // receipt screen) to the dismiss-receipt moment that
+                    // fired DELIVERY_COMPLETED.
+                    val start = lastDeliveryArrivedAt ?: payload.phaseStartedAt
+                    completed.add(
+                        FlowCardSnapshot.PostTask(
+                            phaseStartedAt = start,
+                            phaseEndedAt = payload.completedAt ?: event.occurredAt,
+                            jobId = payload.jobId,
+                            taskId = payload.taskId,
+                            storeName = payload.storeName,
+                            totalPay = payload.totalPay ?: 0.0,
+                            parsedPay = payload.parsedPay,
+                            sessionEarningsAtCompletion = payload.sessionEarningsAtCompletion,
+                        )
+                    )
+                    lastDeliveryArrivedAt = null
+                }
+
+                AppEventType.DASH_STOP -> {
+                    val payload = decode(event, SessionStopPayload::class.java)
+                    val endedAt = payload?.endedAt ?: event.occurredAt
+                    // Flush any half-open cards
+                    openAwaiting?.let { completed.add(it.copy(phaseEndedAt = endedAt)) }
+                    openPickup?.let { completed.add(it.copy(phaseEndedAt = endedAt)) }
+                    openDelivery?.let { completed.add(it.copy(phaseEndedAt = endedAt)) }
+                    openAwaiting = null
+                    openPickup = null
+                    openDelivery = null
+                    lastDeliveryArrivedAt = null
+                }
+
+                else -> {
+                    // Other event types (ZONE_SWITCH, DASH_PAUSED, NOTIFICATION_*,
+                    // SCREEN_VIEWED, ERROR_OCCURRED) don't open or close cards.
+                }
+            }
+        }
+
+        return completed
+    }
+
+    private fun <T> decode(event: AppEventEntity, klass: Class<T>): T? = try {
+        gson.fromJson(event.eventPayload, klass)
+    } catch (e: JsonSyntaxException) {
+        Timber.w(e, "FlowCardMapper: failed to decode %s for %s", klass.simpleName, event.eventType)
+        null
+    }
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/LiveCardBuilder.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/LiveCardBuilder.kt
@@ -1,0 +1,106 @@
+package cloud.trotter.dashbuddy.ui.bubble.cards
+
+import cloud.trotter.dashbuddy.domain.model.cards.FlowCardSnapshot
+import cloud.trotter.dashbuddy.domain.state.AppState
+import cloud.trotter.dashbuddy.domain.state.Flow
+import cloud.trotter.dashbuddy.domain.state.Mode
+import cloud.trotter.dashbuddy.domain.state.TaskPhase
+
+/**
+ * Constructs the live (active) flow card from the current [AppState].
+ *
+ * Unlike [FlowCardMapper.fold], which folds the persisted event log into
+ * completed-card snapshots, this builds the single live card that sits
+ * pinned at the bottom of the bubble HUD stack, expanded and ticking. It
+ * reads from in-memory state (the focused [PlatformRegion] + flow region)
+ * and produces a snapshot whose [FlowCardSnapshot.phaseEndedAt] is null.
+ */
+object LiveCardBuilder {
+
+    fun build(state: AppState): FlowCardSnapshot? {
+        val platform = state.regions.flow.activePlatform
+            ?: state.regions.crossPlatform.mostRecentActivityPlatform
+            ?: return null
+        val region = state.regions.platforms[platform] ?: return null
+        val flow = state.regions.flow.flow
+        val now = state.timestamp
+
+        return when (flow) {
+            Flow.Idle -> {
+                if (region.mode != Mode.Online) return null
+                val started = region.idleEnteredAt ?: region.session?.startedAt ?: return null
+                FlowCardSnapshot.Awaiting(
+                    id = "awaiting:${region.session?.sessionId ?: "?"}:$started",
+                    phaseStartedAt = started,
+                    sessionId = region.session?.sessionId,
+                )
+            }
+
+            Flow.OfferPresented -> {
+                val pending = state.regions.flow.pendingOffer ?: return null
+                val offer = pending.offerFields.parsedOffer
+                FlowCardSnapshot.Offer(
+                    phaseStartedAt = pending.presentedAt,
+                    offerHash = pending.offerHash,
+                    payAmount = offer.payAmount,
+                    distanceMiles = offer.distanceMiles,
+                    itemCount = offer.itemCount,
+                    storeNames = offer.orders.map { it.storeName }.distinct(),
+                    evaluationScore = pending.evaluation?.score,
+                    evaluationAction = pending.evaluation?.action?.name,
+                    netPayAmount = pending.evaluation?.netPayAmount,
+                    dollarsPerMile = pending.evaluation?.dollarsPerMile,
+                    dollarsPerHour = pending.evaluation?.dollarsPerHour,
+                    outcome = null,
+                )
+            }
+
+            Flow.TaskPickupNavigation, Flow.TaskPickupArrived -> {
+                val task = region.activeTask ?: return null
+                if (task.phase != TaskPhase.PICKUP) return null
+                FlowCardSnapshot.Pickup(
+                    phaseStartedAt = task.startedAt,
+                    taskId = task.taskId,
+                    jobId = task.jobId,
+                    storeName = task.storeName ?: "Unknown",
+                    arrivedAt = task.arrivedAt,
+                    deadlineMillis = task.deadlineMillis,
+                    itemCount = task.itemCount,
+                    activity = task.activity,
+                )
+            }
+
+            Flow.TaskDropoffNavigation, Flow.TaskDropoffArrived -> {
+                val task = region.activeTask ?: return null
+                if (task.phase != TaskPhase.DROPOFF) return null
+                FlowCardSnapshot.Delivery(
+                    phaseStartedAt = task.startedAt,
+                    taskId = task.taskId,
+                    jobId = task.jobId,
+                    storeName = task.storeName,
+                    customerHash = task.customerNameHash,
+                    arrivedAt = task.arrivedAt,
+                    deadlineMillis = task.deadlineMillis,
+                )
+            }
+
+            Flow.PostTask -> {
+                val activeTask = region.activeTask ?: region.recentTasks.lastOrNull()
+                val pt = region.lastPostTaskFields
+                FlowCardSnapshot.PostTask(
+                    phaseStartedAt = activeTask?.completedAt
+                        ?: activeTask?.arrivedAt
+                        ?: now,
+                    jobId = activeTask?.jobId ?: region.activeJob?.jobId ?: "unknown",
+                    taskId = activeTask?.taskId,
+                    storeName = activeTask?.storeName,
+                    totalPay = pt?.totalPay ?: 0.0,
+                    parsedPay = pt?.parsedPay,
+                    sessionEarningsAtCompletion = pt?.sessionEarnings,
+                )
+            }
+
+            Flow.SessionEnded -> null
+        }
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
@@ -145,7 +145,7 @@ class EffectMapTest {
     // =========================================================================
 
     @Test
-    fun `offer presented emits Evaluate and Speak (screenshot and log now via rule effects)`() {
+    fun `offer presented emits Evaluate, Speak, and OFFER_RECEIVED log`() {
         val prev = AppState(regions = Regions(flow = FlowRegion(flow = Flow.Idle)))
         val next = AppState(regions = Regions(
             flow = FlowRegion(
@@ -159,9 +159,12 @@ class EffectMapTest {
 
         assertTrue("Should emit EvaluateOffer", effects.any { it is AppEffect.EvaluateOffer })
         assertTrue("Should emit SpeakOffer", effects.any { it is AppEffect.SpeakOffer })
-        // Screenshot + OFFER_RECEIVED log now handled by rule-declared effects
+        // OFFER_RECEIVED now emitted from EffectMap with a typed payload
+        // (#257) — moved out of rule-declared `log` effects which never
+        // persisted to the DB.
+        assertTrue("Should emit OFFER_RECEIVED", effects.logEventTypes().contains(AppEventType.OFFER_RECEIVED))
+        // Screenshot still handled by rule-declared effects
         assertTrue("No hardcoded CaptureScreenshot", effects.none { it is AppEffect.CaptureScreenshot })
-        assertTrue("No hardcoded OFFER_RECEIVED log", !effects.logEventTypes().contains(AppEventType.OFFER_RECEIVED))
     }
 
     @Test

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardMapperTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardMapperTest.kt
@@ -1,0 +1,453 @@
+package cloud.trotter.dashbuddy.ui.bubble.cards
+
+import cloud.trotter.dashbuddy.core.database.event.AppEventEntity
+import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
+import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
+import cloud.trotter.dashbuddy.domain.model.cards.FlowCardSnapshot
+import cloud.trotter.dashbuddy.domain.model.event.AppEventType
+import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.OfferPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.OfferReceivedPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.PickupPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStartPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStopPayload
+import cloud.trotter.dashbuddy.domain.model.offer.ParsedOffer
+import cloud.trotter.dashbuddy.domain.model.order.OrderType
+import cloud.trotter.dashbuddy.domain.model.order.ParsedOrder
+import cloud.trotter.dashbuddy.domain.model.pay.ParsedPay
+import cloud.trotter.dashbuddy.domain.model.pay.ParsedPayItem
+import cloud.trotter.dashbuddy.domain.state.Flow
+import com.google.gson.Gson
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FlowCardMapperTest {
+
+    private val gson = Gson()
+    private var seq = 1L
+
+    private fun event(type: AppEventType, payload: Any, occurredAt: Long): AppEventEntity {
+        val json = payload as? String ?: gson.toJson(payload)
+        return AppEventEntity(
+            sequenceId = seq++,
+            aggregateId = "session-1",
+            eventType = type,
+            eventPayload = json,
+            occurredAt = occurredAt,
+        )
+    }
+
+    private fun parsedOffer(hash: String, pay: Double, miles: Double, store: String = "Wendy's") =
+        ParsedOffer(
+            offerHash = hash,
+            payAmount = pay,
+            distanceMiles = miles,
+            itemCount = 1,
+            orders = listOf(
+                ParsedOrder(
+                    orderIndex = 0,
+                    orderType = OrderType.PICKUP,
+                    storeName = store,
+                    itemCount = 1,
+                    isItemCountEstimated = false,
+                    badges = emptySet(),
+                )
+            ),
+        )
+
+    private fun evaluation(score: Double = 80.0) = OfferEvaluation(
+        action = OfferAction.ACCEPT,
+        score = score,
+        qualityLevel = "Good",
+        recommendationText = "Recommended: ACCEPT",
+        payAmount = 7.50,
+        fuelCostEstimate = 0.5,
+        nonFuelCostEstimate = 0.5,
+        totalOperatingCost = 1.0,
+        operatingCostPerMile = 0.24,
+        netPayAmount = 6.50,
+        distanceMiles = 4.2,
+        dollarsPerMile = 1.55,
+        dollarsPerHour = 22.0,
+        estimatedTimeMinutes = 18.0,
+        itemCount = 1.0,
+        merchantName = "Wendy's",
+    )
+
+    private fun offerPayload(hash: String, outcome: AppEventType, presentedAt: Long, decidedAt: Long) =
+        OfferPayload(
+            offerHash = hash,
+            parsedOffer = parsedOffer(hash, 7.50, 4.2),
+            evaluation = evaluation(),
+            outcome = outcome,
+            presentedAt = presentedAt,
+            decidedAt = decidedAt,
+            returnFlow = Flow.Idle,
+        )
+
+    private fun pickupPayload(taskId: String, jobId: String, store: String, started: Long,
+                              arrived: Long? = null, confirmed: Long? = null) = PickupPayload(
+        jobId = jobId,
+        taskId = taskId,
+        storeName = store,
+        phaseStartedAt = started,
+        arrivedAt = arrived,
+        confirmedAt = confirmed,
+    )
+
+    private fun deliveryPayload(taskId: String, jobId: String, started: Long,
+                                arrived: Long? = null, completed: Long? = null,
+                                totalPay: Double? = null, parsedPay: ParsedPay? = null,
+                                sessionEarnings: Double? = null) = DeliveryPayload(
+        jobId = jobId,
+        taskId = taskId,
+        customerHash = "cust-abc",
+        phaseStartedAt = started,
+        arrivedAt = arrived,
+        completedAt = completed,
+        totalPay = totalPay,
+        parsedPay = parsedPay,
+        sessionEarningsAtCompletion = sessionEarnings,
+    )
+
+    // =========================================================================
+    // Happy path
+    // =========================================================================
+
+    @Test
+    fun `happy path — offer → pickup → delivery → posttask produces five completed cards`() {
+        val parsedPay = ParsedPay(
+            appPayComponents = listOf(ParsedPayItem("Base Pay", 4.50)),
+            customerTips = listOf(ParsedPayItem("Wendy's", 3.00)),
+        )
+        val events = listOf(
+            event(AppEventType.DASH_START,
+                SessionStartPayload("s1", "DoorDash", 1000L, "interaction", "WaitingForOffer"),
+                occurredAt = 1000L),
+            event(AppEventType.OFFER_RECEIVED, "{}", occurredAt = 2000L),
+            event(AppEventType.OFFER_ACCEPTED,
+                offerPayload("offer-1", AppEventType.OFFER_ACCEPTED, 2000L, 2500L),
+                occurredAt = 2500L),
+            event(AppEventType.PICKUP_NAV_STARTED,
+                pickupPayload("T1", "J1", "Wendy's", 2500L),
+                occurredAt = 2500L),
+            event(AppEventType.PICKUP_ARRIVED,
+                pickupPayload("T1", "J1", "Wendy's", 2500L, arrived = 3000L),
+                occurredAt = 3000L),
+            event(AppEventType.PICKUP_CONFIRMED,
+                pickupPayload("T1", "J1", "Wendy's", 2500L, arrived = 3000L, confirmed = 3500L),
+                occurredAt = 3500L),
+            event(AppEventType.DELIVERY_NAV_STARTED,
+                deliveryPayload("T2", "J1", 3500L),
+                occurredAt = 3500L),
+            event(AppEventType.DELIVERY_ARRIVED,
+                deliveryPayload("T2", "J1", 3500L, arrived = 4000L),
+                occurredAt = 4000L),
+            event(AppEventType.DELIVERY_COMPLETED,
+                deliveryPayload("T2", "J1", 3500L, arrived = 4000L, completed = 4500L,
+                    totalPay = 7.50, parsedPay = parsedPay, sessionEarnings = 47.50),
+                occurredAt = 4500L),
+        )
+
+        val cards = FlowCardMapper.fold(events)
+        assertEquals(5, cards.size)
+
+        val awaiting = cards[0] as FlowCardSnapshot.Awaiting
+        assertEquals("s1", awaiting.sessionId)
+        assertEquals(1000L, awaiting.phaseStartedAt)
+        assertEquals(2000L, awaiting.phaseEndedAt)
+
+        val offer = cards[1] as FlowCardSnapshot.Offer
+        assertEquals("offer-1", offer.offerHash)
+        assertEquals(7.50, offer.payAmount!!, 0.001)
+        assertEquals(80.0, offer.evaluationScore!!, 0.001)
+        assertEquals(AppEventType.OFFER_ACCEPTED, offer.outcome)
+        assertTrue("Wendy's" in offer.storeNames)
+
+        val pickup = cards[2] as FlowCardSnapshot.Pickup
+        assertEquals("T1", pickup.taskId)
+        assertEquals("Wendy's", pickup.storeName)
+        assertEquals(3000L, pickup.arrivedAt)
+        assertEquals(3500L, pickup.confirmedAt)
+        assertEquals(3500L, pickup.phaseEndedAt)
+
+        val delivery = cards[3] as FlowCardSnapshot.Delivery
+        assertEquals("T2", delivery.taskId)
+        assertEquals(4000L, delivery.arrivedAt)
+        assertEquals(4000L, delivery.phaseEndedAt)
+
+        val postTask = cards[4] as FlowCardSnapshot.PostTask
+        assertEquals(7.50, postTask.totalPay, 0.001)
+        assertNotNull(postTask.parsedPay)
+        assertEquals(47.50, postTask.sessionEarningsAtCompletion!!, 0.001)
+        assertEquals(4000L, postTask.phaseStartedAt)
+        assertEquals(4500L, postTask.phaseEndedAt)
+    }
+
+    // =========================================================================
+    // Decline path
+    // =========================================================================
+
+    @Test
+    fun `decline path — Awaiting closes, Offer freezes with DECLINED outcome, no Pickup`() {
+        val events = listOf(
+            event(AppEventType.DASH_START,
+                SessionStartPayload("s1", "DoorDash", 1000L, "interaction", "WaitingForOffer"),
+                occurredAt = 1000L),
+            event(AppEventType.OFFER_RECEIVED, "{}", occurredAt = 2000L),
+            event(AppEventType.OFFER_DECLINED,
+                offerPayload("decline-1", AppEventType.OFFER_DECLINED, 2000L, 2300L),
+                occurredAt = 2300L),
+        )
+
+        val cards = FlowCardMapper.fold(events)
+        assertEquals(2, cards.size)
+        assertTrue(cards[0] is FlowCardSnapshot.Awaiting)
+
+        val offer = cards[1] as FlowCardSnapshot.Offer
+        assertEquals(AppEventType.OFFER_DECLINED, offer.outcome)
+    }
+
+    // =========================================================================
+    // Timeout path
+    // =========================================================================
+
+    @Test
+    fun `timeout path — Offer freezes with TIMEOUT outcome`() {
+        val events = listOf(
+            event(AppEventType.DASH_START,
+                SessionStartPayload("s1", "DoorDash", 1000L, "interaction", "WaitingForOffer"),
+                occurredAt = 1000L),
+            event(AppEventType.OFFER_RECEIVED, "{}", occurredAt = 2000L),
+            event(AppEventType.OFFER_TIMEOUT,
+                offerPayload("to-1", AppEventType.OFFER_TIMEOUT, 2000L, 2030L),
+                occurredAt = 2030L),
+        )
+
+        val cards = FlowCardMapper.fold(events)
+        val offer = cards.filterIsInstance<FlowCardSnapshot.Offer>().single()
+        assertEquals(AppEventType.OFFER_TIMEOUT, offer.outcome)
+    }
+
+    // =========================================================================
+    // Multi-delivery dash
+    // =========================================================================
+
+    @Test
+    fun `back-to-back deliveries produce sequential Offer Pickup Delivery PostTask cards`() {
+        val events = listOf(
+            event(AppEventType.DASH_START,
+                SessionStartPayload("s1", "DoorDash", 1000L, "interaction", "WaitingForOffer"),
+                occurredAt = 1000L),
+            // delivery 1
+            event(AppEventType.OFFER_RECEIVED, "{}", occurredAt = 1500L),
+            event(AppEventType.OFFER_ACCEPTED,
+                offerPayload("o1", AppEventType.OFFER_ACCEPTED, 1500L, 1600L), 1600L),
+            event(AppEventType.PICKUP_NAV_STARTED,
+                pickupPayload("T1a", "J1", "A", 1600L), 1600L),
+            event(AppEventType.PICKUP_CONFIRMED,
+                pickupPayload("T1a", "J1", "A", 1600L, confirmed = 2000L), 2000L),
+            event(AppEventType.DELIVERY_NAV_STARTED,
+                deliveryPayload("T1b", "J1", 2000L), 2000L),
+            event(AppEventType.DELIVERY_ARRIVED,
+                deliveryPayload("T1b", "J1", 2000L, arrived = 2500L), 2500L),
+            event(AppEventType.DELIVERY_COMPLETED,
+                deliveryPayload("T1b", "J1", 2000L, arrived = 2500L, completed = 2700L, totalPay = 5.00), 2700L),
+            // delivery 2
+            event(AppEventType.OFFER_RECEIVED, "{}", occurredAt = 3000L),
+            event(AppEventType.OFFER_ACCEPTED,
+                offerPayload("o2", AppEventType.OFFER_ACCEPTED, 3000L, 3100L), 3100L),
+            event(AppEventType.PICKUP_NAV_STARTED,
+                pickupPayload("T2a", "J2", "B", 3100L), 3100L),
+            event(AppEventType.PICKUP_CONFIRMED,
+                pickupPayload("T2a", "J2", "B", 3100L, confirmed = 3500L), 3500L),
+            event(AppEventType.DELIVERY_NAV_STARTED,
+                deliveryPayload("T2b", "J2", 3500L), 3500L),
+            event(AppEventType.DELIVERY_ARRIVED,
+                deliveryPayload("T2b", "J2", 3500L, arrived = 4000L), 4000L),
+            event(AppEventType.DELIVERY_COMPLETED,
+                deliveryPayload("T2b", "J2", 3500L, arrived = 4000L, completed = 4200L, totalPay = 8.00), 4200L),
+        )
+
+        val cards = FlowCardMapper.fold(events)
+
+        // Awaiting + (Offer + Pickup + Delivery + PostTask) × 2 = 9
+        assertEquals(9, cards.size)
+
+        val offers = cards.filterIsInstance<FlowCardSnapshot.Offer>()
+        assertEquals(2, offers.size)
+        assertEquals(listOf("o1", "o2"), offers.map { it.offerHash })
+
+        val pickups = cards.filterIsInstance<FlowCardSnapshot.Pickup>()
+        assertEquals(2, pickups.size)
+        assertEquals(listOf("T1a", "T2a"), pickups.map { it.taskId })
+
+        val postTasks = cards.filterIsInstance<FlowCardSnapshot.PostTask>()
+        assertEquals(listOf(5.00, 8.00), postTasks.map { it.totalPay })
+    }
+
+    // =========================================================================
+    // Session reset
+    // =========================================================================
+
+    @Test
+    fun `DASH_START resets the stack — prior session cards are dropped`() {
+        val events = listOf(
+            event(AppEventType.DASH_START,
+                SessionStartPayload("s1", "DoorDash", 1000L, "interaction", "WaitingForOffer"), 1000L),
+            event(AppEventType.OFFER_RECEIVED, "{}", 1500L),
+            event(AppEventType.OFFER_ACCEPTED,
+                offerPayload("o1", AppEventType.OFFER_ACCEPTED, 1500L, 1600L), 1600L),
+            // new dash starts before delivery completes
+            event(AppEventType.DASH_START,
+                SessionStartPayload("s2", "DoorDash", 5000L, "interaction", "WaitingForOffer"), 5000L),
+            event(AppEventType.OFFER_RECEIVED, "{}", 5500L),
+            event(AppEventType.OFFER_DECLINED,
+                offerPayload("o2", AppEventType.OFFER_DECLINED, 5500L, 5700L), 5700L),
+        )
+
+        val cards = FlowCardMapper.fold(events)
+        // Only the second session's cards remain — Awaiting + Offer
+        assertEquals(2, cards.size)
+        assertEquals("s2", (cards[0] as FlowCardSnapshot.Awaiting).sessionId)
+        assertEquals("o2", (cards[1] as FlowCardSnapshot.Offer).offerHash)
+    }
+
+    // =========================================================================
+    // Store-name update (secondary PICKUP_NAV_STARTED for the same taskId)
+    // =========================================================================
+
+    @Test
+    fun `repeated PICKUP_NAV_STARTED for same task updates store name, does not duplicate`() {
+        val events = listOf(
+            event(AppEventType.DASH_START,
+                SessionStartPayload("s1", "DoorDash", 1000L, "interaction", "WaitingForOffer"), 1000L),
+            event(AppEventType.OFFER_RECEIVED, "{}", 1500L),
+            event(AppEventType.OFFER_ACCEPTED,
+                offerPayload("o1", AppEventType.OFFER_ACCEPTED, 1500L, 1600L), 1600L),
+            event(AppEventType.PICKUP_NAV_STARTED,
+                pickupPayload("T1", "J1", "Unknown", 1600L), 1600L),
+            event(AppEventType.PICKUP_NAV_STARTED,
+                pickupPayload("T1", "J1", "Wendy's", 1600L), 1700L),
+            event(AppEventType.PICKUP_CONFIRMED,
+                pickupPayload("T1", "J1", "Wendy's", 1600L, confirmed = 2000L), 2000L),
+        )
+
+        val cards = FlowCardMapper.fold(events)
+        val pickups = cards.filterIsInstance<FlowCardSnapshot.Pickup>()
+        assertEquals(1, pickups.size)
+        assertEquals("Wendy's", pickups[0].storeName)
+    }
+
+    // =========================================================================
+    // Half-open card on DASH_STOP
+    // =========================================================================
+
+    @Test
+    fun `DASH_STOP closes any half-open card with the stop timestamp`() {
+        val events = listOf(
+            event(AppEventType.DASH_START,
+                SessionStartPayload("s1", "DoorDash", 1000L, "interaction", "WaitingForOffer"), 1000L),
+            // Awaiting open, never gets an offer
+            event(AppEventType.DASH_STOP,
+                SessionStopPayload("s1", endedAt = 3000L, source = "early_offline"), 3000L),
+        )
+
+        val cards = FlowCardMapper.fold(events)
+        assertEquals(1, cards.size)
+        val awaiting = cards[0] as FlowCardSnapshot.Awaiting
+        assertEquals(3000L, awaiting.phaseEndedAt)
+    }
+
+    // =========================================================================
+    // Empty input
+    // =========================================================================
+
+    @Test
+    fun `empty event list produces empty card list`() {
+        val cards = FlowCardMapper.fold(emptyList())
+        assertTrue(cards.isEmpty())
+    }
+
+    @Test
+    fun `Awaiting closes at presentedAt when OFFER_RECEIVED carries typed payload`() {
+        // OFFER_RECEIVED is now emitted by EffectMap with a typed
+        // OfferReceivedPayload that includes presentedAt. The mapper uses
+        // that timestamp (the moment the offer hit the screen) to close
+        // Awaiting — more accurate than the event's own occurredAt.
+        val received = OfferReceivedPayload(
+            offerHash = "o1",
+            parsedOffer = parsedOffer("o1", 7.50, 4.2),
+            presentedAt = 1500L,
+            platform = "DoorDash",
+            returnFlow = Flow.Idle,
+        )
+        val events = listOf(
+            event(AppEventType.DASH_START,
+                SessionStartPayload("s1", "DoorDash", 1000L, "interaction", "WaitingForOffer"),
+                occurredAt = 1000L),
+            // Note: event occurredAt (1505L) deliberately differs from
+            // payload presentedAt (1500L) to prove the mapper prefers the
+            // payload's value.
+            event(AppEventType.OFFER_RECEIVED, received, occurredAt = 1505L),
+        )
+
+        val cards = FlowCardMapper.fold(events)
+        assertEquals(1, cards.size)
+        val awaiting = cards[0] as FlowCardSnapshot.Awaiting
+        assertEquals(1000L, awaiting.phaseStartedAt)
+        assertEquals(1500L, awaiting.phaseEndedAt)
+    }
+
+    @Test
+    fun `Awaiting closes on OFFER_ACCEPTED even when OFFER_RECEIVED is missing`() {
+        // Regression: the rule-declared OFFER_RECEIVED log effect doesn't
+        // persist to the DB (it only goes to Timber). The mapper must
+        // defensively close the Awaiting card on the next OFFER_* closing
+        // event using OfferPayload.presentedAt as the phaseEndedAt — see
+        // bubble-test session 2026-05-17 where no OFFER_RECEIVED row was
+        // ever written and the Awaiting card hung open until DASH_STOP.
+        val events = listOf(
+            event(AppEventType.DASH_START,
+                SessionStartPayload("s1", "DoorDash", 1000L, "interaction", "WaitingForOffer"),
+                occurredAt = 1000L),
+            // Note: no OFFER_RECEIVED here — straight to ACCEPTED.
+            event(AppEventType.OFFER_ACCEPTED,
+                offerPayload("abc", AppEventType.OFFER_ACCEPTED, presentedAt = 1500L, decidedAt = 1600L),
+                occurredAt = 1600L),
+        )
+
+        val cards = FlowCardMapper.fold(events)
+        assertEquals(2, cards.size)
+
+        val awaiting = cards[0] as FlowCardSnapshot.Awaiting
+        assertEquals(1000L, awaiting.phaseStartedAt)
+        // Critical: Awaiting closes at the offer's presentedAt (1500L), NOT
+        // at the closing-event occurredAt (1600L) and NOT left open.
+        assertEquals(1500L, awaiting.phaseEndedAt)
+
+        val offer = cards[1] as FlowCardSnapshot.Offer
+        assertEquals("abc", offer.offerHash)
+        assertEquals(AppEventType.OFFER_ACCEPTED, offer.outcome)
+    }
+
+    @Test
+    fun `events before DASH_START are ignored when DASH_START arrives`() {
+        // A real session: prior stale offer events followed by a new DASH_START
+        // should not contaminate the new session's stack.
+        val events = listOf(
+            event(AppEventType.OFFER_RECEIVED, "{}", 500L),
+            event(AppEventType.OFFER_DECLINED,
+                offerPayload("stale", AppEventType.OFFER_DECLINED, 500L, 700L), 700L),
+            event(AppEventType.DASH_START,
+                SessionStartPayload("s-new", "DoorDash", 1000L, "interaction", "WaitingForOffer"), 1000L),
+        )
+        val cards = FlowCardMapper.fold(events)
+        // Stale Offer card is dropped by the DASH_START reset; the new
+        // Awaiting card is still open (no end-time yet).
+        assertEquals(0, cards.size)
+    }
+}

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -3,6 +3,13 @@ package cloud.trotter.dashbuddy.core.state
 import cloud.trotter.dashbuddy.core.database.event.AppEventEntity
 import cloud.trotter.dashbuddy.domain.model.chat.ChatPersona
 import cloud.trotter.dashbuddy.domain.model.event.AppEventType
+import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.OfferPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.OfferReceivedPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.PickupPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.SessionPausedPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStartPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStopPayload
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
 import cloud.trotter.dashbuddy.domain.pipeline.ParsedFieldsGate
 import cloud.trotter.dashbuddy.domain.pipeline.TimeoutType
@@ -16,6 +23,7 @@ import cloud.trotter.dashbuddy.domain.state.ParsedFields
 import cloud.trotter.dashbuddy.domain.state.PendingOffer
 import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.domain.state.PlatformRegion
+import cloud.trotter.dashbuddy.domain.state.Task
 import cloud.trotter.dashbuddy.domain.state.TaskPhase
 import cloud.trotter.dashbuddy.domain.state.TaskSubFlow
 import cloud.trotter.dashbuddy.domain.util.formatCurrency
@@ -50,7 +58,15 @@ class EffectMap @Inject constructor(
 
     fun diff(prev: AppState, next: AppState, obs: Observation): List<AppEffect> = buildList {
         addAll(diffRuleEffects(obs))
-        addAll(diffFlowRegion(prev.regions.flow, next.regions.flow, obs))
+        // Offer-resolution events fire in the FlowRegion handler. They need to
+        // be scoped to the active platform's session so AppEventDao queries
+        // by dashId see them — without this, the bubble HUD's card stack
+        // never sees offer events (#257).
+        val activeSessionId = next.regions.flow.activePlatform
+            ?.let { next.regions.platforms[it]?.session?.sessionId }
+            ?: prev.regions.flow.activePlatform
+                ?.let { prev.regions.platforms[it]?.session?.sessionId }
+        addAll(diffFlowRegion(prev.regions.flow, next.regions.flow, obs, activeSessionId))
         val allPlatforms = (prev.regions.platforms.keys + next.regions.platforms.keys).distinct()
         for (p in allPlatforms) {
             addAll(
@@ -74,23 +90,38 @@ class EffectMap @Inject constructor(
         prev: FlowRegion,
         next: FlowRegion,
         obs: Observation,
+        sessionId: String?,
     ): List<AppEffect> = buildList {
         val flowObs = obs as? Observation.FlowObservation
         val prevOffer = prev.pendingOffer
         val nextOffer = next.pendingOffer
 
         // Offer presented
-        // Screenshot + log now handled by rule-declared effects on offer screen rules
-        // (deduped via dedupeKey + throttleMs). Evaluate + speak remain here
-        // because they need rich ParsedOffer objects, not string args.
+        // Screenshot for the offer screen still comes from rule-declared
+        // effects (deduped via dedupeKey + throttleMs). DB-persisted
+        // events flow through here so payloads stay typed and consistent
+        // across platforms (#257 design discussion).
         if (prevOffer == null && nextOffer != null) {
             val offer = nextOffer.offerFields
+            val platform = next.activePlatform?.name ?: "Unknown"
+
+            // Log OFFER_RECEIVED with the full parsed offer. Evaluation
+            // hasn't run yet at this point (it fires async via the
+            // EvaluateOffer side effect); the rich evaluation lands on
+            // the closing OFFER_ACCEPTED / DECLINED / TIMEOUT payload.
+            val receivedPayload = OfferReceivedPayload(
+                offerHash = nextOffer.offerHash,
+                parsedOffer = offer.parsedOffer,
+                presentedAt = nextOffer.presentedAt,
+                platform = platform,
+                returnFlow = nextOffer.returnFlow,
+            )
+            add(logEffect(sessionId, AppEventType.OFFER_RECEIVED, receivedPayload))
 
             // Evaluate
             add(AppEffect.EvaluateOffer(offer.parsedOffer))
 
             // Speak offer aloud
-            val platform = next.activePlatform?.name ?: "Unknown"
             add(AppEffect.SpeakOffer(offer.parsedOffer, platform))
         }
 
@@ -100,9 +131,9 @@ class EffectMap @Inject constructor(
         if (prevOffer != null && nextOffer != null &&
             prevOffer.offerHash != nextOffer.offerHash
         ) {
-            // Log resolution of old offer
+            // Log resolution of old offer with full context.
             val outcome = resolveOfferOutcome(obs, prevOffer)
-            add(logEffect(null, outcome, "Replaced by new offer"))
+            add(logEffect(sessionId, outcome, offerPayload(prevOffer, outcome, obs.timestamp, "Replaced by new offer")))
 
             // Evaluate + speak new offer
             val offer = nextOffer.offerFields
@@ -114,12 +145,7 @@ class EffectMap @Inject constructor(
         // Offer resolved (accepted/declined/timeout)
         if (prevOffer != null && nextOffer == null) {
             val outcome = resolveOfferOutcome(obs, prevOffer)
-            val description = when (outcome) {
-                AppEventType.OFFER_ACCEPTED -> "Transitioned to Pickup"
-                AppEventType.OFFER_DECLINED -> "Returned to search"
-                else -> "Offer timed out"
-            }
-            add(logEffect(null, outcome, description))
+            add(logEffect(sessionId, outcome, offerPayload(prevOffer, outcome, obs.timestamp)))
 
             if (outcome == AppEventType.OFFER_TIMEOUT) {
                 add(AppEffect.UpdateBubble("Offer Timed Out!", persona = ChatPersona.Dispatcher))
@@ -169,9 +195,12 @@ class EffectMap @Inject constructor(
                 } else {
                     val sessionId = next.session?.sessionId ?: p.session?.sessionId
                     val completedTask = next.recentTasks.lastOrNull()
-                    val payload = mapOf(
-                        "storeName" to (completedTask?.storeName ?: "Unknown"),
-                        "jobId" to (p.activeJob?.jobId),
+                    val payload = deliveryCompletedPayload(
+                        task = completedTask,
+                        jobId = p.activeJob?.jobId,
+                        completedAt = obs.timestamp,
+                        postTaskFields = p.lastPostTaskFields,
+                        sessionEarnings = next.session?.runningEarnings ?: p.session?.runningEarnings,
                     )
                     add(logEffect(sessionId, AppEventType.DELIVERY_COMPLETED, payload))
                 }
@@ -197,9 +226,12 @@ class EffectMap @Inject constructor(
                     if (modeOverride != null) {
                         addAll(modeOverride)
                     } else if (nextSession != null && prevSession?.sessionId != nextSession.sessionId) {
-                        val payload = mapOf(
-                            "source" to if (next.lastTransitionKind == TransitionKind.Unexpected) "recovery" else "interaction",
-                            "start_screen" to "WaitingForOffer",
+                        val payload = SessionStartPayload(
+                            sessionId = nextSession.sessionId,
+                            platform = next.platform.name,
+                            startedAt = nextSession.startedAt,
+                            source = if (next.lastTransitionKind == TransitionKind.Unexpected) "recovery" else "interaction",
+                            startScreen = "WaitingForOffer",
                         )
                         add(logEffect(nextSession.sessionId, AppEventType.DASH_START, payload))
                         add(AppEffect.StartOdometer)
@@ -233,7 +265,17 @@ class EffectMap @Inject constructor(
                         val platform = prev.platform.name
                         if (parsed is ParsedFields.SessionEndedFields) {
                             val earnings = formatCurrency(parsed.totalEarnings)
-                            add(logEffect(sessionId, AppEventType.DASH_STOP, parsed))
+                            val payload = SessionStopPayload(
+                                sessionId = sessionId,
+                                endedAt = obs.timestamp,
+                                source = "summary_screen",
+                                totalEarnings = parsed.totalEarnings,
+                                sessionDurationMillis = parsed.sessionDurationMillis,
+                                offersAccepted = parsed.offersAccepted,
+                                offersTotal = parsed.offersTotal,
+                                weeklyEarnings = parsed.weeklyEarnings,
+                            )
+                            add(logEffect(sessionId, AppEventType.DASH_STOP, payload))
                             add(AppEffect.StopOdometer)
                             add(
                                 AppEffect.UpdateBubble(
@@ -243,7 +285,13 @@ class EffectMap @Inject constructor(
                             )
                             add(AppEffect.CaptureScreenshot("DashSummary - ${parsed.totalEarnings}"))
                         } else {
-                            add(logEffect(sessionId, AppEventType.DASH_STOP, "Return to Map"))
+                            val payload = SessionStopPayload(
+                                sessionId = sessionId,
+                                endedAt = obs.timestamp,
+                                source = "early_offline",
+                                totalEarnings = prevSession.runningEarnings,
+                            )
+                            add(logEffect(sessionId, AppEventType.DASH_STOP, payload))
                             add(AppEffect.StopOdometer)
                         }
                         add(AppEffect.EndSession(platform))
@@ -269,14 +317,14 @@ class EffectMap @Inject constructor(
                         val flowObs = obs as? Observation.FlowObservation
                         val pausedFields = flowObs?.parsed as? ParsedFields.PausedFields
                         val durationMs = (pausedFields?.remainingMillis ?: 0L) + PAUSE_TIMEOUT_BUFFER_MS
-                        val remainingText = pausedFields?.remainingText ?: "?"
 
-                        add(
-                            logEffect(
-                                sessionId, AppEventType.DASH_PAUSED,
-                                "Paused. Time left: $remainingText",
-                            )
+                        val pausePayload = SessionPausedPayload(
+                            sessionId = sessionId,
+                            pausedAt = obs.timestamp,
+                            remainingText = pausedFields?.remainingText,
+                            remainingMillis = pausedFields?.remainingMillis,
                         )
+                        add(logEffect(sessionId, AppEventType.DASH_PAUSED, pausePayload))
                         add(
                             AppEffect.ScheduleTimeout(
                                 durationMs,
@@ -314,11 +362,7 @@ class EffectMap @Inject constructor(
                     addAll(taskStartOverride)
                 } else {
                     val storeName = nextTask.storeName ?: "Unknown"
-                    val payload = mapOf(
-                        "message" to "Pickup Started",
-                        "storeName" to storeName,
-                        "status" to "NAVIGATING",
-                    )
+                    val payload = pickupPayload(nextTask, storeName)
                     add(logEffect(sessionId, AppEventType.PICKUP_NAV_STARTED, payload))
                     add(AppEffect.ResumeOdometer)
 
@@ -337,13 +381,17 @@ class EffectMap @Inject constructor(
                 nextTask?.phase == TaskPhase.DROPOFF
             ) {
                 val customerHash = nextTask.customerNameHash
-                val payload = mapOf(
-                    "status" to "DROPOFF_STARTED",
-                    "customerHash" to customerHash,
-                    "addressHash" to nextTask.customerAddressHash,
+                val pickupConfirmed = pickupPayload(
+                    task = prevTask,
+                    storeName = prevTask.storeName ?: "Unknown",
+                    confirmedAt = obs.timestamp,
                 )
-                add(logEffect(sessionId, AppEventType.PICKUP_CONFIRMED, payload))
-                add(logEffect(sessionId, AppEventType.DELIVERY_NAV_STARTED, payload))
+                val deliveryStart = deliveryPhasePayload(
+                    task = nextTask,
+                    phaseStartedAt = obs.timestamp,
+                )
+                add(logEffect(sessionId, AppEventType.PICKUP_CONFIRMED, pickupConfirmed))
+                add(logEffect(sessionId, AppEventType.DELIVERY_NAV_STARTED, deliveryStart))
                 add(AppEffect.ResumeOdometer)
 
                 val customer = customerHash?.take(6) ?: "Customer"
@@ -364,13 +412,19 @@ class EffectMap @Inject constructor(
                         TaskPhase.PICKUP -> add(
                             logEffect(
                                 sessionId, AppEventType.PICKUP_ARRIVED,
-                                mapOf("storeName" to (nextTask.storeName ?: "Unknown")),
+                                pickupPayload(
+                                    task = nextTask,
+                                    storeName = nextTask.storeName ?: "Unknown",
+                                ),
                             )
                         )
                         TaskPhase.DROPOFF -> add(
                             logEffect(
                                 sessionId, AppEventType.DELIVERY_ARRIVED,
-                                mapOf("customerHash" to nextTask.customerNameHash),
+                                deliveryPhasePayload(
+                                    task = nextTask,
+                                    phaseStartedAt = nextTask.startedAt,
+                                ),
                             )
                         )
                     }
@@ -399,16 +453,16 @@ class EffectMap @Inject constructor(
                     add(AppEffect.UpdateBubble("Pickup: $storeName", persona))
                 }
 
-                // Store name resolution logging
+                // Store name resolution — re-emit the pickup payload with the
+                // updated store name. The mapper treats the latest
+                // PICKUP_NAV_STARTED per task as canonical, so this is the
+                // store name the Pickup card will render.
                 if (storeChanged) {
+                    val storeName = nextTask.storeName ?: "Unknown"
                     add(
                         logEffect(
                             sessionId, AppEventType.PICKUP_NAV_STARTED,
-                            mapOf(
-                                "message" to "Store Name Updated",
-                                "previous" to (prevTask.storeName ?: "Unknown"),
-                                "updated" to (nextTask.storeName ?: "Unknown"),
-                            ),
+                            pickupPayload(nextTask, storeName),
                         )
                     )
                 }
@@ -607,5 +661,88 @@ class EffectMap @Inject constructor(
             )
         )
     }
+
+    // =========================================================================
+    // PAYLOAD BUILDERS
+    //
+    // Build rich phase-boundary payloads from in-memory state. Same emit
+    // moments as before — richer payload each one writes. The flow-card
+    // mapper folds these into per-phase snapshots without joining other
+    // entities; see #257.
+    // =========================================================================
+
+    private fun offerPayload(
+        offer: PendingOffer,
+        outcome: AppEventType,
+        decidedAt: Long,
+        description: String? = null,
+    ): OfferPayload = OfferPayload(
+        offerHash = offer.offerHash,
+        parsedOffer = offer.offerFields.parsedOffer,
+        evaluation = offer.evaluation,
+        outcome = outcome,
+        presentedAt = offer.presentedAt,
+        decidedAt = decidedAt,
+        returnFlow = offer.returnFlow,
+        description = description,
+    )
+
+    private fun pickupPayload(
+        task: Task,
+        storeName: String,
+        confirmedAt: Long? = null,
+    ): PickupPayload = PickupPayload(
+        jobId = task.jobId,
+        taskId = task.taskId,
+        storeName = storeName,
+        phaseStartedAt = task.startedAt,
+        arrivedAt = task.arrivedAt,
+        confirmedAt = confirmedAt,
+        odometerAtEntry = task.odometerAtEntry,
+        odometerAtArrival = task.odometerAtArrival,
+        deadlineMillis = task.deadlineMillis,
+        itemCount = task.itemCount,
+        redCardTotal = task.redCardTotal,
+        activity = task.activity,
+    )
+
+    private fun deliveryPhasePayload(
+        task: Task,
+        phaseStartedAt: Long,
+    ): DeliveryPayload = DeliveryPayload(
+        jobId = task.jobId,
+        taskId = task.taskId,
+        storeName = task.storeName,
+        customerHash = task.customerNameHash,
+        addressHash = task.customerAddressHash,
+        phaseStartedAt = phaseStartedAt,
+        arrivedAt = task.arrivedAt,
+        odometerAtEntry = task.odometerAtEntry,
+        odometerAtArrival = task.odometerAtArrival,
+        deadlineMillis = task.deadlineMillis,
+    )
+
+    private fun deliveryCompletedPayload(
+        task: Task?,
+        jobId: String?,
+        completedAt: Long,
+        postTaskFields: ParsedFields.PostTaskFields?,
+        sessionEarnings: Double?,
+    ): DeliveryPayload = DeliveryPayload(
+        jobId = jobId ?: task?.jobId ?: "unknown",
+        taskId = task?.taskId ?: "unknown",
+        storeName = task?.storeName,
+        customerHash = task?.customerNameHash,
+        addressHash = task?.customerAddressHash,
+        phaseStartedAt = task?.startedAt ?: completedAt,
+        arrivedAt = task?.arrivedAt,
+        completedAt = completedAt,
+        odometerAtEntry = task?.odometerAtEntry,
+        odometerAtArrival = task?.odometerAtArrival,
+        deadlineMillis = task?.deadlineMillis,
+        totalPay = postTaskFields?.totalPay,
+        parsedPay = postTaskFields?.parsedPay,
+        sessionEarningsAtCompletion = sessionEarnings,
+    )
 
 }

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
@@ -290,7 +290,7 @@ class PlatformRegionStepper @Inject constructor() {
             }
             is ParsedFields.PostTaskFields -> {
                 val payHash = parsed.parsedPay?.hashCode()
-                r = r.copy(lastPostTaskPayHash = payHash)
+                r = r.copy(lastPostTaskPayHash = payHash, lastPostTaskFields = parsed)
                 r.session?.let { session ->
                     val earnings = parsed.sessionEarnings
                     if (earnings != null) {
@@ -483,6 +483,8 @@ class PlatformRegionStepper @Inject constructor() {
             recentTasks = recentTasks,
             sessionGraceDeadline = null,
             idleEnteredAt = null,
+            lastPostTaskPayHash = null,
+            lastPostTaskFields = null,
         )
     }
 
@@ -491,6 +493,7 @@ class PlatformRegionStepper @Inject constructor() {
         return region.copy(
             activeJob = null,
             lastPostTaskPayHash = null,
+            lastPostTaskFields = null,
         )
     }
 }

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapPayloadTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapPayloadTest.kt
@@ -1,0 +1,587 @@
+package cloud.trotter.dashbuddy.core.state
+
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
+import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
+import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
+import cloud.trotter.dashbuddy.domain.model.event.AppEventType
+import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.OfferPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.OfferReceivedPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.PickupPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.SessionPausedPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStartPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStopPayload
+import cloud.trotter.dashbuddy.domain.model.offer.ParsedOffer
+import cloud.trotter.dashbuddy.domain.model.pay.ParsedPay
+import cloud.trotter.dashbuddy.domain.model.pay.ParsedPayItem
+import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.state.AppState
+import cloud.trotter.dashbuddy.domain.state.CrossPlatformRegion
+import cloud.trotter.dashbuddy.domain.state.Flow
+import cloud.trotter.dashbuddy.domain.state.FlowRegion
+import cloud.trotter.dashbuddy.domain.state.Mode
+import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import cloud.trotter.dashbuddy.domain.state.PendingOffer
+import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.domain.state.PlatformRegion
+import cloud.trotter.dashbuddy.domain.state.Regions
+import cloud.trotter.dashbuddy.domain.state.Session
+import cloud.trotter.dashbuddy.domain.state.Task
+import cloud.trotter.dashbuddy.domain.state.TaskPhase
+import cloud.trotter.dashbuddy.domain.state.TaskSubFlow
+import com.google.gson.Gson
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Verifies that EffectMap.diff() emits rich JSON payloads at every
+ * phase-boundary AppEvent. The flow-card stack (#257) folds these events
+ * into per-phase snapshots without joining other entities, so each payload
+ * must carry the full state of the phase as it closed.
+ */
+class EffectMapPayloadTest {
+
+    private val gson = Gson()
+    private val metadataProvider = MetadataProvider { "{}" }
+    private val effectMap = EffectMap(metadataProvider)
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private fun appState(
+        flow: FlowRegion = FlowRegion(),
+        platforms: Map<Platform, PlatformRegion> = emptyMap(),
+    ) = AppState(
+        regions = Regions(
+            flow = flow,
+            platforms = platforms,
+            crossPlatform = CrossPlatformRegion(),
+        ),
+    )
+
+    private fun screenObs(
+        flow: Flow? = null,
+        modeHint: Mode? = null,
+        parsed: ParsedFields = ParsedFields.None,
+        timestamp: Long = 1000L,
+    ) = Observation.Screen(
+        timestamp = timestamp,
+        captureId = null,
+        ruleId = "test.rule",
+        metadata = ReplayMetadata.EMPTY,
+        flow = flow,
+        modeHint = modeHint,
+        parsed = parsed,
+    )
+
+    private fun parsedOffer(hash: String = "offer-1", pay: Double = 7.50, miles: Double = 4.2) =
+        ParsedOffer(
+            offerHash = hash,
+            payAmount = pay,
+            distanceMiles = miles,
+            itemCount = 1,
+        )
+
+    private fun evaluation(score: Double = 75.0, netPay: Double = 6.50) = OfferEvaluation(
+        action = OfferAction.ACCEPT,
+        score = score,
+        qualityLevel = "Good",
+        recommendationText = "Recommended: ACCEPT",
+        payAmount = 7.50,
+        fuelCostEstimate = 0.5,
+        nonFuelCostEstimate = 0.5,
+        totalOperatingCost = 1.0,
+        operatingCostPerMile = 0.24,
+        netPayAmount = netPay,
+        distanceMiles = 4.2,
+        dollarsPerMile = 1.55,
+        dollarsPerHour = 22.0,
+        estimatedTimeMinutes = 18.0,
+        itemCount = 1.0,
+        merchantName = "Wendy's",
+    )
+
+    private fun pendingOffer(
+        hash: String = "offer-1",
+        presentedAt: Long = 900L,
+    ) = PendingOffer(
+        offerHash = hash,
+        offerFields = ParsedFields.OfferFields(parsedOffer = parsedOffer(hash)),
+        presentedAt = presentedAt,
+        evaluation = evaluation(),
+        returnFlow = Flow.Idle,
+        lastClickIntent = null,
+    )
+
+    private fun task(
+        taskId: String = "task-1",
+        jobId: String = "job-1",
+        phase: TaskPhase = TaskPhase.PICKUP,
+        storeName: String? = "Wendy's",
+        startedAt: Long = 1000L,
+        arrivedAt: Long? = null,
+        deadlineMillis: Long? = null,
+    ) = Task(
+        taskId = taskId,
+        jobId = jobId,
+        phase = phase,
+        storeName = storeName,
+        startedAt = startedAt,
+        arrivedAt = arrivedAt,
+        deadlineMillis = deadlineMillis,
+    )
+
+    private fun logEvents(
+        prev: AppState,
+        next: AppState,
+        obs: Observation,
+        type: AppEventType,
+    ): List<AppEffect.LogEvent> = effectMap.diff(prev, next, obs)
+        .filterIsInstance<AppEffect.LogEvent>()
+        .filter { it.event.eventType == type }
+
+    // =========================================================================
+    // Tests — Offer payloads
+    // =========================================================================
+
+    @Test
+    fun `OFFER_RECEIVED emitted on offer arrival with typed payload`() {
+        val region = PlatformRegion(
+            platform = Platform.DoorDash,
+            mode = Mode.Online,
+            session = Session("dash-7", startedAt = 500L),
+        )
+        val prev = appState(
+            flow = FlowRegion(flow = Flow.Idle, pendingOffer = null, activePlatform = Platform.DoorDash),
+            platforms = mapOf(Platform.DoorDash to region),
+        )
+        val newOffer = pendingOffer(hash = "new-1", presentedAt = 1234L)
+        val next = appState(
+            flow = FlowRegion(flow = Flow.OfferPresented, pendingOffer = newOffer, activePlatform = Platform.DoorDash),
+            platforms = mapOf(Platform.DoorDash to region),
+        )
+        val obs = screenObs(flow = Flow.OfferPresented, timestamp = 1234L)
+
+        val logs = logEvents(prev, next, obs, AppEventType.OFFER_RECEIVED)
+        assertEquals(1, logs.size)
+
+        // Regression: aggregateId must match sessionId so the bubble HUD's
+        // getEventsForDash(dashId) query sees it.
+        assertEquals("dash-7", logs[0].event.aggregateId)
+
+        val payload = gson.fromJson(logs[0].event.eventPayload, OfferReceivedPayload::class.java)
+        assertEquals("new-1", payload.offerHash)
+        assertEquals(1234L, payload.presentedAt)
+        assertEquals("DoorDash", payload.platform)
+        assertEquals(7.50, payload.parsedOffer.payAmount!!, 0.001)
+        assertEquals(4.2, payload.parsedOffer.distanceMiles!!, 0.001)
+    }
+
+    @Test
+    fun `OFFER_ACCEPTED carries rich payload AND correct aggregateId (sessionId)`() {
+        val offer = pendingOffer(hash = "abc", presentedAt = 900L)
+        val region = PlatformRegion(
+            platform = Platform.DoorDash,
+            mode = Mode.Online,
+            session = Session("dash-42", startedAt = 500L),
+        )
+        val prev = appState(
+            flow = FlowRegion(flow = Flow.OfferPresented, pendingOffer = offer, activePlatform = Platform.DoorDash),
+            platforms = mapOf(Platform.DoorDash to region),
+        )
+        val next = appState(
+            flow = FlowRegion(flow = Flow.Idle, pendingOffer = null, activePlatform = Platform.DoorDash),
+            platforms = mapOf(Platform.DoorDash to region),
+        )
+        val click = Observation.Click(
+            timestamp = 1500L,
+            captureId = null,
+            ruleId = "test.click",
+            metadata = ReplayMetadata.EMPTY,
+            flow = null,
+            modeHint = null,
+            parsed = ParsedFields.ClickFields(intent = "accept_offer"),
+        )
+
+        val logs = logEvents(prev, next, click, AppEventType.OFFER_ACCEPTED)
+        assertEquals(1, logs.size)
+
+        // Regression: AppEventDao.getEventsForDash(dashId) filters by
+        // aggregateId. Offer events with null aggregateId are invisible
+        // to the bubble HUD's flow-card stack (#257).
+        assertEquals("dash-42", logs[0].event.aggregateId)
+
+        val payload = gson.fromJson(logs[0].event.eventPayload, OfferPayload::class.java)
+        assertEquals("abc", payload.offerHash)
+        assertEquals(7.50, payload.parsedOffer.payAmount!!, 0.001)
+        assertEquals(4.2, payload.parsedOffer.distanceMiles!!, 0.001)
+        assertNotNull(payload.evaluation)
+        assertEquals(75.0, payload.evaluation!!.score, 0.001)
+        assertEquals(AppEventType.OFFER_ACCEPTED, payload.outcome)
+        assertEquals(900L, payload.presentedAt)
+        assertEquals(1500L, payload.decidedAt)
+    }
+
+    @Test
+    fun `OFFER_DECLINED carries rich payload`() {
+        val offer = pendingOffer(hash = "xyz")
+        val prev = appState(flow = FlowRegion(flow = Flow.OfferPresented, pendingOffer = offer))
+        val next = appState(flow = FlowRegion(flow = Flow.Idle, pendingOffer = null))
+        val click = Observation.Click(
+            timestamp = 1600L,
+            captureId = null,
+            ruleId = "test.click",
+            metadata = ReplayMetadata.EMPTY,
+            flow = null,
+            modeHint = null,
+            parsed = ParsedFields.ClickFields(intent = "decline_offer"),
+        )
+
+        val logs = logEvents(prev, next, click, AppEventType.OFFER_DECLINED)
+        assertEquals(1, logs.size)
+
+        val payload = gson.fromJson(logs[0].event.eventPayload, OfferPayload::class.java)
+        assertEquals("xyz", payload.offerHash)
+        assertEquals(AppEventType.OFFER_DECLINED, payload.outcome)
+    }
+
+    @Test
+    fun `OFFER_TIMEOUT carries rich payload`() {
+        val offer = pendingOffer(hash = "to1")
+        val prev = appState(flow = FlowRegion(flow = Flow.OfferPresented, pendingOffer = offer))
+        val next = appState(flow = FlowRegion(flow = Flow.Idle, pendingOffer = null))
+        // No click — falls through to TIMEOUT
+        val obs = screenObs(flow = Flow.Idle, timestamp = 1700L)
+
+        val logs = logEvents(prev, next, obs, AppEventType.OFFER_TIMEOUT)
+        assertEquals(1, logs.size)
+
+        val payload = gson.fromJson(logs[0].event.eventPayload, OfferPayload::class.java)
+        assertEquals("to1", payload.offerHash)
+        assertEquals(AppEventType.OFFER_TIMEOUT, payload.outcome)
+    }
+
+    // =========================================================================
+    // Tests — Pickup payloads
+    // =========================================================================
+
+    @Test
+    fun `PICKUP_NAV_STARTED carries jobId taskId storeName phaseStartedAt`() {
+        val region = PlatformRegion(
+            platform = Platform.DoorDash,
+            mode = Mode.Online,
+            session = Session("s1", startedAt = 500L),
+        )
+        val prev = appState(
+            flow = FlowRegion(flow = Flow.OfferPresented),
+            platforms = mapOf(Platform.DoorDash to region),
+        )
+        val next = appState(
+            flow = FlowRegion(flow = Flow.TaskPickupNavigation),
+            platforms = mapOf(
+                Platform.DoorDash to region.copy(
+                    activeTask = task(
+                        taskId = "T1",
+                        jobId = "J1",
+                        storeName = "Wendy's",
+                        startedAt = 1100L,
+                        deadlineMillis = 5000L,
+                    ),
+                ),
+            ),
+        )
+        val obs = screenObs(flow = Flow.TaskPickupNavigation, timestamp = 1100L)
+
+        val logs = logEvents(prev, next, obs, AppEventType.PICKUP_NAV_STARTED)
+        assertEquals(1, logs.size)
+
+        val payload = gson.fromJson(logs[0].event.eventPayload, PickupPayload::class.java)
+        assertEquals("T1", payload.taskId)
+        assertEquals("J1", payload.jobId)
+        assertEquals("Wendy's", payload.storeName)
+        assertEquals(1100L, payload.phaseStartedAt)
+        assertEquals(5000L, payload.deadlineMillis)
+        assertNull(payload.arrivedAt)
+        assertNull(payload.confirmedAt)
+    }
+
+    @Test
+    fun `PICKUP_ARRIVED carries arrivedAt + storeName`() {
+        val regionPrev = PlatformRegion(
+            platform = Platform.DoorDash,
+            mode = Mode.Online,
+            session = Session("s1", startedAt = 500L),
+            activeTask = task(taskId = "T2", jobId = "J2", arrivedAt = null),
+        )
+        val regionNext = regionPrev.copy(
+            activeTask = task(taskId = "T2", jobId = "J2", arrivedAt = 1800L),
+        )
+        val prev = appState(
+            flow = FlowRegion(flow = Flow.TaskPickupNavigation),
+            platforms = mapOf(Platform.DoorDash to regionPrev),
+        )
+        val next = appState(
+            flow = FlowRegion(flow = Flow.TaskPickupArrived),
+            platforms = mapOf(Platform.DoorDash to regionNext),
+        )
+        val obs = screenObs(flow = Flow.TaskPickupArrived, timestamp = 1800L)
+
+        val logs = logEvents(prev, next, obs, AppEventType.PICKUP_ARRIVED)
+        assertEquals(1, logs.size)
+
+        val payload = gson.fromJson(logs[0].event.eventPayload, PickupPayload::class.java)
+        assertEquals("T2", payload.taskId)
+        assertEquals("Wendy's", payload.storeName)
+        assertEquals(1800L, payload.arrivedAt)
+    }
+
+    @Test
+    fun `PICKUP_CONFIRMED + DELIVERY_NAV_STARTED both carry rich payloads`() {
+        val regionPrev = PlatformRegion(
+            platform = Platform.DoorDash,
+            mode = Mode.Online,
+            session = Session("s1", startedAt = 500L),
+            activeTask = task(
+                taskId = "T3",
+                jobId = "J3",
+                phase = TaskPhase.PICKUP,
+                arrivedAt = 1800L,
+            ),
+        )
+        val regionNext = regionPrev.copy(
+            activeTask = task(
+                taskId = "T4",
+                jobId = "J3",
+                phase = TaskPhase.DROPOFF,
+                storeName = null,
+                arrivedAt = null,
+                startedAt = 2000L,
+            ).copy(customerNameHash = "cust-abc"),
+        )
+        val prev = appState(
+            flow = FlowRegion(flow = Flow.TaskPickupArrived),
+            platforms = mapOf(Platform.DoorDash to regionPrev),
+        )
+        val next = appState(
+            flow = FlowRegion(flow = Flow.TaskDropoffNavigation),
+            platforms = mapOf(Platform.DoorDash to regionNext),
+        )
+        val obs = screenObs(flow = Flow.TaskDropoffNavigation, timestamp = 2000L)
+
+        val effects = effectMap.diff(prev, next, obs).filterIsInstance<AppEffect.LogEvent>()
+        val confirmed = effects.firstOrNull { it.event.eventType == AppEventType.PICKUP_CONFIRMED }
+        val delivery = effects.firstOrNull { it.event.eventType == AppEventType.DELIVERY_NAV_STARTED }
+
+        assertNotNull("PICKUP_CONFIRMED missing", confirmed)
+        assertNotNull("DELIVERY_NAV_STARTED missing", delivery)
+
+        val pickupPayload = gson.fromJson(confirmed!!.event.eventPayload, PickupPayload::class.java)
+        assertEquals("T3", pickupPayload.taskId)
+        assertEquals(2000L, pickupPayload.confirmedAt)
+
+        val deliveryPayload = gson.fromJson(delivery!!.event.eventPayload, DeliveryPayload::class.java)
+        assertEquals("T4", deliveryPayload.taskId)
+        assertEquals("cust-abc", deliveryPayload.customerHash)
+        assertEquals(2000L, deliveryPayload.phaseStartedAt)
+    }
+
+    // =========================================================================
+    // Tests — Delivery payloads
+    // =========================================================================
+
+    @Test
+    fun `DELIVERY_ARRIVED carries dropoff task details`() {
+        val regionPrev = PlatformRegion(
+            platform = Platform.DoorDash,
+            mode = Mode.Online,
+            session = Session("s1", startedAt = 500L),
+            activeTask = task(
+                taskId = "T5",
+                jobId = "J5",
+                phase = TaskPhase.DROPOFF,
+                arrivedAt = null,
+            ).copy(customerNameHash = "cust-xyz"),
+        )
+        val regionNext = regionPrev.copy(
+            activeTask = regionPrev.activeTask?.copy(arrivedAt = 2500L),
+        )
+        val prev = appState(
+            flow = FlowRegion(flow = Flow.TaskDropoffNavigation),
+            platforms = mapOf(Platform.DoorDash to regionPrev),
+        )
+        val next = appState(
+            flow = FlowRegion(flow = Flow.TaskDropoffArrived),
+            platforms = mapOf(Platform.DoorDash to regionNext),
+        )
+        val obs = screenObs(flow = Flow.TaskDropoffArrived, timestamp = 2500L)
+
+        val logs = logEvents(prev, next, obs, AppEventType.DELIVERY_ARRIVED)
+        assertEquals(1, logs.size)
+
+        val payload = gson.fromJson(logs[0].event.eventPayload, DeliveryPayload::class.java)
+        assertEquals("T5", payload.taskId)
+        assertEquals("cust-xyz", payload.customerHash)
+        assertEquals(2500L, payload.arrivedAt)
+    }
+
+    @Test
+    fun `DELIVERY_COMPLETED carries totalPay parsedPay sessionEarnings`() {
+        val parsedPay = ParsedPay(
+            appPayComponents = listOf(ParsedPayItem("Base Pay", 4.50)),
+            customerTips = listOf(ParsedPayItem("Wendy's", 3.00)),
+        )
+        val postFields = ParsedFields.PostTaskFields(
+            totalPay = 7.50,
+            parsedPay = parsedPay,
+            sessionEarnings = 47.50,
+        )
+        val completedTask = task(
+            taskId = "T6",
+            jobId = "J6",
+            phase = TaskPhase.DROPOFF,
+            arrivedAt = 2500L,
+        )
+        val regionPrev = PlatformRegion(
+            platform = Platform.DoorDash,
+            mode = Mode.Online,
+            session = Session("s1", startedAt = 500L, runningEarnings = 47.50),
+            recentTasks = listOf(completedTask),
+            lastPostTaskFields = postFields,
+        )
+        val regionNext = regionPrev.copy()
+        val prev = appState(
+            flow = FlowRegion(flow = Flow.PostTask),
+            platforms = mapOf(Platform.DoorDash to regionPrev),
+        )
+        val next = appState(
+            flow = FlowRegion(flow = Flow.Idle),
+            platforms = mapOf(Platform.DoorDash to regionNext),
+        )
+        val obs = screenObs(flow = Flow.Idle, timestamp = 3000L)
+
+        val logs = logEvents(prev, next, obs, AppEventType.DELIVERY_COMPLETED)
+        assertEquals(1, logs.size)
+
+        val payload = gson.fromJson(logs[0].event.eventPayload, DeliveryPayload::class.java)
+        assertEquals("T6", payload.taskId)
+        assertEquals(7.50, payload.totalPay!!, 0.001)
+        assertNotNull(payload.parsedPay)
+        assertEquals(7.50, payload.parsedPay!!.total, 0.001)
+        assertEquals(47.50, payload.sessionEarningsAtCompletion!!, 0.001)
+        assertEquals(3000L, payload.completedAt)
+    }
+
+    // =========================================================================
+    // Tests — Session payloads
+    // =========================================================================
+
+    @Test
+    fun `DASH_START carries sessionId platform source startScreen`() {
+        val regionPrev = PlatformRegion(platform = Platform.DoorDash, mode = Mode.Offline)
+        val regionNext = PlatformRegion(
+            platform = Platform.DoorDash,
+            mode = Mode.Online,
+            session = Session(sessionId = "s-new", startedAt = 1000L),
+        )
+        val prev = appState(platforms = mapOf(Platform.DoorDash to regionPrev))
+        val next = appState(platforms = mapOf(Platform.DoorDash to regionNext))
+        val obs = screenObs(modeHint = Mode.Online, timestamp = 1000L)
+
+        val logs = logEvents(prev, next, obs, AppEventType.DASH_START)
+        assertEquals(1, logs.size)
+
+        val payload = gson.fromJson(logs[0].event.eventPayload, SessionStartPayload::class.java)
+        assertEquals("s-new", payload.sessionId)
+        assertEquals("DoorDash", payload.platform)
+        assertEquals(1000L, payload.startedAt)
+        assertTrue(payload.source == "interaction" || payload.source == "recovery")
+    }
+
+    @Test
+    fun `DASH_STOP with summary screen carries totalEarnings and source=summary_screen`() {
+        val regionPrev = PlatformRegion(
+            platform = Platform.DoorDash,
+            mode = Mode.Online,
+            session = Session("s1", startedAt = 1000L, runningEarnings = 50.0),
+        )
+        val regionNext = PlatformRegion(platform = Platform.DoorDash, mode = Mode.Offline)
+        val prev = appState(platforms = mapOf(Platform.DoorDash to regionPrev))
+        val next = appState(platforms = mapOf(Platform.DoorDash to regionNext))
+        val summaryFields = ParsedFields.SessionEndedFields(
+            totalEarnings = 50.0,
+            sessionDurationMillis = 4 * 60 * 60 * 1000L,
+            offersAccepted = 5,
+            offersTotal = 8,
+        )
+        val obs = screenObs(
+            flow = Flow.SessionEnded,
+            modeHint = Mode.Offline,
+            parsed = summaryFields,
+            timestamp = 6000L,
+        )
+
+        val logs = logEvents(prev, next, obs, AppEventType.DASH_STOP)
+        assertEquals(1, logs.size)
+
+        val payload = gson.fromJson(logs[0].event.eventPayload, SessionStopPayload::class.java)
+        assertEquals("summary_screen", payload.source)
+        assertEquals(50.0, payload.totalEarnings!!, 0.001)
+        assertEquals(5, payload.offersAccepted)
+        assertEquals(8, payload.offersTotal)
+        assertEquals(6000L, payload.endedAt)
+    }
+
+    @Test
+    fun `DASH_STOP without summary screen carries source=early_offline`() {
+        val regionPrev = PlatformRegion(
+            platform = Platform.DoorDash,
+            mode = Mode.Online,
+            session = Session("s1", startedAt = 1000L, runningEarnings = 30.0),
+        )
+        val regionNext = PlatformRegion(platform = Platform.DoorDash, mode = Mode.Offline)
+        val prev = appState(platforms = mapOf(Platform.DoorDash to regionPrev))
+        val next = appState(platforms = mapOf(Platform.DoorDash to regionNext))
+        val obs = screenObs(modeHint = Mode.Offline, timestamp = 5500L)
+
+        val logs = logEvents(prev, next, obs, AppEventType.DASH_STOP)
+        assertEquals(1, logs.size)
+
+        val payload = gson.fromJson(logs[0].event.eventPayload, SessionStopPayload::class.java)
+        assertEquals("early_offline", payload.source)
+        assertEquals(30.0, payload.totalEarnings!!, 0.001)
+    }
+
+    @Test
+    fun `DASH_PAUSED carries sessionId pausedAt remainingMillis`() {
+        val regionPrev = PlatformRegion(
+            platform = Platform.DoorDash,
+            mode = Mode.Online,
+            session = Session("s1", startedAt = 1000L),
+        )
+        val regionNext = regionPrev.copy(mode = Mode.Paused)
+        val prev = appState(platforms = mapOf(Platform.DoorDash to regionPrev))
+        val next = appState(platforms = mapOf(Platform.DoorDash to regionNext))
+        val pausedFields = ParsedFields.PausedFields(
+            remainingText = "29:42",
+            remainingMillis = 29 * 60 * 1000L,
+        )
+        val obs = screenObs(
+            modeHint = Mode.Paused,
+            parsed = pausedFields,
+            timestamp = 4000L,
+        )
+
+        val logs = logEvents(prev, next, obs, AppEventType.DASH_PAUSED)
+        assertEquals(1, logs.size)
+
+        val payload = gson.fromJson(logs[0].event.eventPayload, SessionPausedPayload::class.java)
+        assertEquals("s1", payload.sessionId)
+        assertEquals(4000L, payload.pausedAt)
+        assertEquals(29 * 60 * 1000L, payload.remainingMillis)
+        assertEquals("29:42", payload.remainingText)
+    }
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/cards/FlowCardSnapshot.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/cards/FlowCardSnapshot.kt
@@ -1,0 +1,142 @@
+package cloud.trotter.dashbuddy.domain.model.cards
+
+import cloud.trotter.dashbuddy.domain.model.event.AppEventType
+import cloud.trotter.dashbuddy.domain.model.pay.ParsedPay
+
+/**
+ * A single card in the bubble HUD's flow-card stack (#257).
+ *
+ * Cards are phase-grouped — five kinds covering one delivery cycle plus
+ * the Awaiting period that precedes it:
+ *   Awaiting → Offer → Pickup → Delivery → PostTask
+ *
+ * Each subtype carries the frozen view-state needed to render the card body
+ * without any reference to live `AppState`. The currently-active phase is
+ * the snapshot whose [phaseEndedAt] is null; it's rebuilt each emission
+ * from the focused `PlatformRegion` and uses `rememberNow()` to tick.
+ * Completed cards have a non-null [phaseEndedAt] and render statically.
+ */
+sealed class FlowCardSnapshot {
+
+    /** Stable identifier — used as the LazyColumn item key. */
+    abstract val id: String
+
+    /** When this phase opened. */
+    abstract val phaseStartedAt: Long
+
+    /** When this phase closed; null if the card is still live. */
+    abstract val phaseEndedAt: Long?
+
+    /** True when [phaseEndedAt] is non-null. */
+    val isCompleted: Boolean get() = phaseEndedAt != null
+
+    /**
+     * The Awaiting card — appears once at the top of each dash session. Live
+     * while the dasher is Online and no offer is on screen. Frozen when the
+     * first OFFER_RECEIVED arrives.
+     */
+    data class Awaiting(
+        override val id: String,
+        override val phaseStartedAt: Long,
+        override val phaseEndedAt: Long? = null,
+        val sessionId: String? = null,
+    ) : FlowCardSnapshot()
+
+    /**
+     * One Offer card per offer presented. Live while the offer is on screen;
+     * frozen when an OFFER_ACCEPTED / OFFER_DECLINED / OFFER_TIMEOUT event
+     * with the same `offerHash` is observed.
+     */
+    data class Offer(
+        override val phaseStartedAt: Long,
+        override val phaseEndedAt: Long? = null,
+        val offerHash: String,
+        val payAmount: Double? = null,
+        val distanceMiles: Double? = null,
+        val itemCount: Int = 1,
+        val storeNames: List<String> = emptyList(),
+        val evaluationScore: Double? = null,
+        val evaluationAction: String? = null,
+        val netPayAmount: Double? = null,
+        val dollarsPerMile: Double? = null,
+        val dollarsPerHour: Double? = null,
+        val outcome: AppEventType? = null,
+    ) : FlowCardSnapshot() {
+        override val id: String get() = "offer:$offerHash"
+    }
+
+    /**
+     * One Pickup card per task with phase=PICKUP. Covers both the nav and
+     * arrival sub-states. Live while the dasher is en route to / at the
+     * store. Frozen when the task transitions to phase=DROPOFF
+     * (PICKUP_CONFIRMED).
+     */
+    data class Pickup(
+        override val phaseStartedAt: Long,
+        override val phaseEndedAt: Long? = null,
+        val taskId: String,
+        val jobId: String,
+        val storeName: String,
+        val arrivedAt: Long? = null,
+        val confirmedAt: Long? = null,
+        val deadlineMillis: Long? = null,
+        val itemCount: Int? = null,
+        val activity: String? = null,
+    ) : FlowCardSnapshot() {
+        override val id: String get() = "pickup:$taskId"
+    }
+
+    /**
+     * One Delivery card per task with phase=DROPOFF, covering nav + arrival
+     * sub-states. Live while the dasher is driving to / at the customer.
+     * Frozen on DELIVERY_ARRIVED (so the card's "closing" content is the
+     * moment the package was delivered; receipt details live on the
+     * subsequent PostTask card).
+     */
+    data class Delivery(
+        override val phaseStartedAt: Long,
+        override val phaseEndedAt: Long? = null,
+        val taskId: String,
+        val jobId: String,
+        val storeName: String? = null,
+        val customerHash: String? = null,
+        val arrivedAt: Long? = null,
+        val deadlineMillis: Long? = null,
+    ) : FlowCardSnapshot() {
+        override val id: String get() = "delivery:$taskId"
+    }
+
+    /**
+     * One PostTask card per delivery — the receipt / expanded-pay screen.
+     * Live while the PostTask flow is showing; frozen when the flow returns
+     * to Idle or moves to a new offer.
+     */
+    data class PostTask(
+        override val phaseStartedAt: Long,
+        override val phaseEndedAt: Long? = null,
+        val jobId: String,
+        val taskId: String? = null,
+        val storeName: String? = null,
+        val totalPay: Double = 0.0,
+        val parsedPay: ParsedPay? = null,
+        val sessionEarningsAtCompletion: Double? = null,
+    ) : FlowCardSnapshot() {
+        override val id: String get() = "posttask:$jobId"
+    }
+}
+
+/**
+ * The full bubble HUD card stack at a point in time. Completed cards are
+ * rendered statically; [active] (if present) is the focused live card,
+ * always at the bottom of the stack, auto-expanded, with a 1Hz ticker.
+ */
+data class CardStack(
+    val completed: List<FlowCardSnapshot> = emptyList(),
+    val active: FlowCardSnapshot? = null,
+) {
+    val isEmpty: Boolean get() = completed.isEmpty() && active == null
+
+    companion object {
+        val Empty = CardStack()
+    }
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/payload/AppEventPayloads.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/payload/AppEventPayloads.kt
@@ -1,0 +1,142 @@
+package cloud.trotter.dashbuddy.domain.model.event.payload
+
+import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
+import cloud.trotter.dashbuddy.domain.model.event.AppEventType
+import cloud.trotter.dashbuddy.domain.model.offer.ParsedOffer
+import cloud.trotter.dashbuddy.domain.model.pay.ParsedPay
+import cloud.trotter.dashbuddy.domain.state.Flow
+
+/**
+ * Rich payloads written into [cloud.trotter.dashbuddy.core.database.event.AppEventEntity.eventPayload]
+ * at each phase-boundary. Each payload captures the full state of the phase
+ * as it closed so the bubble HUD's flow-card stack can fold the event stream
+ * into per-phase snapshots without joining other entities.
+ *
+ * `AppEventEntity.eventPayload` is a JSON `String`, so adding/removing fields
+ * on these classes does not require a database migration. Old rows simply
+ * deserialize into whatever fields they still have.
+ */
+
+/**
+ * Payload for `OFFER_RECEIVED` — emitted when a new offer first appears on
+ * screen. Lean by design: the offer's evaluation hasn't run yet at this
+ * point (the EvaluateOffer side effect fires async), so only the parsed
+ * offer + identity fields are populated. The closing `OFFER_ACCEPTED` /
+ * `OFFER_DECLINED` / `OFFER_TIMEOUT` event carries the rich evaluation.
+ */
+data class OfferReceivedPayload(
+    val offerHash: String,
+    val parsedOffer: ParsedOffer,
+    val presentedAt: Long,
+    val platform: String,
+    val returnFlow: Flow,
+)
+
+/**
+ * Payload for `OFFER_ACCEPTED` / `OFFER_DECLINED` / `OFFER_TIMEOUT`.
+ *
+ * Carries the full offer context and evaluation. The closing event alone is
+ * sufficient to render the Offer card — no need to read OFFER_RECEIVED.
+ */
+data class OfferPayload(
+    val offerHash: String,
+    val parsedOffer: ParsedOffer,
+    val evaluation: OfferEvaluation? = null,
+    val outcome: AppEventType,
+    val presentedAt: Long,
+    val decidedAt: Long,
+    val returnFlow: Flow,
+    /** Optional context — e.g. "Replaced by new offer". */
+    val description: String? = null,
+)
+
+/**
+ * Payload for `PICKUP_NAV_STARTED`, `PICKUP_ARRIVED`, `PICKUP_CONFIRMED`.
+ *
+ * Each phase-boundary fills in progressively more fields:
+ *   NAV_STARTED → phaseStartedAt + entry odometer + task metadata
+ *   ARRIVED     → adds arrivedAt + arrival odometer
+ *   CONFIRMED   → adds confirmedAt (the moment pickup→dropoff transition)
+ */
+data class PickupPayload(
+    val jobId: String,
+    val taskId: String,
+    val storeName: String,
+    val phaseStartedAt: Long,
+    val arrivedAt: Long? = null,
+    val confirmedAt: Long? = null,
+    val odometerAtEntry: Double? = null,
+    val odometerAtArrival: Double? = null,
+    val deadlineMillis: Long? = null,
+    val itemCount: Int? = null,
+    val redCardTotal: Double? = null,
+    val activity: String? = null,
+)
+
+/**
+ * Payload for `DELIVERY_NAV_STARTED`, `DELIVERY_ARRIVED`, `DELIVERY_COMPLETED`.
+ *
+ * `DELIVERY_COMPLETED` is the only one that carries the per-delivery pay
+ * breakdown — captured from the most recent PostTask observation before
+ * leaving the PostTask flow.
+ */
+data class DeliveryPayload(
+    val jobId: String,
+    val taskId: String,
+    val storeName: String? = null,
+    val customerHash: String? = null,
+    val addressHash: String? = null,
+    val phaseStartedAt: Long,
+    val arrivedAt: Long? = null,
+    val completedAt: Long? = null,
+    val odometerAtEntry: Double? = null,
+    val odometerAtArrival: Double? = null,
+    val deadlineMillis: Long? = null,
+    /** Total pay for this delivery — populated on COMPLETED. */
+    val totalPay: Double? = null,
+    /** Itemized pay breakdown — populated on COMPLETED. */
+    val parsedPay: ParsedPay? = null,
+    /** Session running total at the moment of completion. */
+    val sessionEarningsAtCompletion: Double? = null,
+)
+
+/** Payload for `DASH_START`. */
+data class SessionStartPayload(
+    val sessionId: String,
+    val platform: String,
+    val startedAt: Long,
+    /** "interaction" (normal user start) | "recovery" (crash recovery). */
+    val source: String,
+    val startScreen: String,
+)
+
+/**
+ * Payload for `DASH_PAUSED`. The platform's reported pause countdown is
+ * captured so the card stack can render a frozen "paused for Xm Ys" view.
+ */
+data class SessionPausedPayload(
+    val sessionId: String?,
+    val pausedAt: Long,
+    val remainingText: String? = null,
+    val remainingMillis: Long? = null,
+)
+
+/**
+ * Payload for `DASH_STOP`.
+ *
+ * When the dash ends on a SessionEnded summary screen, the full earnings
+ * picture is populated. When it ends via an early offline transition without
+ * a summary screen, only the `source` field is set — the card UI shows an
+ * "incomplete" badge for that case.
+ */
+data class SessionStopPayload(
+    val sessionId: String?,
+    val endedAt: Long,
+    /** "summary_screen" | "early_offline". */
+    val source: String,
+    val totalEarnings: Double? = null,
+    val sessionDurationMillis: Long? = null,
+    val offersAccepted: Int? = null,
+    val offersTotal: Int? = null,
+    val weeklyEarnings: Double? = null,
+)

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/PlatformRegion.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/PlatformRegion.kt
@@ -24,6 +24,12 @@ data class PlatformRegion(
     val ratings: RatingsSnapshot? = null,
     val surgeMultiplier: Double? = null,
     val lastPostTaskPayHash: Int? = null,
+    /**
+     * Most recent PostTask observation's parsed fields. Captured during
+     * PostTask so the closing `DELIVERY_COMPLETED` event (emitted on
+     * leaving PostTask) can include the full pay breakdown.
+     */
+    val lastPostTaskFields: ParsedFields.PostTaskFields? = null,
     val lastObservedAt: Long = 0,
     /** Timestamp when Flow entered Idle while mode is Online. Null otherwise. */
     val idleEnteredAt: Long? = null,


### PR DESCRIPTION
Closes #257.

## Summary

- **Section A — AppEvent payload enrichment.** `EffectMap.kt` now writes structured per-phase payloads (`OfferReceivedPayload`, `OfferPayload`, `PickupPayload`, `DeliveryPayload`, `SessionStopPayload`) instead of thin status strings. Same emit moments; data that was already in-memory (`ParsedOffer`, `OfferEvaluation`, `ParsedPay`, `jobId`, odometer, deadlines, session earnings) is no longer discarded before serialization. `AppEventEntity.eventPayload` is still a JSON `String`, so no DB migration — old rows continue to deserialize.
- **Section B — Flow-card stack UI.** `BubbleScreen`'s single-active-phase dispatcher is replaced with a `LazyColumn` of `FlowCardItem`s — one card per phase since the current `DASH_START`. Completed phases render statically from `FlowCardSnapshot`s produced by `FlowCardMapper.fold(events)`; the active phase is pinned at the bottom, auto-expanded, and ticked by the existing `rememberNow()` 1 Hz helper.

`FlowCardMapper.fold` is a pure projection over the enriched event log (no joins, no DB reads) — the first concrete projection called out in RFC #202, and the data source the session-history followup will reuse.

## Out of scope (per the issue's followups list)

- Session history Activity that reuses `FlowCardItem`
- Bell-icon chat migration replacing `LatestMessageTicker`
- `AppEvents` retention policy (rows are now ~30× larger; will matter eventually, not yet)

## Test plan

- [x] `./gradlew :core:state:testDebugUnitTest --tests "*EffectMapPayloadTest*"`
- [x] `./gradlew :app:testDebugUnitTest --tests "*FlowCardMapperTest*"`
- [x] `./gradlew :app:testDebugUnitTest :core:state:testDebugUnitTest :domain:test` (full module sweep)
- [ ] On-dash sanity pass next field session: every phase emits its card; collapsed cards re-expand on tap; stack survives `DASH_STOP`; next `DASH_START` clears

## Related

- #18 — bubble UI/UX redesign (parent)
- #202 — RFC: incremental event projection layer (this PR ships the first concrete projection)
- #245 — ADR-0007 canonical domain schema (payload field names should align as that lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)