### PR TITLE
docs: field-testing entry for 2026-05-17 dashes (flow-card bubble)

### DIFF
--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -60,23 +60,30 @@ cross-referencing within a single session entry, not across sessions.
   - `Delivery` card (`FlowCardItem.kt:312-325`) has the same shape and the same gap for the deliver-by deadline.
 - **Possible direction (sketch, not a recommendation):** add a secondary caption like `"by ${formatTime(deadlineMillis)}"` under the countdown. Cheap to add; would let the dasher cross-check the countdown against the literal time on the DoorDash UI.
 
-#### 3. Frozen Delivery card disappears under (or is visually absorbed by) the PAID card after delivery completes
+#### 3. No mid-dash freeze of the Drop-off card — it only appears at end-of-dash, flushed by DASH_STOP
 
-- **Repro:** Complete a delivery. Watch the flow-card stack transition from the live Delivery card to the live PAID/PostTask card.
-- **Observed (per the log narrative):** "the drop-off block had the section for the drop off. Whenever that got completed, it got replaced by the paid block." The dasher wants the Delivery summary to **persist** in the history above the receipt — not vanish.
-- **Hypothesis (from a desk read, not verified against the captured event stream):**
-  - `FlowCardMapper.kt:201-224` *does* add a frozen Delivery snapshot to `completed` on `DELIVERY_ARRIVED`, so in principle it should appear in the stack just above the live PAID card once the flow advances to PostTask. So the bug isn't "Delivery card never gets stored."
-  - Two candidate explanations worth distinguishing:
-    - (a) `DELIVERY_ARRIVED` isn't actually firing for this style of completion. `EffectMap.kt:402-432` only emits it when `nextTask.arrivedAt != null && prevTask?.arrivedAt == null` — i.e. an explicit arrival sub-state transition. If DoorDash's "no-contact delivery" flow rolls straight from nav → completed without DashBuddy seeing an ARRIVED screen, the Delivery card stays in `openDelivery` and only gets flushed by DASH_STOP at the end of the dash (`FlowCardMapper.kt:247-258`). Net effect: looks "replaced" because there is no frozen Delivery card in the stack at the moment the PAID card appears.
-    - (b) The Delivery card *is* in `completed` but its frozen body is so terse (line 187-195: "customer · delivered HH:MM" + a +/- delta hero) that the dasher reads it as part of the PAID card chrome rather than a separate card. The visual hierarchy in the stack puts the live card at the bottom, expanded, and the just-previous frozen card flush above it with similar styling.
-  - The user-side description ("it had the section for the drop off … got replaced") slightly favors (a): they're describing the section disappearing, not just shrinking. But (a) and (b) are easy to disambiguate from a captured event log.
-- **What would confirm or refute this:**
-  - (a-vs-b): for the same delivery, check whether a `DELIVERY_ARRIVED` event row exists in `app_events` between the last `DELIVERY_NAV_STARTED` and the `DELIVERY_COMPLETED`. If absent → (a). If present → (b).
-  - Either way, worth a check from the bubble-history side: when the PAID card is the live one, is `cardStack.completed` actually carrying a `FlowCardSnapshot.Delivery` for the same `jobId`?
+- **Repro:** Complete a delivery. Watch the flow-card stack transition from the live Drop-off card to the live PAID/PostTask card. Watch through the rest of the dash, then end the dash and look at the stack.
+- **Observed (per the log narrative):** "the drop-off block had the section for the drop off. Whenever that got completed, it got replaced by the paid block." Later follow-up clarification: the frozen Drop-off card **did appear at the end of the dash, after the dash was ended** — not at delivery completion. The dasher wants the Drop-off summary to be frozen and visible in the history at the moment the PAID card appears, not deferred to end-of-session.
+- **The end-of-dash appearance is strong evidence:** of the two candidates the original entry sketched, this confirms (a) over (b). `FlowCardMapper.kt:247-258` is the only path that flushes a still-open `openDelivery` — and that path runs on `DASH_STOP`. So the Drop-off card never reaches `completed` at delivery time; it sits half-open in `openDelivery` until the session ends.
+- **Hypothesis (from a desk read, narrowed by the end-of-dash observation):**
+  - `DELIVERY_ARRIVED` isn't being emitted for this delivery style. `EffectMap.kt:402-432` only emits it when `nextTask.arrivedAt != null && prevTask?.arrivedAt == null` — i.e. an explicit arrival sub-state transition. If DoorDash's "no-contact delivery" rolls from nav → completion without DashBuddy ever observing an arrival screen, `nextTask.arrivedAt` never flips non-null and `DELIVERY_ARRIVED` never fires.
+  - With no `DELIVERY_ARRIVED`, `FlowCardMapper.kt:201-224` is never invoked for this delivery, so the open Delivery stays in `openDelivery` and the `lastDeliveryArrivedAt` accumulator stays null. `DELIVERY_COMPLETED` at `:226-245` adds a PostTask card but **doesn't** flush `openDelivery` — only DASH_STOP does (`:247-258`).
+  - This also leaves `lastDeliveryArrivedAt` null at the moment the PostTask card is built, so the PostTask's `phaseStartedAt` falls back to `payload.phaseStartedAt` (`FlowCardMapper.kt:231`) rather than the actual arrival time. Worth checking whether the PAID card's timing looks off too.
+- **Possible direction (sketch only — defer to desk review):**
+  - Either teach the platform stepper to mark `task.arrivedAt` whenever a Drop-off transitions to PostTask/Completed (so the existing `DELIVERY_ARRIVED` emission fires naturally), or close `openDelivery` from the `DELIVERY_COMPLETED` branch in `FlowCardMapper.kt:226-245` as a fallback. The mapper-side fix is the smaller patch but defers the data-model question (is there ever a Delivery that completes without arriving?).
+- **What would confirm or refute this at the desk:** pull the captures from this session via the Android Studio plugin and check, for any delivery that did **not** see a frozen Drop-off card appear at the moment of completion:
+  - whether the `app_events` table contains a `DELIVERY_ARRIVED` row between `DELIVERY_NAV_STARTED` and `DELIVERY_COMPLETED` for that taskId (expected: absent);
+  - whether the corresponding `Task` row in the DB shows `arrivedAt == null` despite the delivery completing.
+
+#### 4. "DROP" chip on Drop-off card reads as ambiguous — rename to "DROP OFF"
+
+- **Field observation:** The frozen/live Drop-off card uses a chip labeled `DROP`. The dasher's reaction: "drop doesn't really make sense, even as a card. The three extra characters aren't gonna hurt anything." Rename to `DROP OFF`.
+- **Where this lives:** `FlowCardItem.kt:130` — `is FlowCardSnapshot.Delivery -> "DROP" to MaterialTheme.colorScheme.secondary`. Two-line patch (label string + verifying the chip's `Modifier.padding` still fits the wider text).
+- **Polish-shape, not a research item.** Logged here so it doesn't get lost; the desk review can fold it into whatever PR addresses #3.
 
 ### Research / design
 
-#### 4. PAID card receipt is mis-shaped — "made-up" labels and an awkward base/tip split
+#### 5. PAID card receipt is mis-shaped — "made-up" labels and an awkward base/tip split
 
 - **Field observation, verbatim:** "it says base pay twenty seventy five tip bonus boost. That's not true. It says a dollar. And I think you made up bonus boost. It should say the actual name of that pay, because I think that's actually supposed to be peak pay and record the peak pay that I got for that offer." Specifically on an HEB shop-for-items order.
 - **Developer's mental model for the receipt:** read it like an actual receipt.

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -94,9 +94,20 @@ cross-referencing within a single session entry, not across sessions.
   - Pull the offer-screen snapshot for the HEB offer from the captures and inspect the UI tree for `display_name` nodes — count how many qualify under the `each` filter and what their ancestor paths look like.
   - Check `parsedOffer.orders` in the OFFER_RECEIVED payload: do both entries have `storeName: "HEB"` (duplicate) or are they meaningfully distinct (e.g. different `orderType`, different `itemCount`)? If distinct, this might actually be a real stacked HEB-on-HEB offer and only the rendering needs to clarify; if identical, the rule is double-counting.
 
+#### 6. Stacked pickup overwrites the Pickup card on store change — same unfixed bug as 2026-05-16 #1, now visible in the HUD
+
+- **Repro (third dash session of 2026-05-17, stacked order):** Take a stacked offer with two pickup stops at different merchants — first **Costa Pacifica**, then **Chili's Bar and Grill**. Confirm pickup at Costa Pacifica. Watch the live Pickup card.
+- **Observed:** The same Pickup card stays live; the store name flips from "Costa Pacifica" to "Chili's Bar and Grill" in place. The dasher's mental model: "the pickup box should end, and then another pickup box should start … the new pickup overwrote [the first one] instead of ending that pickup block and starting a new pickup block." No frozen Costa Pacifica card in the history; the deadline/arrival/items reset to Chili's values on the same card.
+- **Already-tracked architectural bug, not a new finding.** This is the **same unfixed issue** as 2026-05-16 item #1 — the pickup phase doesn't recognize a new pickup, it just mutates the active one. That entry traced it to `PlatformRegionStepper.kt:401-441`: PICKUP→PICKUP falls into the same-phase `copy()` branch at `:430-441` and rewrites `storeName` on the existing `activeTask`, same `taskId`, no transition boundary. Nothing has shipped for it yet. This dash adds two pieces of confirmation:
+  - the new flow-card HUD makes the bug **visible** (was previously a silent odometer-only symptom);
+  - the odometer side of the same bug is presumed still active today — dasher's note: "right now, I'm pretty sure my odometer isn't gonna be running."
+- **Why the HUD inherits it:** `FlowCardMapper.kt:115-121` takes the in-place-update branch when `current?.taskId == payload.taskId`, instead of closing and opening a card. `EffectMap.kt:460-468` re-emits `PICKUP_NAV_STARTED` with the new store name on a same-task store change, which is what feeds the mapper. So even though the card layer is new, every layer downstream of the stepper inherits the "one task across both stores" data model.
+- **Direction the dasher already endorses (just logging it again for emphasis):** the pickup phase needs to **end the current pickup and start a new one** when it sees a different pickup. That's option A from 2026-05-16 — fix it in `PlatformRegionStepper.updateTaskLifecycle`, mint a new `Task` on a same-phase store-name change, and the odometer + flow-card + per-store TNP attribution all fall out for free. A mapper-side workaround that closes the Pickup card on a same-`taskId` storeName change would mask the HUD symptom but leave the odometer broken — not worth doing.
+- **What would confirm or refute this at the desk:** for today's Costa Pacifica → Chili's transition, check that `activeTask.taskId` is constant across the two stores in the captures (expected: yes, consistent with 2026-05-16) and that the inter-store leg has no `ResumeOdometer` effect between the Costa Pacifica `PauseOdometer` and the Chili's arrival.
+
 ### Research / design
 
-#### 6. PAID card receipt is mis-shaped — "made-up" labels and an awkward base/tip split
+#### 7. PAID card receipt is mis-shaped — "made-up" labels and an awkward base/tip split
 
 - **Field observation, verbatim:** "it says base pay twenty seventy five tip bonus boost. That's not true. It says a dollar. And I think you made up bonus boost. It should say the actual name of that pay, because I think that's actually supposed to be peak pay and record the peak pay that I got for that offer." Specifically on an HEB shop-for-items order.
 - **Developer's mental model for the receipt:** read it like an actual receipt.
@@ -121,7 +132,7 @@ cross-referencing within a single session entry, not across sessions.
 
 ### Verification TODOs
 
-#### 7. Investigate the decline-button click around 19:18 Central, 2026-05-17
+#### 8. Investigate the decline-button click around 19:18 Central, 2026-05-17
 
 - **Field flag:** dasher declined a DoorDash offer at **19:18 local Central time** during the second dash session, specifically to capture ground-truth on the still-open decline question from yesterday's log (#1 in the 2026-05-16 entry — decline reported as `OFFER_TIMEOUT` instead of `OFFER_DECLINED`).
 - **What to check at the desk:** open the captures around 19:18 Central and look for:

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -132,14 +132,17 @@ cross-referencing within a single session entry, not across sessions.
 
 ### Verification TODOs
 
-#### 8. Investigate the decline-button click around 19:18 Central, 2026-05-17
+#### 8. Investigate the decline-button click — 2026-05-17 decline timestamps
 
-- **Field flag:** dasher declined a DoorDash offer at **19:18 local Central time** during the second dash session, specifically to capture ground-truth on the still-open decline question from yesterday's log (#1 in the 2026-05-16 entry — decline reported as `OFFER_TIMEOUT` instead of `OFFER_DECLINED`).
-- **What to check at the desk:** open the captures around 19:18 Central and look for:
+- **Field flags:** dasher declined two DoorDash offers during 2026-05-17 specifically to capture ground-truth on the still-open decline question from yesterday's log (#1 in the 2026-05-16 entry — decline reported as `OFFER_TIMEOUT` instead of `OFFER_DECLINED`):
+  - **19:18 Central**, second dash session.
+  - **~20:29 Central**, third dash session, **Sprouts** offer, declined just before that session ended.
+- **What to check at the desk:** open the captures around each timestamp and look for:
   - whether an "unknown click" appears for the final decline button (the **confirm** tap in the are-you-sure dialog, not the initial decline tap);
   - what `intent` the click was tagged with, if any (`initial_decline` vs `decline_offer` vs unmatched);
   - what `screenIs` value the confirm-decline dialog was classified as at the moment of the click (should be `offer_popup_confirm_decline` for the rule at `core/pipeline/src/main/assets/rules/doordash.json:2319-2328` to match);
   - what `PendingOffer.lastClickIntent` carried at the moment the offer resolved.
+- **Two data points** — if both declines look identical in the captures, the issue is consistent and the 2026-05-16 hypothesis is testable in one direction; if they diverge (one matches `decline_offer`, one falls through to timeout), the cause is sensitive to a condition that varies between the two offers — worth diffing the offer types / screen states.
 - **Why it matters:** this is the data the 2026-05-16 decline hypothesis was specifically waiting on. If the confirm click shows up as `initial_decline` (or unmatched), the hypothesis holds. If it tags as `decline_offer` and the screen matches, the bug is elsewhere (timing race, payload not threaded through, etc.).
 
 ---

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -34,6 +34,73 @@ cross-referencing within a single session entry, not across sessions.
 
 ---
 
+## 2026-05-17 — DoorDash session (first run on the flow-card bubble)
+
+- **Platform tested:** DoorDash
+- **Branch under test:** `master` at `29c9528` (post-#258 bubble-flow-cards merge — first dash on the new flow-card stack HUD)
+- **Field conditions:** developer dashed on DoorDash; included at least one shop-for-items pickup at HEB. Overall reaction to the new bubble: "I really like the new format. It looks good." The notes below are bugs / polish items spotted *within* that overall-positive read.
+
+### Bugs
+
+#### 1. Pickup card hero says "5 min left" while still checking out, but the frozen card claims "+34 min ahead"
+
+- **Repro:** Take a pickup where you arrive at the store with plenty of slack on the pickup-by deadline, but spend a long time inside (e.g. shopping at HEB). Get to the register with the live bubble showing only a few minutes until pickup-by. Complete checkout. Look at the frozen Pickup card after the phase ends.
+- **Observed:** Live Pickup card was showing roughly "5:00 till pickup-by" while the dasher was still at the register and hadn't checked out. After the phase ended, the same card froze with a hero of "+34m ahead". The two numbers can't both be true for the same delivery — they describe wildly different states of urgency.
+- **Hypothesis (from a desk read, not verified against field logs):**
+  - `FlowCardItem.kt:358` computes the frozen-card delta as `arrivalRemaining = deadlineMillis - arrivedAt`. `arrivedAt` is the **store-arrival** timestamp, not the moment the dasher hit "Picked up". So if you arrived 34 min before deadline and then spent 29 min shopping, the frozen card says "+34m ahead" even though the actual checkout happened with 5 min of slack.
+  - `Pickup` snapshot already carries `confirmedAt` (the pickup-confirmation timestamp) — `FlowCardSnapshot.kt:81` and `FlowCardMapper.kt:159-183` set it on PICKUP_CONFIRMED. The frozen delta should plausibly key off `confirmedAt` (urgency at the moment you actually finished pickup), not `arrivedAt` (urgency at the moment you walked in the door).
+  - Open question: which number does the dasher actually want post-hoc? "How close did I come to being late?" → confirmedAt. "How long was my buffer when I got here?" → arrivedAt. The current code picks arrivedAt; the live countdown picks neither (it's `deadlineMillis - now`), so the two views diverge precisely when shopping takes a long time. The post-task summary that the developer references ("plus thirty four minutes ahead") looks like the same value.
+- **What would confirm or refute this:** capture a PICKUP_CONFIRMED event from a shop-for-items pickup and check whether the payload's `confirmedAt` is materially later than `arrivedAt`, and whether the frozen card's hero matches `deadlineMillis - arrivedAt` (current behavior) vs `deadlineMillis - confirmedAt` (proposed).
+
+#### 2. Pickup card never displays the actual pickup-by deadline time
+
+- **Field observation:** Live Pickup card shows the countdown (e.g. "5:00") and the caption "till pickup-by", but the **wall-clock deadline itself** is nowhere on the card. The dasher cannot answer "what time do I need to be checked out by?" — only "how many minutes left" relative to now. That's a problem when the live countdown disagrees with the post-task summary (see #1) and the dasher wants to sanity-check.
+- **Where this lives:**
+  - `FlowCardItem.kt:351-356` — the active-card branch renders `formatCountdown(remaining)` as the hero and `deadlineLabel` ("till pickup-by") as the caption. No use of `formatTime(deadlineMillis)`.
+  - `Delivery` card (`FlowCardItem.kt:312-325`) has the same shape and the same gap for the deliver-by deadline.
+- **Possible direction (sketch, not a recommendation):** add a secondary caption like `"by ${formatTime(deadlineMillis)}"` under the countdown. Cheap to add; would let the dasher cross-check the countdown against the literal time on the DoorDash UI.
+
+#### 3. Frozen Delivery card disappears under (or is visually absorbed by) the PAID card after delivery completes
+
+- **Repro:** Complete a delivery. Watch the flow-card stack transition from the live Delivery card to the live PAID/PostTask card.
+- **Observed (per the log narrative):** "the drop-off block had the section for the drop off. Whenever that got completed, it got replaced by the paid block." The dasher wants the Delivery summary to **persist** in the history above the receipt — not vanish.
+- **Hypothesis (from a desk read, not verified against the captured event stream):**
+  - `FlowCardMapper.kt:201-224` *does* add a frozen Delivery snapshot to `completed` on `DELIVERY_ARRIVED`, so in principle it should appear in the stack just above the live PAID card once the flow advances to PostTask. So the bug isn't "Delivery card never gets stored."
+  - Two candidate explanations worth distinguishing:
+    - (a) `DELIVERY_ARRIVED` isn't actually firing for this style of completion. `EffectMap.kt:402-432` only emits it when `nextTask.arrivedAt != null && prevTask?.arrivedAt == null` — i.e. an explicit arrival sub-state transition. If DoorDash's "no-contact delivery" flow rolls straight from nav → completed without DashBuddy seeing an ARRIVED screen, the Delivery card stays in `openDelivery` and only gets flushed by DASH_STOP at the end of the dash (`FlowCardMapper.kt:247-258`). Net effect: looks "replaced" because there is no frozen Delivery card in the stack at the moment the PAID card appears.
+    - (b) The Delivery card *is* in `completed` but its frozen body is so terse (line 187-195: "customer · delivered HH:MM" + a +/- delta hero) that the dasher reads it as part of the PAID card chrome rather than a separate card. The visual hierarchy in the stack puts the live card at the bottom, expanded, and the just-previous frozen card flush above it with similar styling.
+  - The user-side description ("it had the section for the drop off … got replaced") slightly favors (a): they're describing the section disappearing, not just shrinking. But (a) and (b) are easy to disambiguate from a captured event log.
+- **What would confirm or refute this:**
+  - (a-vs-b): for the same delivery, check whether a `DELIVERY_ARRIVED` event row exists in `app_events` between the last `DELIVERY_NAV_STARTED` and the `DELIVERY_COMPLETED`. If absent → (a). If present → (b).
+  - Either way, worth a check from the bubble-history side: when the PAID card is the live one, is `cardStack.completed` actually carrying a `FlowCardSnapshot.Delivery` for the same `jobId`?
+
+### Research / design
+
+#### 4. PAID card receipt is mis-shaped — "made-up" labels and an awkward base/tip split
+
+- **Field observation, verbatim:** "it says base pay twenty seventy five tip bonus boost. That's not true. It says a dollar. And I think you made up bonus boost. It should say the actual name of that pay, because I think that's actually supposed to be peak pay and record the peak pay that I got for that offer." Specifically on an HEB shop-for-items order.
+- **Developer's mental model for the receipt:** read it like an actual receipt.
+  - **Total** at the top (already present — hero is `$%.2f` totalPay).
+  - **DoorDash pay** as one section, broken down into **Base pay** + **any other app-pay component DoorDash actually names** (peak pay, promo, etc.), using whatever label DoorDash itself uses on that order's screen.
+  - **Customer tips** as a separate section, broken down **per order** in the offer — tip line per store/customer, since one offer can be a stacked multi-tip job.
+- **Where this lives:**
+  - Parse rule `core/pipeline/src/main/assets/rules/doordash.json:469-489` — extracts `payLineItems` as `{type, amount}` pairs from id-suffix `pay_line_item_title` / `pay_line_item_value`. So whatever text DoorDash renders on the receipt is what lands in `type`.
+  - `ParsedFieldsFactory.kt:141-153` then **splits the line-items based on a substring match for "pay"**: items whose `type` contains "pay" (case-insensitive) → `appPayComponents`, everything else → `customerTips`. So:
+    - if the actual DoorDash label is "Peak pay" → routed to `appPay` ✓
+    - if the actual label is "Bonus" / "Boost" / "Bonus Boost" / "Promo" → routed to `customerTips` ✗ (and then rendered as `"tip · Bonus Boost"` by `FlowCardItem.kt:415-416`)
+  - That matches the verbatim observation almost exactly: a $1 line shows up under tips as "tip · Bonus Boost" because the actual DoorDash receipt label doesn't contain the substring "pay". The dasher reads it as wrong twice: wrong category (it's a DoorDash pay, not a tip), wrong label (the dasher expected "Peak pay"; whatever DoorDash literally rendered was different).
+- **Two distinct issues bundled here, worth separating before any fix:**
+  - **Categorization is fragile.** The "contains 'pay'" partition is a heuristic that breaks the moment DoorDash labels a pay component without the word "pay". The robust shape is to drive the split from the receipt's structure (which section the line lives under — "DoorDash pay" vs "Customer tips" subtrees — rather than the line's text) since the rule already locates both sub-totals separately at `:453-468`.
+  - **Display labels are platform-faithful but dasher-unfaithful.** The dasher's mental label for the $1 was "peak pay"; the actual on-screen text was something else. There's a discoverable mismatch between what DoorDash calls things and what dashers call them. Worth keeping the **literal DoorDash label** as the source of truth, since the alternative is a translation table that drifts every time DoorDash renames a program. The actionable miss is the categorization — once a "Bonus Boost" or "Boost" line ends up under **DoorDash pay** rather than under **tips**, the dasher reading "DoorDash pay: Base pay $20.75, Bonus Boost $1.00, total tips $X" can tell at a glance what kind of pay each line is.
+- **Receipt-shape proposal (extracted from the verbatim mental model):**
+  - Header: total
+  - DoorDash pay section (sub-total + per-component lines using DoorDash's labels)
+  - Customer tips section (sub-total + per-order lines using store/customer label)
+  - The current PostTaskBody (`FlowCardItem.kt:399-424`) already has the per-line rendering; what's missing is (a) the section grouping, (b) sub-totals per section, (c) reliable categorization.
+- **What would confirm or refute the hypothesis:** capture the HEB order's PostTask parsed payload (`AppEventEntity` for `DELIVERY_COMPLETED`) and check the literal `type` strings on each `parsedPay` item. If any non-"pay" string sits in `customerTips` despite being on the "DoorDash pay" side of the receipt, the partition heuristic is the cause and (1) above is the fix shape. If categorization is correct and the user is just objecting to the literal label, this is a labels-only conversation.
+
+---
+
 ## 2026-05-16 — DoorDash session (stacked pickups)
 
 - **Platform tested:** DoorDash

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -38,7 +38,7 @@ cross-referencing within a single session entry, not across sessions.
 
 - **Platform tested:** DoorDash
 - **Branch under test:** `master` at `29c9528` (post-#258 bubble-flow-cards merge — first dash on the new flow-card stack HUD)
-- **Field conditions:** developer dashed on DoorDash; included at least one shop-for-items pickup at HEB. Overall reaction to the new bubble: "I really like the new format. It looks good." The notes below are bugs / polish items spotted *within* that overall-positive read.
+- **Field conditions:** developer dashed on DoorDash; included at least one shop-for-items pickup at HEB. Multiple dash sessions across the day, all on the same build. Overall reaction to the new bubble: "I really like the new format. It looks good." The notes below are bugs / polish items spotted *within* that overall-positive read.
 
 ### Bugs
 
@@ -81,9 +81,22 @@ cross-referencing within a single session entry, not across sessions.
 - **Where this lives:** `FlowCardItem.kt:130` — `is FlowCardSnapshot.Delivery -> "DROP" to MaterialTheme.colorScheme.secondary`. Two-line patch (label string + verifying the chip's `Modifier.padding` still fits the wider text).
 - **Polish-shape, not a research item.** Logged here so it doesn't get lost; the desk review can fold it into whatever PR addresses #3.
 
+#### 5. HEB offer shows two pickups for the same store
+
+- **Repro (second dash session of 2026-05-17):** Receive a DoorDash offer for a single HEB shop-for-items pickup. Look at the offer card's per-pickup list in the bubble.
+- **Observed:** The Offer card lists **two pickups at HEB** for a single-pickup offer. The dasher's wording: "I just got offered a HEB, and it shows two pickups for HEB. I don't know why."
+- **Hypothesis (from a desk read, not yet verified against captures):**
+  - The Offer card's pickup count comes from `parsedOffer.orders` size, populated by the rule at `core/pipeline/src/main/assets/rules/doordash.json:310-394`. The `each` iterator selects nodes matching `hasIdSuffix: "display_name"` AND `not(Customer dropoff)` AND `not(Business handoff)`, scoped to `ancestor(2)`.
+  - For HEB **shop-for-items**, the DoorDash offer UI may render the store name in **two** subtrees — once as the order summary header and once inside the shop-for-items item-list subtree — and both nodes share the `display_name` id suffix. The `each` then yields a duplicate, and the `ancestor(2)` scope can't disambiguate because both ancestors qualify.
+  - Static-pickup offers (Best Buy, Chick-fil-A in the 2026-05-16 log) didn't reportedly show this, which is consistent with the duplicate being specific to the shop-for-items UI shape.
+  - Worth confirming this isn't actually a real double-stack of two HEB orders (single-merchant stacked pickup): if the offer screen says "1 pickup" / "1 order" anywhere in the chrome, that contradicts the duplicate hypothesis.
+- **What would confirm or refute this at the desk:**
+  - Pull the offer-screen snapshot for the HEB offer from the captures and inspect the UI tree for `display_name` nodes — count how many qualify under the `each` filter and what their ancestor paths look like.
+  - Check `parsedOffer.orders` in the OFFER_RECEIVED payload: do both entries have `storeName: "HEB"` (duplicate) or are they meaningfully distinct (e.g. different `orderType`, different `itemCount`)? If distinct, this might actually be a real stacked HEB-on-HEB offer and only the rendering needs to clarify; if identical, the rule is double-counting.
+
 ### Research / design
 
-#### 5. PAID card receipt is mis-shaped — "made-up" labels and an awkward base/tip split
+#### 6. PAID card receipt is mis-shaped — "made-up" labels and an awkward base/tip split
 
 - **Field observation, verbatim:** "it says base pay twenty seventy five tip bonus boost. That's not true. It says a dollar. And I think you made up bonus boost. It should say the actual name of that pay, because I think that's actually supposed to be peak pay and record the peak pay that I got for that offer." Specifically on an HEB shop-for-items order.
 - **Developer's mental model for the receipt:** read it like an actual receipt.

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -119,6 +119,18 @@ cross-referencing within a single session entry, not across sessions.
   - The current PostTaskBody (`FlowCardItem.kt:399-424`) already has the per-line rendering; what's missing is (a) the section grouping, (b) sub-totals per section, (c) reliable categorization.
 - **What would confirm or refute the hypothesis:** capture the HEB order's PostTask parsed payload (`AppEventEntity` for `DELIVERY_COMPLETED`) and check the literal `type` strings on each `parsedPay` item. If any non-"pay" string sits in `customerTips` despite being on the "DoorDash pay" side of the receipt, the partition heuristic is the cause and (1) above is the fix shape. If categorization is correct and the user is just objecting to the literal label, this is a labels-only conversation.
 
+### Verification TODOs
+
+#### 7. Investigate the decline-button click around 19:18 Central, 2026-05-17
+
+- **Field flag:** dasher declined a DoorDash offer at **19:18 local Central time** during the second dash session, specifically to capture ground-truth on the still-open decline question from yesterday's log (#1 in the 2026-05-16 entry — decline reported as `OFFER_TIMEOUT` instead of `OFFER_DECLINED`).
+- **What to check at the desk:** open the captures around 19:18 Central and look for:
+  - whether an "unknown click" appears for the final decline button (the **confirm** tap in the are-you-sure dialog, not the initial decline tap);
+  - what `intent` the click was tagged with, if any (`initial_decline` vs `decline_offer` vs unmatched);
+  - what `screenIs` value the confirm-decline dialog was classified as at the moment of the click (should be `offer_popup_confirm_decline` for the rule at `core/pipeline/src/main/assets/rules/doordash.json:2319-2328` to match);
+  - what `PendingOffer.lastClickIntent` carried at the moment the offer resolved.
+- **Why it matters:** this is the data the 2026-05-16 decline hypothesis was specifically waiting on. If the confirm click shows up as `initial_decline` (or unmatched), the hypothesis holds. If it tags as `decline_offer` and the screen matches, the bug is elsewhere (timing race, payload not threaded through, etc.).
+
 ---
 
 ## 2026-05-16 — DoorDash session (stacked pickups)


### PR DESCRIPTION
## Summary

Field-testing log entry for the 2026-05-17 dash sessions on the post-#258 bubble-flow-cards build. Docs-only — no app code changes. Each item is logged as a hypothesis with file:line refs and a confirm/refute step, per `CLAUDE.md` ▸ Field Testing Logs.

### Bugs
- **#1** Pickup card hero says "5 min left" live but freezes to "+34m ahead" because the frozen delta uses `arrivedAt` instead of `confirmedAt` (`FlowCardItem.kt:358`).
- **#2** No wall-clock display of the pickup-by / deliver-by deadline — only the countdown (`FlowCardItem.kt:351-356`).
- **#3** Drop-off card never freezes mid-dash — only appears at end-of-dash, flushed by `DASH_STOP`. Evidence points to `DELIVERY_ARRIVED` not firing for no-contact-style completions (`EffectMap.kt:402-432`).
- **#4** Rename the card chip from `DROP` → `DROP OFF` (`FlowCardItem.kt:130`). Polish item.
- **#5** HEB shop-for-items offer surfaces as two pickups in the Offer card — likely the `display_name` iterator double-matching the store-name node (`doordash.json:310-394`).
- **#6** Stacked pickup overwrites the Pickup card on store change. **Same unfixed bug as 2026-05-16 #1** — the pickup phase doesn't recognize a new pickup, manifesting now in the HUD in addition to the silent inter-store odometer drop.

### Research / design
- **#7** PAID-card receipt is mis-shaped — `ParsedFieldsFactory.kt:141-153` partitions pay line-items on `type.contains("pay")`, which mis-files DoorDash pay components named without "pay" (Bonus Boost, Boost, Promo) under tips. Includes developer's mental model for the correct receipt shape.

### Verification TODOs
- **#8** Decline-button click investigation — two timestamps to look around: **19:18 Central** (dash #2) and **~20:29 Central** Sprouts (dash #3). Ground-truth data for the still-open 2026-05-16 #1 hypothesis (decline reported as `OFFER_TIMEOUT`).

## Test plan

- [ ] Pull the session captures into the Android Studio plugin
- [ ] Cross-check each item's "what would confirm or refute" step against the captured event log
- [ ] Triage items into focused GitHub issues

---
_Generated by [Claude Code](https://claude.ai/code/session_01DN9ATa91SqiUHEhKAiUYL8)_