### PR TITLE
fix(#297): stop fatal bubble-HUD LazyColumn duplicate-key crash

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleScreen.kt
@@ -211,7 +211,12 @@ fun DashboardView(
                         }
                     }
                     items(
-                        items = cardStack.completed.asReversed(),
+                        // distinctBy is a last-line crash guard: a duplicate
+                        // key here is a fatal Compose exception, so never trust
+                        // the upstream list to be unique (FlowCardMapper already
+                        // dedups, but the HUD must not crash if a new source of
+                        // collisions ever slips through).
+                        items = cardStack.completed.distinctBy { it.id }.asReversed(),
                         key = { it.id },
                     ) { snap ->
                         val expanded = expandedIds[snap.id] == true

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardMapper.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardMapper.kt
@@ -317,7 +317,20 @@ object FlowCardMapper {
             }
         }
 
-        return completed
+        // Dedup by card id, keeping the last (most-complete) occurrence.
+        // The card id is the LazyColumn key, which MUST be unique or Compose
+        // throws a fatal IllegalArgumentException ("Key ... was already used").
+        // Several real event orderings emit the same id twice:
+        //   • DELIVERY_ARRIVED *and* DELIVERY_CONFIRMED for one dropoff — the
+        //     mapper once assumed these were mutually exclusive, but
+        //     arrival-bearing dropoffs (photo / PIN / hand-it-to-customer /
+        //     alcohol ID-scan) fire both. Field DB 2026-06-03 (taskId
+        //     c0041f37: ARRIVED 17:59:23 → CONFIRMED 17:59:33 → crash 17:59:34).
+        //   • A dropoff that double-fires DELIVERY_CONFIRMED (same DB, 22:00).
+        //   • The same offerHash decided twice / a job that double-completes.
+        // associateBy keeps each id at its first-seen position with the last
+        // value — chronological order preserved, newest content wins.
+        return completed.associateBy { it.id }.values.toList()
     }
 
     private fun <T> decode(event: AppEventEntity, klass: Class<T>): T? = try {

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardMapperTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardMapperTest.kt
@@ -243,6 +243,93 @@ class FlowCardMapperTest {
     }
 
     // =========================================================================
+    // Duplicate-key crash regressions (field DB 2026-06-03)
+    // =========================================================================
+
+    @Test
+    fun `delivery with BOTH arrival and confirmed produces ONE delivery card (no duplicate key)`() {
+        // Field crash: arrival-bearing dropoffs (photo / PIN / hand-it /
+        // alcohol ID-scan) fire DELIVERY_ARRIVED *and* DELIVERY_CONFIRMED for
+        // the same taskId. The mapper added a `delivery:<taskId>` card for each
+        // → duplicate LazyColumn key → fatal crash (taskId c0041f37,
+        // ARRIVED 17:59:23 → CONFIRMED 17:59:33 → crash 17:59:34).
+        val events = listOf(
+            event(AppEventType.DASH_START,
+                SessionStartPayload("s1", "DoorDash", 1000L, "interaction", "WaitingForOffer"), 1000L),
+            event(AppEventType.OFFER_RECEIVED, "{}", 1500L),
+            event(AppEventType.OFFER_ACCEPTED,
+                offerPayload("o1", AppEventType.OFFER_ACCEPTED, 1500L, 1600L), 1600L),
+            event(AppEventType.PICKUP_NAV_STARTED,
+                pickupPayload("T1", "J1", "Wendy's", 1600L), 1600L),
+            event(AppEventType.PICKUP_CONFIRMED,
+                pickupPayload("T1", "J1", "Wendy's", 1600L, confirmed = 2000L), 2000L),
+            event(AppEventType.DELIVERY_NAV_STARTED,
+                deliveryPayload("T2", "J1", 2000L), 2000L),
+            event(AppEventType.DELIVERY_ARRIVED,
+                deliveryPayload("T2", "J1", 2000L, arrived = 2500L), 2500L),
+            event(AppEventType.DELIVERY_CONFIRMED,
+                deliveryPayload("T2", "J1", 2000L, arrived = 2500L), 2600L),
+            event(AppEventType.DELIVERY_COMPLETED,
+                deliveryPayload("T2", "J1", 2000L, arrived = 2500L, completed = 2700L, totalPay = 7.50), 2700L),
+        )
+
+        val cards = FlowCardMapper.fold(events)
+
+        // Exactly one delivery card, and all card ids are unique (the invariant
+        // the LazyColumn key requires).
+        val deliveries = cards.filterIsInstance<FlowCardSnapshot.Delivery>()
+        assertEquals(1, deliveries.size)
+        assertEquals("T2", deliveries[0].taskId)
+        assertEquals(cards.map { it.id }.distinct().size, cards.size)
+    }
+
+    @Test
+    fun `double DELIVERY_CONFIRMED for same task produces ONE delivery card`() {
+        // Same field session, 22:00 crash: taskId 4d62f8ea fired ARRIVED then
+        // DELIVERY_CONFIRMED twice (22:00:37 and 22:00:41).
+        val events = listOf(
+            event(AppEventType.DASH_START,
+                SessionStartPayload("s1", "DoorDash", 1000L, "interaction", "WaitingForOffer"), 1000L),
+            event(AppEventType.DELIVERY_NAV_STARTED,
+                deliveryPayload("D1", "J1", 2000L), 2000L),
+            event(AppEventType.DELIVERY_ARRIVED,
+                deliveryPayload("D1", "J1", 2000L, arrived = 2500L), 2500L),
+            event(AppEventType.DELIVERY_CONFIRMED,
+                deliveryPayload("D1", "J1", 2000L, arrived = 2500L), 2600L),
+            event(AppEventType.DELIVERY_CONFIRMED,
+                deliveryPayload("D1", "J1", 2000L, arrived = 2500L), 2640L),
+        )
+
+        val cards = FlowCardMapper.fold(events)
+        assertEquals(1, cards.filterIsInstance<FlowCardSnapshot.Delivery>().size)
+        assertEquals(cards.map { it.id }.distinct().size, cards.size)
+    }
+
+    @Test
+    fun `same offer hash decided twice produces ONE offer card`() {
+        // The offer:<hash> crash family (field 2026-05-25) — the same offer
+        // re-presented and re-decided would add two offer cards with the same
+        // offerHash → duplicate key. Dedup keeps the last decision.
+        val events = listOf(
+            event(AppEventType.DASH_START,
+                SessionStartPayload("s1", "DoorDash", 1000L, "interaction", "WaitingForOffer"), 1000L),
+            event(AppEventType.OFFER_RECEIVED, "{}", 1500L),
+            event(AppEventType.OFFER_DECLINED,
+                offerPayload("dup-hash", AppEventType.OFFER_DECLINED, 1500L, 1700L), 1700L),
+            event(AppEventType.OFFER_RECEIVED, "{}", 2000L),
+            event(AppEventType.OFFER_ACCEPTED,
+                offerPayload("dup-hash", AppEventType.OFFER_ACCEPTED, 2000L, 2100L), 2100L),
+        )
+
+        val cards = FlowCardMapper.fold(events)
+        val offers = cards.filterIsInstance<FlowCardSnapshot.Offer>()
+        assertEquals(1, offers.size)
+        // Last decision wins.
+        assertEquals(AppEventType.OFFER_ACCEPTED, offers[0].outcome)
+        assertEquals(cards.map { it.id }.distinct().size, cards.size)
+    }
+
+    // =========================================================================
     // Decline path
     // =========================================================================
 

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -116,6 +116,14 @@ immediately (no second pass needed) so it gets triaged.
       recognized — flag it for a redaction + sensitive rule.
   - Confirmed: 0/2.
 
+- **Bubble HUD no longer crashes on arrival-bearing dropoffs (#297).** Complete a
+  dropoff that has an explicit arrival step — a **photo**, **PIN entry**,
+  **hand-it-to-customer**, or **alcohol ID-scan** delivery (these fire both
+  `DELIVERY_ARRIVED` and `DELIVERY_CONFIRMED`). The bubble must **not** crash, and
+  the completed-card stack should show exactly **one** delivery card for that stop
+  (no duplicate). Previously this was a hard `LazyColumn` duplicate-key crash.
+  - Confirmed: 0/2.
+
 ---
 
 ## Untriaged — carried over from scratch notes
@@ -127,6 +135,34 @@ immediately (no second pass needed) so it gets triaged.
   - **Status:** Triaged → tracked as #279 (summary attribution fixed in PR; the
     "summary after the idle screen" ordering was the root cause). Field-validate
     via the #279 checklist item above.
+
+---
+
+## 2026-06-03 — DoorDash session (live capture during dash)
+
+- **Platform tested:** DoorDash
+- **Branch under test:** `master` (post-#149 merge era; build from the dev phone)
+- **Field conditions:** full session with captures + app logs + DB snapshot
+  archived to `logs/2026/06/03/` (`captures/`, `app.log` + rotations, `db/dashbuddy-v2.db`).
+
+### Bugs
+
+1. **Bubble HUD crashes (FATAL) with a `LazyColumn` duplicate-key error.** Two
+   crashes this session: 17:59:34 (`Key "delivery:c0041f37…"`) and 22:00:37
+   (`Key "delivery:4d62f8ea…"`). Also seen in prior sessions as `offer:` (05-25)
+   and `posttask:` (05-22).
+   - **Confirmed root cause (from `db/dashbuddy-v2.db` `app_events`):** the
+     dropoff fired **both** `DELIVERY_ARRIVED` and `DELIVERY_CONFIRMED` for the
+     same taskId (c0041f37: ARRIVED 17:59:23 → CONFIRMED 17:59:33 → crash
+     17:59:34; 4d62f8ea even double-fired CONFIRMED at 22:00:37 and 22:00:41).
+     `FlowCardMapper.fold` added a `delivery:<taskId>` card on each closing
+     event and never deduplicated — and the card `id` is the `LazyColumn` key,
+     which must be unique. The mapper assumed ARRIVED/CONFIRMED were mutually
+     exclusive, but arrival-bearing dropoffs (photo / PIN / hand-it-to-customer,
+     and now the alcohol ID-scan from #149) fire both.
+   - **Status:** Triaged → tracked as #297. Fixed in PR (dedup-by-id in the
+     mapper + a `distinctBy` backstop at the `LazyColumn` + regression tests).
+     Field-validate next dash (see checklist).
 
 ---
 


### PR DESCRIPTION
Closes #297.

## The crash
Recurring `FATAL EXCEPTION` in the bubble HUD: `IllegalArgumentException: Key "delivery:<uuid>" was already used` (also `offer:<hash>`, `posttask:<jobId>`). Crashes the overlay mid-dash — seen 05-22, 05-25, 05-31, and twice on 06-03.

## Root cause (confirmed against the 2026-06-03 field DB)
`FlowCardMapper.fold` builds the completed-card list with no uniqueness guarantee, and the card `id` *is* the `LazyColumn` key. The mapper assumed `DELIVERY_ARRIVED` and `DELIVERY_CONFIRMED` were mutually exclusive, but arrival-bearing dropoffs (photo / PIN / hand-it-to-customer, and the alcohol ID-scan from #149) fire **both**, each adding a `delivery:<taskId>` card:

```
taskId c0041f37:  ARRIVED 17:59:23 → CONFIRMED 17:59:33      → crash 17:59:34
taskId 4d62f8ea:  ARRIVED 21:56:44 → CONFIRMED 22:00:37 (×2) → crash 22:00:37
```
Crash timestamps match the `CONFIRMED` events to the second. `offer:`/`posttask:` are the same family (same offer decided twice / job double-completing).

## Fix
- **`FlowCardMapper.fold`** dedups the completed list by `id`, keeping the last (most-complete) occurrence, order preserved.
- **`distinctBy { it.id }` backstop** at the `BubbleScreen` `LazyColumn` — a key collision must never be able to crash the glance HUD again, whatever the source.
- **Regression tests**: ARRIVED+CONFIRMED → one delivery card; double-CONFIRMED → one; same offerHash decided twice → one. Full `:app` suite green.

Field-test log entry (2026-06-03) + a checklist item to confirm an arrival-bearing dropoff no longer crashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)