### PR TITLE
fix: stacked-pickup transitions mint a new Task per store

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
@@ -365,6 +365,62 @@ class EffectMapTest {
     }
 
     @Test
+    fun `stacked pickup transition fires PICKUP_NAV_STARTED and ResumeOdometer for the new task`() {
+        // Costa Pacifica pickup completed (moved to recentTasks) and a new
+        // Chili's pickup task minted by the stepper. The diff-task gate must
+        // fire even though prevTask is non-null — it now keys on "taskId changed".
+        val (platform, _) = stateWithPlatform()
+        val session = Session("sess-1", startedAt = 100L)
+        val costaPacifica = Task(
+            taskId = "task-A", jobId = "job-1", phase = TaskPhase.PICKUP,
+            storeName = "Costa Pacifica", startedAt = 800L, arrivedAt = 850L, completedAt = 1_000L,
+        )
+        val prev = AppState(regions = Regions(
+            flow = FlowRegion(flow = Flow.TaskPickupArrived),
+            platforms = mapOf(platform to PlatformRegion(
+                platform, mode = Mode.Online, session = session, activeTask = costaPacifica,
+            )),
+        ))
+
+        val chilis = Task(
+            taskId = "task-B", jobId = "job-1", phase = TaskPhase.PICKUP,
+            storeName = "Chili's Grill & Bar", startedAt = 1_001L,
+        )
+        val next = AppState(regions = Regions(
+            flow = FlowRegion(flow = Flow.TaskPickupNavigation),
+            platforms = mapOf(platform to PlatformRegion(
+                platform, mode = Mode.Online, session = session,
+                activeTask = chilis, recentTasks = listOf(costaPacifica),
+            )),
+        ))
+
+        val effects = effectMap.diff(
+            prev, next,
+            screenObs(
+                flow = Flow.TaskPickupNavigation,
+                parsed = ParsedFields.TaskFields(
+                    storeName = "Chili's Grill & Bar",
+                    phase = TaskPhase.PICKUP,
+                    subFlow = TaskSubFlow.NAVIGATION,
+                ),
+            ),
+        )
+
+        assertTrue(
+            "Stacked transition should emit PICKUP_NAV_STARTED for the new task",
+            effects.logEventTypes().contains(AppEventType.PICKUP_NAV_STARTED),
+        )
+        assertTrue(
+            "Stacked transition should emit ResumeOdometer for the inter-store leg",
+            effects.any { it is AppEffect.ResumeOdometer },
+        )
+        assertTrue(
+            "Bubble should announce the new store",
+            effects.any { it is AppEffect.UpdateBubble && it.text.contains("Chili") },
+        )
+    }
+
+    @Test
     fun `pickup to dropoff emits PICKUP_CONFIRMED and DELIVERY_NAV_STARTED`() {
         val (platform, _) = stateWithPlatform()
         val session = Session("sess-1", startedAt = 100L)

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepperTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepperTest.kt
@@ -1,0 +1,266 @@
+package cloud.trotter.dashbuddy.core.state
+
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
+import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.state.Flow
+import cloud.trotter.dashbuddy.domain.state.FlowRegion
+import cloud.trotter.dashbuddy.domain.state.Job
+import cloud.trotter.dashbuddy.domain.state.Mode
+import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import cloud.trotter.dashbuddy.domain.state.PlatformRegion
+import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.domain.state.Session
+import cloud.trotter.dashbuddy.domain.state.Task
+import cloud.trotter.dashbuddy.domain.state.TaskPhase
+import cloud.trotter.dashbuddy.domain.state.TaskSubFlow
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Tests for [PlatformRegionStepper] — focused on the task-lifecycle branch
+ * that handles same-phase PICKUP → PICKUP transitions (stacked pickups) vs.
+ * legitimate same-task in-place updates (Unknown → resolved name, text drift,
+ * parser flicker on the arrived screen).
+ */
+class PlatformRegionStepperTest {
+
+    private val stepper = PlatformRegionStepper()
+    private val policy = TransitionPolicy()
+
+    // =========================================================================
+    // HELPERS
+    // =========================================================================
+
+    private val platform = Platform.DoorDash
+    private val session = Session("sess-1", startedAt = 100L)
+    private val job = Job(jobId = "job-1", offerStoreHint = emptyList(), parentOfferHash = null, startedAt = 200L)
+
+    private fun pickupTask(
+        taskId: String,
+        storeName: String,
+        arrivedAt: Long? = null,
+        startedAt: Long = 300L,
+    ) = Task(
+        taskId = taskId,
+        jobId = "job-1",
+        phase = TaskPhase.PICKUP,
+        storeName = storeName,
+        startedAt = startedAt,
+        arrivedAt = arrivedAt,
+    )
+
+    private fun region(activeTask: Task?) = PlatformRegion(
+        platform = platform,
+        mode = Mode.Online,
+        session = session,
+        activeJob = job,
+        activeTask = activeTask,
+    )
+
+    private fun screenObs(
+        flow: Flow,
+        storeName: String?,
+        phase: TaskPhase,
+        subFlow: TaskSubFlow,
+        timestamp: Long = 1_000L,
+    ): Observation.Screen = Observation.Screen(
+        timestamp = timestamp,
+        captureId = "cap-$timestamp",
+        ruleId = "doordash.screen.test",
+        metadata = ReplayMetadata.EMPTY,
+        flow = flow,
+        modeHint = Mode.Online,
+        parsed = ParsedFields.TaskFields(
+            storeName = storeName,
+            phase = phase,
+            subFlow = subFlow,
+        ),
+    )
+
+    // =========================================================================
+    // STACKED-PICKUP MINT-NEW-TASK
+    // =========================================================================
+
+    @Test
+    fun `stacked pickup mints a new task with a different taskId`() {
+        val costaPacifica = pickupTask("task-A", "Costa Pacifica", arrivedAt = 800L)
+        val prev = region(activeTask = costaPacifica)
+
+        val next = stepper.step(
+            prev = prev,
+            prevFlow = FlowRegion(flow = Flow.TaskPickupArrived),
+            nextFlow = FlowRegion(flow = Flow.TaskPickupNavigation),
+            obs = screenObs(
+                flow = Flow.TaskPickupNavigation,
+                storeName = "Chili's Grill & Bar",
+                phase = TaskPhase.PICKUP,
+                subFlow = TaskSubFlow.NAVIGATION,
+            ),
+            policy = policy,
+        )
+
+        assertNotNull("activeTask should be set", next.activeTask)
+        assertNotEquals(
+            "Stacked pickup should mint a new taskId",
+            costaPacifica.taskId,
+            next.activeTask?.taskId,
+        )
+        assertEquals(
+            "New task should carry the new storeName",
+            "Chili's Grill & Bar",
+            next.activeTask?.storeName,
+        )
+        assertNull(
+            "New task should reset arrivedAt to null (will be set on Chili's arrival)",
+            next.activeTask?.arrivedAt,
+        )
+        assertTrue(
+            "Costa Pacifica task should be moved to recentTasks with completedAt",
+            next.recentTasks.any { it.taskId == "task-A" && it.completedAt != null },
+        )
+    }
+
+    // =========================================================================
+    // FALSE-POSITIVE GUARDS — these must NOT mint new tasks
+    // =========================================================================
+
+    @Test
+    fun `Unknown to resolved name pre-arrival keeps the same task`() {
+        val initial = pickupTask("task-A", "Unknown", arrivedAt = null)
+        val prev = region(activeTask = initial)
+
+        val next = stepper.step(
+            prev = prev,
+            prevFlow = FlowRegion(flow = Flow.TaskPickupNavigation),
+            nextFlow = FlowRegion(flow = Flow.TaskPickupNavigation),
+            obs = screenObs(
+                flow = Flow.TaskPickupNavigation,
+                storeName = "Costa Pacifica",
+                phase = TaskPhase.PICKUP,
+                subFlow = TaskSubFlow.NAVIGATION,
+            ),
+            policy = policy,
+        )
+
+        assertEquals(
+            "Unknown→resolved should NOT mint a new task",
+            "task-A",
+            next.activeTask?.taskId,
+        )
+        assertEquals("Costa Pacifica", next.activeTask?.storeName)
+    }
+
+    @Test
+    fun `text drift pre-arrival keeps the same task`() {
+        val initial = pickupTask("task-A", "Best Buy", arrivedAt = null)
+        val prev = region(activeTask = initial)
+
+        val next = stepper.step(
+            prev = prev,
+            prevFlow = FlowRegion(flow = Flow.TaskPickupNavigation),
+            nextFlow = FlowRegion(flow = Flow.TaskPickupNavigation),
+            obs = screenObs(
+                flow = Flow.TaskPickupNavigation,
+                storeName = "Best Buy #1234",
+                phase = TaskPhase.PICKUP,
+                subFlow = TaskSubFlow.NAVIGATION,
+            ),
+            policy = policy,
+        )
+
+        assertEquals(
+            "Pre-arrival text drift should NOT mint a new task (arrivedAt gate)",
+            "task-A",
+            next.activeTask?.taskId,
+        )
+        assertEquals("Best Buy #1234", next.activeTask?.storeName)
+    }
+
+    @Test
+    fun `parser flicker on the ARRIVED screen keeps the same task`() {
+        // Simulates the doordash pickup_arrival storeName parser bug:
+        // the wrong instructions_title wins (e.g. "Walk into store"). The
+        // stepper must not mint a new task just because storeName changed,
+        // since the subFlow is still ARRIVED.
+        val arrived = pickupTask("task-A", "Costa Pacifica", arrivedAt = 800L)
+        val prev = region(activeTask = arrived)
+
+        val next = stepper.step(
+            prev = prev,
+            prevFlow = FlowRegion(flow = Flow.TaskPickupArrived),
+            nextFlow = FlowRegion(flow = Flow.TaskPickupArrived),
+            obs = screenObs(
+                flow = Flow.TaskPickupArrived,
+                storeName = "Walk into store",
+                phase = TaskPhase.PICKUP,
+                subFlow = TaskSubFlow.ARRIVED,
+            ),
+            policy = policy,
+        )
+
+        assertEquals(
+            "ARRIVED-screen parser flicker should NOT mint a new task (subFlow gate)",
+            "task-A",
+            next.activeTask?.taskId,
+        )
+    }
+
+    @Test
+    fun `classifier flicker NAVIGATION re-entry on the same store keeps the same task`() {
+        // Simulates a brief classifier flip ARRIVED → NAVIGATION → ARRIVED
+        // on the same store: the storeName hasn't changed, so the storeName
+        // gate prevents a spurious mint.
+        val arrived = pickupTask("task-A", "Costa Pacifica", arrivedAt = 800L)
+        val prev = region(activeTask = arrived)
+
+        val next = stepper.step(
+            prev = prev,
+            prevFlow = FlowRegion(flow = Flow.TaskPickupArrived),
+            nextFlow = FlowRegion(flow = Flow.TaskPickupNavigation),
+            obs = screenObs(
+                flow = Flow.TaskPickupNavigation,
+                storeName = "Costa Pacifica",
+                phase = TaskPhase.PICKUP,
+                subFlow = TaskSubFlow.NAVIGATION,
+            ),
+            policy = policy,
+        )
+
+        assertEquals(
+            "Same-store NAVIGATION re-entry should NOT mint a new task (storeName gate)",
+            "task-A",
+            next.activeTask?.taskId,
+        )
+    }
+
+    @Test
+    fun `PICKUP to DROPOFF still mints a new task (regression guard)`() {
+        val pickup = pickupTask("task-A", "Costa Pacifica", arrivedAt = 800L)
+        val prev = region(activeTask = pickup)
+
+        val next = stepper.step(
+            prev = prev,
+            prevFlow = FlowRegion(flow = Flow.TaskPickupArrived),
+            nextFlow = FlowRegion(flow = Flow.TaskDropoffNavigation),
+            obs = screenObs(
+                flow = Flow.TaskDropoffNavigation,
+                storeName = null,
+                phase = TaskPhase.DROPOFF,
+                subFlow = TaskSubFlow.NAVIGATION,
+            ),
+            policy = policy,
+        )
+
+        assertNotEquals(
+            "Phase change PICKUP→DROPOFF should mint a new task",
+            "task-A",
+            next.activeTask?.taskId,
+        )
+        assertEquals(TaskPhase.DROPOFF, next.activeTask?.phase)
+    }
+
+}

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -353,9 +353,15 @@ class EffectMap @Inject constructor(
             val prevTask = prev.activeTask
             val nextTask = next.activeTask
 
-            // Task started — pickup navigation
-            if (prevTask == null && nextTask != null &&
-                nextTask.phase == TaskPhase.PICKUP
+            // Task started — pickup navigation.
+            //
+            // Fires whenever a new PICKUP task is the active task — either the
+            // first task of the session (prevTask == null) or a new task minted
+            // for a stacked-pickup transition (prevTask is the now-completed
+            // previous pickup with a different taskId).
+            if (nextTask != null &&
+                nextTask.phase == TaskPhase.PICKUP &&
+                prevTask?.taskId != nextTask.taskId
             ) {
                 val taskStartOverride = triggerOverrideEffects(obs, TransitionTrigger.TASK_START)
                 if (taskStartOverride != null) {

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
@@ -398,9 +398,35 @@ class PlatformRegionStepper @Inject constructor() {
             val currentTask = region.activeTask
             val jobId = region.activeJob?.jobId ?: return region
 
-            // Phase/subflow change → new task or update
-            if (currentTask == null || currentTask.phase != taskPhase) {
-                // New task (different phase or no active task)
+            // Phase/subflow change → new task or update.
+            //
+            // Stacked-pickup transition: same PICKUP phase, but the platform has
+            // routed us from a confirmed-arrived store back to navigation toward
+            // a different store. Treat as a new task so the second pickup gets
+            // its own taskId, its own odometer leg, and its own flow-card.
+            //
+            // Three signals combined for robustness: we must have already
+            // arrived at the previous store; the new screen must be a
+            // navigation/pre-arrival (subflow=NAVIGATION); and the parsed
+            // storeName must be a different, non-Unknown name. Any single
+            // signal alone is vulnerable to parser flakiness (notably the
+            // pickup_arrival storeName parser, which picks the wrong
+            // instructions_title on multi-node screens — see the field-test
+            // 2026-05-17 Chili's capture).
+            val isStackedPickupTransition = currentTask != null &&
+                currentTask.phase == TaskPhase.PICKUP &&
+                taskPhase == TaskPhase.PICKUP &&
+                currentTask.arrivedAt != null &&
+                taskSubFlow == TaskSubFlow.NAVIGATION &&
+                taskFields?.storeName != null &&
+                !taskFields.storeName.equals("Unknown", ignoreCase = true) &&
+                taskFields.storeName != currentTask.storeName
+
+            if (currentTask == null ||
+                currentTask.phase != taskPhase ||
+                isStackedPickupTransition
+            ) {
+                // New task (different phase, no active task, or stacked-pickup transition)
                 val completedTask = currentTask?.copy(completedAt = obs.timestamp)
                 val recentTasks = if (completedTask != null) {
                     (region.recentTasks + completedTask).takeLast(MAX_RECENT_TASKS)


### PR DESCRIPTION
## Summary

DoorDash stacked pickups (one offer, two pickup stops at different merchants — e.g. **Costa Pacifica → Chili's** on 2026-05-17, **Best Buy → Chick-fil-A** on 2026-05-16) were treated as one continuous Task with `storeName` mutated in place when the platform routed the dasher to store # 2. Three downstream symptoms followed:

- **Odometer paused for the inter-store leg.** `EffectMap.kt` only emitted `ResumeOdometer` for `prevTask == null && nextTask != null`. The store-to-store mutation didn't satisfy that gate — odometer stayed paused from arrival at store # 1 through the drive to store # 2. Matches the "few tenths short" 2026-05-16 observation.
- **Per-store TNP attribution impossible** — no separate Task for the second leg's pay/mileage to attach to.
- **Flow-card HUD overwrote the Pickup card in place.** `FlowCardMapper` updates the open card when `current.taskId == payload.taskId`. The Costa Pacifica card never froze; it morphed into a Chili's card. Field log 2026-05-17 # 6.

Ground-truth captures: `/home/betty/dashbuddy/logs/2026/05/17/field-test-2/captures/doordash/accessibility.window/pickup_navigation/2026-05-17_19-46-08-308__...__fc76dc.json` (Costa Pacifica) and `pickup_pre_arrival/2026-05-17_20-03-50-343__...__100ca3.json` (Chili's) — same pickup-phase span, both stores observed, only `storeName` differs.

## Fix

Mint a new `Task` (new `taskId`) at the **stepper** the moment a stacked-pickup transition is observed. Triple-signal trigger so it survives the known post-arrival storeName parser bug (see Notes):

1. Same phase `PICKUP → PICKUP`.
2. `currentTask.arrivedAt != null` (excludes Unknown→resolved and pre-arrival text drift).
3. `taskSubFlow == NAVIGATION` (the new screen is a navigation/pre-arrival, not an arrived screen).
4. Parsed `storeName` is non-null, non-Unknown, and different from current.

Also broaden the `PICKUP_NAV_STARTED + ResumeOdometer` gate in `EffectMap.diffTask` from `prevTask == null` to `prevTask?.taskId != nextTask.taskId` so the second pickup's emission fires correctly.

After this lands, the existing `storeChanged` branch in `EffectMap.kt:434-468` becomes dead code for the stacked-pickup case — left as-is; it still handles legitimate same-task text drift safely.

## Why the triple signal

Captures reveal the `pickup_arrival` storeName parser is unreliable: on the 2026-05-17 Chili's arrival the rule walks four `instructions_title` nodes — `["Parking instructions", "Walk into store", "Additional notes", "Chili's Grill & Bar"]` — and picks `"Walk into store"` as storeName because of `rejectIf: contains("instructions"|"notes")`. A single-signal gate (e.g. storeName != prev) would be vulnerable. The triple gate requires *all three* to change, so any single parser blip is harmless.

In the captured Costa Pacifica → Chili's flow, `pickup_pre_arrival` (uses the reliable `user_name` selector → correct storeName) fires *before* the broken `pickup_arrival`, so the new task is minted with the correct name.

## Tests

- **`PlatformRegionStepperTest`** *(new file)* — 5 cases:
  1. Stacked pickup mints a new taskId; previous task moves to recentTasks with completedAt; new task's arrivedAt resets to null.
  2. Unknown → resolved name pre-arrival keeps the same task.
  3. Text drift pre-arrival (Best Buy → Best Buy #1234) keeps the same task.
  4. Parser flicker on the ARRIVED screen (\"Walk into store\" misparse) keeps the same task.
  5. Classifier flicker NAVIGATION re-entry on the same store keeps the same task.
  6. PICKUP → DROPOFF regression guard.
- **`EffectMapTest`** *(updated)* — adds the stacked-pickup gate-broadening test (`stacked pickup transition fires PICKUP_NAV_STARTED and ResumeOdometer for the new task`). Existing `pickup start emits PICKUP_NAV_STARTED and ResumeOdometer` test at line 340 doubles as the first-pickup regression guard.

## Notes — related bugs, not in this PR

- **`pickup_arrival` storeName parser** picks wrong `instructions_title` (Chili's → \"Walk into store\", McDonalds → order #). Rule at `doordash.json:960-975`. Tolerated by this PR's stepper fix (pre-arrival parse wins first). Separate PR.
- **HEB offer card double-pickup** (field log 2026-05-17 # 5). Offer-rule `each` over `display_name` duplicates for shop-for-items. Not stepper-related. Separate PR.

Both tracked in project memory.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest --tests \"*PlatformRegionStepperTest*\" --tests \"*EffectMapTest*\"` — new tests + existing
- [x] `./gradlew :core:state:testDebugUnitTest :app:testDebugUnitTest :core:pipeline:testDebugUnitTest` — broader sweep
- [ ] Next dash with a stacked DoorDash offer:
  - Store # 1 Pickup card **freezes** when store # 2 opens (no card overwrite).
  - In-app odometer matches the car odometer within tenths (no lost inter-store leg).
  - `app_events` shows two distinct `taskId`s with their own `PICKUP_NAV_STARTED` / `PICKUP_ARRIVED` rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)