### PR TITLE
refactor(arch): invert :core:pipeline→:core:data onto domain interfaces (#355)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,8 +77,8 @@ The project uses modular Clean Architecture with a strict dependency graph:
 
 ```
 :app → :domain, :core:data, :core:database, :core:datastore, :core:designsystem, :core:location, :core:network, :core:pipeline, :core:state
-:core:state → :domain, :core:data, :core:database, :core:pipeline
-:core:pipeline → :domain, :core:data
+:core:state → :domain, :core:database, :core:pipeline
+:core:pipeline → :domain
 :core:data → :domain, :core:database, :core:datastore, :core:location, :core:network
 :core:database → :domain
 :core:network → :domain
@@ -86,9 +86,10 @@ The project uses modular Clean Architecture with a strict dependency graph:
 :core:datastore → :domain
 ```
 
-- **`:domain`** — Pure Kotlin library. Domain models, state regions, evaluation logic, and
-  pipeline/provider contracts. No Android dependencies. (Repository *implementations* live in
-  `:core:data`; only a few provider/data-source interfaces are inverted into `:domain` today.)
+- **`:domain`** — Pure Kotlin library. Domain models, state regions, evaluation logic,
+  pipeline/provider contracts, and the capture contracts (`CaptureBus`, `EnvelopeBuilder`,
+  capture schemas/DTOs) plus the `PlatformPreferences` read interface (#355). No Android
+  dependencies. (Repository *implementations* and Hilt bindings live in `:core:data`.)
 - **`:core:pipeline`** — Accessibility pipeline, notification pipeline, JSON rule engine
   (RuleCompiler, Ruleset, JsonRuleInterpreter), observation classifier. Reads third-party UI.
 - **`:core:state`** — Multi-region state machine (StateMachine, FlowRegionStepper,

--- a/app/src/test/java/cloud/trotter/dashbuddy/test/util/TestResourceLoader.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/test/util/TestResourceLoader.kt
@@ -1,7 +1,7 @@
 package cloud.trotter.dashbuddy.test.util
 
-import cloud.trotter.dashbuddy.core.database.log.dto.UiNodeDto
-import cloud.trotter.dashbuddy.core.database.log.mapper.toDomain
+import cloud.trotter.dashbuddy.domain.capture.dto.UiNodeDto
+import cloud.trotter.dashbuddy.domain.capture.toDomain
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json

--- a/core/data/src/debug/java/cloud/trotter/dashbuddy/core/data/di/CaptureBusModule.kt
+++ b/core/data/src/debug/java/cloud/trotter/dashbuddy/core/data/di/CaptureBusModule.kt
@@ -1,6 +1,6 @@
 package cloud.trotter.dashbuddy.core.data.di
 
-import cloud.trotter.dashbuddy.core.data.capture.CaptureBus
+import cloud.trotter.dashbuddy.domain.capture.CaptureBus
 import cloud.trotter.dashbuddy.core.data.capture.DiskCaptureBus
 import dagger.Binds
 import dagger.Module

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/capture/DiskCaptureBus.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/capture/DiskCaptureBus.kt
@@ -1,5 +1,6 @@
 package cloud.trotter.dashbuddy.core.data.capture
 
+import cloud.trotter.dashbuddy.domain.capture.CaptureBus
 import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/capture/NoOpCaptureBus.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/capture/NoOpCaptureBus.kt
@@ -1,5 +1,6 @@
 package cloud.trotter.dashbuddy.core.data.capture
 
+import cloud.trotter.dashbuddy.domain.capture.CaptureBus
 import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/di/SettingsBindModule.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/di/SettingsBindModule.kt
@@ -1,0 +1,25 @@
+package cloud.trotter.dashbuddy.core.data.di
+
+import cloud.trotter.dashbuddy.core.data.settings.PlatformPreferencesRepository
+import cloud.trotter.dashbuddy.domain.settings.PlatformPreferences
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+/**
+ * Binds the domain-facing settings contracts to their :core:data
+ * implementations (#355). Pipelines inject [PlatformPreferences]; the
+ * settings UI keeps injecting the concrete repository for the write side.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class SettingsBindModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindPlatformPreferences(
+        impl: PlatformPreferencesRepository,
+    ): PlatformPreferences
+}

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/settings/PlatformPreferencesRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/settings/PlatformPreferencesRepository.kt
@@ -3,6 +3,7 @@ package cloud.trotter.dashbuddy.core.data.settings
 import android.content.Context
 import android.content.pm.PackageManager
 import cloud.trotter.dashbuddy.core.datastore.settings.PlatformPreferencesDataSource
+import cloud.trotter.dashbuddy.domain.settings.PlatformPreferences
 import cloud.trotter.dashbuddy.domain.state.Platform
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
@@ -15,11 +16,11 @@ import javax.inject.Singleton
 class PlatformPreferencesRepository @Inject constructor(
     private val dataSource: PlatformPreferencesDataSource,
     @param:ApplicationContext private val context: Context,
-) {
+) : PlatformPreferences {
     private val packageManager: PackageManager = context.packageManager
 
     /** Flow of enabled Platform enum values. Defaults to installed apps if no preference saved. */
-    val enabledPlatforms: Flow<Set<Platform>> = dataSource.enabledPlatforms.map { saved ->
+    override val enabledPlatforms: Flow<Set<Platform>> = dataSource.enabledPlatforms.map { saved ->
         if (saved != null) {
             saved.mapNotNull { Platform.fromWire(it) }.toSet()
         } else {
@@ -28,7 +29,7 @@ class PlatformPreferencesRepository @Inject constructor(
     }
 
     /** Flow of enabled package names (for listener filtering). */
-    val enabledPackages: Flow<Set<String>> = enabledPlatforms.map { platforms ->
+    override val enabledPackages: Flow<Set<String>> = enabledPlatforms.map { platforms ->
         platforms.mapNotNull { it.packageName }.toSet()
     }
 

--- a/core/data/src/release/java/cloud/trotter/dashbuddy/core/data/di/CaptureBusModule.kt
+++ b/core/data/src/release/java/cloud/trotter/dashbuddy/core/data/di/CaptureBusModule.kt
@@ -1,6 +1,6 @@
 package cloud.trotter.dashbuddy.core.data.di
 
-import cloud.trotter.dashbuddy.core.data.capture.CaptureBus
+import cloud.trotter.dashbuddy.domain.capture.CaptureBus
 import cloud.trotter.dashbuddy.core.data.capture.NoOpCaptureBus
 import dagger.Binds
 import dagger.Module

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/log/dto/ClickLogEntryDto.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/log/dto/ClickLogEntryDto.kt
@@ -1,5 +1,6 @@
 package cloud.trotter.dashbuddy.core.database.log.dto
 
+import cloud.trotter.dashbuddy.domain.capture.dto.UiNodeDto
 import kotlinx.serialization.Serializable
 
 @Serializable

--- a/core/pipeline/build.gradle.kts
+++ b/core/pipeline/build.gradle.kts
@@ -40,7 +40,6 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.timber)
 
-    implementation(project(":core:data"))
     implementation(project(":domain"))
 
     ksp(libs.hilt.compiler)

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/AccessibilityPipeline.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/AccessibilityPipeline.kt
@@ -1,13 +1,13 @@
 package cloud.trotter.dashbuddy.core.pipeline.accessibility
 
 import android.view.accessibility.AccessibilityEvent
-import cloud.trotter.dashbuddy.core.data.capture.CaptureBus
-import cloud.trotter.dashbuddy.core.data.capture.EnvelopeBuilder
-import cloud.trotter.dashbuddy.core.data.capture.WindowContextDto
-import cloud.trotter.dashbuddy.core.data.capture.schema.ClickCapturePayload
-import cloud.trotter.dashbuddy.core.data.capture.schema.ClickContextSchema
-import cloud.trotter.dashbuddy.core.data.capture.schema.UiNodeSchema
-import cloud.trotter.dashbuddy.core.data.settings.PlatformPreferencesRepository
+import cloud.trotter.dashbuddy.domain.capture.CaptureBus
+import cloud.trotter.dashbuddy.domain.capture.EnvelopeBuilder
+import cloud.trotter.dashbuddy.domain.capture.WindowContextDto
+import cloud.trotter.dashbuddy.domain.capture.schema.ClickCapturePayload
+import cloud.trotter.dashbuddy.domain.capture.schema.ClickContextSchema
+import cloud.trotter.dashbuddy.domain.capture.schema.UiNodeSchema
+import cloud.trotter.dashbuddy.domain.settings.PlatformPreferences
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
 import cloud.trotter.dashbuddy.domain.pipeline.ObservationIdentity
 import cloud.trotter.dashbuddy.domain.pipeline.identity
@@ -50,7 +50,7 @@ class AccessibilityPipeline @Inject constructor(
     private val source: AccessibilitySource,
     private val classifier: ObservationClassifier,
     private val captureBus: CaptureBus,
-    private val platformPreferences: PlatformPreferencesRepository,
+    private val platformPreferences: PlatformPreferences,
 ) {
     companion object {
         const val SCREEN_PIPELINE_ID = "accessibility.window"
@@ -244,7 +244,7 @@ class AccessibilityPipeline @Inject constructor(
  * Same-shape buttons (e.g. DoorDash's `primary_action_button`) appear on many
  * screens with different labels and meanings. [UiNode.structuralHash] ignores
  * text, so without the screen mix all such clicks collide in the per-bucket
- * dedup set inside [cloud.trotter.dashbuddy.core.data.capture.DiskCaptureBus]
+ * dedup set inside the disk capture bus (`DiskCaptureBus` in `:core:data`)
  * and only the first one in a session survives — silently dropping later
  * clicks the developer needs to triage screen-specific behavior.
  */

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/input/AccessibilityListener.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/input/AccessibilityListener.kt
@@ -4,7 +4,7 @@ import android.accessibilityservice.AccessibilityService
 import android.accessibilityservice.AccessibilityServiceInfo
 import android.view.accessibility.AccessibilityEvent
 import cloud.trotter.dashbuddy.core.pipeline.BuildConfig
-import cloud.trotter.dashbuddy.core.data.settings.PlatformPreferencesRepository
+import cloud.trotter.dashbuddy.domain.settings.PlatformPreferences
 import cloud.trotter.dashbuddy.domain.state.Platform
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
@@ -22,7 +22,7 @@ class AccessibilityListener : AccessibilityService() {
     lateinit var accessibilitySource: AccessibilitySource
 
     @Inject
-    lateinit var platformPreferences: PlatformPreferencesRepository
+    lateinit var platformPreferences: PlatformPreferences
 
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/notification/NotificationFilter.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/notification/NotificationFilter.kt
@@ -1,6 +1,6 @@
 package cloud.trotter.dashbuddy.core.pipeline.notification
 
-import cloud.trotter.dashbuddy.core.data.settings.PlatformPreferencesRepository
+import cloud.trotter.dashbuddy.domain.settings.PlatformPreferences
 import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData
 import cloud.trotter.dashbuddy.domain.state.Platform
 import kotlinx.coroutines.flow.first
@@ -16,7 +16,7 @@ import javax.inject.Singleton
  */
 @Singleton
 class NotificationFilter @Inject constructor(
-    private val platformPreferences: PlatformPreferencesRepository,
+    private val platformPreferences: PlatformPreferences,
 ) {
     /** Cached enabled packages — refreshed lazily. */
     @Volatile

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/notification/NotificationPipeline.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/notification/NotificationPipeline.kt
@@ -1,9 +1,9 @@
 package cloud.trotter.dashbuddy.core.pipeline.notification
 
-import cloud.trotter.dashbuddy.core.data.capture.CaptureBus
-import cloud.trotter.dashbuddy.core.data.capture.EnvelopeBuilder
-import cloud.trotter.dashbuddy.core.data.capture.schema.RawNotificationSchema
-import cloud.trotter.dashbuddy.core.data.settings.PlatformPreferencesRepository
+import cloud.trotter.dashbuddy.domain.capture.CaptureBus
+import cloud.trotter.dashbuddy.domain.capture.EnvelopeBuilder
+import cloud.trotter.dashbuddy.domain.capture.schema.RawNotificationSchema
+import cloud.trotter.dashbuddy.domain.settings.PlatformPreferences
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
 import cloud.trotter.dashbuddy.domain.pipeline.ObservationIdentity
 import cloud.trotter.dashbuddy.domain.pipeline.identity
@@ -35,7 +35,7 @@ class NotificationPipeline @Inject constructor(
     private val filter: NotificationFilter,
     private val classifier: ObservationClassifier,
     private val captureBus: CaptureBus,
-    private val platformPreferences: PlatformPreferencesRepository,
+    private val platformPreferences: PlatformPreferences,
 ) {
     companion object {
         const val PIPELINE_ID = "notification"

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/notification/input/NotificationListener.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/notification/input/NotificationListener.kt
@@ -2,7 +2,7 @@ package cloud.trotter.dashbuddy.core.pipeline.notification.input
 
 import android.service.notification.NotificationListenerService
 import android.service.notification.StatusBarNotification
-import cloud.trotter.dashbuddy.core.data.settings.PlatformPreferencesRepository
+import cloud.trotter.dashbuddy.domain.settings.PlatformPreferences
 import cloud.trotter.dashbuddy.domain.state.Platform
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
@@ -20,7 +20,7 @@ class NotificationListener : NotificationListenerService() {
     lateinit var notificationSource: NotificationSource
 
     @Inject
-    lateinit var platformPreferences: PlatformPreferencesRepository
+    lateinit var platformPreferences: PlatformPreferences
 
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 

--- a/core/state/build.gradle.kts
+++ b/core/state/build.gradle.kts
@@ -42,7 +42,6 @@ dependencies {
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.timber)
 
-    implementation(project(":core:data"))
     implementation(project(":core:database"))
     implementation(project(":core:pipeline"))
     implementation(project(":domain"))

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -17,4 +17,5 @@ dependencies {
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.serialization.json)
     testImplementation(libs.junit)
+    testImplementation(libs.kotlin.reflect)
 }

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/capture/CaptureBus.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/capture/CaptureBus.kt
@@ -1,4 +1,4 @@
-package cloud.trotter.dashbuddy.core.data.capture
+package cloud.trotter.dashbuddy.domain.capture
 
 /**
  * Pipeline-side capture interface. Pipelines build a [CaptureEnvelope]

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/capture/EnvelopeBuilder.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/capture/EnvelopeBuilder.kt
@@ -1,4 +1,4 @@
-package cloud.trotter.dashbuddy.core.data.capture
+package cloud.trotter.dashbuddy.domain.capture
 
 import cloud.trotter.dashbuddy.domain.capture.CaptureSchema
 import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/capture/UiNodeMapper.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/capture/UiNodeMapper.kt
@@ -1,7 +1,7 @@
-package cloud.trotter.dashbuddy.core.database.log.mapper
+package cloud.trotter.dashbuddy.domain.capture
 
-import cloud.trotter.dashbuddy.core.database.log.dto.BoundingBoxDto
-import cloud.trotter.dashbuddy.core.database.log.dto.UiNodeDto
+import cloud.trotter.dashbuddy.domain.capture.dto.BoundingBoxDto
+import cloud.trotter.dashbuddy.domain.capture.dto.UiNodeDto
 import cloud.trotter.dashbuddy.domain.model.accessibility.BoundingBox
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
 

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/capture/dto/BoundingBoxDto.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/capture/dto/BoundingBoxDto.kt
@@ -1,4 +1,4 @@
-package cloud.trotter.dashbuddy.core.database.log.dto
+package cloud.trotter.dashbuddy.domain.capture.dto
 
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/capture/dto/UiNodeDto.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/capture/dto/UiNodeDto.kt
@@ -1,4 +1,4 @@
-package cloud.trotter.dashbuddy.core.database.log.dto
+package cloud.trotter.dashbuddy.domain.capture.dto
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/capture/schema/ClickContextSchema.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/capture/schema/ClickContextSchema.kt
@@ -1,8 +1,8 @@
-package cloud.trotter.dashbuddy.core.data.capture.schema
+package cloud.trotter.dashbuddy.domain.capture.schema
 
-import cloud.trotter.dashbuddy.core.database.log.mapper.toDto
-import cloud.trotter.dashbuddy.core.database.log.mapper.toDomain
-import cloud.trotter.dashbuddy.core.database.log.dto.UiNodeDto
+import cloud.trotter.dashbuddy.domain.capture.toDto
+import cloud.trotter.dashbuddy.domain.capture.toDomain
+import cloud.trotter.dashbuddy.domain.capture.dto.UiNodeDto
 import cloud.trotter.dashbuddy.domain.capture.CaptureSchema
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
 import kotlinx.serialization.Serializable

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/capture/schema/RawNotificationSchema.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/capture/schema/RawNotificationSchema.kt
@@ -1,4 +1,4 @@
-package cloud.trotter.dashbuddy.core.data.capture.schema
+package cloud.trotter.dashbuddy.domain.capture.schema
 
 import cloud.trotter.dashbuddy.domain.capture.CaptureSchema
 import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/capture/schema/UiNodeSchema.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/capture/schema/UiNodeSchema.kt
@@ -1,8 +1,8 @@
-package cloud.trotter.dashbuddy.core.data.capture.schema
+package cloud.trotter.dashbuddy.domain.capture.schema
 
-import cloud.trotter.dashbuddy.core.database.log.mapper.toDomain
-import cloud.trotter.dashbuddy.core.database.log.mapper.toDto
-import cloud.trotter.dashbuddy.core.database.log.dto.UiNodeDto
+import cloud.trotter.dashbuddy.domain.capture.toDomain
+import cloud.trotter.dashbuddy.domain.capture.toDto
+import cloud.trotter.dashbuddy.domain.capture.dto.UiNodeDto
 import cloud.trotter.dashbuddy.domain.capture.CaptureSchema
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
 import kotlinx.serialization.json.Json

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/settings/PlatformPreferences.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/settings/PlatformPreferences.kt
@@ -1,0 +1,19 @@
+package cloud.trotter.dashbuddy.domain.settings
+
+import cloud.trotter.dashbuddy.domain.state.Platform
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Read-side contract for which gig platforms are enabled (#355). Inverted into
+ * :domain so the sensor pipelines can filter without depending on :core:data;
+ * the concrete repository (DataStore-backed, with installed-app detection and
+ * the write side) lives in :core:data and is bound via Hilt.
+ */
+interface PlatformPreferences {
+
+    /** Enabled platforms. Defaults to the installed ones when nothing is saved. */
+    val enabledPlatforms: Flow<Set<Platform>>
+
+    /** Package names of the enabled platforms (listener-level event filtering). */
+    val enabledPackages: Flow<Set<String>>
+}

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/capture/MapperEnforcementTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/capture/MapperEnforcementTest.kt
@@ -1,6 +1,6 @@
-package cloud.trotter.dashbuddy.core.database.log.mapper
+package cloud.trotter.dashbuddy.domain.capture
 
-import cloud.trotter.dashbuddy.core.database.log.dto.UiNodeDto
+import cloud.trotter.dashbuddy.domain.capture.dto.UiNodeDto
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
 import org.junit.Assert.assertEquals
 import org.junit.Test

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/capture/UiNodeMapperTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/capture/UiNodeMapperTest.kt
@@ -1,7 +1,7 @@
-package cloud.trotter.dashbuddy.core.database.log.mapper
+package cloud.trotter.dashbuddy.domain.capture
 
-import cloud.trotter.dashbuddy.core.database.log.dto.BoundingBoxDto
-import cloud.trotter.dashbuddy.core.database.log.dto.UiNodeDto
+import cloud.trotter.dashbuddy.domain.capture.dto.BoundingBoxDto
+import cloud.trotter.dashbuddy.domain.capture.dto.UiNodeDto
 import cloud.trotter.dashbuddy.domain.model.accessibility.BoundingBox
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
 import org.junit.Assert.assertEquals


### PR DESCRIPTION
Fixes #355.

## What moved where

| Symbol | From | To |
|---|---|---|
| `CaptureBus` (interface) | `core.data.capture` | `domain.capture` |
| `EnvelopeBuilder`, `WindowContextDto`, `CaptureResult`, `CaptureEnvelopeDto` | `core.data.capture` | `domain.capture` |
| `UiNodeSchema`, `ClickContextSchema` (+`ClickCapturePayload`), `RawNotificationSchema` | `core.data.capture.schema` | `domain.capture.schema` |
| `UiNodeDto`, `BoundingBoxDto`, `UiNodeMapper` (toDto/toDomain) | `core.database.log.*` | `domain.capture(.dto)` |
| `MapperEnforcementTest`, `UiNodeMapperTest` | `:core:database` tests | `:domain` tests |

All of it was pure kotlinx-serialization code over domain types — the audit's "EnvelopeBuilder must live in :core:data" rationale didn't hold. `DiskCaptureBus`/`NoOpCaptureBus` (Android `Context`, file IO) stay in `:core:data`, implementing the domain interface; the #346 per-variant `CaptureBusModule`s re-bind to the domain type unchanged.

**New `domain.settings.PlatformPreferences`** — the read-side contract (`enabledPlatforms`, `enabledPackages`) the five pipeline consumers actually use. `PlatformPreferencesRepository` implements it (write side + installed-app detection unchanged, concrete class still injected by the settings UI); new `SettingsBindModule` provides the binding.

## Dependency graph

- `:core:pipeline → :domain` only (`:core:data` dep deleted; `grep "core.data." core/pipeline/src` → 0)
- `:core:state` loses its declared-but-never-imported `:core:data` dep
- `:core:database` now imports `UiNodeDto` from `:domain` in `ClickLogEntryDto` (database→domain was already an edge)
- CLAUDE.md module graph updated in this PR per the every-PR context rule

## Verification

- Full `testDebugUnitTest` + `:domain:test` green (AllMatchersSuite included); moved mapper tests run in `:domain` (1 + 10 tests)
- Release Hilt graph validated: `:app:compileReleaseKotlin :app:kspReleaseKotlin` green
- No behavior change — pure structure; helps #192 (matchers OTA needs a clean pipeline boundary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)