### PR TITLE
fix(#279): attribute the dash summary across both end-of-dash orderings

### DIFF
--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -227,12 +227,73 @@ class EffectMap @Inject constructor(
         next: PlatformRegion,
         obs: Observation,
     ): List<AppEffect> {
-        if (prev.mode == next.mode) return emptyList()
         val prevSession = prev.session
         val nextSession = next.session
         val sessionId = nextSession?.sessionId ?: prevSession?.sessionId
+        // Finalize when the session actually ENDS (goes null, or is replaced by a
+        // different sessionId) — NOT on the bare offline mode-flip. A graced
+        // (maybe-transient) offline keeps the session alive, so a summary that
+        // arrives after the idle/offline screen still attributes to it; a real
+        // end (summary either ordering, grace expiry, or a fresh dash replacing
+        // the old one) flips this true.
+        val prevEnded = prevSession != null &&
+            (nextSession == null || nextSession.sessionId != prevSession.sessionId)
+        if (prev.mode == next.mode && !prevEnded) return emptyList()
 
         return buildList {
+            if (prevEnded) {
+                // A rule-defined MODE_TO_OFFLINE override (only on an actual mode
+                // flip to offline) replaces the default finalize, as before.
+                val offlineOverride =
+                    if (prev.mode != Mode.Offline && next.mode == Mode.Offline) {
+                        triggerOverrideEffects(obs, TransitionTrigger.MODE_TO_OFFLINE)
+                    } else {
+                        null
+                    }
+                if (offlineOverride != null) {
+                    addAll(offlineOverride)
+                } else {
+                    val endParsed = (obs as? Observation.FlowObservation)?.parsed
+                    if (endParsed is ParsedFields.SessionEndedFields) {
+                        val earnings = formatCurrency(endParsed.totalEarnings)
+                        add(
+                            logEffect(
+                                sessionId,
+                                AppEventType.DASH_STOP,
+                                SessionStopPayload(
+                                    sessionId = sessionId,
+                                    endedAt = obs.timestamp,
+                                    source = "summary_screen",
+                                    totalEarnings = endParsed.totalEarnings,
+                                    sessionDurationMillis = endParsed.sessionDurationMillis,
+                                    offersAccepted = endParsed.offersAccepted,
+                                    offersTotal = endParsed.offersTotal,
+                                    weeklyEarnings = endParsed.weeklyEarnings,
+                                ),
+                            ),
+                        )
+                        add(AppEffect.StopOdometer)
+                        add(AppEffect.UpdateBubble("Session Ended. Total: $earnings", ChatPersona.Dispatcher))
+                        add(AppEffect.CaptureScreenshot("DashSummary - ${endParsed.totalEarnings}"))
+                    } else {
+                        add(
+                            logEffect(
+                                sessionId,
+                                AppEventType.DASH_STOP,
+                                SessionStopPayload(
+                                    sessionId = sessionId,
+                                    endedAt = obs.timestamp,
+                                    source = "early_offline",
+                                    totalEarnings = prevSession?.runningEarnings,
+                                ),
+                            ),
+                        )
+                        add(AppEffect.StopOdometer)
+                    }
+                    add(AppEffect.EndSession(prev.platform.name))
+                }
+            }
+
             when {
                 // Session start: offline/paused → online
                 prev.mode != Mode.Online && next.mode == Mode.Online -> {
@@ -267,50 +328,11 @@ class EffectMap @Inject constructor(
                     }
                 }
 
-                // Session end: online/paused → offline
-                next.mode == Mode.Offline -> {
-                    val modeOverride = triggerOverrideEffects(obs, TransitionTrigger.MODE_TO_OFFLINE)
-                    if (modeOverride != null) {
-                        addAll(modeOverride)
-                    } else if (prevSession != null) {
-                        // Check if this is a session summary screen
-                        val flowObs = obs as? Observation.FlowObservation
-                        val parsed = flowObs?.parsed
-                        val platform = prev.platform.name
-                        if (parsed is ParsedFields.SessionEndedFields) {
-                            val earnings = formatCurrency(parsed.totalEarnings)
-                            val payload = SessionStopPayload(
-                                sessionId = sessionId,
-                                endedAt = obs.timestamp,
-                                source = "summary_screen",
-                                totalEarnings = parsed.totalEarnings,
-                                sessionDurationMillis = parsed.sessionDurationMillis,
-                                offersAccepted = parsed.offersAccepted,
-                                offersTotal = parsed.offersTotal,
-                                weeklyEarnings = parsed.weeklyEarnings,
-                            )
-                            add(logEffect(sessionId, AppEventType.DASH_STOP, payload))
-                            add(AppEffect.StopOdometer)
-                            add(
-                                AppEffect.UpdateBubble(
-                                    "Session Ended. Total: $earnings",
-                                    ChatPersona.Dispatcher,
-                                )
-                            )
-                            add(AppEffect.CaptureScreenshot("DashSummary - ${parsed.totalEarnings}"))
-                        } else {
-                            val payload = SessionStopPayload(
-                                sessionId = sessionId,
-                                endedAt = obs.timestamp,
-                                source = "early_offline",
-                                totalEarnings = prevSession.runningEarnings,
-                            )
-                            add(logEffect(sessionId, AppEventType.DASH_STOP, payload))
-                            add(AppEffect.StopOdometer)
-                        }
-                        add(AppEffect.EndSession(platform))
-                    }
-
+                // Going offline. Session finalize (and any MODE_TO_OFFLINE
+                // override) is handled by the `prevEnded` block above, which
+                // defers while a grace window keeps the session alive. Only the
+                // pause-safety-timer cancel remains here.
+                prev.mode != Mode.Offline && next.mode == Mode.Offline -> {
                     // Cancel pause safety timer
                     if (prev.mode == Mode.Paused) {
                         val resumeOverride = triggerOverrideEffects(obs, TransitionTrigger.RESUME_FROM_PAUSE)

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
@@ -128,7 +128,15 @@ class PlatformRegionStepper @Inject constructor() {
         )
 
         // Session lifecycle on mode transitions
+        val sessionEndFlow = (obs as? Observation.FlowObservation)?.flow
         when {
+            // Authoritative end when the summary shows BEFORE the idle/offline
+            // screen (a real mode change Online→Offline): end now, no grace. The
+            // AFTER-idle ordering (mode already Offline, no change) doesn't reach
+            // this function and is handled mode-independently in updateLifecycle.
+            sessionEndFlow == Flow.SessionEnded && region.session != null -> {
+                region = endSession(region, obs.timestamp)
+            }
             prev.mode != Mode.Online && newMode == Mode.Online -> {
                 if (region.sessionGraceDeadline != null && region.session != null) {
                     // Grace active — resume the existing session (clear deadline, keep sessionId)
@@ -144,12 +152,9 @@ class PlatformRegionStepper @Inject constructor() {
                 }
             }
             prev.mode != Mode.Offline && newMode == Mode.Offline -> {
-                val flow = (obs as? Observation.FlowObservation)?.flow
-                if (flow == Flow.SessionEnded) {
-                    // Authoritative end signal — end immediately, no grace
-                    region = endSession(region, obs.timestamp)
-                } else if (region.session != null) {
-                    // Non-authoritative offline — grace period, preserve session
+                // Non-authoritative offline — grace period, preserve the session
+                // (SessionEnded is handled by the authoritative arm above).
+                if (region.session != null) {
                     region = region.copy(
                         sessionGraceDeadline = obs.timestamp + policy.gracePeriodMs,
                     )
@@ -235,6 +240,13 @@ class PlatformRegionStepper @Inject constructor() {
         nextFlow: FlowRegion,
         obs: Observation.FlowObservation,
     ): PlatformRegion {
+        // Authoritative session end: a session:ended observation (the dash
+        // summary) ends the session immediately, even when already Offline — the
+        // summary commonly shows AFTER the idle/offline screen, mid-grace. Must
+        // run before the Offline early-return below or that ordering is missed.
+        if (obs.flow == Flow.SessionEnded && region.session != null) {
+            return endSession(region, obs.timestamp)
+        }
         if (region.mode == Mode.Offline) return region.copy(idleEnteredAt = null, taskClearGraceDeadline = null)
 
         var r = region

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapPayloadTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapPayloadTest.kt
@@ -556,6 +556,70 @@ class EffectMapPayloadTest {
     }
 
     @Test
+    fun `offline while session is graced does NOT finalize (deferred for the summary)`() {
+        // idle_map offline: the stepper preserves the session under a grace
+        // deadline (next.session still present). EffectMap must NOT finalize here —
+        // the dash summary commonly shows AFTER this idle/offline screen.
+        val regionPrev = PlatformRegion(
+            platform = Platform.DoorDash,
+            mode = Mode.Online,
+            session = Session("s1", startedAt = 1000L, runningEarnings = 30.0),
+        )
+        val regionNext = PlatformRegion(
+            platform = Platform.DoorDash,
+            mode = Mode.Offline,
+            session = Session("s1", startedAt = 1000L, runningEarnings = 30.0),
+            sessionGraceDeadline = 15_000L,
+        )
+        val prev = appState(platforms = mapOf(Platform.DoorDash to regionPrev))
+        val next = appState(platforms = mapOf(Platform.DoorDash to regionNext))
+        val obs = screenObs(flow = Flow.Idle, modeHint = Mode.Offline, timestamp = 5000L)
+
+        val effects = effectMap.diff(prev, next, obs)
+        assertTrue(
+            "no DASH_STOP while graced",
+            effects.none { it is AppEffect.LogEvent && it.event.eventType == AppEventType.DASH_STOP },
+        )
+        assertTrue("no EndSession while graced", effects.none { it is AppEffect.EndSession })
+        assertTrue("no StopOdometer while graced", effects.none { it is AppEffect.StopOdometer })
+    }
+
+    @Test
+    fun `summary AFTER the idle screen (offline to offline) still finalizes with summary_screen`() {
+        // Already Offline under grace; the dash_summary now arrives and the stepper
+        // ends the session (next.session == null). The rich summary must attribute
+        // to the just-ended dash even though the mode didn't change.
+        val regionPrev = PlatformRegion(
+            platform = Platform.DoorDash,
+            mode = Mode.Offline,
+            session = Session("s1", startedAt = 1000L, runningEarnings = 50.0),
+            sessionGraceDeadline = 15_000L,
+        )
+        val regionNext = PlatformRegion(platform = Platform.DoorDash, mode = Mode.Offline)
+        val prev = appState(platforms = mapOf(Platform.DoorDash to regionPrev))
+        val next = appState(platforms = mapOf(Platform.DoorDash to regionNext))
+        val summaryFields = ParsedFields.SessionEndedFields(
+            totalEarnings = 50.0,
+            sessionDurationMillis = 4 * 60 * 60 * 1000L,
+            offersAccepted = 5,
+            offersTotal = 8,
+        )
+        val obs = screenObs(
+            flow = Flow.SessionEnded,
+            modeHint = Mode.Offline,
+            parsed = summaryFields,
+            timestamp = 6000L,
+        )
+
+        val logs = logEvents(prev, next, obs, AppEventType.DASH_STOP)
+        assertEquals(1, logs.size)
+        val payload = gson.fromJson(logs[0].event.eventPayload, SessionStopPayload::class.java)
+        assertEquals("summary_screen", payload.source)
+        assertEquals(50.0, payload.totalEarnings!!, 0.001)
+        assertEquals(5, payload.offersAccepted)
+    }
+
+    @Test
     fun `DASH_PAUSED carries sessionId pausedAt remainingMillis`() {
         val regionPrev = PlatformRegion(
             platform = Platform.DoorDash,

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/IdleAnchorTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/IdleAnchorTest.kt
@@ -117,6 +117,28 @@ class IdleAnchorTest {
     }
 
     @Test
+    fun `session-ended summary while already offline ends the session (summary after idle)`() {
+        // Dash ends: the idle/offline screen comes first → session preserved under grace.
+        val offlineGraced = step(
+            onlineRegion(),
+            screen(flow = Flow.Idle, modeHint = Mode.Offline, timestamp = 1000L),
+            prevFlow = FlowRegion(flow = Flow.Idle),
+        )
+        assertNotNull("session preserved under grace", offlineGraced.session)
+        assertNotNull("grace armed", offlineGraced.sessionGraceDeadline)
+
+        // dash_summary then arrives while STILL offline (mode unchanged). The
+        // authoritative session:ended end must fire anyway, clearing the session so
+        // the summary attributes to the just-ended dash instead of expiring as thin.
+        val ended = step(
+            offlineGraced,
+            screen(flow = Flow.SessionEnded, modeHint = Mode.Offline, timestamp = 2000L),
+            prevFlow = FlowRegion(flow = Flow.Idle),
+        )
+        assertNull("session ended by the summary even though mode stayed offline", ended.session)
+    }
+
+    @Test
     fun `idleEnteredAt reset after leaving and re-entering Idle`() {
         // Start idle at 800
         val prev = onlineRegion(idleEnteredAt = 800L)

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -78,6 +78,13 @@ immediately (no second pass needed) so it gets triaged.
   transfer and confirm the bubble does **nothing** (sensitive → skipped),
   rather than reacting to it.
   - Confirmed: 0/2.
+- **End-of-dash summary attribution (#279).** End a dash and watch the bubble:
+  the **dash summary** (total earnings / duration) should land and attribute to
+  the just-ended dash — whether the summary shows BEFORE or AFTER the
+  idle/offline screen (the after-idle ordering was the bug). It must NOT finalize
+  as a thin "early offline" the instant the idle/offline screen appears; the rich
+  total should reach the HUD.
+  - Confirmed: 0/2.
 
 ---
 
@@ -87,7 +94,9 @@ immediately (no second pass needed) so it gets triaged.
   Hypothesis: the idle-map offline screen shows *before* the dash summary, and
   there may be no way to reach the summary actions once on idle/offline. Needs a
   field repro + capture to confirm.
-  - **Status:** Open (untriaged).
+  - **Status:** Triaged → tracked as #279 (summary attribution fixed in PR; the
+    "summary after the idle screen" ordering was the root cause). Field-validate
+    via the #279 checklist item above.
 
 ---
 


### PR DESCRIPTION
Part **A** of #279 (summary attribution). The session grace was correct; the handling around it dropped the summary.

## Fix
- **Stepper:** `session:ended` (the dash summary) now ends the session authoritatively **even with no mode change** — the summary commonly shows AFTER the idle/offline screen (mode already Offline, mid-grace). Handled in `updateLifecycle` above its Offline early-return; the before-idle ordering stays in `applyModeTransition`.
- **EffectMap:** finalize (`DASH_STOP`/`StopOdometer`/`EndSession`) when the session actually **ends** (goes null / is replaced), not on the bare offline mode-flip. So a graced offline **defers** (no premature `early_offline` stop), and the summary — *either ordering* — emits a rich `summary_screen` `DASH_STOP` attributed to the just-ended dash.

## Tests
- `EffectMapPayloadTest`: grace-defer (no finalize while graced); summary-after-idle (Offline→Offline) finalizes `summary_screen`.
- `IdleAnchorTest`: `session:ended` while already Offline ends the session.
- Full `:app` + `:core:state` green (**693**, 0 failures).

## Field validation
Added a "Next field test" checklist item (#279): end a dash and confirm the rich summary attributes to it in **both** orderings (summary before *and* after the idle screen), not a thin early-offline.

## Part B (separate)
The other half of #279 — a genuinely new dash started during the grace window resuming the old session — is evaluated in the issue; not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)