### PR TITLE
fix: recognize DoorDash confirm-decline click via descendant text

### DIFF
--- a/core/pipeline/src/main/assets/rules/doordash.json
+++ b/core/pipeline/src/main/assets/rules/doordash.json
@@ -2324,7 +2324,7 @@
         "modeHint": "online"
       },
       "require": {
-        "hasText": "Decline offer"
+        "hasAnyText": "Decline offer"
       }
     },
     {

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompiler.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompiler.kt
@@ -919,6 +919,17 @@ object RuleCompiler {
                 ;{ node -> node.text?.let { str -> regex.containsMatchIn(str) } == true }
             }
 
+            // Matches when *any* text node anywhere in this subtree (including
+            // the node itself and any descendant's text or contentDescription)
+            // equals the value, case-insensitive. Necessary for buttons whose
+            // text lives in a child TextView (e.g. the DoorDash confirm-decline
+            // Button has no text on the outer node; the text is in a nested
+            // textView_prism_button_title child).
+            "hasAnyText" -> {
+                val s = (value as JsonPrimitive).content
+                ;{ node -> node.allText.any { it.equals(s, ignoreCase = true) } }
+            }
+
             "hasDesc" -> {
                 val s = (value as JsonPrimitive).content
                 ;{ node -> node.contentDescription?.equals(s, ignoreCase = true) == true }

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompilerTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompilerTest.kt
@@ -168,6 +168,47 @@ class RuleCompilerTest {
         assertFalse(pred(node(text = null)))
     }
 
+    @Test
+    fun `hasAnyText matches text on the node itself`() {
+        val pred = RuleCompiler.compileNodePred(json("hasAnyText" to "Decline offer"))
+        assertTrue(pred(node(text = "Decline offer")))
+        assertTrue(pred(node(text = "decline offer")))
+        assertFalse(pred(node(text = "Decline")))
+    }
+
+    @Test
+    fun `hasAnyText matches text on a direct child`() {
+        // The DoorDash confirm-decline regression: outer Button has no text,
+        // child TextView carries "Decline offer". hasText fails; hasAnyText must succeed.
+        val pred = RuleCompiler.compileNodePred(json("hasAnyText" to "Decline offer"))
+        val confirmDeclineButton = tree(
+            node(text = "Decline offer", className = "android.widget.TextView"),
+        ).copy(isClickable = true, className = "android.widget.Button")
+        assertTrue(pred(confirmDeclineButton))
+    }
+
+    @Test
+    fun `hasAnyText matches text on a deeper descendant`() {
+        val pred = RuleCompiler.compileNodePred(json("hasAnyText" to "Arrived at store"))
+        val wrapper = tree(tree(node(text = "Arrived at store")))
+        assertTrue(pred(wrapper))
+    }
+
+    @Test
+    fun `hasAnyText matches contentDescription anywhere in the tree`() {
+        val pred = RuleCompiler.compileNodePred(json("hasAnyText" to "Submit"))
+        val root = tree(node(contentDescription = "Submit"))
+        assertTrue(pred(root))
+    }
+
+    @Test
+    fun `hasAnyText returns false when text is absent throughout the tree`() {
+        val pred = RuleCompiler.compileNodePred(json("hasAnyText" to "Decline offer"))
+        val root = tree(node(text = "Accept"), node(text = "Cancel"))
+        assertFalse(pred(root))
+        assertFalse(pred(node(text = null)))
+    }
+
     // =========================================================================
     // compileNodePred — content description & class predicates
     // =========================================================================


### PR DESCRIPTION
## Summary

Root-causes the decline-flow bug (decline confirmed in dialog → bubble reports \"Offer Timed Out\" / `OFFER_TIMEOUT` instead of `OFFER_DECLINED`) from the 2026-05-17 field-test captures.

**Smoking gun:** the confirm-decline tap *was* captured (19:17:52.013, Costa Pacifica offer at \`/home/betty/dashbuddy/logs/2026/05/17/field-test-2/captures/doordash/accessibility.click/UNKNOWN/2026-05-17_19-17-52-013__doordash__accessibility.click__UNKNOWN__220cc3.json\`). The click's \`screenTarget\` is correctly \`offer_popup_confirm_decline\`. But the node is:

```
Button(no id, no text)
  └─ TextView(id=textView_prism_button_title, text=\"Decline offer\")
```

The \`doordash.click.decline_offer\` rule (\`core/pipeline/src/main/assets/rules/doordash.json:2319-2328\`) requires \`hasText: \"Decline offer\"\`, and \`hasText\` checks only \`node.text\` (`RuleCompiler.kt:901-904\`). The outer Button has no text, so the rule never matches → classification is \`UNKNOWN\` → \`PendingOffer.lastClickIntent\` stays at \`initial_decline\` → \`EffectMap.resolveOfferOutcome\` doesn't recognize the intent → the offer eventually times out as \`OFFER_TIMEOUT\`.

This confirms the 2026-05-16 field-log hypothesis on the *cause* side, and crucially confirms the developer's own constraint that the second click is real — synthesizing decline from \`initial_decline\` would have produced false declines for offers the dasher let time out or backed out of (which is why commit \`0ae3cdd\` was correctly reverted in \`e4dbe26\`).

## Fix

Add a `hasAnyText` rule predicate that uses the existing `UiNode.allText` recursive collector — matches when any text or `contentDescription` anywhere in the subtree (including the node itself) equals the value, case-insensitive. Switch only the `decline_offer` rule to use it. No other rule is touched.

## Follow-up — not in this PR

The same \"Button with text in a child TextView\" shape is reused on many DoorDash screens. Notably:

- `doordash.click.arrived_at_store` (rule \`:2331-2354\`) has the same `hasIdSuffix + hasText` pattern over a `primary_action_button`. The 2026-05-15 captures show \"Arrived at store\" clicks falling into UNKNOWN for the same reason.
- Other `primary_action_button` confirms (pickup-confirm, dropoff-confirm) likely have the same shape.

These deserve their own investigation against the captures and are not changed here to keep this PR narrowly scoped to the decline outcome bug.

## Related

- Depends on / complements **#259** (still open) — that PR fixes the dedup so the confirm-decline click always survives capture. In this session it survived by luck (unique-enough structural hash). With #259 merged, *every* future confirm-decline click is guaranteed to land.
- Decline hypothesis lives at `docs/field-testing/README.md` (2026-05-16 + 2026-05-17 entries #1 and #8 respectively).

## Test plan

- [x] `./gradlew :core:pipeline:testDebugUnitTest --tests \"*RuleCompilerTest*\"` — 4 new tests for `hasAnyText` (self-match, direct child, deep descendant, contentDescription, absent).
- [x] `./gradlew :core:pipeline:testDebugUnitTest :app:testDebugUnitTest :core:state:testDebugUnitTest` — broader sweep, all green.
- [ ] Next field session: decline a DoorDash offer (confirm in dialog). Bubble should show \"Offer Declined\" and the AppEvent log should record \`OFFER_DECLINED\`, not \`OFFER_TIMEOUT\`.
- [ ] Same field session: let an offer time out without tapping decline. Should still resolve as \`OFFER_TIMEOUT\` (no regression on the genuine-timeout path).
- [ ] Same field session: tap initial decline, then back out of the dialog and accept. Should resolve as \`OFFER_ACCEPTED\` (no spurious decline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)