### PR TITLE
fix: card polish — wall-clock deadline caption + DROP→DROP OFF

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardItem.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardItem.kt
@@ -127,7 +127,7 @@ private fun PhaseChip(snapshot: FlowCardSnapshot, isActive: Boolean) {
         is FlowCardSnapshot.Awaiting -> "AWAIT" to MaterialTheme.colorScheme.tertiary
         is FlowCardSnapshot.Offer -> "OFFER" to MaterialTheme.colorScheme.primary
         is FlowCardSnapshot.Pickup -> "PICKUP" to MaterialTheme.colorScheme.secondary
-        is FlowCardSnapshot.Delivery -> "DROP OFF" to MaterialTheme.colorScheme.secondary
+        is FlowCardSnapshot.Delivery -> "DROPOFF" to MaterialTheme.colorScheme.secondary
         is FlowCardSnapshot.PostTask -> "PAID" to MaterialTheme.colorScheme.primary
     }
     Surface(

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardItem.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardItem.kt
@@ -127,7 +127,7 @@ private fun PhaseChip(snapshot: FlowCardSnapshot, isActive: Boolean) {
         is FlowCardSnapshot.Awaiting -> "AWAIT" to MaterialTheme.colorScheme.tertiary
         is FlowCardSnapshot.Offer -> "OFFER" to MaterialTheme.colorScheme.primary
         is FlowCardSnapshot.Pickup -> "PICKUP" to MaterialTheme.colorScheme.secondary
-        is FlowCardSnapshot.Delivery -> "DROP" to MaterialTheme.colorScheme.secondary
+        is FlowCardSnapshot.Delivery -> "DROP OFF" to MaterialTheme.colorScheme.secondary
         is FlowCardSnapshot.PostTask -> "PAID" to MaterialTheme.colorScheme.primary
     }
     Surface(
@@ -352,7 +352,10 @@ private fun DeadlineBody(
             if (deadlineMillis != null) {
                 val remaining = deadlineMillis - now
                 HeroBig(text = formatCountdown(remaining), color = deadlineColor(remaining))
-                Caption(deadlineLabel)
+                // Caption is `${deadlineLabel} · by HH:MM` — the wall-clock anchor
+                // lets the dasher cross-check the countdown against what DoorDash
+                // itself is showing on screen (field log 2026-05-19 #1 / 2026-05-17 #2).
+                Caption("$deadlineLabel · by ${formatTime(deadlineMillis)}")
             } else {
                 // No deadline parsed — fall back to elapsed time
                 HeroBig(formatDuration(now - phaseStartedAt))


### PR DESCRIPTION
## Summary

Two trivial FlowCardItem tweaks in one small PR.

### #1 (field log 2026-05-19 #1 / 2026-05-17 #2) — Wall-clock deadline caption

Active Pickup/Delivery cards previously showed only the relative countdown (`5:00` / `till pickup-by`) with no wall-clock anchor. Dasher couldn't cross-check the countdown against what DoorDash itself was showing on screen. Caption now reads:

```
5:00
till pickup-by · by 5:38 PM
```

The literal deadline time sits alongside the countdown so the dasher can sanity-check both — critical when the countdown looks suspicious (cf. the pre-#267 \"1434:38\" bug).

### #4 (field log 2026-05-17 #4) — DROP → DROP OFF rename

Frozen/live Drop-off card chip renamed from `DROP` to `DROP OFF`. Dasher's reaction: *\"drop doesn't really make sense even as a card. The three extra characters aren't gonna hurt anything.\"*

## Test plan

- [x] `./gradlew :core:state:testDebugUnitTest :app:testDebugUnitTest :core:pipeline:testDebugUnitTest` — all green
- [ ] **Next field session:** Pickup/Delivery cards show `till pickup-by · by HH:MM` under the countdown. Drop-off card chip reads `DROP OFF`.

## No new unit tests

Pure UI label/caption tweaks; `FlowCardItem` has no Compose UI test scaffolding in the repo. Validation via next-session visual check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)