### PR TITLE
fix(#297): stop fatal bubble-HUD LazyColumn duplicate-key crash

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleScreen.kt
@@ -211,7 +211,12 @@ fun DashboardView(
                         }
                     }
                     items(
-                        items = cardStack.completed.asReversed(),
+                        // distinctBy is a last-line crash guard: a duplicate
+                        // key here is a fatal Compose exception, so never trust
+                        // the upstream list to be unique (FlowCardMapper already
+                        // dedups, but the HUD must not crash if a new source of
+                        // collisions ever slips through).
+                        items = cardStack.completed.distinctBy { it.id }.asReversed(),
                         key = { it.id },
                     ) { snap ->
                         val expanded = expandedIds[snap.id] == true

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardMapper.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardMapper.kt
@@ -317,7 +317,20 @@ object FlowCardMapper {
             }
         }
 
-        return completed
+        // Dedup by card id, keeping the last (most-complete) occurrence.
+        // The card id is the LazyColumn key, which MUST be unique or Compose
+        // throws a fatal IllegalArgumentException ("Key ... was already used").
+        // Several real event orderings emit the same id twice:
+        //   • DELIVERY_ARRIVED *and* DELIVERY_CONFIRMED for one dropoff — the
+        //     mapper once assumed these were mutually exclusive, but
+        //     arrival-bearing dropoffs (photo / PIN / hand-it-to-customer /
+        //     alcohol ID-scan) fire both. Field DB 2026-06-03 (taskId
+        //     c0041f37: ARRIVED 17:59:23 → CONFIRMED 17:59:33 → crash 17:59:34).
+        //   • A dropoff that double-fires DELIVERY_CONFIRMED (same DB, 22:00).
+        //   • The same offerHash decided twice / a job that double-completes.
+        // associateBy keeps each id at its first-seen position with the last
+        // value — chronological order preserved, newest content wins.
+        return completed.associateBy { it.id }.values.toList()
     }
 
     private fun <T> decode(event: AppEventEntity, klass: Class<T>): T? = try {

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardMapperTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardMapperTest.kt
@@ -243,6 +243,93 @@ class FlowCardMapperTest {
     }
 
     // =========================================================================
+    // Duplicate-key crash regressions (field DB 2026-06-03)
+    // =========================================================================
+
+    @Test
+    fun `delivery with BOTH arrival and confirmed produces ONE delivery card (no duplicate key)`() {
+        // Field crash: arrival-bearing dropoffs (photo / PIN / hand-it /
+        // alcohol ID-scan) fire DELIVERY_ARRIVED *and* DELIVERY_CONFIRMED for
+        // the same taskId. The mapper added a `delivery:<taskId>` card for each
+        // → duplicate LazyColumn key → fatal crash (taskId c0041f37,
+        // ARRIVED 17:59:23 → CONFIRMED 17:59:33 → crash 17:59:34).
+        val events = listOf(
+            event(AppEventType.DASH_START,
+                SessionStartPayload("s1", "DoorDash", 1000L, "interaction", "WaitingForOffer"), 1000L),
+            event(AppEventType.OFFER_RECEIVED, "{}", 1500L),
+            event(AppEventType.OFFER_ACCEPTED,
+                offerPayload("o1", AppEventType.OFFER_ACCEPTED, 1500L, 1600L), 1600L),
+            event(AppEventType.PICKUP_NAV_STARTED,
+                pickupPayload("T1", "J1", "Wendy's", 1600L), 1600L),
+            event(AppEventType.PICKUP_CONFIRMED,
+                pickupPayload("T1", "J1", "Wendy's", 1600L, confirmed = 2000L), 2000L),
+            event(AppEventType.DELIVERY_NAV_STARTED,
+                deliveryPayload("T2", "J1", 2000L), 2000L),
+            event(AppEventType.DELIVERY_ARRIVED,
+                deliveryPayload("T2", "J1", 2000L, arrived = 2500L), 2500L),
+            event(AppEventType.DELIVERY_CONFIRMED,
+                deliveryPayload("T2", "J1", 2000L, arrived = 2500L), 2600L),
+            event(AppEventType.DELIVERY_COMPLETED,
+                deliveryPayload("T2", "J1", 2000L, arrived = 2500L, completed = 2700L, totalPay = 7.50), 2700L),
+        )
+
+        val cards = FlowCardMapper.fold(events)
+
+        // Exactly one delivery card, and all card ids are unique (the invariant
+        // the LazyColumn key requires).
+        val deliveries = cards.filterIsInstance<FlowCardSnapshot.Delivery>()
+        assertEquals(1, deliveries.size)
+        assertEquals("T2", deliveries[0].taskId)
+        assertEquals(cards.map { it.id }.distinct().size, cards.size)
+    }
+
+    @Test
+    fun `double DELIVERY_CONFIRMED for same task produces ONE delivery card`() {
+        // Same field session, 22:00 crash: taskId 4d62f8ea fired ARRIVED then
+        // DELIVERY_CONFIRMED twice (22:00:37 and 22:00:41).
+        val events = listOf(
+            event(AppEventType.DASH_START,
+                SessionStartPayload("s1", "DoorDash", 1000L, "interaction", "WaitingForOffer"), 1000L),
+            event(AppEventType.DELIVERY_NAV_STARTED,
+                deliveryPayload("D1", "J1", 2000L), 2000L),
+            event(AppEventType.DELIVERY_ARRIVED,
+                deliveryPayload("D1", "J1", 2000L, arrived = 2500L), 2500L),
+            event(AppEventType.DELIVERY_CONFIRMED,
+                deliveryPayload("D1", "J1", 2000L, arrived = 2500L), 2600L),
+            event(AppEventType.DELIVERY_CONFIRMED,
+                deliveryPayload("D1", "J1", 2000L, arrived = 2500L), 2640L),
+        )
+
+        val cards = FlowCardMapper.fold(events)
+        assertEquals(1, cards.filterIsInstance<FlowCardSnapshot.Delivery>().size)
+        assertEquals(cards.map { it.id }.distinct().size, cards.size)
+    }
+
+    @Test
+    fun `same offer hash decided twice produces ONE offer card`() {
+        // The offer:<hash> crash family (field 2026-05-25) — the same offer
+        // re-presented and re-decided would add two offer cards with the same
+        // offerHash → duplicate key. Dedup keeps the last decision.
+        val events = listOf(
+            event(AppEventType.DASH_START,
+                SessionStartPayload("s1", "DoorDash", 1000L, "interaction", "WaitingForOffer"), 1000L),
+            event(AppEventType.OFFER_RECEIVED, "{}", 1500L),
+            event(AppEventType.OFFER_DECLINED,
+                offerPayload("dup-hash", AppEventType.OFFER_DECLINED, 1500L, 1700L), 1700L),
+            event(AppEventType.OFFER_RECEIVED, "{}", 2000L),
+            event(AppEventType.OFFER_ACCEPTED,
+                offerPayload("dup-hash", AppEventType.OFFER_ACCEPTED, 2000L, 2100L), 2100L),
+        )
+
+        val cards = FlowCardMapper.fold(events)
+        val offers = cards.filterIsInstance<FlowCardSnapshot.Offer>()
+        assertEquals(1, offers.size)
+        // Last decision wins.
+        assertEquals(AppEventType.OFFER_ACCEPTED, offers[0].outcome)
+        assertEquals(cards.map { it.id }.distinct().size, cards.size)
+    }
+
+    // =========================================================================
     // Decline path
     // =========================================================================
 

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -136,6 +136,15 @@ immediately (no second pass needed) so it gets triaged.
   showing this internal-sounding message useful, or should it be reworded/demoted?
   - Confirmed: 0/2.
 
+- **Bubble HUD no longer crashes on arrival-bearing dropoffs (#297).** Complete a
+  dropoff with an explicit arrival step — a **photo**, **PIN entry**,
+  **hand-it-to-customer**, or **alcohol ID-scan** delivery (these fire both
+  `DELIVERY_ARRIVED` and `DELIVERY_CONFIRMED`). The bubble must **not** crash, and
+  the completed-card stack should show exactly **one** delivery card for that stop
+  (no duplicate). This was the fatal `LazyColumn` duplicate-key crash from the
+  2026-06-03 session (#297).
+  - Confirmed: 0/2.
+
 ---
 
 ## Untriaged — carried over from scratch notes
@@ -259,6 +268,25 @@ immediately (no second pass needed) so it gets triaged.
   - Cross-check the screenshot output: a `Pictures/DashBuddy/… Delivery - …png`
     file existing for that delivery means the screenshot effect ran to
     completion (pushes suspicion toward (a)/(c), away from (b)).
+- **RESOLVED — root cause found 2026-06-04 from the stack trace (≠ the
+  hypotheses above).** The trace is a Compose layout crash, not an effect/parse
+  crash: `java.lang.IllegalArgumentException: Key "delivery:<uuid>" was already
+  used … provide a unique key for each item`, thrown from
+  `LazyListMeasure → SubcomposeLayout` (the bubble card stack), **not** from
+  `EffectMap` / `UiInteractionHandler` / a parse class / `ScreenShotHandler`. So
+  the SETTLE_UI deferred-click and expanded-parse hypotheses (a)/(b)/(c) were
+  red herrings — the auto-expand click only *triggers a recomposition* that
+  re-measures the `LazyColumn`, and the completed-card list already contained a
+  **duplicate `delivery:<taskId>` card**. `FlowCardMapper.fold` added a delivery
+  card on *both* `DELIVERY_ARRIVED` and `DELIVERY_CONFIRMED`, assuming they were
+  mutually exclusive; arrival-bearing dropoffs (photo / PIN / hand-it-to-customer,
+  and the alcohol ID-scan from #149) fire both. Confirmed in this session's
+  `db/dashbuddy-v2.db` (`app_events`): taskId `c0041f37` ARRIVED 17:59:23 →
+  CONFIRMED 17:59:33 → crash 17:59:34; taskId `4d62f8ea` ARRIVED 21:56:44 →
+  CONFIRMED 22:00:37 (×2) → crash 22:00:37. The `offer:` (05-25) and `posttask:`
+  (05-22) crash variants are the same family. **Tracked as #297; fixed** (dedup
+  the card list by id + a `distinctBy` backstop at the `LazyColumn` + regression
+  tests). Field-validate via the #297 checklist item.
 
 ### Verification TODOs
 


### PR DESCRIPTION
Closes #297. (Supersedes #298, which was auto-closed when its branch was removed during a conflict with the parallel field-log merge #296 — same fix, rebased onto current master.)

## The crash
Recurring `FATAL EXCEPTION` in the bubble HUD: `IllegalArgumentException: Key "delivery:<uuid>" was already used`, thrown from `LazyListMeasure → SubcomposeLayout`. Crashes the overlay mid-dash — 05-22, 05-25, 05-31, ×2 on 06-03.

## Root cause (confirmed against the 2026-06-03 field DB)
`FlowCardMapper.fold` builds the completed-card list with no uniqueness guarantee, and the card `id` *is* the `LazyColumn` key. It assumed `DELIVERY_ARRIVED` and `DELIVERY_CONFIRMED` were mutually exclusive, but arrival-bearing dropoffs (photo / PIN / hand-it-to-customer, and the alcohol ID-scan from #149) fire **both**, each adding a `delivery:<taskId>` card:

```
taskId c0041f37:  ARRIVED 17:59:23 → CONFIRMED 17:59:33      → crash 17:59:34
taskId 4d62f8ea:  ARRIVED 21:56:44 → CONFIRMED 22:00:37 (×2) → crash 22:00:37
```
This pins the field log's open post-delivery crash (2026-06-03 #1): the auto-expand click only triggered the recomposition that re-measured the stack — the SETTLE_UI/click hypothesis was a red herring. `offer:`/`posttask:` are the same family.

## Fix
- **`FlowCardMapper.fold`** dedups by `id`, keeping the last (most-complete) occurrence, order preserved.
- **`distinctBy { it.id }` backstop** at the `BubbleScreen` `LazyColumn` — a key collision must never crash the glance HUD again.
- **Regression tests**: ARRIVED+CONFIRMED → one delivery card; double-CONFIRMED → one; same offerHash twice → one. Full `:app` suite green.

Field log 2026-06-03 #1 updated with the confirmed root cause + a checklist item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)