### PR TITLE
feat(bubble): auto-expand the offer bubble after the screenshot (#110 Stage 2a)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
@@ -62,6 +62,12 @@ class SideEffectEngine @Inject constructor(
     companion object {
         /** Default throttle between repeated firings of the same action. */
         const val DEFAULT_ACTION_THROTTLE_MS = 500L
+
+        /**
+         * Delay before auto-expanding the offer bubble, so it lands AFTER the offer
+         * screenshot's settle + capture and never covers the captured frame.
+         */
+        const val OFFER_BUBBLE_EXPAND_DELAY_MS = ScreenShotHandler.SETTLE_MS + 250L
     }
 
     /**
@@ -103,7 +109,7 @@ class SideEffectEngine @Inject constructor(
             }
 
             is AppEffect.UpdateBubble -> {
-                bubbleManager.postMessage(effect.text, effect.persona)
+                bubbleManager.postMessage(effect.text, effect.persona, effect.expand)
             }
 
             is AppEffect.CaptureScreenshot -> {
@@ -152,14 +158,20 @@ class SideEffectEngine @Inject constructor(
                 // 1. Emit the Decision back to State Machine
                 _events.emit(OfferEvaluationEvent(result.action, result))
 
-                // 2. Show the Bubble (Side Effect)
+                // 2. Show the Bubble (Side Effect) — auto-expand so the dasher sees the
+                // evaluation. Launched on a short delay so it lands AFTER the offer
+                // screenshot's settle+capture (clean frame) without blocking the pipeline.
                 val persona = when (result.action) {
                     OfferAction.ACCEPT -> ChatPersona.GoodOffer
                     OfferAction.DECLINE -> ChatPersona.BadOffer
                     OfferAction.MANUAL_REVIEW -> ChatPersona.Inspector
                     OfferAction.NOTHING -> ChatPersona.Inspector
                 }
-                bubbleManager.postMessage(result.toAnnotatedString(), persona)
+                val message = result.toAnnotatedString()
+                scope.launch {
+                    delay(OFFER_BUBBLE_EXPAND_DELAY_MS)
+                    bubbleManager.postMessage(message, persona, expand = true)
+                }
             }
 
             // --- TIMING LOGIC (Pure Coroutines) ---

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -60,6 +60,14 @@ On the **second clean** confirmation, move the item into that session's log
 entry and delete it here. If an item is found **broken**, move it to the log
 immediately (no second pass needed) so it gets triaged.
 
+- **Offer bubble auto-expands (#110 Stage 2a, PR pending).** When an offer arrives while you're in
+  the DoorDash app (DashBuddy backgrounded), the bubble should **auto-expand on its own** to show the
+  evaluation — and pop up **after** the clean offer screenshot (it must not cover the captured frame).
+  **KEY UNKNOWN to confirm:** does it actually auto-expand *from the background*? Android may restrict
+  background auto-expand — if it only appears as a **collapsed bubble / heads-up notification** (you
+  have to tap it), note that exactly; it decides whether Stage 2/3 keep auto-expand or pivot to a
+  tap-to-review notification. Also confirm the ~0.75s delay before it pops feels right.
+  - Confirmed: 0/2.
 - **Screenshots settle before capture (PR #325).** Captures saved to `Pictures/DashBuddy` should
   be **clean / fully-rendered** (UI settled), not grabbed mid-transition or half-drawn — there's now
   a 500ms settle before every screenshot. Spot-check the offer + post-task captures after a dash.


### PR DESCRIPTION
## Auto-expand the offer bubble after the screenshot — #110 Stage 2a

When an offer is evaluated, the bubble now **auto-expands** to show the verdict (no tap needed). It's posted on a short delay (`OFFER_BUBBLE_EXPAND_DELAY_MS` = screenshot settle + 250ms) and launched off the effect pipeline, so it lands **after** the clean offer screenshot rather than covering the captured frame.

Also fixes `SideEffectEngine.UpdateBubble` silently dropping its `expand` flag (so state-driven bubble updates can auto-expand at all).

No DoorDash-clicking yet — manual Accept/Decline + collapse-on-action are Stage 2b; the opt-in auto-action countdown is Stage 3.

### Field validation (important)
Added a checklist item flagging the **key unknown**: whether the bubble actually auto-expands *from the background* (DoorDash foreground). If Android restricts it to a collapsed bubble / heads-up notification, the field test tells us and we pivot.

Verified: `:app:assembleDebug` + `testDebugUnitTest` green.

Advances #110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
