### PR TITLE
fix: frozen Drop-off card shows duration + started/completed times

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardItem.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardItem.kt
@@ -348,33 +348,47 @@ private fun DeadlineBody(
     ) {
         val now = if (isActive) rememberNow().value else (phaseEndedAt ?: phaseStartedAt)
 
-        if (deadlineMillis != null) {
-            val remaining = deadlineMillis - now
-            val color = deadlineColor(remaining)
-            if (isActive) {
-                HeroBig(text = formatCountdown(remaining), color = color)
+        if (isActive) {
+            if (deadlineMillis != null) {
+                val remaining = deadlineMillis - now
+                HeroBig(text = formatCountdown(remaining), color = deadlineColor(remaining))
                 Caption(deadlineLabel)
             } else {
-                val arrivalRemaining = arrivedAt?.let { deadlineMillis - it }
-                if (arrivalRemaining != null) {
+                // No deadline parsed — fall back to elapsed time
+                HeroBig(formatDuration(now - phaseStartedAt))
+                Caption(if (arrivedAt == null) "en route" else "at stop")
+            }
+        } else {
+            // Frozen card. Three cases:
+            //   (a) arrivedAt + deadlineMillis → delta vs deadline ("+Xm ahead" / "Xm late")
+            //   (b) arrivedAt null but phaseEndedAt set → drop-off completed without
+            //       an observed arrival sub-state (typical DoorDash no-contact flow).
+            //       Show total phase duration with started/completed times in
+            //       the tertiary row instead of the "—" placeholder.
+            //   (c) nothing useful → placeholder
+            val arrivalRemaining = if (deadlineMillis != null && arrivedAt != null)
+                deadlineMillis - arrivedAt else null
+            when {
+                arrivalRemaining != null -> {
                     val deltaLabel = if (arrivalRemaining >= 0)
                         "+${formatCountdown(arrivalRemaining)} ahead"
                     else
                         "${formatCountdown(-arrivalRemaining)} late"
                     HeroBig(text = deltaLabel, color = deadlineColor(arrivalRemaining))
                     Caption("vs $deadlineLabel")
-                } else {
+                }
+                phaseEndedAt != null -> {
+                    HeroBig(formatDuration(phaseEndedAt - phaseStartedAt))
+                    Caption("duration")
+                }
+                else -> {
                     HeroBig("—")
                     Caption(deadlineLabel)
                 }
             }
-        } else if (isActive) {
-            // No deadline parsed — fall back to elapsed time
-            HeroBig(formatDuration(now - phaseStartedAt))
-            Caption(if (arrivedAt == null) "en route" else "at stop")
         }
 
-        // Tertiary row — store/customer + arrival time + items
+        // Tertiary row — store/customer + lifecycle times + items
         val tertiary = buildString {
             append(primary)
             arrivedAt?.let {
@@ -382,6 +396,13 @@ private fun DeadlineBody(
             }
             confirmedAt?.let {
                 append(" · picked up ${formatTime(it)}")
+            }
+            // When we don't have an arrival (no-contact-delivery case),
+            // surface the started/completed wall-clock so the dasher can
+            // read what happened — paralleling Pickup's "arrived · picked up".
+            if (arrivedAt == null && phaseEndedAt != null && !isActive) {
+                append(" · started ${formatTime(phaseStartedAt)}")
+                append(" · completed ${formatTime(phaseEndedAt)}")
             }
             itemCount?.let {
                 if (it > 0) append(" · ${it}i")


### PR DESCRIPTION
## Summary

Field log 2026-05-19 #3: frozen Drop-off card displays \"—\" / \"till deliver-by\" — same shape as an active card with no countdown, not a closed/summary shape. Dasher direction (verbatim): *\"it should show the time the dropoff started vs completed like the pickup blocks.\"*

Root cause: `DeadlineBody`'s frozen branch only handles the case where `arrivedAt` is non-null (computes \"+Xm ahead\" / \"Xm late\" vs deadline). When `arrivedAt` is null — typical for DoorDash no-contact deliveries where `DELIVERY_ARRIVED` never fires — it falls through to `HeroBig(\"—\")` + `Caption(deadlineLabel)`. The snapshot already carries `phaseStartedAt` + `phaseEndedAt`; the renderer just wasn't using them.

## Fix

Restructure `DeadlineBody`'s frozen branch as three cases:
1. `arrivedAt + deadlineMillis` → existing delta-vs-deadline display (unchanged)
2. `arrivedAt` null but `phaseEndedAt` set → **new:** show total phase duration as hero + `\"duration\"` caption
3. nothing useful → existing `\"—\"` placeholder

Tertiary row also appends `\"started HH:MM · completed HH:MM\"` in case (2) so the dasher can read what happened and when — paralleling Pickup's `\"arrived · picked up\"` framing. Doesn't fire for Pickup cards since they always have arrivedAt populated.

Also cleaned up: split active vs frozen branches at the top of the body instead of nesting `isActive` inside the `deadlineMillis != null` check. Reads cleaner.

## Test plan

- [x] `./gradlew :core:state:testDebugUnitTest :app:testDebugUnitTest :core:pipeline:testDebugUnitTest` — all green; no test regressions
- [ ] **Next field session:** complete a delivery, end dash, look at the post-session card stack:
  - Frozen Drop-off card hero shows total drop-off-leg duration (e.g. \"22:00\" for a 22-min delivery), NOT \"—\"
  - Tertiary row shows `customer · started HH:MM · completed HH:MM`
  - Frozen Pickup cards still show \"+Xm ahead\" / \"Xm late\" with `arrived · picked up` (no regression)

## No new unit tests

`FlowCardItem` is a `@Composable` with no existing Compose UI test scaffolding in the repo. Adding the test infrastructure is meaningful scope expansion beyond this UI-only fix. Validation is via the existing `FlowCardMapperTest` coverage for the underlying snapshot data + the next field session's manual visual check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)