### PR TITLE
feat: post-task best-effort + dup-skip + UDF click delay + safety screenshots

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
@@ -174,7 +174,7 @@ class SideEffectEngine @Inject constructor(
                     Timber.w("Timer Expired: ${effect.type}")
 
                     // Emit Timeout Event back to State Machine
-                    _events.emit(TimeoutEvent(type = effect.type))
+                    _events.emit(TimeoutEvent(type = effect.type, payload = effect.payload))
 
                     activeTimers.remove(effect.type)
                 }
@@ -184,11 +184,6 @@ class SideEffectEngine @Inject constructor(
             is AppEffect.CancelTimeout -> {
                 activeTimers[effect.type]?.cancel()
                 activeTimers.remove(effect.type)
-            }
-
-            is AppEffect.Delayed -> {
-                delay(effect.delayMs)
-                execute(effect.effect, scope, recovering)
             }
 
             is AppEffect.SequentialEffect -> {

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
@@ -624,6 +624,170 @@ class EffectMapTest {
         )
     }
 
+    @Test
+    fun `leaving PostTask with no recent task does NOT emit DELIVERY_COMPLETED (duplicate-skip)`() {
+        // Reproduces the per-platform iteration bug: a platform that didn't own
+        // the delivery still enters this code path on PostTask exit, but has no
+        // recentTasks. The deliveryCompletedPayload "unknown" fallback fires
+        // unless we skip on null. This test asserts the skip works.
+        val (platform, _) = stateWithPlatform()
+        val session = Session("sess-1", startedAt = 100L)
+        val prev = AppState(regions = Regions(
+            flow = FlowRegion(flow = Flow.PostTask),
+            platforms = mapOf(platform to PlatformRegion(
+                platform, mode = Mode.Online, session = session,
+                recentTasks = emptyList(), activeJob = null,
+            )),
+        ))
+        val next = AppState(regions = Regions(
+            flow = FlowRegion(flow = Flow.Idle),
+            platforms = mapOf(platform to PlatformRegion(
+                platform, mode = Mode.Online, session = session,
+                recentTasks = emptyList(), activeJob = null,
+            )),
+        ))
+
+        val effects = effectMap.diff(prev, next, screenObs(flow = Flow.Idle))
+        assertTrue(
+            "Should NOT emit DELIVERY_COMPLETED when there's no completed task to attribute",
+            !effects.logEventTypes().contains(AppEventType.DELIVERY_COMPLETED),
+        )
+    }
+
+    // =========================================================================
+    // POST-TASK ANNOUNCEMENT (single-bubble, per-task idempotency)
+    // =========================================================================
+
+    @Test
+    fun `collapsed-only PostTask emits single minimal Saved bubble`() {
+        val (platform, _) = stateWithPlatform()
+        val session = Session("sess-1", startedAt = 100L)
+        val task = Task(taskId = "task-1", jobId = "job-1", phase = TaskPhase.DROPOFF, storeName = "Chipotle", startedAt = 900L, completedAt = 1000L)
+        val prev = AppState(regions = Regions(
+            flow = FlowRegion(flow = Flow.PostTask),
+            platforms = mapOf(platform to PlatformRegion(
+                platform, mode = Mode.Online, session = session, recentTasks = listOf(task),
+                lastAnnouncedPostTaskTaskId = null,
+            )),
+        ))
+        val next = prev
+        val effects = effectMap.diff(prev, next, screenObs(
+            flow = Flow.PostTask,
+            parsed = ParsedFields.PostTaskFields(totalPay = 7.50, parsedPay = null),
+        ))
+        val bubbles = effects.filterIsInstance<AppEffect.UpdateBubble>()
+        assertEquals(1, bubbles.size)
+        assertTrue("Bubble should contain Saved", bubbles[0].text.contains("Saved"))
+        assertTrue("Bubble should contain totalPay value", bubbles[0].text.contains("7.50"))
+    }
+
+    @Test
+    fun `PostTask with same taskId already announced does NOT re-emit bubble`() {
+        val (platform, _) = stateWithPlatform()
+        val session = Session("sess-1", startedAt = 100L)
+        val task = Task(taskId = "task-1", jobId = "job-1", phase = TaskPhase.DROPOFF, storeName = "Chipotle", startedAt = 900L, completedAt = 1000L)
+        // prev region already has lastAnnouncedPostTaskTaskId = task-1
+        val region = PlatformRegion(
+            platform, mode = Mode.Online, session = session, recentTasks = listOf(task),
+            lastAnnouncedPostTaskTaskId = "task-1",
+        )
+        val prev = AppState(regions = Regions(flow = FlowRegion(flow = Flow.PostTask), platforms = mapOf(platform to region)))
+        val next = prev
+        val effects = effectMap.diff(prev, next, screenObs(
+            flow = Flow.PostTask,
+            parsed = ParsedFields.PostTaskFields(totalPay = 7.50, parsedPay = null),
+        ))
+        assertTrue(
+            "Should NOT emit a second bubble for the same taskId",
+            effects.filterIsInstance<AppEffect.UpdateBubble>().isEmpty(),
+        )
+    }
+
+    @Test
+    fun `expanded PostTask on first sighting emits single full receipt bubble`() {
+        val (platform, _) = stateWithPlatform()
+        val session = Session("sess-1", startedAt = 100L)
+        val task = Task(taskId = "task-1", jobId = "job-1", phase = TaskPhase.DROPOFF, storeName = "Chipotle", startedAt = 900L, completedAt = 1000L)
+        val region = PlatformRegion(
+            platform, mode = Mode.Online, session = session, recentTasks = listOf(task),
+            lastAnnouncedPostTaskTaskId = null,
+        )
+        val prev = AppState(regions = Regions(flow = FlowRegion(flow = Flow.PostTask), platforms = mapOf(platform to region)))
+        val next = prev
+        val parsedPay = cloud.trotter.dashbuddy.domain.model.pay.ParsedPay(
+            appPayComponents = listOf(cloud.trotter.dashbuddy.domain.model.pay.ParsedPayItem("Base", 4.50)),
+            customerTips = listOf(cloud.trotter.dashbuddy.domain.model.pay.ParsedPayItem("Chipotle", 3.00)),
+        )
+        val effects = effectMap.diff(prev, next, screenObs(
+            flow = Flow.PostTask,
+            parsed = ParsedFields.PostTaskFields(totalPay = 7.50, parsedPay = parsedPay),
+        ))
+        val bubbles = effects.filterIsInstance<AppEffect.UpdateBubble>()
+        assertEquals(1, bubbles.size)
+        assertTrue("Bubble should contain breakdown line", bubbles[0].text.contains("Tip"))
+        assertTrue("Bubble should contain store name", bubbles[0].text.contains("Chipotle"))
+    }
+
+    // =========================================================================
+    // CLICK DELAY VIA SETTLE_UI TIMEOUT (UDF round-trip)
+    // =========================================================================
+
+    @Test
+    fun `click effect with delayMs emits ScheduleTimeout instead of immediate RequestEffect`() {
+        val nodeRef = cloud.trotter.dashbuddy.domain.pipeline.NodeRef(
+            viewIdSuffix = "com.example:id/btn",
+            text = null, classNameHint = "android.widget.Button",
+            boundsInScreen = cloud.trotter.dashbuddy.domain.model.accessibility.BoundingBox(0, 0, 100, 50),
+            pathFingerprint = "fp",
+        )
+        val effect = cloud.trotter.dashbuddy.domain.pipeline.RequestedEffect(
+            verb = cloud.trotter.dashbuddy.domain.pipeline.EffectVerb.CLICK,
+            targetRef = nodeRef,
+            delayMs = 500L,
+            ruleId = "test.rule",
+        )
+        val obs = screenObs(flow = Flow.PostTask).copy(effects = listOf(effect))
+        val effects = effectMap.diff(AppState(), AppState(), obs)
+        val scheduled = effects.filterIsInstance<AppEffect.ScheduleTimeout>()
+        assertEquals(1, scheduled.size)
+        assertEquals(cloud.trotter.dashbuddy.domain.pipeline.TimeoutType.SETTLE_UI, scheduled[0].type)
+        assertEquals(500L, scheduled[0].durationMs)
+        // Payload should carry the click context
+        assertEquals("com.example:id/btn", scheduled[0].payload["target.viewIdSuffix"])
+        assertEquals("test.rule", scheduled[0].payload["ruleId"])
+        // And NOT emit a RequestEffect for the click directly
+        assertTrue(
+            "Click should be deferred, not dispatched directly",
+            effects.filterIsInstance<AppEffect.RequestEffect>().isEmpty(),
+        )
+    }
+
+    @Test
+    fun `SETTLE_UI timeout re-emits the click as immediate RequestEffect`() {
+        val payload = mapOf<String, Any?>(
+            "verb" to "CLICK",
+            "ruleId" to "test.rule",
+            "target.viewIdSuffix" to "com.example:id/btn",
+            "target.classNameHint" to "android.widget.Button",
+            "target.pathFingerprint" to "fp",
+            "target.bounds.left" to 0,
+            "target.bounds.top" to 0,
+            "target.bounds.right" to 100,
+            "target.bounds.bottom" to 50,
+        )
+        val timeoutObs = Observation.Timeout(
+            timestamp = 1000L,
+            type = cloud.trotter.dashbuddy.domain.pipeline.TimeoutType.SETTLE_UI,
+            payload = payload,
+        )
+        val effects = effectMap.diff(AppState(), AppState(), timeoutObs)
+        val requested = effects.filterIsInstance<AppEffect.RequestEffect>()
+        assertEquals(1, requested.size)
+        assertEquals(cloud.trotter.dashbuddy.domain.pipeline.EffectVerb.CLICK, requested[0].effect.verb)
+        assertEquals("com.example:id/btn", requested[0].effect.targetRef?.viewIdSuffix)
+        assertEquals(null, requested[0].effect.delayMs)  // immediate, not deferred again
+    }
+
     // =========================================================================
     // NOTIFICATION EFFECTS
     // =========================================================================

--- a/core/pipeline/src/main/assets/rules/doordash.json
+++ b/core/pipeline/src/main/assets/rules/doordash.json
@@ -510,6 +510,15 @@
           "tolerance": 0.02,
           "onFail": "skip"
         }
