### PR TITLE
fix(effects): move screenshot save off the main thread (#349)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/ScreenShotHandler.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/ScreenShotHandler.kt
@@ -2,16 +2,18 @@ package cloud.trotter.dashbuddy.state.effects
 
 import android.accessibilityservice.AccessibilityService
 import android.content.ContentValues
+import android.content.Context
 import android.graphics.Bitmap
 import android.net.Uri
 import android.provider.MediaStore
 import android.view.Display
-import cloud.trotter.dashbuddy.DashBuddyApplication
-import cloud.trotter.dashbuddy.core.pipeline.accessibility.input.AccessibilityListener
-//import cloud.trotter.dashbuddy.log.Logger as Log
+import cloud.trotter.dashbuddy.core.pipeline.accessibility.input.AccessibilitySource
 import cloud.trotter.dashbuddy.core.state.AppEffect
+import cloud.trotter.dashbuddy.di.IoDispatcher
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.asExecutor
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -23,7 +25,11 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class ScreenShotHandler @Inject constructor() {
+class ScreenShotHandler @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+    private val accessibilitySource: AccessibilitySource,
+    @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+) {
 
     companion object {
         /** UI-settle delay before every capture — mirrors the click settle (500ms). */
@@ -31,27 +37,28 @@ class ScreenShotHandler @Inject constructor() {
     }
 
     fun capture(scope: CoroutineScope, effect: AppEffect.CaptureScreenshot) {
-        scope.launch(Dispatchers.IO) {
+        scope.launch(ioDispatcher) {
             // Let the third-party UI settle before grabbing the frame, so captures
             // aren't taken mid-transition. This is the only screenshot path, so the
             // delay applies to all screenshots everywhere.
             delay(SETTLE_MS)
-            val service = AccessibilityListener.instance ?: return@launch
-
-            val mainExecutor =
-                androidx.core.content.ContextCompat.getMainExecutor(DashBuddyApplication.context)
+            val service = accessibilitySource.getService() ?: return@launch
 
             try {
                 service.takeScreenshot(
                     Display.DEFAULT_DISPLAY,
-                    mainExecutor,
+                    // IO-backed executor: the callback does PNG compression + MediaStore
+                    // writes, which must never run on the main thread (#349).
+                    ioDispatcher.asExecutor(),
                     object : AccessibilityService.TakeScreenshotCallback {
                         override fun onSuccess(result: AccessibilityService.ScreenshotResult) {
-                            // 1. Save using MediaStore (Synchronously on this background thread)
-                            saveToGallery(result, effect.filenamePrefix)
-
-                            // 2. CLEANUP: Critical!
-                            result.hardwareBuffer.close()
+                            try {
+                                saveToGallery(result, effect.filenamePrefix)
+                            } finally {
+                                // The bitmap wraps this buffer, so close only after the
+                                // save completes — but on every path (#349).
+                                result.hardwareBuffer.close()
+                            }
                         }
 
                         override fun onFailure(errorCode: Int) {
@@ -69,13 +76,12 @@ class ScreenShotHandler @Inject constructor() {
 
     /**
      * Saves the screenshot to the public "Pictures/DashBuddy" folder using MediaStore.
-     * This makes it immediately visible in Gallery apps.
+     * This makes it immediately visible in Gallery apps. Runs on the IO executor.
      */
     private fun saveToGallery(
         result: AccessibilityService.ScreenshotResult,
         filenamePrefix: String
     ) {
-        val context = DashBuddyApplication.context
         val resolver = context.contentResolver
 
         try {

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/input/AccessibilitySource.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/input/AccessibilitySource.kt
@@ -59,6 +59,13 @@ class AccessibilitySource @Inject constructor() {
         serviceRef = WeakReference(service)
     }
 
+    /**
+     * The live service instance, for service-level capabilities beyond node access
+     * (e.g. `takeScreenshot`). Prefer the narrower accessors when one fits — this exists
+     * so consumers inject this source instead of reaching for service statics (#349).
+     */
+    fun getService(): AccessibilityService? = serviceRef?.get()
+
     /** Active-window root snapshot: the converted [UiNode] tree + the **real package** owning it. */
     data class RootSnapshot(val tree: UiNode, val packageName: String?)
 

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -302,6 +302,12 @@ _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **bro
   recurrence. If it shows two pickups again, grab the `offer_popup` capture + a screenshot pair so
   parse vs render can be split.
   - Confirmed: 0/2.
+- **Screenshots still save + no offer-time jank (#349).** Screenshot saving moved fully off the
+  main thread (the PNG compress + MediaStore write used to run on main, right when the offer
+  card/notification renders). Confirm: (a) offer + dash-summary screenshots still land in
+  `Pictures/DashBuddy`; (b) no visible stutter the moment an offer arrives (should be same or
+  smoother than before).
+  - Confirmed: 0/2.
 
 ---
 


### PR DESCRIPTION
Fixes #349 (audit item A-17). P0 campaign PR 3.

## What
- `takeScreenshot` callback executor switched from the **main** executor to an IO-backed one (`ioDispatcher.asExecutor()`, reusing #341's injected dispatcher) — the PNG compression + MediaStore IO that ran on the main thread exactly at offer-render time now runs on IO. The buffer-wrapping bitmap is saved before `hardwareBuffer.close()`, which now happens in a `finally` (previously leaked on save failure).
- `ScreenShotHandler` loses its static reach-ins: injected `@ApplicationContext Context`, `AccessibilitySource` (new narrow `getService()` accessor in `:core:pipeline`), `@IoDispatcher`. Only the documented #119 seam still touches `DashBuddyApplication` statics repo-wide.

## Verification
- Verified by construction: every byte of save work executes on the IO executor (the callback's thread), with a thread-hostile path no longer possible; `:app` compiles, `SideEffectEngineTest` green.
- On-device confirmation rides the new field-checklist item (screenshots still land in `Pictures/DashBuddy`, no offer-time jank) — Robolectric can't exercise `takeScreenshot`.

CLAUDE.md drift check: none. Memory updated post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)