### PR TITLE
docs: Claude memory-upkeep policy + re-add #294 field checklist item

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,7 +255,29 @@ At the start of a session or before picking up new work:
    starting B, C, or D.
 3. **Determine logical next steps** from the milestone/phase ordering, then check those candidates
    for unresolved blockers before committing to a direction.
-4. **Update `memory/project_state.md`** if the current state has drifted from what's recorded.
+4. **Update the project-state memory** (`project_state_<date>.md` in the memory directory —
+   see *Claude Memory Upkeep* below) if the current state has drifted from what's recorded.
+
+## Claude Memory Upkeep
+
+The persistent memory directory (path in `CLAUDE.local.md` § Local workstation) is shared state
+for **every** Claude agent and session that works on this repo — orientation quality next session
+depends on what got written down this session. **Keeping memories current is part of finishing
+any piece of work, not an optional extra.** Whenever your work changes project status — merging
+a PR, closing / re-scoping / filing issues, completing a milestone phase, locking a design
+decision, running an audit, or discovering that something a memory records is no longer true —
+update the relevant memory file(s) **in the same session**, and keep the `MEMORY.md` index in
+sync (one pointer line per memory).
+
+Rules of thumb:
+
+- **A stale memory is worse than no memory** — it actively misleads the next agent. Correct or
+  delete wrong memories on sight; deleting a wrong memory is as valuable as writing a new one.
+- The dated `project_state_<date>.md` snapshot is **replaced** when a newer full audit
+  supersedes it (delete the old file, update the `MEMORY.md` pointer) — don't accumulate
+  stale snapshots.
+- Don't duplicate what the repo already records (code, git history, issues, ADRs, this file) —
+  memories hold status, decisions, and context that are *not* derivable from the repo.
 
 ## Field Testing Logs
 

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -278,6 +278,15 @@ _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **bro
   window transition. What to watch/capture: that tapping Exit produces a click
   capture (and note whether back-gesture vs button changes what DoorDash shows next).
   - Confirmed: 0/2.
+- **Drop-off odometer vs "at door" timer disagreement (#294, recheck — survivor of #220).**
+  On a drop-off arrival, watch **both surfaces at the same moment**: when the HUD flips to
+  **AT DOOR**, does the **odometer stop accruing** (bubble session-miles flat while parked)?
+  The label is flow-region-driven while `PauseOdometer` fires on the platform-task
+  `arrivedAt` flip, so they *can* disagree — and desk analysis (2026-06-04/05 logs) suggests
+  `arrivedAt` often stays **null on no-contact drop-offs**, i.e. the odometer may keep
+  counting exactly while the label says AT DOOR. Note the delivery type (hand-to-customer vs
+  leave-at-door) for each sighting; capture if seen.
+  - Confirmed: 0/2.
 
 ---
 


### PR DESCRIPTION
[skip ci] — docs-only diff (CLAUDE.md + field-testing README), no compiled code.

## What

1. **CLAUDE.md — new "Claude Memory Upkeep" section.** Directs all future Claude agents to update the persistent memory directory whenever their work changes project status (PR merges, issue closes/re-scopes, milestone phases, invalidated facts), to keep the `MEMORY.md` index in sync, to correct/delete stale memories on sight, and to *replace* (not accumulate) dated `project_state_<date>.md` snapshots. Session Orientation item 4 updated to match.
2. **docs/field-testing/README.md — re-add the #294 checklist item.** Issue #294 said its field-recheck item was added to the checklist, but it never actually landed (verified in file + git history during the 2026-06-10 audit). Added with dual-surface instructions (AT DOOR label vs odometer pause) and the no-contact-dropoff `arrivedAt`-null hypothesis from the June desk analyses.

Part of the 2026-06-10 full issue audit: all 49 open issues received dated status comments, 4 closed (#53, #85 not planned; #158, #200 completed), 7 marked in-progress, project board reconciled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)