### PR TITLE
feat(tts): speak the offer evaluation, not the raw parsed offer (#110)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
@@ -149,7 +149,7 @@ class SideEffectEngine @Inject constructor(
             is AppEffect.PlayNotificationSound -> { /* Implementation */
             }
 
-            is AppEffect.SpeakOffer -> ttsEffectHandler.speakOffer(effect.parsedOffer, effect.platformName)
+            is AppEffect.SpeakOffer -> ttsEffectHandler.speakOffer(effect.evaluation)
 
             is AppEffect.StartSession -> bubbleManager.startSession(effect.sessionId, effect.platformName)
             is AppEffect.EndSession -> bubbleManager.endSession(effect.platformName)

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/TtsEffectHandler.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/TtsEffectHandler.kt
@@ -6,7 +6,8 @@ import android.media.AudioFocusRequest
 import android.media.AudioManager
 import android.speech.tts.TextToSpeech
 import android.speech.tts.UtteranceProgressListener
-import cloud.trotter.dashbuddy.domain.model.offer.ParsedOffer
+import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
+import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
 import dagger.hilt.android.qualifiers.ApplicationContext
 import timber.log.Timber
 import java.util.Locale
@@ -59,27 +60,34 @@ class TtsEffectHandler @Inject constructor(
         }
     }
 
-    fun speakOffer(offer: ParsedOffer, platformName: String) {
+    /** Speak the offer's evaluation aloud — the verdict, then the card's headline economics. */
+    fun speakOffer(eval: OfferEvaluation) {
         if (!isReady) {
             Timber.w("TTS not ready, skipping offer speech")
             return
         }
-        val text = formatOffer(offer, platformName)
+        val text = formatEvaluation(eval)
         Timber.i("TTS speaking: %s", text)
 
         audioManager.requestAudioFocus(audioFocusRequest)
-        tts?.speak(text, TextToSpeech.QUEUE_FLUSH, null, "offer_${offer.offerHash}")
+        tts?.speak(text, TextToSpeech.QUEUE_FLUSH, null, "offer_${eval.merchantName}")
     }
 
-    private fun formatOffer(offer: ParsedOffer, platformName: String): String {
-        val parts = mutableListOf<String>()
-        parts += "$platformName offer"
-        offer.payAmount?.let { parts += "$%.2f".format(it) }
-        offer.orders.firstOrNull()?.let { parts += it.storeName.trim() }
-        offer.distanceMiles?.let { parts += "%.1f miles".format(it) }
-        offer.dueByTimeText?.let { parts += it }
-            ?: offer.timeToCompleteMinutes?.let { parts += "$it minutes" }
-        return parts.joinToString(". ") + "."
+    private fun formatEvaluation(eval: OfferEvaluation): String {
+        val verdict = when (eval.action) {
+            OfferAction.ACCEPT -> "Accept"
+            OfferAction.DECLINE -> "Decline"
+            OfferAction.MANUAL_REVIEW -> "Review"
+            else -> "Offer"
+        }
+        return "%s. %s. %.0f dollars an hour net. Net %.2f, %.1f miles, score %d.".format(
+            verdict,
+            eval.merchantName.trim(),
+            eval.dollarsPerHour,
+            eval.netPayAmount,
+            eval.distanceMiles,
+            eval.score.toInt(),
+        )
     }
 
     fun shutdown() {

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
@@ -176,7 +176,8 @@ class EffectMapTest {
         val effects = effectMap.diff(prev, next, screenObs(flow = Flow.OfferPresented, parsed = testOfferFields))
 
         assertTrue("Should emit EvaluateOffer", effects.any { it is AppEffect.EvaluateOffer })
-        assertTrue("Should emit SpeakOffer", effects.any { it is AppEffect.SpeakOffer })
+        // SpeakOffer (like the notification) waits for the evaluation to land — not on first sighting.
+        assertTrue("No SpeakOffer before eval lands", effects.none { it is AppEffect.SpeakOffer })
         // OFFER_RECEIVED now emitted from EffectMap with a typed payload
         // (#257) — moved out of rule-declared `log` effects which never
         // persisted to the DB.
@@ -212,6 +213,10 @@ class EffectMapTest {
         val posts = effects.filterIsInstance<AppEffect.PostOfferNotification>()
         assertEquals("Exactly one PostOfferNotification", 1, posts.size)
         assertEquals("Carries the landed evaluation", testEvaluation, posts[0].evaluation)
+        // Spoken read also fires on eval-landing, carrying the same evaluation.
+        val spoken = effects.filterIsInstance<AppEffect.SpeakOffer>()
+        assertEquals("Exactly one SpeakOffer", 1, spoken.size)
+        assertEquals("Speaks the landed evaluation", testEvaluation, spoken[0].evaluation)
         // Offer didn't just appear — only its evaluation landed — so don't re-evaluate.
         assertTrue("Should not re-evaluate", effects.none { it is AppEffect.EvaluateOffer })
     }

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/AppEffect.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/AppEffect.kt
@@ -64,7 +64,8 @@ sealed class AppEffect {
     data object PauseOdometer : AppEffect()   // pause GPS while stationary; session total preserved
     data object ResumeOdometer : AppEffect()  // resume GPS after stationary pause
     data class EvaluateOffer(val parsedOffer: ParsedOffer) : AppEffect()
-    data class SpeakOffer(val parsedOffer: ParsedOffer, val platformName: String) : AppEffect()
+    /** Speak the offer's evaluation aloud (verdict + headline economics). Fires on eval-landing. */
+    data class SpeakOffer(val evaluation: OfferEvaluation) : AppEffect()
 
     /**
      * Post the offer evaluation as a heads-up notification with Accept/Decline actions. Emitted by

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -127,11 +127,9 @@ class EffectMap @Inject constructor(
             )
             add(logEffect(sessionId, AppEventType.OFFER_RECEIVED, receivedPayload))
 
-            // Evaluate
+            // Evaluate (the heads-up notification + spoken read fire later, once the async
+            // evaluation lands on the pending offer — see the eval-landing block below).
             add(AppEffect.EvaluateOffer(offer.parsedOffer))
-
-            // Speak offer aloud
-            add(AppEffect.SpeakOffer(offer.parsedOffer, platform))
         }
 
         // Offer replaced (different hash)
@@ -144,23 +142,22 @@ class EffectMap @Inject constructor(
             val outcome = resolveOfferOutcome(obs, prevOffer)
             add(logEffect(sessionId, outcome, offerPayload(prevOffer, outcome, obs.timestamp, "Replaced by new offer")))
 
-            // Evaluate + speak new offer
+            // Evaluate the new offer (notification + spoken read fire on eval-landing below).
             val offer = nextOffer.offerFields
             add(AppEffect.EvaluateOffer(offer.parsedOffer))
-            val platform = next.activePlatform?.name ?: "Unknown"
-            add(AppEffect.SpeakOffer(offer.parsedOffer, platform))
         }
 
-        // Evaluation landed (async loopback) → post the offer's heads-up notification. Keyed on the
-        // evaluation arriving in state (same offer, eval null → non-null) rather than fired inline
-        // from the EvaluateOffer handler, so the offer's UI effects stay first-class + testable.
-        // (TTS will move here too when it reads the evaluation — #110 step ii.)
+        // Evaluation landed (async loopback) → fire the offer's UI side-effects: the heads-up
+        // notification and the spoken read, both off the evaluation. Keyed on the evaluation
+        // arriving in state (same offer, eval null → non-null) rather than fired inline from the
+        // EvaluateOffer handler, so the offer's UI effects stay first-class + testable.
         val landedEval = nextOffer?.evaluation
         if (prevOffer != null && nextOffer != null && landedEval != null &&
             prevOffer.offerHash == nextOffer.offerHash &&
             prevOffer.evaluation == null
         ) {
             add(AppEffect.PostOfferNotification(landedEval))
+            add(AppEffect.SpeakOffer(landedEval))
         }
 
         // Offer resolved (accepted/declined/timeout)

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -73,6 +73,14 @@ _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **bro
   frame). The bubble is still there to tap open for the full card. Watch for `OfferActionReceiver: …`
   then `Performing offer action …` in the log. Real orders — watch carefully.
   - Confirmed: 0/2.
+- **Offer TTS now speaks the EVALUATION, not the raw offer (#110 step ii, PR pending).** The spoken
+  read used to announce the parsed offer (`DoorDash offer. $7.50. <store>. 3.2 miles.`); it now speaks
+  the verdict + headline economics: e.g. **"Accept. H-E-B. 22 dollars an hour net. Net 22.48, 12.9
+  miles, score 74."** Confirm on an offer: (1) it speaks the **verdict word** (Accept/Decline/Review)
+  first; (2) the numbers match the card; (3) it fires **once**, right after the eval (≈ in sync with
+  the heads-up notification, after the screenshot settle) — not before the eval, not twice. Watch the
+  log for `TTS speaking: Accept. …`. Real orders — listen on a quiet leg.
+  - Confirmed: 0/2.
 - **Bubble Accept/Decline now click DoorDash + collapse (re-test of 2026-06-09 #1 + #3, PR pending).**
   The click was searching the wrong window (`rootInActiveWindow` = the bubble); now it searches **all**
   windows, and the collapse cast was fixed (`findActivity`). To test: open the bubble (tap its head,


### PR DESCRIPTION
## TTS reads the evaluation — #110 step ii

The spoken offer read used to announce the **raw `ParsedOffer`** ("DoorDash offer. $7.50. \<store\>. 3 miles.") at `OfferPresented` — before the evaluation even existed. Now it speaks the **verdict + the card's headline economics**, riding the same eval-landing hook the notification uses (from #332).

### Change
- **`AppEffect.SpeakOffer(evaluation)`** — was `(parsedOffer, platformName)`.
- **`EffectMap`** emits `SpeakOffer` in the **eval-landing block** (next to `PostOfferNotification`); removed from `OfferPresented` / offer-replaced. So the offer's two UI side-effects (notify + speak) now fire together, off the evaluation.
- **`TtsEffectHandler.speakOffer(eval)`** → `formatEvaluation`: `"Accept. H-E-B. 22 dollars an hour net. Net 22.48, 12.9 miles, score 74."`
- **`EffectMapTest`**: `SpeakOffer` now asserted on eval-landing (carrying the eval) and asserted **absent** on first sighting.

### Verification
`:app:assembleDebug` + `testDebugUnitTest` green, warning-free. Field-test item added (listen for the verdict-first spoken read, once, in sync with the notification).

Advances #110. Next: #4 eval settle/dedupe → Stage 3 countdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