+      ],
+      "effects": [
+        {
+          "screenshot": {
+            "prefix": "DeliveryBreakdown - {totalPay}"
+          },
+          "dedupeKey": "delivery-ss-expanded-{totalPay}-{sessionEarnings}",
+          "throttleMs": 60000
+        }
       ]
     },
     {
@@ -593,7 +602,15 @@
             }
           },
           "dedupeKey": "expand_pay_breakdown",
-          "throttleMs": 1000
+          "throttleMs": 1000,
+          "delayMs": 500
+        },
+        {
+          "screenshot": {
+            "prefix": "Delivery - {totalPay}"
+          },
+          "dedupeKey": "delivery-ss-collapsed-{totalPay}-{sessionEarnings}",
+          "throttleMs": 60000
         }
       ]
     },
@@ -2239,6 +2256,15 @@
           "le": "weeklyEarnings",
           "tolerance": 0.02,
           "onFail": "dropParsed"
+        }
+      ],
+      "effects": [
+        {
+          "screenshot": {
+            "prefix": "DashSummary - {totalEarnings}"
+          },
+          "dedupeKey": "dash-summary-ss-{totalEarnings}-{sessionDurationMillis}",
+          "throttleMs": 60000
         }
       ]
     },

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/CompiledRules.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/CompiledRules.kt
@@ -108,4 +108,12 @@ data class CompiledEffect(
     val onlyIf: cloud.trotter.dashbuddy.domain.pipeline.ParsedFieldsGate? = null,
     val dedupeKey: String? = null,
     val throttleMs: Long? = null,
+    /**
+     * Optional delay (ms) before the effect fires. When non-null and > 0,
+     * EffectMap routes the effect through a SETTLE_UI timeout so the delay
+     * is state-machine-visible (cancellable / observable). Capped at 5000ms.
+     * Primarily used to let dynamic UI (e.g. RecyclerView pages) settle
+     * before an auto-click.
+     */
+    val delayMs: Long? = null,
 )

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompiler.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompiler.kt
@@ -37,6 +37,13 @@ object RuleCompiler {
     const val MAX_REGEX_LENGTH = 200
     private const val MAX_EACH_SIZE = 50
 
+    /**
+     * Hard cap on per-effect `delayMs` (ms). Prevents rules from holding
+     * deferred side effects indefinitely. Tuned for the longest sensible
+     * UI-settling / countdown window (e.g. auto-accept countdowns).
+     */
+    const val MAX_EFFECT_DELAY_MS = 5000L
+
     // ==========================================================================
     //  Permission introspection
     // ==========================================================================
@@ -703,7 +710,7 @@ object RuleCompiler {
         cloud.trotter.dashbuddy.domain.pipeline.EffectVerb.SESSION_END to setOf("platformName"),
     )
 
-    private val effectMetaKeys = setOf("onlyIf", "dedupeKey", "throttleMs")
+    private val effectMetaKeys = setOf("onlyIf", "dedupeKey", "throttleMs", "delayMs")
 
     internal fun compileEffectEntry(obj: JsonObject): CompiledEffect {
         val verbEntries = obj.entries.filter { it.key !in effectMetaKeys }
@@ -739,6 +746,13 @@ object RuleCompiler {
             args = argMap.toMap()
         }
 
+        val delayMs = obj["delayMs"]?.jsonPrimitive?.longOrNull
+        if (delayMs != null && delayMs > MAX_EFFECT_DELAY_MS) {
+            throw RuleCompileException(
+                "Effect delayMs=$delayMs exceeds cap of ${MAX_EFFECT_DELAY_MS}ms",
+            )
+        }
+
         return CompiledEffect(
             verb = verb,
             targetBindName = targetBindName,
@@ -746,6 +760,7 @@ object RuleCompiler {
             onlyIf = obj["onlyIf"]?.jsonObject?.let { compileGate(it) },
             dedupeKey = obj["dedupeKey"]?.jsonPrimitive?.content,
             throttleMs = obj["throttleMs"]?.jsonPrimitive?.longOrNull,
+            delayMs = delayMs,
         )
     }
 

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/Ruleset.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/Ruleset.kt
@@ -179,6 +179,7 @@ class Ruleset<TInput>(rules: List<CompiledRule<TInput>>) {
             onlyIf = effect.onlyIf,
             dedupeKey = effect.dedupeKey?.let { resolveTemplate(it, parsedFields) },
             throttleMs = effect.throttleMs,
+            delayMs = effect.delayMs,
             ruleId = ruleId,
         )
     }
@@ -207,6 +208,7 @@ class Ruleset<TInput>(rules: List<CompiledRule<TInput>>) {
                     onlyIf = effect.onlyIf,
                     dedupeKey = effect.dedupeKey,
                     throttleMs = effect.throttleMs,
+                    delayMs = effect.delayMs,
                     ruleId = ruleId,
                 )
             }

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompilerTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompilerTest.kt
@@ -837,4 +837,39 @@ class RuleCompilerTest {
         )
         assertTrue(compiler.enumeratePermissions(listOf(rule)).isEmpty())
     }
