### PR TITLE
fix(bubble): cross-window offer-action click + collapse (#110)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/UiInteractionHandler.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/UiInteractionHandler.kt
@@ -19,9 +19,9 @@ class UiInteractionHandler @Inject constructor(
     fun performClick(templateNode: UiNode, description: String) {
         Timber.i("UiInteractionHandler: Attempting click ($description)")
 
-        val liveRoot = accessibilitySource.getLiveNativeRoot()
-        if (liveRoot == null) {
-            Timber.w("Failed to click: Live root window is null.")
+        val roots = accessibilitySource.getLiveWindowRoots()
+        if (roots.isEmpty()) {
+            Timber.w("Failed to click: no live windows.")
             return
         }
 
@@ -29,18 +29,21 @@ class UiInteractionHandler @Inject constructor(
         val targetText = templateNode.text
         val targetBounds = templateNode.boundsInScreen
 
-        // Strategy 1: find by view ID
+        // Search across ALL windows, strongest strategy first (so a weak bounds match in one
+        // window can't beat a viewId match in another). The target node may live in a window
+        // other than the active one — e.g. DoorDash's offer while the bubble holds focus.
         val candidates = mutableListOf<AccessibilityNodeInfo>()
+        // Strategy 1: find by view ID
         if (!targetId.isNullOrEmpty()) {
-            candidates.addAll(liveRoot.findAccessibilityNodeInfosByViewId(targetId))
+            for (root in roots) candidates.addAll(root.findAccessibilityNodeInfosByViewId(targetId))
         }
         // Strategy 2: find by text
         if (candidates.isEmpty() && !targetText.isNullOrEmpty()) {
-            candidates.addAll(liveRoot.findAccessibilityNodeInfosByText(targetText))
+            for (root in roots) candidates.addAll(root.findAccessibilityNodeInfosByText(targetText))
         }
-        // Strategy 3: walk the tree matching by bounds + className
+        // Strategy 3: walk each tree matching by bounds + className
         if (candidates.isEmpty()) {
-            findNodeByBounds(liveRoot, targetBounds, templateNode.className, candidates)
+            for (root in roots) findNodeByBounds(root, targetBounds, templateNode.className, candidates)
         }
 
         if (candidates.isEmpty()) {

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleScreen.kt
@@ -1,5 +1,8 @@
 package cloud.trotter.dashbuddy.ui.bubble
 
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
 import android.text.Html
 import android.text.format.DateFormat
 import android.widget.TextView
@@ -90,7 +93,7 @@ fun BubbleScreen(
     // Collapse the bubble to its head after the user acts on an offer.
     val context = LocalContext.current
     LaunchedEffect(Unit) {
-        viewModel.collapse.collect { (context as? android.app.Activity)?.finish() }
+        viewModel.collapse.collect { context.findActivity()?.finish() }
     }
 
     val flow = appState.regions.flow
@@ -150,6 +153,16 @@ fun BubbleScreen(
             }
         }
     }
+}
+
+/** Unwrap a Compose [LocalContext] (often a ContextThemeWrapper) to the hosting Activity. */
+private fun Context.findActivity(): Activity? {
+    var ctx: Context = this
+    while (ctx is ContextWrapper) {
+        if (ctx is Activity) return ctx
+        ctx = ctx.baseContext
+    }
+    return null
 }
 
 // ---------------------------------------------------------------------------

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/input/AccessibilitySource.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/input/AccessibilitySource.kt
@@ -36,6 +36,21 @@ class AccessibilitySource @Inject constructor() {
         return service.rootInActiveWindow
     }
 
+    /**
+     * All live window roots (native), active window first. Needed for clicks: the node to tap
+     * (e.g. DoorDash's Accept/Decline button) may be in a window other than the active one —
+     * when the user taps the bubble, the *bubble* is the active window, so a search limited to
+     * [getLiveNativeRoot] misses the underlying app's nodes. Requires
+     * `flagRetrieveInteractiveWindows` (set in the service config).
+     */
+    fun getLiveWindowRoots(): List<AccessibilityNodeInfo> {
+        val service = serviceRef?.get() ?: return emptyList()
+        val roots = mutableListOf<AccessibilityNodeInfo>()
+        service.rootInActiveWindow?.let { roots.add(it) }
+        (service.windows ?: emptyList()).forEach { window -> window.root?.let { roots.add(it) } }
+        return roots
+    }
+
     // --- 2. The Service Connection (Pull) ---
     // We use a WeakReference so we don't leak the Service if it restarts
     private var serviceRef: WeakReference<AccessibilityService>? = null

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -63,6 +63,15 @@ immediately (no second pass needed) so it gets triaged.
 _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **broken** on the
 2026-06-09 dash — moved to that session's log entry below for triage.)_
 
+- **Bubble Accept/Decline now click DoorDash + collapse (re-test of 2026-06-09 #1 + #3, PR pending).**
+  The click was searching the wrong window (`rootInActiveWindow` = the bubble); now it searches **all**
+  windows, and the collapse cast was fixed (`findActivity`). To test: open the bubble (tap its head,
+  since auto-expand is still off — that's the separate notification work), then on an offer tap
+  **Accept** or **Decline** → confirm DashBuddy actually taps DoorDash's button (Accept accepts;
+  Decline opens DoorDash's confirm), **and** the bubble **collapses to its head** afterward (vs
+  dismiss — note which). Watch the log for `Performing offer action …` *without* a following
+  `Could not find any live node`. Real orders — watch carefully.
+  - Confirmed: 0/2.
 - **Screenshots settle before capture (PR #325).** Captures saved to `Pictures/DashBuddy` should
   be **clean / fully-rendered** (UI settled), not grabbed mid-transition or half-drawn — there's now
   a 500ms settle before every screenshot. Spot-check the offer + post-task captures after a dash.


### PR DESCRIPTION
## Fix the offer-action click + collapse (#110, field bugs)

First live test (2026-06-09 log) found two defects in the Stage 2b manual flow:

**#1 — Accept/Decline couldn't click DoorDash.** The whole chain fired, but `performClick` resolves nodes against `getLiveNativeRoot()` = `rootInActiveWindow`. When the dasher taps the **bubble**, the *bubble* is the active window — so the search ran against DashBuddy's own tree and found nothing, even though the viewId was correct (`Could not find any live node`). Now `performClick` searches **all** window roots via the new `getLiveWindowRoots()` (the service already requests `flagRetrieveInteractiveWindows`), strongest strategy first (viewId → text → bounds across windows). Finds DoorDash's button regardless of which window holds focus. Fixes Accept and Decline.

**#3 — bubble didn't collapse on action.** `(context as? Activity)` was null because `LocalContext` is a `ContextThemeWrapper`. Fixed with a `findActivity()` unwrap.

Both are surface-independent — also needed for the upcoming notification-action path.

### Verification
`:app:assembleDebug` + `testDebugUnitTest` green, warning-free. Field re-validation item added.

Advances #110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
