### PR TITLE
refactor(#286): unify session/task grace into one pendingDestructive guard

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/state/StateMachineTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/state/StateMachineTest.kt
@@ -7,6 +7,7 @@ import cloud.trotter.dashbuddy.domain.model.order.ParsedOrder
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
 import cloud.trotter.dashbuddy.domain.pipeline.TimeoutType
 import cloud.trotter.dashbuddy.domain.state.AppState
+import cloud.trotter.dashbuddy.domain.state.DestructiveKind
 import cloud.trotter.dashbuddy.domain.state.Flow
 import cloud.trotter.dashbuddy.domain.state.FlowRegion
 import cloud.trotter.dashbuddy.domain.state.Mode
@@ -455,7 +456,7 @@ class StateMachineTest {
         val dd = state.regions.platforms[Platform.DoorDash]!!
         assertEquals(Mode.Offline, dd.mode)
         assertNull(dd.session) // ended immediately — no grace
-        assertNull(dd.sessionGraceDeadline) // no grace set
+        assertNull(dd.pendingDestructive) // no grace set
     }
 
     @Test
@@ -482,7 +483,8 @@ class StateMachineTest {
         val afterOffline = state.regions.platforms[Platform.DoorDash]!!
         assertEquals(Mode.Offline, afterOffline.mode)
         assertNotNull(afterOffline.session) // session preserved during grace
-        assertNotNull(afterOffline.sessionGraceDeadline)
+        assertNotNull(afterOffline.pendingDestructive)
+        assertEquals(DestructiveKind.SESSION_END, afterOffline.pendingDestructive?.kind)
 
         // Back to Online within grace window (well within 10s)
         val t3 = t2 + 3000
@@ -493,7 +495,49 @@ class StateMachineTest {
         val resumed = state.regions.platforms[Platform.DoorDash]!!
         assertEquals(Mode.Online, resumed.mode)
         assertEquals(originalSessionId, resumed.session!!.sessionId) // SAME session
-        assertNull(resumed.sessionGraceDeadline) // grace cleared
+        assertNull(resumed.pendingDestructive) // grace cleared
+    }
+
+    @Test
+    fun `session grace — starting a new dash within the grace window starts fresh, not a resume`() {
+        var state = AppState()
+
+        // Online
+        val t1 = tick()
+        state = machine.step(state, screenObs(
+            flow = Flow.OfferPresented, parsed = offerFields(), timestamp = t1,
+        )).newState
+        val originalSessionId = state.regions.platforms[Platform.DoorDash]!!.session!!.sessionId
+
+        // Offline — dash-end is provisional (grace armed)
+        val t2 = t1 + 2000
+        state = machine.step(state, screenObs(
+            modeHint = Mode.Offline, flow = Flow.Idle, parsed = ParsedFields.IdleFields(), timestamp = t2,
+        )).newState
+        assertNotNull(state.regions.platforms[Platform.DoorDash]!!.pendingDestructive)
+
+        // The set-end-time screen (startingDash) arrives WITHIN the grace window —
+        // the old dash really ended; commit it now (#279-B).
+        val t3 = t2 + 1000
+        state = machine.step(state, screenObs(
+            modeHint = Mode.Offline, flow = Flow.Idle,
+            parsed = ParsedFields.IdleFields(startingDash = true), timestamp = t3,
+        )).newState
+        val afterStart = state.regions.platforms[Platform.DoorDash]!!
+        assertNull("the dash-start signal ends the old dash", afterStart.session)
+        assertNull(afterStart.pendingDestructive)
+
+        // Dash Now → Online → a FRESH session, not the resumed old one.
+        val t4 = t3 + 1000
+        state = machine.step(state, screenObs(
+            flow = Flow.OfferPresented, parsed = offerFields(), timestamp = t4,
+        )).newState
+        val fresh = state.regions.platforms[Platform.DoorDash]!!
+        assertNotNull(fresh.session)
+        assertTrue(
+            "a genuinely new dash, not a grace-resume of the old session",
+            fresh.session!!.sessionId != originalSessionId,
+        )
     }
 
     @Test
@@ -532,7 +576,7 @@ class StateMachineTest {
             "Expected new session ID, but got same as original",
             afterExpiry.session!!.sessionId != originalSessionId,
         )
-        assertNull(afterExpiry.sessionGraceDeadline)
+        assertNull(afterExpiry.pendingDestructive)
     }
 
     @Test
@@ -560,7 +604,8 @@ class StateMachineTest {
         assertEquals(Mode.Offline, result.mode)
         // Pause timeout goes through applyModeTransition, gets grace
         assertNotNull(result.session) // session preserved during grace
-        assertNotNull(result.sessionGraceDeadline)
+        assertNotNull(result.pendingDestructive)
+        assertEquals(DestructiveKind.SESSION_END, result.pendingDestructive?.kind)
     }
 
     // =========================================================================

--- a/core/pipeline/src/main/assets/rules/doordash.json
+++ b/core/pipeline/src/main/assets/rules/doordash.json
@@ -2113,6 +2113,9 @@
               "hasIdSuffix": "starting_point_name"
             },
             "read": "text"