+
+    // =========================================================================
+    // delayMs on effects
+    // =========================================================================
+
+    @Test
+    fun `compileEffectEntry accepts delayMs within cap`() {
+        val obj = parseJson("""{"click": "${'$'}btn", "delayMs": 500}""").jsonObject
+        val effect = RuleCompiler.compileEffectEntry(obj)
+        assertEquals(500L, effect.delayMs)
+    }
+
+    @Test
+    fun `compileEffectEntry omits delayMs when not specified`() {
+        val obj = parseJson("""{"click": "${'$'}btn"}""").jsonObject
+        val effect = RuleCompiler.compileEffectEntry(obj)
+        assertNull(effect.delayMs)
+    }
+
+    @Test(expected = RuleCompileException::class)
+    fun `compileEffectEntry rejects delayMs above 5000ms cap`() {
+        val obj = parseJson("""{"click": "${'$'}btn", "delayMs": 6000}""").jsonObject
+        RuleCompiler.compileEffectEntry(obj)
+    }
+
+    @Test
+    fun `compileEffectEntry treats delayMs as meta-key not verb-key`() {
+        // Regression guard: with delayMs alongside a verb, compileEffectEntry
+        // must not flag it as a second verb.
+        val obj = parseJson("""{"click": "${'$'}btn", "delayMs": 500, "throttleMs": 1000, "dedupeKey": "k"}""").jsonObject
+        val effect = RuleCompiler.compileEffectEntry(obj)
+        assertEquals(500L, effect.delayMs)
+        assertEquals(1000L, effect.throttleMs)
+        assertEquals("k", effect.dedupeKey)
+    }
 }

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/AppEffect.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/AppEffect.kt
@@ -44,7 +44,16 @@ sealed class AppEffect {
     ) : AppEffect()
 
     // Dash Paused!
