### PR TITLE
feat(designsystem): shared Compose component library (#95)

### DIFF
--- a/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/component/DashAccordion.kt
+++ b/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/component/DashAccordion.kt
@@ -1,0 +1,103 @@
+package cloud.trotter.dashbuddy.core.designsystem.component
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import cloud.trotter.dashbuddy.core.designsystem.theme.DashBuddyTheme
+import cloud.trotter.dashbuddy.core.designsystem.theme.DashTheme
+
+/**
+ * Expandable row with a `$/mi`-style [trailing] summary — Personal Economy cost accordions.
+ * Caller owns the [expanded] state and the [onToggle] lambda (hoisted, pure).
+ */
+@Composable
+fun DashAccordion(
+    title: String,
+    expanded: Boolean,
+    onToggle: () -> Unit,
+    modifier: Modifier = Modifier,
+    trailing: String? = null,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    val c = DashTheme.colors
+    Surface(
+        modifier = modifier,
+        shape = MaterialTheme.shapes.medium,
+        color = c.surface,
+        border = BorderStroke(1.dp, if (expanded) c.lineStrong else c.line),
+    ) {
+        Column {
+            Row(
+                Modifier
+                    .fillMaxWidth()
+                    .clickable { onToggle() }
+                    .padding(horizontal = 14.dp, vertical = 13.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
+                Text(title, Modifier.weight(1f), style = MaterialTheme.typography.titleMedium, color = c.text)
+                if (trailing != null) Text(trailing, style = DashTheme.num.smNum, color = c.text2)
+                Chevron(expanded, c.text3)
+            }
+            if (expanded) {
+                Column(
+                    Modifier.padding(start = 14.dp, end = 14.dp, bottom = 16.dp),
+                    content = content,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun Chevron(expanded: Boolean, tint: Color) {
+    val rot by animateFloatAsState(if (expanded) 180f else 0f, label = "chevron")
+    Canvas(Modifier.size(14.dp).rotate(rot)) {
+        val w = size.width
+        val h = size.height
+        val sw = 2.dp.toPx()
+        drawLine(tint, Offset(w * 0.25f, h * 0.4f), Offset(w * 0.5f, h * 0.62f), strokeWidth = sw, cap = StrokeCap.Round)
+        drawLine(tint, Offset(w * 0.5f, h * 0.62f), Offset(w * 0.75f, h * 0.4f), strokeWidth = sw, cap = StrokeCap.Round)
+    }
+}
+
+@Preview
+@Composable
+private fun DashAccordionPreview() = DashBuddyTheme {
+    Surface(color = MaterialTheme.colorScheme.background) {
+        var open by remember { mutableStateOf(true) }
+        DashAccordion(
+            title = "Tires",
+            expanded = open,
+            onToggle = { open = !open },
+            trailing = "$0.016/mi",
+            modifier = Modifier.padding(16.dp),
+        ) {
+            Text("Set cost ÷ lifetime miles.", style = MaterialTheme.typography.bodySmall, color = DashTheme.colors.text3)
+        }
+    }
+}

--- a/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/component/DashCard.kt
+++ b/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/component/DashCard.kt
@@ -1,0 +1,76 @@
+package cloud.trotter.dashbuddy.core.designsystem.component
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import cloud.trotter.dashbuddy.core.designsystem.theme.DashBuddyTheme
+import cloud.trotter.dashbuddy.core.designsystem.theme.DashTheme
+
+/**
+ * Card surface — the `.db-card` / `.db-card-active` tokens. `active` raises elevation tone
+ * (surface-2 + stronger hairline) for the pinned/active HUD card. Content is a [ColumnScope].
+ */
+@Composable
+fun DashCard(
+    modifier: Modifier = Modifier,
+    active: Boolean = false,
+    contentPadding: Boolean = true,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    val c = DashTheme.colors
+    Surface(
+        modifier = modifier,
+        shape = MaterialTheme.shapes.medium,
+        color = if (active) c.surface2 else c.surface,
+        border = BorderStroke(1.dp, if (active) c.lineStrong else c.line),
+    ) {
+        Column(
+            modifier = if (contentPadding) Modifier.padding(12.dp) else Modifier,
+            content = content,
+        )
+    }
+}
+
+/**
+ * Tinted info strip — the analytics `Callout`. Body text on a soft semantic background
+ * (e.g. accentDim / goodBg / warnBg / badBg).
+ */
+@Composable
+fun DashCallout(
+    text: String,
+    modifier: Modifier = Modifier,
+    container: Color = DashTheme.colors.accentDim,
+) {
+    Surface(modifier = modifier, shape = MaterialTheme.shapes.small, color = container) {
+        Text(
+            text = text,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+            style = MaterialTheme.typography.bodySmall,
+            color = DashTheme.colors.text2,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun DashCardPreview() = DashBuddyTheme {
+    Surface(color = MaterialTheme.colorScheme.background) {
+        Column(Modifier.padding(16.dp)) {
+            DashCard(active = true) {
+                Text("Active card", style = MaterialTheme.typography.titleMedium, color = DashTheme.colors.text)
+            }
+            Column(Modifier.padding(top = 12.dp)) {
+                DashCallout("You kept $612 of $812 gross — a 75% true margin.")
+            }
+        }
+    }
+}

--- a/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/component/DashCharts.kt
+++ b/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/component/DashCharts.kt
@@ -1,0 +1,174 @@
+package cloud.trotter.dashbuddy.core.designsystem.component
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import cloud.trotter.dashbuddy.core.designsystem.theme.DashBuddyTheme
+import cloud.trotter.dashbuddy.core.designsystem.theme.DashTheme
+import kotlin.math.roundToInt
+
+/** A single bar. [highlight] paints it in the brand accent (e.g. a "hot" day/zone). */
+data class DashBar(val label: String, val value: Float, val highlight: Boolean = false)
+
+/** Simple labelled bar chart — earnings-by-period, etc. */
+@Composable
+fun DashBarChart(bars: List<DashBar>, modifier: Modifier = Modifier, height: Dp = 96.dp) {
+    val c = DashTheme.colors
+    val max = bars.maxOfOrNull { it.value }?.takeIf { it > 0f } ?: 1f
+    Column(modifier) {
+        Row(
+            Modifier.fillMaxWidth().height(height),
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            verticalAlignment = Alignment.Bottom,
+        ) {
+            bars.forEach { b ->
+                Box(Modifier.weight(1f).fillMaxHeight(), contentAlignment = Alignment.BottomCenter) {
+                    Box(
+                        Modifier
+                            .fillMaxWidth(0.7f)
+                            .fillMaxHeight((b.value / max).coerceIn(0.02f, 1f))
+                            .clip(MaterialTheme.shapes.extraSmall)
+                            .background(if (b.highlight) c.accent else c.surface3),
+                    )
+                }
+            }
+        }
+        Spacer(Modifier.height(6.dp))
+        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+            bars.forEach { b ->
+                Text(
+                    b.label,
+                    Modifier.weight(1f),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = c.text3,
+                    textAlign = TextAlign.Center,
+                )
+            }
+        }
+    }
+}
+
+/** Circular progress gauge with a centred value + caption — ratings, on-time scorecard. */
+@Composable
+fun DashGaugeRing(
+    progress: Float,
+    value: String,
+    label: String,
+    modifier: Modifier = Modifier,
+    color: Color = DashTheme.colors.accent,
+    diameter: Dp = 88.dp,
+) {
+    val c = DashTheme.colors
+    val track = c.surface3
+    Column(
+        modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Box(Modifier.size(diameter), contentAlignment = Alignment.Center) {
+            Canvas(Modifier.fillMaxSize()) {
+                val stroke = 7.dp.toPx()
+                val arcSize = Size(size.width - stroke, size.height - stroke)
+                val topLeft = Offset(stroke / 2f, stroke / 2f)
+                drawArc(track, -90f, 360f, false, topLeft, arcSize, style = Stroke(stroke, cap = StrokeCap.Round))
+                drawArc(
+                    color, -90f, 360f * progress.coerceIn(0f, 1f), false,
+                    topLeft, arcSize, style = Stroke(stroke, cap = StrokeCap.Round),
+                )
+            }
+            Text(value, style = DashTheme.num.lgNum, color = c.text)
+        }
+        Text(label, style = MaterialTheme.typography.bodySmall, color = c.text2)
+    }
+}
+
+/** A proportion in a stacked bar / legend. */
+data class DashSegment(val label: String, val value: Float, val color: Color, val note: String? = null)
+
+/** Stacked proportion bar — offer funnel, time split, deadhead ratio. */
+@Composable
+fun DashStackBar(segments: List<DashSegment>, modifier: Modifier = Modifier, height: Dp = 12.dp) {
+    val total = segments.sumOf { it.value.toDouble() }.toFloat().takeIf { it > 0f } ?: 1f
+    Row(modifier.clip(CircleShape).fillMaxWidth().height(height)) {
+        segments.forEach { s ->
+            Box(Modifier.weight((s.value / total).coerceAtLeast(0.0001f)).fillMaxHeight().background(s.color))
+        }
+    }
+}
+
+/** Legend for a [DashStackBar]. Shows each key + its `note` (or computed percent). */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun DashLegend(segments: List<DashSegment>, modifier: Modifier = Modifier) {
+    val c = DashTheme.colors
+    val total = segments.sumOf { it.value.toDouble() }.toFloat().takeIf { it > 0f } ?: 1f
+    FlowRow(
+        modifier,
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        segments.forEach { s ->
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                Box(Modifier.size(9.dp).clip(MaterialTheme.shapes.extraSmall).background(s.color))
+                Text(s.label, style = MaterialTheme.typography.bodySmall, color = c.text2)
+                Text(
+                    s.note ?: "${(s.value / total * 100f).roundToInt()}%",
+                    style = DashTheme.num.smNum,
+                    color = c.text,
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun DashChartsPreview() = DashBuddyTheme {
+    Surface(color = MaterialTheme.colorScheme.background) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+            DashBarChart(
+                listOf(
+                    DashBar("M", 96f), DashBar("T", 110f), DashBar("W", 88f),
+                    DashBar("T", 132f, highlight = true), DashBar("F", 158f, highlight = true),
+                ),
+            )
+            DashGaugeRing(progress = 0.96f, value = "96%", label = "Before deadline", color = DashTheme.colors.good)
+            val segs = listOf(
+                DashSegment("Accepted", 54f, DashTheme.colors.good),
+                DashSegment("Declined", 32f, DashTheme.colors.bad),
+                DashSegment("Timed out", 5f, DashTheme.colors.neutral),
+            )
+            DashStackBar(segs, height = 14.dp)
+            DashLegend(segs)
+        }
+    }
+}

--- a/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/component/DashChip.kt
+++ b/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/component/DashChip.kt
@@ -1,0 +1,52 @@
+package cloud.trotter.dashbuddy.core.designsystem.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import cloud.trotter.dashbuddy.core.designsystem.theme.DashBuddyTheme
+import cloud.trotter.dashbuddy.core.designsystem.theme.DashTheme
+
+/**
+ * Uppercase pill / badge — the `.db-chip` token. Phase chips, status badges, outcome chips,
+ * analytics legend keys. Pure data + tokens.
+ */
+@Composable
+fun DashChip(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = DashTheme.colors.neutral,
+    container: Color = DashTheme.colors.neutralBg,
+    uppercase: Boolean = true,
+) {
+    Text(
+        text = if (uppercase) text.uppercase() else text,
+        style = DashTheme.num.chip,
+        color = color,
+        modifier = modifier
+            .clip(CircleShape)
+            .background(container)
+            .padding(horizontal = 9.dp, vertical = 4.dp),
+    )
+}
+
+@Preview
+@Composable
+private fun DashChipPreview() = DashBuddyTheme {
+    Surface(color = MaterialTheme.colorScheme.background) {
+        DashChip(
+            "Offer",
+            color = DashTheme.colors.stOffer,
+            container = DashTheme.colors.stOfferBg,
+            modifier = Modifier.padding(16.dp),
+        )
+    }
+}

--- a/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/component/DashSegmented.kt
+++ b/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/component/DashSegmented.kt
@@ -1,0 +1,74 @@
+package cloud.trotter.dashbuddy.core.designsystem.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import cloud.trotter.dashbuddy.core.designsystem.theme.DashBuddyTheme
+import cloud.trotter.dashbuddy.core.designsystem.theme.DashTheme
+
+/**
+ * Pill segmented control — analytics tabs / period switches. Selected segment fills with the
+ * brand accent. Pure data + an `onSelect` lambda.
+ */
+@Composable
+fun DashSegmented(
+    options: List<String>,
+    selected: String,
+    onSelect: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val c = DashTheme.colors
+    Row(
+        modifier = modifier
+            .clip(CircleShape)
+            .background(c.surface2)
+            .padding(3.dp),
+        horizontalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        options.forEach { opt ->
+            val isSel = opt == selected
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .clip(CircleShape)
+                    .background(if (isSel) c.accent else Color.Transparent)
+                    .clickable { onSelect(opt) }
+                    .padding(vertical = 8.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = opt,
+                    style = MaterialTheme.typography.labelLarge,
+                    color = if (isSel) c.accentText else c.text2,
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun DashSegmentedPreview() = DashBuddyTheme {
+    Surface(color = MaterialTheme.colorScheme.background) {
+        DashSegmented(
+            options = listOf("Money", "Patterns", "Decisions", "Time"),
+            selected = "Money",
+            onSelect = {},
+            modifier = Modifier.padding(16.dp),
+        )
+    }
+}

--- a/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/component/DashSlider.kt
+++ b/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/component/DashSlider.kt
@@ -1,0 +1,71 @@
+package cloud.trotter.dashbuddy.core.designsystem.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import cloud.trotter.dashbuddy.core.designsystem.theme.DashBuddyTheme
+import cloud.trotter.dashbuddy.core.designsystem.theme.DashTheme
+
+/**
+ * Slider with a min / value / max readout below (the live value in the brand accent, numeric).
+ * Economy costs, strategy targets, wizard steps. [format] turns the raw float into display text.
+ */
+@Composable
+fun DashSlider(
+    value: Float,
+    onValueChange: (Float) -> Unit,
+    valueRange: ClosedFloatingPointRange<Float>,
+    modifier: Modifier = Modifier,
+    steps: Int = 0,
+    format: (Float) -> String = { it.toString() },
+) {
+    val c = DashTheme.colors
+    Column(modifier) {
+        Slider(
+            value = value,
+            onValueChange = onValueChange,
+            valueRange = valueRange,
+            steps = steps,
+            colors = SliderDefaults.colors(
+                thumbColor = c.accent,
+                activeTrackColor = c.accent,
+                inactiveTrackColor = c.surface3,
+            ),
+        )
+        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+            Text(format(valueRange.start), style = MaterialTheme.typography.bodySmall, color = c.text3)
+            Text(format(value), style = DashTheme.num.smNum, color = c.accent)
+            Text(format(valueRange.endInclusive), style = MaterialTheme.typography.bodySmall, color = c.text3)
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun DashSliderPreview() = DashBuddyTheme {
+    Surface(color = MaterialTheme.colorScheme.background) {
+        var v by remember { mutableFloatStateOf(22f) }
+        DashSlider(
+            value = v,
+            onValueChange = { v = it },
+            valueRange = 10f..40f,
+            modifier = Modifier.padding(16.dp),
+            format = { "$" + it.toInt() },
+        )
+    }
+}

--- a/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/component/DashStatTile.kt
+++ b/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/component/DashStatTile.kt
@@ -1,0 +1,66 @@
+package cloud.trotter.dashbuddy.core.designsystem.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import cloud.trotter.dashbuddy.core.designsystem.theme.DashBuddyTheme
+import cloud.trotter.dashbuddy.core.designsystem.theme.DashTheme
+
+/**
+ * Mini stat cell — uppercase label (+ optional [leading] slot), a numeric value, optional sub.
+ * Dashboard "Today" glance, analytics tiles, ratings counts.
+ */
+@Composable
+fun DashStatTile(
+    label: String,
+    value: String,
+    modifier: Modifier = Modifier,
+    sub: String? = null,
+    valueColor: Color = DashTheme.colors.text,
+    leading: (@Composable () -> Unit)? = null,
+) {
+    DashCard(modifier = modifier) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            if (leading != null) leading()
+            Text(
+                text = label.uppercase(),
+                style = MaterialTheme.typography.labelMedium,
+                color = DashTheme.colors.text3,
+            )
+        }
+        Spacer(Modifier.height(6.dp))
+        Text(text = value, style = DashTheme.num.xlNum, color = valueColor)
+        if (sub != null) {
+            Spacer(Modifier.height(4.dp))
+            Text(text = sub, style = MaterialTheme.typography.bodySmall, color = DashTheme.colors.text3)
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun DashStatTilePreview() = DashBuddyTheme {
+    Surface(color = MaterialTheme.colorScheme.background) {
+        DashStatTile(
+            label = "Net/hr",
+            value = "$19.40",
+            sub = "after real costs",
+            valueColor = DashTheme.colors.good,
+            modifier = Modifier.padding(16.dp),
+        )
+    }
+}


### PR DESCRIPTION
## Shared component library (#95) — completes MAD Phase 5 `:core:designsystem`

Builds the brand atoms/molecules from the design handoff so every upcoming surface (HUD, Analytics, Ratings, settings refresh) composes from one source of truth — the "solid foundation" before feature work.

### Components (all pure data + lambdas, brand tokens, `@Preview`)
- **`DashChip`** — uppercase pill / badge (phase chips, status, outcome, legend keys)
- **`DashCard`** (+ `active`) / **`DashCallout`** — card surfaces + tinted info strip
- **`DashStatTile`** — labelled numeric stat cell (+ optional leading slot)
- **`DashSegmented`** — pill segmented control (analytics tabs / period)
- **`DashSlider`** — slider with min/value/max readout (economy, strategy, wizard)
- **`DashBarChart`**, **`DashGaugeRing`**, **`DashStackBar`** + **`DashLegend`** — analytics/ratings primitives
- **`DashAccordion`** — expandable cost row (economy)

### Scope (Package-by-Feature)
Builds the **shared** library only. Genuinely feature-local composables (`FakeOfferCard`, `PermissionCard`, wizard cards) stay in `:app` and get reconciled when their feature modules are extracted in Phase 6 — per the rule in this issue. No app screens are rewired yet; that happens as each surface is redesigned.

### Verification
- ✅ `:core:designsystem:assembleDebug`, `:app:assembleDebug`, `testDebugUnitTest`
- Library isn't consumed by any shipping screen yet → no behavior change, no field-test item needed.

Closes #95.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
