### PR TITLE
feat(bubble): manual Accept/Decline buttons + collapse-on-action (#110 Stage 2b)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
@@ -5,7 +5,9 @@ import cloud.trotter.dashbuddy.core.data.strategy.StrategyRepository
 import cloud.trotter.dashbuddy.core.database.effects.EffectsFiredDao
 import cloud.trotter.dashbuddy.core.database.effects.EffectsFiredEntity
 import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
 import cloud.trotter.dashbuddy.domain.model.chat.ChatPersona
+import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.domain.model.state.OfferEvaluationEvent
 import cloud.trotter.dashbuddy.domain.model.state.StateEvent
 import cloud.trotter.dashbuddy.domain.model.state.TimeoutEvent
@@ -119,6 +121,16 @@ class SideEffectEngine @Inject constructor(
             is AppEffect.ClickNode -> {
                 Timber.i("Executing Effect: Clicking Node (${effect.description})")
                 uiInteractionHandler.performClick(effect.node, effect.description)
+            }
+
+            is AppEffect.PerformOfferAction -> {
+                val template = offerActionNode(effect.platform, effect.action)
+                if (template != null) {
+                    Timber.i("Performing offer action: ${effect.action} on ${effect.platform.wire}")
+                    uiInteractionHandler.performClick(template, "Bubble ${effect.action}")
+                } else {
+                    Timber.w("No offer-action node for ${effect.platform.wire}/${effect.action}")
+                }
             }
 
             is AppEffect.RequestEffect -> {
@@ -271,6 +283,21 @@ class SideEffectEngine @Inject constructor(
         )
         Timber.i("Auto-Click [%s]: target id=%s", effect.ruleId, ref.viewIdSuffix)
         uiInteractionHandler.performClick(template, "Auto-Click [${effect.ruleId}]")
+    }
+
+    /**
+     * Resolve the platform's offer Accept/Decline button to a click template. DoorDash-only
+     * for now; Decline targets the *initial* decline button (its confirm dialog is left to the
+     * user in Native mode — auto-confirm is #110 Stage 2c). See #85 for the GigPlatform interface.
+     */
+    private fun offerActionNode(platform: Platform, action: OfferAction): UiNode? {
+        if (platform != Platform.DoorDash) return null
+        val pkg = platform.packageName ?: return null
+        return when (action) {
+            OfferAction.ACCEPT -> UiNode(viewIdResourceName = "$pkg:id/accept_button", text = "Accept")
+            OfferAction.DECLINE -> UiNode(viewIdResourceName = "$pkg:id/secondary_action_button_dash_plus")
+            else -> null
+        }
     }
 
     private fun screenshotFromArgs(scope: CoroutineScope, args: Map<String, String>) {

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleScreen.kt
@@ -67,6 +67,7 @@ import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.domain.state.PlatformRegion
 import cloud.trotter.dashbuddy.ui.bubble.cards.FlowCardItem
 import cloud.trotter.dashbuddy.ui.formatters.getIconResId
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateMapOf
 import java.util.Date
 import java.util.concurrent.TimeUnit
@@ -85,6 +86,12 @@ fun BubbleScreen(
     val lastSessionSummary by viewModel.lastSessionSummary.collectAsState()
     val cardStack by viewModel.cardStack.collectAsState()
     var showFullChat by remember { mutableStateOf(false) }
+
+    // Collapse the bubble to its head after the user acts on an offer.
+    val context = LocalContext.current
+    LaunchedEffect(Unit) {
+        viewModel.collapse.collect { (context as? android.app.Activity)?.finish() }
+    }
 
     val flow = appState.regions.flow
 
@@ -136,7 +143,9 @@ fun BubbleScreen(
                     region = focusedRegion,
                     messages = messages,
                     lastSessionSummary = lastSessionSummary,
-                    onOpenChat = { showFullChat = true }
+                    onOpenChat = { showFullChat = true },
+                    onAccept = { viewModel.acceptOffer() },
+                    onDecline = { viewModel.declineOffer() },
                 )
             }
         }
@@ -153,7 +162,9 @@ fun DashboardView(
     region: PlatformRegion?,
     messages: List<ChatMessage>,
     lastSessionSummary: SessionSummary?,
-    onOpenChat: () -> Unit
+    onOpenChat: () -> Unit,
+    onAccept: () -> Unit = {},
+    onDecline: () -> Unit = {},
 ) {
     val expandedIds = remember { mutableStateMapOf<String, Boolean>() }
     val listState = rememberLazyListState()
@@ -208,6 +219,8 @@ fun DashboardView(
                                 isActive = true,
                                 expanded = true,
                                 onToggleExpand = { /* active always expanded */ },
+                                onAccept = onAccept,
+                                onDecline = onDecline,
                             )
                         }
                     }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleViewModel.kt
@@ -13,11 +13,14 @@ import cloud.trotter.dashbuddy.domain.state.Mode
 import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.domain.state.PlatformRegion
 import cloud.trotter.dashbuddy.core.state.StateManagerV2
+import cloud.trotter.dashbuddy.domain.pipeline.Observation
 import cloud.trotter.dashbuddy.ui.bubble.cards.FlowCardMapper
 import cloud.trotter.dashbuddy.ui.bubble.cards.LiveCardBuilder
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
@@ -38,7 +41,7 @@ class BubbleViewModel @Inject constructor(
     private val bubbleManager: BubbleManager,
     private val chatRepository: ChatRepository,
     odometerRepository: OdometerRepository,
-    stateManager: StateManagerV2,
+    private val stateManager: StateManagerV2,
     appEventRepo: AppEventRepo,
 ) : ViewModel() {
 
@@ -165,6 +168,25 @@ class BubbleViewModel @Inject constructor(
             }
         }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+
+    // --- Offer actions (bubble Accept/Decline) ---
+
+    // Signals the bubble to collapse to its head after the user acts on an offer.
+    private val _collapse = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    val collapse = _collapse.asSharedFlow()
+
+    /** User tapped Accept in the bubble → perform the platform accept + collapse. */
+    fun acceptOffer() = onOfferAction("accept_offer")
+
+    /** User tapped Decline → perform the platform's initial decline + collapse. */
+    fun declineOffer() = onOfferAction("decline_offer")
+
+    private fun onOfferAction(action: String) {
+        stateManager.dispatch(
+            Observation.UiInput(timestamp = System.currentTimeMillis(), action = action)
+        )
+        _collapse.tryEmit(Unit)
+    }
 }
 
 private fun Flow.isTaskFlow(): Boolean = this in setOf(

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardItem.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardItem.kt
@@ -15,8 +15,12 @@ import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -67,6 +71,8 @@ fun FlowCardItem(
     expanded: Boolean,
     onToggleExpand: () -> Unit,
     modifier: Modifier = Modifier,
+    onAccept: () -> Unit = {},
+    onDecline: () -> Unit = {},
 ) {
     val effectiveExpanded = isActive || expanded
     Card(
@@ -89,6 +95,9 @@ fun FlowCardItem(
             CardHeader(snapshot = snapshot, isActive = isActive, expanded = effectiveExpanded)
             if (effectiveExpanded) {
                 CardBody(snapshot = snapshot, isActive = isActive)
+                if (snapshot is FlowCardSnapshot.Offer && isActive && snapshot.outcome == null) {
+                    OfferActionRow(onAccept = onAccept, onDecline = onDecline)
+                }
             }
         }
     }
@@ -615,6 +624,28 @@ private fun PostTaskBody(snap: FlowCardSnapshot.PostTask) {
 // ---------------------------------------------------------------------------
 // Primitives
 // ---------------------------------------------------------------------------
+
+/** Manual Accept / Decline buttons on the active offer card (#110 Stage 2b). */
+@Composable
+private fun OfferActionRow(onAccept: () -> Unit, onDecline: () -> Unit) {
+    val c = DashTheme.colors
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(top = 4.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        OutlinedButton(
+            onClick = onDecline,
+            modifier = Modifier.weight(1f),
+            border = BorderStroke(1.5.dp, c.bad),
+            colors = ButtonDefaults.outlinedButtonColors(contentColor = c.bad),
+        ) { Text("Decline", fontWeight = FontWeight.Bold) }
+        Button(
+            onClick = onAccept,
+            modifier = Modifier.weight(1f),
+            colors = ButtonDefaults.buttonColors(containerColor = c.good, contentColor = c.textInv),
+        ) { Text("Accept", fontWeight = FontWeight.Bold) }
+    }
+}
 
 @Composable
 private fun HeroBig(text: String, color: Color = MaterialTheme.colorScheme.onSurface) {

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/AppEffect.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/AppEffect.kt
@@ -1,7 +1,9 @@
 package cloud.trotter.dashbuddy.core.state
 
 import cloud.trotter.dashbuddy.core.database.event.AppEventEntity
+import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.domain.model.chat.ChatPersona
 import cloud.trotter.dashbuddy.domain.model.offer.ParsedOffer
 import cloud.trotter.dashbuddy.domain.pipeline.TimeoutType
@@ -66,6 +68,15 @@ sealed class AppEffect {
     data class ClickNode(
         val node: UiNode,
         val description: String = "Auto-Click"
+    ) : AppEffect()
+
+    /**
+     * HUD-initiated offer action (bubble Accept/Decline) → perform the platform's offer
+     * click. Platform-agnostic; the app layer resolves the concrete node (see #85 GigPlatform).
+     */
+    data class PerformOfferAction(
+        val action: OfferAction,
+        val platform: Platform,
     ) : AppEffect()
 
     /** A rule-originated side effect. */

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -14,6 +14,7 @@ import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStopPayload
 import cloud.trotter.dashbuddy.domain.model.accessibility.BoundingBox
 import cloud.trotter.dashbuddy.domain.pipeline.EffectVerb
 import cloud.trotter.dashbuddy.domain.pipeline.NodeRef
+import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
 import cloud.trotter.dashbuddy.domain.pipeline.ParsedFieldsGate
 import cloud.trotter.dashbuddy.domain.pipeline.RequestedEffect
@@ -169,6 +170,21 @@ class EffectMap @Inject constructor(
                 "decline_offer" -> add(
                     AppEffect.UpdateBubble("Offer Declined", persona = ChatPersona.Dispatcher)
                 )
+            }
+        }
+
+        // HUD-initiated accept/decline (bubble buttons) → perform the platform's offer
+        // click, while an offer is on screen. Decline taps the initial decline button;
+        // in Native mode the user confirms in DoorDash's own dialog (auto-confirm = 2c).
+        if (obs is Observation.UiInput &&
+            (next.flow == Flow.OfferPresented || prev.flow == Flow.OfferPresented)
+        ) {
+            val platform = next.activePlatform ?: prev.activePlatform
+            if (platform != null) {
+                when (obs.action) {
+                    "accept_offer" -> add(AppEffect.PerformOfferAction(OfferAction.ACCEPT, platform))
+                    "decline_offer" -> add(AppEffect.PerformOfferAction(OfferAction.DECLINE, platform))
+                }
             }
         }
     }

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -60,6 +60,15 @@ On the **second clean** confirmation, move the item into that session's log
 entry and delete it here. If an item is found **broken**, move it to the log
 immediately (no second pass needed) so it gets triaged.
 
+- **Manual Accept/Decline buttons (#110 Stage 2b, PR pending).** With the offer bubble open, the
+  card now has **Decline** (left, red outline) + **Accept** (right, green) buttons. Confirm: tapping
+  **Accept** makes DashBuddy tap DoorDash's Accept (offer accepted); tapping **Decline** taps the
+  initial Decline so DoorDash's **native confirm dialog** appears (you confirm there — auto-confirm
+  is Stage 2c). **KEY THINGS TO CONFIRM:** (1) the *correct* button fires (Accept accepts; Decline
+  opens the confirm — never the wrong one); (2) on either tap the bubble **collapses to its head**
+  (not dismissed/closed) — note exactly which on your phone; (3) if the click misses (wrong/no node),
+  note it (esp. Decline's `secondary_action_button_dash_plus`). Real orders — watch carefully.
+  - Confirmed: 0/2.
 - **Offer bubble auto-expands (#110 Stage 2a, PR pending).** When an offer arrives while you're in
   the DoorDash app (DashBuddy backgrounded), the bubble should **auto-expand on its own** to show the
   evaluation — and pop up **after** the clean offer screenshot (it must not cover the captured frame).


### PR DESCRIPTION
## Manual Accept/Decline + collapse-on-action — #110 Stage 2b

The offer card's **Accept / Decline** buttons now drive DoorDash:

- Tap → `BubbleViewModel` dispatches `Observation.UiInput("accept_offer" / "decline_offer")`.
- `EffectMap` (while OfferPresented) emits a platform-agnostic **`PerformOfferAction(ACCEPT/DECLINE, platform)`**.
- `SideEffectEngine` resolves it to the DoorDash node and clicks via the existing accessibility `performClick` (Accept = `accept_button`; Decline = the *initial* decline `secondary_action_button_dash_plus`).
- On either tap the bubble **collapses to its head** (`BubbleViewModel.collapse` → `BubbleScreen` `LaunchedEffect` → `BubbleActivity.finish()`).

**Decline = Native mode:** taps the initial decline, then you confirm in DoorDash's own dialog. Opt-in **auto-confirm** of that dialog is Stage 2c; the opt-in auto-action **countdown** is Stage 3.

DoorDash IDs are resolved app-side (kept out of `:core:state`); TODO toward the `GigPlatform` abstraction (#85).

### Verification
`:app:assembleDebug` + `testDebugUnitTest` green. Field-test item added (correct-button + collapse-vs-dismiss checks — it clicks real orders).

Advances #110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