-    data class ScheduleTimeout(val durationMs: Long, val type: TimeoutType) : AppEffect()
+    data class ScheduleTimeout(
+        val durationMs: Long,
+        val type: TimeoutType,
+        /**
+         * Opaque payload carried through the timer back into [Observation.Timeout].
+         * Used to thread effect context (e.g. click target NodeRef fields) through
+         * the UDF round-trip when the firing of a downstream effect must be deferred.
+         */
+        val payload: Map<String, Any?> = emptyMap(),
+    ) : AppEffect()
     data class CancelTimeout(val type: TimeoutType) : AppEffect()
 
     data object StartOdometer : AppEffect()
@@ -65,7 +74,6 @@ sealed class AppEffect {
             get() = "effect:${effect.ruleId}:${effect.dedupeKey ?: effect.targetRef?.pathFingerprint ?: effect.verb.wire}"
     }
 
-    data class Delayed(val delayMs: Long, val effect: AppEffect) : AppEffect()
     data class SequentialEffect(
         val effects: List<AppEffect>
     ) : AppEffect()

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -10,8 +10,12 @@ import cloud.trotter.dashbuddy.domain.model.event.payload.PickupPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionPausedPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStartPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStopPayload
+import cloud.trotter.dashbuddy.domain.model.accessibility.BoundingBox
+import cloud.trotter.dashbuddy.domain.pipeline.EffectVerb
+import cloud.trotter.dashbuddy.domain.pipeline.NodeRef
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
 import cloud.trotter.dashbuddy.domain.pipeline.ParsedFieldsGate
+import cloud.trotter.dashbuddy.domain.pipeline.RequestedEffect
 import cloud.trotter.dashbuddy.domain.pipeline.TimeoutType
 import cloud.trotter.dashbuddy.domain.pipeline.TransitionTrigger
 import cloud.trotter.dashbuddy.domain.state.AppState
