### PR TITLE
fix: re-open Awaiting cards between deliveries / after declined offers

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardMapper.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardMapper.kt
@@ -104,6 +104,18 @@ object FlowCardMapper {
                             outcome = payload.outcome,
                         )
                     )
+                    // Re-open Awaiting if the dasher returned to the
+                    // waiting-for-offer state (declined / timeout). Accept
+                    // skips this — they're going into pickup.
+                    if (payload.outcome == AppEventType.OFFER_DECLINED ||
+                        payload.outcome == AppEventType.OFFER_TIMEOUT
+                    ) {
+                        openAwaiting = FlowCardSnapshot.Awaiting(
+                            id = "awaiting:${event.aggregateId}:${payload.decidedAt}",
+                            phaseStartedAt = payload.decidedAt,
+                            sessionId = event.aggregateId,
+                        )
+                    }
                 }
 
                 AppEventType.PICKUP_NAV_STARTED -> {
@@ -267,6 +279,18 @@ object FlowCardMapper {
                         )
                     )
                     lastDeliveryArrivedAt = null
+                    // Re-open Awaiting — dasher dismissed the receipt and
+                    // is back to waiting for the next offer. (For stacked
+                    // deliveries where the dasher goes straight to the next
+                    // dropoff, this Awaiting would transiently close on the
+                    // next OFFER_RECEIVED — acceptable until stacked-delivery
+                    // intermediate-leg detection lands as a separate fix.)
+                    val awaitingStart = payload.completedAt ?: event.occurredAt
+                    openAwaiting = FlowCardSnapshot.Awaiting(
+                        id = "awaiting:${event.aggregateId}:${awaitingStart}",
+                        phaseStartedAt = awaitingStart,
+                        sessionId = event.aggregateId,
+                    )
                 }
 
                 AppEventType.DASH_STOP -> {

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardMapperTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardMapperTest.kt
@@ -329,8 +329,9 @@ class FlowCardMapperTest {
 
         val cards = FlowCardMapper.fold(events)
 
-        // Awaiting + (Offer + Pickup + Delivery + PostTask) × 2 = 9
-        assertEquals(9, cards.size)
+        // Awaiting(start) + Offer1 + Pickup1 + Delivery1 + PostTask1 +
+        // Awaiting(between) + Offer2 + Pickup2 + Delivery2 + PostTask2 = 10
+        assertEquals(10, cards.size)
 
         val offers = cards.filterIsInstance<FlowCardSnapshot.Offer>()
         assertEquals(2, offers.size)
@@ -342,6 +343,87 @@ class FlowCardMapperTest {
 
         val postTasks = cards.filterIsInstance<FlowCardSnapshot.PostTask>()
         assertEquals(listOf(5.00, 8.00), postTasks.map { it.totalPay })
+
+        // Two Awaiting cards: one at session start, one between deliveries.
+        val awaitings = cards.filterIsInstance<FlowCardSnapshot.Awaiting>()
+        assertEquals(2, awaitings.size)
+        // Second Awaiting opens at delivery-1 completion (2700L) and closes
+        // when delivery-2's OFFER_RECEIVED fires (3000L).
+        assertEquals(2700L, awaitings[1].phaseStartedAt)
+        assertEquals(3000L, awaitings[1].phaseEndedAt)
+    }
+
+    // =========================================================================
+    // Awaiting re-opens between deliveries / after declined/timed-out offers
+    // =========================================================================
+
+    @Test
+    fun `declined then accepted offer produces two Awaiting cards in stack`() {
+        // Field log 2026-05-19 #7: post-session card stack should include an
+        // Awaiting block for each between-offer / between-delivery gap.
+        // Sequence: start → decline → accept → full delivery → DASH_STOP.
+        val events = listOf(
+            event(AppEventType.DASH_START,
+                SessionStartPayload("s1", "DoorDash", 1000L, "interaction", "WaitingForOffer"),
+                occurredAt = 1000L),
+            event(AppEventType.OFFER_RECEIVED, "{}", 1500L),
+            event(AppEventType.OFFER_DECLINED,
+                offerPayload("decline-1", AppEventType.OFFER_DECLINED, 1500L, 1700L), 1700L),
+            // Dasher returns to awaiting — Awaiting #2 opens at 1700L.
+            event(AppEventType.OFFER_RECEIVED, "{}", 2000L),
+            event(AppEventType.OFFER_ACCEPTED,
+                offerPayload("o1", AppEventType.OFFER_ACCEPTED, 2000L, 2100L), 2100L),
+            event(AppEventType.PICKUP_NAV_STARTED,
+                pickupPayload("T1", "J1", "A", 2100L), 2100L),
+            event(AppEventType.DELIVERY_NAV_STARTED,
+                deliveryPayload("T2", "J1", 2200L), 2200L),
+            event(AppEventType.DELIVERY_COMPLETED,
+                deliveryPayload("T2", "J1", 2200L, completed = 3000L, totalPay = 7.00), 3000L),
+            event(AppEventType.DASH_STOP, "{}", 3500L),
+        )
+        val cards = FlowCardMapper.fold(events)
+        val awaitings = cards.filterIsInstance<FlowCardSnapshot.Awaiting>()
+        // Three Awaiting cards: start, after decline, after delivery.
+        assertEquals(3, awaitings.size)
+        assertEquals(1000L, awaitings[0].phaseStartedAt)  // session start
+        assertEquals(1700L, awaitings[1].phaseStartedAt)  // after decline
+        assertEquals(3000L, awaitings[2].phaseStartedAt)  // after delivery
+    }
+
+    @Test
+    fun `timeout opens a new Awaiting card`() {
+        val events = listOf(
+            event(AppEventType.DASH_START,
+                SessionStartPayload("s1", "DoorDash", 1000L, "interaction", "WaitingForOffer"),
+                occurredAt = 1000L),
+            event(AppEventType.OFFER_RECEIVED, "{}", 1500L),
+            event(AppEventType.OFFER_TIMEOUT,
+                offerPayload("to-1", AppEventType.OFFER_TIMEOUT, 1500L, 1530L), 1530L),
+            event(AppEventType.DASH_STOP, "{}", 2000L),
+        )
+        val cards = FlowCardMapper.fold(events)
+        val awaitings = cards.filterIsInstance<FlowCardSnapshot.Awaiting>()
+        assertEquals(2, awaitings.size)
+        assertEquals(1530L, awaitings[1].phaseStartedAt)  // opened at timeout decidedAt
+    }
+
+    @Test
+    fun `accepted offer does NOT open Awaiting between Offer and Pickup`() {
+        val events = listOf(
+            event(AppEventType.DASH_START,
+                SessionStartPayload("s1", "DoorDash", 1000L, "interaction", "WaitingForOffer"),
+                occurredAt = 1000L),
+            event(AppEventType.OFFER_RECEIVED, "{}", 1500L),
+            event(AppEventType.OFFER_ACCEPTED,
+                offerPayload("o1", AppEventType.OFFER_ACCEPTED, 1500L, 1600L), 1600L),
+            event(AppEventType.PICKUP_NAV_STARTED,
+                pickupPayload("T1", "J1", "A", 1600L), 1600L),
+            event(AppEventType.DASH_STOP, "{}", 2000L),
+        )
+        val cards = FlowCardMapper.fold(events)
+        val awaitings = cards.filterIsInstance<FlowCardSnapshot.Awaiting>()
+        // Only the session-start Awaiting — no spurious one between Offer and Pickup.
+        assertEquals(1, awaitings.size)
     }
 
     // =========================================================================


### PR DESCRIPTION
## Summary

Field log 2026-05-19 #7: post-session card stack shows only the **first** Awaiting block. Between-delivery and after-decline awaiting periods are missing.

Root cause: `FlowCardMapper.kt` opens `openAwaiting` in exactly one place — `DASH_START` (`:53`). It's closed by `OFFER_RECEIVED` and defensively by `OFFER_*` events, but **never re-opened** after the first close. DB timeline from 2026-05-19 confirms ~7 distinct awaiting periods in the session, only 1 Awaiting card in the historical stack.

The live HUD's `LiveCardBuilder.build(state)` correctly renders an Awaiting card during these gaps (`LiveCardBuilder.kt:28-37`), so the live experience and post-session reconstruction were diverging.

## Fix

Re-open `openAwaiting` at every event that conceptually returns the dasher to awaiting state:

- After `OFFER_DECLINED` — dasher declined, returned to awaiting
- After `OFFER_TIMEOUT` — offer expired without acceptance
- After `DELIVERY_COMPLETED` — delivery done, dismissed receipt

`OFFER_ACCEPTED` is deliberately skipped (dasher is going into pickup, not awaiting). Existing close paths handle the new Awaiting cards correctly.

## Tests

- **Updated** `back-to-back deliveries`: now expects 10 cards (1 Awaiting between deliveries 1 and 2, anchored at delivery-1 completedAt and closed at delivery-2 OFFER_RECEIVED).
- **New** `declined then accepted offer produces two Awaiting cards`: 3 Awaiting cards (start, after decline, after delivery).
- **New** `timeout opens a new Awaiting card`: opens at `payload.decidedAt`.
- **New** `accepted offer does NOT open Awaiting`: regression guard — no spurious Awaiting between Offer and Pickup.

- [x] `./gradlew :app:testDebugUnitTest --tests \"*FlowCardMapperTest*\"`
- [x] `./gradlew :core:state:testDebugUnitTest :app:testDebugUnitTest :core:pipeline:testDebugUnitTest`
- [ ] Next field session: post-session card stack should show distinct Awaiting blocks between deliveries / declined offers, mirroring the live HUD.

## Out of scope

- **Stacked-delivery handling** — when an intermediate delivery completes mid-job, the new Awaiting would transiently close on the next offer. Acceptable interim until stacked-delivery intermediate-leg detection lands (PR #264 followup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)