### PR TITLE
feat: DELIVERY_CONFIRMED event closes drop-off task on transition away

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardMapper.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardMapper.kt
@@ -223,6 +223,31 @@ object FlowCardMapper {
                     lastDeliveryArrivedAt = payload.arrivedAt ?: event.occurredAt
                 }
 
+                AppEventType.DELIVERY_CONFIRMED -> {
+                    // Dasher finished the drop-off. Closes the open Delivery
+                    // card. Fires before DELIVERY_COMPLETED (which carries the
+                    // PostTask pay breakdown). Analogue of PICKUP_CONFIRMED.
+                    val payload = decode(event, DeliveryPayload::class.java) ?: continue
+                    val current = openDelivery
+                    val closed = if (current?.taskId == payload.taskId) {
+                        current.copy(phaseEndedAt = event.occurredAt)
+                    } else {
+                        FlowCardSnapshot.Delivery(
+                            phaseStartedAt = payload.phaseStartedAt,
+                            phaseEndedAt = event.occurredAt,
+                            taskId = payload.taskId,
+                            jobId = payload.jobId,
+                            storeName = payload.storeName,
+                            customerHash = payload.customerHash,
+                            arrivedAt = payload.arrivedAt,
+                            deadlineMillis = payload.deadlineMillis,
+                        )
+                    }
+                    completed.add(closed)
+                    openDelivery = null
+                    lastDeliveryArrivedAt = lastDeliveryArrivedAt ?: event.occurredAt
+                }
+
                 AppEventType.DELIVERY_COMPLETED -> {
                     val payload = decode(event, DeliveryPayload::class.java) ?: continue
                     // PostTask card spans from delivery arrival (start of the

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
@@ -421,6 +421,94 @@ class EffectMapTest {
     }
 
     @Test
+    fun `dropoff to PostTask (activeTask null) emits DELIVERY_CONFIRMED`() {
+        // The platform routed dasher into PostTask; the dropoff is done.
+        // activeTask transitions to null (stepper moved it to recentTasks).
+        val (platform, _) = stateWithPlatform()
+        val session = Session("sess-1", startedAt = 100L)
+        val dropoffTask = Task(
+            taskId = "task-1", jobId = "job-1", phase = TaskPhase.DROPOFF,
+            storeName = "Chipotle", startedAt = 900L, arrivedAt = null,
+        )
+        val prev = AppState(regions = Regions(
+            flow = FlowRegion(flow = Flow.TaskDropoffNavigation),
+            platforms = mapOf(platform to PlatformRegion(
+                platform, mode = Mode.Online, session = session, activeTask = dropoffTask,
+            )),
+        ))
+        val next = AppState(regions = Regions(
+            flow = FlowRegion(flow = Flow.PostTask),
+            platforms = mapOf(platform to PlatformRegion(
+                platform, mode = Mode.Online, session = session,
+                activeTask = null, recentTasks = listOf(dropoffTask.copy(completedAt = 1000L)),
+            )),
+        ))
+
+        val effects = effectMap.diff(prev, next, screenObs(flow = Flow.PostTask, parsed = ParsedFields.PostTaskFields(totalPay = 7.50)))
+
+        assertTrue(
+            "Should emit DELIVERY_CONFIRMED on activeTask cleared from dropoff",
+            effects.logEventTypes().contains(AppEventType.DELIVERY_CONFIRMED),
+        )
+    }
+
+    @Test
+    fun `dropoff to next-pickup (different taskId) emits DELIVERY_CONFIRMED`() {
+        // Stacked next-offer accepted before PostTask shows: prev dropoff
+        // is no longer active; the next pickup task takes over.
+        val (platform, _) = stateWithPlatform()
+        val session = Session("sess-1", startedAt = 100L)
+        val prevDropoff = Task(
+            taskId = "task-A", jobId = "job-1", phase = TaskPhase.DROPOFF,
+            storeName = "Chipotle", startedAt = 900L,
+        )
+        val nextPickup = Task(
+            taskId = "task-B", jobId = "job-2", phase = TaskPhase.PICKUP,
+            storeName = "Wendy's", startedAt = 1100L,
+        )
+        val prev = AppState(regions = Regions(
+            flow = FlowRegion(flow = Flow.TaskDropoffArrived),
+            platforms = mapOf(platform to PlatformRegion(
+                platform, mode = Mode.Online, session = session, activeTask = prevDropoff,
+            )),
+        ))
+        val next = AppState(regions = Regions(
+            flow = FlowRegion(flow = Flow.TaskPickupNavigation),
+            platforms = mapOf(platform to PlatformRegion(
+                platform, mode = Mode.Online, session = session, activeTask = nextPickup,
+            )),
+        ))
+
+        val effects = effectMap.diff(prev, next, screenObs(flow = Flow.TaskPickupNavigation, parsed = ParsedFields.TaskFields(storeName = "Wendy's", phase = TaskPhase.PICKUP, subFlow = TaskSubFlow.NAVIGATION)))
+
+        assertTrue(
+            "Should emit DELIVERY_CONFIRMED for the leaving dropoff",
+            effects.logEventTypes().contains(AppEventType.DELIVERY_CONFIRMED),
+        )
+    }
+
+    @Test
+    fun `same dropoff task (in-place update) does NOT emit DELIVERY_CONFIRMED`() {
+        val (platform, _) = stateWithPlatform()
+        val session = Session("sess-1", startedAt = 100L)
+        val task = Task(
+            taskId = "task-1", jobId = "job-1", phase = TaskPhase.DROPOFF,
+            storeName = "Chipotle", startedAt = 900L,
+        )
+        val prevRegion = PlatformRegion(platform, mode = Mode.Online, session = session, activeTask = task)
+        val nextRegion = PlatformRegion(platform, mode = Mode.Online, session = session, activeTask = task.copy(storeName = "Updated Chipotle"))
+        val prev = AppState(regions = Regions(flow = FlowRegion(flow = Flow.TaskDropoffNavigation), platforms = mapOf(platform to prevRegion)))
+        val next = AppState(regions = Regions(flow = FlowRegion(flow = Flow.TaskDropoffNavigation), platforms = mapOf(platform to nextRegion)))
+
+        val effects = effectMap.diff(prev, next, screenObs(flow = Flow.TaskDropoffNavigation, parsed = ParsedFields.TaskFields(storeName = "Updated Chipotle", phase = TaskPhase.DROPOFF, subFlow = TaskSubFlow.NAVIGATION)))
+
+        assertTrue(
+            "Should NOT emit DELIVERY_CONFIRMED for same-task update",
+            !effects.logEventTypes().contains(AppEventType.DELIVERY_CONFIRMED),
+        )
+    }
+
+    @Test
     fun `pickup to dropoff emits PICKUP_CONFIRMED and DELIVERY_NAV_STARTED`() {
         val (platform, _) = stateWithPlatform()
         val session = Session("sess-1", startedAt = 100L)
@@ -441,6 +529,10 @@ class EffectMapTest {
         assertTrue("Should emit PICKUP_CONFIRMED", effects.logEventTypes().contains(AppEventType.PICKUP_CONFIRMED))
         assertTrue("Should emit DELIVERY_NAV_STARTED", effects.logEventTypes().contains(AppEventType.DELIVERY_NAV_STARTED))
         assertTrue("Should emit ResumeOdometer", effects.any { it is AppEffect.ResumeOdometer })
+        assertTrue(
+            "Should NOT emit DELIVERY_CONFIRMED on a pickup-leaving transition",
+            !effects.logEventTypes().contains(AppEventType.DELIVERY_CONFIRMED),
+        )
     }
 
     @Test

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardMapperTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardMapperTest.kt
@@ -187,6 +187,61 @@ class FlowCardMapperTest {
         assertEquals(4500L, postTask.phaseEndedAt)
     }
 
+    @Test
+    fun `no-arrival delivery (DELIVERY_CONFIRMED only) closes Delivery card and opens PostTask`() {
+        // DoorDash drop-off doesn't surface a recognized ARRIVED screen. The
+        // stepper emits DELIVERY_CONFIRMED when the active dropoff task transitions
+        // away (PostTask entry, next offer, etc.); that signal closes the Delivery
+        // card. DELIVERY_COMPLETED still fires later with pay breakdown.
+        // Sequence mirrors the happy-path but DELIVERY_ARRIVED is absent.
+        val parsedPay = ParsedPay(
+            appPayComponents = listOf(ParsedPayItem("Base Pay", 4.50)),
+            customerTips = listOf(ParsedPayItem("Wendy's", 3.00)),
+        )
+        val events = listOf(
+            event(AppEventType.DASH_START,
+                SessionStartPayload("s1", "DoorDash", 1000L, "interaction", "WaitingForOffer"),
+                occurredAt = 1000L),
+            event(AppEventType.OFFER_RECEIVED, "{}", occurredAt = 2000L),
+            event(AppEventType.OFFER_ACCEPTED,
+                offerPayload("offer-1", AppEventType.OFFER_ACCEPTED, 2000L, 2500L),
+                occurredAt = 2500L),
+            event(AppEventType.PICKUP_NAV_STARTED,
+                pickupPayload("T1", "J1", "Wendy's", 2500L),
+                occurredAt = 2500L),
+            event(AppEventType.PICKUP_ARRIVED,
+                pickupPayload("T1", "J1", "Wendy's", 2500L, arrived = 3000L),
+                occurredAt = 3000L),
+            event(AppEventType.PICKUP_CONFIRMED,
+                pickupPayload("T1", "J1", "Wendy's", 2500L, arrived = 3000L, confirmed = 3500L),
+                occurredAt = 3500L),
+            event(AppEventType.DELIVERY_NAV_STARTED,
+                deliveryPayload("T2", "J1", 3500L),
+                occurredAt = 3500L),
+            // No DELIVERY_ARRIVED — DoorDash drop-off skips this.
+            event(AppEventType.DELIVERY_CONFIRMED,
+                deliveryPayload("T2", "J1", 3500L),
+                occurredAt = 4200L),
+            event(AppEventType.DELIVERY_COMPLETED,
+                deliveryPayload("T2", "J1", 3500L, completed = 4500L,
+                    totalPay = 7.50, parsedPay = parsedPay, sessionEarnings = 47.50),
+                occurredAt = 4500L),
+        )
+
+        val cards = FlowCardMapper.fold(events)
+        // Expected: Awaiting, Offer, Pickup, Delivery, PostTask
+        assertEquals(5, cards.size)
+
+        val delivery = cards[3] as FlowCardSnapshot.Delivery
+        assertEquals("T2", delivery.taskId)
+        assertEquals(4200L, delivery.phaseEndedAt)
+        assertNull("arrivedAt stays null for no-arrival deliveries", delivery.arrivedAt)
+
+        val postTask = cards[4] as FlowCardSnapshot.PostTask
+        assertEquals(7.50, postTask.totalPay, 0.001)
+        assertEquals(4500L, postTask.phaseEndedAt)
+    }
+
     // =========================================================================
     // Decline path
     // =========================================================================

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -382,6 +382,21 @@ class EffectMap @Inject constructor(
                 }
             }
 
+            // Delivery confirmed: the active task is no longer this dropoff,
+            // either because it became null (PostTask / Idle / session end) or
+            // because a new task took over (next pickup, next dropoff leg).
+            // DoorDash drop-off doesn't surface an explicit "arrived" screen
+            // we can rely on, so this transition is the closure signal.
+            if (prevTask?.phase == TaskPhase.DROPOFF &&
+                (nextTask == null || nextTask.taskId != prevTask.taskId)
+            ) {
+                val deliveryConfirmed = deliveryPhasePayload(
+                    task = prevTask,
+                    phaseStartedAt = prevTask.startedAt,
+                )
+                add(logEffect(sessionId, AppEventType.DELIVERY_CONFIRMED, deliveryConfirmed))
+            }
+
             // Task phase changed — pickup → dropoff (pickup confirmed)
             if (prevTask?.phase == TaskPhase.PICKUP &&
                 nextTask?.phase == TaskPhase.DROPOFF

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/AppEventType.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/AppEventType.kt
@@ -24,7 +24,8 @@ enum class AppEventType {
     // --- Delivery Phase ---
     DELIVERY_NAV_STARTED,
     DELIVERY_ARRIVED,
-    DELIVERY_COMPLETED,
+    DELIVERY_CONFIRMED, // Dasher finished the drop-off (handoff or POD photo done); analogue of PICKUP_CONFIRMED
+    DELIVERY_COMPLETED, // PostTask exit (receipt dismissed); carries pay breakdown
 
     // --- System / Generic ---
     SCREEN_VIEWED, // For generic screen transitions like "Earnings Screen"


### PR DESCRIPTION
## Summary

Field log 2026-05-17 #3: the Drop-off card never freezes at delivery completion — only when `DASH_STOP` fires at end-of-session. Root cause confirmed by querying `field-test-2/db/dashbuddy-v2.db`: across all 4 deliveries in the session, **zero `DELIVERY_ARRIVED` events**. DoorDash's drop-off completion is a multi-step bottomsheet flow (confirm correct order → method selection → POD photo) and none of those screens are recognized — they all classify as UNKNOWN. The mapper's `openDelivery` card never gets a closure signal until `DASH_STOP` flushes it.

Earlier exploration ruled out screen-rule recognition for this PR: text discriminators are unreliable per delivery (sometimes the sheet is just a bare confirm with no fixed headers) and unreliable across time (April 2026 captures show a completely different completion UI). Compose-heavy screens give thin structural anchors.

## Approach

Instead, key off the task transition the stepper already detects. Add `AppEventType.DELIVERY_CONFIRMED`, emit it from `EffectMap` whenever `prevTask.phase == DROPOFF` and the next region's `activeTask` is either `null` (PostTask / Idle / session end) or a different `taskId` (next pickup, next dropoff leg). The mapper handles it by closing `openDelivery` and pushing the frozen card to `completed`. Analogous to `PICKUP_CONFIRMED`. Existing `DELIVERY_COMPLETED` (PostTask exit, carries pay breakdown) stays unchanged — distinct lifecycle moments.

Event-model symmetry after this PR:

| Phase | Start | Arrived | Confirmed | Receipt finalized |
|---|---|---|---|---|
| Pickup | `PICKUP_NAV_STARTED` | `PICKUP_ARRIVED` | `PICKUP_CONFIRMED` | n/a |
| Delivery | `DELIVERY_NAV_STARTED` | `DELIVERY_ARRIVED` *(when surfaced)* | **`DELIVERY_CONFIRMED`** *(new)* | `DELIVERY_COMPLETED` |

Covers all closure paths flagged in design discussion:

| Transition | Why |
|---|---|
| Dropoff → PostTask | Normal happy path — PAID receipt shown |
| Dropoff → Idle | PostTask summary sometimes doesn't show; flow goes straight to waiting-for-offer |
| Dropoff → Pickup (new taskId) | Next stacked offer accepted before PostTask appears |
| Dropoff → DROPOFF (different taskId) | Stacked-delivery next leg (intermediate-leg detection is a separate stepper fix) |
| Dropoff → null at session end | Also covered by `DASH_STOP` flush |

## Test plan

- [x] `./gradlew :app:testDebugUnitTest --tests \"*FlowCardMapperTest*\" --tests \"*EffectMapTest*\"`
- [x] `./gradlew :core:state:testDebugUnitTest :app:testDebugUnitTest :core:pipeline:testDebugUnitTest` — broader sweep
- [ ] **Next field session:**
  - Single delivery → Drop-off card freezes at PostTask entry (not at DASH_STOP).
  - AppEvents log has a `DELIVERY_CONFIRMED` row between `DELIVERY_NAV_STARTED` and `DELIVERY_COMPLETED`.
  - Stacked delivery (multi-customer drop-offs) → **last** delivery's card freezes correctly at PostTask entry. Note: intermediate deliveries still don't show up as separate frozen cards (stacked-delivery followup will address that separately).

## Out of scope (followups, tracked in project memory)

1. **Intermediate deliveries in a stacked-delivery job.** The stepper doesn't mint new dropoff tasks on a drop1→drop2 transition — analogous to the stacked-pickup architectural fix (PR #262) but for the drop-off side. Separate investigation needed.
2. **Drop-off completion screen recognition.** The confirm sheet / method selection / POD photo screens stay UNKNOWN. Deferred until we have more capture variety from post-#259 sessions.
3. **Duplicate `DELIVERY_COMPLETED` events.** Every real completion is followed by 1-2 duplicates with `storeName: \"Unknown\"`. Separate bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)