### PR TITLE
refactor(state): ObservationJournal + SnapshotStore extraction; replay fidelity (#352)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/di/DispatchersModule.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/di/DispatchersModule.kt
@@ -1,24 +1,19 @@
 package cloud.trotter.dashbuddy.di
 
+import cloud.trotter.dashbuddy.core.state.di.DefaultDispatcher
+import cloud.trotter.dashbuddy.core.state.di.IoDispatcher
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
-import javax.inject.Qualifier
-
-@Qualifier
-@Retention(AnnotationRetention.BINARY)
-annotation class IoDispatcher
-
-@Qualifier
-@Retention(AnnotationRetention.BINARY)
-annotation class DefaultDispatcher
 
 /**
- * Injectable dispatchers so coroutine-owning singletons are testable with virtual time
- * (#341). The data-layer hygiene pass (#364) migrates its hardcoded scopes onto these too.
+ * Bindings for the injectable dispatchers so coroutine-owning singletons are
+ * testable with virtual time (#341/#352). The qualifier annotations live in
+ * `:core:state` (`core.state.di`) so state-layer classes can use them too;
+ * the data-layer hygiene pass (#364) migrates its hardcoded scopes onto these.
  */
 @Module
 @InstallIn(SingletonComponent::class)

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/ScreenShotHandler.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/ScreenShotHandler.kt
@@ -9,7 +9,7 @@ import android.provider.MediaStore
 import android.view.Display
 import cloud.trotter.dashbuddy.core.pipeline.accessibility.input.AccessibilitySource
 import cloud.trotter.dashbuddy.core.state.AppEffect
-import cloud.trotter.dashbuddy.di.IoDispatcher
+import cloud.trotter.dashbuddy.core.state.di.IoDispatcher
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
@@ -17,7 +17,7 @@ import cloud.trotter.dashbuddy.domain.pipeline.RequestedEffect
 import cloud.trotter.dashbuddy.domain.pipeline.TimeoutType
 import cloud.trotter.dashbuddy.core.state.AppEffect
 import cloud.trotter.dashbuddy.core.state.EffectExecutor
-import cloud.trotter.dashbuddy.di.DefaultDispatcher
+import cloud.trotter.dashbuddy.core.state.di.DefaultDispatcher
 import cloud.trotter.dashbuddy.ui.bubble.BubbleManager
 import cloud.trotter.dashbuddy.ui.formatters.toNotificationSummary
 import kotlinx.coroutines.CancellationException

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/state/StateManagerV2RestoreBufferTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/state/StateManagerV2RestoreBufferTest.kt
@@ -1,0 +1,105 @@
+package cloud.trotter.dashbuddy.core.state
+
+import cloud.trotter.dashbuddy.core.database.observation.ObservationDao
+import cloud.trotter.dashbuddy.core.database.observation.ObservationEntity
+import cloud.trotter.dashbuddy.core.database.snapshot.AppStateSnapshotDao
+import cloud.trotter.dashbuddy.core.database.snapshot.AppStateSnapshotEntity
+import cloud.trotter.dashbuddy.core.pipeline.PipelineV2
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
+import cloud.trotter.dashbuddy.domain.model.state.StateEvent
+import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.state.Flow
+import cloud.trotter.dashbuddy.domain.state.Mode
+import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+/**
+ * #352 — events that arrive while crash recovery is still restoring must be
+ * buffered and processed afterwards, not silently dropped. The pipeline's hot
+ * SharedFlows don't replay, and the old code only attached its collector AFTER
+ * restore completed.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class StateManagerV2RestoreBufferTest {
+
+    private class FakeObservationDao : ObservationDao {
+        val inserted = mutableListOf<ObservationEntity>()
+        override suspend fun insert(entity: ObservationEntity): Long {
+            inserted += entity; return inserted.size.toLong()
+        }
+
+        override suspend fun since(afterVersion: Long): List<ObservationEntity> =
+            inserted.filter { it.correlationVersion > afterVersion }
+                .sortedBy { it.correlationVersion }
+
+        override suspend fun latest(): ObservationEntity? =
+            inserted.maxByOrNull { it.correlationVersion }
+
+        override suspend fun pruneOlderThan(cutoff: Long) {}
+    }
+
+    /** latest() sleeps so the test can interleave a live event mid-restore. */
+    private class SlowSnapshotDao(private val delayMs: Long) : AppStateSnapshotDao {
+        override suspend fun insert(entity: AppStateSnapshotEntity) {}
+        override suspend fun latest(): AppStateSnapshotEntity? {
+            delay(delayMs)
+            return null
+        }
+
+        override suspend fun pruneOlderThan(cutoff: Long) {}
+    }
+
+    private fun screenObs(t: Long) = Observation.Screen(
+        timestamp = t, captureId = null, ruleId = "doordash.screen.idle",
+        metadata = ReplayMetadata.EMPTY, flow = Flow.Idle, modeHint = Mode.Online,
+        parsed = ParsedFields.None,
+    )
+
+    @Test
+    fun `events arriving during restore are processed after it, not dropped`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val pipelineEvents = MutableSharedFlow<StateEvent>(extraBufferCapacity = 16)
+        val engineEvents = MutableSharedFlow<StateEvent>(extraBufferCapacity = 16)
+        val pipeline: PipelineV2 = mock()
+        whenever(pipeline.events).thenReturn(pipelineEvents)
+        val engine: EffectExecutor = mock()
+        whenever(engine.events).thenReturn(engineEvents)
+
+        val manager = StateManagerV2(
+            pipeline = pipeline,
+            engine = engine,
+            stateMachine = StateMachine(
+                FlowRegionStepper(), PlatformRegionStepper(),
+                CrossPlatformRegionStepper(), TransitionPolicy(),
+                EffectMap(MetadataProvider { "{}" }),
+            ),
+            journal = ObservationJournal(FakeObservationDao()),
+            snapshots = SnapshotStore(SlowSnapshotDao(delayMs = 100)),
+            defaultDispatcher = dispatcher,
+            ioDispatcher = dispatcher,
+        )
+
+        manager.initialize()
+        advanceTimeBy(50)
+        runCurrent() // restore still sleeping in SlowSnapshotDao.latest()
+
+        pipelineEvents.emit(screenObs(t = 1_000L))
+        runCurrent() // event lands in the buffer; restore hasn't finished
+        assertEquals(0L, manager.state.value.correlationVersion)
+
+        advanceTimeBy(60)
+        runCurrent() // restore completes; buffered event drains and steps state
+        assertEquals(1L, manager.state.value.correlationVersion)
+        assertEquals(Flow.Idle, manager.state.value.regions.flow.flow)
+    }
+}

