### PR TITLE
fix(recognition): stop recognizing our own bubble overlay as a DoorDash offer (#4)

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/TriageRulesTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/TriageRulesTest.kt
@@ -381,7 +381,12 @@ class TriageRulesTest {
 
     @Test
     fun `navigation_generic — does not steal an offer popup (offer_popup wins)`() {
-        assertEquals("offer_popup", screen(tree(node(text = "Decline"), node(text = "Accept"), node(id = "maneuverView"))))
+        // A real offer popup carries the DoorDash accept_button structure (not just the button
+        // labels) — the require demands it so our own overlay can't masquerade as an offer (#4).
+        assertEquals(
+            "offer_popup",
+            screen(tree(node(text = "Decline"), node(text = "Accept"), node(id = "accept_button"), node(id = "maneuverView"))),
+        )
     }
 
     // =========================================================================

--- a/core/pipeline/src/main/assets/rules/doordash.json
+++ b/core/pipeline/src/main/assets/rules/doordash.json
@@ -317,6 +317,18 @@
                 }
               ]
             }
+          },
+          {
+            "exists": {
+              "any": [
+                {
+                  "hasIdSuffix": "accept_button"
+                },
+                {
+                  "hasIdSuffix": "accept_decline_footer_container"
+                }
+              ]
+            }
           }
         ]
       },

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/event/type/window/content_changed/ContentChangedPipeline.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/event/type/window/content_changed/ContentChangedPipeline.kt
@@ -5,6 +5,7 @@ import cloud.trotter.dashbuddy.core.pipeline.BuildConfig
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
 import cloud.trotter.dashbuddy.core.pipeline.accessibility.TreeSnapshot
 import cloud.trotter.dashbuddy.core.pipeline.accessibility.input.AccessibilitySource
