### PR TITLE
feat(state): accumulate accepted-offer economics on the Job, incl. add-ons (#317)

### DIFF
--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
@@ -6,6 +6,7 @@ import cloud.trotter.dashbuddy.domain.pipeline.TimeoutType
 import cloud.trotter.dashbuddy.domain.state.DestructiveKind
 import cloud.trotter.dashbuddy.domain.state.Flow
 import cloud.trotter.dashbuddy.domain.state.FlowRegion
+import cloud.trotter.dashbuddy.domain.state.AcceptedOfferEconomics
 import cloud.trotter.dashbuddy.domain.state.Job
 import cloud.trotter.dashbuddy.domain.state.Mode
 import cloud.trotter.dashbuddy.domain.state.ParsedFields
@@ -386,19 +387,46 @@ class PlatformRegionStepper @Inject constructor() {
         nextFlow: FlowRegion,
         obs: Observation.FlowObservation,
     ): PlatformRegion {
-        // Job start: offer accepted → pickup begins
-        if (prevFlowVal == Flow.OfferPresented && nextFlowVal.isTaskFlow() && region.activeJob == null) {
-            val offerFields = prevFlow.pendingOffer?.offerFields
-            val storeHints = offerFields?.parsedOffer?.orders?.map { it.storeName } ?: emptyList()
-            val offerHash = prevFlow.pendingOffer?.offerHash
+        // Offer accepted → capture its economics onto the job. A first accept STARTS a new
+        // Job; an add-on accepted while a job is already active APPENDS (so stacked pay,
+        // time, and distance accumulate) rather than being silently dropped. Deduped by
+        // offerHash so a re-entered OfferPresented for the same offer (screen oscillation)
+        // does not double-count.
+        if (prevFlowVal == Flow.OfferPresented && nextFlowVal.isTaskFlow()) {
+            val pending = prevFlow.pendingOffer
+            val parsedOffer = pending?.offerFields?.parsedOffer
+            val eval = pending?.evaluation
+            val economics = AcceptedOfferEconomics(
+                offerHash = pending?.offerHash,
+                payAmount = eval?.payAmount ?: parsedOffer?.payAmount,
+                netPay = eval?.netPayAmount,
+                estMinutes = eval?.estimatedTimeMinutes ?: parsedOffer?.timeToCompleteMinutes?.toDouble(),
+                distanceMiles = eval?.distanceMiles ?: parsedOffer?.distanceMiles,
+                acceptedAt = obs.timestamp,
+            )
+            val storeHints = parsedOffer?.orders?.map { it.storeName } ?: emptyList()
+            val existing = region.activeJob
 
-            val jobId = UUID.randomUUID().toString()
+            if (existing == null) {
+                return region.copy(
+                    activeJob = Job(
+                        jobId = UUID.randomUUID().toString(),
+                        offerStoreHint = storeHints,
+                        parentOfferHash = pending?.offerHash,
+                        acceptedOffers = listOf(economics),
+                        startedAt = obs.timestamp,
+                    ),
+                )
+            }
+
+            // Add-on into the active job — append unless this offer was already counted.
+            val alreadyCounted = economics.offerHash != null &&
+                existing.acceptedOffers.any { it.offerHash == economics.offerHash }
+            if (alreadyCounted) return region
             return region.copy(
-                activeJob = Job(
-                    jobId = jobId,
-                    offerStoreHint = storeHints,
-                    parentOfferHash = offerHash,
-                    startedAt = obs.timestamp,
+                activeJob = existing.copy(
+                    acceptedOffers = existing.acceptedOffers + economics,
+                    offerStoreHint = existing.offerStoreHint + storeHints,
                 ),
             )
         }

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/JobEconomicsTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/JobEconomicsTest.kt
@@ -1,0 +1,155 @@
+package cloud.trotter.dashbuddy.core.state
+
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
+import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
+import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
+import cloud.trotter.dashbuddy.domain.model.offer.ParsedOffer
+import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.state.AcceptedOfferEconomics
+import cloud.trotter.dashbuddy.domain.state.Flow
+import cloud.trotter.dashbuddy.domain.state.FlowRegion
+import cloud.trotter.dashbuddy.domain.state.Job
+import cloud.trotter.dashbuddy.domain.state.Mode
+import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import cloud.trotter.dashbuddy.domain.state.PendingOffer
+import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.domain.state.PlatformRegion
+import cloud.trotter.dashbuddy.domain.state.Session
+import cloud.trotter.dashbuddy.domain.state.TaskPhase
+import cloud.trotter.dashbuddy.domain.state.TaskSubFlow
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+/**
+ * Accepted-offer economics on the [Job] (issue #317). A first accept seeds the job's
+ * economics; an **add-on** offer accepted while a job is already active accumulates onto the
+ * same job (so the Task card's per-job blended $/hr is correct for stacked orders), and a
+ * re-entered OfferPresented for the same offer must not double-count.
+ */
+class JobEconomicsTest {
+
+    private val stepper = PlatformRegionStepper()
+    private val flowStepper = FlowRegionStepper()
+    private val policy = TransitionPolicy()
+
+    // ---- helpers ----
+
+    private fun onlineRegion(activeJob: Job?) = PlatformRegion(
+        platform = Platform.DoorDash,
+        mode = Mode.Online,
+        session = Session("sess-1", startedAt = 100L),
+        activeJob = activeJob,
+    )
+
+    private fun eval(net: Double, est: Double, dist: Double, pay: Double) = OfferEvaluation(
+        action = OfferAction.ACCEPT,
+        score = 75.0,
+        qualityLevel = "Good",
+        recommendationText = "Accept",
+        payAmount = pay,
+        fuelCostEstimate = 0.0,
+        netPayAmount = net,
+        distanceMiles = dist,
+        dollarsPerMile = if (dist > 0) net / dist else 0.0,
+        dollarsPerHour = if (est > 0) net / (est / 60.0) else 0.0,
+        estimatedTimeMinutes = est,
+        itemCount = 1.0,
+        merchantName = "Test Store",
+    )
+
+    private fun offerFlow(offerHash: String, net: Double, est: Double, dist: Double, pay: Double) = FlowRegion(
+        flow = Flow.OfferPresented,
+        pendingOffer = PendingOffer(
+            offerHash = offerHash,
+            offerFields = ParsedFields.OfferFields(
+                parsedOffer = ParsedOffer(
+                    offerHash = offerHash,
+                    payAmount = pay,
+                    distanceMiles = dist,
+                    timeToCompleteMinutes = est.toLong(),
+                ),
+            ),
+            presentedAt = 500L,
+            evaluation = eval(net = net, est = est, dist = dist, pay = pay),
+            returnFlow = Flow.Idle,
+        ),
+    )
+
+    private fun acceptObs(timestamp: Long, store: String) = Observation.Screen(
+        timestamp = timestamp, captureId = null, ruleId = "doordash.screen.pickup_nav",
+        metadata = ReplayMetadata.EMPTY, flow = Flow.TaskPickupNavigation, modeHint = Mode.Online,
+        parsed = ParsedFields.TaskFields(
+            phase = TaskPhase.PICKUP, subFlow = TaskSubFlow.NAVIGATION, storeName = store,
+        ),
+    )
+
+    private fun jobWith(offerHash: String, net: Double, est: Double, dist: Double, pay: Double) = Job(
+        jobId = "job-1",
+        offerStoreHint = listOf("H-E-B"),
+        parentOfferHash = offerHash,
+        acceptedOffers = listOf(
+            AcceptedOfferEconomics(
+                offerHash = offerHash, payAmount = pay, netPay = net,
+                estMinutes = est, distanceMiles = dist, acceptedAt = 200L,
+            ),
+        ),
+        startedAt = 200L,
+    )
+
+    private fun step(prev: PlatformRegion, prevFlow: FlowRegion, obs: Observation): PlatformRegion {
+        val nextFlow = if (obs is Observation.FlowObservation) flowStepper.step(prevFlow, obs) else prevFlow
+        return stepper.step(prev, prevFlow, nextFlow, obs, policy)
+    }
+
+    // ---- tests ----
+
+    @Test
+    fun `first accept seeds job economics from the offer`() {
+        val r1 = step(
+            onlineRegion(activeJob = null),
+            offerFlow("offer-1", net = 6.0, est = 18.0, dist = 4.0, pay = 8.5),
+            acceptObs(1_000L, "H-E-B"),
+        )
+
+        val job = r1.activeJob
+        assertNotNull("offer accept must start a job", job)
+        assertEquals(1, job!!.acceptedOffers.size)
+        assertEquals(6.0, job.totalNetPay, 0.001)
+        assertEquals(18.0, job.totalEstMinutes, 0.001)
+        assertEquals(8.5, job.totalPayAmount, 0.001)
+        assertEquals(listOf("offer-1"), job.parentOfferHashes)
+    }
+
+    @Test
+    fun `add-on offer accepted mid-job accumulates onto the active job`() {
+        val r1 = step(
+            onlineRegion(activeJob = jobWith("offer-1", net = 6.0, est = 18.0, dist = 4.0, pay = 8.5)),
+            offerFlow("offer-2", net = 5.0, est = 12.0, dist = 3.0, pay = 7.0),
+            acceptObs(2_000L, "Chipotle"),
+        )
+
+        val job = r1.activeJob
+        assertNotNull(job)
+        assertEquals("add-on stays on the same job, not a new one", "job-1", job!!.jobId)
+        assertEquals(2, job.acceptedOffers.size)
+        assertEquals("net pay blends across the stacked offers", 11.0, job.totalNetPay, 0.001)
+        assertEquals("est minutes sum across the stacked offers", 30.0, job.totalEstMinutes, 0.001)
+        assertEquals(15.5, job.totalPayAmount, 0.001)
+        assertEquals(listOf("offer-1", "offer-2"), job.parentOfferHashes)
+    }
+
+    @Test
+    fun `re-accepting the same offer does not double-count`() {
+        val r1 = step(
+            onlineRegion(activeJob = jobWith("offer-1", net = 6.0, est = 18.0, dist = 4.0, pay = 8.5)),
+            offerFlow("offer-1", net = 6.0, est = 18.0, dist = 4.0, pay = 8.5),
+            acceptObs(2_000L, "H-E-B"),
+        )
+
+        val job = r1.activeJob
+        assertNotNull(job)
+        assertEquals("offer-1 already counted → no duplicate", 1, job!!.acceptedOffers.size)
+        assertEquals(6.0, job.totalNetPay, 0.001)
+    }
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/Job.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/Job.kt
@@ -1,9 +1,32 @@
 package cloud.trotter.dashbuddy.domain.state
 
 /**
+ * Economics captured from one accepted offer, at accept time. A [Job] accumulates one of
+ * these per accepted offer, so an **add-on** accepted mid-delivery adds to (not replaces) the
+ * job's pay/time/distance.
+ *
+ * Fields are nullable because the offer's [cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation]
+ * may not have completed by the moment of accept; we capture the richest available source
+ * (evaluation first, then the parsed offer).
+ */
+data class AcceptedOfferEconomics(
+    val offerHash: String?,
+    /** Gross pay shown on the offer screen. */
+    val payAmount: Double? = null,
+    /** Net pay after operating costs (from the offer evaluation), when available. */
+    val netPay: Double? = null,
+    /** Estimated minutes for this offer's route. */
+    val estMinutes: Double? = null,
+    /** Quoted distance in miles. */
+    val distanceMiles: Double? = null,
+    val acceptedAt: Long,
+)
+
+/**
  * Accumulation of related [Task]s. A DoorDash batched delivery is one Job
  * (2–3 pickup Tasks + 2–3 dropoff Tasks). An Uber ride is one Job (1 pickup
- * + 1 dropoff).
+ * + 1 dropoff). An **add-on** offer accepted mid-delivery appends to the active
+ * Job (same [jobId]) rather than starting a new one — see [acceptedOffers].
  *
  * The offer's store names are **hints**, not sources of truth. The actual
  * authoritative store name comes from Task observations when the driver
@@ -13,6 +36,23 @@ data class Job(
     val jobId: String,
     val offerStoreHint: List<String>,
     val parentOfferHash: String?,
+    /** Economics of every offer accepted into this job (≥1 once started; >1 for stacked/add-ons). */
+    val acceptedOffers: List<AcceptedOfferEconomics> = emptyList(),
     val tasks: List<Task> = emptyList(),
     val startedAt: Long,
-)
+) {
+    /** Total accepted gross pay across all offers in this job. */
+    val totalPayAmount: Double get() = acceptedOffers.sumOf { it.payAmount ?: 0.0 }
+
+    /** Total accepted net pay (after operating costs) across all offers. */
+    val totalNetPay: Double get() = acceptedOffers.sumOf { it.netPay ?: 0.0 }
+
+    /** Total estimated minutes across all offers — the denominator for the job's blended $/hr. */
+    val totalEstMinutes: Double get() = acceptedOffers.sumOf { it.estMinutes ?: 0.0 }
+
+    /** Total quoted distance in miles across all offers. */
+    val totalDistanceMiles: Double get() = acceptedOffers.sumOf { it.distanceMiles ?: 0.0 }
+
+    /** Every offer hash that contributed to this job (the add-on chain). */
+    val parentOfferHashes: List<String> get() = acceptedOffers.mapNotNull { it.offerHash }
+}


### PR DESCRIPTION
## Job accepted-offer economics + add-on accumulation (#317)

Phase 1a — the data foundation for the bubble Task card's live $/hr (#96).

### Problem
Accepting an offer while a Job is already active (an **add-on** / stacked order) hits the `activeJob == null` guard in `PlatformRegionStepper` and is **silently dropped** — the offer's pay/time/distance never land on the job. Even the first offer's economics died with the `PendingOffer` once accepted (#317). The post-task summary that would otherwise capture pay often doesn't show for add-ons, so accept-time economics are the only reliable anchor.

### Change
- **`AcceptedOfferEconomics`** record + **`Job.acceptedOffers`** with computed sums (`totalNetPay`, `totalPayAmount`, `totalEstMinutes`, `totalDistanceMiles`, `parentOfferHashes`).
- `PlatformRegionStepper`: on `OfferPresented → task`, **create** a job seeded with the offer's economics, or **append** to the active job for an add-on. Prefers the evaluation's net/est/distance, falls back to the parsed offer. Deduped by `offerHash` so screen oscillation can't double-count.
- `parentOfferHash` (singular, write-only today) kept for back-compat; `parentOfferHashes` exposes the full add-on chain.

### Tests
`JobEconomicsTest`: first accept seeds economics · add-on accumulates onto the same job (net/time blend) · re-accepting the same offer doesn't double-count. Full `testDebugUnitTest` + `:app:assembleDebug` green.

### Field validation
The accumulated economics aren't surfaced in the UI yet (that's the Task-card blended $/hr in a later Phase-1 step), so there's no on-dash item to watch from this PR alone — it's unit-test-covered. The field-test item lands when the Task card renders the $/hr.

Closes #317.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
