### PR TITLE
refactor(offer): post notification as a first-class eval-landing effect (#110)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/OfferActionReceiver.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/OfferActionReceiver.kt
@@ -40,7 +40,5 @@ class OfferActionReceiver : BroadcastReceiver() {
     companion object {
         const val ACTION = "cloud.trotter.dashbuddy.action.OFFER_ACTION"
         const val EXTRA_ACTION = "offer_action"
-        const val ACCEPT = "accept_offer"
-        const val DECLINE = "decline_offer"
     }
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
@@ -66,10 +66,10 @@ class SideEffectEngine @Inject constructor(
         const val DEFAULT_ACTION_THROTTLE_MS = 500L
 
         /**
-         * Delay before auto-expanding the offer bubble, so it lands AFTER the offer
-         * screenshot's settle + capture and never covers the captured frame.
+         * Delay before posting the offer notification, so it lands AFTER the offer screenshot's
+         * settle + capture and never covers the captured frame.
          */
-        const val OFFER_BUBBLE_EXPAND_DELAY_MS = ScreenShotHandler.SETTLE_MS + 250L
+        const val OFFER_NOTIFICATION_DELAY_MS = ScreenShotHandler.SETTLE_MS + 250L
     }
 
     /**
@@ -163,25 +163,22 @@ class SideEffectEngine @Inject constructor(
             // --- LOOPBACKS (Produces Events) ---
 
             is AppEffect.EvaluateOffer -> {
+                // Loopback only: evaluate, then emit the decision back to the state machine. The
+                // notification is posted by the PostOfferNotification effect EffectMap emits once
+                // the evaluation lands on the pending offer — keeps this handler thin.
                 val config = strategyRepository.evaluationConfigFlow.first()
-
                 val result = offerEvaluator.evaluate(effect.parsedOffer, config)
-
-                // 1. Emit the Decision back to State Machine
                 _events.emit(OfferEvaluationEvent(result.action, result))
+            }
 
-                // 2. Post the offer as a heads-up notification with Accept/Decline actions — the
-                // bubble can't auto-expand from the background (#110 field test). Launched on a
-                // short delay so the heads-up lands AFTER the offer screenshot's settle+capture.
-                val persona = when (result.action) {
-                    OfferAction.ACCEPT -> ChatPersona.GoodOffer
-                    OfferAction.DECLINE -> ChatPersona.BadOffer
-                    OfferAction.MANUAL_REVIEW -> ChatPersona.Inspector
-                    OfferAction.NOTHING -> ChatPersona.Inspector
-                }
-                val summary = result.toNotificationSummary()
+            is AppEffect.PostOfferNotification -> {
+                // The bubble can't auto-expand from the background (#110 field test), so surface the
+                // evaluation as a heads-up notification with Accept/Decline actions. Delayed so it
+                // lands AFTER the offer screenshot's settle + capture (clean frame).
+                val summary = effect.evaluation.toNotificationSummary()
+                val persona = offerPersona(effect.evaluation.action)
                 scope.launch {
-                    delay(OFFER_BUBBLE_EXPAND_DELAY_MS)
+                    delay(OFFER_NOTIFICATION_DELAY_MS)
                     bubbleManager.postOfferNotification(summary, persona)
                 }
             }
@@ -372,6 +369,14 @@ class SideEffectEngine @Inject constructor(
         else -> ChatPersona.Dispatcher
     }
 
+    /** Map an offer verdict to the persona that voices its notification. */
+    private fun offerPersona(action: OfferAction): ChatPersona = when (action) {
+        OfferAction.ACCEPT -> ChatPersona.GoodOffer
+        OfferAction.DECLINE -> ChatPersona.BadOffer
+        OfferAction.MANUAL_REVIEW -> ChatPersona.Inspector
+        OfferAction.NOTHING -> ChatPersona.Inspector
+    }
+
     /**
      * Check if the given [PermissionTier] is granted.
      *
@@ -396,6 +401,7 @@ class SideEffectEngine @Inject constructor(
         is AppEffect.EndSession,
         is AppEffect.ProcessTipNotification,
         is AppEffect.SpeakOffer,
+        is AppEffect.PostOfferNotification,
         -> true
         else -> false
     }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManager.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManager.kt
@@ -17,6 +17,7 @@ import cloud.trotter.dashbuddy.R
 import cloud.trotter.dashbuddy.core.data.chat.ChatRepository
 import cloud.trotter.dashbuddy.state.effects.OfferActionReceiver
 import cloud.trotter.dashbuddy.domain.model.chat.ChatPersona
+import cloud.trotter.dashbuddy.domain.state.OfferIntent
 import cloud.trotter.dashbuddy.ui.formatters.getIconResId // <-- Your new UI Formatter!
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
@@ -179,8 +180,8 @@ class BubbleManager @Inject constructor(
             .setPriority(NotificationCompat.PRIORITY_MAX)
 
         if (offerActionable) {
-            builder.addAction(offerAction("Decline", OfferActionReceiver.DECLINE, 11))
-            builder.addAction(offerAction("Accept", OfferActionReceiver.ACCEPT, 10))
+            builder.addAction(offerAction("Decline", OfferIntent.DECLINE, 11))
+            builder.addAction(offerAction("Accept", OfferIntent.ACCEPT, 10))
         }
 
         notificationManager.notify(1, builder.build())

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleViewModel.kt
@@ -10,6 +10,7 @@ import cloud.trotter.dashbuddy.domain.state.AppState
 import cloud.trotter.dashbuddy.domain.state.Flow
 import cloud.trotter.dashbuddy.domain.state.FlowRegion
 import cloud.trotter.dashbuddy.domain.state.Mode
+import cloud.trotter.dashbuddy.domain.state.OfferIntent
 import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.domain.state.PlatformRegion
 import cloud.trotter.dashbuddy.core.state.StateManagerV2
@@ -176,10 +177,10 @@ class BubbleViewModel @Inject constructor(
     val collapse = _collapse.asSharedFlow()
 
     /** User tapped Accept in the bubble → perform the platform accept + collapse. */
-    fun acceptOffer() = onOfferAction("accept_offer")
+    fun acceptOffer() = onOfferAction(OfferIntent.ACCEPT)
 
     /** User tapped Decline → perform the platform's initial decline + collapse. */
-    fun declineOffer() = onOfferAction("decline_offer")
+    fun declineOffer() = onOfferAction(OfferIntent.DECLINE)
 
     private fun onOfferAction(action: String) {
         stateManager.dispatch(

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/formatters/OfferFormatters.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/formatters/OfferFormatters.kt
@@ -1,72 +1,7 @@
 package cloud.trotter.dashbuddy.ui.formatters
 
-import android.text.Spannable
-import android.text.SpannableString
-import android.text.SpannableStringBuilder
-import android.text.style.ForegroundColorSpan
-import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.withStyle
 import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
 import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
-import cloud.trotter.dashbuddy.core.designsystem.theme.DashColors
-import cloud.trotter.dashbuddy.core.designsystem.theme.darkDashColors
-import androidx.compose.ui.graphics.toArgb
-
-/**
- * For System Overlays, Notifications, and traditional Views (Effect Handlers)
- */
-fun OfferEvaluation.toSpannableString(): SpannableString {
-    val builder = SpannableStringBuilder()
-
-    val c = darkDashColors()
-    val color = when (this.action) {
-        OfferAction.ACCEPT -> c.good.toArgb()
-        OfferAction.DECLINE -> c.bad.toArgb()
-        OfferAction.MANUAL_REVIEW -> c.warn.toArgb()
-        else -> c.warn.toArgb()
-    }
-
-    val start = builder.length
-    builder.append(this.recommendationText)
-    builder.setSpan(
-        ForegroundColorSpan(color),
-        start,
-        builder.length,
-        Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
-    )
-
-    builder.append(" | Score: ${this.score.toInt()}")
-
-    // TODO: Paste any of your other old Spannable logic here using `this.propertyName`
-
-    return SpannableString.valueOf(builder)
-}
-
-/**
- * For Jetpack Compose UIs (FakeOfferCard)
- */
-fun OfferEvaluation.toAnnotatedString(colors: DashColors = darkDashColors()): AnnotatedString {
-    return buildAnnotatedString {
-        val composeColor = when (this@toAnnotatedString.action) {
-            OfferAction.ACCEPT -> colors.good
-            OfferAction.DECLINE -> colors.bad
-            OfferAction.MANUAL_REVIEW -> colors.warn
-            else -> colors.warn
-        }
-
-        withStyle(style = SpanStyle(color = composeColor)) {
-            append(this@toAnnotatedString.recommendationText)
-        }
-
-        append(" | Score: ${this@toAnnotatedString.score.toInt()}")
-
-        if (this@toAnnotatedString.fuelCostEstimate > 0.0) {
-            append(" | Net: $%.2f".format(this@toAnnotatedString.netPayAmount))
-        }
-    }
-}
 
 /**
  * Condensed offer summary for the heads-up notification — the top of the offer card as plain

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
@@ -1,6 +1,8 @@
 package cloud.trotter.dashbuddy.core.state
 
 import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
+import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
+import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
 import cloud.trotter.dashbuddy.domain.model.event.AppEventType
 import cloud.trotter.dashbuddy.domain.model.offer.ParsedOffer
 import cloud.trotter.dashbuddy.domain.model.order.OrderType
@@ -116,6 +118,22 @@ class EffectMapTest {
         returnFlow = Flow.Idle,
     )
 
+    private val testEvaluation = OfferEvaluation(
+        action = OfferAction.ACCEPT,
+        score = 74.0,
+        qualityLevel = "Good",
+        recommendationText = "Take it",
+        payAmount = 7.50,
+        fuelCostEstimate = 0.50,
+        netPayAmount = 7.00,
+        distanceMiles = 3.2,
+        dollarsPerMile = 2.19,
+        dollarsPerHour = 22.0,
+        estimatedTimeMinutes = 19.0,
+        itemCount = 1.0,
+        merchantName = "Chipotle",
+    )
+
     private fun stateWithPlatform(
         mode: Mode = Mode.Online,
         sessionId: String? = "sess-1",
@@ -165,6 +183,37 @@ class EffectMapTest {
         assertTrue("Should emit OFFER_RECEIVED", effects.logEventTypes().contains(AppEventType.OFFER_RECEIVED))
         // Screenshot still handled by rule-declared effects
         assertTrue("No hardcoded CaptureScreenshot", effects.none { it is AppEffect.CaptureScreenshot })
+        // Notification waits for the evaluation to land — not posted on first sighting.
+        assertTrue("No PostOfferNotification before eval lands", effects.none { it is AppEffect.PostOfferNotification })
+    }
+
+    @Test
+    fun `evaluation landing on the pending offer emits PostOfferNotification`() {
+        // The async eval loopback attaches the evaluation to the SAME pending offer
+        // (eval null → non-null). EffectMap surfaces it as a heads-up notification here,
+        // rather than the EvaluateOffer handler firing the notification inline.
+        val prev = AppState(regions = Regions(
+            flow = FlowRegion(
+                flow = Flow.OfferPresented,
+                pendingOffer = testPendingOffer, // evaluation == null
+                activePlatform = Platform.DoorDash,
+            ),
+        ))
+        val next = AppState(regions = Regions(
+            flow = FlowRegion(
+                flow = Flow.OfferPresented,
+                pendingOffer = testPendingOffer.copy(evaluation = testEvaluation),
+                activePlatform = Platform.DoorDash,
+            ),
+        ))
+
+        val effects = effectMap.diff(prev, next, screenObs(flow = Flow.OfferPresented))
+
+        val posts = effects.filterIsInstance<AppEffect.PostOfferNotification>()
+        assertEquals("Exactly one PostOfferNotification", 1, posts.size)
+        assertEquals("Carries the landed evaluation", testEvaluation, posts[0].evaluation)
+        // Offer didn't just appear — only its evaluation landed — so don't re-evaluate.
+        assertTrue("Should not re-evaluate", effects.none { it is AppEffect.EvaluateOffer })
     }
 
     @Test

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/AppEffect.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/AppEffect.kt
@@ -2,6 +2,7 @@ package cloud.trotter.dashbuddy.core.state
 
 import cloud.trotter.dashbuddy.core.database.event.AppEventEntity
 import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
+import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
 import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.domain.model.chat.ChatPersona
@@ -64,6 +65,14 @@ sealed class AppEffect {
     data object ResumeOdometer : AppEffect()  // resume GPS after stationary pause
     data class EvaluateOffer(val parsedOffer: ParsedOffer) : AppEffect()
     data class SpeakOffer(val parsedOffer: ParsedOffer, val platformName: String) : AppEffect()
+
+    /**
+     * Post the offer evaluation as a heads-up notification with Accept/Decline actions. Emitted by
+     * [EffectMap] when the async evaluation lands on the pending offer (eval null → non-null) — not
+     * fired inline from the [EvaluateOffer] loopback handler — so the offer's UI side-effects stay
+     * first-class and testable. The app layer formats the summary + persona from the evaluation.
+     */
+    data class PostOfferNotification(val evaluation: OfferEvaluation) : AppEffect()
 
     data class ClickNode(
         val node: UiNode,

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -15,6 +15,7 @@ import cloud.trotter.dashbuddy.domain.model.accessibility.BoundingBox
 import cloud.trotter.dashbuddy.domain.pipeline.EffectVerb
 import cloud.trotter.dashbuddy.domain.pipeline.NodeRef
 import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
+import cloud.trotter.dashbuddy.domain.state.OfferIntent
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
 import cloud.trotter.dashbuddy.domain.pipeline.ParsedFieldsGate
 import cloud.trotter.dashbuddy.domain.pipeline.RequestedEffect
@@ -150,6 +151,18 @@ class EffectMap @Inject constructor(
             add(AppEffect.SpeakOffer(offer.parsedOffer, platform))
         }
 
+        // Evaluation landed (async loopback) → post the offer's heads-up notification. Keyed on the
+        // evaluation arriving in state (same offer, eval null → non-null) rather than fired inline
+        // from the EvaluateOffer handler, so the offer's UI effects stay first-class + testable.
+        // (TTS will move here too when it reads the evaluation — #110 step ii.)
+        val landedEval = nextOffer?.evaluation
+        if (prevOffer != null && nextOffer != null && landedEval != null &&
+            prevOffer.offerHash == nextOffer.offerHash &&
+            prevOffer.evaluation == null
+        ) {
+            add(AppEffect.PostOfferNotification(landedEval))
+        }
+
         // Offer resolved (accepted/declined/timeout)
         if (prevOffer != null && nextOffer == null) {
             val outcome = resolveOfferOutcome(obs, prevOffer)
@@ -164,10 +177,10 @@ class EffectMap @Inject constructor(
         if (flowObs is Observation.Click && prev.flow == Flow.OfferPresented) {
             val fields = flowObs.parsed as? ParsedFields.ClickFields
             when (fields?.intent) {
-                "accept_offer" -> add(
+                OfferIntent.ACCEPT -> add(
                     AppEffect.UpdateBubble("Offer Accepted", persona = ChatPersona.Dispatcher)
                 )
-                "decline_offer" -> add(
+                OfferIntent.DECLINE -> add(
                     AppEffect.UpdateBubble("Offer Declined", persona = ChatPersona.Dispatcher)
                 )
             }
@@ -182,8 +195,8 @@ class EffectMap @Inject constructor(
             val platform = next.activePlatform ?: prev.activePlatform
             if (platform != null) {
                 when (obs.action) {
-                    "accept_offer" -> add(AppEffect.PerformOfferAction(OfferAction.ACCEPT, platform))
-                    "decline_offer" -> add(AppEffect.PerformOfferAction(OfferAction.DECLINE, platform))
+                    OfferIntent.ACCEPT -> add(AppEffect.PerformOfferAction(OfferAction.ACCEPT, platform))
+                    OfferIntent.DECLINE -> add(AppEffect.PerformOfferAction(OfferAction.DECLINE, platform))
                 }
             }
         }
@@ -789,8 +802,8 @@ class EffectMap @Inject constructor(
         // 1. Stored click intent on PendingOffer — covers the common case where
         //    the click was observed first and the resolving obs is a Screen
         when (prevOffer?.lastClickIntent) {
-            "accept_offer" -> return AppEventType.OFFER_ACCEPTED
-            "decline_offer" -> return AppEventType.OFFER_DECLINED
+            OfferIntent.ACCEPT -> return AppEventType.OFFER_ACCEPTED
+            OfferIntent.DECLINE -> return AppEventType.OFFER_DECLINED
         }
         // 2. Direct click observation — covers the edge case where click and
         //    flow change arrive in the same observation
@@ -799,8 +812,8 @@ class EffectMap @Inject constructor(
             else -> null
         }
         return when (clickFields?.intent) {
-            "accept_offer" -> AppEventType.OFFER_ACCEPTED
-            "decline_offer" -> AppEventType.OFFER_DECLINED
+            OfferIntent.ACCEPT -> AppEventType.OFFER_ACCEPTED
+            OfferIntent.DECLINE -> AppEventType.OFFER_DECLINED
             else -> AppEventType.OFFER_TIMEOUT
         }
     }

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/OfferIntent.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/OfferIntent.kt
@@ -1,0 +1,12 @@
+package cloud.trotter.dashbuddy.domain.state
+
+/**
+ * Wire identifiers for the offer **accept / decline** intents. One source of truth shared by:
+ * the ruleset click classification (`ClickFields.intent`), the HUD + notification action
+ * dispatch ([cloud.trotter.dashbuddy.domain.pipeline.Observation.UiInput]), and the EffectMap
+ * routing. Keep them here so a UI-dispatched intent and a rule-parsed intent never drift.
+ */
+object OfferIntent {
+    const val ACCEPT = "accept_offer"
+    const val DECLINE = "decline_offer"
+}


### PR DESCRIPTION
## Straighten the offer UI side-effects before building TTS / countdown on top

Code-quality pass on the #110 offer-copilot plumbing (UDF / MAD / clean-code), per review. No behavior change — same notification, content, and timing — but the wiring is now consistent and testable.

### The refactor (UDF consistency)
The offer's heads-up notification was fired **inline from the `EvaluateOffer` loopback handler** — persona mapping, summary building, and a magic delay all lived in the executor. Meanwhile TTS (`SpeakOffer`) was already a first-class `AppEffect`. Two UI effects for the same offer, emitted from different places.

Now:
- `EvaluateOffer` is **loopback-only** — evaluate, emit the decision. Thin.
- New **`AppEffect.PostOfferNotification(evaluation)`** is emitted by `EffectMap` when the async evaluation **lands on the pending offer** (`eval null → non-null`, same hash), executed by a thin `SideEffectEngine` handler that formats summary + persona.
- This is the **shared eval-landing hook** that TTS-reads-eval (#110 step ii) and the Stage 3 countdown will move onto.

### Cleanups bundled
- **Dead code** — removed `OfferEvaluation.toAnnotatedString` / `toSpannableString` (both unused after the notification switch).
- **Misnamed constant** — `OFFER_BUBBLE_EXPAND_DELAY_MS` → `OFFER_NOTIFICATION_DELAY_MS` (we don't expand anymore).
- **Duplicated magic strings** — `"accept_offer"` / `"decline_offer"` centralized into `domain/state/OfferIntent` (was duplicated across `BubbleViewModel`, `OfferActionReceiver`, and `EffectMap` ×3).

### Tests
`EffectMapTest`: new case asserts `PostOfferNotification` is emitted (carrying the evaluation) when the eval lands, and **not** on first offer sighting. Full suite green, warning-free.

### Dedicated notification style — explored, decided to keep MessagingStyle
The design handoff specifies the **"Current Dash" MessagingStyle** notification as what backs the bubble. Android conversation bubbles *require* a MessagingStyle + Person + long-lived shortcut, so swapping to a non-conversation style (BigText/custom) would **break the floating chat-head**. Conclusion: keep MessagingStyle. (The only realistic future tweak is giving the offer its own notify-id within the same conversation so a chat message can't clobber it mid-window — deferred until field evidence shows it matters.)

Advances #110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
