### PR TITLE
fix(state): eval/diff correctness pack (#345)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
@@ -187,7 +187,7 @@ class SideEffectEngine @Inject constructor(
                 // the evaluation lands on the pending offer — keeps this handler thin.
                 val config = strategyRepository.evaluationConfigFlow.first()
                 val result = offerEvaluator.evaluate(effect.parsedOffer, config)
-                _events.emit(OfferEvaluationEvent(result.action, result))
+                _events.emit(OfferEvaluationEvent(result.action, result, offerHash = effect.offerHash))
             }
 
             is AppEffect.PostOfferNotification -> {

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/AppEffect.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/AppEffect.kt
@@ -69,7 +69,12 @@ sealed class AppEffect {
     data object StopOdometer : AppEffect()
     data object PauseOdometer : AppEffect()   // pause GPS while stationary; session total preserved
     data object ResumeOdometer : AppEffect()  // resume GPS after stationary pause
-    data class EvaluateOffer(val parsedOffer: ParsedOffer) : AppEffect()
+    /**
+     * Evaluate the pending offer. [offerHash] rides the async round-trip so the result
+     * can be correlated back — a replaced offer must never inherit the previous offer's
+     * evaluation (#345).
+     */
+    data class EvaluateOffer(val parsedOffer: ParsedOffer, val offerHash: String) : AppEffect()
     /** Speak the offer's evaluation aloud (verdict + headline economics). Fires on eval-landing. */
     data class SpeakOffer(val evaluation: OfferEvaluation) : AppEffect()
 

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -129,7 +129,7 @@ class EffectMap @Inject constructor(
 
             // Evaluate (the heads-up notification + spoken read fire later, once the async
             // evaluation lands on the pending offer — see the eval-landing block below).
-            add(AppEffect.EvaluateOffer(offer.parsedOffer))
+            add(AppEffect.EvaluateOffer(offer.parsedOffer, nextOffer.offerHash))
         }
 
         // Offer replaced (different hash)
@@ -144,7 +144,7 @@ class EffectMap @Inject constructor(
 
             // Evaluate the new offer (notification + spoken read fire on eval-landing below).
             val offer = nextOffer.offerFields
-            add(AppEffect.EvaluateOffer(offer.parsedOffer))
+            add(AppEffect.EvaluateOffer(offer.parsedOffer, nextOffer.offerHash))
         }
 
         // Evaluation landed (async loopback) → fire the offer's UI side-effects: the heads-up
@@ -412,9 +412,11 @@ class EffectMap @Inject constructor(
         nextFlow: FlowRegion,
         obs: Observation,
     ): List<AppEffect> {
-        val flowObs = obs as? Observation.FlowObservation ?: return emptyList()
+        // Diffs are computed from prev/next region state for EVERY observation type:
+        // lazy expiry can retire a task on a non-flow observation (a routed timeout,
+        // #342), and that closure must still emit DELIVERY_CONFIRMED (#345).
         val nextFlowVal = nextFlow.flow
-        val sessionId = next.session?.sessionId
+        val sessionId = next.session?.sessionId ?: prev.session?.sessionId
 
         return buildList {
             val prevTask = prev.activeTask
@@ -763,10 +765,15 @@ class EffectMap @Inject constructor(
 
     private fun evaluateGate(gate: ParsedFieldsGate?, parsed: ParsedFields): Boolean {
         if (gate == null) return true
-        val fieldsMap = parsedFieldsToMap(parsed)
+        // Fail CLOSED: if fields can't be extracted we can't prove the condition,
+        // and a gated action (potentially an auto-click) must not fire (#345).
+        val fieldsMap = parsedFieldsToMap(parsed) ?: return false
         return when (gate) {
             is ParsedFieldsGate.FieldEquals -> fieldsMap[gate.field] == gate.value
-            is ParsedFieldsGate.FieldNotEquals -> fieldsMap[gate.field] != gate.value
+            // An ABSENT field (wrong name, or ParsedFields.None) proves nothing —
+            // only a present-but-different value satisfies "not equals".
+            is ParsedFieldsGate.FieldNotEquals ->
+                gate.field in fieldsMap && fieldsMap[gate.field] != gate.value
             is ParsedFieldsGate.FieldNotNull -> fieldsMap[gate.field] != null
         }
     }
@@ -777,10 +784,11 @@ class EffectMap @Inject constructor(
      *
      * `activity` is excluded because it is a classification tag inherited
      * from the sealed parent — rules gate on structural fields, not the
-     * activity discriminator. If gate evaluation fails, the gate rejects
-     * (safe default — the action simply won't fire).
+     * activity discriminator. Returns null on extraction failure so the
+     * caller rejects (fail closed) instead of evaluating against an empty
+     * map, where FieldNotEquals would spuriously fire (#345).
      */
-    private fun parsedFieldsToMap(parsed: ParsedFields): Map<String, Any?> {
+    private fun parsedFieldsToMap(parsed: ParsedFields): Map<String, Any?>? {
         if (parsed is ParsedFields.None) return emptyMap()
         return try {
             parsed::class.java.declaredFields
@@ -791,7 +799,7 @@ class EffectMap @Inject constructor(
                 }
         } catch (e: Exception) {
             Timber.w(e, "Gate field extraction failed for %s", parsed::class.simpleName)
-            emptyMap()
+            null
         }
     }
 

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/FlowRegionStepper.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/FlowRegionStepper.kt
@@ -133,6 +133,14 @@ class FlowRegionStepper @Inject constructor() {
         val evaluation = obs.payload["evaluation"] as? OfferEvaluation
             ?: return prev.copy(lastObservedAt = obs.timestamp)
 
+        // Correlate by hash: an evaluation computed for a since-replaced offer must not
+        // land on the current one (the notification/TTS would speak the wrong economics,
+        // #345). A null hash (legacy replayed stubs) is accepted as-before.
+        val evalHash = obs.payload["offerHash"] as? String
+        if (evalHash != null && evalHash != offer.offerHash) {
+            return prev.copy(lastObservedAt = obs.timestamp)
+        }
+
         return prev.copy(
             pendingOffer = offer.copy(evaluation = evaluation),
             lastObservedAt = obs.timestamp,

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/StateManagerV2.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/StateManagerV2.kt
@@ -361,6 +361,7 @@ class StateManagerV2 @Inject constructor(
                 payload = mapOf(
                     "action" to event.action.name,
                     "evaluation" to event.evaluation,
+                    "offerHash" to event.offerHash,
                 ),
             )
 

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/EvalDiffCorrectnessTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/EvalDiffCorrectnessTest.kt
@@ -1,0 +1,206 @@
+package cloud.trotter.dashbuddy.core.state
+
+import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
+import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
+import cloud.trotter.dashbuddy.domain.model.event.AppEventType
+import cloud.trotter.dashbuddy.domain.model.offer.ParsedOffer
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
+import cloud.trotter.dashbuddy.domain.pipeline.EffectVerb
+import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.pipeline.ParsedFieldsGate
+import cloud.trotter.dashbuddy.domain.pipeline.RequestedEffect
+import cloud.trotter.dashbuddy.domain.pipeline.TimeoutType
+import cloud.trotter.dashbuddy.domain.state.AppState
+import cloud.trotter.dashbuddy.domain.state.DestructiveKind
+import cloud.trotter.dashbuddy.domain.state.Flow
+import cloud.trotter.dashbuddy.domain.state.FlowRegion
+import cloud.trotter.dashbuddy.domain.state.Job
+import cloud.trotter.dashbuddy.domain.state.Mode
+import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import cloud.trotter.dashbuddy.domain.state.PendingDestructive
+import cloud.trotter.dashbuddy.domain.state.PendingOffer
+import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.domain.state.PlatformRegion
+import cloud.trotter.dashbuddy.domain.state.Regions
+import cloud.trotter.dashbuddy.domain.state.Session
+import cloud.trotter.dashbuddy.domain.state.Task
+import cloud.trotter.dashbuddy.domain.state.TaskPhase
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #345 — eval/diff correctness pack:
+ * 1. An offer evaluation must land only on the offer it was computed FOR (hash-correlated).
+ * 2. Task closures committed by non-flow observations (e.g. a routed timeout, #342) must
+ *    still emit DELIVERY_CONFIRMED.
+ * 3. Effect gates fail CLOSED: an absent/unextractable field never satisfies a gate.
+ */
+class EvalDiffCorrectnessTest {
+
+    private val flowStepper = FlowRegionStepper()
+    private val effectMap = EffectMap(MetadataProvider { "{}" })
+
+    private val machine = StateMachine(
+        flowStepper = FlowRegionStepper(),
+        platformStepper = PlatformRegionStepper(),
+        crossPlatformStepper = CrossPlatformRegionStepper(),
+        transitionPolicy = TransitionPolicy(),
+        effectMap = effectMap,
+    )
+
+    // ---- helpers ----
+
+    private fun offer(hash: String) = PendingOffer(
+        offerHash = hash,
+        offerFields = ParsedFields.OfferFields(
+            parsedOffer = ParsedOffer(offerHash = hash, payAmount = 7.5, distanceMiles = 3.0),
+        ),
+        presentedAt = 1_000L,
+        returnFlow = Flow.Idle,
+    )
+
+    private fun evaluation() = OfferEvaluation(
+        action = OfferAction.ACCEPT,
+        score = 75.0,
+        qualityLevel = "Good",
+        recommendationText = "Recommended: ACCEPT",
+        payAmount = 7.50,
+        fuelCostEstimate = 0.5,
+        netPayAmount = 6.50,
+        distanceMiles = 3.0,
+        dollarsPerMile = 2.17,
+        dollarsPerHour = 22.0,
+        estimatedTimeMinutes = 18.0,
+        itemCount = 1.0,
+        merchantName = "Wendy's",
+    )
+
+    private fun loopback(evalForHash: String?) = Observation.Loopback(
+        timestamp = 2_000L,
+        effect = "offer_evaluated",
+        payload = mapOf(
+            "action" to OfferAction.ACCEPT.name,
+            "evaluation" to evaluation(),
+            "offerHash" to evalForHash,
+        ),
+    )
+
+    // ---- 1. eval correlation ----
+
+    @Test
+    fun `evaluation for a replaced offer does not land on the current offer`() {
+        val region = FlowRegion(flow = Flow.OfferPresented, pendingOffer = offer("offer-B"))
+
+        val next = flowStepper.step(region, loopback(evalForHash = "offer-A"))
+
+        assertNull(next.pendingOffer?.evaluation)
+    }
+
+    @Test
+    fun `evaluation with the matching hash lands`() {
+        val region = FlowRegion(flow = Flow.OfferPresented, pendingOffer = offer("offer-A"))
+
+        val next = flowStepper.step(region, loopback(evalForHash = "offer-A"))
+
+        assertNotNull(next.pendingOffer?.evaluation)
+    }
+
+    @Test
+    fun `evaluation with no hash lands (legacy replay stubs)`() {
+        val region = FlowRegion(flow = Flow.OfferPresented, pendingOffer = offer("offer-A"))
+
+        val next = flowStepper.step(region, loopback(evalForHash = null))
+
+        assertNotNull(next.pendingOffer?.evaluation)
+    }
+
+    // ---- 2. task closure on a non-flow observation ----
+
+    @Test
+    fun `task-retire committed by a routed timeout emits DELIVERY_CONFIRMED`() {
+        val dropoff = Task(
+            taskId = "t1", jobId = "j1", phase = TaskPhase.DROPOFF,
+            storeName = "HEB", startedAt = 300L,
+        )
+        val region = PlatformRegion(
+            platform = Platform.DoorDash,
+            mode = Mode.Online,
+            session = Session("sess-1", startedAt = 100L),
+            activeJob = Job("j1", offerStoreHint = emptyList(), parentOfferHash = null, startedAt = 200L),
+            activeTask = dropoff,
+            pendingDestructive = PendingDestructive(
+                DestructiveKind.TASK_RETIRE, since = 800L, deadline = 1_000L,
+            ),
+        )
+        val prev = AppState(
+            regions = Regions(platforms = mapOf(Platform.DoorDash to region)),
+            timestamp = 900L,
+        )
+        val obs = Observation.Timeout(
+            timestamp = 2_000L,
+            type = TimeoutType.SETTLE_UI,
+            targetPlatform = Platform.DoorDash,
+        )
+
+        val transition = machine.step(prev, obs)
+
+        assertNull(transition.newState.regions.platforms.getValue(Platform.DoorDash).activeTask)
+        val confirmed = transition.effects
+            .filterIsInstance<AppEffect.LogEvent>()
+            .any { it.event.eventType == AppEventType.DELIVERY_CONFIRMED }
+        assertTrue("DELIVERY_CONFIRMED must be emitted for a timeout-committed retire", confirmed)
+    }
+
+    // ---- 3. gates fail closed ----
+
+    private fun screenWithGatedEffect(gate: ParsedFieldsGate, parsed: ParsedFields) =
+        Observation.Screen(
+            timestamp = 1_500L,
+            captureId = null,
+            ruleId = "doordash.screen.test",
+            metadata = ReplayMetadata.EMPTY,
+            flow = null,
+            modeHint = null,
+            parsed = parsed,
+            effects = listOf(
+                RequestedEffect(
+                    verb = EffectVerb.BUBBLE,
+                    args = mapOf("text" to "gated"),
+                    onlyIf = gate,
+                    ruleId = "doordash.screen.test",
+                ),
+            ),
+        )
+
+    private fun ruleEffectsFor(obs: Observation): List<AppEffect.RequestEffect> {
+        val state = AppState(regions = Regions(), timestamp = 1_000L)
+        return effectMap.diff(state, state, obs).filterIsInstance<AppEffect.RequestEffect>()
+    }
+
+    @Test
+    fun `FieldNotEquals does not fire when the field is absent`() {
+        val obs = screenWithGatedEffect(
+            gate = ParsedFieldsGate.FieldNotEquals("someField", "someValue"),
+            parsed = ParsedFields.None,
+        )
+
+        assertTrue(ruleEffectsFor(obs).isEmpty())
+    }
+
+    @Test
+    fun `gates still fire on a present satisfying field`() {
+        val parsed = ParsedFields.OfferFields(
+            parsedOffer = ParsedOffer(offerHash = "h", payAmount = 7.5),
+        )
+        val obs = screenWithGatedEffect(
+            gate = ParsedFieldsGate.FieldNotNull("parsedOffer"),
+            parsed = parsed,
+        )
+
+        assertFalse(ruleEffectsFor(obs).isEmpty())
+    }
+}

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -308,6 +308,19 @@ _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **bro
   `Pictures/DashBuddy`; (b) no visible stutter the moment an offer arrives (should be same or
   smoother than before).
   - Confirmed: 0/2.
+- **Paused dash auto-expires when the pause clock runs out (#342).** The pause-safety timer
+  used to fire into a void (routed to no platform region) — now it reaches the paused region.
+  If you pause mid-dash and deliberately DON'T resume: once the pause duration lapses, the HUD
+  should flip out of PAUSED on its own (offline with grace) without needing a DoorDash screen
+  change. Also regression-watch the normal path: resuming before expiry must NOT flash offline
+  (the timer is cancelled on resume).
+  - Confirmed: 0/2.
+- **Offer evaluation always matches the offer on screen (#345).** Evaluations are now
+  hash-correlated, so a rapidly replaced offer can't inherit the previous offer's verdict —
+  the heads-up notification + spoken read should always describe the CURRENT offer's economics.
+  Watch for any mismatch between the card's numbers and what's spoken/notified, especially when
+  offers arrive back-to-back.
+  - Confirmed: 0/2.
 
 ---
 

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/state/OfferEvaluationEvent.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/state/OfferEvaluationEvent.kt
@@ -6,5 +6,7 @@ import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
 data class OfferEvaluationEvent(
     val action: OfferAction,
     val evaluation: OfferEvaluation? = null,
+    /** Hash of the offer this evaluation was computed FOR — correlated by the stepper (#345). */
+    val offerHash: String? = null,
     override val timestamp: Long = System.currentTimeMillis()
 ) : StateEvent


### PR DESCRIPTION
Fixes #345 (audit items A-6, A-7, gate fail-open). P0 campaign PR 5.

## What
1. **Eval correlation by offerHash** — `EvaluateOffer(parsedOffer, offerHash)` → `OfferEvaluationEvent(offerHash)` → loopback payload → `FlowRegionStepper` drops mismatched evals. A replaced offer can't inherit the old verdict; notification/TTS always describe the current offer.
2. **diffTask runs for every observation type** — `flowObs` was only used as an early-return gate (verified: zero other uses); removing it lets timeout-committed retires (#342 made these real) emit `DELIVERY_CONFIRMED`. Plus the prev-session sessionId fallback diffPlatformRegion already had.
3. **Gates fail closed** — extraction failure → reject all gate kinds; `FieldNotEquals` requires field presence (absent field ≠ "not equals"). Matters before #110 Stage 3 puts auto-clicks behind gates.

## Tests
`EvalDiffCorrectnessTest` (6 new, :core:state): correlation drop/land/legacy-null; DELIVERY_CONFIRMED on routed-timeout retire (uses #342's harness); gate absent-field rejection + positive control. Full `testDebugUnitTest` green.

Field-checklist items added: #342's pause-expiry watch (carried from PR #371) and #345's eval-matches-screen watch.

CLAUDE.md drift check: none. Memory updated post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)