### PR TITLE
fix(privacy): bind capture persistence per build variant (#346)

### DIFF
--- a/core/data/src/debug/java/cloud/trotter/dashbuddy/core/data/di/CaptureBusModule.kt
+++ b/core/data/src/debug/java/cloud/trotter/dashbuddy/core/data/di/CaptureBusModule.kt
@@ -1,0 +1,23 @@
+package cloud.trotter.dashbuddy.core.data.di
+
+import cloud.trotter.dashbuddy.core.data.capture.CaptureBus
+import cloud.trotter.dashbuddy.core.data.capture.DiskCaptureBus
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+/**
+ * Debug variant: captures persist to disk — the INBOX triage / golden-corpus
+ * workflow depends on them. Release binds [cloud.trotter.dashbuddy.core.data.capture.NoOpCaptureBus]
+ * instead (#346).
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class CaptureBusModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindCaptureBus(impl: DiskCaptureBus): CaptureBus
+}

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/capture/CaptureBus.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/capture/CaptureBus.kt
@@ -6,7 +6,9 @@ package cloud.trotter.dashbuddy.core.data.capture
  * here. The bus decides whether/how to persist and returns the captureId
  * if written (null if deduped or skipped).
  *
- * Release builds bind [NoOpCaptureBus]. Debug builds bind [DiskCaptureBus].
+ * Release builds bind [NoOpCaptureBus]; debug builds bind [DiskCaptureBus] —
+ * enforced by the per-variant `CaptureBusModule` source sets in `:core:data`
+ * (`src/debug` / `src/release`, #346).
  */
 interface CaptureBus {
 

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/capture/NoOpCaptureBus.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/capture/NoOpCaptureBus.kt
@@ -1,11 +1,21 @@
 package cloud.trotter.dashbuddy.core.data.capture
 
+import timber.log.Timber
 import javax.inject.Inject
+import javax.inject.Singleton
 
 /**
- * No-op capture bus for release builds. Discards all captures.
+ * No-op capture bus, bound in RELEASE builds (#346): third-party screen
+ * content is never persisted. Logs once at startup so an accidentally-dashed
+ * release build is diagnosable when a session's captures folder is empty.
  */
+@Singleton
 class NoOpCaptureBus @Inject constructor() : CaptureBus {
+
+    init {
+        Timber.i("Capture persistence disabled (release build) — no envelopes will be written")
+    }
+
     override fun offer(
         captureId: String,
         source: String,

--- a/core/data/src/release/java/cloud/trotter/dashbuddy/core/data/di/CaptureBusModule.kt
+++ b/core/data/src/release/java/cloud/trotter/dashbuddy/core/data/di/CaptureBusModule.kt
@@ -1,0 +1,23 @@
+package cloud.trotter.dashbuddy.core.data.di
+
+import cloud.trotter.dashbuddy.core.data.capture.CaptureBus
+import cloud.trotter.dashbuddy.core.data.capture.NoOpCaptureBus
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+/**
+ * Release variant: capture persistence is OFF — third-party screen content is
+ * never written to disk (privacy pledge, #346). Debug binds
+ * [cloud.trotter.dashbuddy.core.data.capture.DiskCaptureBus] instead.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class CaptureBusModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindCaptureBus(impl: NoOpCaptureBus): CaptureBus
+}

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/di/PipelineModule.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/di/PipelineModule.kt
@@ -1,7 +1,5 @@
 package cloud.trotter.dashbuddy.core.pipeline.di
 
-import cloud.trotter.dashbuddy.core.data.capture.CaptureBus
-import cloud.trotter.dashbuddy.core.data.capture.DiskCaptureBus
 import cloud.trotter.dashbuddy.domain.capture.ReplayMetadataProvider
 import cloud.trotter.dashbuddy.core.pipeline.ReplayMetadataProviderImpl
 import dagger.Binds
@@ -14,12 +12,8 @@ import javax.inject.Singleton
 @InstallIn(SingletonComponent::class)
 abstract class PipelineModule {
 
-    // =========================================================================
-    // CAPTURE
-    // =========================================================================
-
-    @Binds @Singleton
-    abstract fun bindCaptureBus(impl: DiskCaptureBus): CaptureBus
+    // CaptureBus is bound in :core:data's per-variant CaptureBusModule
+    // (debug → DiskCaptureBus, release → NoOpCaptureBus, #346).
 
     @Binds @Singleton
     abstract fun bindReplayMetadataProvider(impl: ReplayMetadataProviderImpl): ReplayMetadataProvider


### PR DESCRIPTION
Fixes #346 (audit item A-8 — corroborated independently by the pipeline and data auditors). P0 campaign PR 10 — completes the P0 set.

## Decision (recorded on the issue before implementing)
**Option A — build-variant binding.** Debug builds (what actually gets dashed; the triage corpus depends on them) keep `DiskCaptureBus`; release builds get `NoOpCaptureBus`. The EvidenceConfig runtime-gate (Option B) is consent-surface work that belongs to #170.

## What
- Per-variant `CaptureBusModule` in `:core:data` (`src/debug` → Disk, `src/release` → NoOp); binding removed from `:core:pipeline`'s DI module (types live in `:core:data`; also trims the cross-module coupling #355 will finish inverting).
- `NoOpCaptureBus` promoted to `@Singleton` with a one-time startup log — an accidentally-dashed release build shows up as "Capture persistence disabled (release build)" instead of silently-missing data.
- `CaptureBus`'s KDoc contract is now actually true (and says where the binding lives).
- Field-checklist sanity item: captures folder non-empty after a debug dash.

## Verification
- Debug: full `testDebugUnitTest` green (debug graph binds Disk as before).
- Release: `:app:compileReleaseKotlin` + `:app:kspReleaseKotlin` green — the release Hilt graph resolves with NoOp (`:app:assembleRelease` stops only at `packageRelease`'s keystore, which lives in CI secrets per `release.yml`, unchanged).

CLAUDE.md drift check: none. Memory updated post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)