@@ -58,6 +62,7 @@ class EffectMap @Inject constructor(
 
     fun diff(prev: AppState, next: AppState, obs: Observation): List<AppEffect> = buildList {
         addAll(diffRuleEffects(obs))
+        addAll(diffSettleUiTimeout(obs))
         // Offer-resolution events fire in the FlowRegion handler. They need to
         // be scoped to the active platform's session so AppEventDao queries
         // by dashId see them — without this, the bubble HUD's card stack
@@ -187,7 +192,14 @@ class EffectMap @Inject constructor(
             addAll(diffPostTask(p, next, nextFlow, obs))
             addAll(diffNotification(obs))
 
-            // Delivery completed: leaving PostTask for a non-PostTask flow
+            // Delivery completed: leaving PostTask for a non-PostTask flow.
+            //
+            // `diff` iterates over all platforms, but `nextFlow.flow` is global.
+            // On PostTask exit the condition fires for every platform that has a
+            // PlatformRegion entry; only the one that actually owned the delivery
+            // has `completedTask` non-null. Skip the rest — without this guard,
+            // non-owning platforms emit a degenerate DELIVERY_COMPLETED row via
+            // deliveryCompletedPayload's "unknown" fallback.
             if (prevFlow.flow == Flow.PostTask && nextFlow.flow != Flow.PostTask) {
                 val taskCompletedOverride = triggerOverrideEffects(obs, TransitionTrigger.TASK_COMPLETED)
                 if (taskCompletedOverride != null) {
@@ -195,14 +207,16 @@ class EffectMap @Inject constructor(
                 } else {
                     val sessionId = next.session?.sessionId ?: p.session?.sessionId
                     val completedTask = next.recentTasks.lastOrNull()
-                    val payload = deliveryCompletedPayload(
-                        task = completedTask,
-                        jobId = p.activeJob?.jobId,
-                        completedAt = obs.timestamp,
-                        postTaskFields = p.lastPostTaskFields,
-                        sessionEarnings = next.session?.runningEarnings ?: p.session?.runningEarnings,
-                    )
-                    add(logEffect(sessionId, AppEventType.DELIVERY_COMPLETED, payload))
+                    if (completedTask != null) {
+                        val payload = deliveryCompletedPayload(
+                            task = completedTask,
+                            jobId = p.activeJob?.jobId,
+                            completedAt = obs.timestamp,
+                            postTaskFields = p.lastPostTaskFields,
+                            sessionEarnings = next.session?.runningEarnings ?: p.session?.runningEarnings,
+                        )
+                        add(logEffect(sessionId, AppEventType.DELIVERY_COMPLETED, payload))
+                    }
                 }
             }
         }
@@ -498,7 +512,22 @@ class EffectMap @Inject constructor(
 
     /**
      * Handle PostTask effects while on the PostTask screen.
-     * DELIVERY_COMPLETED is emitted from [diffPlatformRegion] when leaving PostTask.
+     *
+     * Emits at most ONE "Saved: $X" bubble per delivery, gated by the
+     * per-task idempotency field `lastAnnouncedPostTaskTaskId` (which the
+     * stepper stamps with the current taskId on every PostTaskFields
+     * observation). The bubble uses whatever shape is available on first
+     * sighting:
+     *  - parsedPay present (expanded) → full receipt with line items
+     *  - parsedPay null (collapsed) → minimal "Saved: $X"
+     *
+     * If the breakdown arrives later (e.g. auto-expand succeeds after a
+     * collapsed-first sighting), it's still captured in `lastPostTaskFields`
+     * by the stepper and surfaces via the post-task card in the bubble HUD
+     * + the DELIVERY_COMPLETED payload. But no second bubble fires.
+     *
+     * DELIVERY_COMPLETED itself is emitted from [diffPlatformRegion] when
+     * leaving PostTask (with the full pay breakdown if it was ever captured).
      */
     private fun diffPostTask(
         prev: PlatformRegion,
@@ -510,20 +539,22 @@ class EffectMap @Inject constructor(
         val flowObs = obs as? Observation.FlowObservation ?: return emptyList()
         val parsed = flowObs.parsed as? ParsedFields.PostTaskFields ?: return emptyList()
 
-        return buildList {
-            val payData = parsed.parsedPay
+        val taskId = next.recentTasks.lastOrNull()?.taskId ?: return emptyList()
+        if (prev.lastAnnouncedPostTaskTaskId == taskId) return emptyList()
+        if (parsed.totalPay <= 0) return emptyList()
 
-            // If we got expanded pay data AND it's different from last emission, log it
-            if (payData != null && next.lastPostTaskPayHash != prev.lastPostTaskPayHash) {
-                val receiptText = buildString {
-                    append("Saved: ${formatCurrency(payData.total)}")
-                    payData.customerTips.forEach { item ->
-                        append("\nTip: ${item.type} • ${formatCurrency(item.amount)}")
-                    }
+        val payData = parsed.parsedPay
+        val text = if (payData != null) {
+            buildString {
+                append("Saved: ${formatCurrency(payData.total)}")
+                payData.customerTips.forEach { item ->
+                    append("\nTip: ${item.type} • ${formatCurrency(item.amount)}")
                 }
-                add(AppEffect.UpdateBubble(receiptText, ChatPersona.Earnings))
             }
+        } else {
+            "Saved: ${formatCurrency(parsed.totalPay)}"
         }
+        return listOf(AppEffect.UpdateBubble(text, ChatPersona.Earnings))
     }
 
     /**
@@ -594,7 +625,86 @@ class EffectMap @Inject constructor(
         if (flowObs.effects.isEmpty()) return emptyList()
         return flowObs.effects
             .filter { evaluateGate(it.onlyIf, flowObs.parsed) }
-            .map { AppEffect.RequestEffect(it) }
+            .map { effect ->
+                if (effect.verb == EffectVerb.CLICK && (effect.delayMs ?: 0L) > 0L) {
+                    // Defer the click through the state machine via SETTLE_UI
+                    // timeout — keeps the delay observable + cancellable instead
+                    // of sleeping in a hidden coroutine. Payload carries the
+                    // click context so the timeout handler can reconstruct.
+                    AppEffect.ScheduleTimeout(
+                        durationMs = effect.delayMs!!,
+                        type = TimeoutType.SETTLE_UI,
+                        payload = serializeClickContext(effect),
+                    )
+                } else {
+                    AppEffect.RequestEffect(effect)
+                }
+            }
+    }
+
+    /**
+     * Catch the SETTLE_UI timeout fired by a deferred click (see
+     * [diffRuleEffects]) and re-emit it as an immediate-fire click.
+     */
+    private fun diffSettleUiTimeout(obs: Observation): List<AppEffect> {
+        val timeout = obs as? Observation.Timeout ?: return emptyList()
+        if (timeout.type != TimeoutType.SETTLE_UI) return emptyList()
+        val verb = (timeout.payload["verb"] as? String)
+            ?.let { runCatching { EffectVerb.valueOf(it) }.getOrNull() }
+            ?: return emptyList()
+        if (verb != EffectVerb.CLICK) return emptyList()
+        val ruleId = timeout.payload["ruleId"] as? String ?: return emptyList()
+        val targetRef = deserializeNodeRef(timeout.payload) ?: return emptyList()
+        val effect = RequestedEffect(
+            verb = verb,
+            args = emptyMap(),
+            targetRef = targetRef,
+            onlyIf = null,
+            dedupeKey = timeout.payload["dedupeKey"] as? String,
+            throttleMs = (timeout.payload["throttleMs"] as? Number)?.toLong(),
+            delayMs = null,  // immediate fire this time
+            ruleId = ruleId,
+        )
+        return listOf(AppEffect.RequestEffect(effect))
+    }
+
+    private fun serializeClickContext(effect: RequestedEffect): Map<String, Any?> {
+        val ref = effect.targetRef
+        val map = mutableMapOf<String, Any?>(
+            "verb" to effect.verb.name,
+            "ruleId" to effect.ruleId,
+        )
+        if (effect.dedupeKey != null) map["dedupeKey"] = effect.dedupeKey
+        if (effect.throttleMs != null) map["throttleMs"] = effect.throttleMs
+        if (ref != null) {
+            map["target.viewIdSuffix"] = ref.viewIdSuffix
+            map["target.text"] = ref.text
+            map["target.classNameHint"] = ref.classNameHint
+            map["target.pathFingerprint"] = ref.pathFingerprint
+            map["target.bounds.left"] = ref.boundsInScreen.left
+            map["target.bounds.top"] = ref.boundsInScreen.top
+            map["target.bounds.right"] = ref.boundsInScreen.right
+            map["target.bounds.bottom"] = ref.boundsInScreen.bottom
+        }
+        return map
+    }
+
+    private fun deserializeNodeRef(payload: Map<String, Any?>): NodeRef? {
+        val pathFingerprint = payload["target.pathFingerprint"] as? String ?: return null
+        val viewIdSuffix = payload["target.viewIdSuffix"] as? String
+        val text = payload["target.text"] as? String
+        val classNameHint = payload["target.classNameHint"] as? String
+        val left = (payload["target.bounds.left"] as? Number)?.toInt() ?: 0
+        val top = (payload["target.bounds.top"] as? Number)?.toInt() ?: 0
+        val right = (payload["target.bounds.right"] as? Number)?.toInt() ?: 0
+        val bottom = (payload["target.bounds.bottom"] as? Number)?.toInt() ?: 0
+        return NodeRef(
+            viewIdSuffix = viewIdSuffix,
+            text = text,
+            classNameHint = classNameHint,
+            boundsInScreen = BoundingBox(left, top, right, bottom),
+            pathFingerprint = pathFingerprint,
+        )
     }
 
     private fun evaluateGate(gate: ParsedFieldsGate?, parsed: ParsedFields): Boolean {

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
@@ -290,7 +290,16 @@ class PlatformRegionStepper @Inject constructor() {
             }
             is ParsedFields.PostTaskFields -> {
                 val payHash = parsed.parsedPay?.hashCode()
-                r = r.copy(lastPostTaskPayHash = payHash, lastPostTaskFields = parsed)
+                // Stamp the per-task announcement gate so EffectMap.diffPostTask
+                // can detect "first time seeing PostTask for this taskId" by
+                // comparing prev region's value to the current taskId. The
+                // currently-completing task is at recentTasks.lastOrNull().
+                val postTaskTaskId = r.recentTasks.lastOrNull()?.taskId
+                r = r.copy(
+                    lastPostTaskPayHash = payHash,
+                    lastPostTaskFields = parsed,
+                    lastAnnouncedPostTaskTaskId = postTaskTaskId ?: r.lastAnnouncedPostTaskTaskId,
+                )
                 r.session?.let { session ->
                     val earnings = parsed.sessionEarnings
                     if (earnings != null) {

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/StateManagerV2.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/StateManagerV2.kt
@@ -351,6 +351,7 @@ class StateManagerV2 @Inject constructor(
             is TimeoutEvent -> Observation.Timeout(
                 timestamp = event.timestamp,
                 type = event.type,
+                payload = event.payload,
             )
 
             is OfferEvaluationEvent -> Observation.Loopback(

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/state/TimeoutEvent.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/state/TimeoutEvent.kt
@@ -5,4 +5,5 @@ import cloud.trotter.dashbuddy.domain.pipeline.TimeoutType
 data class TimeoutEvent(
     override val timestamp: Long = System.currentTimeMillis(),
     val type: TimeoutType = TimeoutType.SESSION_PAUSED_SAFETY,
+    val payload: Map<String, Any?> = emptyMap(),
 ) : StateEvent

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/Observation.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/Observation.kt
@@ -96,6 +96,12 @@ sealed interface Observation : cloud.trotter.dashbuddy.domain.model.state.StateE
         override val ruleId: String? = null,
         override val metadata: ReplayMetadata = ReplayMetadata.EMPTY,
         val type: TimeoutType,
+        /**
+         * Carries opaque context from the original [AppEffect.ScheduleTimeout]'s
+         * payload back into the state machine. Used for deferred-effect patterns
+         * like click-after-settle where the timer fire needs to know what to do.
+         */
+        val payload: Map<String, Any?> = emptyMap(),
     ) : Observation
 
     /** A UI interaction event from the bubble HUD or overlay. */

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/RequestedEffect.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/RequestedEffect.kt
@@ -20,6 +20,12 @@ data class RequestedEffect(
     val onlyIf: ParsedFieldsGate? = null,
     val dedupeKey: String? = null,
     val throttleMs: Long? = null,
+    /**
+     * Optional delay (ms) before the effect fires. When non-null and > 0,
+     * EffectMap routes the effect through a SETTLE_UI timeout so the delay
+     * is state-machine-visible. See `CompiledEffect.delayMs`.
+     */
+    val delayMs: Long? = null,
     val ruleId: String,
 )
 

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/PlatformRegion.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/PlatformRegion.kt
@@ -33,6 +33,15 @@ data class PlatformRegion(
     val lastObservedAt: Long = 0,
     /** Timestamp when Flow entered Idle while mode is Online. Null otherwise. */
     val idleEnteredAt: Long? = null,
+    /**
+     * Per-task idempotency for the post-task announcement bubble. Set to the
+     * dropoff `taskId` the moment EffectMap.diffPostTask emits the "Saved: $X"
+     * bubble for that delivery. Subsequent PostTask observations for the same
+     * taskId no-op — including collapse/re-expand cycles that previously
+     * re-tripped the hash-based gate. Naturally resets when the next delivery
+     * starts (its taskId differs from this stored value).
+     */
+    val lastAnnouncedPostTaskTaskId: String? = null,
 )
 
 /**


### PR DESCRIPTION
## Summary

Bundle of related fixes from the 2026-05-19 field session, all clustered around the PostTask flow. Five coordinated changes:

### 1. Skip duplicate `DELIVERY_COMPLETED`
3/3 deliveries in field-test-2 + 3/3 in field-test (2026-05-19) had a real `DELIVERY_COMPLETED` immediately followed by a duplicate with `taskId: \"unknown\"`. Root cause: `EffectMap.diff` iterates over all platforms (`:70-82`) but `nextFlow.flow` is global — non-owning platforms emit a degenerate row via the `\"unknown\"` fallback. Fixed by skipping the emission when `completedTask == null`.

### 2. Single-bubble post-task announcement (best-effort)
`diffPostTask` previously gated on `parsedPay != null`, so collapsed-only emissions produced nothing. **Whataburger (5/19):** dasher dismissed before expansion → no bubble. The hash gate was also non-monotonic across collapse cycles. **H-E-B (5/19):** TWO `Saved: 29.83` bubbles 8s apart after a re-expand.

New shape: **one bubble per delivery, ever**. Fires on first sighting (usually collapsed, sometimes expanded) with whatever shape is available. If breakdown arrives later, `lastPostTaskFields` silently captures it (existing stepper wiring) — surfaces in the PostTask card and `DELIVERY_COMPLETED` payload, but no second bubble.

### 3. `PlatformRegion.lastAnnouncedPostTaskTaskId` for idempotency
Per-task gate replacing the hash gate. Stepper stamps the current taskId on every `PostTaskFields` observation; `diffPostTask` checks prev state's value before emitting. Resets naturally on new task.

### 4. UDF click delay via `SETTLE_UI` timeout (delete `AppEffect.Delayed`)
Rule effects now carry `delayMs: Long?` (capped at 5000ms). EffectMap routes CLICK with `delayMs > 0` through `ScheduleTimeout(SETTLE_UI, payload=clickContext)` instead of firing immediately. SideEffectEngine schedules the timer; when it fires, `TimeoutEvent` flows back through `StateManagerV2` as `Observation.Timeout`, and `EffectMap.diffSettleUiTimeout` unpacks the payload and emits the click as immediate `RequestEffect`.

Keeps the delay state-machine-visible (cancellable, observable, no hidden coroutines). `performClick`'s find-by-ID-on-live-tree is the natural cancel-if-screen-changed safety. **`AppEffect.Delayed` deleted** as the straggler it was — per the Gemini-cited UDF caution.

Applied `delayMs: 500` to `doordash.screen.delivery_summary_collapsed` to let the RecyclerView populate before the auto-expand click — restores the half-second settle the matcher-era code had (per the H-E-B half-expanded observation).

Foundation for future auto-accept/decline countdowns up to 5s.

### 5. Safety-net screenshots on post-task + dash-summary screens
- `delivery_summary_collapsed` + `_expanded` get screenshot effects (`{totalPay}-{sessionEarnings}` dedupeKey for per-delivery uniqueness)
- `dash_summary` previously had **no effects block at all** — now gets a screenshot with `{totalEarnings}-{sessionDurationMillis}` dedupeKey

Cleanup-of-collapsed-when-expanded-succeeds deferred to a separate PR (needs new state tracking + delete capability).

## Test plan

- [x] `./gradlew :app:testDebugUnitTest --tests \"*EffectMapTest*\" --tests \"*RuleCompilerTest*\"` — 9 new test cases pass
- [x] `./gradlew :core:state:testDebugUnitTest :app:testDebugUnitTest :core:pipeline:testDebugUnitTest` — broader sweep green
- [x] `./gradlew :app:testDebugUnitTest --tests \"*DefaultRulesIntegrationTest*\"` — doordash.json compiles cleanly with all new effects
- [ ] Next field session:
  - `app_events` has exactly **one** `DELIVERY_COMPLETED` per delivery
  - Bubble shows `Saved: \$X` immediately on collapsed; no re-fire on collapse/re-expand
  - App logs show `~500ms` between collapsed-screen detection and auto-click attempt
  - H-E-B-style \"half-expanded\" pattern should not recur
  - Each delivery has at least one screenshot under `captures/.../DeliveryBreakdown - \$X.png` or `Delivery - \$X.png`
  - End-of-dash produces `DashSummary - \$X.png` screenshot

## Followups (tracked in plan file)

- Awaiting cards between deliveries (Bug 7 of 2026-05-19)
- Deadline rollover fix (Bug 2 of 2026-05-19)
- Wall-clock deadline caption (Bug 1 of 2026-05-19)
- Frozen Drop-off \"started/completed\" shape (Bug 3 of 2026-05-19)
- Zone-nav rule (Bug 5 of 2026-05-19)
- Dash summary recognition (Bug 6 of 2026-05-19) — blocked on next session's capture
- Cleanup of collapsed screenshot when expanded succeeds
- Stacked-delivery intermediate-leg detection (from PR #264)

🤖 Generated with [Claude Code](https://claude.com/claude-code)