### PR TITLE
fix(effects): harden SideEffectEngine execution edge (#341)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -149,6 +149,7 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.mockito.core)
     testImplementation(libs.mockito.kotlin)
+    testImplementation(libs.kotlinx.coroutines.test)
 }
 
 kotlin {

--- a/app/src/main/java/cloud/trotter/dashbuddy/di/DispatchersModule.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/di/DispatchersModule.kt
@@ -1,0 +1,34 @@
+package cloud.trotter.dashbuddy.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class IoDispatcher
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class DefaultDispatcher
+
+/**
+ * Injectable dispatchers so coroutine-owning singletons are testable with virtual time
+ * (#341). The data-layer hygiene pass (#364) migrates its hardcoded scopes onto these too.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+object DispatchersModule {
+
+    @Provides
+    @IoDispatcher
+    fun provideIoDispatcher(): CoroutineDispatcher = Dispatchers.IO
+
+    @Provides
+    @DefaultDispatcher
+    fun provideDefaultDispatcher(): CoroutineDispatcher = Dispatchers.Default
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
@@ -17,10 +17,14 @@ import cloud.trotter.dashbuddy.domain.pipeline.RequestedEffect
 import cloud.trotter.dashbuddy.domain.pipeline.TimeoutType
 import cloud.trotter.dashbuddy.core.state.AppEffect
 import cloud.trotter.dashbuddy.core.state.EffectExecutor
+import cloud.trotter.dashbuddy.di.IoDispatcher
 import cloud.trotter.dashbuddy.ui.bubble.BubbleManager
 import cloud.trotter.dashbuddy.ui.formatters.toNotificationSummary
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.delay
@@ -46,6 +50,7 @@ class SideEffectEngine @Inject constructor(
     private val uiInteractionHandler: UiInteractionHandler,
     private val effectsFiredDao: EffectsFiredDao,
     private val ttsEffectHandler: TtsEffectHandler,
+    @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : EffectExecutor {
 
     // 1. OUTPUT STREAM: Events going BACK to the StateMachine (The Loopback)
@@ -81,9 +86,23 @@ class SideEffectEngine @Inject constructor(
      *   - Keyed effects are checked against `effects_fired` for idempotency.
      *   - Loopback effects (timers, evaluations) replay deterministically.
      */
+    /**
+     * Backstop for the effect coroutines this engine spawns (timers, IO writes): an uncaught
+     * failure must never reach the default handler and kill the process (#341).
+     */
+    private val effectExceptionHandler = CoroutineExceptionHandler { _, t ->
+        Timber.e(t, "SideEffectEngine: effect coroutine crashed (isolated)")
+    }
+
     override fun process(effect: AppEffect, scope: CoroutineScope, recovering: Boolean) {
-        scope.launch(Dispatchers.Default) {
-            execute(effect, scope, recovering)
+        scope.launch(effectExceptionHandler) {
+            try {
+                execute(effect, scope, recovering)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Timber.e(e, "Effect failed (isolated): %s", effect::class.simpleName)
+            }
         }
     }
 
@@ -105,7 +124,7 @@ class SideEffectEngine @Inject constructor(
         when (effect) {
             // --- FIRE & FORGET (UI / IO) ---
             is AppEffect.LogEvent -> {
-                scope.launch(Dispatchers.IO) {
+                scope.launch(ioDispatcher + effectExceptionHandler) {
                     appEventRepo.insert(effect.event)
                 }
             }
@@ -177,7 +196,7 @@ class SideEffectEngine @Inject constructor(
                 // lands AFTER the offer screenshot's settle + capture (clean frame).
                 val summary = effect.evaluation.toNotificationSummary()
                 val persona = offerPersona(effect.evaluation.action)
-                scope.launch {
+                scope.launch(effectExceptionHandler) {
                     delay(OFFER_NOTIFICATION_DELAY_MS)
                     bubbleManager.postOfferNotification(summary, persona)
                 }
@@ -189,22 +208,24 @@ class SideEffectEngine @Inject constructor(
                 // Cancel existing timer of this type
                 activeTimers[effect.type]?.cancel()
 
-                // Start new timer
-                val job = scope.launch {
+                // LAZY start so the map entry exists before the body can run; the completion
+                // handler removes only ITSELF (two-arg remove), so an expiring timer can never
+                // untrack a replacement scheduled for the same type (#341).
+                val job = scope.launch(effectExceptionHandler, start = CoroutineStart.LAZY) {
                     delay(effect.durationMs)
                     Timber.w("Timer Expired: ${effect.type}")
 
                     // Emit Timeout Event back to State Machine
                     _events.emit(TimeoutEvent(type = effect.type, payload = effect.payload))
-
-                    activeTimers.remove(effect.type)
                 }
+                job.invokeOnCompletion { activeTimers.remove(effect.type, job) }
                 activeTimers[effect.type] = job
+                job.start()
             }
 
             is AppEffect.CancelTimeout -> {
+                // Untracking happens via the job's self-removing completion handler.
                 activeTimers[effect.type]?.cancel()
-                activeTimers.remove(effect.type)
             }
 
             is AppEffect.SequentialEffect -> {
@@ -214,7 +235,7 @@ class SideEffectEngine @Inject constructor(
 
         // Record keyed effect as fired for idempotency
         if (key != null) {
-            scope.launch(Dispatchers.IO) {
+            scope.launch(ioDispatcher + effectExceptionHandler) {
                 effectsFiredDao.markFired(
                     EffectsFiredEntity(
                         effectKey = key,
@@ -336,13 +357,15 @@ class SideEffectEngine @Inject constructor(
         val durationMs = args["durationMs"]?.toLongOrNull() ?: return
 
         activeTimers[type]?.cancel()
-        val job = scope.launch {
+        // Same LAZY + self-removing pattern as AppEffect.ScheduleTimeout (#341).
+        val job = scope.launch(effectExceptionHandler, start = CoroutineStart.LAZY) {
             delay(durationMs)
             Timber.w("Timer Expired (rule): %s", type)
             _events.emit(TimeoutEvent(type = type))
-            activeTimers.remove(type)
         }
+        job.invokeOnCompletion { activeTimers.remove(type, job) }
         activeTimers[type] = job
+        job.start()
     }
 
     private fun cancelTimeoutFromArgs(args: Map<String, String>) {
@@ -353,8 +376,8 @@ class SideEffectEngine @Inject constructor(
             Timber.w("Unknown timeout type: %s", typeWire)
             return
         }
+        // Untracking happens via the job's self-removing completion handler.
         activeTimers[type]?.cancel()
-        activeTimers.remove(type)
     }
 
     private fun resolvePersona(wire: String?): ChatPersona = when (wire?.lowercase()) {
@@ -392,6 +415,7 @@ class SideEffectEngine @Inject constructor(
         is AppEffect.PlayNotificationSound,
         is AppEffect.CaptureScreenshot,
         is AppEffect.ClickNode,
+        is AppEffect.PerformOfferAction,
         is AppEffect.RequestEffect,
         is AppEffect.StartOdometer,
         is AppEffect.StopOdometer,

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/TtsEffectHandler.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/TtsEffectHandler.kt
@@ -70,7 +70,13 @@ class TtsEffectHandler @Inject constructor(
         Timber.i("TTS speaking: %s", text)
 
         audioManager.requestAudioFocus(audioFocusRequest)
-        tts?.speak(text, TextToSpeech.QUEUE_FLUSH, null, "offer_${eval.merchantName}")
+        val result = tts?.speak(text, TextToSpeech.QUEUE_FLUSH, null, "offer_${eval.merchantName}")
+        if (result != TextToSpeech.SUCCESS) {
+            // A failed speak() never fires an utterance callback — release focus here or
+            // other apps stay ducked (#341).
+            Timber.w("TTS speak returned %s — abandoning audio focus", result)
+            audioManager.abandonAudioFocusRequest(audioFocusRequest)
+        }
     }
 
     private fun formatEvaluation(eval: OfferEvaluation): String {

--- a/app/src/test/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngineTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngineTest.kt
@@ -1,0 +1,183 @@
+package cloud.trotter.dashbuddy.state.effects
+
+import cloud.trotter.dashbuddy.core.data.event.AppEventRepo
+import cloud.trotter.dashbuddy.core.data.strategy.StrategyRepository
+import cloud.trotter.dashbuddy.core.database.effects.EffectsFiredDao
+import cloud.trotter.dashbuddy.core.state.AppEffect
+import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
+import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
+import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluator
+import cloud.trotter.dashbuddy.domain.model.state.TimeoutEvent
+import cloud.trotter.dashbuddy.domain.pipeline.TimeoutType
+import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.ui.bubble.BubbleManager
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+/**
+ * Behavior tests for the SideEffectEngine execution edge (#341):
+ * crash isolation, recovery suppression of external effects, and timer lifecycle.
+ *
+ * All engine coroutines run on the test scheduler (the engine inherits the caller
+ * scope's dispatcher and takes an injected IO dispatcher), so time is virtual.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SideEffectEngineTest {
+
+    private val appEventRepo: AppEventRepo = mock()
+    private val odometerEffectHandler: OdometerEffectHandler = mock()
+    private val tipEffectHandler: TipEffectHandler = mock()
+    private val bubbleManager: BubbleManager = mock()
+    private val offerEvaluator: OfferEvaluator = mock()
+    private val strategyRepository: StrategyRepository = mock()
+    private val screenShotHandler: ScreenShotHandler = mock()
+    private val uiInteractionHandler: UiInteractionHandler = mock()
+    private val effectsFiredDao: EffectsFiredDao = mock()
+    private val ttsEffectHandler: TtsEffectHandler = mock()
+
+    private fun buildEngine(ioDispatcher: CoroutineDispatcher) = SideEffectEngine(
+        appEventRepo = appEventRepo,
+        odometerEffectHandler = odometerEffectHandler,
+        tipEffectHandler = tipEffectHandler,
+        bubbleManager = bubbleManager,
+        offerEvaluator = offerEvaluator,
+        strategyRepository = strategyRepository,
+        screenShotHandler = screenShotHandler,
+        uiInteractionHandler = uiInteractionHandler,
+        effectsFiredDao = effectsFiredDao,
+        ttsEffectHandler = ttsEffectHandler,
+        ioDispatcher = ioDispatcher,
+    )
+
+    /** Mirrors production: StateManagerV2's scope is SupervisorJob + dispatcher, NO exception handler. */
+    private fun TestScope.engineScope(dispatcher: CoroutineDispatcher) =
+        CoroutineScope(SupervisorJob() + dispatcher)
+
+    // =========================================================================
+    // Crash isolation
+    // =========================================================================
+
+    @Test
+    fun `a throwing handler is isolated and the engine keeps processing`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val engine = buildEngine(dispatcher)
+        val scope = engineScope(dispatcher)
+        val eval: OfferEvaluation = mock()
+        doThrow(RuntimeException("boom")).whenever(ttsEffectHandler).speakOffer(any())
+
+        // Pre-#341 this exception escaped to the scope (no handler) and killed the process;
+        // in runTest it would surface as an uncaught-exception test failure.
+        engine.process(AppEffect.SpeakOffer(eval), scope, recovering = false)
+        runCurrent()
+
+        // Engine is still alive: the next effect executes normally.
+        engine.process(AppEffect.SpeakOffer(eval), scope, recovering = false)
+        runCurrent()
+        verify(ttsEffectHandler, times(2)).speakOffer(any())
+    }
+
+    // =========================================================================
+    // Recovery suppression — PerformOfferAction must never replay a click
+    // =========================================================================
+
+    @Test
+    fun `PerformOfferAction is suppressed during recovery and executes live`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val engine = buildEngine(dispatcher)
+        val scope = engineScope(dispatcher)
+        val effect = AppEffect.PerformOfferAction(OfferAction.ACCEPT, Platform.DoorDash)
+
+        engine.process(effect, scope, recovering = true)
+        runCurrent()
+        verify(uiInteractionHandler, never()).performClick(any(), any())
+
+        engine.process(effect, scope, recovering = false)
+        runCurrent()
+        verify(uiInteractionHandler, times(1)).performClick(any(), any())
+    }
+
+    // =========================================================================
+    // Timer lifecycle
+    // =========================================================================
+
+    @Test
+    fun `an expired timer cannot untrack a replacement of the same type`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val engine = buildEngine(dispatcher)
+        val scope = engineScope(dispatcher)
+        val fired = mutableListOf<TimeoutEvent>()
+        backgroundScope.launch(dispatcher) {
+            engine.events.collect { if (it is TimeoutEvent) fired.add(it) }
+        }
+        runCurrent()
+
+        // First timer expires and self-removes.
+        engine.process(AppEffect.ScheduleTimeout(durationMs = 10, type = TimeoutType.SETTLE_UI), scope, false)
+        advanceTimeBy(11)
+        runCurrent()
+        assertEquals(1, fired.size)
+
+        // A replacement scheduled afterwards must remain tracked: cancelling it works.
+        engine.process(AppEffect.ScheduleTimeout(durationMs = 100, type = TimeoutType.SETTLE_UI), scope, false)
+        runCurrent()
+        engine.process(AppEffect.CancelTimeout(TimeoutType.SETTLE_UI), scope, false)
+        runCurrent()
+        advanceTimeBy(500)
+        runCurrent()
+        assertEquals(1, fired.size) // replacement was cancelled, not orphaned
+    }
+
+    @Test
+    fun `rescheduling a timer type replaces the previous timer`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val engine = buildEngine(dispatcher)
+        val scope = engineScope(dispatcher)
+        val fired = mutableListOf<TimeoutEvent>()
+        backgroundScope.launch(dispatcher) {
+            engine.events.collect { if (it is TimeoutEvent) fired.add(it) }
+        }
+        runCurrent()
+
+        engine.process(AppEffect.ScheduleTimeout(durationMs = 100, type = TimeoutType.SETTLE_UI), scope, false)
+        runCurrent()
+        engine.process(AppEffect.ScheduleTimeout(durationMs = 50, type = TimeoutType.SETTLE_UI), scope, false)
+        runCurrent()
+        advanceTimeBy(500)
+        runCurrent()
+        assertEquals(1, fired.size) // only the replacement fired
+    }
+
+    @Test
+    fun `timers still arm during recovery (loopback, not external)`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val engine = buildEngine(dispatcher)
+        val scope = engineScope(dispatcher)
+        val fired = mutableListOf<TimeoutEvent>()
+        backgroundScope.launch(dispatcher) {
+            engine.events.collect { if (it is TimeoutEvent) fired.add(it) }
+        }
+        runCurrent()
+
+        engine.process(AppEffect.ScheduleTimeout(durationMs = 10, type = TimeoutType.SESSION_PAUSED_SAFETY), scope, recovering = true)
+        advanceTimeBy(11)
+        runCurrent()
+        assertEquals(1, fired.size)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -74,6 +74,7 @@ hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.r
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
 kotlinx-coroutines-play-services = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-play-services", version.ref = "kotlinxCoroutinesPlayServices" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinSerialization" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }


### PR DESCRIPTION
Fixes #341 (audit items A-1, A-2 + two A-28 races). First PR of the P0 fix campaign.

## What
1. **Crash isolation** — `process()` try/catches `execute()` (rethrows `CancellationException`) and all engine-spawned coroutines carry a `CoroutineExceptionHandler`. A throwing effect (e.g. `EvaluateOffer`'s DataStore read) is logged, not fatal.
2. **`PerformOfferAction` is now external** — crash-recovery replay can never re-click offer Accept/Decline, independent of future payload-persistence work (#352/#366).
3. **Timer lifecycle race fixed** — LAZY-started jobs + self-removing two-arg `remove(type, job)` completion handlers in both scheduling paths; `CancelTimeout` no longer does an unkeyed remove that could evict a replacement timer.
4. **TTS focus leak** — focus abandoned when `speak()` returns failure (no utterance callback ever fires on that path).
5. **Testability** — injected `@IoDispatcher` (new `DispatchersModule`; #364 will migrate the data layer onto it), engine inherits the caller scope's dispatcher (StateManagerV2's scope already supplies `Default`), `kotlinx-coroutines-test` added.

## Tests
- New `SideEffectEngineTest` (5 tests, virtual time): throwing handler isolated + engine stays alive; PerformOfferAction suppressed in recovery / executes live; expired timer can't untrack a replacement; reschedule replaces; timers arm during recovery (loopback semantics preserved).
- Full `testDebugUnitTest` green across all modules.

No field-checklist item: no new on-dash-observable behavior (crash-resistance + race fixes); TTS-focus path only observable on rare TTS failure.

CLAUDE.md drift check: none (handler roster unchanged; DI contents not enumerated there). Memory update follows merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)