### PR TITLE
fix(wizard): Skip is a true skip; Finish preserves uncollected settings (#347)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/WizardScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/WizardScreen.kt
@@ -68,6 +68,9 @@ fun WizardScreen(
     val isCherryPicker = state.strategy == DashStrategy.CHERRY_PICKER
 
     var showCompletionSheet by remember { mutableStateOf(false) }
+    // Skip and Finish share the completion sheet but must NOT share a save path:
+    // Skip writes nothing (#347).
+    var skippedSetup by remember { mutableStateOf(false) }
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
     Scaffold(
@@ -75,7 +78,10 @@ fun WizardScreen(
             WizardTopBar(
                 currentStep = pagerState.currentPage,
                 totalSteps = steps.size,
-                onSkip = { showCompletionSheet = true }
+                onSkip = {
+                    skippedSetup = true
+                    showCompletionSheet = true
+                }
             )
         },
         bottomBar = {
@@ -89,6 +95,7 @@ fun WizardScreen(
                     if (pagerState.currentPage < steps.size - 1) {
                         coroutineScope.launch { pagerState.animateScrollToPage(pagerState.currentPage + 1) }
                     } else {
+                        skippedSetup = false
                         showCompletionSheet = true
                     }
                 }
@@ -269,7 +276,11 @@ fun WizardScreen(
                 )
                 Spacer(modifier = Modifier.height(16.dp))
                 Text(
-                    "Your setup is complete. Remember, you can always tweak these targets, change your vehicle, or adjust your automation strategy later in the Settings menu.",
+                    if (skippedSetup) {
+                        "Setup skipped — nothing was changed. You can run the wizard anytime from the Settings menu."
+                    } else {
+                        "Your setup is complete. Remember, you can always tweak these targets, change your vehicle, or adjust your automation strategy later in the Settings menu."
+                    },
                     style = MaterialTheme.typography.bodyLarge,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     textAlign = TextAlign.Center
@@ -280,7 +291,11 @@ fun WizardScreen(
                         coroutineScope.launch {
                             sheetState.hide()
                             showCompletionSheet = false
-                            viewModel.saveAndFinish(onComplete)
+                            if (skippedSetup) {
+                                viewModel.skipAndFinish(onComplete)
+                            } else {
+                                viewModel.saveAndFinish(onComplete)
+                            }
                         }
                     },
                     modifier = Modifier

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/WizardViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/WizardViewModel.kt
@@ -452,6 +452,19 @@ class WizardViewModel @Inject constructor(
         _state.update { it.copy(maxItems = items) }
     }
 
+    /**
+     * Skip = a true skip (#347): mark first-run complete and write NOTHING else.
+     * A later re-run + Skip must never reset tuned strategy/economy settings —
+     * the old path funneled Skip through [saveAndFinish], silently restoring
+     * hardcoded automation defaults.
+     */
+    fun skipAndFinish(onComplete: () -> Unit) {
+        viewModelScope.launch {
+            appStateRepository.setFirstRunComplete()
+            onComplete()
+        }
+    }
+
     fun saveAndFinish(onComplete: () -> Unit) {
         viewModelScope.launch {
             val finalState = _state.value
@@ -534,17 +547,23 @@ class WizardViewModel @Inject constructor(
             val isCherryPicker = finalState.strategy == DashStrategy.CHERRY_PICKER
             val isPlatinum = finalState.strategy == DashStrategy.PROTECT_PLATINUM
 
+            // Only write what the wizard actually collects (#347): the strategy-derived
+            // toggles and the SHOPPING step's preference. The threshold values are NOT
+            // wizard inputs — preserve their current values so a re-run + Finish
+            // round-trips losslessly instead of resetting tuned automation config.
+            val currentAutomation = strategyRepository.automationConfig.first()
             strategyRepository.setProtectStatsMode(isPlatinum)
             strategyRepository.setMasterAutomation(isCherryPicker)
             strategyRepository.updateAutomation(
-                autoAccept = false,
-                acceptMinPay = 0.0,
-                acceptMinRatio = 2.0, // Default $2.00/mi
+                autoAccept = currentAutomation.autoAcceptEnabled,
+                acceptMinPay = currentAutomation.autoAcceptMinPay,
+                acceptMinRatio = currentAutomation.autoAcceptMinRatio,
                 autoDecline = isCherryPicker,
-                declineMaxPay = 3.50, // Default auto-decline anything under $3.50
-                declineMinRatio = 0.50 // Default auto-decline anything under $0.50/mi
-            ) // TODO: Update UI to collect all fields?
-            strategyRepository.setAllowShopping(true)
+                declineMaxPay = currentAutomation.autoDeclineMaxPay,
+                declineMinRatio = currentAutomation.autoDeclineMinRatio,
+            )
+            // allowShopping is NOT collected by any wizard step (SHOPPING collects
+            // maxItems only) — settings own that toggle; the wizard must not touch it.
 
             val currentRules = strategyRepository.scoringRules.first().toMutableList()
             val updatedRules = currentRules.map { rule ->

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/model/WizardState.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/model/WizardState.kt
@@ -51,7 +51,6 @@ data class WizardState(
 
     // Strategy Variables
     val strategy: DashStrategy = DashStrategy.MANUAL,
-    val allowShopping: Boolean = true,
 
     // Targets & Enforcement
     val enforceMinPayout: Boolean = false,

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/WizardViewModelTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/WizardViewModelTest.kt
@@ -1,0 +1,147 @@
+package cloud.trotter.dashbuddy.ui.main.setup.wizard
+
+import cloud.trotter.dashbuddy.core.data.settings.AppPreferencesRepository
+import cloud.trotter.dashbuddy.core.data.state.AppStateRepository
+import cloud.trotter.dashbuddy.core.data.strategy.StrategyRepository
+import cloud.trotter.dashbuddy.core.data.vehicle.VehicleRepository
+import cloud.trotter.dashbuddy.core.data.fuel.FuelPriceRepository
+import cloud.trotter.dashbuddy.domain.config.OfferAutomationConfig
+import cloud.trotter.dashbuddy.domain.evaluation.UserEconomy
+import cloud.trotter.dashbuddy.domain.model.vehicle.FuelType
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.clearInvocations
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.verifyNoMoreInteractions
+import org.mockito.kotlin.whenever
+import org.mockito.kotlin.wheneverBlocking
+
+/**
+ * #347 — the wizard must only persist what it actually collects:
+ * - Skip is a TRUE skip (first-run flag only; nothing else written).
+ * - Finish preserves automation thresholds it doesn't collect (no more
+ *   hardcoded-default resets on re-run) and never touches allowShopping
+ *   (no wizard step collects it).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class WizardViewModelTest {
+
+    private val strategyRepository: StrategyRepository = mock()
+    private val appPreferencesRepository: AppPreferencesRepository = mock()
+    private val appStateRepository: AppStateRepository = mock()
+    private val vehicleRepository: VehicleRepository = mock()
+    private val gasPriceRepository: FuelPriceRepository = mock()
+
+    /** Values a user would have tuned in settings — must survive a wizard pass. */
+    private val tunedAutomation = OfferAutomationConfig(
+        masterAutoPilotEnabled = true,
+        autoAcceptEnabled = true,
+        autoAcceptMinPay = 12.0,
+        autoAcceptMinRatio = 3.25,
+        autoDeclineEnabled = true,
+        autoDeclineMaxPay = 5.25,
+        autoDeclineMinRatio = 0.80,
+    )
+
+    private fun stubRepositories() {
+        whenever(appPreferencesRepository.vehicleYear).thenReturn(flowOf(null))
+        whenever(appPreferencesRepository.vehicleMake).thenReturn(flowOf(null))
+        whenever(appPreferencesRepository.vehicleModel).thenReturn(flowOf(null))
+        whenever(appPreferencesRepository.vehicleTrim).thenReturn(flowOf(null))
+        whenever(appPreferencesRepository.estimatedMpg).thenReturn(flowOf(null))
+        whenever(appPreferencesRepository.fuelType).thenReturn(flowOf(FuelType.REGULAR))
+        whenever(appPreferencesRepository.isGasPriceAuto).thenReturn(flowOf(false))
+        whenever(appPreferencesRepository.gasPrice).thenReturn(flowOf(null))
+        whenever(appPreferencesRepository.userEconomy).thenReturn(flowOf(UserEconomy()))
+        whenever(strategyRepository.protectStatsMode).thenReturn(flowOf(false))
+        whenever(strategyRepository.scoringRules).thenReturn(flowOf(emptyList()))
+        whenever(strategyRepository.automationConfig).thenReturn(flowOf(tunedAutomation))
+        wheneverBlocking { vehicleRepository.getYears() }.thenReturn(emptyList())
+        wheneverBlocking { gasPriceRepository.fetchGasPriceOnly(any()) }
+            .thenReturn(Result.failure(RuntimeException("offline in test")))
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `skip writes nothing but the first-run flag`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        stubRepositories()
+        val viewModel = WizardViewModel(
+            strategyRepository, appPreferencesRepository, appStateRepository,
+            vehicleRepository, gasPriceRepository,
+        )
+        testScheduler.advanceUntilIdle() // let init's loads settle
+        clearInvocations(strategyRepository, appPreferencesRepository)
+
+        var completed = false
+        viewModel.skipAndFinish { completed = true }
+        testScheduler.advanceUntilIdle()
+
+        assert(completed)
+        verify(appStateRepository).setFirstRunComplete()
+        verifyNoMoreInteractions(strategyRepository)
+        verifyNoMoreInteractions(appPreferencesRepository)
+    }
+
+    @Test
+    fun `finish preserves automation thresholds the wizard does not collect`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        stubRepositories()
+        val viewModel = WizardViewModel(
+            strategyRepository, appPreferencesRepository, appStateRepository,
+            vehicleRepository, gasPriceRepository,
+        )
+        testScheduler.advanceUntilIdle()
+
+        var completed = false
+        viewModel.saveAndFinish { completed = true }
+        testScheduler.advanceUntilIdle()
+
+        assert(completed)
+        // Strategy default is MANUAL → autoDecline=false (collected); every
+        // threshold must round-trip from the tuned config, not reset to defaults.
+        verify(strategyRepository).updateAutomation(
+            autoAccept = eq(true),
+            acceptMinPay = eq(12.0),
+            acceptMinRatio = eq(3.25),
+            autoDecline = eq(false),
+            declineMaxPay = eq(5.25),
+            declineMinRatio = eq(0.80),
+        )
+        verify(strategyRepository, org.mockito.kotlin.never()).setAllowShopping(any())
+        verify(appStateRepository).setFirstRunComplete()
+    }
+
+    @Test
+    fun `skip never reads or fetches anything new`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        stubRepositories()
+        val viewModel = WizardViewModel(
+            strategyRepository, appPreferencesRepository, appStateRepository,
+            vehicleRepository, gasPriceRepository,
+        )
+        testScheduler.advanceUntilIdle()
+        clearInvocations(vehicleRepository, gasPriceRepository)
+
+        viewModel.skipAndFinish { }
+        testScheduler.advanceUntilIdle()
+
+        verifyNoInteractions(vehicleRepository)
+        verifyNoMoreInteractions(gasPriceRepository)
+    }
+}

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -321,6 +321,13 @@ _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **bro
   Watch for any mismatch between the card's numbers and what's spoken/notified, especially when
   offers arrive back-to-back.
   - Confirmed: 0/2.
+- **Deadline countdowns still correct under the new transform clock (#343).** Time parsing
+  (`parseDeadline`/`parseTime`) is now anchored to the observation's instant instead of the
+  wall clock at evaluation time (replay determinism; the 05-19 "1434:38 ghost countdown" class).
+  Live behavior should be identical — confirm pickup/dropoff "by HH:MM" countdowns on the cards
+  match DoorDash's stated times, and no absurd ~24h countdowns appear (especially around
+  midnight or just-past deadlines).
+  - Confirmed: 0/2.
 
 ---
 


### PR DESCRIPTION
Fixes #347 (audit item A-9). P0 campaign PR 8.

## What
- **Skip** → new `skipAndFinish()`: first-run flag only, zero other writes. The shared completion sheet tracks whether it was opened via Skip or Finish and routes to the right path (with honest "nothing was changed" copy on skip).
- **Finish** → thresholds the wizard has no UI for (`acceptMinPay/MinRatio`, `declineMaxPay/MinRatio`, `autoAccept`) now round-trip from the live `OfferAutomationConfig` instead of resetting to hardcoded literals; `autoDecline` remains strategy-derived (the GOAL step actually collects that).
- **Found while fixing**: `allowShopping` was force-set `true` on every finish but **no wizard step collects it** (SHOPPING collects `maxItems` only) — the write is removed and the dead `WizardState.allowShopping` field deleted. Settings own that toggle.

## Tests
`WizardViewModelTest` (3 new, full repo-mock harness incl. init's 13 flow reads): skip writes only the first-run flag; finish preserves tuned thresholds verbatim + never touches allowShopping; skip performs no new reads/fetches. Full `testDebugUnitTest` green.

Also carries #343's owed field-checklist item (deadline countdowns under the observation-anchored clock).

CLAUDE.md drift check: none. Memory updated post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)