### PR TITLE
fix(#302): shopping items/min off-by-one — include item counts in dedup identity

### DIFF
--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -159,6 +159,62 @@ immediately (no second pass needed) so it gets triaged.
 
 ---
 
+## 2026-06-05 — DoorDash session (Shop & Deliver, items/min off-by-one)
+
+- **Platform tested:** DoorDash
+- **Branch under test:** `master` (post-#297 merge era). Data archived to
+  `logs/2026/06/04/` and `logs/2026/06/05/` (`captures/`, `app.log` + rotations,
+  `db/dashbuddy-v2.db`).
+- **Field conditions:** multiple Shop & Deliver orders. Developer observation:
+  on Shop & Deliver, the **items/min count finished one short** — at the end of
+  shopping the HUD showed one less than the full item count even though shopping
+  was actually done.
+
+### Bugs
+
+#### 1. Shop & Deliver items/min (and `shop X/total`) caps at `total − 1` — terminal `To shop (0)` frame deduped away
+
+- **Validated against the data — on 06-04/06-05 every shop order ends at `remaining = 1`, never `0`:**
+  | Session | Order size | Last *processed* `pickup_shopping` frame |
+  |---|---|---|
+  | 06-04 ~20:18 | 20 items | `shopped=19 / remaining=1` |
+  | 06-05 ~18:32 | 32 items | `shopped=31 / remaining=1` |
+  | 06-05 ~20:05 | 15 items | `shopped=14 / remaining=1` |
+
+  (from `db/dashbuddy-v2.db` `observations`, `ruleId = doordash.screen.pickup_shopping`.)
+- **But 06-03 DID record the terminal frame** (`remaining = 0`): order #1 hit
+  `shopped=21 / remaining=0` at 17:28:39, order #2 hit `shopped=46 / remaining=0`
+  at 21:35:26. So this is **intermittent, not an inherent gap** — the `To shop (0)`
+  frame *can* be and *was* observed; on 06-04/05 it was dropped. (On 06-05 the log
+  even shows `pickup_shopping` frames classified *after* the last recorded one at
+  20:05:19 that never reached the `observations` table — i.e. **dropped**, not absent.)
+- **Root cause — the post-classification dedup discards count-only changes.**
+  `AccessibilityPipeline` suppresses an observation when its identity equals the
+  previously-emitted one (`AccessibilityPipeline.kt:134`, `identity == lastIdentity`).
+  Identity = `ObservationIdentity("screen", target, parsed.dedupeHash(), modeHint)`
+  (`ObservationIdentity.kt:29`), and **`TaskFields.dedupeHash()` excludes
+  `itemsRemaining` / `itemsShopped`** (`ParsedFields.kt` — it hashes only
+  phase / subFlow / storeName / arrivalConfirmed). So *every* `pickup_shopping`
+  frame shares one identity regardless of progress; a frame that differs only by
+  item count (including the decisive `To shop (0)` / `Done(total)`) is treated as a
+  duplicate and dropped. It's intermittent because an interleaving different-identity
+  screen (`shopping_item`) sometimes breaks the dedup chain right before the (0)
+  frame (06-03) and sometimes doesn't (06-04/05).
+- **Why the metric shows the symptom (code, `FlowCardItem.kt:420-428`):** the
+  Shop & Deliver tertiary line renders `shop $shopped/$total` and `%.1f/min` where
+  `shopped = itemsShopped`, `total = shopped + itemsRemaining`,
+  `perMin = shopped / elapsedMin`. The per-frame parse is correct; because the
+  `→ total` frame is deduped, `itemsShopped` freezes at `total − 1` and the pace is
+  computed on `total − 1`.
+- **Direction (hypothesis):** include the shopping item counts in
+  `TaskFields.dedupeHash()` so each shopping-progress state is a distinct identity
+  and the dedup never collapses count changes — which makes the terminal frame
+  (and every intermediate count) record reliably. Lower-risk than a "finalize on
+  completion" heuristic, and fixes the live card too. To re-confirm on a future
+  dash: watch that the shop card reaches `total/total` at the end.
+
+---
+
 ## 2026-06-03 — DoorDash session (live capture during dash)
 
 - **Platform tested:** DoorDash

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/ParsedFields.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/ParsedFields.kt
@@ -84,6 +84,15 @@ sealed class ParsedFields {
             h = 31 * h + subFlow.hashCode()
             h = 31 * h + storeName.hashCode()
             h = 31 * h + arrivalConfirmed.hashCode()
+            // Shopping progress IS semantic identity for Shop & Deliver. Without
+            // the item counts here, the post-classification dedup
+            // (AccessibilityPipeline: identity == lastIdentity -> drop) collapses
+            // count-only changes — including the decisive "To shop (0)" / Done(total)
+            // frame — so itemsShopped caps at total-1 and items/min finishes one
+            // short. Null for non-shopping tasks, so this is a no-op there.
+            // (field log 2026-06-05)
+            h = 31 * h + itemsRemaining.hashCode()
+            h = 31 * h + itemsShopped.hashCode()
             return h
         }
     }

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/state/ParsedFieldsShoppingDedupeTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/state/ParsedFieldsShoppingDedupeTest.kt
@@ -1,0 +1,62 @@
+package cloud.trotter.dashbuddy.domain.state
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+/**
+ * Regression for the Shop & Deliver items/min off-by-one (field log 2026-06-05).
+ *
+ * The post-classification dedup suppresses an observation whose identity equals
+ * the previously-emitted one, and that identity hashes [ParsedFields.dedupeHash].
+ * For a shopping task the item counts ARE the progress identity, so they must be
+ * part of the hash — otherwise the decisive "To shop (0)" / Done(total) frame is
+ * collapsed against the prior frame and dropped, capping itemsShopped at total-1.
+ */
+class ParsedFieldsShoppingDedupeTest {
+
+    private fun shopping(remaining: Int?, shopped: Int?) = ParsedFields.TaskFields(
+        activity = PickupActivity.SHOPPING,
+        phase = TaskPhase.PICKUP,
+        subFlow = TaskSubFlow.ARRIVED,
+        storeName = "H-E-B",
+        itemsRemaining = remaining,
+        itemsShopped = shopped,
+    )
+
+    @Test
+    fun `shopping frames with different item counts have different dedupe hashes`() {
+        assertNotEquals(
+            "remaining 1 and remaining 0 must be distinct identities, or the terminal frame is deduped away",
+            shopping(remaining = 1, shopped = 14).dedupeHash(),
+            shopping(remaining = 0, shopped = 15).dedupeHash(),
+        )
+    }
+
+    @Test
+    fun `each step of shopping progress is a distinct identity`() {
+        val hashes = (0..5).map { shopped ->
+            shopping(remaining = 5 - shopped, shopped = shopped).dedupeHash()
+        }
+        assertEquals("all six progress states must be unique", 6, hashes.toSet().size)
+    }
+
+    @Test
+    fun `identical shopping frames still dedupe (same hash)`() {
+        assertEquals(
+            shopping(remaining = 3, shopped = 12).dedupeHash(),
+            shopping(remaining = 3, shopped = 12).dedupeHash(),
+        )
+    }
+
+    @Test
+    fun `non-shopping tasks with null counts are unaffected`() {
+        val a = ParsedFields.TaskFields(
+            phase = TaskPhase.DROPOFF, subFlow = TaskSubFlow.NAVIGATION, storeName = "H-E-B",
+        )
+        val b = ParsedFields.TaskFields(
+            phase = TaskPhase.DROPOFF, subFlow = TaskSubFlow.NAVIGATION, storeName = "H-E-B",
+        )
+        assertEquals(a.dedupeHash(), b.dedupeHash())
+    }
+}


### PR DESCRIPTION
Closes #302.

## Symptom (field 2026-06-05)
Shop & Deliver items/min finishes **one short** — HUD freezes at `total−1/total`, pace computed on `total−1`, even when shopping is done.

## Validated against the field DBs
`observations` (ruleId `pickup_shopping`): on **06-04/06-05** every order ended at `remaining=1` (19/20, 31/32, 14/15) and the terminal frame never reached the DB. But **06-03 DID record `remaining=0`** (21/21 and 46/46) — so it's observable but **intermittently dropped**, not an inherent gap. The 06-05 log shows `pickup_shopping` frames classified *after* the last recorded one that never landed in `observations`.

## Root cause
Post-classification dedup drops an observation whose identity equals the previous one (`AccessibilityPipeline.kt:134`). Identity hashes `parsed.dedupeHash()` (`ObservationIdentity.kt:29`), and **`TaskFields.dedupeHash()` excluded `itemsRemaining`/`itemsShopped`** — so every `pickup_shopping` frame shared one identity and the decisive change to `To shop (0)` was collapsed as a duplicate. Intermittent because an interleaving `shopping_item` sometimes breaks the dedup chain before the (0) frame (06-03) and sometimes doesn't (06-04/05). Symptom renders at `FlowCardItem.kt:420-428`.

## Fix
Add the item counts to `TaskFields.dedupeHash()` — for a shopping task the progress count IS semantic identity. Null for non-shopping tasks → no-op there. Fixes the frozen card *and* the live card (every count change, incl. →0, now records).

Tests: `ParsedFieldsShoppingDedupeTest` (distinct hash per progress step; `remaining=0` ≠ `remaining=1`; identical frames still dedupe; non-shopping unaffected). Full `:domain` + `:app` suites green. Field log 2026-06-05 entry added with the validated root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)