### PR TITLE
fix(state): route Timeout observations to their platform region (#342)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
@@ -216,7 +216,9 @@ class SideEffectEngine @Inject constructor(
                     Timber.w("Timer Expired: ${effect.type}")
 
                     // Emit Timeout Event back to State Machine
-                    _events.emit(TimeoutEvent(type = effect.type, payload = effect.payload))
+                    _events.emit(
+                        TimeoutEvent(type = effect.type, platform = effect.platform, payload = effect.payload)
+                    )
                 }
                 job.invokeOnCompletion { activeTimers.remove(effect.type, job) }
                 activeTimers[effect.type] = job
@@ -280,7 +282,10 @@ class SideEffectEngine @Inject constructor(
             EffectVerb.ODOMETER_STOP -> odometerEffectHandler.shutDown()
             EffectVerb.ODOMETER_PAUSE -> odometerEffectHandler.pause()
             EffectVerb.ODOMETER_RESUME -> odometerEffectHandler.resume()
-            EffectVerb.SCHEDULE_TIMEOUT -> scheduleTimeoutFromArgs(scope, e.args)
+            EffectVerb.SCHEDULE_TIMEOUT -> scheduleTimeoutFromArgs(
+                scope, e.args,
+                Platform.fromRuleId(e.ruleId).takeIf { it != Platform.Unknown },
+            )
             EffectVerb.CANCEL_TIMEOUT -> cancelTimeoutFromArgs(e.args)
         }
     }
@@ -346,7 +351,11 @@ class SideEffectEngine @Inject constructor(
         bubbleManager.endSession(platformName)
     }
 
