### PR TITLE
docs(field-log): 2026-06-03 DoorDash dash — post-delivery crash + grace-resume + #276 pace

### DIFF
--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -105,7 +105,11 @@ immediately (no second pass needed) so it gets triaged.
   - Also regression-watch the grace refactor: backing out of the app mid-pickup
     and returning still **keeps the active task**; a brief offline blip mid-dash
     still **resumes the same** dash (no spurious new session).
-  - Confirmed: 0/2.
+  - Confirmed: 0/2. **Partial — 2026-06-03 (DoorDash):** the *brief-offline-blip
+    resumes same dash* sub-case was seen — an app-switch return fired
+    "Session resumed (grace)" (same session, no fresh start). Still unconfirmed:
+    that the **active task** survived the blip, and the explicit start-path cases
+    (on-demand / scheduled fresh start). See 2026-06-03 log entry #3.
 
 - **Alcohol delivery ID-verification flow recognized + arrival timing (#149).**
   On an alcohol dropoff, the ID-check flow is now recognized (previously
@@ -121,13 +125,15 @@ immediately (no second pass needed) so it gets triaged.
       recognized — flag it for a redaction + sensitive rule.
   - Confirmed: 0/2.
 
-- **App-switch mid-dash → "recovered" notice → dash continuity (2026-06-03 #3).**
-  Mid-dash, switch to another app and come back to DoorDash. If a "recovered"
-  notice appears, **note which app showed it** (DoorDash vs the DashBuddy bubble —
-  a screenshot is ideal; no DashBuddy string says "recovered", so it's expected to
-  be DoorDash's). Then confirm DashBuddy **kept the same in-progress dash/task**
-  with earnings intact — it must **not** start a fresh dash, double-start, or
-  forget the active task (cross-refs #286/#290 grace and 2026-05-29 #2).
+- **App-switch mid-dash → "Session resumed (grace)" → dash + task continuity
+  (2026-06-03 #3).** The bubble's `"Session resumed (grace)"` message
+  (`EffectMap.kt:319`) fires when a region goes Offline then back Online within
+  ~10s on the **same** session. An app-switch return can trip this (DashBuddy
+  stops seeing DoorDash → reads Offline → resumes on return). When it appears,
+  confirm DashBuddy **kept the same in-progress dash AND the active task** with
+  earnings intact — it must **not** start a fresh dash, double-start, or forget
+  the task (cross-refs #286/#290 grace and 2026-05-29 #2). Also a UX read: is
+  showing this internal-sounding message useful, or should it be reworded/demoted?
   - Confirmed: 0/2.
 
 ---
@@ -230,56 +236,61 @@ immediately (no second pass needed) so it gets triaged.
 
 ### Open questions / investigations
 
-#### 3. Switched apps mid-dash, came back to DoorDash, and "it said it had recovered"
+#### 3. Switched apps mid-dash, came back to DoorDash, bubble showed "Session resumed (grace)"
 
 - **Field observation:** Started another dash, switched to a different app, and
-  on returning to the DoorDash app saw a message that "it had recovered." Unclear
-  *which* app surfaced the message or what exactly was recovered; flagged as a
-  thing to watch.
-- **Status:** Open (needs disambiguation — which app, and whether DashBuddy kept
-  the dash). **Add to the next-field-test checklist** so the next dash captures
-  the missing detail.
-- **First, the disambiguating fact (desk grep, high confidence):** there is **no
-  user-facing "recovered" / "resumed" / "restored" string anywhere in DashBuddy's
-  code.** The only hits are a Timber log line in `StateManagerV2.kt:256`
-  ("Recovery complete …") and a code *comment* in `FlowCardMapper.kt:159`
-  ("probably a recovered session") — neither renders to the user. So if the
-  dasher *read* the word "recovered" on screen, it was almost certainly
-  **DoorDash's own** UI (DoorDash shows a recovery/restore notice when its own
-  process is reaped and relaunched), **not** a DashBuddy message.
-- **Hypotheses (desk read, speculative — two layers, possibly both):**
-  - **(a) The "recovered" text was DoorDash's**, triggered by the OS reaping
-    *DoorDash* while it was backgrounded during the app-switch, then DoorDash
-    restoring on return. This is the platform's own behavior and inert to us —
-    *except* that DoorDash relaunching emits a fresh burst of accessibility
-    events (a cold-start / splash / restored screen) that our pipeline then
-    re-classifies. The real question is what DashBuddy *did* with that burst.
-  - **(b) DashBuddy's own crash-recovery may have run silently.** If the OS
-    reaped *DashBuddy's* process (or its accessibility service) while
-    backgrounded, on return `StateManagerV2.restoreState` (`:214-261`) replays
-    from the latest snapshot + the observation tail with `recovering = true`
-    (external effects suppressed). This posts **no** on-screen message, so it
-    wouldn't be what the dasher *read* — but it could still be running under the
-    hood. The thing to verify is whether that replay **preserved the active
-    dash/task** or quietly reset/duplicated the session.
-- **Why this matters / cross-refs:** this sits right on top of two live concerns —
-  the **#286/#290 grace-vs-fresh-dash** checklist item (a mid-dash app-switch +
-  return should *resume the same* dash, not start fresh or double-start) and the
-  **2026-05-29 bug #2** "forgot I was at HEB" (looking at another screen mustn't
-  mutate active-task state). The "recovered" notice is a new variant of the same
-  app-switch boundary, so the on-dash check is: **after the recovery notice, did
-  the bubble still show the same in-progress dash/task, with earnings intact?**
+  on returning to DoorDash the **DashBuddy bubble** showed a message the dasher
+  recalled as "recovered (grace)." Dasher wasn't sure why it fired.
+- **Status:** Open — but **source now pinned** (see below). The likely-correct
+  read is that this is the grace mechanism *working*; the open part is whether an
+  app-switch *should* trip it and whether surfacing the message is desirable.
+- **Source pinned (desk grep, high confidence):** the bubble string is literally
+  **`"Session resumed (grace)"`** — `EffectMap.kt:319`,
+  `add(AppEffect.UpdateBubble("Session resumed (grace)"))`. (This **corrects** the
+  earlier hypothesis in this entry's first draft that the notice was DoorDash's
+  own UI — it is a DashBuddy bubble message. The earlier grep missed it because it
+  lives in `:core:state`, not `:app`.)
+- **When it fires (`EffectMap.kt:299-320`):** on an **Offline → Online**
+  transition where the resumed region's `session.sessionId` **equals** the prior
+  session's id (`:316`). That branch is reached only when the session was held
+  alive under the **grace window** (`DEFAULT_GRACE_MS = 10_000L`) rather than
+  finalized — i.e. DashBuddy briefly saw the region go Offline, then back Online
+  within ~10s, and resumed the **same** dash (no new `DASH_START`, no odometer
+  restart — `:317` comment: "same session, no start effects needed").
+- **What most likely happened (hypothesis):** while DoorDash was backgrounded
+  during the app-switch, DashBuddy stopped seeing DoorDash's online/idle screen
+  and the region read as **Offline**; returning within the grace window flipped it
+  back **Online** with the same session → the grace-resume branch fired and posted
+  the bubble. By construction (`:316` checks `prevSession?.sessionId ==
+  nextSession.sessionId`) this means it **resumed the same dash**, which is the
+  *desired* outcome for a brief mid-dash blip.
+- **This is a (partial) positive for #286/#290.** That checklist item's
+  regression-watch is exactly "a brief offline blip mid-dash still **resumes the
+  same** dash (no spurious new session)." Seeing "Session resumed (grace)" — and
+  *not* a fresh-session reset — on an app-switch return is one clean sighting of
+  that path holding. Logged as a partial confirmation there.
+- **The genuinely open parts (not defects yet — UX / scope questions):**
+  - **(a) Should a mere app-switch register as Offline at all?** If DashBuddy is
+    just backgrounded (its service alive, simply not receiving DoorDash events),
+    treating "I stopped seeing DoorDash" as "the region went Offline" is the same
+    class of concern as 2026-05-29 bug #2 ("looking at another screen mustn't
+    mutate active-task state"). Here it recovered cleanly via grace, but it's
+    worth confirming the *task* (not just the session) also survived intact.
+  - **(b) Is surfacing "Session resumed (grace)" to the user desirable?** It reads
+    as internal-mechanism jargon (the dasher didn't know what it meant). Even at
+    alpha-single-user, it may be noise — candidate to demote to a debug log, or
+    reword to something a dasher parses ("Picked your dash back up"). Dasher's
+    call; logging as a UX observation, not prescribing.
 - **What would confirm or refute this at the desk:**
-  - Establish **which app** showed "recovered" (DoorDash vs the DashBuddy bubble).
-    Given the grep above, expectation is DoorDash. A screenshot of the notice next
-    time would settle it instantly.
-  - Pull DashBuddy logcat around the app-return: presence of "Replaying N
-    observations after snapshot…" / "Recovery complete" (`StateManagerV2.kt:240,
-    256`) confirms (b) — DashBuddy's own recovery ran. Absence means the service
-    stayed alive and only DoorDash restarted.
-  - Either way, check the session/task continuity: did `activeTask` and the dash
-    session survive, or did a new `DASH_START` / "fresh session" fire? That's the
-    actual pass/fail, independent of who printed the word "recovered."
+  - Pull DashBuddy logcat around the app-return: expect a `"Session grace resume:
+    <id>"` line (`EffectMap.kt:318`) and an Offline→Online region transition
+    within 10s, with the **same** `sessionId` before and after. That confirms the
+    grace path (vs a fresh start, which would log `DASH_START` with
+    `source = "interaction"`/`"recovery"` at `:310-313`).
+  - Confirm the **active task** survived the blip (not just the session): check
+    `activeTask` was non-null across the transition and `pendingDestructive`
+    (the retire-grace) was cancelled on return, per `TaskLifecycleGuardTest`'s
+    "returning to a task cancels the grace" expectation.
 
 ---
 

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -67,7 +67,12 @@ immediately (no second pass needed) so it gets triaged.
   `total == "Done (x)" + "To shop (y)"`. **Add-on case:** if you accept an
   add-on / second order at the same store mid-shop, confirm "To shop" jumps up,
   the total grows, and the pace keeps counting on the *same* card (no reset).
-  - Confirmed: 0/2.
+  - Confirmed: 1/2. **Partial — 2026-06-03 (DoorDash):** the live pace *did*
+    render and **tick** on the pickup/shop card during the shop. **Not** seen
+    this dash: the finalized/frozen card, the `total == "Done (x)" + "To shop
+    (y)"` cross-check, and the add-on case. Counting this as one clean
+    live-ticking sighting; the next dash should confirm finalization + add-on
+    before retiring the item. (See 2026-06-03 log entry.)
 - **Offers behind a loading overlay (#275, merged 2026-06-02).** When an offer
   briefly shows a spinner (on present, or right as you tap), confirm it stays
   recognized as an offer — the bubble shouldn't flicker out of the offer view
@@ -127,6 +132,92 @@ immediately (no second pass needed) so it gets triaged.
   - **Status:** Triaged → tracked as #279 (summary attribution fixed in PR; the
     "summary after the idle screen" ordering was the root cause). Field-validate
     via the #279 checklist item above.
+
+---
+
+## 2026-06-03 — DoorDash session (live capture during dash)
+
+- **Platform tested:** DoorDash
+- **Branch under test:** `master` at `776b0a8` (post-#272 merge; latest code on
+  `master` is the #271 card-polish + #270 nav-generic-idle merges) — inferred,
+  developer to correct if the build came from elsewhere.
+- **Field conditions:** developer dashing on DoorDash; entry captured live.
+  Includes a Shop & Deliver leg (pacing observed) and an app **crash** at the
+  end of a delivery right around the post-dropoff auto-expand click.
+
+### Bugs
+
+#### 1. App crashed after dropoff, at/just after the automated "expand delivery details" click
+
+- **Field observation:** Right after completing a dropoff, the app crashed —
+  "as soon as the app clicked, or just after the click" — referring to the
+  **automated** click that expands the post-delivery pay breakdown. The dasher
+  did not (yet) provide a stack trace; timing is the main signal we have.
+- **Status:** Open. **Most valuable next artifact: the crash stack trace /
+  logcat** — without it the layer below is a guess between three candidates.
+- **What fires at that exact moment (the post-task collapsed screen):**
+  `doordash.json:659-678` runs **two** effects when the collapsed `post_task`
+  screen matches: (1) `click: $expandButton` (gated `isExpanded == false`,
+  `dedupeKey: expand_pay_breakdown`, `throttleMs: 1000`, **`delayMs: 500`**),
+  then (2) a `screenshot` (`prefix: "Delivery - {totalPay}"`, `throttleMs:
+  60000`). So "at/just after the click" overlaps the click dispatch, the
+  platform's expand animation, **and** the screenshot capture — three places a
+  crash could originate.
+- **Hypotheses (desk read, not verified against a trace — all speculative):**
+  - **(a) The auto-click dispatch itself.** `SideEffectEngine.kt:113-116` →
+    `UiInteractionHandler.performClick` (`UiInteractionHandler.kt:19-64`) →
+    `AccNodeUtils.clickNode`. `performClick` re-resolves the target against the
+    *live* root via `findAccessibilityNodeInfosByViewId` / `…ByText` / a bounds
+    walk (`findNodeByBounds`, `:70-88`). The empty/null paths are guarded
+    (returns with a `Timber.w`), but the recursive `findNodeByBounds` and the
+    raw `AccessibilityNodeInfo` operations aren't wrapped in try/catch — a stale
+    / recycled node mid-expand could throw `IllegalStateException`. Plausible but
+    not obviously the most likely.
+  - **(b) The screenshot effect that fires right after.** `ScreenShotHandler.kt`
+    uses `service.takeScreenshot` → `Bitmap.wrapHardwareBuffer` →
+    MediaStore write, then `result.hardwareBuffer.close()` in `onSuccess`
+    (`:39-45`). The body is `try/catch(Exception)` wrapped and `saveToGallery`
+    catches its own exceptions, so an *app-killing* crash here seems less likely
+    — but the `hardwareBuffer.close()` sits *outside* `saveToGallery`'s guard, so
+    if `saveToGallery` throws unexpectedly the buffer may leak rather than crash.
+    Lower suspicion, but worth ruling out via the trace.
+  - **(c) Processing the *expanded* screen the click produced (favored on
+    timing).** "Just after the click" is also exactly when the breakdown expands
+    and DoorDash emits a burst of accessibility events for the new content, which
+    our pipeline then parses (the expanded `post_task` parse that yields
+    `parsedPay` / `payLineItems`, c.f. `ParsedFieldsFactory` per 2026-05-19 #4).
+    A null/format assumption in that expanded-pay parse would crash *as a result
+    of* the click rather than *in* it — which matches the dasher's "just after"
+    wording better than the click dispatch itself.
+- **Relationship to prior work:** the post-task auto-expand pipeline was last
+  touched in **#266** (2026-05-19 bug #4 — first-click race / re-fire). Note the
+  rule now carries `delayMs: 500` (an initial delay before the first click),
+  which is the #266 timing fix. This crash is a **new** symptom (a hard crash,
+  not the previous "click didn't complete" / "bubble re-fired"), so it's either
+  a regression introduced alongside that flow or a latent path #266 didn't touch.
+- **What would confirm or refute this at the desk:**
+  - **Pull the crash stack trace** (logcat / the on-device crash log). The top
+    frame immediately disambiguates (a) `UiInteractionHandler`/`AccNodeUtils`
+    vs (b) `ScreenShotHandler` vs (c) the expanded-`post_task` parse path.
+  - If a snapshot of the expanded breakdown was captured this dash, run it
+    through the parse path that builds `parsedPay`/`payLineItems` and check for
+    a null/format assumption that the live expanded screen would violate.
+  - Cross-check the screenshot output: a `Pictures/DashBuddy/… Delivery - …png`
+    file existing for that delivery means the screenshot effect ran to
+    completion (pushes suspicion toward (a)/(c), away from (b)).
+
+### Verification TODOs
+
+#### 2. Shop & Deliver live pace ticked during the shop (#276 partial confirmation)
+
+- **Field observation:** On a Shop & Deliver leg, the bubble pickup/shop card
+  showed the live items/min pace and it **ticked** while shopping — the core
+  #276 behavior. The dasher did **not** see the finalization (the frozen card
+  after the leg) this dash, so the `total == "Done (x)" + "To shop (y)"`
+  cross-check and the add-on-mid-shop case remain unconfirmed.
+- **Status:** Partial confirmation logged against the #276 checklist item
+  (Confirmed 1/2 — live ticking only). Needs a second dash to confirm
+  finalization + add-on before the checklist item is retired.
 
 ---
 

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -121,6 +121,15 @@ immediately (no second pass needed) so it gets triaged.
       recognized — flag it for a redaction + sensitive rule.
   - Confirmed: 0/2.
 
+- **App-switch mid-dash → "recovered" notice → dash continuity (2026-06-03 #3).**
+  Mid-dash, switch to another app and come back to DoorDash. If a "recovered"
+  notice appears, **note which app showed it** (DoorDash vs the DashBuddy bubble —
+  a screenshot is ideal; no DashBuddy string says "recovered", so it's expected to
+  be DoorDash's). Then confirm DashBuddy **kept the same in-progress dash/task**
+  with earnings intact — it must **not** start a fresh dash, double-start, or
+  forget the active task (cross-refs #286/#290 grace and 2026-05-29 #2).
+  - Confirmed: 0/2.
+
 ---
 
 ## Untriaged — carried over from scratch notes
@@ -218,6 +227,59 @@ immediately (no second pass needed) so it gets triaged.
 - **Status:** Partial confirmation logged against the #276 checklist item
   (Confirmed 1/2 — live ticking only). Needs a second dash to confirm
   finalization + add-on before the checklist item is retired.
+
+### Open questions / investigations
+
+#### 3. Switched apps mid-dash, came back to DoorDash, and "it said it had recovered"
+
+- **Field observation:** Started another dash, switched to a different app, and
+  on returning to the DoorDash app saw a message that "it had recovered." Unclear
+  *which* app surfaced the message or what exactly was recovered; flagged as a
+  thing to watch.
+- **Status:** Open (needs disambiguation — which app, and whether DashBuddy kept
+  the dash). **Add to the next-field-test checklist** so the next dash captures
+  the missing detail.
+- **First, the disambiguating fact (desk grep, high confidence):** there is **no
+  user-facing "recovered" / "resumed" / "restored" string anywhere in DashBuddy's
+  code.** The only hits are a Timber log line in `StateManagerV2.kt:256`
+  ("Recovery complete …") and a code *comment* in `FlowCardMapper.kt:159`
+  ("probably a recovered session") — neither renders to the user. So if the
+  dasher *read* the word "recovered" on screen, it was almost certainly
+  **DoorDash's own** UI (DoorDash shows a recovery/restore notice when its own
+  process is reaped and relaunched), **not** a DashBuddy message.
+- **Hypotheses (desk read, speculative — two layers, possibly both):**
+  - **(a) The "recovered" text was DoorDash's**, triggered by the OS reaping
+    *DoorDash* while it was backgrounded during the app-switch, then DoorDash
+    restoring on return. This is the platform's own behavior and inert to us —
+    *except* that DoorDash relaunching emits a fresh burst of accessibility
+    events (a cold-start / splash / restored screen) that our pipeline then
+    re-classifies. The real question is what DashBuddy *did* with that burst.
+  - **(b) DashBuddy's own crash-recovery may have run silently.** If the OS
+    reaped *DashBuddy's* process (or its accessibility service) while
+    backgrounded, on return `StateManagerV2.restoreState` (`:214-261`) replays
+    from the latest snapshot + the observation tail with `recovering = true`
+    (external effects suppressed). This posts **no** on-screen message, so it
+    wouldn't be what the dasher *read* — but it could still be running under the
+    hood. The thing to verify is whether that replay **preserved the active
+    dash/task** or quietly reset/duplicated the session.
+- **Why this matters / cross-refs:** this sits right on top of two live concerns —
+  the **#286/#290 grace-vs-fresh-dash** checklist item (a mid-dash app-switch +
+  return should *resume the same* dash, not start fresh or double-start) and the
+  **2026-05-29 bug #2** "forgot I was at HEB" (looking at another screen mustn't
+  mutate active-task state). The "recovered" notice is a new variant of the same
+  app-switch boundary, so the on-dash check is: **after the recovery notice, did
+  the bubble still show the same in-progress dash/task, with earnings intact?**
+- **What would confirm or refute this at the desk:**
+  - Establish **which app** showed "recovered" (DoorDash vs the DashBuddy bubble).
+    Given the grep above, expectation is DoorDash. A screenshot of the notice next
+    time would settle it instantly.
+  - Pull DashBuddy logcat around the app-return: presence of "Replaying N
+    observations after snapshot…" / "Recovery complete" (`StateManagerV2.kt:240,
+    256`) confirms (b) — DashBuddy's own recovery ran. Absence means the service
+    stayed alive and only DoorDash restarted.
+  - Either way, check the session/task continuity: did `activeTask` and the dash
+    session survive, or did a new `DASH_START` / "fresh session" fire? That's the
+    actual pass/fail, independent of who printed the word "recovered."
 
 ---
 

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -157,19 +157,52 @@ immediately (no second pass needed) so it gets triaged.
   `master` is the #271 card-polish + #270 nav-generic-idle merges) — inferred,
   developer to correct if the build came from elsewhere.
 - **Field conditions:** developer dashing on DoorDash; entry captured live.
-  Includes a Shop & Deliver leg (pacing observed) and an app **crash** at the
-  end of a delivery right around the post-dropoff auto-expand click.
+  Includes a Shop & Deliver leg (pacing observed), an app-switch grace-resume,
+  and a **reproducible crash in the post-delivery phase on both deliveries**
+  (around the auto-expand click). Multiple short back-to-back dashes.
 
 ### Bugs
 
-#### 1. App crashed after dropoff, at/just after the automated "expand delivery details" click
+#### 1. App crashes in the post-delivery phase, at/around the automated "expand delivery details" click (REPRODUCED — both deliveries this dash)
 
-- **Field observation:** Right after completing a dropoff, the app crashed —
-  "as soon as the app clicked, or just after the click" — referring to the
-  **automated** click that expands the post-delivery pay breakdown. The dasher
-  did not (yet) provide a stack trace; timing is the main signal we have.
-- **Status:** Open. **Most valuable next artifact: the crash stack trace /
-  logcat** — without it the layer below is a guess between three candidates.
+- **Field observation:** Crashed in the post-delivery phase on **both** deliveries
+  this session. First: right after a dropoff, "as soon as the app clicked, or just
+  after the click" — the **automated** click that expands the post-delivery pay
+  breakdown. Second: started a new dash immediately after the first delivery and it
+  crashed again in the same post-delivery phase. Dasher's read: "there is something
+  going on in the post-delivery phase," and it's "probably something to do with"
+  the **recent state-machine / hooks-and-triggers changes.** No stack trace yet —
+  dasher plans to pull captures + logcat.
+- **Status:** Open — **reproducible (2/2 deliveries this dash).** The repeat on
+  both deliveries rules out the earlier "one-off stale-node race" framing: a
+  consistent crash points at a **code path** in the post-delivery phase, not
+  timing luck. **Blocked on the crash stack trace** to pin the layer.
+- **Recent-change surface (the dasher's "hooks and triggers" hunch, corroborated
+  at the desk).** The post-delivery phase has the most recent churn anywhere in
+  the state machine, all in the build under test: `4575441` (post-task
+  best-effort + dup-skip + UDF click delay + safety screenshots, #266) reworked
+  the exact expand/announce flow; `d584060` (DELIVERY_CONFIRMED closes drop-off
+  task on transition away) changed how the task is retired here; `5f44413`
+  (transition override system) is the trigger plumbing — the post-delivery
+  transition fires `triggerOverrideEffects(obs, TASK_COMPLETED)`
+  (`EffectMap.kt:206`).
+- **Sharpened hypothesis — the new SETTLE_UI deferred-click path (now favored).**
+  The #266 work no longer clicks inline; the `delayMs: 500` expand click
+  (`doordash.json:670`) is routed through a brand-new round-trip:
+  `diffRuleEffects` (`EffectMap.kt:653-662`) sees CLICK with `delayMs > 0` and
+  emits `ScheduleTimeout(SETTLE_UI)` carrying a **serialized** click context
+  (`serializeClickContext`, `:695-714`); when it fires, `diffSettleUiTimeout`
+  (`:673-693`) **reconstructs** a `NodeRef` (`deserializeNodeRef`, `:716-732`)
+  and re-dispatches the click against possibly-changed live UI. That serialize →
+  defer ~500ms → reconstruct → re-dispatch chain is new surface sitting exactly
+  in the crashing phase, and the ~500ms delay matches "just after." It then
+  re-enters `UiInteractionHandler.performClick` (see hypothesis (a) below — the
+  unguarded `findNodeByBounds` recursion / raw node ops).
+- **What the desk pass ruled OUT:** the `effect.delayMs!!` at `EffectMap.kt:659`
+  is **guarded** by `(effect.delayMs ?: 0L) > 0L` at `:653` (not the NPE);
+  `serializeClickContext` / `deserializeNodeRef` use null-safe casts throughout;
+  `parsedFieldsToMap`'s reflection (`:753-758`) is `try`-wrapped. No obvious throw
+  site among them — consistent with needing the trace.
 - **What fires at that exact moment (the post-task collapsed screen):**
   `doordash.json:659-678` runs **two** effects when the collapsed `post_task`
   screen matches: (1) `click: $expandButton` (gated `isExpanded == false`,
@@ -212,8 +245,14 @@ immediately (no second pass needed) so it gets triaged.
   a regression introduced alongside that flow or a latent path #266 didn't touch.
 - **What would confirm or refute this at the desk:**
   - **Pull the crash stack trace** (logcat / the on-device crash log). The top
-    frame immediately disambiguates (a) `UiInteractionHandler`/`AccNodeUtils`
-    vs (b) `ScreenShotHandler` vs (c) the expanded-`post_task` parse path.
+    frame immediately disambiguates: `EffectMap.diffSettleUiTimeout` /
+    `deserializeNodeRef` or `UiInteractionHandler` / `AccNodeUtils` → the new
+    deferred-click path; a parse class → the expanded-screen path (c);
+    `ScreenShotHandler` → (b).
+  - Look for a `SETTLE_UI` timeout firing right before the crash — its presence
+    ties the crash to the deferred-click round-trip. And test whether the crash
+    still repros on a delivery where the expand never auto-fires (throttle/dedupe
+    suppressed) — if it doesn't, the deferred-click path is the culprit.
   - If a snapshot of the expanded breakdown was captured this dash, run it
     through the parse path that builds `parsedPay`/`payLineItems` and check for
     a null/format assumption that the live expanded screen would violate.


### PR DESCRIPTION
Field-testing log capture from a live DoorDash session on 2026-06-03. Docs-only — adds a new session entry and updates the "Next field test" checklist. **No code touched.**

`[skip ci]`

## Session observations logged

**Bug #1 — Post-delivery crash, REPRODUCED (2/2 deliveries).** App crashed in the post-delivery phase on both deliveries, at/around the automated "expand delivery details" click. Reproduction rules out a one-off stale-node race → points at a code path. Sharpened hypothesis: the new **SETTLE_UI deferred-click round-trip** (#266 — serialize click context → `ScheduleTimeout(SETTLE_UI)` → reconstruct `NodeRef` → re-dispatch ~500ms later) is new surface sitting exactly in the crashing phase. Desk pass ruled out the obvious NPE candidates (`delayMs!!` is guarded; serialize/deserialize null-safe). **Blocked on the crash stack trace** — entry lists exact discriminators (top frame + presence of a `SETTLE_UI` timeout before the crash).

**Open question #3 — App-switch "Session resumed (grace)".** Mid-dash app-switch return surfaced the bubble's `"Session resumed (grace)"` message (`EffectMap.kt:319`). Pinned to the grace mechanism resuming the **same** session (working as designed) → logged as a partial positive for the #286/#290 regression-watch. Genuinely-open parts: should an app-switch register as Offline at all, and is surfacing that internal-sounding message desirable.

**Verification #2 — Shop & Deliver pace (#276).** Live items/min pace rendered and ticked during the shop → partial confirmation (1/2). Finalization + add-on case still unconfirmed.

## Checklist updates (`## Next field test — things to look for`)
- #276 → Confirmed 1/2 (live ticking only).
- #286/#290 → partial (brief-offline-blip resumed same dash); active-task survival + start-paths still open.
- New item: app-switch → "Session resumed (grace)" → dash + task continuity (0/2).

All hypotheses framed as hypotheses per the field-log protocol — no fixes applied, no code changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KvvWcjuYdUYxC6d2vuaieA)_