### PR TITLE
feat(notification): format the offer notification text with Android spans (#110)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/formatters/OfferFormatters.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/formatters/OfferFormatters.kt
@@ -1,20 +1,62 @@
 package cloud.trotter.dashbuddy.ui.formatters
 
+import android.graphics.Typeface
+import android.text.Spannable
+import android.text.SpannableStringBuilder
+import android.text.style.ForegroundColorSpan
+import android.text.style.RelativeSizeSpan
+import android.text.style.StyleSpan
+import androidx.compose.ui.graphics.toArgb
+import cloud.trotter.dashbuddy.core.designsystem.theme.darkDashColors
 import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
 import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
 
 /**
- * Condensed offer summary for the heads-up notification — the top of the offer card as plain
- * text (verdict + net $/hr, then net pay · miles · $/mi · score · store).
+ * Formatted offer summary for the heads-up notification. Built with **Android** text spans — the
+ * kind notifications actually honor (Compose `AnnotatedString` spans don't render in a
+ * notification). The verdict word is bold, larger, and colored good / warn / bad; the headline
+ * `$/hr` is bold. Two lines:
+ *
+ * ```
+ * ACCEPT · $22/hr net          <- verdict colored + larger, whole line bold
+ * Net $22.48 · 12.9 mi · $1.74/mi · Score 74 · H-E-B
+ * ```
+ *
+ * Note: bold + size are reliable across devices; foreground color in a MessagingStyle notification
+ * is device/version dependent (the system may re-theme it), so the line still reads cleanly without
+ * it. `toString()` yields the plain text used for chat storage.
  */
-fun OfferEvaluation.toNotificationSummary(): String {
+fun OfferEvaluation.toNotificationSummary(): CharSequence {
+    val colors = darkDashColors()
     val verdict = when (action) {
         OfferAction.ACCEPT -> "ACCEPT"
         OfferAction.DECLINE -> "DECLINE"
         OfferAction.MANUAL_REVIEW -> "REVIEW"
         else -> "OFFER"
     }
-    return "%s · $%.0f/hr net\nNet $%.2f · %.1f mi · $%.2f/mi · Score %d · %s".format(
-        verdict, dollarsPerHour, netPayAmount, distanceMiles, dollarsPerMile, score.toInt(), merchantName,
-    )
+    val verdictColor = when (action) {
+        OfferAction.ACCEPT -> colors.good
+        OfferAction.DECLINE -> colors.bad
+        OfferAction.MANUAL_REVIEW -> colors.warn
+        else -> colors.warn
+    }.toArgb()
+
+    return SpannableStringBuilder().apply {
+        val start = length
+        append(verdict)
+        setSpan(ForegroundColorSpan(verdictColor), start, length, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+        setSpan(RelativeSizeSpan(1.2f), start, length, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+
+        append(" · ")
+        append("$%.0f/hr net".format(dollarsPerHour))
+        // Whole headline (verdict + rate) bold.
+        setSpan(StyleSpan(Typeface.BOLD), start, length, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+
+        append("\n")
+        append(
+            "Net $%.2f · %.1f mi · $%.2f/mi · Score %d · %s".format(
+                netPayAmount, distanceMiles, dollarsPerMile, score.toInt(), merchantName,
+            ),
+        )
+    }
 }

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -63,6 +63,15 @@ immediately (no second pass needed) so it gets triaged.
 _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **broken** on the
 2026-06-09 dash — moved to that session's log entry below for triage.)_
 
+- **Notification text now formatted (verdict bold/colored/larger, headline bold) (#110, PR pending).**
+  The heads-up offer notification's text is now an Android `SpannableString` — verdict word (ACCEPT /
+  DECLINE / REVIEW) bold, ~1.2× size, colored good/warn/bad; the `$X/hr net` headline bold. To check:
+  on an offer, **look at the heads-up notification** and note what actually renders — (a) is the
+  verdict **bold + larger**? (b) is it **colored** (green/amber/red)? `MessagingStyle` on Android 12+
+  may re-theme/strip the **color** even when bold survives — so report specifically whether the color
+  shows. If color is stripped, the line still reads fine; we'd then weigh a `BigTextStyle` variant
+  (more reliable spans, but can't coexist with the bubble's MessagingStyle).
+  - Confirmed: 0/2.
 - **Self-recognition fixed: our own bubble is no longer parsed as a DoorDash offer (#4, PR pending).**
   Root cause of the 2026-06-09 offer flip-flop: when the bubble was the active window over DoorDash,
   our own overlay got snapshotted, mislabeled `doordash`, and matched `offer_popup` → a phantom


### PR DESCRIPTION
Make the offer notification text look nice — build the summary as an Android SpannableString (verdict bold/1.2x/colored good-warn-bad, headline bold) instead of a Compose AnnotatedString whose spans a notification can't read. toNotificationSummary() now returns CharSequence; toString() yields plain text for chat storage. Stays MessagingStyle (bubble requirement) so on Android 12+ bold/size are reliable but foreground color may be re-themed — degrades to clean plain text, no regression. Field item added to report what renders on-device. Advances #110.