+          },
+          "startingDash": {
+            "literal": true
           }
         }
       }

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/ParsedFieldsFactory.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/ParsedFieldsFactory.kt
@@ -114,6 +114,7 @@ object ParsedFieldsFactory {
         waitTimeEstimate = f.str("waitTimeEstimate"),
         isHeadingBackToZone = f.bool("isHeadingBackToZone") ?: false,
         spotSaveDeadline = f.long("spotSaveDeadline"),
+        startingDash = f.bool("startingDash") ?: false,
     )
 
     private fun buildTask(f: Map<String, Any?>) = ParsedFields.TaskFields(

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
@@ -3,11 +3,13 @@ package cloud.trotter.dashbuddy.core.state
 import cloud.trotter.dashbuddy.domain.model.ratings.RatingsSnapshot
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
 import cloud.trotter.dashbuddy.domain.pipeline.TimeoutType
+import cloud.trotter.dashbuddy.domain.state.DestructiveKind
 import cloud.trotter.dashbuddy.domain.state.Flow
 import cloud.trotter.dashbuddy.domain.state.FlowRegion
 import cloud.trotter.dashbuddy.domain.state.Job
 import cloud.trotter.dashbuddy.domain.state.Mode
 import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import cloud.trotter.dashbuddy.domain.state.PendingDestructive
 import cloud.trotter.dashbuddy.domain.state.PlatformRegion
 import cloud.trotter.dashbuddy.domain.state.Session
 import cloud.trotter.dashbuddy.domain.state.SessionType
@@ -53,20 +55,26 @@ class PlatformRegionStepper @Inject constructor() {
         // Handle timeout-driven transitions
         if (obs is Observation.Timeout) return handleTimeout(prev, obs, policy)
 
-        // Lazy grace expiration: if grace deadline has passed, end session now
         var current = prev
-        if (current.sessionGraceDeadline != null && obs.timestamp > current.sessionGraceDeadline!!) {
-            current = endSession(
-                current.copy(sessionGraceDeadline = null),
-                current.sessionGraceDeadline!!,
-            )
+
+        // Lazy expiry: a pending destructive transition (dash-end / task-retire)
+        // whose deadline has passed is confirmed — committed now. Driven by
+        // obs.timestamp (never a wall clock) so crash-recovery replay matches.
+        current.pendingDestructive?.let { pend ->
+            if (obs.timestamp > pend.deadline) {
+                current = commitDestructive(current, pend.kind, pend.deadline)
+            }
         }
 
-        // Lazy task-clear grace expiration: a transient idle/offer mid-task armed
-        // a deadline (see updateTaskLifecycle). If it has passed without returning
-        // to a task flow, retire the task now — the session/job survive.
-        if (current.taskClearGraceDeadline != null && obs.timestamp > current.taskClearGraceDeadline!!) {
-            current = retireActiveTask(current, current.taskClearGraceDeadline!!)
+        // Authoritative dash-start signal (#279-B): the set-end-time screen while a
+        // dash-end is pending in its grace window means the old dash really ended
+        // and a new one is starting — commit the end now so the next Online mints
+        // a fresh session instead of resuming the old one.
+        if (current.pendingDestructive?.kind == DestructiveKind.SESSION_END) {
+            val startParsed = (obs as? Observation.FlowObservation)?.parsed
+            if ((startParsed as? ParsedFields.IdleFields)?.startingDash == true) {
+                current = endSession(current, obs.timestamp)
+            }
         }
 
         val flowObs = obs as? Observation.FlowObservation ?: return current
@@ -127,22 +135,19 @@ class PlatformRegionStepper @Inject constructor() {
             lastTransitionKind = kind,
         )
 
-        // Session lifecycle on mode transitions
-        val sessionEndFlow = (obs as? Observation.FlowObservation)?.flow
+        // Session lifecycle on mode transitions. An authoritative `session:ended`
+        // is committed mode-independently in updateLifecycle (covers both the
+        // before-idle and after-idle orderings), so it isn't special-cased here.
         when {
-            // Authoritative end when the summary shows BEFORE the idle/offline
-            // screen (a real mode change Online→Offline): end now, no grace. The
-            // AFTER-idle ordering (mode already Offline, no change) doesn't reach
-            // this function and is handled mode-independently in updateLifecycle.
-            sessionEndFlow == Flow.SessionEnded && region.session != null -> {
-                region = endSession(region, obs.timestamp)
-            }
             prev.mode != Mode.Online && newMode == Mode.Online -> {
-                if (region.sessionGraceDeadline != null && region.session != null) {
-                    // Grace active — resume the existing session (clear deadline, keep sessionId)
-                    region = region.copy(sessionGraceDeadline = null)
+                val pend = region.pendingDestructive
+                if (pend?.kind == DestructiveKind.SESSION_END && region.session != null) {
+                    // Grace active + the same session is still present → a genuine
+                    // resume (a transient offline flash). A real new-dash start
+                    // would already have committed the end in step() (startingDash).
+                    region = region.copy(pendingDestructive = null)
                 } else if (region.session == null) {
-                    // No grace or no session — create new session
+                    // No session — start a fresh one.
                     region = region.copy(
                         session = Session(
                             sessionId = UUID.randomUUID().toString(),
@@ -152,11 +157,17 @@ class PlatformRegionStepper @Inject constructor() {
                 }
             }
             prev.mode != Mode.Offline && newMode == Mode.Offline -> {
-                // Non-authoritative offline — grace period, preserve the session
-                // (SessionEnded is handled by the authoritative arm above).
-                if (region.session != null) {
+                // Non-authoritative offline — arm a provisional dash-end, keeping
+                // the session alive until it's confirmed or cancelled.
+                if (region.session != null &&
+                    region.pendingDestructive?.kind != DestructiveKind.SESSION_END
+                ) {
                     region = region.copy(
-                        sessionGraceDeadline = obs.timestamp + policy.gracePeriodMs,
+                        pendingDestructive = PendingDestructive(
+                            kind = DestructiveKind.SESSION_END,
+                            since = obs.timestamp,
+                            deadline = obs.timestamp + policy.gracePeriodMs,
+                        ),
                     )
                 }
             }
@@ -247,7 +258,13 @@ class PlatformRegionStepper @Inject constructor() {
         if (obs.flow == Flow.SessionEnded && region.session != null) {
             return endSession(region, obs.timestamp)
         }
-        if (region.mode == Mode.Offline) return region.copy(idleEnteredAt = null, taskClearGraceDeadline = null)
+        if (region.mode == Mode.Offline) {
+            // Clear the idle anchor and any TASK_RETIRE pending, but PRESERVE a
+            // SESSION_END pending — that IS the graced-offline state.
+            val keptPending = region.pendingDestructive
+                ?.takeIf { it.kind == DestructiveKind.SESSION_END }
+            return region.copy(idleEnteredAt = null, pendingDestructive = keptPending)
+        }
 
         var r = region
         val prev = prevFlow.flow
@@ -492,7 +509,7 @@ class PlatformRegionStepper @Inject constructor() {
                         arrivedAt = if (taskSubFlow == TaskSubFlow.ARRIVED) obs.timestamp else null,
                     ),
                     recentTasks = recentTasks,
-                    taskClearGraceDeadline = null,
+                    pendingDestructive = null,
                 )
             }
 
@@ -512,7 +529,7 @@ class PlatformRegionStepper @Inject constructor() {
                     redCardTotal = taskFields?.redCardTotal ?: currentTask.redCardTotal,
                     arrivedAt = if (justArrived) obs.timestamp else currentTask.arrivedAt,
                 ),
-                taskClearGraceDeadline = null,
+                pendingDestructive = null,
             )
         }
 
@@ -523,7 +540,7 @@ class PlatformRegionStepper @Inject constructor() {
             return region.copy(
                 activeTask = null,
                 recentTasks = (region.recentTasks + completedTask).takeLast(MAX_RECENT_TASKS),
-                taskClearGraceDeadline = null,
+                pendingDestructive = null,
             )
         }
 
@@ -533,9 +550,13 @@ class PlatformRegionStepper @Inject constructor() {
         // Arm a grace deadline; returning to a task flow cancels it (above), and a
         // sustained idle past the window retires the task lazily in step().
         if (prevFlowVal.isTaskFlow() && !nextFlowVal.isTaskFlow() && nextFlowVal != Flow.PostTask) {
-            if (region.activeTask != null && region.taskClearGraceDeadline == null) {
+            if (region.activeTask != null && region.pendingDestructive == null) {
                 return region.copy(
-                    taskClearGraceDeadline = obs.timestamp + TransitionPolicy.DEFAULT_GRACE_MS,
+                    pendingDestructive = PendingDestructive(
+                        kind = DestructiveKind.TASK_RETIRE,
+                        since = obs.timestamp,
+                        deadline = obs.timestamp + TransitionPolicy.DEFAULT_GRACE_MS,
+                    ),
                 )
             }
         }
@@ -547,18 +568,29 @@ class PlatformRegionStepper @Inject constructor() {
     // HELPERS
     // =========================================================================
 
+    /** Commit a pending destructive transition — its deadline lapsed, or an
+     *  authoritative signal confirmed it. */
+    private fun commitDestructive(
+        region: PlatformRegion,
+        kind: DestructiveKind,
+        timestamp: Long,
+    ): PlatformRegion = when (kind) {
+        DestructiveKind.SESSION_END -> endSession(region, timestamp)
+        DestructiveKind.TASK_RETIRE -> retireActiveTask(region, timestamp)
+    }
+
     /**
-     * Retire the active task when its clear-grace deadline lazily expires
+     * Retire the active task when its retire-grace deadline lazily expires
      * (a sustained idle/offer mid-task). Completes it into recentTasks. Unlike
      * [endSession], the session and job live on — only the task is closed.
      */
     private fun retireActiveTask(region: PlatformRegion, timestamp: Long): PlatformRegion {
         val completed = region.activeTask?.copy(completedAt = timestamp)
-            ?: return region.copy(taskClearGraceDeadline = null)
+            ?: return region.copy(pendingDestructive = null)
         return region.copy(
             activeTask = null,
             recentTasks = (region.recentTasks + completed).takeLast(MAX_RECENT_TASKS),
-            taskClearGraceDeadline = null,
+            pendingDestructive = null,
         )
     }
 
@@ -573,8 +605,7 @@ class PlatformRegionStepper @Inject constructor() {
             activeJob = null,
             activeTask = null,
             recentTasks = recentTasks,
-            sessionGraceDeadline = null,
-            taskClearGraceDeadline = null,
+            pendingDestructive = null,
             idleEnteredAt = null,
             lastPostTaskPayHash = null,
             lastPostTaskFields = null,

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapPayloadTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapPayloadTest.kt
@@ -17,11 +17,13 @@ import cloud.trotter.dashbuddy.domain.model.pay.ParsedPayItem
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
 import cloud.trotter.dashbuddy.domain.state.AppState
 import cloud.trotter.dashbuddy.domain.state.CrossPlatformRegion
+import cloud.trotter.dashbuddy.domain.state.DestructiveKind
 import cloud.trotter.dashbuddy.domain.state.Flow
 import cloud.trotter.dashbuddy.domain.state.FlowRegion
 import cloud.trotter.dashbuddy.domain.state.Mode
 import cloud.trotter.dashbuddy.domain.state.ParsedFields
 import cloud.trotter.dashbuddy.domain.state.PendingOffer
+import cloud.trotter.dashbuddy.domain.state.PendingDestructive
 import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.domain.state.PlatformRegion
 import cloud.trotter.dashbuddy.domain.state.Regions
@@ -569,7 +571,7 @@ class EffectMapPayloadTest {
             platform = Platform.DoorDash,
             mode = Mode.Offline,
             session = Session("s1", startedAt = 1000L, runningEarnings = 30.0),
-            sessionGraceDeadline = 15_000L,
+            pendingDestructive = PendingDestructive(DestructiveKind.SESSION_END, since = 1_000L, deadline = 15_000L),
         )
         val prev = appState(platforms = mapOf(Platform.DoorDash to regionPrev))
         val next = appState(platforms = mapOf(Platform.DoorDash to regionNext))
@@ -593,7 +595,7 @@ class EffectMapPayloadTest {
             platform = Platform.DoorDash,
             mode = Mode.Offline,
             session = Session("s1", startedAt = 1000L, runningEarnings = 50.0),
-            sessionGraceDeadline = 15_000L,
+            pendingDestructive = PendingDestructive(DestructiveKind.SESSION_END, since = 1_000L, deadline = 15_000L),
         )
         val regionNext = PlatformRegion(platform = Platform.DoorDash, mode = Mode.Offline)
         val prev = appState(platforms = mapOf(Platform.DoorDash to regionPrev))

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/IdleAnchorTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/IdleAnchorTest.kt
@@ -2,6 +2,7 @@ package cloud.trotter.dashbuddy.core.state
 
 import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.state.DestructiveKind
 import cloud.trotter.dashbuddy.domain.state.Flow
 import cloud.trotter.dashbuddy.domain.state.FlowRegion
 import cloud.trotter.dashbuddy.domain.state.Mode
@@ -125,7 +126,8 @@ class IdleAnchorTest {
             prevFlow = FlowRegion(flow = Flow.Idle),
         )
         assertNotNull("session preserved under grace", offlineGraced.session)
-        assertNotNull("grace armed", offlineGraced.sessionGraceDeadline)
+        assertNotNull("grace armed", offlineGraced.pendingDestructive)
+        assertEquals(DestructiveKind.SESSION_END, offlineGraced.pendingDestructive?.kind)
 
         // dash_summary then arrives while STILL offline (mode unchanged). The
         // authoritative session:ended end must fire anyway, clearing the session so

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/TaskLifecycleGuardTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/TaskLifecycleGuardTest.kt
@@ -2,11 +2,13 @@ package cloud.trotter.dashbuddy.core.state
 
 import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.state.DestructiveKind
 import cloud.trotter.dashbuddy.domain.state.Flow
 import cloud.trotter.dashbuddy.domain.state.FlowRegion
 import cloud.trotter.dashbuddy.domain.state.Job
 import cloud.trotter.dashbuddy.domain.state.Mode
 import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import cloud.trotter.dashbuddy.domain.state.PendingDestructive
 import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.domain.state.PlatformRegion
 import cloud.trotter.dashbuddy.domain.state.Session
@@ -39,13 +41,13 @@ class TaskLifecycleGuardTest {
 
     // ---- helpers ----
 
-    private fun region(activeTask: Task?, taskClearGraceDeadline: Long? = null) = PlatformRegion(
+    private fun region(activeTask: Task?, pending: PendingDestructive? = null) = PlatformRegion(
         platform = Platform.DoorDash,
         mode = Mode.Online,
         session = Session("sess-1", startedAt = 100L),
         activeJob = Job("job-1", offerStoreHint = emptyList(), parentOfferHash = null, startedAt = 200L),
         activeTask = activeTask,
-        taskClearGraceDeadline = taskClearGraceDeadline,
+        pendingDestructive = pending,
     )
 
     private fun pickupTask(taskId: String, storeName: String, arrivedAt: Long? = null) = Task(
@@ -106,7 +108,8 @@ class TaskLifecycleGuardTest {
 
         assertNotNull("a transient idle must not forget the task", r1.activeTask)
         assertEquals("task-A", r1.activeTask?.taskId)
-        assertEquals("grace deadline armed", 1_000L + graceMs, r1.taskClearGraceDeadline)
+        assertEquals("retire-grace armed", 1_000L + graceMs, r1.pendingDestructive?.deadline)
+        assertEquals(DestructiveKind.TASK_RETIRE, r1.pendingDestructive?.kind)
     }
 
     @Test
@@ -120,7 +123,7 @@ class TaskLifecycleGuardTest {
         )
 
         assertEquals("returning to the task must keep the same taskId", "task-A", r2.activeTask?.taskId)
-        assertNull("returning to a task cancels the grace", r2.taskClearGraceDeadline)
+        assertNull("returning to a task cancels the grace", r2.pendingDestructive)
     }
 
     @Test
@@ -139,11 +142,14 @@ class TaskLifecycleGuardTest {
 
     @Test
     fun `PostTask completes the task and clears a pending grace`() {
-        val r0 = region(pickupTask("task-A", "H-E-B", arrivedAt = 800L), taskClearGraceDeadline = 11_000L)
+        val r0 = region(
+            pickupTask("task-A", "H-E-B", arrivedAt = 800L),
+            pending = PendingDestructive(DestructiveKind.TASK_RETIRE, since = 800L, deadline = 11_000L),
+        )
         val (r1, _) = step(r0, FlowRegion(flow = Flow.Idle), postTaskObs(timestamp = 1_005L))
 
         assertNull("PostTask is authoritative — the task completes", r1.activeTask)
-        assertNull(r1.taskClearGraceDeadline)
+        assertNull(r1.pendingDestructive)
         assertTrue(r1.recentTasks.any { it.taskId == "task-A" && it.completedAt != null })
     }
 

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -85,6 +85,13 @@ immediately (no second pass needed) so it gets triaged.
   as a thin "early offline" the instant the idle/offline screen appears; the rich
   total should reach the HUD.
   - Confirmed: 0/2.
+- **New dash right after ending one starts fresh (#286 / #279-B).** End a dash,
+  then start a new one within ~10s. The bubble should treat it as a **brand-new
+  dash** (fresh session / earnings reset), not "Session resumed (grace)". Also
+  regression-watch the grace refactor: backing out of the app mid-pickup and
+  returning still **keeps the active task**; a brief offline blip mid-dash still
+  **resumes the same** dash (no spurious new session).
+  - Confirmed: 0/2.
 
 ---
 

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/ParsedFields.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/ParsedFields.kt
@@ -42,6 +42,13 @@ sealed class ParsedFields {
         val waitTimeEstimate: String? = null,
         val isHeadingBackToZone: Boolean = false,
         val spotSaveDeadline: Long? = null,
+        /**
+         * The dasher is starting/scheduling a new dash (e.g. the set-end-time
+         * screen). Used by the state machine to end a just-finished dash that's
+         * still in its grace window and start a fresh one rather than resuming.
+         * Transient signal — excluded from [dedupeHash].
+         */
+        val startingDash: Boolean = false,
     ) : ParsedFields() {
         override fun dedupeHash(): Int {
             var h = zoneName.hashCode()

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/PlatformRegion.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/PlatformRegion.kt
@@ -17,16 +17,18 @@ data class PlatformRegion(
     val activeJob: Job? = null,
     val activeTask: Task? = null,
     val recentTasks: List<Task> = emptyList(),
-    val sessionGraceDeadline: Long? = null,
     /**
-     * Deadline after which a transient idle/offer seen mid-task retires the
-     * active task. Armed when leaving a task flow to a non-task flow while
-     * online; cancelled on returning to a task flow; lazily expired in
-     * [PlatformRegionStepper.step]. Keeps a brief informational screen (the
-     * timeline, or the idle map flashing before the delivery summary) from
-     * forgetting the task.
+     * A pending "destructive" transition — ending the dash or retiring the
+     * active task — that is **provisional** until confirmed. Armed when leaving
+     * a more-active state (online→offline, or task-flow→non-task) so a transient
+     * screen flash (backing out of the app mid-pickup, or the idle map flashing
+     * before the dash summary) doesn't immediately drop the task/session.
+     * Resolved in [PlatformRegionStepper]: confirmed by an authoritative signal
+     * (session:ended, PostTask, a fresh dash) or deadline expiry → commit;
+     * cancelled when the prior more-active state returns within the window.
+     * Replaces the former separate sessionGraceDeadline / taskClearGraceDeadline.
      */
-    val taskClearGraceDeadline: Long? = null,
+    val pendingDestructive: PendingDestructive? = null,
     val lastTransitionKind: TransitionKind? = null,
     val zoneName: String? = null,
     val sessionType: SessionType? = null,
@@ -52,6 +54,29 @@ data class PlatformRegion(
      */
     val lastAnnouncedPostTaskTaskId: String? = null,
 )
+
+/**
+ * A provisional transition toward a less-active state, pending confirmation.
+ * See [PlatformRegion.pendingDestructive]. Plain data (Gson-serializable) so it
+ * survives crash-recovery replay; resolution is driven by `obs.timestamp`, never
+ * a wall clock, keeping the reducer pure.
+ */
+data class PendingDestructive(
+    val kind: DestructiveKind,
+    /** The obs.timestamp that armed it. */
+    val since: Long,
+    /** Once an observation's timestamp passes this, the transition is committed. */
+    val deadline: Long,
+    val reason: String? = null,
+)
+
+enum class DestructiveKind {
+    /** End the dash/session — online→offline without an authoritative end signal. */
+    SESSION_END,
+
+    /** Retire the active task — a task flow gave way to idle/offer mid-delivery. */
+    TASK_RETIRE,
+}
 
 /**
  * Classification of a mode transition for logging and lifecycle decisions.


### PR DESCRIPTION
Closes #286 (sub-issue of #281). **Completes #279** (folds in Part B).

The structural payoff from the #281 architecture review. Replaces the two independently-managed grace deadlines (`sessionGraceDeadline` + `taskClearGraceDeadline`) and their scattered arm/clear/expire sites with **one** provisional-transition guard:

```
PendingDestructive { kind: SESSION_END | TASK_RETIRE, since, deadline }
```

A transition to a *less-active* state arms it (provisional); it resolves on later observations — **confirm** (authoritative signal or deadline expiry → commit `endSession`/`retireActiveTask`) or **cancel** (prior state returns within the window). One arm/confirm/cancel/expire path instead of N scattered fields.

- Reducer stays **pure + replayable** (`obs.timestamp` + lazy expiry — no clock).
- `EffectMap` stays **grace-agnostic** (fires at *commit*, on `prevSession→null`); `idleEnteredAt` untouched.
- **#279-B resolved cleanly:** a `startingDash` signal (new `IdleFields` field emitted by the `set_dash_end_time` rule) is just another **confirm** trigger for a pending `SESSION_END` → end the old dash, start fresh on next Online (instead of resuming). No 7th bespoke field.

## Behavior preservation
Migrated `TaskLifecycleGuardTest` / `IdleAnchorTest` / `EffectMapPayloadTest` / `StateMachineTest` to assert on `pendingDestructive`; added a **new-dash-during-grace** test. Every field-validated behavior is guarded: idle-flash-mid-pickup keeps the task; transient offline resumes; summary attributes (both orderings); sustained idle/offline ends. Full `:app` + `:core:state` green (**694**).

Field-test item added to `docs/field-testing/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)