+import cloud.trotter.dashbuddy.domain.state.Platform
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filter
@@ -34,18 +35,26 @@ class ContentChangedPipeline @Inject constructor(
         }
         .mapNotNull { event ->
             val types = pendingChangeTypes.getAndSet(0)
-            source.getCurrentRootNode()?.let { tree ->
-                if (BuildConfig.DEBUG) {
-                    val nodeCount = countNodes(tree)
-                    Timber.d("🌳 Tree snapshot: %d nodes, pkg=%s", nodeCount, event.packageName)
-                }
-                TreeSnapshot(
-                    tree = tree,
-                    source = TreeSnapshot.Source.CONTENT_CHANGED,
-                    contentChangeTypes = types,
-                    packageName = event.packageName?.toString(),
+            val snapshot = source.getCurrentRootSnapshot() ?: return@mapNotNull null
+            // Attribute to the window actually on screen, not the triggering event. Drop snapshots
+            // of non-target windows (our own bubble overlay, launcher, etc.) so we never recognize
+            // our own UI as the platform — the #4 self-recognition feedback loop.
+            if (snapshot.packageName !in Platform.watchedPackages()) {
+                Timber.v(
+                    "🚫 Skip active window: non-target pkg=%s (event pkg=%s)",
+                    snapshot.packageName, event.packageName,
                 )
+                return@mapNotNull null
             }
+            if (BuildConfig.DEBUG) {
+                Timber.d("🌳 Tree snapshot: %d nodes, pkg=%s", countNodes(snapshot.tree), snapshot.packageName)
+            }
+            TreeSnapshot(
+                tree = snapshot.tree,
+                source = TreeSnapshot.Source.CONTENT_CHANGED,
+                contentChangeTypes = types,
+                packageName = snapshot.packageName,
+            )
         }
 
     private fun countNodes(node: UiNode): Int =

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/event/type/window/state_changed/StateChangedPipeline.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/event/type/window/state_changed/StateChangedPipeline.kt
@@ -3,6 +3,7 @@ package cloud.trotter.dashbuddy.core.pipeline.accessibility.event.type.window.st
 import android.view.accessibility.AccessibilityEvent
 import cloud.trotter.dashbuddy.core.pipeline.accessibility.TreeSnapshot
 import cloud.trotter.dashbuddy.core.pipeline.accessibility.input.AccessibilitySource
+import cloud.trotter.dashbuddy.domain.state.Platform
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.mapNotNull
@@ -19,13 +20,21 @@ class StateChangedPipeline @Inject constructor(
             Timber.d("⚡ STATE_CHANGED from %s  types=0x%02x", it.className, it.contentChangeTypes)
         }
         .mapNotNull { event ->
-            source.getCurrentRootNode()?.let { tree ->
-                TreeSnapshot(
-                    tree = tree,
-                    source = TreeSnapshot.Source.STATE_CHANGED,
-                    contentChangeTypes = event.contentChangeTypes,
-                    packageName = event.packageName?.toString(),
+            val snapshot = source.getCurrentRootSnapshot() ?: return@mapNotNull null
+            // Attribute to the on-screen window, not the event; drop non-target windows (e.g. our
+            // own bubble overlay) so we don't recognize our own UI as the platform (#4).
+            if (snapshot.packageName !in Platform.watchedPackages()) {
+                Timber.v(
+                    "🚫 Skip active window: non-target pkg=%s (event pkg=%s)",
+                    snapshot.packageName, event.packageName,
                 )
+                return@mapNotNull null
             }
+            TreeSnapshot(
+                tree = snapshot.tree,
+                source = TreeSnapshot.Source.STATE_CHANGED,
+                contentChangeTypes = event.contentChangeTypes,
+                packageName = snapshot.packageName,
+            )
         }
 }

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/event/type/window/windows_changed/WindowsChangedPipeline.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/event/type/window/windows_changed/WindowsChangedPipeline.kt
@@ -4,6 +4,7 @@ import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityWindowInfo
 import cloud.trotter.dashbuddy.core.pipeline.accessibility.TreeSnapshot
 import cloud.trotter.dashbuddy.core.pipeline.accessibility.input.AccessibilitySource
+import cloud.trotter.dashbuddy.domain.state.Platform
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
@@ -58,6 +59,10 @@ class WindowsChangedPipeline @Inject constructor(
                     // Get the package from the native root before converting to UiNode
                     val nativeRoot = w.root ?: return@mapNotNull null
                     val pkg = nativeRoot.packageName?.toString()
+                    // Only snapshot watched-platform windows (e.g. an Uber overlay) — never our own
+                    // bubble overlay or other apps. Prevents recognizing our own UI (#4) and keeps
+                    // non-target windows out of the pipeline.
+                    if (pkg !in Platform.watchedPackages()) return@mapNotNull null
                     val tree = try {
                         source.getRootForWindow(w)
                     } catch (_: Exception) {

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/input/AccessibilitySource.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/input/AccessibilitySource.kt
@@ -59,20 +59,26 @@ class AccessibilitySource @Inject constructor() {
         serviceRef = WeakReference(service)
     }
 
-    /**
-     * Fetches the current Root Node directly from the system.
-     * * SAFE to call from background threads.
-     */
-    fun getCurrentRootNode(): UiNode? {
-        val root = getLiveNativeRoot() ?: return null
+    /** Active-window root snapshot: the converted [UiNode] tree + the **real package** owning it. */
+    data class RootSnapshot(val tree: UiNode, val packageName: String?)
 
-        return try {
+    /**
+     * Snapshots the active window's root as a [UiNode] tree plus the **real package that owns that
+     * window** — read from the native root and captured together. Use this instead of a bare tree so
+     * a snapshot is attributed to the window actually on screen, not to a triggering event from a
+     * different app. Lets callers drop non-target windows (e.g. our own bubble overlay) rather than
+     * mislabeling them as the platform — the #4 self-recognition feedback loop.
+     *
+     * SAFE to call from background threads.
+     */
+    fun getCurrentRootSnapshot(): RootSnapshot? {
+        val root = getLiveNativeRoot() ?: return null
+        val tree = try {
             root.toUiNode()
         } catch (_: Exception) {
             null
-        } finally {
-            // nothing here... do we need it?
-        }
+        } ?: return null
+        return RootSnapshot(tree = tree, packageName = root.packageName?.toString())
     }
 
     // --- 3. Multi-Window Support ---

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -63,6 +63,16 @@ immediately (no second pass needed) so it gets triaged.
 _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **broken** on the
 2026-06-09 dash — moved to that session's log entry below for triage.)_
 
+- **Self-recognition fixed: our own bubble is no longer parsed as a DoorDash offer (#4, PR pending).**
+  Root cause of the 2026-06-09 offer flip-flop: when the bubble was the active window over DoorDash,
+  our own overlay got snapshotted, mislabeled `doordash`, and matched `offer_popup` → a phantom
+  re-eval (the spurious DECLINE-6 / "22.5 mi"). Now active-window snapshots are attributed to the
+  window's real package (our overlay is dropped), and the offer rule demands the `accept_button`
+  structure our overlay lacks. To test: on an offer, **open the bubble** over the DoorDash offer →
+  confirm the verdict / notification / spoken read **stay stable** (no flip to DECLINE, no re-eval)
+  while the bubble is up. Watch the log for `🚫 Skip active window: non-target pkg=cloud.trotter.dashbuddy`
+  (proof our overlay is being dropped) and **no** second `offer_popup` classification. Real orders.
+  - Confirmed: 0/2.
 - **Offer heads-up notification with Accept/Decline (#110 surface pivot, PR pending).** Since the
   bubble can't auto-expand from the background, an offer now fires a **heads-up notification** showing
   the condensed card (`ACCEPT · $22/hr net` / `Net $22 · 12.9 mi · $1.74/mi · Score 74 · H-E-B`) with
@@ -353,7 +363,21 @@ Distance flips **12.9 mi ↔ 22.5 mi**, and there's an `UNKNOWN` window carrying
 - **To dig:** diff the two captured `offer_popup` JSONs (`…7f6048.json` @44.374 vs `…225fd4.json`
   @52.489) for the one-leg-vs-total parse divergence; consider debouncing/settling offer eval or
   de-duping re-evals of the same `offerHash`.
-- **Status:** Open.
+- **Root cause CONFIRMED (desk, 2026-06-09 — diffed the two captures):** **self-recognition, not a
+  stacked-offer parse and not the loading-bar reject.** Frame `225fd4` @52.489 (the "DECLINE-6"
+  frame) is **our own Bubble HUD overlay** — its tree is `…android:id/content →
+  androidx.compose.ui.platform.ComposeView` with our text (`"Recommended: ACCEPT | Score: 74 | Net:
+  $22.48"`, `"H-E-B · 40 items"`, `"AWESOME OFFER"`), yet it was tagged `platform: doordash`.
+  `ContentChanged`/`StateChanged` snapshot `rootInActiveWindow` but labeled it with the **event's**
+  package; while our bubble was the active window over DoorDash, our overlay got mislabeled DoorDash
+  and matched `offer_popup` (whose `require` was just "Decline" + "Accept" — satisfied by the bubble's
+  new #327 Accept/Decline buttons), then parsed to junk ($0.00 / 0.0 mi) → phantom re-eval. (No
+  `progress_bar` in our overlay, so the removed loading-bar reject was a red herring.)
+- **Fixed (PR pending):** (1) attribute active-window snapshots to the window's **real** package and
+  drop non-target windows — our overlay is skipped (`🚫 Skip active window: non-target pkg=…`); (2)
+  `offer_popup.require` now also demands the `accept_button` / `accept_decline_footer_container` id,
+  which our `content`-only overlay lacks. Dropped the settle/dedupe idea — it would have masked this.
+- **Status:** Fixed — needs field re-validation (see checklist).
 
 ---
 


### PR DESCRIPTION
## #4 root cause: we were recognizing *ourselves*

The 2026-06-09 field flip-flop (`ACCEPT-74 → DECLINE-6 (-$9.62) → ACCEPT-74`) wasn't a stacked-offer parse or the removed loading-bar reject. Diffing the two captured `offer_popup` frames:

| | `7f6048` @44.374 (real) | `225fd4` @52.489 (the DECLINE) |
|---|---|---|
| Tree | DoorDash native, `com.doordash.driverapp:id/accept_button` … | `android:id/content → androidx.compose.ui.platform.ComposeView` |
| Text | `$28.00 Guaranteed`, `12.9 mi`, `Shop for items` | `Recommended: ACCEPT | Score: 74 | Net: $22.48`, `H-E-B · 40 items` |
| ids | full `accept_decline_*` structure | only `content` |

The DECLINE frame is **our own Bubble HUD overlay** — Compose, our offer-card + notification text — yet tagged `platform: doordash`. `ContentChanged`/`StateChanged` snapshot `rootInActiveWindow` but label it with the **event's** package. When the bubble is the active window over DoorDash, DoorDash's events cause our overlay to be snapshotted and **mislabeled DoorDash**, where it matches `offer_popup` (require was just `"Decline"` + `"Accept"` — satisfied by the bubble's new #327 Accept/Decline buttons), parses to junk (`$0.00`/`0.0 mi`), and fires a phantom re-eval.

### Fix #1 (root) — attribute snapshots to the window actually on screen
- `AccessibilitySource.getCurrentRootSnapshot()` returns the tree **+ the native root's real package**, captured together.
- `ContentChanged` / `StateChanged` use it and **drop snapshots whose package isn't a watched platform** — our overlay (`cloud.trotter.dashbuddy`) is skipped instead of mislabeled.
- `WindowsChanged` also gates per-window package on `watchedPackages()` (keeps Uber overlays, drops our own).

### Fix #2 (defense in depth) — require real offer structure
`offer_popup.require` now also demands `accept_button` / `accept_decline_footer_container` — present in **30/30** golden offer fixtures, absent from our `content`-only overlay. So even a leaked foreign window can't match.

### Notes
- Dropped the earlier settle/dedupe idea — it would have masked this, not fixed it.
- Also a **pledge** win: we should never have been parsing our own UI as the target app.
- Updated the one synthetic `TriageRulesTest` case (its minimal `Decline`+`Accept` tree now includes the structural id, like a real offer). `AllMatchersSuite` + `GoldenSnapshotRegressionTest` + full suite green.

Fixes the #4 field bug. Field re-validation item added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
