### PR TITLE
docs(field-testing): 2-confirmation rule + auto-add checklist on PR/close

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,6 +237,14 @@ GH="/c/Program Files/GitHub CLI/gh.exe"
 "$GH" pr merge <NUMBER> --merge
 ```
 
+**Docs-only / non-code PRs can skip CI.** The `pr-check.yml` workflow skips the
+`build-and-test` job when the **PR description (body)** contains the literal
+string **`[skip ci]`** (`if: ${{ !contains(github.event.pull_request.body, '[skip ci]') }}`).
+So for a PR that touches no compiled code (only Markdown/docs), put `[skip ci]`
+in the PR body to avoid a pointless ~6-minute build. Note the exact token is
+`[skip ci]` in the **body** — not `[no-ci]`, not a comment, not a label. Only use
+it when the diff genuinely has no code; when in doubt, let CI run.
+
 ## Session Orientation
 
 At the start of a session or before picking up new work:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,9 +257,21 @@ out", "field testing now", "what should I look for") — **first read the
 `## Next field test — things to look for` checklist in `docs/field-testing/README.md` and
 report it back concisely**: tell the developer, in plain terms, what to watch for and how to
 tell if each item is working. This is the primary job of a field-testing agent launched on
-the phone before a dash. Keep it short and glanceable — they're about to be driving. When an
-item is later confirmed (or found broken) in the field, move it into that session's log entry
-and delete it from the checklist.
+the phone before a dash. Keep it short and glanceable — they're about to be driving.
+
+**Each checklist item needs two independent field confirmations before it's validated** — a
+single dash can pass by luck or miss the edge case. Track with a `- Confirmed: N/2` sub-line
+(note each sighting's date/conditions). Only on the **second clean** confirmation do you move
+the item into that session's log entry and delete it from the checklist; if an item is found
+**broken**, move it to the log immediately so it gets triaged.
+
+**Closing the loop — add items when work needs field validation.** Whenever you open a PR or
+close an issue for a change that **needs or would benefit from field validation** — on-dash
+behavior, bubble/HUD changes, recognition rules or parsers, or anything verified only against
+captured data — **also add a matching item to the `## Next field test — things to look for`
+checklist** (what to watch + how to tell it's working + the PR/issue number, starting at
+`Confirmed: 0/2`). Treat this as part of finishing the PR/closing the issue, not an
+afterthought — it's how field-validation work reaches the developer on the next dash.
 
 When the developer narrates observations from an active or just-completed dashing session —
 any of: "this is a field testing log", "dashing log", "field log", "on-dash testing notes",

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -48,11 +48,17 @@ For items with multiple sub-concerns at different statuses, use one
 
 ## Next field test — things to look for
 
-**Living checklist (not a session entry).** These are recently-merged changes
-that were validated only against captured data and need eyes on a live dash.
-A field-testing agent should read this section at the start of a session and
-report it to the developer; when an item is confirmed (or found broken),
-move it into that session's log entry and delete it here.
+**Living checklist (not a session entry).** Recently-merged changes (and open
+PRs / closed issues) that were validated only against captured data and need
+eyes on a live dash. A field-testing agent reads this section at the start of a
+session and reports it to the developer.
+
+**Each item needs two independent field confirmations before it's considered
+validated** — one dash can pass by luck or miss the edge case. Track progress
+with a `- Confirmed: N/2` sub-line (note the date/conditions of each sighting).
+On the **second clean** confirmation, move the item into that session's log
+entry and delete it here. If an item is found **broken**, move it to the log
+immediately (no second pass needed) so it gets triaged.
 
 - **Shop & Deliver items/min (#276, merged 2026-06-02).** On a real Shop &
   Deliver, open the bubble pickup card and confirm it shows
@@ -61,14 +67,17 @@ move it into that session's log entry and delete it here.
   `total == "Done (x)" + "To shop (y)"`. **Add-on case:** if you accept an
   add-on / second order at the same store mid-shop, confirm "To shop" jumps up,
   the total grows, and the pace keeps counting on the *same* card (no reset).
+  - Confirmed: 0/2.
 - **Offers behind a loading overlay (#275, merged 2026-06-02).** When an offer
   briefly shows a spinner (on present, or right as you tap), confirm it stays
   recognized as an offer — the bubble shouldn't flicker out of the offer view
   or drop to a blank/idle state mid-offer.
+  - Confirmed: 0/2.
 - **Cashout / transfer screens blocked (#275, merged 2026-06-02).** Open the
   DasherDirect/Crimson balance, a card-details screen, or initiate an instant
   transfer and confirm the bubble does **nothing** (sensitive → skipped),
   rather than reacting to it.
+  - Confirmed: 0/2.
 
 ---
 human entered logs during claude sub shortfall

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -80,12 +80,14 @@ immediately (no second pass needed) so it gets triaged.
   - Confirmed: 0/2.
 
 ---
-human entered logs during claude sub shortfall
 
-- final dash summay issue. hypothesis - idle map offline screen shows before the summary, and (maybe) there is no way to get to the summary actions from the idle offline screen?
-- 
+## Untriaged — carried over from scratch notes
 
-
+- **Final dash-summary may be unreachable from the idle/offline screen.**
+  Hypothesis: the idle-map offline screen shows *before* the dash summary, and
+  there may be no way to reach the summary actions once on idle/offline. Needs a
+  field repro + capture to confirm.
+  - **Status:** Open (untriaged).
 
 ---
 


### PR DESCRIPTION
[skip ci] — docs-only PR (no compiled code touched).

Field-testing process + CI doc tweaks:
- Checklist items need **two independent field confirmations** before validated (`Confirmed: N/2`).
- CLAUDE.md: opening a PR / closing an issue that needs field validation **also adds the matching checklist item**.
- CLAUDE.md: docs-only PRs can use **`[skip ci]`** in the PR body to skip the build-and-test job.
- Tidied the field log's malformed "scratch notes" block (kept its one real observation as an Untriaged item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)