### PR TITLE
feat(capture): 500ms UI-settle delay before every screenshot

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/ScreenShotHandler.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/ScreenShotHandler.kt
@@ -12,6 +12,7 @@ import cloud.trotter.dashbuddy.core.pipeline.accessibility.input.AccessibilityLi
 import cloud.trotter.dashbuddy.core.state.AppEffect
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.io.IOException
@@ -24,8 +25,17 @@ import javax.inject.Singleton
 @Singleton
 class ScreenShotHandler @Inject constructor() {
 
+    companion object {
+        /** UI-settle delay before every capture — mirrors the click settle (500ms). */
+        const val SETTLE_MS = 500L
+    }
+
     fun capture(scope: CoroutineScope, effect: AppEffect.CaptureScreenshot) {
         scope.launch(Dispatchers.IO) {
+            // Let the third-party UI settle before grabbing the frame, so captures
+            // aren't taken mid-transition. This is the only screenshot path, so the
+            // delay applies to all screenshots everywhere.
+            delay(SETTLE_MS)
             val service = AccessibilityListener.instance ?: return@launch
 
             val mainExecutor =

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -60,6 +60,10 @@ On the **second clean** confirmation, move the item into that session's log
 entry and delete it here. If an item is found **broken**, move it to the log
 immediately (no second pass needed) so it gets triaged.
 
+- **Screenshots settle before capture (PR #325).** Captures saved to `Pictures/DashBuddy` should
+  be **clean / fully-rendered** (UI settled), not grabbed mid-transition or half-drawn — there's now
+  a 500ms settle before every screenshot. Spot-check the offer + post-task captures after a dash.
+  - Confirmed: 0/2.
 - **Offer card redesign — visuals (#110 Stage 1, PR pending).** When an offer arrives, glance
   at the bubble offer card and confirm the new layout reads at a glance: a **score ring** (green/
   amber/red by score) beside the **net $/hr** hero; a **verdict banner** (ACCEPT / DECLINE /


### PR DESCRIPTION
## 500ms UI-settle before every screenshot

Clicks already wait for the UI to settle (the `SETTLE_UI` timeout), but screenshots are grabbed immediately — so captures can land mid-transition / half-drawn. Add a **500ms settle** in `ScreenShotHandler.capture()`, which is the **single path all screenshots flow through** (every `AppEffect.CaptureScreenshot` + the direct dash-summary call), so it applies everywhere.

Bonus: this is the clean ordering point for #110 Stage 2 — the offer screenshot captures the settled DoorDash screen *before* the bubble auto-expands over it.

Verified: `:app:assembleDebug` + `testDebugUnitTest` green. Field-test item added (captures should be clean, not mid-transition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
