### PR TITLE
fix(state): deterministic session/job/task IDs (#344)

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -15,6 +15,7 @@
             <option value="$PROJECT_DIR$/core/data" />
             <option value="$PROJECT_DIR$/core/database" />
             <option value="$PROJECT_DIR$/core/datastore" />
+            <option value="$PROJECT_DIR$/core/designsystem" />
             <option value="$PROJECT_DIR$/core/location" />
             <option value="$PROJECT_DIR$/core/network" />
             <option value="$PROJECT_DIR$/core/pipeline" />

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
@@ -18,7 +18,6 @@ import cloud.trotter.dashbuddy.domain.state.Task
 import cloud.trotter.dashbuddy.domain.state.TaskPhase
 import cloud.trotter.dashbuddy.domain.state.TaskSubFlow
 import cloud.trotter.dashbuddy.domain.state.TransitionKind
-import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -45,6 +44,21 @@ class PlatformRegionStepper @Inject constructor() {
         /** Max completed tasks retained per platform during a session. */
         const val MAX_RECENT_TASKS = 20
     }
+
+    /**
+     * Deterministic entity-id mint (#344): derived only from replay-stable inputs
+     * (platform, obs.timestamp, [PlatformRegion.mintCounter]) so crash-recovery
+     * replay reproduces the live run's IDs. UUID.randomUUID broke effect
+     * idempotency keys ("start_session:$sessionId") and diverged restored state
+     * from already-persisted rows. Every mint MUST bump mintCounter in the same
+     * copy() — use [offset] when minting more than one id per observation.
+     */
+    private fun mintId(
+        kind: String,
+        region: PlatformRegion,
+        obs: Observation,
+        offset: Long = 0,
+    ): String = "$kind-${region.platform.wire}-${obs.timestamp}-${region.mintCounter + offset}"
 
     fun step(
         prev: PlatformRegion,
@@ -154,9 +168,10 @@ class PlatformRegionStepper @Inject constructor() {
                     // No session — start a fresh one.
                     region = region.copy(
                         session = Session(
-                            sessionId = UUID.randomUUID().toString(),
+                            sessionId = mintId("session", region, obs),
                             startedAt = obs.timestamp,
                         ),
+                        mintCounter = region.mintCounter + 1,
                     )
                 }
             }
@@ -195,8 +210,8 @@ class PlatformRegionStepper @Inject constructor() {
             val parsed = flowObs.parsed
             val storeName = (parsed as? ParsedFields.TaskFields)?.storeName
 
-            val jobId = UUID.randomUUID().toString()
-            val taskId = UUID.randomUUID().toString()
+            val jobId = mintId("job", region, obs)
+            val taskId = mintId("task", region, obs, offset = 1)
 
             return region.copy(
                 activeJob = Job(
@@ -213,6 +228,7 @@ class PlatformRegionStepper @Inject constructor() {
                     startedAt = obs.timestamp,
                     recovered = true,
                 ),
+                mintCounter = region.mintCounter + 2,
             )
         }
 
@@ -413,12 +429,13 @@ class PlatformRegionStepper @Inject constructor() {
             if (existing == null) {
                 return region.copy(
                     activeJob = Job(
-                        jobId = UUID.randomUUID().toString(),
+                        jobId = mintId("job", region, obs),
                         offerStoreHint = storeHints,
                         parentOfferHash = pending?.offerHash,
                         acceptedOffers = listOf(economics),
                         startedAt = obs.timestamp,
                     ),
+                    mintCounter = region.mintCounter + 1,
                 )
             }
 
@@ -437,14 +454,14 @@ class PlatformRegionStepper @Inject constructor() {
         // Job start: task flow without active job (recovery or mid-session restart)
         if (nextFlowVal.isTaskFlow() && region.activeJob == null) {
             val parsed = obs.parsed as? ParsedFields.TaskFields
-            val jobId = UUID.randomUUID().toString()
             return region.copy(
                 activeJob = Job(
-                    jobId = jobId,
+                    jobId = mintId("job", region, obs),
                     offerStoreHint = listOfNotNull(parsed?.storeName),
                     parentOfferHash = null,
                     startedAt = obs.timestamp,
                 ),
+                mintCounter = region.mintCounter + 1,
             )
         }
 
@@ -523,7 +540,7 @@ class PlatformRegionStepper @Inject constructor() {
 
                 return region.copy(
                     activeTask = Task(
-                        taskId = UUID.randomUUID().toString(),
+                        taskId = mintId("task", region, obs),
                         jobId = jobId,
                         phase = taskPhase,
                         subPhase = taskSubFlow,
@@ -541,6 +558,7 @@ class PlatformRegionStepper @Inject constructor() {
                     ),
                     recentTasks = recentTasks,
                     pendingDestructive = null,
+                    mintCounter = region.mintCounter + 1,
                 )
             }
 

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/DeterministicIdsTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/DeterministicIdsTest.kt
@@ -1,0 +1,119 @@
+package cloud.trotter.dashbuddy.core.state
+
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
+import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.state.Flow
+import cloud.trotter.dashbuddy.domain.state.FlowRegion
+import cloud.trotter.dashbuddy.domain.state.Mode
+import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.domain.state.PlatformRegion
+import cloud.trotter.dashbuddy.domain.state.TaskPhase
+import cloud.trotter.dashbuddy.domain.state.TaskSubFlow
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+/**
+ * #344 — entity IDs must be replay-deterministic. The stepper used to mint
+ * session/job/task IDs with UUID.randomUUID(), so crash-recovery replay produced
+ * different IDs than the live run: ID-keyed effect idempotency
+ * ("start_session:$sessionId") never matched `effects_fired`, and restored state
+ * diverged from already-persisted rows. IDs now derive from (kind, platform,
+ * obs.timestamp, mintCounter).
+ */
+class DeterministicIdsTest {
+
+    private fun idleObs(timestamp: Long) = Observation.Screen(
+        timestamp = timestamp, captureId = null, ruleId = "doordash.screen.idle",
+        metadata = ReplayMetadata.EMPTY, flow = Flow.Idle, modeHint = Mode.Online,
+        parsed = ParsedFields.None,
+    )
+
+    private fun taskObs(
+        flow: Flow,
+        phase: TaskPhase,
+        subFlow: TaskSubFlow,
+        storeName: String? = null,
+        customerAddressHash: String? = null,
+        timestamp: Long,
+    ) = Observation.Screen(
+        timestamp = timestamp, captureId = null, ruleId = "doordash.screen.test",
+        metadata = ReplayMetadata.EMPTY, flow = flow, modeHint = Mode.Online,
+        parsed = ParsedFields.TaskFields(
+            phase = phase, subFlow = subFlow,
+            storeName = storeName, customerAddressHash = customerAddressHash,
+        ),
+    )
+
+    /**
+     * Drives a fresh stepper through: go online (session mint) → pickup nav
+     * (job + task mint) → dropoff nav (second task mint) — all at the SAME
+     * observation timestamp, the hardest case for non-counter schemes.
+     */
+    private fun runScript(): PlatformRegion {
+        val stepper = PlatformRegionStepper()
+        val flowStepper = FlowRegionStepper()
+        val policy = TransitionPolicy()
+        var flow = FlowRegion()
+        var region = PlatformRegion(Platform.DoorDash)
+
+        fun apply(obs: Observation) {
+            val nextFlow =
+                if (obs is Observation.FlowObservation) flowStepper.step(flow, obs) else flow
+            region = stepper.step(region, flow, nextFlow, obs, policy)
+            flow = nextFlow
+        }
+
+        apply(idleObs(timestamp = 1_000L))
+        apply(
+            taskObs(
+                Flow.TaskPickupNavigation, TaskPhase.PICKUP, TaskSubFlow.NAVIGATION,
+                storeName = "HEB", timestamp = 1_000L,
+            )
+        )
+        apply(
+            taskObs(
+                Flow.TaskDropoffNavigation, TaskPhase.DROPOFF, TaskSubFlow.NAVIGATION,
+                customerAddressHash = "cust-1", timestamp = 1_000L,
+            )
+        )
+        return region
+    }
+
+    @Test
+    fun `the same observation script mints identical ids on every run`() {
+        val a = runScript()
+        val b = runScript()
+
+        assertNotNull(a.session?.sessionId)
+        assertEquals(a.session?.sessionId, b.session?.sessionId)
+        assertEquals(a.activeJob?.jobId, b.activeJob?.jobId)
+        assertEquals(a.activeTask?.taskId, b.activeTask?.taskId)
+        assertEquals(
+            a.recentTasks.map { it.taskId },
+            b.recentTasks.map { it.taskId },
+        )
+    }
+
+    @Test
+    fun `mints sharing one observation timestamp still get distinct ids`() {
+        val region = runScript()
+
+        val pickupTaskId = region.recentTasks.last().taskId
+        val dropoffTaskId = region.activeTask?.taskId
+
+        // Both tasks were minted at timestamp 1000 — the counter keeps them apart.
+        assertNotEquals(pickupTaskId, dropoffTaskId)
+        assertNotEquals(region.activeJob?.jobId, pickupTaskId)
+        assertNotEquals(region.session?.sessionId, region.activeJob?.jobId)
+    }
+
+    @Test
+    fun `mintCounter advances with every mint`() {
+        val region = runScript()
+        // session + job + pickup task + dropoff task = 4 mints
+        assertEquals(4L, region.mintCounter)
+    }
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/PlatformRegion.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/PlatformRegion.kt
@@ -42,6 +42,13 @@ data class PlatformRegion(
      */
     val lastPostTaskFields: ParsedFields.PostTaskFields? = null,
     val lastObservedAt: Long = 0,
+    /**
+     * Monotonic counter for deterministic entity-id minting (#344). Bumped by the
+     * stepper on every session/job/task mint and persisted with snapshots, so
+     * crash-recovery replay reproduces the live run's IDs — and two mints sharing
+     * an observation timestamp still get distinct IDs.
+     */
+    val mintCounter: Long = 0,
     /** Timestamp when Flow entered Idle while mode is Online. Null otherwise. */
     val idleEnteredAt: Long? = null,
     /**


### PR DESCRIPTION
Fixes #344 (audit item A-5). P0 campaign PR 6 — replay-integrity workstream.

## What
Six `UUID.randomUUID()` sites in `PlatformRegionStepper` (session start, healed job+task, accepted-offer job, recovery job, task mint) replaced with deterministic IDs: `"$kind-$platform-$obsTimestamp-$mintCounter"`. The new `PlatformRegion.mintCounter` rides snapshots and bumps atomically with each mint, so:
- replaying the same observation tail reproduces the live run's IDs (ID-keyed `effects_fired` dedup like `start_session:` now actually works across recovery),
- multiple mints at one observation timestamp (job+task together, stacked transitions in a debounce burst) stay distinct.

Stepper purity strengthened: no randomness left (the documented `obs.timestamp` invariant now covers identity too).

## Tests
`DeterministicIdsTest` (3 new): script-identity across runs, same-timestamp distinctness, counter advancement. Full `testDebugUnitTest` green — including the stacked-pickup/dropoff distinctness guards.

No field-checklist item: IDs are internal; observable behavior unchanged outside crash recovery (which #352 will exercise further).

CLAUDE.md drift check: none. Memory updated post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)