### PR TITLE
feat(bubble): offer heads-up notification with Accept/Decline actions (#110)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -84,6 +84,10 @@
             </intent-filter>
         </service>
 
+        <receiver
+            android:name=".state.effects.OfferActionReceiver"
+            android:exported="false" />
+
     </application>
 
 </manifest>

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/OfferActionReceiver.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/OfferActionReceiver.kt
@@ -1,0 +1,46 @@
+package cloud.trotter.dashbuddy.state.effects
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import cloud.trotter.dashbuddy.core.state.StateManagerV2
+import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.android.EntryPointAccessors
+import dagger.hilt.components.SingletonComponent
+import timber.log.Timber
+
+/**
+ * Handles the offer notification's **Accept / Decline** action buttons. Each fires the same
+ * `UiInput` intent the bubble buttons do → EffectMap → `PerformOfferAction` → accessibility
+ * click — so the dasher can act straight from the heads-up notification without opening the
+ * bubble (which can't auto-expand from the background; see #110 field test 2026-06-09).
+ *
+ * Uses [EntryPointAccessors] rather than `@AndroidEntryPoint` so we don't need the Hilt
+ * `super.onReceive()` call (which doesn't compile against the abstract receiver in Kotlin).
+ */
+class OfferActionReceiver : BroadcastReceiver() {
+
+    @EntryPoint
+    @InstallIn(SingletonComponent::class)
+    interface Deps {
+        fun stateManager(): StateManagerV2
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val action = intent.getStringExtra(EXTRA_ACTION) ?: return
+        Timber.i("OfferActionReceiver: %s", action)
+        val deps = EntryPointAccessors.fromApplication(context.applicationContext, Deps::class.java)
+        deps.stateManager().dispatch(
+            Observation.UiInput(timestamp = System.currentTimeMillis(), action = action),
+        )
+    }
+
+    companion object {
+        const val ACTION = "cloud.trotter.dashbuddy.action.OFFER_ACTION"
+        const val EXTRA_ACTION = "offer_action"
+        const val ACCEPT = "accept_offer"
+        const val DECLINE = "decline_offer"
+    }
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
@@ -18,7 +18,7 @@ import cloud.trotter.dashbuddy.domain.pipeline.TimeoutType
 import cloud.trotter.dashbuddy.core.state.AppEffect
 import cloud.trotter.dashbuddy.core.state.EffectExecutor
 import cloud.trotter.dashbuddy.ui.bubble.BubbleManager
-import cloud.trotter.dashbuddy.ui.formatters.toAnnotatedString
+import cloud.trotter.dashbuddy.ui.formatters.toNotificationSummary
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -170,19 +170,19 @@ class SideEffectEngine @Inject constructor(
                 // 1. Emit the Decision back to State Machine
                 _events.emit(OfferEvaluationEvent(result.action, result))
 
-                // 2. Show the Bubble (Side Effect) — auto-expand so the dasher sees the
-                // evaluation. Launched on a short delay so it lands AFTER the offer
-                // screenshot's settle+capture (clean frame) without blocking the pipeline.
+                // 2. Post the offer as a heads-up notification with Accept/Decline actions — the
+                // bubble can't auto-expand from the background (#110 field test). Launched on a
+                // short delay so the heads-up lands AFTER the offer screenshot's settle+capture.
                 val persona = when (result.action) {
                     OfferAction.ACCEPT -> ChatPersona.GoodOffer
                     OfferAction.DECLINE -> ChatPersona.BadOffer
                     OfferAction.MANUAL_REVIEW -> ChatPersona.Inspector
                     OfferAction.NOTHING -> ChatPersona.Inspector
                 }
-                val message = result.toAnnotatedString()
+                val summary = result.toNotificationSummary()
                 scope.launch {
                     delay(OFFER_BUBBLE_EXPAND_DELAY_MS)
-                    bubbleManager.postMessage(message, persona, expand = true)
+                    bubbleManager.postOfferNotification(summary, persona)
                 }
             }
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManager.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManager.kt
@@ -15,6 +15,7 @@ import androidx.core.content.pm.ShortcutManagerCompat
 import androidx.core.graphics.drawable.IconCompat
 import cloud.trotter.dashbuddy.R
 import cloud.trotter.dashbuddy.core.data.chat.ChatRepository
+import cloud.trotter.dashbuddy.state.effects.OfferActionReceiver
 import cloud.trotter.dashbuddy.domain.model.chat.ChatPersona
 import cloud.trotter.dashbuddy.ui.formatters.getIconResId // <-- Your new UI Formatter!
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -123,7 +124,12 @@ class BubbleManager @Inject constructor(
         ShortcutManagerCompat.pushDynamicShortcut(context, shortcut)
     }
 
-    private fun showNotification(text: CharSequence, persona: ChatPersona, expand: Boolean) {
+    private fun showNotification(
+        text: CharSequence,
+        persona: ChatPersona,
+        expand: Boolean,
+        offerActionable: Boolean = false,
+    ) {
 
         val senderPerson = Person.Builder()
             .setName(persona.displayName)
@@ -161,7 +167,7 @@ class BubbleManager @Inject constructor(
             .setGroupConversation(true)
             .addMessage(text, System.currentTimeMillis(), senderPerson)
 
-        val notification = NotificationCompat.Builder(context, channelId)
+        val builder = NotificationCompat.Builder(context, channelId)
             .setSmallIcon(R.drawable.bag_red_idle)
             .setStyle(style)
             .setBubbleMetadata(bubbleMetadata)
@@ -171,8 +177,31 @@ class BubbleManager @Inject constructor(
             .addPerson(senderPerson)
             .setCategory(Notification.CATEGORY_MESSAGE)
             .setPriority(NotificationCompat.PRIORITY_MAX)
-            .build()
 
-        notificationManager.notify(1, notification)
+        if (offerActionable) {
+            builder.addAction(offerAction("Decline", OfferActionReceiver.DECLINE, 11))
+            builder.addAction(offerAction("Accept", OfferActionReceiver.ACCEPT, 10))
+        }
+
+        notificationManager.notify(1, builder.build())
+    }
+
+    /** Post the offer evaluation as a heads-up notification with Accept / Decline action buttons. */
+    fun postOfferNotification(summary: CharSequence, persona: ChatPersona) {
+        Timber.tag("Chat").i("[${persona.displayName}]: $summary")
+        scope.launch { chatRepository.saveMessage(_activeDashId.value, summary.toString(), persona) }
+        showNotification(summary, persona, expand = false, offerActionable = true)
+    }
+
+    private fun offerAction(label: String, action: String, requestCode: Int): NotificationCompat.Action {
+        val intent = Intent(context, OfferActionReceiver::class.java).apply {
+            this.action = OfferActionReceiver.ACTION
+            putExtra(OfferActionReceiver.EXTRA_ACTION, action)
+        }
+        val pi = PendingIntent.getBroadcast(
+            context, requestCode, intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+        return NotificationCompat.Action.Builder(0, label, pi).build()
     }
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/formatters/OfferFormatters.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/formatters/OfferFormatters.kt
@@ -67,3 +67,19 @@ fun OfferEvaluation.toAnnotatedString(colors: DashColors = darkDashColors()): An
         }
     }
 }
+
+/**
+ * Condensed offer summary for the heads-up notification — the top of the offer card as plain
+ * text (verdict + net $/hr, then net pay · miles · $/mi · score · store).
+ */
+fun OfferEvaluation.toNotificationSummary(): String {
+    val verdict = when (action) {
+        OfferAction.ACCEPT -> "ACCEPT"
+        OfferAction.DECLINE -> "DECLINE"
+        OfferAction.MANUAL_REVIEW -> "REVIEW"
+        else -> "OFFER"
+    }
+    return "%s · $%.0f/hr net\nNet $%.2f · %.1f mi · $%.2f/mi · Score %d · %s".format(
+        verdict, dollarsPerHour, netPayAmount, distanceMiles, dollarsPerMile, score.toInt(), merchantName,
+    )
+}

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -63,6 +63,16 @@ immediately (no second pass needed) so it gets triaged.
 _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **broken** on the
 2026-06-09 dash — moved to that session's log entry below for triage.)_
 
+- **Offer heads-up notification with Accept/Decline (#110 surface pivot, PR pending).** Since the
+  bubble can't auto-expand from the background, an offer now fires a **heads-up notification** showing
+  the condensed card (`ACCEPT · $22/hr net` / `Net $22 · 12.9 mi · $1.74/mi · Score 74 · H-E-B`) with
+  **Decline** + **Accept** action buttons. Confirm: (1) the notification **pops as a heads-up** while
+  you're in DoorDash (it should, unlike the bubble — it's `IMPORTANCE_HIGH`); (2) the summary numbers
+  are right; (3) tapping **Accept**/**Decline** from the notification actually performs it on DoorDash
+  (same click path as the bubble, now fixed); (4) it lands **after** the offer screenshot (clean
+  frame). The bubble is still there to tap open for the full card. Watch for `OfferActionReceiver: …`
+  then `Performing offer action …` in the log. Real orders — watch carefully.
+  - Confirmed: 0/2.
 - **Bubble Accept/Decline now click DoorDash + collapse (re-test of 2026-06-09 #1 + #3, PR pending).**
   The click was searching the wrong window (`rootInActiveWindow` = the bubble); now it searches **all**
   windows, and the collapse cast was fixed (`findActivity`). To test: open the bubble (tap its head,


### PR DESCRIPTION
## Offer heads-up notification with Accept/Decline — #110 surface pivot

Field test confirmed the bubble can't auto-expand from the background (OS gate). So the offer copilot's primary surface becomes a **heads-up notification** the dasher can act on directly.

### What's new
- **Condensed summary** — `ACCEPT · $22/hr net` + `Net $22.48 · 12.9 mi · $1.74/mi · Score 74 · H-E-B` (new `OfferEvaluation.toNotificationSummary()`).
- **Accept / Decline action buttons** — a new `OfferActionReceiver` (via `EntryPointAccessors`) dispatches the same `UiInput("accept_offer"/"decline_offer")` the bubble buttons do → `EffectMap` → `PerformOfferAction` → the (now cross-window) accessibility click. Act straight from the notification, no bubble-open needed.
- **`EvaluateOffer`** now posts `postOfferNotification(...)` with `expand=false` (so the heads-up actually shows — the old `expand=true` suppressed the notification *and* failed to expand), still delayed past the offer screenshot.
- The bubble persists (tap its head for the full card).

### Verification
`:app:assembleDebug` + `testDebugUnitTest` green, warning-free. Field-test item added.

Advances #110. Next: TTS reads the evaluation → #4 eval settle → Stage 3 countdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