--- a/core/database/schemas/cloud.trotter.dashbuddy.core.database.DashBuddyDatabase/7.json
+++ b/core/database/schemas/cloud.trotter.dashbuddy.core.database.DashBuddyDatabase/7.json
@@ -1,0 +1,404 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 7,
+    "identityHash": "eea36522b3db638532f623f60da3e431",
+    "entities": [
+      {
+        "tableName": "app_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sequenceId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `aggregateId` TEXT, `eventType` TEXT NOT NULL, `eventPayload` TEXT NOT NULL, `occurredAt` INTEGER NOT NULL, `metadata` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "sequenceId",
+            "columnName": "sequenceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "aggregateId",
+            "columnName": "aggregateId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "eventType",
+            "columnName": "eventType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventPayload",
+            "columnName": "eventPayload",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "occurredAt",
+            "columnName": "occurredAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadata",
+            "columnName": "metadata",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "sequenceId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_app_events_aggregateId",
+            "unique": false,
+            "columnNames": [
+              "aggregateId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_app_events_aggregateId` ON `${TABLE_NAME}` (`aggregateId`)"
+          },
+          {
+            "name": "index_app_events_eventType",
+            "unique": false,
+            "columnNames": [
+              "eventType"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_app_events_eventType` ON `${TABLE_NAME}` (`eventType`)"
+          },
+          {
+            "name": "index_app_events_occurredAt",
+            "unique": false,
+            "columnNames": [
+              "occurredAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_app_events_occurredAt` ON `${TABLE_NAME}` (`occurredAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "app_state_snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`correlationVersion` INTEGER NOT NULL, `capturedAt` INTEGER NOT NULL, `sessionId` TEXT, `stateJson` TEXT NOT NULL, PRIMARY KEY(`correlationVersion`))",
+        "fields": [
+          {
+            "fieldPath": "correlationVersion",
+            "columnName": "correlationVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "capturedAt",
+            "columnName": "capturedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "stateJson",
+            "columnName": "stateJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "correlationVersion"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `dashId` TEXT, `text` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `personaType` TEXT NOT NULL, `personaName` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dashId",
+            "columnName": "dashId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personaType",
+            "columnName": "personaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personaName",
+            "columnName": "personaName",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_messages_dashId",
+            "unique": false,
+            "columnNames": [
+              "dashId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_messages_dashId` ON `${TABLE_NAME}` (`dashId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "effects_fired",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `effectKey` TEXT NOT NULL, `firedAt` INTEGER NOT NULL, `correlationVersion` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "effectKey",
+            "columnName": "effectKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firedAt",
+            "columnName": "firedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "correlationVersion",
+            "columnName": "correlationVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_effects_fired_effectKey",
+            "unique": true,
+            "columnNames": [
+              "effectKey"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_effects_fired_effectKey` ON `${TABLE_NAME}` (`effectKey`)"
+          }
+        ]
+      },
+      {
+        "tableName": "observations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sequenceId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `occurredAt` INTEGER NOT NULL, `sessionId` TEXT, `pipelineId` TEXT NOT NULL, `ruleId` TEXT, `platform` TEXT, `flow` TEXT, `modeHint` TEXT, `parsedJson` TEXT NOT NULL, `captureId` TEXT, `metadataJson` TEXT NOT NULL, `correlationVersion` INTEGER NOT NULL, `timeoutType` TEXT, `payloadJson` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "sequenceId",
+            "columnName": "sequenceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "occurredAt",
+            "columnName": "occurredAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pipelineId",
+            "columnName": "pipelineId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ruleId",
+            "columnName": "ruleId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "flow",
+            "columnName": "flow",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "modeHint",
+            "columnName": "modeHint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "parsedJson",
+            "columnName": "parsedJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "captureId",
+            "columnName": "captureId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "metadataJson",
+            "columnName": "metadataJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "correlationVersion",
+            "columnName": "correlationVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeoutType",
+            "columnName": "timeoutType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "payloadJson",
+            "columnName": "payloadJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "sequenceId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_observations_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_observations_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          },
+          {
+            "name": "index_observations_occurredAt",
+            "unique": false,
+            "columnNames": [
+              "occurredAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_observations_occurredAt` ON `${TABLE_NAME}` (`occurredAt`)"
+          },
+          {
+            "name": "index_observations_correlationVersion",
+            "unique": false,
+            "columnNames": [
+              "correlationVersion"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_observations_correlationVersion` ON `${TABLE_NAME}` (`correlationVersion`)"
+          }
+        ]
+      },
+      {
+        "tableName": "snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `screenType` TEXT NOT NULL, `structuralHash` INTEGER NOT NULL, `contentHash` INTEGER NOT NULL, `filePath` TEXT NOT NULL, `timestamp` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "screenType",
+            "columnName": "screenType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "structuralHash",
+            "columnName": "structuralHash",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentHash",
+            "columnName": "contentHash",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_snapshots_screenType",
+            "unique": false,
+            "columnNames": [
+              "screenType"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_snapshots_screenType` ON `${TABLE_NAME}` (`screenType`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'eea36522b3db638532f623f60da3e431')"
+    ]
+  }
+}

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/DashBuddyDatabase.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/DashBuddyDatabase.kt
@@ -25,7 +25,7 @@ import cloud.trotter.dashbuddy.core.database.snapshot.AppStateSnapshotEntity
         ObservationEntity::class,
         SnapshotRecord::class,
     ],
-    version = 6,
+    version = 7,
     exportSchema = true
 )
 @TypeConverters(DataTypeConverters::class)

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/observation/ObservationDao.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/observation/ObservationDao.kt
@@ -10,8 +10,12 @@ interface ObservationDao {
     @Insert
     suspend fun insert(entity: ObservationEntity): Long
 
-    /** All observations after a given correlationVersion, ordered for replay. */
-    @Query("SELECT * FROM observations WHERE correlationVersion > :afterVersion ORDER BY sequenceId ASC")
+    /**
+     * All observations after a given correlationVersion, in PROCESSING order for
+     * replay (#352). correlationVersion is assigned by the reducer; sequenceId is
+     * insert-landing order, which concurrent writers could scramble.
+     */
+    @Query("SELECT * FROM observations WHERE correlationVersion > :afterVersion ORDER BY correlationVersion ASC")
     suspend fun since(afterVersion: Long): List<ObservationEntity>
 
     /** Latest observation by correlationVersion. */

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/observation/ObservationEntity.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/observation/ObservationEntity.kt
@@ -33,4 +33,10 @@ data class ObservationEntity(
     val metadataJson: String,
     val correlationVersion: Long,
     val timeoutType: String? = null,
+    /**
+     * Typed projection of non-flow observation payloads (#352) — UiInput action,
+     * Loopback effect/offerHash/evaluation, Timeout target platform — so crash
+     * recovery replays REAL internal observations instead of stubs.
+     */
+    val payloadJson: String? = null,
 )

--- a/core/state/build.gradle.kts
+++ b/core/state/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.hilt)
     alias(libs.plugins.ksp)
+    alias(libs.plugins.kotlin.serialization)
 }
 
 android {
@@ -49,4 +50,5 @@ dependencies {
     ksp(libs.hilt.compiler)
 
     testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/ObservationJournal.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/ObservationJournal.kt
@@ -1,0 +1,220 @@
+package cloud.trotter.dashbuddy.core.state
+
+import cloud.trotter.dashbuddy.core.database.observation.ObservationDao
+import cloud.trotter.dashbuddy.core.database.observation.ObservationEntity
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
+import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
+import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.pipeline.TimeoutType
+import cloud.trotter.dashbuddy.domain.state.AppState
+import cloud.trotter.dashbuddy.domain.state.Flow
+import cloud.trotter.dashbuddy.domain.state.Mode
+import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import cloud.trotter.dashbuddy.domain.state.Platform
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Typed projection of the non-flow observations' payloads (#352). FlowObservations
+ * persist their ParsedFields; Timeout/UiInput/Loopback used to replay as STUBS —
+ * notably the `offer_evaluated` loopback, so replayed state never carried its
+ * evaluations. Map-payload entries beyond these fields are #366's typed-payload work.
+ */
+@Serializable
+internal data class InternalObsPayload(
+    val action: String? = null,
+    val effect: String? = null,
+    val offerHash: String? = null,
+    val evaluation: OfferEvaluation? = null,
+    val targetPlatform: String? = null,
+)
+
+/**
+ * The append-only observation log (#352) — owns persistence, the replay-tail read,
+ * and the entity↔observation codec. Extracted from StateManagerV2 so recovery
+ * fidelity is testable in isolation.
+ */
+@Singleton
+class ObservationJournal @Inject constructor(
+    private val observationDao: ObservationDao,
+) {
+
+    /**
+     * Single-writer queue: entries land in submission order with no gaps. The old
+     * per-insert fire-and-forget launches could land out of order, and a crash
+     * could persist cv=N+1 while cv=N was still in flight.
+     */
+    private val writeQueue = Channel<ObservationEntity>(Channel.UNLIMITED)
+
+    /** Starts the single writer. Call once; [dispatcher] is IO in production. */
+    fun start(scope: CoroutineScope, dispatcher: CoroutineDispatcher) {
+        scope.launch(dispatcher) {
+            for (entity in writeQueue) {
+                try {
+                    observationDao.insert(entity)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Throwable) {
+                    Timber.e(e, "Failed to persist observation cv=%d", entity.correlationVersion)
+                }
+            }
+        }
+    }
+
+    /** Append to the log — ordered, asynchronous. */
+    fun append(obs: Observation, state: AppState) {
+        writeQueue.trySend(obs.toEntity(state))
+    }
+
+    /** The replay tail after [afterVersion], in correlation-version order. */
+    suspend fun tailAfter(afterVersion: Long): List<Observation> =
+        observationDao.since(afterVersion).map { it.toObservation() }
+
+    suspend fun pruneOlderThan(cutoff: Long) = observationDao.pruneOlderThan(cutoff)
+
+    // ── Codec ───────────────────────────────────────────────────────────
+
+    internal fun Observation.toEntity(state: AppState): ObservationEntity {
+        val flowObs = this as? Observation.FlowObservation
+        val session = state.regions.platforms[platform]?.session
+        return ObservationEntity(
+            occurredAt = timestamp,
+            sessionId = session?.sessionId,
+            pipelineId = pipelineIdOf(this),
+            ruleId = ruleId,
+            platform = platform.name,
+            flow = flowObs?.flow?.name,
+            modeHint = flowObs?.modeHint?.name,
+            parsedJson = if (flowObs != null) {
+                StateJson.encodeToString<ParsedFields>(flowObs.parsed)
+            } else "{}",
+            captureId = captureId,
+            metadataJson = StateJson.encodeToString(metadata),
+            correlationVersion = state.correlationVersion,
+            timeoutType = (this as? Observation.Timeout)?.type?.name,
+            payloadJson = internalPayloadOf(this)?.let { StateJson.encodeToString(it) },
+        )
+    }
+
+    private fun internalPayloadOf(obs: Observation): InternalObsPayload? = when (obs) {
+        is Observation.Timeout -> obs.targetPlatform?.let {
+            InternalObsPayload(targetPlatform = it.wire)
+        }
+        // Persisting the REAL action is safe: PerformOfferAction is classified
+        // external (#341), so recovery can never replay an offer click from it.
+        is Observation.UiInput -> InternalObsPayload(action = obs.action)
+        is Observation.Loopback -> InternalObsPayload(
+            effect = obs.effect,
+            offerHash = obs.payload["offerHash"] as? String,
+            evaluation = obs.payload["evaluation"] as? OfferEvaluation,
+        )
+        else -> null
+    }
+
+    /** Reconstruct an [Observation] from a persisted row, for crash-recovery replay. */
+    internal fun ObservationEntity.toObservation(): Observation {
+        val payload = payloadJson?.let {
+            try {
+                StateJson.decodeFromString<InternalObsPayload>(it)
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to decode internal payload — replaying as stub")
+                null
+            }
+        }
+        return when (pipelineId) {
+            "accessibility.window" -> Observation.Screen(
+                timestamp = occurredAt,
+                captureId = captureId,
+                ruleId = ruleId,
+                metadata = ReplayMetadata.EMPTY,
+                flow = flow?.let { runCatching { enumValueOf<Flow>(it) }.getOrNull() },
+                modeHint = modeHint?.let { runCatching { enumValueOf<Mode>(it) }.getOrNull() },
+                parsed = deserializeParsed(parsedJson),
+                target = ruleId?.substringAfterLast('.'),
+            )
+
+            "accessibility.click" -> Observation.Click(
+                timestamp = occurredAt,
+                captureId = captureId,
+                ruleId = ruleId,
+                metadata = ReplayMetadata.EMPTY,
+                flow = flow?.let { runCatching { enumValueOf<Flow>(it) }.getOrNull() },
+                modeHint = modeHint?.let { runCatching { enumValueOf<Mode>(it) }.getOrNull() },
+                parsed = deserializeParsed(parsedJson),
+                target = ruleId?.substringAfterLast('.'),
+            )
+
+            "notification" -> Observation.Notification(
+                timestamp = occurredAt,
+                captureId = captureId,
+                ruleId = ruleId,
+                metadata = ReplayMetadata.EMPTY,
+                flow = flow?.let { runCatching { enumValueOf<Flow>(it) }.getOrNull() },
+                modeHint = modeHint?.let { runCatching { enumValueOf<Mode>(it) }.getOrNull() },
+                parsed = deserializeParsed(parsedJson),
+                target = ruleId?.substringAfterLast('.'),
+            )
+
+            "internal.timeout" -> Observation.Timeout(
+                timestamp = occurredAt,
+                type = timeoutType?.let {
+                    runCatching { enumValueOf<TimeoutType>(it) }.getOrNull()
+                } ?: TimeoutType.SETTLE_UI,
+                targetPlatform = payload?.targetPlatform?.let(Platform::fromWire),
+            )
+
+            "internal.ui" -> Observation.UiInput(
+                timestamp = occurredAt,
+                action = payload?.action ?: "replay",
+            )
+
+            "internal.loopback" -> Observation.Loopback(
+                timestamp = occurredAt,
+                effect = payload?.effect ?: "replay",
+                // Rebuild the exact keys FlowRegionStepper.handleLoopback reads, so
+                // a replayed offer_evaluated LANDS its evaluation (#352).
+                payload = buildMap {
+                    payload?.offerHash?.let { put("offerHash", it) }
+                    payload?.evaluation?.let {
+                        put("evaluation", it)
+                        put("action", it.action.name)
+                    }
+                },
+            )
+
+            else -> Observation.Loopback(
+                timestamp = occurredAt,
+                effect = "unknown_pipeline:$pipelineId",
+            )
+        }
+    }
+
+    private fun pipelineIdOf(obs: Observation): String = when (obs) {
+        is Observation.Screen -> "accessibility.window"
+        is Observation.Click -> "accessibility.click"
+        is Observation.Notification -> "notification"
+        is Observation.Timeout -> "internal.timeout"
+        is Observation.UiInput -> "internal.ui"
+        is Observation.Loopback -> "internal.loopback"
+    }
+
+    private fun deserializeParsed(json: String): ParsedFields {
+        // Non-flow observations persist "{}" — that's a legitimate None, not corruption.
+        if (json.isBlank() || json == "{}") return ParsedFields.None
+        return try {
+            StateJson.decodeFromString<ParsedFields>(json)
+        } catch (e: Exception) {
+            // LOUD (#353): a silent fallback here hid replay corruption entirely.
+            Timber.e(e, "Failed to decode persisted ParsedFields — replaying as None: %s", json.take(120))
+            ParsedFields.None
+        }
+    }
+}

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/SnapshotStore.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/SnapshotStore.kt
@@ -1,0 +1,109 @@
+package cloud.trotter.dashbuddy.core.state
+
+import cloud.trotter.dashbuddy.core.database.snapshot.AppStateSnapshotDao
+import cloud.trotter.dashbuddy.core.database.snapshot.AppStateSnapshotEntity
+import cloud.trotter.dashbuddy.domain.state.AppState
+import cloud.trotter.dashbuddy.domain.state.Flow
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.serialization.encodeToString
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Snapshot cadence + persistence + restore (#352), extracted from StateManagerV2
+ * so the recovery seam is testable in isolation.
+ */
+@Singleton
+class SnapshotStore @Inject constructor(
+    private val snapshotDao: AppStateSnapshotDao,
+) {
+
+    companion object {
+        /** Write a state snapshot every N accepted observations. */
+        const val SNAPSHOT_INTERVAL = 5
+
+        /** Keep snapshots for 24h. */
+        const val SNAPSHOT_RETENTION_MS = 24 * 60 * 60 * 1000L
+    }
+
+    /** A successfully decoded snapshot. */
+    data class Restored(val state: AppState, val correlationVersion: Long)
+
+    fun maybeSnapshot(scope: CoroutineScope, dispatcher: CoroutineDispatcher, prev: AppState, next: AppState) {
+        val shouldSnapshot =
+            next.correlationVersion % SNAPSHOT_INTERVAL == 0L ||
+                isMajorTransition(prev, next)
+
+        if (!shouldSnapshot) return
+
+        scope.launch(dispatcher) {
+            try {
+                val activeSession = next.regions.platforms.values
+                    .maxByOrNull { it.lastObservedAt }?.session
+                snapshotDao.insert(
+                    AppStateSnapshotEntity(
+                        correlationVersion = next.correlationVersion,
+                        capturedAt = System.currentTimeMillis(),
+                        sessionId = activeSession?.sessionId,
+                        stateJson = StateJson.encodeToString(next),
+                    )
+                )
+                // Prune snapshots older than the retention window.
+                snapshotDao.pruneOlderThan(System.currentTimeMillis() - SNAPSHOT_RETENTION_MS)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
+                Timber.e(e, "Failed to write state snapshot")
+            }
+        }
+    }
+
+    /**
+     * The latest decodable snapshot, or null. Schema drift within kotlinx's
+     * tolerance decodes with defaults; anything beyond fails LOUDLY here and the
+     * caller starts fresh (#353).
+     */
+    suspend fun restoreLatest(): Restored? {
+        val snapshot = snapshotDao.latest() ?: return null
+        return try {
+            Restored(
+                state = StateJson.decodeFromString<AppState>(snapshot.stateJson),
+                correlationVersion = snapshot.correlationVersion,
+            )
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to deserialize snapshot — starting fresh")
+            null
+        }
+    }
+
+    private fun isMajorTransition(prev: AppState, next: AppState): Boolean {
+        val allPlatforms = (prev.regions.platforms.keys + next.regions.platforms.keys)
+        for (p in allPlatforms) {
+            val prevRegion = prev.regions.platforms[p]
+            val nextRegion = next.regions.platforms[p]
+
+            // Session start/end
+            if (prevRegion?.session?.sessionId != nextRegion?.session?.sessionId) return true
+
+            // Job start/end
+            if (prevRegion?.activeJob?.jobId != nextRegion?.activeJob?.jobId) return true
+        }
+
+        // Flow transitions that mark lifecycle boundaries
+        val prevFlow = prev.regions.flow.flow
+        val nextFlow = next.regions.flow.flow
+        if (prevFlow != nextFlow) {
+            val majorFlows = setOf(
+                Flow.OfferPresented,
+                Flow.SessionEnded,
+            )
+            if (nextFlow in majorFlows || prevFlow in majorFlows) return true
+        }
+
+        return false
+    }
+}

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/StateManagerV2.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/StateManagerV2.kt
@@ -1,22 +1,15 @@
 package cloud.trotter.dashbuddy.core.state
 
-import cloud.trotter.dashbuddy.core.database.observation.ObservationDao
-import cloud.trotter.dashbuddy.core.database.observation.ObservationEntity
-import cloud.trotter.dashbuddy.core.database.snapshot.AppStateSnapshotDao
-import cloud.trotter.dashbuddy.core.database.snapshot.AppStateSnapshotEntity
-import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
+import cloud.trotter.dashbuddy.core.state.di.DefaultDispatcher
+import cloud.trotter.dashbuddy.core.state.di.IoDispatcher
 import cloud.trotter.dashbuddy.domain.model.state.OfferEvaluationEvent
 import cloud.trotter.dashbuddy.domain.model.state.StateEvent
 import cloud.trotter.dashbuddy.domain.model.state.TimeoutEvent
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
-import cloud.trotter.dashbuddy.domain.pipeline.TimeoutType
 import cloud.trotter.dashbuddy.domain.state.AppState
-import cloud.trotter.dashbuddy.domain.state.Flow
-import cloud.trotter.dashbuddy.domain.state.ParsedFields
 import cloud.trotter.dashbuddy.core.pipeline.PipelineV2
-import kotlinx.serialization.encodeToString
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -25,7 +18,6 @@ import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import timber.log.Timber
-import java.util.concurrent.CancellationException
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -34,11 +26,13 @@ class StateManagerV2 @Inject constructor(
     private val pipeline: PipelineV2,
     private val engine: EffectExecutor,
     private val stateMachine: StateMachine,
-    private val observationDao: ObservationDao,
-    private val snapshotDao: AppStateSnapshotDao,
+    private val journal: ObservationJournal,
+    private val snapshots: SnapshotStore,
+    @param:DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher,
+    @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) {
 
-    private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+    private val scope = CoroutineScope(defaultDispatcher + SupervisorJob())
 
     // UI input stream (clicks, debug buttons)
     private val uiInputChannel = Channel<StateEvent>(Channel.UNLIMITED)
@@ -46,40 +40,33 @@ class StateManagerV2 @Inject constructor(
     private val _state = MutableStateFlow(AppState())
     val state = _state.asStateFlow()
 
-    companion object {
-        /** Write a state snapshot every N accepted observations. */
-        const val SNAPSHOT_INTERVAL = 5
-
-        /** Prune state snapshots older than this (24 hours). */
-        const val SNAPSHOT_RETENTION_MS = 24 * 60 * 60 * 1000L
-    }
-
     fun initialize() {
         Timber.i("Initializing V2 State Machine (multi-region)...")
+        journal.start(scope, ioDispatcher)
         scope.launch {
+            // Collect BEFORE restoring (#352): the pipeline flows are hot and don't
+            // replay, so events arriving during recovery used to be silently lost.
+            // They buffer here and process — in arrival order — once restore is done.
+            val buffer = Channel<StateEvent>(Channel.UNLIMITED)
+            scope.launch {
+                merge(
+                    pipeline.events,
+                    engine.events,
+                    uiInputChannel.receiveAsFlow(),
+                ).collect { buffer.send(it) }
+            }
+
             restoreState()
-            startProcessor()
+
+            for (stateEvent in buffer) {
+                Timber.d("PROCESSING: ${stateEvent::class.simpleName}")
+                processEvent(stateEvent)
+            }
         }
     }
 
     fun dispatch(stateEvent: StateEvent) {
         uiInputChannel.trySend(stateEvent)
-    }
-
-    private fun startProcessor() {
-        scope.launch {
-            Timber.d("Connecting all event streams...")
-
-            merge(
-                pipeline.events,
-                engine.events,
-                uiInputChannel.receiveAsFlow()
-            )
-                .collect { stateEvent ->
-                    Timber.d("PROCESSING: ${stateEvent::class.simpleName}")
-                    processEvent(stateEvent)
-                }
-        }
     }
 
     private fun processEvent(stateEvent: StateEvent) {
@@ -93,11 +80,11 @@ class StateManagerV2 @Inject constructor(
             _state.value = transition.newState
         }
 
-        // Persist observation to append-only log
-        persistObservation(obs, transition.newState)
+        // Persist observation to the append-only log (ordered single writer, #352)
+        journal.append(obs, transition.newState)
 
         // Periodic + major-transition snapshots
-        maybeSnapshot(transition.newState, currentState)
+        snapshots.maybeSnapshot(scope, ioDispatcher, currentState, transition.newState)
 
         // Emit effects — the engine serializes execution in this order (#351).
         transition.effects.forEach { effect ->
@@ -105,143 +92,31 @@ class StateManagerV2 @Inject constructor(
         }
     }
 
-    // ── Observation Persistence ─────────────────────────────────────────
-
-    private fun persistObservation(obs: Observation, state: AppState) {
-        scope.launch(Dispatchers.IO) {
-            try {
-                observationDao.insert(obs.toEntity(state))
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Throwable) {
-                Timber.e(e, "Failed to persist observation")
-            }
-        }
-    }
-
-    private fun Observation.toEntity(state: AppState): ObservationEntity {
-        val flowObs = this as? Observation.FlowObservation
-        val session = state.regions.platforms[platform]?.session
-        return ObservationEntity(
-            occurredAt = timestamp,
-            sessionId = session?.sessionId,
-            pipelineId = pipelineIdOf(this),
-            ruleId = ruleId,
-            platform = platform.name,
-            flow = flowObs?.flow?.name,
-            modeHint = flowObs?.modeHint?.name,
-            parsedJson = if (flowObs != null) StateJson.encodeToString<ParsedFields>(flowObs.parsed) else "{}",
-            captureId = captureId,
-            metadataJson = StateJson.encodeToString(metadata),
-            correlationVersion = state.correlationVersion,
-            timeoutType = (this as? Observation.Timeout)?.type?.name,
-        )
-    }
-
-    private fun pipelineIdOf(obs: Observation): String = when (obs) {
-        is Observation.Screen -> "accessibility.window"
-        is Observation.Click -> "accessibility.click"
-        is Observation.Notification -> "notification"
-        is Observation.Timeout -> "internal.timeout"
-        is Observation.UiInput -> "internal.ui"
-        is Observation.Loopback -> "internal.loopback"
-    }
-
-    // ── Snapshots ───────────────────────────────────────────────────────
-
-    private fun maybeSnapshot(next: AppState, prev: AppState) {
-        val shouldSnapshot =
-            next.correlationVersion % SNAPSHOT_INTERVAL == 0L ||
-                    isMajorTransition(prev, next)
-
-        if (!shouldSnapshot) return
-
-        scope.launch(Dispatchers.IO) {
-            try {
-                val activeSession = next.regions.platforms.values
-                    .maxByOrNull { it.lastObservedAt }?.session
-                snapshotDao.insert(
-                    AppStateSnapshotEntity(
-                        correlationVersion = next.correlationVersion,
-                        capturedAt = System.currentTimeMillis(),
-                        sessionId = activeSession?.sessionId,
-                        stateJson = StateJson.encodeToString(next),
-                    )
-                )
-                // Prune snapshots older than 24h
-                snapshotDao.pruneOlderThan(System.currentTimeMillis() - SNAPSHOT_RETENTION_MS)
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Throwable) {
-                Timber.e(e, "Failed to write state snapshot")
-            }
-        }
-    }
-
-    private fun isMajorTransition(prev: AppState, next: AppState): Boolean {
-        val allPlatforms = (prev.regions.platforms.keys + next.regions.platforms.keys)
-        for (p in allPlatforms) {
-            val prevRegion = prev.regions.platforms[p]
-            val nextRegion = next.regions.platforms[p]
-
-            // Session start/end
-            if (prevRegion?.session?.sessionId != nextRegion?.session?.sessionId) return true
-
-            // Job start/end
-            if (prevRegion?.activeJob?.jobId != nextRegion?.activeJob?.jobId) return true
-        }
-
-        // Flow transitions that mark lifecycle boundaries
-        val prevFlow = prev.regions.flow.flow
-        val nextFlow = next.regions.flow.flow
-        if (prevFlow != nextFlow) {
-            val majorFlows = setOf(
-                Flow.OfferPresented,
-                Flow.SessionEnded,
-            )
-            if (nextFlow in majorFlows || prevFlow in majorFlows) return true
-        }
-
-        return false
-    }
-
     // ── Crash Recovery ──────────────────────────────────────────────────
 
     private suspend fun restoreState() {
         try {
-            val snapshot = snapshotDao.latest()
-            if (snapshot == null) {
-                Timber.i("No snapshot found — starting fresh")
+            val restored = snapshots.restoreLatest()
+            if (restored == null) {
+                Timber.i("No usable snapshot — starting fresh")
                 _state.value = AppState()
                 return
             }
 
-            // Restore from snapshot. Schema drift within kotlinx's tolerance
-            // (unknown/missing-optional fields) decodes with defaults; anything
-            // beyond that fails LOUDLY and falls back to fresh state (#353).
-            val restoredState = try {
-                StateJson.decodeFromString<AppState>(snapshot.stateJson)
-            } catch (e: Exception) {
-                Timber.e(e, "Failed to deserialize snapshot — starting fresh")
-                _state.value = AppState()
-                return
-            }
-
-            // Tail-replay observations after the snapshot
-            val tail = observationDao.since(snapshot.correlationVersion)
+            // Tail-replay observations after the snapshot, in cv order (#352)
+            val tail = journal.tailAfter(restored.correlationVersion)
             if (tail.isEmpty()) {
-                Timber.i("Restored from snapshot at cv=%d, no tail", snapshot.correlationVersion)
-                _state.value = restoredState
+                Timber.i("Restored from snapshot at cv=%d, no tail", restored.correlationVersion)
+                _state.value = restored.state
                 return
             }
 
             Timber.i(
                 "Replaying %d observations after snapshot cv=%d",
-                tail.size, snapshot.correlationVersion,
+                tail.size, restored.correlationVersion,
             )
 
-            val finalState = tail.fold(restoredState) { acc, entity ->
-                val obs = entity.toObservation()
+            val finalState = tail.fold(restored.state) { acc, obs ->
                 val transition = stateMachine.step(acc, obs)
                 // Process effects in recovery mode (external suppressed, keyed deduped)
                 transition.effects.forEach { effect ->
@@ -259,87 +134,6 @@ class StateManagerV2 @Inject constructor(
         } catch (e: Exception) {
             Timber.e(e, "State recovery failed — starting fresh")
             _state.value = AppState()
-        }
-    }
-
-    /**
-     * Reconstruct an [Observation] from a persisted [ObservationEntity].
-     * Used during crash-recovery tail replay.
-     */
-    private fun ObservationEntity.toObservation(): Observation {
-        return when (pipelineId) {
-            "accessibility.window" -> Observation.Screen(
-                timestamp = occurredAt,
-                captureId = captureId,
-                ruleId = ruleId,
-                metadata = ReplayMetadata.EMPTY,
-                flow = flow?.let { runCatching { enumValueOf<Flow>(it) }.getOrNull() },
-                modeHint = modeHint?.let {
-                    runCatching { enumValueOf<cloud.trotter.dashbuddy.domain.state.Mode>(it) }.getOrNull()
-                },
-                parsed = deserializeParsed(parsedJson),
-                target = ruleId?.substringAfterLast('.'),
-            )
-
-            "accessibility.click" -> Observation.Click(
-                timestamp = occurredAt,
-                captureId = captureId,
-                ruleId = ruleId,
-                metadata = ReplayMetadata.EMPTY,
-                flow = flow?.let { runCatching { enumValueOf<Flow>(it) }.getOrNull() },
-                modeHint = modeHint?.let {
-                    runCatching { enumValueOf<cloud.trotter.dashbuddy.domain.state.Mode>(it) }.getOrNull()
-                },
-                parsed = deserializeParsed(parsedJson),
-                target = ruleId?.substringAfterLast('.'),
-            )
-
-            "notification" -> Observation.Notification(
-                timestamp = occurredAt,
-                captureId = captureId,
-                ruleId = ruleId,
-                metadata = ReplayMetadata.EMPTY,
-                flow = flow?.let { runCatching { enumValueOf<Flow>(it) }.getOrNull() },
-                modeHint = modeHint?.let {
-                    runCatching { enumValueOf<cloud.trotter.dashbuddy.domain.state.Mode>(it) }.getOrNull()
-                },
-                parsed = deserializeParsed(parsedJson),
-                target = ruleId?.substringAfterLast('.'),
-            )
-
-            "internal.timeout" -> Observation.Timeout(
-                timestamp = occurredAt,
-                type = timeoutType?.let {
-                    runCatching { enumValueOf<TimeoutType>(it) }.getOrNull()
-                } ?: TimeoutType.SETTLE_UI,
-            )
-
-            "internal.ui" -> Observation.UiInput(
-                timestamp = occurredAt,
-                action = "replay",
-            )
-
-            "internal.loopback" -> Observation.Loopback(
-                timestamp = occurredAt,
-                effect = "replay",
-            )
-
-            else -> Observation.Loopback(
-                timestamp = occurredAt,
-                effect = "unknown_pipeline:$pipelineId",
-            )
-        }
-    }
-
-    private fun deserializeParsed(json: String): ParsedFields {
-        // Non-flow observations persist "{}" — that's a legitimate None, not corruption.
-        if (json.isBlank() || json == "{}") return ParsedFields.None
-        return try {
-            StateJson.decodeFromString<ParsedFields>(json)
-        } catch (e: Exception) {
-            // LOUD (#353): the old silent fallback hid replay corruption entirely.
-            Timber.e(e, "Failed to decode persisted ParsedFields — replaying as None: %s", json.take(120))
-            ParsedFields.None
         }
     }
 

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/di/DispatcherQualifiers.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/di/DispatcherQualifiers.kt
@@ -1,0 +1,16 @@
+package cloud.trotter.dashbuddy.core.state.di
+
+import javax.inject.Qualifier
+
+/**
+ * Dispatcher qualifiers (#341/#352). Defined here (not :app) so coroutine-owning
+ * classes in :core:state can take injectable dispatchers and stay testable with
+ * virtual time; :app's DispatchersModule provides the bindings.
+ */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class IoDispatcher
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class DefaultDispatcher

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/ObservationJournalTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/ObservationJournalTest.kt
@@ -1,0 +1,178 @@
+package cloud.trotter.dashbuddy.core.state
+
+import cloud.trotter.dashbuddy.core.database.observation.ObservationDao
+import cloud.trotter.dashbuddy.core.database.observation.ObservationEntity
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
+import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
+import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
+import cloud.trotter.dashbuddy.domain.model.offer.ParsedOffer
+import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.pipeline.TimeoutType
+import cloud.trotter.dashbuddy.domain.state.AppState
+import cloud.trotter.dashbuddy.domain.state.Flow
+import cloud.trotter.dashbuddy.domain.state.FlowRegion
+import cloud.trotter.dashbuddy.domain.state.Mode
+import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import cloud.trotter.dashbuddy.domain.state.PendingOffer
+import cloud.trotter.dashbuddy.domain.state.Platform
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #352 — the observation journal's fidelity guarantees:
+ * - single-writer appends land in submission order, gap-free (the old
+ *   per-insert fire-and-forget launches could reorder);
+ * - internal observations (Loopback/UiInput/Timeout) round-trip with their
+ *   REAL payloads instead of replaying as stubs — most importantly the
+ *   `offer_evaluated` loopback, whose evaluation must land on replay.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ObservationJournalTest {
+
+    private class FakeObservationDao : ObservationDao {
+        val inserted = mutableListOf<ObservationEntity>()
+        override suspend fun insert(entity: ObservationEntity): Long {
+            delay(1) // emulate IO latency — single-writer order must still hold
+            inserted += entity
+            return inserted.size.toLong()
+        }
+
+        override suspend fun since(afterVersion: Long): List<ObservationEntity> =
+            inserted.filter { it.correlationVersion > afterVersion }
+                .sortedBy { it.correlationVersion }
+
+        override suspend fun latest(): ObservationEntity? =
+            inserted.maxByOrNull { it.correlationVersion }
+
+        override suspend fun pruneOlderThan(cutoff: Long) {
+            inserted.removeAll { it.occurredAt < cutoff }
+        }
+    }
+
+    private fun screenObs(t: Long) = Observation.Screen(
+        timestamp = t, captureId = null, ruleId = "doordash.screen.idle",
+        metadata = ReplayMetadata.EMPTY, flow = Flow.Idle, modeHint = Mode.Online,
+        parsed = ParsedFields.None,
+    )
+
+    private fun state(cv: Long) = AppState(timestamp = cv, correlationVersion = cv)
+
+    private fun evaluation() = OfferEvaluation(
+        action = OfferAction.ACCEPT, score = 74.0, qualityLevel = "Good",
+        recommendationText = "Recommended: ACCEPT", payAmount = 7.50,
+        fuelCostEstimate = 0.5, netPayAmount = 6.50, distanceMiles = 3.2,
+        dollarsPerMile = 2.03, dollarsPerHour = 22.0, estimatedTimeMinutes = 18.0,
+        itemCount = 3.0, merchantName = "HEB",
+    )
+
+    @Test
+    fun `appends land in submission order with no gaps`() = runTest {
+        val dao = FakeObservationDao()
+        val journal = ObservationJournal(dao)
+        journal.start(CoroutineScope(SupervisorJob() + StandardTestDispatcher(testScheduler)), StandardTestDispatcher(testScheduler))
+
+        (1L..20L).forEach { cv -> journal.append(screenObs(t = cv), state(cv)) }
+        advanceUntilIdle()
+
+        assertEquals((1L..20L).toList(), dao.inserted.map { it.correlationVersion })
+    }
+
+    @Test
+    fun `offer_evaluated loopback round-trips and lands its evaluation`() = runTest {
+        val dao = FakeObservationDao()
+        val journal = ObservationJournal(dao)
+        journal.start(CoroutineScope(SupervisorJob() + StandardTestDispatcher(testScheduler)), StandardTestDispatcher(testScheduler))
+        val eval = evaluation()
+        val loopback = Observation.Loopback(
+            timestamp = 2_000L,
+            effect = "offer_evaluated",
+            payload = mapOf(
+                "action" to eval.action.name,
+                "evaluation" to eval,
+                "offerHash" to "offer-A",
+            ),
+        )
+
+        journal.append(loopback, state(cv = 1))
+        advanceUntilIdle()
+        val replayed = journal.tailAfter(0).single() as Observation.Loopback
+
+        assertEquals("offer_evaluated", replayed.effect)
+        assertEquals("offer-A", replayed.payload["offerHash"])
+        assertEquals(eval, replayed.payload["evaluation"])
+
+        // And the replayed loopback LANDS on a pending offer — the fidelity gap
+        // this issue exists for.
+        val region = FlowRegion(
+            flow = Flow.OfferPresented,
+            pendingOffer = PendingOffer(
+                offerHash = "offer-A",
+                offerFields = ParsedFields.OfferFields(
+                    parsedOffer = ParsedOffer(offerHash = "offer-A", payAmount = 7.5),
+                ),
+                presentedAt = 1_000L,
+                returnFlow = Flow.Idle,
+            ),
+        )
+        val next = FlowRegionStepper().step(region, replayed)
+        assertNotNull(next.pendingOffer?.evaluation)
+    }
+
+    @Test
+    fun `UiInput action and Timeout target platform survive the round-trip`() = runTest {
+        val dao = FakeObservationDao()
+        val journal = ObservationJournal(dao)
+        journal.start(CoroutineScope(SupervisorJob() + StandardTestDispatcher(testScheduler)), StandardTestDispatcher(testScheduler))
+
+        journal.append(Observation.UiInput(timestamp = 1L, action = "accept_offer"), state(1))
+        journal.append(
+            Observation.Timeout(
+                timestamp = 2L, type = TimeoutType.SESSION_PAUSED_SAFETY,
+                targetPlatform = Platform.DoorDash,
+            ),
+            state(2),
+        )
+        advanceUntilIdle()
+        val tail = journal.tailAfter(0)
+
+        val ui = tail[0] as Observation.UiInput
+        assertEquals("accept_offer", ui.action)
+
+        val timeout = tail[1] as Observation.Timeout
+        assertEquals(TimeoutType.SESSION_PAUSED_SAFETY, timeout.type)
+        assertEquals(Platform.DoorDash, timeout.targetPlatform)
+        assertEquals(Platform.DoorDash, timeout.platform) // routing (#342) preserved
+    }
+
+    @Test
+    fun `flow observations round-trip their parsed fields`() = runTest {
+        val dao = FakeObservationDao()
+        val journal = ObservationJournal(dao)
+        journal.start(CoroutineScope(SupervisorJob() + StandardTestDispatcher(testScheduler)), StandardTestDispatcher(testScheduler))
+        val parsed = ParsedFields.OfferFields(
+            parsedOffer = ParsedOffer(offerHash = "h9", payAmount = 11.25, distanceMiles = 4.0),
+        )
+        val obs = Observation.Screen(
+            timestamp = 5L, captureId = null, ruleId = "doordash.screen.offer_popup",
+            metadata = ReplayMetadata.EMPTY, flow = Flow.OfferPresented, modeHint = Mode.Online,
+            parsed = parsed,
+        )
+
+        journal.append(obs, state(5))
+        advanceUntilIdle()
+        val replayed = journal.tailAfter(0).single() as Observation.Screen
+
+        assertEquals(parsed, replayed.parsed)
+        assertEquals(Flow.OfferPresented, replayed.flow)
+        assertTrue(replayed.platform == Platform.DoorDash)
+    }
+}


### PR DESCRIPTION
Fixes #352 (audit items A-12 + A-25). P1 campaign PR 3 — completes the replay-integrity workstream's state-layer half (#343 clock, #344 IDs, #351 ordering/idempotency, #353 serialization, now journal/recovery).

## What
- **`ObservationJournal`**: single-writer worker (ordered, gap-free appends — fire-and-forget launches could land out of order), cv-ordered replay tail (`ObservationDao.since` now `ORDER BY correlationVersion`), and the full entity↔observation codec.
- **Replay payload fidelity**: `ObservationEntity.payloadJson` (schema v7) carries a typed `InternalObsPayload` — UiInput's real `action`, Loopback's `effect`/`offerHash`/`evaluation`, Timeout's `targetPlatform`. A replayed `offer_evaluated` now **lands its evaluation** (proven against the real `FlowRegionStepper`); #342's routing and #345's hash-correlation survive replay. Persisting real actions is safe because #341 made `PerformOfferAction` external.
- **`SnapshotStore`**: cadence + loud restore, extracted.
- **`StateManagerV2`** 373→175 lines (merge + reduce + legacy bridge only) with the restore-window fix: events buffer from before restore and drain after — nothing dropped mid-recovery. Dispatchers now injectable (qualifiers moved to `core.state.di`; `:app` re-exports bindings — `SideEffectEngine`/`ScreenShotHandler` imports updated).

## Tests
`ObservationJournalTest` (4) + `StateManagerV2RestoreBufferTest` (1) as described; full `testDebugUnitTest` green.

## Device note (alpha-sanctioned)
Schema v6→v7 → destructive fallback wipes the DB once on first launch.

Follow-up noted on #366: its typed Observation payloads supersede the `InternalObsPayload` map-projection — fold then.

CLAUDE.md drift check: none. Memory updated post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)