### PR TITLE
fix(ui): economy inputs keep the decimal separator while typing (#350)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/components/economy/CurrencyInput.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/components/economy/CurrencyInput.kt
@@ -4,18 +4,25 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.text.input.KeyboardType
 import java.util.Locale
 
 /**
  * A currency-style input field. Renders the current value as a $-prefixed
- * decimal; the user can scrub it via a numeric keyboard. Commits on blur or
- * enter — there's no separate "submit" button.
+ * decimal; the user can scrub it via a numeric keyboard. Commits every
+ * parseable keystroke (live footers update as you type).
+ *
+ * While the field is FOCUSED the text is the source of truth — the upstream
+ * value round-trip must not re-seed it mid-typing (typing "1." used to commit
+ * 1.0, round-trip, and reset the text to "1", eating the decimal separator —
+ * #350). On blur, the formatted upstream value re-syncs/normalizes the text.
  *
  * Used for: purchase price, insurance/registration deltas, phone plan total.
  */
@@ -27,7 +34,11 @@ fun CurrencyInput(
     modifier: Modifier = Modifier,
     suffix: String? = null,
 ) {
-    var text by remember(value) { mutableStateOf(formatCurrency(value)) }
+    var isFocused by remember { mutableStateOf(false) }
+    var text by remember { mutableStateOf(formatCurrency(value)) }
+    LaunchedEffect(value, isFocused) {
+        if (!isFocused) text = formatCurrency(value)
+    }
 
     OutlinedTextField(
         value = text,
@@ -40,13 +51,14 @@ fun CurrencyInput(
         suffix = suffix?.let { { Text(it) } },
         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
         singleLine = true,
-        modifier = modifier,
+        modifier = modifier.onFocusChanged { isFocused = it.isFocused },
     )
 }
 
 /**
- * A non-currency decimal input field. Same shape as [CurrencyInput] but no
- * `$` prefix. Use this for any value that isn't money (e.g. minutes, miles).
+ * A non-currency decimal input field. Same shape (and the same focus-aware
+ * text handling, #350) as [CurrencyInput] but no `$` prefix. Use this for any
+ * value that isn't money (e.g. minutes, miles).
  */
 @Composable
 fun NumberInput(
@@ -56,7 +68,11 @@ fun NumberInput(
     modifier: Modifier = Modifier,
     suffix: String? = null,
 ) {
-    var text by remember(value) { mutableStateOf(formatCurrency(value)) }
+    var isFocused by remember { mutableStateOf(false) }
+    var text by remember { mutableStateOf(formatCurrency(value)) }
+    LaunchedEffect(value, isFocused) {
+        if (!isFocused) text = formatCurrency(value)
+    }
 
     OutlinedTextField(
         value = text,
@@ -68,12 +84,13 @@ fun NumberInput(
         suffix = suffix?.let { { Text(it) } },
         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
         singleLine = true,
-        modifier = modifier,
+        modifier = modifier.onFocusChanged { isFocused = it.isFocused },
     )
 }
 
 /**
- * An integer-style input field with a custom label. No prefix.
+ * An integer-style input field with a custom label. No prefix. Same
+ * focus-aware text handling as [CurrencyInput] (#350).
  * Used for: phone plan line count, etc.
  */
 @Composable
@@ -83,7 +100,11 @@ fun IntegerInput(
     onValueChange: (Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var text by remember(value) { mutableStateOf(value.toString()) }
+    var isFocused by remember { mutableStateOf(false) }
+    var text by remember { mutableStateOf(value.toString()) }
+    LaunchedEffect(value, isFocused) {
+        if (!isFocused) text = value.toString()
+    }
 
     OutlinedTextField(
         value = text,
@@ -94,7 +115,7 @@ fun IntegerInput(
         label = { Text(label) },
         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
         singleLine = true,
-        modifier = modifier,
+        modifier = modifier.onFocusChanged { isFocused = it.isFocused },
     )
 }
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/components/economy/PairedCurrencyAndIntervalInput.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/components/economy/PairedCurrencyAndIntervalInput.kt
@@ -10,11 +10,13 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import java.util.Locale
@@ -79,7 +81,12 @@ private fun IntervalInput(
     suffix: String,
     modifier: Modifier = Modifier,
 ) {
-    var text by remember(value) { mutableStateOf(formatInterval(value)) }
+    // Focus-aware text handling — same pattern as CurrencyInput (#350).
+    var isFocused by remember { mutableStateOf(false) }
+    var text by remember { mutableStateOf(formatInterval(value)) }
+    LaunchedEffect(value, isFocused) {
+        if (!isFocused) text = formatInterval(value)
+    }
 
     OutlinedTextField(
         value = text,
@@ -91,7 +98,7 @@ private fun IntervalInput(
         suffix = { Text(suffix) },
         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
         singleLine = true,
-        modifier = modifier,
+        modifier = modifier.onFocusChanged { isFocused = it.isFocused },
     )
 }
 

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -328,6 +328,12 @@ _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **bro
   match DoorDash's stated times, and no absurd ~24h countdowns appear (especially around
   midnight or just-past deadlines).
   - Confirmed: 0/2.
+- **Economy fields keep the decimal point while typing (#350; desk-verifiable, no dash
+  needed).** In Settings → Personal Economy (or the wizard's costs step), type `12.5` into any
+  cost field — the `.` must survive (the value round-trip used to reset the text mid-typing and
+  eat the separator). Also confirm: the live `$ /mi` footer still updates per keystroke, and the
+  field normalizes (e.g. `012.50` → `12.5`) when you tap away.
+  - Confirmed: 0/2.
 
 ---
 


### PR DESCRIPTION
Fixes #350 (audit item A-18). P0 campaign PR 9.

## What
All four economy text fields (`CurrencyInput`, `NumberInput`, `IntegerInput`, `IntervalInput`) switch from `remember(value)` (which re-initialized the text on every committed-keystroke round-trip, eating the decimal separator) to the focus-aware two-source pattern: text owns truth while focused; `LaunchedEffect(value, isFocused)` re-seeds the formatted value on blur/external change. Keystroke commits unchanged — live `$ /mi` footers keep updating; blur normalizes display.

## Verification
Compile + full `testDebugUnitTest` green. Behavior is interaction-level (Compose focus + IME round-trip) — verified by construction and via the new **desk-verifiable** checklist item (type `12.5`, separator survives; footer live; blur normalizes). A `createComposeRule`-based UI test would need the compose-test harness wiring — deferred to #244's coverage work rather than bolted on here.

Unblocks #357 (EconomyEditor extraction inherits fixed inputs). Note: `NumberInput` remains unused (#359's dead-code list decides keep-or-delete; fixed here for consistency either way).

CLAUDE.md drift check: none. Memory updated post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)