### PR TITLE
fix(network): stop logging the EIA api_key; debug-gate all HTTP logging (#348)

### DIFF
--- a/core/network/src/main/java/cloud/trotter/dashbuddy/core/network/di/GasPriceApiModule.kt
+++ b/core/network/src/main/java/cloud/trotter/dashbuddy/core/network/di/GasPriceApiModule.kt
@@ -1,5 +1,6 @@
 package cloud.trotter.dashbuddy.core.network.di
 
+import cloud.trotter.dashbuddy.core.network.BuildConfig
 import cloud.trotter.dashbuddy.core.network.fuel.price.eia.EiaApi
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import dagger.Module
@@ -11,6 +12,7 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
+import timber.log.Timber
 import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 
@@ -24,9 +26,21 @@ object GasPriceApiModule {
         val contentType = "application/json".toMediaType()
 
         val client = OkHttpClient.Builder()
-            .addInterceptor(HttpLoggingInterceptor().apply {
-                level = HttpLoggingInterceptor.Level.BODY
-            })
+            .apply {
+                // Debug-only, Timber-piped, and the EIA key travels as a query param —
+                // redact it so the secret never reaches logcat or the persisted file log (#348).
+                if (BuildConfig.DEBUG) {
+                    val timberLogger = HttpLoggingInterceptor.Logger { message ->
+                        Timber.tag("EiaApi").v(message)
+                    }
+                    addInterceptor(
+                        HttpLoggingInterceptor(timberLogger).apply {
+                            level = HttpLoggingInterceptor.Level.BODY
+                            redactQueryParams("api_key")
+                        }
+                    )
+                }
+            }
             .connectTimeout(30, TimeUnit.SECONDS)
             .readTimeout(30, TimeUnit.SECONDS)
             .writeTimeout(30, TimeUnit.SECONDS)

--- a/core/network/src/main/java/cloud/trotter/dashbuddy/core/network/di/VehicleNetworkModule.kt
+++ b/core/network/src/main/java/cloud/trotter/dashbuddy/core/network/di/VehicleNetworkModule.kt
@@ -1,5 +1,6 @@
 package cloud.trotter.dashbuddy.core.network.di
 
+import cloud.trotter.dashbuddy.core.network.BuildConfig
 import cloud.trotter.dashbuddy.core.network.vehicle.efficiency.epa.EpaApi
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import dagger.Module
@@ -39,7 +40,8 @@ object VehicleNetworkModule {
         }
 
         val client = OkHttpClient.Builder()
-            .addInterceptor(loggingInterceptor)
+            // Debug builds only — release gets no HTTP logging at all (#348).
+            .apply { if (BuildConfig.DEBUG) addInterceptor(loggingInterceptor) }
             .build()
 
         // Configure JSON parsing to be highly forgiving since we don't control the government's API schemas


### PR DESCRIPTION
Fixes #348 (audit item A-10). P0 campaign PR 2.

## What
- **GasPriceApiModule**: the unconditional `HttpLoggingInterceptor(BODY)` with the default platform logger printed the full request line — including `api_key=<secret>` (`EiaApi` sends it as a query param) — in every build type. Now: debug-only, piped through `Timber.tag("EiaApi").v` (consistent with the EPA module, and VERBOSE keeps it below the file-log's default persistence threshold), with `redactQueryParams("api_key")` so the key never appears even in debug logs.
- **VehicleNetworkModule**: same debug gate applied to its existing Timber-piped interceptor (no secret there; release just shouldn't log HTTP bodies).

`:core:network:build` green; no behavior change to the API calls themselves.

CLAUDE.md drift check: none. Memory updated post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)