-    private suspend fun scheduleTimeoutFromArgs(scope: CoroutineScope, args: Map<String, String>) {
+    private suspend fun scheduleTimeoutFromArgs(
+        scope: CoroutineScope,
+        args: Map<String, String>,
+        platform: Platform?,
+    ) {
         val typeWire = args["type"] ?: return
         val type = try {
             TimeoutType.valueOf(typeWire)
@@ -361,7 +370,7 @@ class SideEffectEngine @Inject constructor(
         val job = scope.launch(effectExceptionHandler, start = CoroutineStart.LAZY) {
             delay(durationMs)
             Timber.w("Timer Expired (rule): %s", type)
-            _events.emit(TimeoutEvent(type = type))
+            _events.emit(TimeoutEvent(type = type, platform = platform))
         }
         job.invokeOnCompletion { activeTimers.remove(type, job) }
         activeTimers[type] = job

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/AppEffect.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/AppEffect.kt
@@ -51,6 +51,12 @@ sealed class AppEffect {
         val durationMs: Long,
         val type: TimeoutType,
         /**
+         * Platform region this timer belongs to — threaded through TimeoutEvent →
+         * Observation.Timeout so the fire routes back to the owning region instead
+         * of Platform.Unknown (#342). Null = not platform-scoped.
+         */
+        val platform: Platform? = null,
+        /**
          * Opaque payload carried through the timer back into [Observation.Timeout].
          * Used to thread effect context (e.g. click target NodeRef fields) through
          * the UDF round-trip when the firing of a downstream effect must be deferred.

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -393,6 +393,9 @@ class EffectMap @Inject constructor(
                             AppEffect.ScheduleTimeout(
                                 durationMs,
                                 TimeoutType.SESSION_PAUSED_SAFETY,
+                                // Route the fire back to THIS region — without it the timeout
+                                // steps Platform.Unknown and the pause never expires (#342).
+                                platform = next.platform,
                             )
                         )
                         add(AppEffect.UpdateBubble("Dash Paused!"))
@@ -684,6 +687,7 @@ class EffectMap @Inject constructor(
                     AppEffect.ScheduleTimeout(
                         durationMs = effect.delayMs!!,
                         type = TimeoutType.SETTLE_UI,
+                        platform = flowObs.platform.takeIf { it != Platform.Unknown },
                         payload = serializeClickContext(effect),
                     )
                 } else {

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
@@ -53,19 +53,22 @@ class PlatformRegionStepper @Inject constructor() {
         obs: Observation,
         policy: TransitionPolicy,
     ): PlatformRegion {
-        // Handle timeout-driven transitions
-        if (obs is Observation.Timeout) return handleTimeout(prev, obs, policy)
-
         var current = prev
 
         // Lazy expiry: a pending destructive transition (dash-end / task-retire)
         // whose deadline has passed is confirmed — committed now. Driven by
         // obs.timestamp (never a wall clock) so crash-recovery replay matches.
+        // Runs BEFORE the timeout branch: a routed timeout (#342) is exactly the
+        // kind of non-flow observation that must be able to commit an overdue
+        // provisional transition.
         current.pendingDestructive?.let { pend ->
             if (obs.timestamp > pend.deadline) {
                 current = commitDestructive(current, pend.kind, pend.deadline)
             }
         }
+
+        // Handle timeout-driven transitions
+        if (obs is Observation.Timeout) return handleTimeout(current, obs, policy)
 
         // Authoritative dash-start signal (#279-B): the set-end-time screen while a
         // dash-end is pending in its grace window means the old dash really ended

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/StateManagerV2.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/StateManagerV2.kt
@@ -351,6 +351,7 @@ class StateManagerV2 @Inject constructor(
             is TimeoutEvent -> Observation.Timeout(
                 timestamp = event.timestamp,
                 type = event.type,
+                targetPlatform = event.platform,
                 payload = event.payload,
             )
 

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/TimeoutRoutingTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/TimeoutRoutingTest.kt
@@ -1,0 +1,102 @@
+package cloud.trotter.dashbuddy.core.state
+
+import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.pipeline.TimeoutType
+import cloud.trotter.dashbuddy.domain.state.AppState
+import cloud.trotter.dashbuddy.domain.state.DestructiveKind
+import cloud.trotter.dashbuddy.domain.state.Job
+import cloud.trotter.dashbuddy.domain.state.Mode
+import cloud.trotter.dashbuddy.domain.state.PendingDestructive
+import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.domain.state.PlatformRegion
+import cloud.trotter.dashbuddy.domain.state.Regions
+import cloud.trotter.dashbuddy.domain.state.Session
+import cloud.trotter.dashbuddy.domain.state.Task
+import cloud.trotter.dashbuddy.domain.state.TaskPhase
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * #342 — [Observation.Timeout] must step the region it was armed for. Timeouts carry
+ * no ruleId, so without an explicit [Observation.Timeout.targetPlatform] they derive
+ * [Platform.Unknown] and the owning region never sees the fire — which left the
+ * SESSION_PAUSED_SAFETY timer dead at the region level.
+ */
+class TimeoutRoutingTest {
+
+    private val machine = StateMachine(
+        flowStepper = FlowRegionStepper(),
+        platformStepper = PlatformRegionStepper(),
+        crossPlatformStepper = CrossPlatformRegionStepper(),
+        transitionPolicy = TransitionPolicy(),
+        effectMap = EffectMap(MetadataProvider { "{}" }),
+    )
+
+    private fun pausedRegion() = PlatformRegion(
+        platform = Platform.DoorDash,
+        mode = Mode.Paused,
+        session = Session("sess-1", startedAt = 1_000L),
+    )
+
+    private fun state(region: PlatformRegion) = AppState(
+        regions = Regions(platforms = mapOf(Platform.DoorDash to region)),
+        timestamp = 1_000L,
+    )
+
+    @Test
+    fun `pause-safety timeout routed to its platform expires the pause`() {
+        val obs = Observation.Timeout(
+            timestamp = 5_000L,
+            type = TimeoutType.SESSION_PAUSED_SAFETY,
+            targetPlatform = Platform.DoorDash,
+        )
+
+        val next = machine.step(state(pausedRegion()), obs).newState
+        val region = next.regions.platforms.getValue(Platform.DoorDash)
+
+        // Paused → Offline with a provisional (graced) session end armed.
+        assertEquals(Mode.Offline, region.mode)
+        assertEquals(DestructiveKind.SESSION_END, region.pendingDestructive?.kind)
+    }
+
+    @Test
+    fun `timeout without a target platform leaves other regions untouched`() {
+        val obs = Observation.Timeout(
+            timestamp = 5_000L,
+            type = TimeoutType.SESSION_PAUSED_SAFETY,
+        )
+
+        val next = machine.step(state(pausedRegion()), obs).newState
+
+        // Routed to Platform.Unknown — the DoorDash region must not change.
+        assertEquals(Mode.Paused, next.regions.platforms.getValue(Platform.DoorDash).mode)
+    }
+
+    @Test
+    fun `routed timeout commits an expired task-retire deadline (lazy expiry)`() {
+        val region = PlatformRegion(
+            platform = Platform.DoorDash,
+            mode = Mode.Online,
+            session = Session("sess-1", startedAt = 100L),
+            activeJob = Job("j1", offerStoreHint = emptyList(), parentOfferHash = null, startedAt = 200L),
+            activeTask = Task(
+                taskId = "t1", jobId = "j1", phase = TaskPhase.PICKUP,
+                storeName = "HEB", startedAt = 300L,
+            ),
+            pendingDestructive = PendingDestructive(
+                DestructiveKind.TASK_RETIRE, since = 800L, deadline = 1_000L,
+            ),
+        )
+        // A non-flow observation past the deadline — only reaches the region when routed.
+        val obs = Observation.Timeout(
+            timestamp = 2_000L,
+            type = TimeoutType.SETTLE_UI,
+            targetPlatform = Platform.DoorDash,
+        )
+
+        val next = machine.step(state(region), obs).newState
+
+        assertNull(next.regions.platforms.getValue(Platform.DoorDash).activeTask)
+    }
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/state/TimeoutEvent.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/state/TimeoutEvent.kt
@@ -1,9 +1,12 @@
 package cloud.trotter.dashbuddy.domain.model.state
 
 import cloud.trotter.dashbuddy.domain.pipeline.TimeoutType
+import cloud.trotter.dashbuddy.domain.state.Platform
 
 data class TimeoutEvent(
     override val timestamp: Long = System.currentTimeMillis(),
     val type: TimeoutType = TimeoutType.SESSION_PAUSED_SAFETY,
+    /** Platform region the timer belongs to — threads through to Observation.Timeout (#342). */
+    val platform: Platform? = null,
     val payload: Map<String, Any?> = emptyMap(),
 ) : StateEvent

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/Observation.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/Observation.kt
@@ -97,12 +97,21 @@ sealed interface Observation : cloud.trotter.dashbuddy.domain.model.state.StateE
         override val metadata: ReplayMetadata = ReplayMetadata.EMPTY,
         val type: TimeoutType,
         /**
+         * The platform region this timer belongs to. Timeouts carry no ruleId, so
+         * without an explicit target they derive [Platform.Unknown] and the owning
+         * region never sees the fire — the pause-safety timer was dead (#342).
+         * Null = not platform-scoped.
+         */
+        val targetPlatform: Platform? = null,
+        /**
          * Carries opaque context from the original [AppEffect.ScheduleTimeout]'s
          * payload back into the state machine. Used for deferred-effect patterns
          * like click-after-settle where the timer fire needs to know what to do.
          */
         val payload: Map<String, Any?> = emptyMap(),
-    ) : Observation
+    ) : Observation {
+        override val platform: Platform get() = targetPlatform ?: Platform.fromRuleId(ruleId)
+    }
 
     /** A UI interaction event from the bubble HUD or overlay. */
     data class UiInput(


### PR DESCRIPTION
Fixes #342 (audit item A-3). P0 campaign PR 4.

## What
- `Observation.Timeout.targetPlatform` (explicit, overrides the ruleId-derived `platform`) threaded through the whole round-trip: `AppEffect.ScheduleTimeout(platform)` → `TimeoutEvent(platform)` → bridge → routing. The pause-safety and SETTLE_UI timers now stamp their owning platform; rule-driven timers derive it from the requesting rule id.
- Lazy `pendingDestructive` expiry moved above the timeout early-return in `PlatformRegionStepper.step()` — a routed timeout can now commit an overdue graced transition (it's exactly the non-flow observation that should be able to).

## Tests
`TimeoutRoutingTest` (new, :core:state): routed SESSION_PAUSED_SAFETY flips Paused→Offline + arms graced session end; unrouted timeout leaves other regions untouched; routed timeout commits an expired TASK_RETIRE. All existing grace/lifecycle tests green; full `testDebugUnitTest` green.

## Knock-on (intentional, tracked)
Committing TASK_RETIRE via a timeout makes the `diffTask`-skips-non-flow-observations gap *reachable* (state retires the task; no `DELIVERY_CONFIRMED` event emitted). That's exactly #345 item 2 — next in the P0 queue; landing this first is the right order (state correctness, then event-emission correctness).

Field-checklist item for the pause-expiry behavior rides in the NEXT PR (#345) — an edit-guard hiccup kept it out of this one.

CLAUDE.md drift check: none. Memory updated post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)