### PR TITLE
fix: include screen context in click-capture dedup hash

### DIFF
--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/AccessibilityPipeline.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/AccessibilityPipeline.kt
@@ -11,6 +11,7 @@ import cloud.trotter.dashbuddy.core.data.settings.PlatformPreferencesRepository
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
 import cloud.trotter.dashbuddy.domain.pipeline.ObservationIdentity
 import cloud.trotter.dashbuddy.domain.pipeline.identity
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
 import cloud.trotter.dashbuddy.domain.state.ParsedFields
 import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.core.pipeline.ObservationClassifier
@@ -202,9 +203,10 @@ class AccessibilityPipeline @Inject constructor(
             }
 
             is PipelineEvent.Click -> {
+                val screenTarget = classifier.lastScreenTarget
                 val clickPayload = ClickCapturePayload(
                     node = event.node,
-                    screenTarget = classifier.lastScreenTarget,
+                    screenTarget = screenTarget,
                 )
                 val capture = EnvelopeBuilder.build(
                     pipelineId = CLICK_PIPELINE_ID,
@@ -213,7 +215,7 @@ class AccessibilityPipeline @Inject constructor(
                     ruleId = flowObs.ruleId,
                     classificationName = flowObs.target,
                     payload = clickPayload,
-                    contentHash = event.node.structuralHash,
+                    contentHash = clickDedupHash(event.node, screenTarget),
                     metadata = flowObs.metadata,
                 )
                 val captureId = captureBus.offer(
@@ -235,3 +237,16 @@ class AccessibilityPipeline @Inject constructor(
         }
     }
 }
+
+/**
+ * Dedup hash for a click capture that includes the current screen target.
+ *
+ * Same-shape buttons (e.g. DoorDash's `primary_action_button`) appear on many
+ * screens with different labels and meanings. [UiNode.structuralHash] ignores
+ * text, so without the screen mix all such clicks collide in the per-bucket
+ * dedup set inside [cloud.trotter.dashbuddy.core.data.capture.DiskCaptureBus]
+ * and only the first one in a session survives — silently dropping later
+ * clicks the developer needs to triage screen-specific behavior.
+ */
+internal fun clickDedupHash(node: UiNode, screenTarget: String?): Int =
+    31 * node.structuralHash + (screenTarget?.hashCode() ?: 0)

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/AccessibilityPipelineDedupTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/AccessibilityPipelineDedupTest.kt
@@ -1,0 +1,52 @@
+package cloud.trotter.dashbuddy.core.pipeline.accessibility
+
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class AccessibilityPipelineDedupTest {
+
+    private fun primaryActionButton(): UiNode = UiNode(
+        viewIdResourceName = "com.doordash.driverapp:id/primary_action_button",
+        className = "android.widget.Button",
+        isClickable = true,
+    )
+
+    private fun otherButton(): UiNode = UiNode(
+        viewIdResourceName = "com.doordash.driverapp:id/secondary_action_button",
+        className = "android.widget.Button",
+        isClickable = true,
+    )
+
+    @Test
+    fun `same node and same screen produces same hash`() {
+        val a = clickDedupHash(primaryActionButton(), "offer_popup_confirm_decline")
+        val b = clickDedupHash(primaryActionButton(), "offer_popup_confirm_decline")
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun `same node on different screens produces different hash`() {
+        // The bug this fix addresses: a primary_action_button tapped on
+        // pickup_pre_arrival ("Arrived at store") and again on
+        // offer_popup_confirm_decline ("Decline offer") must not collide.
+        val onPickup = clickDedupHash(primaryActionButton(), "pickup_pre_arrival")
+        val onConfirmDecline = clickDedupHash(primaryActionButton(), "offer_popup_confirm_decline")
+        assertNotEquals(onPickup, onConfirmDecline)
+    }
+
+    @Test
+    fun `same node with null screen on both produces same hash`() {
+        val a = clickDedupHash(primaryActionButton(), null)
+        val b = clickDedupHash(primaryActionButton(), null)
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun `different nodes on same screen produce different hash`() {
+        val primary = clickDedupHash(primaryActionButton(), "offer_popup")
+        val other = clickDedupHash(otherButton(), "offer_popup")
+        assertNotEquals(primary, other)
+    }
+}


### PR DESCRIPTION
## Summary

`DiskCaptureBus` dedupes click captures by `(bucket, contentHash)` where `bucket = platform/source/classification`. For unknown clicks the bucket is `<platform>/accessibility.click/UNKNOWN` — shared across the whole session — and the `contentHash` was a bare `UiNode.structuralHash`, which only mixes `className` + `viewIdResourceName` + children (no text, no screen).

DoorDash's `com.doordash.driverapp:id/primary_action_button` is reused on many screens — "Arrived at store" on `pickup_pre_arrival`, "Confirm pickup" on `pickup_arrival`, "Decline offer" on `offer_popup_confirm_decline`, etc. They all hash to the same structural value, so the first one in a session wins the bucket slot and every subsequent one is silently dropped.

That's why the 2026-05-15 field session captured 23 UNKNOWN clicks but **not** the confirm-decline tap we need to triage the decline-flow bug from `docs/field-testing/README.md` (2026-05-16 entry).

This PR mixes `classifier.lastScreenTarget` into the `contentHash` for clicks via a small `internal clickDedupHash(node, screenTarget)` helper. Same-shape buttons on different screens now produce different hashes and all survive the dedup.

- **`CaptureBus` interface:** unchanged — `contentHash` is already documented as "Optional structural hash for per-bucket deduplication," and the caller chooses what to hash.
- **`DiskCaptureBus` behavior:** unchanged — same code path, just receives a wider hash for clicks.
- **Directory layout on disk:** unchanged — each capture file's `payload.screenTarget` still carries the screen for review.
- **Screen + notification capture paths:** untouched.

## Why this is the prerequisite for the decline fix

The field log's two-tap-decline hypothesis (`initial_decline` vs `decline_offer`, with the confirm rule gated on `screenIs: "offer_popup_confirm_decline"`) can only be confirmed or refuted by *seeing* the click that fires on the confirm dialog. Today that click is being silently dropped by the dedup, so the validating capture never lands on disk. This change makes the next field session actually persist it.

## Test plan

- [x] `./gradlew :core:pipeline:testDebugUnitTest --tests "*AccessibilityPipelineDedupTest*"` — new helper tests
- [x] `./gradlew :core:pipeline:testDebugUnitTest :app:testDebugUnitTest` — broader sweep
- [ ] Next field session: open DoorDash, take an offer, tap **Decline** → **Decline offer**. Pull captures and verify `captures/doordash/accessibility.click/UNKNOWN/` contains multiple files, including one with `payload.screenTarget == "offer_popup_confirm_decline"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)