### PR TITLE
fix: scope pickup_arrival storeName parse to the contact-card subtree

### DIFF
--- a/core/pipeline/src/main/assets/rules/doordash.json
+++ b/core/pipeline/src/main/assets/rules/doordash.json
@@ -907,6 +907,12 @@
         "flow": "task:pickup:arrived",
         "modeHint": "online"
       },
+      "bind": {
+        "contactView": {
+          "find": { "hasIdSuffix": "mx_contact_view" },
+          "optional": true
+        }
+      },
       "require": {
         "all": [
           {
@@ -958,20 +964,11 @@
             "transform": "sha256"
           },
           "storeName": {
+            "from": "contactView",
             "find": {
               "hasIdSuffix": "instructions_title"
             },
-            "read": "text",
-            "rejectIf": {
-              "any": [
-                {
-                  "hasTextContaining": "instructions"
-                },
-                {
-                  "hasTextContaining": "notes"
-                }
-              ]
-            }
+            "read": "text"
           },
           "deadlineText": {
             "find": {


### PR DESCRIPTION
## Summary

The DoorDash `pickup_arrival` storeName rule walks `instructions_title` nodes in DFS order via `find` and nullifies via `rejectIf` if the first match is `instructions` or `notes`. On screens with multiple `instructions_title` nodes — verified across all 9 unique `pickup_arrival` captures in `/home/betty/dashbuddy/logs` (Chili's-style with Parking / Walk-in / Notes / contact-card sections, 3-4 nodes each) — this is structurally fragile. The actual store name is always the `instructions_title` inside the `mx_contact_view` container; the noise nodes are siblings in a separate `instructions_view` subtree that always appears first in DFS order.

## Why fix it now (the bug is latent but real)

In the captured field sessions the bug doesn't currently produce a wrong storeName in the DB. Trace: when the first `instructions_title` is e.g. \"Parking instructions\", `rejectIf` returns null and the stepper's `?: currentTask.storeName` fallback at `PlatformRegionStepper.kt:432` preserves the prior correct storeName from `pickup_pre_arrival`'s reliable `user_name` parse. Confirmed by querying `field-test-2/db/dashbuddy-v2.db`:

| Merchant | `storeName` in `app_events` PICKUP_* rows |
|---|---|
| H-E-B | `H-E-B` |
| McDonald's | `McDonald's` |
| Costa Pacifica → Chili's (stacked) | `Costa Pacifica`, then `Chili's Grill & Bar` |

But the bug shape is **\"first `instructions_title` is some non-store-name text that doesn't match `instructions`/`notes`\"** — e.g., an order number, a status string, or anything else DoorDash labels with the same id in a future UI tweak. When that happens, the wrong text becomes storeName and the fallback never gets a chance. The developer has previously observed McDonald's parsing as an order number from a session that pre-dates these captures — fitting this exact shape.

The fix eliminates the structural fragility rather than waiting for the next visible recurrence.

## Fix

Add a rule-level `bind` for `mx_contact_view` (optional, so a future DoorDash UI without that container falls back to today's whole-tree search and `pickup_arrival` still classifies). Switch the storeName field to `from: \"contactView\"` so `find` searches only inside the contact-card subtree — where the single descendant `instructions_title` is the actual store name. Drop the now-unnecessary `rejectIf` (would have become a false-negative risk against any merchant whose display name contains \"Notes\").

```json
\"bind\": {
  \"contactView\": {
    \"find\": { \"hasIdSuffix\": \"mx_contact_view\" },
    \"optional\": true
  }
},
...
\"storeName\": {
  \"from\": \"contactView\",
  \"find\": { \"hasIdSuffix\": \"instructions_title\" },
  \"read\": \"text\"
}
```

## Test plan

- [x] `./gradlew :core:pipeline:testDebugUnitTest :app:testDebugUnitTest :core:state:testDebugUnitTest` — full sweep
- [x] `./gradlew :app:testDebugUnitTest --tests \"*DefaultRulesIntegrationTest*\" --rerun` — confirms doordash.json compiles cleanly through the rule engine
- [ ] Next field session: pickup_arrival on any merchant with parking / walk-in / notes sections — bubble should display the actual store name; AppEvents row's storeName matches the merchant.
- [ ] If a pickup with the bug shape is encountered (first `instructions_title` is non-store-name text that doesn't match `instructions|notes`), the fix should produce the correct storeName. No current capture demonstrates this shape — the next observed-bad case becomes the regression-test ground truth.

## Notes

- Same `find: hasIdSuffix:` + `rejectIf` pattern may exist on other screen rules. Not audited in this PR — if symptoms appear, treat individually.
- HEB offer-card double-pickup (#5 in field log) is a distinct offer-parser bug; separate PR; tracked in project memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)