### PR TITLE
fix(rules): anchor time transforms to the observation clock (#343)

### DIFF
--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/ObservationClassifier.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/ObservationClassifier.kt
@@ -11,6 +11,7 @@ import cloud.trotter.dashbuddy.domain.state.ParsedFields
 import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.core.pipeline.rules.JsonRuleInterpreter
 import cloud.trotter.dashbuddy.core.pipeline.rules.ParsedFieldsFactory
+import cloud.trotter.dashbuddy.core.pipeline.rules.TransformRegistry
 import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -45,26 +46,39 @@ class ObservationClassifier @Inject constructor(
             is PipelineEvent.Notification -> Platform.fromPackage(event.raw.packageName).wire
         }.takeIf { it != Platform.Unknown.wire }
 
-        return when (event) {
-            is PipelineEvent.Screen -> classifyScreen(event, platformWire)
-            is PipelineEvent.Click -> classifyClick(event, platformWire)
-            is PipelineEvent.Notification -> classifyNotification(event, platformWire)
+        // One coherent instant per classification (#343): time transforms (parseTime/
+        // parseDeadline) and the resulting observation timestamp see the same "now" —
+        // the notification's postTime, or the moment this screen/click is classified.
+        val eventNow = when (event) {
+            is PipelineEvent.Notification -> event.raw.postTime
+            else -> System.currentTimeMillis()
+        }
+        return TransformRegistry.withClock(eventNow) {
+            when (event) {
+                is PipelineEvent.Screen -> classifyScreen(event, platformWire, eventNow)
+                is PipelineEvent.Click -> classifyClick(event, platformWire, eventNow)
+                is PipelineEvent.Notification -> classifyNotification(event, platformWire)
+            }
         }
     }
 
     // ── Screen ──────────────────────────────────────────────────────────
 
-    private fun classifyScreen(event: PipelineEvent.Screen, platformWire: String?): Observation.Screen {
+    private fun classifyScreen(
+        event: PipelineEvent.Screen,
+        platformWire: String?,
+        now: Long,
+    ): Observation.Screen {
         val ruleset = interpreter.screenRuleset
         if (ruleset == null) {
             Timber.w("ObservationClassifier: no screen ruleset loaded")
-            return makeScreenObservation("UNKNOWN", null, null, ParsedFields.None, null)
+            return makeScreenObservation(now, "UNKNOWN", null, null, ParsedFields.None, null)
         }
 
         val result = ruleset.matchFirst(event.tree, platformWire)
         if (result == null) {
             Timber.i("SCREEN: UNKNOWN")
-            return makeScreenObservation("UNKNOWN", null, null, ParsedFields.None, null)
+            return makeScreenObservation(now, "UNKNOWN", null, null, ParsedFields.None, null)
         }
 
         Timber.i("SCREEN: ${result.intent}")
@@ -74,6 +88,7 @@ class ObservationClassifier @Inject constructor(
 
         val parsed = ParsedFieldsFactory.create(result.shape, result.fields)
         val obs = makeScreenObservation(
+            now = now,
             screenName = result.intent,
             flow = result.flow,
             modeHint = result.modeHint,
@@ -94,6 +109,7 @@ class ObservationClassifier @Inject constructor(
     }
 
     private fun makeScreenObservation(
+        now: Long,
         screenName: String,
         flow: Flow?,
         modeHint: Mode?,
@@ -103,7 +119,7 @@ class ObservationClassifier @Inject constructor(
         transitionOverrides: Map<TransitionTrigger, List<RequestedEffect>> = emptyMap(),
         expectedOutcomes: Set<Flow>? = null,
     ) = Observation.Screen(
-        timestamp = System.currentTimeMillis(),
+        timestamp = now,
         captureId = null,
         ruleId = ruleId,
         metadata = metadataProvider.current(),
@@ -118,13 +134,17 @@ class ObservationClassifier @Inject constructor(
 
     // ── Click ───────────────────────────────────────────────────────────
 
-    private fun classifyClick(event: PipelineEvent.Click, platformWire: String?): Observation.Click {
+    private fun classifyClick(
+        event: PipelineEvent.Click,
+        platformWire: String?,
+        now: Long,
+    ): Observation.Click {
         val ruleset = interpreter.clickRuleset
         if (ruleset != null) {
             val result = ruleset.matchFirst(event.node, platformWire, lastScreenTarget)
             if (result != null) {
                 return Observation.Click(
-                    timestamp = System.currentTimeMillis(),
+                    timestamp = now,
                     captureId = null,
                     ruleId = result.ruleId,
                     metadata = metadataProvider.current(),
@@ -146,7 +166,7 @@ class ObservationClassifier @Inject constructor(
         val nodeText = event.node.text?.takeIf { it.isNotBlank() }
         Timber.d("ObservationClassifier: UNKNOWN click — id=$nodeId text=$nodeText")
         return Observation.Click(
-            timestamp = System.currentTimeMillis(),
+            timestamp = now,
             captureId = null,
             ruleId = null,
             metadata = metadataProvider.current(),

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/TransformRegistry.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/TransformRegistry.kt
@@ -12,9 +12,10 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import java.security.MessageDigest
+import java.time.Instant
 import java.time.LocalTime
+import java.time.ZoneId
 import java.time.format.DateTimeFormatter
-import java.util.Calendar
 import java.util.Locale
 
 /**
@@ -27,6 +28,39 @@ import java.util.Locale
  * Matches ADR-0001 v2 specification.
  */
 object TransformRegistry {
+
+    /**
+     * Reference clock for time transforms (#343): the OBSERVATION's instant + zone,
+     * not evaluation wall-clock — re-parsing a captured screen at a different hour
+     * (or replaying it in tests) must yield the same millis.
+     */
+    data class TransformClock(val nowMillis: Long, val zoneId: ZoneId)
+
+    // Scoped per classification via [withClock]. Classification is synchronous per
+    // event, so a ThreadLocal is safe (pipelines classify concurrently on different
+    // threads). Promote to an explicit parameter when the compiled-lambda signatures
+    // are reworked (#239/#362).
+    private val scopedClock = ThreadLocal<TransformClock?>()
+
+    /**
+     * Runs [block] with time transforms anchored to [nowMillis]/[zoneId].
+     * Unscoped callers fall back to the system clock.
+     */
+    fun <T> withClock(
+        nowMillis: Long,
+        zoneId: ZoneId = ZoneId.systemDefault(),
+        block: () -> T,
+    ): T {
+        scopedClock.set(TransformClock(nowMillis, zoneId))
+        return try {
+            block()
+        } finally {
+            scopedClock.remove()
+        }
+    }
+
+    private fun currentClock(): TransformClock =
+        scopedClock.get() ?: TransformClock(System.currentTimeMillis(), ZoneId.systemDefault())
 
     /**
      * Threshold for rolling a parsed wall-clock time forward to tomorrow.
@@ -308,20 +342,19 @@ object TransformRegistry {
             }
         }
 
-        val now = Calendar.getInstance()
-        val target = Calendar.getInstance().apply {
-            set(Calendar.HOUR_OF_DAY, localTime.hour)
-            set(Calendar.MINUTE, localTime.minute)
-            set(Calendar.SECOND, 0)
-            set(Calendar.MILLISECOND, 0)
-        }
+        // Anchor "today" to the scoped clock (#343) — the observation's instant and
+        // zone — never the evaluation wall clock, so replaying a captured screen at a
+        // different hour (or zone) yields the same millis.
+        val clock = currentClock()
+        val today = Instant.ofEpochMilli(clock.nowMillis).atZone(clock.zoneId).toLocalDate()
+        val targetMillis = today.atTime(localTime).atZone(clock.zoneId).toInstant().toEpochMilli()
         // Roll forward only when the target is *significantly* in the past —
         // interpret as "this time tomorrow" (e.g. late-night offer for next
         // morning pickup). Past by less than the threshold stays as today's
         // timestamp so a blown deadline renders as "X min late" instead of
         // jumping ~24h ahead. See field log 2026-05-19 #2 for the bug shape
         // ("1434:38" ghost countdown caused by 37-second-past re-parse).
-        return applyRollover(target.timeInMillis, now.timeInMillis)
+        return applyRollover(targetMillis, clock.nowMillis)
     }
 
     /**

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/TransformClockTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/TransformClockTest.kt
@@ -1,0 +1,75 @@
+package cloud.trotter.dashbuddy.core.pipeline.rules
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import java.time.Instant
+import java.time.ZoneId
+
+/**
+ * #343 — time transforms must be deterministic against the OBSERVATION's clock,
+ * not the evaluation wall clock. `Calendar.getInstance()` inside parseTime/
+ * parseDeadline meant a captured screen re-parsed at a different hour (or
+ * replayed across the 12h rollover threshold) produced different millis — the
+ * 2026-05-19 "1434:38 ghost countdown" class. [TransformRegistry.withClock]
+ * anchors "today" explicitly.
+ */
+class TransformClockTest {
+
+    private val zone = ZoneId.of("America/Chicago")
+
+    /** 2026-06-10 14:00 local in [zone]. */
+    private val anchor = Instant.parse("2026-06-10T19:00:00Z").toEpochMilli()
+
+    private fun millisAt(hour: Int, minute: Int): Long =
+        Instant.ofEpochMilli(anchor).atZone(zone).toLocalDate()
+            .atTime(hour, minute).atZone(zone).toInstant().toEpochMilli()
+
+    @Test
+    fun `parseDeadline is deterministic under a fixed clock`() {
+        val a = TransformRegistry.withClock(anchor, zone) {
+            TransformRegistry.apply("parseDeadline", "Pick up by 5:39 PM")
+        }
+        val b = TransformRegistry.withClock(anchor, zone) {
+            TransformRegistry.apply("parseDeadline", "Pick up by 5:39 PM")
+        }
+        assertNotNull(a)
+        assertEquals(a, b)
+        assertEquals(millisAt(17, 39), a)
+    }
+
+    @Test
+    fun `future-today time anchors to the clock's day`() {
+        val parsed = TransformRegistry.withClock(anchor, zone) {
+            TransformRegistry.apply("parseTime", "8:52 PM")
+        }
+        assertEquals(millisAt(20, 52), parsed)
+    }
+
+    @Test
+    fun `slightly-past time stays today (ghost-countdown guard)`() {
+        // 13:55 is 5 minutes before the 14:00 anchor — well under the 12h threshold.
+        val parsed = TransformRegistry.withClock(anchor, zone) {
+            TransformRegistry.apply("parseTime", "13:55")
+        }
+        assertEquals(millisAt(13, 55), parsed)
+    }
+
+    @Test
+    fun `far-past time rolls to tomorrow`() {
+        // 1:00 AM is 13h before the 14:00 anchor — past the 12h threshold.
+        val parsed = TransformRegistry.withClock(anchor, zone) {
+            TransformRegistry.apply("parseTime", "1:00 AM")
+        }
+        assertEquals(millisAt(1, 0) + 24L * 3_600_000L, parsed)
+    }
+
+    @Test
+    fun `clock scope does not leak after the block`() {
+        TransformRegistry.withClock(anchor, zone) {
+            TransformRegistry.apply("parseTime", "8:52 PM")
+        }
+        // Unscoped call falls back to the system clock — just verify it parses.
+        assertNotNull(TransformRegistry.apply("parseTime", "8:52 PM"))
+    }
+}


### PR DESCRIPTION
Fixes #343 (audit item A-4). P0 campaign PR 7 — replay-integrity workstream.

## What
- `TransformRegistry.withClock(nowMillis, zoneId) { ... }` scopes the reference clock for time transforms; `parseTime`/`parseDeadline` anchor "today" to it via java.time (Calendar removed). ThreadLocal-scoped because classification is synchronous per event — documented for promotion to an explicit parameter during the #239/#362 signature rework (avoids churning RuleCompiler's compiled-lambda types ahead of those issues).
- `ObservationClassifier` captures one instant per classification (notification `postTime`, else the classify moment), runs the match inside `withClock`, and stamps the observation with the same instant — transforms and `obs.timestamp` now agree.

## Tests
`TransformClockTest` (5 new): fixed-clock determinism (zone-pinned), today-anchoring, both sides of the 12h rollover threshold, scope cleanup. Full `testDebugUnitTest` green — the golden corpus parses identically under the scoped clock, and the existing `applyRollover` ghost-countdown guards still pass.

Field-checklist item rides in the NEXT PR (#347) — edit-guard race kept it out of this one.

Remaining from the issue (noted there): stamping the device zone into capture envelopes for cross-zone replay — belongs with the envelope/versioning work (#352/ADR-0003), not this fix.

CLAUDE.md drift check: none. Memory updated post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)