### PR TITLE
chore(state): clear unnecessary safe-call warning in EffectMap

### DIFF
--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -302,7 +302,7 @@ class EffectMap @Inject constructor(
                                     sessionId = sessionId,
                                     endedAt = obs.timestamp,
                                     source = SessionEndSource.EARLY_OFFLINE,
-                                    totalEarnings = prevSession?.runningEarnings,
+                                    totalEarnings = prevSession.runningEarnings,
                                 ),
                             ),
                         )


### PR DESCRIPTION
## Clear the build warning in EffectMap

The build emitted one Kotlin warning: `EffectMap.kt:305 Unnecessary safe call on a non-null receiver of type 'Session'`. `prevSession` is already smart-cast to non-null at that point, so `prevSession?.runningEarnings` → `prevSession.runningEarnings`. No behavior change; the build is now warning-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
