### PR TITLE
fix(pipeline): one shared enabled-platforms StateFlow — kill 5 caches, runBlocking, frozen listener gating (#356)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/di/DispatchersModule.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/di/DispatchersModule.kt
@@ -1,5 +1,6 @@
 package cloud.trotter.dashbuddy.di
 
+import cloud.trotter.dashbuddy.core.data.di.ApplicationScope
 import cloud.trotter.dashbuddy.core.state.di.DefaultDispatcher
 import cloud.trotter.dashbuddy.core.state.di.IoDispatcher
 import dagger.Module
@@ -7,13 +8,18 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import javax.inject.Singleton
 
 /**
  * Bindings for the injectable dispatchers so coroutine-owning singletons are
- * testable with virtual time (#341/#352). The qualifier annotations live in
- * `:core:state` (`core.state.di`) so state-layer classes can use them too;
- * the data-layer hygiene pass (#364) migrates its hardcoded scopes onto these.
+ * testable with virtual time (#341/#352), plus the app-lifetime scope for
+ * long-lived shared flows (#356). The dispatcher qualifiers live in
+ * `:core:state` (`core.state.di`), the scope qualifier in `:core:data`
+ * (`core.data.di`); the data-layer hygiene pass (#364) migrates the remaining
+ * hardcoded scopes onto these.
  */
 @Module
 @InstallIn(SingletonComponent::class)
@@ -26,4 +32,10 @@ object DispatchersModule {
     @Provides
     @DefaultDispatcher
     fun provideDefaultDispatcher(): CoroutineDispatcher = Dispatchers.Default
+
+    @Provides
+    @Singleton
+    @ApplicationScope
+    fun provideApplicationScope(): CoroutineScope =
+        CoroutineScope(SupervisorJob() + Dispatchers.Default)
 }

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/di/ApplicationScope.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/di/ApplicationScope.kt
@@ -1,0 +1,12 @@
+package cloud.trotter.dashbuddy.core.data.di
+
+import javax.inject.Qualifier
+
+/**
+ * App-lifetime [kotlinx.coroutines.CoroutineScope] for singletons that host
+ * long-lived shared flows (#356 — e.g. the enabled-platforms StateFlow).
+ * Provided by :app's DispatchersModule; inject a test scope in unit tests.
+ */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class ApplicationScope

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/settings/PlatformPreferencesRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/settings/PlatformPreferencesRepository.kt
@@ -2,13 +2,17 @@ package cloud.trotter.dashbuddy.core.data.settings
 
 import android.content.Context
 import android.content.pm.PackageManager
+import cloud.trotter.dashbuddy.core.data.di.ApplicationScope
 import cloud.trotter.dashbuddy.core.datastore.settings.PlatformPreferencesDataSource
 import cloud.trotter.dashbuddy.domain.settings.PlatformPreferences
 import cloud.trotter.dashbuddy.domain.state.Platform
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -16,22 +20,34 @@ import javax.inject.Singleton
 class PlatformPreferencesRepository @Inject constructor(
     private val dataSource: PlatformPreferencesDataSource,
     @param:ApplicationContext private val context: Context,
+    @param:ApplicationScope scope: CoroutineScope,
 ) : PlatformPreferences {
     private val packageManager: PackageManager = context.packageManager
 
-    /** Flow of enabled Platform enum values. Defaults to installed apps if no preference saved. */
-    override val enabledPlatforms: Flow<Set<Platform>> = dataSource.enabledPlatforms.map { saved ->
-        if (saved != null) {
-            saved.mapNotNull { Platform.fromWire(it) }.toSet()
-        } else {
-            detectInstalledPlatforms()
+    /**
+     * THE single materialization of the enabled-platforms preference (#356).
+     * Eagerly shared for the app's lifetime so every consumer — listeners,
+     * filters, pipelines, UI — reads one always-current value instead of
+     * holding a private cache. Defaults to installed apps if nothing saved.
+     */
+    override val enabledPlatforms: StateFlow<Set<Platform>> = dataSource.enabledPlatforms
+        .map { saved ->
+            if (saved != null) {
+                saved.mapNotNull { Platform.fromWire(it) }.toSet()
+            } else {
+                detectInstalledPlatforms()
+            }
         }
-    }
+        .stateIn(scope, SharingStarted.Eagerly, detectInstalledPlatforms())
 
-    /** Flow of enabled package names (for listener filtering). */
-    override val enabledPackages: Flow<Set<String>> = enabledPlatforms.map { platforms ->
-        platforms.mapNotNull { it.packageName }.toSet()
-    }
+    /** Package names of the enabled platforms (listener-level event filtering). */
+    override val enabledPackages: StateFlow<Set<String>> = enabledPlatforms
+        .map { platforms -> platforms.mapNotNull { it.packageName }.toSet() }
+        .stateIn(
+            scope,
+            SharingStarted.Eagerly,
+            enabledPlatforms.value.mapNotNull { it.packageName }.toSet(),
+        )
 
     /** Check which supported platforms are installed on device. */
     fun detectInstalledPlatforms(): Set<Platform> =

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/AccessibilityPipeline.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/AccessibilityPipeline.kt
@@ -60,20 +60,6 @@ class AccessibilityPipeline @Inject constructor(
     /** Last emitted observation identity — for post-classification dedup. */
     private var lastIdentity: ObservationIdentity? = null
 
-    /** Cached enabled platforms — updated reactively from preferences. */
-    @Volatile
-    private var enabledPlatforms: Set<Platform> = Platform.entries.toSet()
-
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-
-    init {
-        scope.launch {
-            platformPreferences.enabledPlatforms.collect { platforms ->
-                enabledPlatforms = platforms
-            }
-        }
-    }
-
     // ── Source flows ────────────────────────────────────────────────────
 
     private fun screenEvents(): Flow<PipelineEvent.Screen> = merge(
@@ -125,7 +111,8 @@ class AccessibilityPipeline @Inject constructor(
                 else -> null
             }
             val platform = Platform.fromPackage(pkg)
-            platform == Platform.Unknown || platform in enabledPlatforms
+            platform == Platform.Unknown ||
+                platform in platformPreferences.enabledPlatforms.value
         }
 
         // Dedup + Capture: write unique observations to disk, skip duplicates

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/event/type/window/content_changed/ContentChangedPipeline.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/event/type/window/content_changed/ContentChangedPipeline.kt
@@ -39,7 +39,7 @@ class ContentChangedPipeline @Inject constructor(
             // Attribute to the window actually on screen, not the triggering event. Drop snapshots
             // of non-target windows (our own bubble overlay, launcher, etc.) so we never recognize
             // our own UI as the platform — the #4 self-recognition feedback loop.
-            if (snapshot.packageName !in Platform.watchedPackages()) {
+            if (snapshot.packageName !in Platform.watchedPackages) {
                 Timber.v(
                     "🚫 Skip active window: non-target pkg=%s (event pkg=%s)",
                     snapshot.packageName, event.packageName,

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/event/type/window/state_changed/StateChangedPipeline.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/event/type/window/state_changed/StateChangedPipeline.kt
@@ -23,7 +23,7 @@ class StateChangedPipeline @Inject constructor(
             val snapshot = source.getCurrentRootSnapshot() ?: return@mapNotNull null
             // Attribute to the on-screen window, not the event; drop non-target windows (e.g. our
             // own bubble overlay) so we don't recognize our own UI as the platform (#4).
-            if (snapshot.packageName !in Platform.watchedPackages()) {
+            if (snapshot.packageName !in Platform.watchedPackages) {
                 Timber.v(
                     "🚫 Skip active window: non-target pkg=%s (event pkg=%s)",
                     snapshot.packageName, event.packageName,

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/event/type/window/windows_changed/WindowsChangedPipeline.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/event/type/window/windows_changed/WindowsChangedPipeline.kt
@@ -62,7 +62,7 @@ class WindowsChangedPipeline @Inject constructor(
                     // Only snapshot watched-platform windows (e.g. an Uber overlay) — never our own
                     // bubble overlay or other apps. Prevents recognizing our own UI (#4) and keeps
                     // non-target windows out of the pipeline.
-                    if (pkg !in Platform.watchedPackages()) return@mapNotNull null
+                    if (pkg !in Platform.watchedPackages) return@mapNotNull null
                     val tree = try {
                         source.getRootForWindow(w)
                     } catch (_: Exception) {

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/input/AccessibilityListener.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/input/AccessibilityListener.kt
@@ -7,11 +7,6 @@ import cloud.trotter.dashbuddy.core.pipeline.BuildConfig
 import cloud.trotter.dashbuddy.domain.settings.PlatformPreferences
 import cloud.trotter.dashbuddy.domain.state.Platform
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -24,11 +19,7 @@ class AccessibilityListener : AccessibilityService() {
     @Inject
     lateinit var platformPreferences: PlatformPreferences
 
-    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
-    /** Cached set of enabled package names — updated reactively from preferences. */
-    @Volatile
-    private var enabledPackages: Set<String> = Platform.watchedPackages()
 
     override fun onCreate() {
         super.onCreate()
@@ -43,7 +34,7 @@ class AccessibilityListener : AccessibilityService() {
         // In debug builds we receive ALL event types from ALL packages.
         // Log unhandled types so we can see what fires, then return.
         if (BuildConfig.DEBUG && event.eventType !in HANDLED_TYPES) {
-            if (pkg in enabledPackages) {
+            if (pkg in platformPreferences.enabledPackages.value) {
                 Timber.d(
                     "🔎 Unhandled event: type=0x%04x (%s) pkg=%s class=%s",
                     event.eventType,
@@ -55,7 +46,7 @@ class AccessibilityListener : AccessibilityService() {
             return
         }
 
-        if (pkg !in enabledPackages) return
+        if (pkg !in platformPreferences.enabledPackages.value) return
 
         accessibilitySource.emit(event)
     }
@@ -67,7 +58,6 @@ class AccessibilityListener : AccessibilityService() {
     override fun onDestroy() {
         super.onDestroy()
         _instance = null
-        serviceScope.cancel()
         Timber.d("Accessibility service destroyed")
     }
 
@@ -90,13 +80,6 @@ class AccessibilityListener : AccessibilityService() {
         // Register with the source
         accessibilitySource.registerService(this)
 
-        // Start collecting enabled platforms preference
-        serviceScope.launch {
-            platformPreferences.enabledPackages.collect { packages ->
-                enabledPackages = packages
-                Timber.d("Accessibility filter updated: %s", packages)
-            }
-        }
     }
 
     companion object {

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/notification/NotificationFilter.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/notification/NotificationFilter.kt
@@ -2,9 +2,6 @@ package cloud.trotter.dashbuddy.core.pipeline.notification
 
 import cloud.trotter.dashbuddy.domain.settings.PlatformPreferences
 import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData
-import cloud.trotter.dashbuddy.domain.state.Platform
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -13,29 +10,14 @@ import javax.inject.Singleton
  *
  * All notifications from watched packages pass through — unwanted ongoing
  * notifications are handled downstream via `"shape": "noise"` rules.
+ *
+ * Stateless (#356): reads the shared enabled-packages StateFlow at the gate.
+ * No private cache, no blocking init on the hot path, nothing to refresh.
  */
 @Singleton
 class NotificationFilter @Inject constructor(
     private val platformPreferences: PlatformPreferences,
 ) {
-    /** Cached enabled packages — refreshed lazily. */
-    @Volatile
-    private var cachedPackages: Set<String> = Platform.watchedPackages()
-
-    @Volatile
-    private var initialized = false
-
-    fun isRelevant(raw: RawNotificationData): Boolean {
-        if (!initialized) {
-            cachedPackages = runBlocking { platformPreferences.enabledPackages.first() }
-            initialized = true
-        }
-        return raw.packageName in cachedPackages
-    }
-
-    /** Called by the pipeline to update the cached set when preferences change. */
-    fun updateEnabledPackages(packages: Set<String>) {
-        cachedPackages = packages
-        initialized = true
-    }
+    fun isRelevant(raw: RawNotificationData): Boolean =
+        raw.packageName in platformPreferences.enabledPackages.value
 }

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/notification/NotificationPipeline.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/notification/NotificationPipeline.kt
@@ -43,20 +43,6 @@ class NotificationPipeline @Inject constructor(
 
     private var lastIdentity: ObservationIdentity? = null
 
-    /** Cached enabled platforms — updated reactively from preferences. */
-    @Volatile
-    private var enabledPlatforms: Set<Platform> = Platform.entries.toSet()
-
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-
-    init {
-        scope.launch {
-            platformPreferences.enabledPlatforms.collect { platforms ->
-                enabledPlatforms = platforms
-            }
-        }
-    }
-
     fun output(): Flow<Observation.Notification> = source.events
         .mapNotNull { sbn -> sbn.toDomain() }
         .filter { raw -> filter.isRelevant(raw) }
@@ -74,7 +60,8 @@ class NotificationPipeline @Inject constructor(
         // Gate: drop observations from disabled platforms (defense-in-depth)
         .filter { (_, raw) ->
             val platform = Platform.fromPackage(raw.packageName)
-            platform == Platform.Unknown || platform in enabledPlatforms
+            platform == Platform.Unknown ||
+                platform in platformPreferences.enabledPlatforms.value
         }
         // Dedup + Capture
         .mapNotNull { (obs, raw) ->

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/notification/input/NotificationListener.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/notification/input/NotificationListener.kt
@@ -3,13 +3,7 @@ package cloud.trotter.dashbuddy.core.pipeline.notification.input
 import android.service.notification.NotificationListenerService
 import android.service.notification.StatusBarNotification
 import cloud.trotter.dashbuddy.domain.settings.PlatformPreferences
-import cloud.trotter.dashbuddy.domain.state.Platform
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -22,25 +16,17 @@ class NotificationListener : NotificationListenerService() {
     @Inject
     lateinit var platformPreferences: PlatformPreferences
 
-    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
-
-    /** Cached set of enabled package names — updated reactively from preferences. */
-    @Volatile
-    private var enabledPackages: Set<String> = Platform.watchedPackages()
-
     override fun onListenerConnected() {
         Timber.i("Notification Listener Connected!")
-
-        serviceScope.launch {
-            platformPreferences.enabledPackages.collect { packages ->
-                enabledPackages = packages
-            }
-        }
     }
 
     override fun onNotificationPosted(sbn: StatusBarNotification?) {
         if (sbn == null) return
-        if (sbn.packageName !in enabledPackages) return
+        // Shared StateFlow read (#356) — no per-service collector. The old
+        // serviceScope was cancelled in onListenerDisconnected and reused on
+        // rebind, so its re-launched collector was a no-op and package gating
+        // froze at the last value for the process lifetime.
+        if (sbn.packageName !in platformPreferences.enabledPackages.value) return
 
         Timber.d(
             "\uD83D\uDCEC Notification from %s: clearable=%s ongoing=%s channel=%s",
@@ -55,6 +41,6 @@ class NotificationListener : NotificationListenerService() {
 
     override fun onListenerDisconnected() {
         super.onListenerDisconnected()
-        serviceScope.cancel()
+        Timber.i("Notification Listener Disconnected.")
     }
 }

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/notification/NotificationFilterTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/notification/NotificationFilterTest.kt
@@ -1,0 +1,62 @@
+package cloud.trotter.dashbuddy.core.pipeline.notification
+
+import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData
+import cloud.trotter.dashbuddy.domain.settings.PlatformPreferences
+import cloud.trotter.dashbuddy.domain.state.Platform
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #356 — notification gating must track the shared enabled-platforms state
+ * WITHOUT a process restart. The old filter cached the preference once via
+ * runBlocking on the hot path and its refresh hook had no callers, so a
+ * settings toggle never reached it.
+ */
+class NotificationFilterTest {
+
+    private class FakePrefs(
+        initial: Set<Platform>,
+    ) : PlatformPreferences {
+        override val enabledPlatforms = MutableStateFlow(initial)
+        override val enabledPackages: StateFlow<Set<String>>
+            get() = MutableStateFlow(
+                enabledPlatforms.value.mapNotNull { it.packageName }.toSet()
+            )
+    }
+
+    private fun raw(packageName: String) = RawNotificationData(
+        title = "t",
+        text = "x",
+        tickerText = null,
+        bigText = null,
+        packageName = packageName,
+        postTime = 1_000L,
+        isClearable = true,
+    )
+
+    @Test
+    fun `gating follows the shared state without restart or refresh call`() {
+        val prefs = FakePrefs(initial = setOf(Platform.DoorDash))
+        val filter = NotificationFilter(prefs)
+        val doordashPackage = Platform.DoorDash.packageName!!
+
+        assertTrue(filter.isRelevant(raw(doordashPackage)))
+
+        // Toggle the platform off — the very next gate check must see it.
+        prefs.enabledPlatforms.value = emptySet()
+        assertFalse(filter.isRelevant(raw(doordashPackage)))
+
+        // And back on.
+        prefs.enabledPlatforms.value = setOf(Platform.DoorDash)
+        assertTrue(filter.isRelevant(raw(doordashPackage)))
+    }
+
+    @Test
+    fun `unwatched packages are always irrelevant`() {
+        val filter = NotificationFilter(FakePrefs(initial = Platform.entries.toSet()))
+        assertFalse(filter.isRelevant(raw("com.some.random.app")))
+    }
+}

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -63,6 +63,14 @@ immediately (no second pass needed) so it gets triaged.
 _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **broken** on the
 2026-06-09 dash — moved to that session's log entry below for triage.)_
 
+- **Platform toggles now take effect live — no app restart (#356, PR pending).**
+  All notification/accessibility gating now reads one shared enabled-platforms state. To check:
+  mid-session, toggle a platform OFF in DashBuddy settings — its notifications should stop
+  reaching the HUD/log immediately (next notification, not next restart); toggle back ON and
+  they resume. If convenient, also note whether gating still works after Android kills/rebinds
+  the notification listener (e.g. after a long screen-off period) — the old code froze gating
+  at the last value when that happened.
+  - Confirmed: 0/2.
 - **Event log reworked: domain AppEvent + transactional insert + obs-derived timestamps (#354/#300/#119, PR #382).**
   The bubble HUD's completed-card stack now renders from payloads decoded at the repository
   (was: Gson inside the mapper), `app_events.occurredAt` is the observation timestamp (was: wall

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/settings/PlatformPreferences.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/settings/PlatformPreferences.kt
@@ -1,19 +1,23 @@
 package cloud.trotter.dashbuddy.domain.settings
 
 import cloud.trotter.dashbuddy.domain.state.Platform
-import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
 
 /**
  * Read-side contract for which gig platforms are enabled (#355). Inverted into
  * :domain so the sensor pipelines can filter without depending on :core:data;
  * the concrete repository (DataStore-backed, with installed-app detection and
  * the write side) lives in :core:data and is bound via Hilt.
+ *
+ * Exposed as [StateFlow] (#356): the repository materializes the preference
+ * ONCE; every consumer reads `.value` at its gate instead of holding a private
+ * cache that can silently freeze.
  */
 interface PlatformPreferences {
 
     /** Enabled platforms. Defaults to the installed ones when nothing is saved. */
-    val enabledPlatforms: Flow<Set<Platform>>
+    val enabledPlatforms: StateFlow<Set<Platform>>
 
     /** Package names of the enabled platforms (listener-level event filtering). */
-    val enabledPackages: Flow<Set<String>>
+    val enabledPackages: StateFlow<Set<String>>
 }

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/Platform.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/Platform.kt
@@ -36,7 +36,7 @@ enum class Platform(val wire: String, val packageName: String?) {
             byPackage[packageName] ?: Unknown
 
         /** All known package names for OS-level event subscription. */
-        fun watchedPackages(): Set<String> =
+        val watchedPackages: Set<String> =
             entries.mapNotNull { it.packageName }.toSet()
     }
 }


### PR DESCRIPTION
Fixes #356.

## The shape of the fix

`PlatformPreferences` (the #355 domain interface) now exposes **`StateFlow`** instead of `Flow`. `PlatformPreferencesRepository` is the single materialization — `stateIn(@ApplicationScope, Eagerly, detectInstalledPlatforms())` — and every gate reads `.value`. A consumer can no longer hold a stale private copy, because there is nothing to copy.

## What died

| Cache | File | Staleness bug it had |
|---|---|---|
| `cachedPackages` + `runBlocking` init + dead `updateEnabledPackages` | `NotificationFilter` | froze at first notification, refresh hook had zero callers; blocked a Default thread on DataStore on the hot path |
| `enabledPackages` + `serviceScope` collector | `NotificationListener` | scope cancelled in `onListenerDisconnected`, reused on rebind → collector no-op → **gating frozen for process lifetime** |
| `enabledPlatforms` + ad-hoc scope | `NotificationPipeline` | private copy |
| `enabledPlatforms` + ad-hoc scope | `AccessibilityPipeline` | private copy |
| `enabledPackages` + `serviceScope` collector | `AccessibilityListener` | private copy (scope now fully removed — nothing left used it) |

Also: `Platform.watchedPackages` fun → cached `val` (was re-allocated per accessibility event in three sub-pipelines).

## Acceptance (from the issue)

- ✅ Exactly one DataStore→Set materialization (`stateIn` in the repo; no other `enabledPackages`/`enabledPlatforms` collector exists in `:core:pipeline`)
- ✅ Zero `runBlocking` in `:core:pipeline`
- ✅ `NotificationFilterTest`: toggling a platform flips gating on the very next check — no restart, no refresh call; listener rebind can't freeze anything because no per-service collector exists

New `@ApplicationScope` qualifier (`core.data.di`) + provider in `:app`'s `DispatchersModule` — #364's data-layer scope migration can reuse it.

Field-testing checklist entry added (live platform toggle mid-session; post-rebind gating).

Full `testDebugUnitTest` + `:domain:test` + release compile/KSP green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)