### PR TITLE
docs(field-testing): cover scheduled-dash start in the fresh-dash checklist (#290)

### DIFF
--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -85,12 +85,21 @@ immediately (no second pass needed) so it gets triaged.
   as a thin "early offline" the instant the idle/offline screen appears; the rich
   total should reach the HUD.
   - Confirmed: 0/2.
-- **New dash right after ending one starts fresh (#286 / #279-B).** End a dash,
-  then start a new one within ~10s. The bubble should treat it as a **brand-new
-  dash** (fresh session / earnings reset), not "Session resumed (grace)". Also
-  regression-watch the grace refactor: backing out of the app mid-pickup and
-  returning still **keeps the active task**; a brief offline blip mid-dash still
-  **resumes the same** dash (no spurious new session).
+- **New dash right after ending one starts fresh (#286 / #279-B / #290).** End a
+  dash, then start a new one within ~10s. The bubble should treat it as a
+  **brand-new dash** (fresh session / earnings reset), not "Session resumed
+  (grace)". Cover **both** start paths, because they emit the fresh-dash signal
+  from different screens:
+    - **On-demand** start (tap Dash → the set-end-time screen) — the original
+      `startingDash` carrier.
+    - **Scheduled** start (#290): in your zone with a scheduled block, the idle
+      map reads **"Start your scheduled dash"** and tapping Dash auto-starts with
+      *no* set-end-time screen. This is the path that previously resumed the old
+      session. Confirm the new dash is fresh, and that "You have another dash
+      starting soon" (when you're *not* starting) does **not** reset anything.
+  - Also regression-watch the grace refactor: backing out of the app mid-pickup
+    and returning still **keeps the active task**; a brief offline blip mid-dash
+    still **resumes the same** dash (no spurious new session).
   - Confirmed: 0/2.
 
 ---


### PR DESCRIPTION
Docs-only. Expands the #286/#279-B field-test item to cover the scheduled-dash start path closed by #290 (the "Start your scheduled dash" idle map), distinguishing it from the on-demand set-end-time path and from the no-op "another dash starting soon" variant.

[skip ci]

🤖 Generated with [Claude Code](https://claude.com/claude-code)