### PR TITLE
fix: navigation_generic sets flow:idle/modeHint:online (Bug #5 of 2026-05-19)

### DIFF
--- a/core/pipeline/src/main/assets/rules/doordash.json
+++ b/core/pipeline/src/main/assets/rules/doordash.json
@@ -1690,6 +1690,10 @@
     {
       "id": "doordash.screen.navigation_generic",
       "priority": 95,
+      "state": {
+        "flow": "idle",
+        "modeHint": "online"
+      },
       "reject": [
         {
           "allTextContains": "accept"


### PR DESCRIPTION
## Summary

Field log 2026-05-19 #5: dasher went online, tapped a zone/hotspot to navigate toward it, and the bubble behaved as if a task were active. **Real symptom (per dasher recall):** the OFFER state from a prior offer persists during the nav-to-zone window — especially severe pre-#261 when offers wouldn't time out until they backed out of the map or got another offer.

Root cause: `doordash.screen.navigation_generic` (priority 95, lines 1691-1717) has **no `state` block at all**. When it matches, it doesn't set `flow` or `modeHint`, so the prior screen's flow persists. If the previous flow was `offer:presented` (sticky from a not-yet-resolved offer) or `task:pickup/dropoff:*` (from a still-active task), that stays put — the bubble's in-task/in-offer chrome stays visible even though the platform is just showing a Maps nav screen.

## Fix

Add `state: { flow: idle, modeHint: online }` to the rule (matching what `waiting_for_offer` and `dash_along_the_way` already set):

```json
{
  \"id\": \"doordash.screen.navigation_generic\",
  \"priority\": 95,
  \"state\": { \"flow\": \"idle\", \"modeHint\": \"online\" },
  ...
}
```

This provides a fallback signal that returns flow to idle when the nav screen appears, even if the offer/task state was sticky from upstream resolution gaps. Doesn't address the underlying \"offer doesn't time out\" root cause (largely fixed by #261), but is a real safety net.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest --tests \"*DefaultRulesIntegrationTest*\"` — doordash.json still compiles
- [x] `./gradlew :core:pipeline:testDebugUnitTest :core:state:testDebugUnitTest :app:testDebugUnitTest` — full sweep green
- [ ] **Next field session:** go online, tap a zone/hotspot to navigate. Bubble should stay in the awaiting-offer state (no in-task / in-offer chrome) regardless of any prior offer/task that didn't cleanly resolve.

## Out of scope

- **Branch consolidation** of the four idle-screen rules (`navigation_generic`, `on_dash_map`, `dash_along_the_way`, `waiting_for_offer`) into one branched rule — recurrence-prevention refactor; dasher chose minimal fix for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)