### PR TITLE
refactor(#283): name magic strings for activity + DASH_STOP source

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardItem.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardItem.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import cloud.trotter.dashbuddy.domain.model.cards.FlowCardSnapshot
+import cloud.trotter.dashbuddy.domain.state.PickupActivity
 import cloud.trotter.dashbuddy.domain.model.event.AppEventType
 import kotlinx.coroutines.delay
 import java.util.Date
@@ -416,7 +417,7 @@ private fun DeadlineBody(
             // Shop & Deliver: show progress + a live items/min pace (derived off
             // `now`, so it ticks while shopping and freezes with the card). The bare
             // "items left" count alone isn't useful; pace + shopped/total is.
-            if (activity == "shopping") {
+            if (activity == PickupActivity.SHOPPING) {
                 val shopped = itemsShopped ?: 0
                 val total = shopped + (itemsRemaining ?: 0)
                 if (total > 0) {

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -5,6 +5,7 @@ import cloud.trotter.dashbuddy.domain.model.chat.ChatPersona
 import cloud.trotter.dashbuddy.domain.model.event.AppEventType
 import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.OfferPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.SessionEndSource
 import cloud.trotter.dashbuddy.domain.model.event.payload.OfferReceivedPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.PickupPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionPausedPayload
@@ -24,6 +25,7 @@ import cloud.trotter.dashbuddy.domain.state.FlowRegion
 import cloud.trotter.dashbuddy.domain.state.Mode
 import cloud.trotter.dashbuddy.domain.state.TransitionKind
 import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import cloud.trotter.dashbuddy.domain.state.PickupActivity
 import cloud.trotter.dashbuddy.domain.state.PendingOffer
 import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.domain.state.PlatformRegion
@@ -263,7 +265,7 @@ class EffectMap @Inject constructor(
                                 SessionStopPayload(
                                     sessionId = sessionId,
                                     endedAt = obs.timestamp,
-                                    source = "summary_screen",
+                                    source = SessionEndSource.SUMMARY_SCREEN,
                                     totalEarnings = endParsed.totalEarnings,
                                     sessionDurationMillis = endParsed.sessionDurationMillis,
                                     offersAccepted = endParsed.offersAccepted,
@@ -283,7 +285,7 @@ class EffectMap @Inject constructor(
                                 SessionStopPayload(
                                     sessionId = sessionId,
                                     endedAt = obs.timestamp,
-                                    source = "early_offline",
+                                    source = SessionEndSource.EARLY_OFFLINE,
                                     totalEarnings = prevSession?.runningEarnings,
                                 ),
                             ),
@@ -794,8 +796,8 @@ class EffectMap @Inject constructor(
         customerHash: String?,
     ): ChatPersona {
         return when {
-            activity == "shopping" -> ChatPersona.Shopper
-            activity == "confirmed" -> ChatPersona.Customer(customerHash?.take(6) ?: "Customer")
+            activity == PickupActivity.SHOPPING -> ChatPersona.Shopper
+            activity == PickupActivity.CONFIRMED -> ChatPersona.Customer(customerHash?.take(6) ?: "Customer")
             arrived -> ChatPersona.Merchant(storeName)
             else -> ChatPersona.Navigator
         }

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/payload/AppEventPayloads.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/payload/AppEventPayloads.kt
@@ -122,6 +122,15 @@ data class SessionPausedPayload(
     val remainingMillis: Long? = null,
 )
 
+/** Wire values for [SessionStopPayload.source]. Kept as strings on the payload
+ *  (domain is gson-free); these are the single source of truth on the Kotlin side. */
+object SessionEndSource {
+    /** The dash-summary screen was observed — rich totals populated. */
+    const val SUMMARY_SCREEN = "summary_screen"
+    /** Went offline without a summary (grace expiry / early offline) — thin. */
+    const val EARLY_OFFLINE = "early_offline"
+}
+
 /**
  * Payload for `DASH_STOP`.
  *
@@ -133,7 +142,7 @@ data class SessionPausedPayload(
 data class SessionStopPayload(
     val sessionId: String?,
     val endedAt: Long,
-    /** "summary_screen" | "early_offline". */
+    /** One of [SessionEndSource]. */
     val source: String,
     val totalEarnings: Double? = null,
     val sessionDurationMillis: Long? = null,

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/ParsedFields.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/ParsedFields.kt
@@ -4,13 +4,20 @@ import cloud.trotter.dashbuddy.domain.model.accessibility.ParsedTime
 import cloud.trotter.dashbuddy.domain.model.offer.ParsedOffer
 import cloud.trotter.dashbuddy.domain.model.pay.ParsedPay
 
+/** Known wire values for the open [ParsedFields.activity] tag (rule-emitted). */
+object PickupActivity {
+    const val SHOPPING = "shopping"
+    const val CONFIRMED = "confirmed"
+}
+
 /**
  * Typed parsed data produced by rules and consumed by the state machine.
  * Each subtype corresponds to a [Flow] family — the [FieldsFactory]
  * validates that rule output conforms to the contract at load time.
  *
  * All subtypes carry an optional [activity] tag for platform-specific
- * refinements within a flow (e.g., "shopping", "scanning_card").
+ * refinements within a flow (e.g., "shopping", "scanning_card"). The tag is an
+ * open, rule-emitted string; [PickupActivity] names the values the code keys on.
  */
 sealed class ParsedFields {
     abstract val activity: String?


### PR DESCRIPTION
Closes #283 (sub-issue of #281).

Right-sized from the original "convert to enums": the fields are either an intentionally **open** rule-emitted tag (`ParsedFields.activity`) or a small documented set (`SessionStopPayload.source`), and **:domain is gson-free** — a typed/closed enum on the payload would drag gson into domain and churn ~25 sites against the open-tag design.

Instead: `SessionEndSource` + `PickupActivity` **constants** in :domain (single Kotlin source of truth), referenced by EffectMap (`DASH_STOP` source + `determinePickupPersona`) and FlowCardItem. Fields stay wire-strings → zero serialization change. Build + :app/:core:state green (693).

Also noted: `activity` is never assigned `"confirmed"` in code — the persona's confirmed branch is a forward guard, left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)