### PR TITLE
feat(recognition): recognize nav_arriving ('Arriving at' / 'Arriving soon') screen

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/TriageRulesTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/TriageRulesTest.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Before
@@ -202,6 +203,40 @@ class TriageRulesTest {
         assertEquals(
             "pickup_pre_arrival",
             screen(tree(node(id = "user_name_label", text = "Pickup from"), node(id = "bottom_sheet_container"))),
+        )
+    }
+
+    @Test
+    fun `nav_arriving — bare 'Arriving at' overlay (final approach, was UNKNOWN)`() {
+        assertEquals(
+            "nav_arriving",
+            screen(tree(
+                node(id = "arriving_at_subtitle", text = "Arriving at"),
+                node(id = "arriving_at_title", text = "Wing Daddy's Sauce House (Jackson Keller Rd)"),
+            )),
+        )
+    }
+
+    @Test
+    fun `nav_arriving — 'Arriving soon' header variant`() {
+        assertEquals(
+            "nav_arriving",
+            screen(tree(node(id = "bottom_sheet_arrived_header_v2", text = "Arriving soon"))),
+        )
+    }
+
+    @Test
+    fun `nav_arriving — rejects the full-nav variant (task_title present stays navigation)`() {
+        // The full 'Arriving soon' nav frame carries bottom_sheet_task_title; the
+        // reject keeps it out of nav_arriving so pickup/dropoff_navigation (which
+        // own the task context + flow) win and arrival logic is undisturbed.
+        assertNotEquals(
+            "nav_arriving",
+            screen(tree(
+                node(id = "arriving_at_subtitle", text = "Arriving at"),
+                node(id = "bottom_sheet_arrived_header_v2", text = "Arriving soon"),
+                node(id = "bottom_sheet_task_title", text = "Deliver to Diane B"),
+            )),
         )
     }
 

--- a/core/pipeline/src/main/assets/rules/doordash.json
+++ b/core/pipeline/src/main/assets/rules/doordash.json
@@ -2499,6 +2499,20 @@
       }
     },
     {
+      "id": "doordash.screen.nav_arriving",
+      "priority": 69,
+      "require": {
+        "any": [
+          { "exists": { "hasIdSuffix": "arriving_at_subtitle" } },
+          { "exists": { "hasIdSuffix": "arriving_at_title" } },
+          { "exists": { "hasIdSuffix": "bottom_sheet_arrived_header_v2" } }
+        ]
+      },
+      "reject": [
+        { "exists": { "hasIdSuffix": "bottom_sheet_task_title" } }
+      ]
+    },
+    {
       "id": "doordash.screen.side_nav_drawer",
       "priority": 200,
       "require": {

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -188,6 +188,27 @@ immediately (no second pass needed) so it gets triaged.
     so still **no second data point** on whether another screen can trigger it. Fix
     stays held; keep watching (esp. dashes with a scheduled block queued).
 
+- **`nav_arriving` screen now recognized — confirm it fires + gauge frequency
+  (PR #312).** The in-app nav "Arriving at \<destination\>" / "Arriving soon"
+  overlay was UNKNOWN; it now classifies as `nav_arriving` (neutral — no behavior
+  change yet). On a dash, glance at whether this screen actually appears as you
+  reach a stop, for **both pickups and dropoffs**, and roughly how often (the
+  capture corpus only caught it ~5/50 times — we need to know if that's
+  capture-cadence or it genuinely doesn't show every approach). This decides
+  whether "Arriving" can be the **arming** signal for the nav-exit arrival model
+  ([design](../capture-analysis/2026-06-task-arrival-navexit-model.md)). What to
+  watch: does "Arriving at …"/"Arriving soon" reliably show on final approach?
+  - Confirmed: 0/2.
+- **Try EXITING the map with the Exit button (not the back gesture) — capture the
+  click.** The dev currently exits nav with the system **back gesture**, so no
+  `exit_button` tap is ever captured (0 in all June). The nav screen *does* have an
+  explicit **Exit** button (`id=exit_button`). On a dash, deliberately tap that
+  **Exit** button a few times (pickup and dropoff) so we capture the click — it may
+  give a cleaner, explicit "left navigation" signal than inferring it from the
+  window transition. What to watch/capture: that tapping Exit produces a click
+  capture (and note whether back-gesture vs button changes what DoorDash shows next).
+  - Confirmed: 0/2.
+
 ---
 
 ## Untriaged — carried over from scratch notes


### PR DESCRIPTION
Recognizes the in-app nav **final-approach overlay** that was landing in UNKNOWN — `id=arriving_at_subtitle` "Arriving at" + `arriving_at_title <destination>`, and the `bottom_sheet_arrived_header_v2` "Arriving soon" variant. (The bare overlay has no `bottom_sheet_task_title`, so `pickup/dropoff_navigation` never matched it.)

## What
- New rule `doordash.screen.nav_arriving` (priority 69, **neutral — no `state.flow`**) keyed on those ids, with a **reject on `bottom_sheet_task_title`** so the *full* nav variant stays `pickup/dropoff_navigation` (keeps task context + flow). Being neutral, it has the **same state-machine effect as the prior UNKNOWN — zero behavior change** — but it's now named and captured cleanly.
- 3 synthetic tests in `TriageRulesTest` (bare overlay → `nav_arriving`; "Arriving soon" header → `nav_arriving`; full-nav variant with `task_title` is rejected). `AllMatchersSuite` green.

## Why
This is the recognition step toward the [nav-exit arrival model](https://github.com/sjtrotter/DashBuddy/blob/master/docs/capture-analysis/2026-06-task-arrival-navexit-model.md): getting "Arriving" out of UNKNOWN lets us (a) field-evaluate how reliably it fires (captures only caught it ~5/50 — cadence or genuine?) and (b) later use it as the **arming** signal for arrival (the `pendingDestructive`-style armed-then-fired pattern).

## Field validation
Two `Next field test` items added: confirm `nav_arriving` fires + gauge frequency (pickup + dropoff); and try exiting the map with the **Exit button** (not the back gesture) so we capture the `exit_button` click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)