### PR TITLE
refactor(ui): extract shared EconomyEditor — one definition of the ten cost sections (#357)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/components/economy/EconomyEditor.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/components/economy/EconomyEditor.kt
@@ -1,0 +1,356 @@
+package cloud.trotter.dashbuddy.ui.components.economy
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import cloud.trotter.dashbuddy.core.designsystem.theme.DashBuddyTheme
+import cloud.trotter.dashbuddy.domain.evaluation.EconomyField
+import cloud.trotter.dashbuddy.domain.evaluation.UserEconomy
+import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleClass
+
+/**
+ * The shared personal-economy editor (#357): the ten cost accordions used by
+ * BOTH the setup wizard's ECONOMY_COSTS step and the Personal Economy settings
+ * screen. Defined exactly once so the two surfaces can never diverge again.
+ *
+ * Pure data-in / lambdas-out: values and derived per-mile summaries come from
+ * [economy] (the wizard builds a live [UserEconomy] from its draft state; the
+ * settings screen passes the persisted one), edits flow up through the
+ * per-section callbacks. Chrome — Card vs Scaffold, headers, footers — stays
+ * with the caller. [VehicleClassPicker] and [TrueCostFooter] live here too
+ * because both surfaces render them identically.
+ */
+@Composable
+fun EconomyEditor(
+    economy: UserEconomy,
+    onTiresChange: (setCost: Double, lifetimeMi: Double) -> Unit,
+    onOilChange: (cost: Double, intervalMi: Double) -> Unit,
+    onBrakesChange: (cost: Double, intervalMi: Double) -> Unit,
+    onFluidsChange: (cost: Double, intervalMi: Double) -> Unit,
+    onMiscChange: (yearly: Double, yearlyMi: Double) -> Unit,
+    onDepreciationChange: (include: Boolean, price: Double, lifetimeMi: Double) -> Unit,
+    onInsuranceChange: (perMonth: Double) -> Unit,
+    onRegistrationChange: (perYear: Double) -> Unit,
+    onPhoneChange: (total: Double, lines: Int, dashPercent: Double) -> Unit,
+    onExpectedAnnualDashMilesChange: (miles: Double) -> Unit,
+) {
+    val userSet = economy.userSetFields
+
+    // -------- Tires --------
+    EconomyAccordionRow(
+        title = "Tires",
+        summary = "\$${"%.3f".format(economy.tireCostPerMile)}/mi",
+        isUserSet = EconomyField.TIRE_COST in userSet || EconomyField.TIRE_LIFETIME in userSet,
+    ) {
+        PairedCurrencyAndIntervalInput(
+            costLabel = "Set of 4",
+            costValue = economy.tireSetCost,
+            onCostChange = { onTiresChange(it, economy.tireLifetimeMi) },
+            intervalLabel = "Lifetime",
+            intervalValue = economy.tireLifetimeMi,
+            onIntervalChange = { onTiresChange(economy.tireSetCost, it) },
+        )
+    }
+
+    // -------- Oil changes --------
+    EconomyAccordionRow(
+        title = "Oil changes",
+        summary = "\$${"%.3f".format(economy.oilCostPerMile)}/mi",
+        isUserSet = EconomyField.OIL_COST in userSet || EconomyField.OIL_INTERVAL in userSet,
+    ) {
+        PairedCurrencyAndIntervalInput(
+            costLabel = "Each",
+            costValue = economy.oilCost,
+            onCostChange = { onOilChange(it, economy.oilIntervalMi) },
+            intervalLabel = "Every",
+            intervalValue = economy.oilIntervalMi,
+            onIntervalChange = { onOilChange(economy.oilCost, it) },
+        )
+    }
+
+    // -------- Brakes --------
+    EconomyAccordionRow(
+        title = "Brakes",
+        summary = "\$${"%.3f".format(economy.brakesCostPerMile)}/mi",
+        isUserSet = EconomyField.BRAKES_COST in userSet || EconomyField.BRAKES_INTERVAL in userSet,
+    ) {
+        PairedCurrencyAndIntervalInput(
+            costLabel = "Each",
+            costValue = economy.brakesCost,
+            onCostChange = { onBrakesChange(it, economy.brakesIntervalMi) },
+            intervalLabel = "Every",
+            intervalValue = economy.brakesIntervalMi,
+            onIntervalChange = { onBrakesChange(economy.brakesCost, it) },
+        )
+    }
+
+    // -------- Fluids --------
+    EconomyAccordionRow(
+        title = "Fluids",
+        summary = "\$${"%.3f".format(economy.fluidsCostPerMile)}/mi",
+        isUserSet = EconomyField.FLUIDS_COST in userSet || EconomyField.FLUIDS_INTERVAL in userSet,
+    ) {
+        PairedCurrencyAndIntervalInput(
+            costLabel = "Each",
+            costValue = economy.fluidsCost,
+            onCostChange = { onFluidsChange(it, economy.fluidsIntervalMi) },
+            intervalLabel = "Every",
+            intervalValue = economy.fluidsIntervalMi,
+            onIntervalChange = { onFluidsChange(economy.fluidsCost, it) },
+        )
+    }
+
+    // -------- Misc repairs --------
+    EconomyAccordionRow(
+        title = "Misc repairs",
+        summary = "\$${"%.3f".format(economy.miscCostPerMile)}/mi",
+        isUserSet = EconomyField.MISC_YEARLY in userSet || EconomyField.MISC_YEARLY_MI in userSet,
+    ) {
+        PairedCurrencyAndIntervalInput(
+            costLabel = "Yearly budget",
+            costValue = economy.miscYearly,
+            onCostChange = { onMiscChange(it, economy.miscYearlyMi) },
+            intervalLabel = "Driving",
+            intervalValue = economy.miscYearlyMi,
+            onIntervalChange = { onMiscChange(economy.miscYearly, it) },
+            intervalSuffix = "mi/yr",
+            helperText = "Annual catch-all for repairs not in oil/brakes/fluids.",
+        )
+    }
+
+    // -------- Depreciation --------
+    EconomyAccordionRow(
+        title = "Depreciation",
+        summary = if (economy.includeDepreciation) {
+            "\$${"%.3f".format(economy.depreciationCostPerMile)}/mi"
+        } else {
+            "off"
+        },
+        isUserSet = EconomyField.INCLUDE_DEPRECIATION in userSet ||
+            EconomyField.PURCHASE_PRICE in userSet ||
+            EconomyField.TOTAL_LIFETIME_MI in userSet,
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text("Include depreciation", modifier = Modifier.weight(1f))
+            Switch(
+                checked = economy.includeDepreciation,
+                onCheckedChange = {
+                    onDepreciationChange(it, economy.purchasePrice, economy.totalLifetimeMi)
+                },
+            )
+        }
+        if (economy.includeDepreciation) {
+            PairedCurrencyAndIntervalInput(
+                costLabel = "Purchase price",
+                costValue = economy.purchasePrice,
+                onCostChange = { onDepreciationChange(true, it, economy.totalLifetimeMi) },
+                intervalLabel = "Lifetime",
+                intervalValue = economy.totalLifetimeMi,
+                onIntervalChange = { onDepreciationChange(true, economy.purchasePrice, it) },
+                helperText = "Total expected miles from new to retirement, " +
+                    "e.g. 200,000 for a typical sedan.",
+            )
+        }
+    }
+
+    // -------- Insurance --------
+    EconomyAccordionRow(
+        title = "Insurance",
+        summary = "\$${"%.3f".format(economy.insuranceCostPerMile)}/mi*",
+        isUserSet = EconomyField.INSURANCE_DELTA in userSet,
+    ) {
+        CurrencyInput(
+            label = "Extra for gig work",
+            value = economy.insuranceDeltaPerMonth,
+            onValueChange = onInsuranceChange,
+            suffix = "/mo",
+        )
+        Text(
+            text = "Monthly add-on for rideshare/delivery rider above your personal policy.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+
+    // -------- Registration --------
+    EconomyAccordionRow(
+        title = "Registration",
+        summary = "\$${"%.3f".format(economy.registrationCostPerMile)}/mi*",
+        isUserSet = EconomyField.REGISTRATION_DELTA in userSet,
+    ) {
+        CurrencyInput(
+            label = "Commercial delta",
+            value = economy.registrationDeltaPerYear,
+            onValueChange = onRegistrationChange,
+            suffix = "/yr",
+        )
+        Text(
+            text = "Annual fee above your personal registration (commercial " +
+                "registration / inspection / endorsement).",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+
+    // -------- Phone & data --------
+    EconomyAccordionRow(
+        title = "Phone & data",
+        summary = "\$${"%.3f".format(economy.phoneCostPerMile)}/mi*",
+        isUserSet = EconomyField.PHONE_PLAN_TOTAL in userSet ||
+            EconomyField.PHONE_PLAN_LINES in userSet ||
+            EconomyField.PHONE_DASH_PERCENT in userSet,
+    ) {
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            CurrencyInput(
+                label = "Plan total",
+                value = economy.phonePlanTotal,
+                onValueChange = {
+                    onPhoneChange(it, economy.phonePlanLines, economy.phoneDashPercent)
+                },
+                suffix = "/mo",
+                modifier = Modifier.weight(1f),
+            )
+            IntegerInput(
+                label = "Lines",
+                value = economy.phonePlanLines,
+                onValueChange = {
+                    onPhoneChange(economy.phonePlanTotal, it, economy.phoneDashPercent)
+                },
+                modifier = Modifier.weight(1f),
+            )
+        }
+        Text("% for gig work: ${economy.phoneDashPercent.toInt()}%")
+        Slider(
+            value = economy.phoneDashPercent.toFloat(),
+            onValueChange = {
+                onPhoneChange(economy.phonePlanTotal, economy.phonePlanLines, it.toDouble())
+            },
+            valueRange = 0f..100f,
+        )
+        val perLine = economy.phonePlanTotal / economy.phonePlanLines.coerceAtLeast(1)
+        Text(
+            text = "Your line: \$${"%.2f".format(perLine)}/mo" +
+                " × ${economy.phoneDashPercent.toInt()}%" +
+                " = \$${"%.2f".format(perLine * economy.phoneDashPercent / 100.0)}/mo for gig work",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+
+    // -------- Expected annual gig miles --------
+    EconomyAccordionRow(
+        title = "Expected gig miles / yr",
+        summary = "${economy.expectedAnnualDashMiles.toInt().formatWithCommas()} mi",
+        isUserSet = EconomyField.EXPECTED_ANNUAL_DASH_MI in userSet,
+    ) {
+        Text(
+            text = "${economy.expectedAnnualDashMiles.toInt().formatWithCommas()} miles per year",
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.Medium,
+        )
+        Slider(
+            value = economy.expectedAnnualDashMiles.toFloat(),
+            onValueChange = { onExpectedAnnualDashMilesChange(it.toDouble()) },
+            valueRange = 500f..30_000f,
+            steps = 58, // 500-mile increments
+        )
+        Text(
+            text = "Used to amortize fixed costs (insurance, registration, phone) into " +
+                "a per-mile rate. Bigger number → smaller per-mile share.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+/** The vehicle-class chip picker both economy surfaces render above the editor. */
+@Composable
+fun VehicleClassPicker(
+    selected: VehicleClass,
+    onClassChange: (VehicleClass) -> Unit,
+) {
+    Text(
+        text = "Vehicle class",
+        style = MaterialTheme.typography.titleSmall,
+        modifier = Modifier.padding(bottom = 4.dp),
+    )
+    FlowRow(
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        VehicleClass.entries.forEach { vc ->
+            FilterChip(
+                selected = selected == vc,
+                onClick = { onClassChange(vc) },
+                label = { Text(vc.displayName) },
+            )
+        }
+    }
+}
+
+/** The live "your true cost vs IRS rate" footer both economy surfaces render below the editor. */
+@Composable
+fun TrueCostFooter(operatingCostPerMile: Double) {
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(
+            modifier = Modifier.padding(12.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = "Your true cost: \$${"%.2f".format(operatingCostPerMile)}/mi",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+            )
+            Text(
+                text = "IRS standard mileage rate: \$0.67/mi",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+private fun Int.formatWithCommas(): String = "%,d".format(this)
+
+@Preview(showBackground = true, heightDp = 1200)
+@Composable
+private fun EconomyEditorPreview() = DashBuddyTheme {
+    Surface(color = MaterialTheme.colorScheme.background) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            val economy = UserEconomy()
+            VehicleClassPicker(selected = economy.vehicleClass, onClassChange = {})
+            EconomyEditor(
+                economy = economy,
+                onTiresChange = { _, _ -> },
+                onOilChange = { _, _ -> },
+                onBrakesChange = { _, _ -> },
+                onFluidsChange = { _, _ -> },
+                onMiscChange = { _, _ -> },
+                onDepreciationChange = { _, _, _ -> },
+                onInsuranceChange = {},
+                onRegistrationChange = {},
+                onPhoneChange = { _, _, _ -> },
+                onExpectedAnnualDashMilesChange = {},
+            )
+            TrueCostFooter(operatingCostPerMile = economy.operatingCostPerMile)
+        }
+    }
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/EconomySettingsScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/EconomySettingsScreen.kt
@@ -1,12 +1,8 @@
 package cloud.trotter.dashbuddy.ui.main.settings
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.FlowRow
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
@@ -14,33 +10,30 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Slider
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import cloud.trotter.dashbuddy.domain.evaluation.EconomyField
-import cloud.trotter.dashbuddy.domain.evaluation.UserEconomy
-import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleClass
-import cloud.trotter.dashbuddy.ui.components.economy.CurrencyInput
-import cloud.trotter.dashbuddy.ui.components.economy.EconomyAccordionRow
-import cloud.trotter.dashbuddy.ui.components.economy.IntegerInput
-import cloud.trotter.dashbuddy.ui.components.economy.PairedCurrencyAndIntervalInput
+import cloud.trotter.dashbuddy.ui.components.economy.EconomyEditor
+import cloud.trotter.dashbuddy.ui.components.economy.TrueCostFooter
+import cloud.trotter.dashbuddy.ui.components.economy.VehicleClassPicker
 
+/**
+ * Personal Economy settings. Chrome only: the Scaffold, intro copy, and the
+ * reset action. The ten cost sections, vehicle class picker, and true-cost
+ * footer are the shared [EconomyEditor] family (#357) — also used by the
+ * setup wizard's ECONOMY_COSTS step. Everything below the screen level takes
+ * data + lambdas, never the ViewModel.
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun EconomySettingsScreen(
@@ -82,240 +75,30 @@ fun EconomySettingsScreen(
             )
 
             Spacer(modifier = Modifier.height(12.dp))
-
-            // Vehicle class picker
-            Text(
-                text = "Vehicle class",
-                style = MaterialTheme.typography.titleSmall,
+            VehicleClassPicker(
+                selected = eco.vehicleClass,
+                onClassChange = viewModel::setVehicleClass,
             )
-            FlowRow(
-                horizontalArrangement = Arrangement.spacedBy(6.dp),
-                verticalArrangement = Arrangement.spacedBy(4.dp),
-            ) {
-                VehicleClass.entries.forEach { vc ->
-                    FilterChip(
-                        selected = eco.vehicleClass == vc,
-                        onClick = { viewModel.setVehicleClass(vc) },
-                        label = { Text(vc.displayName) },
-                    )
-                }
-            }
 
             Spacer(modifier = Modifier.height(12.dp))
-
-            EconomyAccordions(eco = eco, viewModel = viewModel)
+            EconomyEditor(
+                economy = eco,
+                onTiresChange = viewModel::setTires,
+                onOilChange = viewModel::setOil,
+                onBrakesChange = viewModel::setBrakes,
+                onFluidsChange = viewModel::setFluids,
+                onMiscChange = viewModel::setMiscRepairs,
+                onDepreciationChange = viewModel::setDepreciation,
+                onInsuranceChange = viewModel::setInsurance,
+                onRegistrationChange = viewModel::setRegistration,
+                onPhoneChange = viewModel::setPhone,
+                onExpectedAnnualDashMilesChange = viewModel::setExpectedAnnualDashMiles,
+            )
 
             Spacer(modifier = Modifier.height(16.dp))
-            Surface(
-                color = MaterialTheme.colorScheme.surfaceContainerHigh,
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                Column(
-                    modifier = Modifier.padding(12.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                ) {
-                    Text(
-                        text = "Your true cost: \$${"%.2f".format(eco.operatingCostPerMile)}/mi",
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.Bold,
-                    )
-                    Text(
-                        text = "IRS standard mileage rate: \$0.67/mi",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-            }
+            TrueCostFooter(operatingCostPerMile = eco.operatingCostPerMile)
 
             Spacer(modifier = Modifier.height(32.dp))
         }
-    }
-}
-
-@Composable
-private fun EconomyAccordions(eco: UserEconomy, viewModel: EconomySettingsViewModel) {
-    val userSet = eco.userSetFields
-
-    EconomyAccordionRow(
-        title = "Tires",
-        summary = "\$${"%.3f".format(eco.tireCostPerMile)}/mi",
-        isUserSet = EconomyField.TIRE_COST in userSet || EconomyField.TIRE_LIFETIME in userSet,
-    ) {
-        PairedCurrencyAndIntervalInput(
-            costLabel = "Set of 4",
-            costValue = eco.tireSetCost,
-            onCostChange = { viewModel.setTires(it, eco.tireLifetimeMi) },
-            intervalLabel = "Lifetime",
-            intervalValue = eco.tireLifetimeMi,
-            onIntervalChange = { viewModel.setTires(eco.tireSetCost, it) },
-        )
-    }
-
-    EconomyAccordionRow(
-        title = "Oil changes",
-        summary = "\$${"%.3f".format(eco.oilCostPerMile)}/mi",
-        isUserSet = EconomyField.OIL_COST in userSet || EconomyField.OIL_INTERVAL in userSet,
-    ) {
-        PairedCurrencyAndIntervalInput(
-            costLabel = "Each",
-            costValue = eco.oilCost,
-            onCostChange = { viewModel.setOil(it, eco.oilIntervalMi) },
-            intervalLabel = "Every",
-            intervalValue = eco.oilIntervalMi,
-            onIntervalChange = { viewModel.setOil(eco.oilCost, it) },
-        )
-    }
-
-    EconomyAccordionRow(
-        title = "Brakes",
-        summary = "\$${"%.3f".format(eco.brakesCostPerMile)}/mi",
-        isUserSet = EconomyField.BRAKES_COST in userSet || EconomyField.BRAKES_INTERVAL in userSet,
-    ) {
-        PairedCurrencyAndIntervalInput(
-            costLabel = "Each",
-            costValue = eco.brakesCost,
-            onCostChange = { viewModel.setBrakes(it, eco.brakesIntervalMi) },
-            intervalLabel = "Every",
-            intervalValue = eco.brakesIntervalMi,
-            onIntervalChange = { viewModel.setBrakes(eco.brakesCost, it) },
-        )
-    }
-
-    EconomyAccordionRow(
-        title = "Fluids",
-        summary = "\$${"%.3f".format(eco.fluidsCostPerMile)}/mi",
-        isUserSet = EconomyField.FLUIDS_COST in userSet || EconomyField.FLUIDS_INTERVAL in userSet,
-    ) {
-        PairedCurrencyAndIntervalInput(
-            costLabel = "Each",
-            costValue = eco.fluidsCost,
-            onCostChange = { viewModel.setFluids(it, eco.fluidsIntervalMi) },
-            intervalLabel = "Every",
-            intervalValue = eco.fluidsIntervalMi,
-            onIntervalChange = { viewModel.setFluids(eco.fluidsCost, it) },
-        )
-    }
-
-    EconomyAccordionRow(
-        title = "Misc repairs",
-        summary = "\$${"%.3f".format(eco.miscCostPerMile)}/mi",
-        isUserSet = EconomyField.MISC_YEARLY in userSet || EconomyField.MISC_YEARLY_MI in userSet,
-    ) {
-        PairedCurrencyAndIntervalInput(
-            costLabel = "Yearly budget",
-            costValue = eco.miscYearly,
-            onCostChange = { viewModel.setMiscRepairs(it, eco.miscYearlyMi) },
-            intervalLabel = "Driving",
-            intervalValue = eco.miscYearlyMi,
-            onIntervalChange = { viewModel.setMiscRepairs(eco.miscYearly, it) },
-            intervalSuffix = "mi/yr",
-        )
-    }
-
-    EconomyAccordionRow(
-        title = "Depreciation",
-        summary = if (eco.includeDepreciation) "\$${"%.3f".format(eco.depreciationCostPerMile)}/mi" else "off",
-        isUserSet = EconomyField.INCLUDE_DEPRECIATION in userSet ||
-            EconomyField.PURCHASE_PRICE in userSet ||
-            EconomyField.TOTAL_LIFETIME_MI in userSet,
-    ) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Text("Include depreciation", modifier = Modifier.weight(1f))
-            Switch(
-                checked = eco.includeDepreciation,
-                onCheckedChange = {
-                    viewModel.setDepreciation(it, eco.purchasePrice, eco.totalLifetimeMi)
-                },
-            )
-        }
-        if (eco.includeDepreciation) {
-            PairedCurrencyAndIntervalInput(
-                costLabel = "Purchase price",
-                costValue = eco.purchasePrice,
-                onCostChange = { viewModel.setDepreciation(true, it, eco.totalLifetimeMi) },
-                intervalLabel = "Lifetime",
-                intervalValue = eco.totalLifetimeMi,
-                onIntervalChange = { viewModel.setDepreciation(true, eco.purchasePrice, it) },
-                helperText = "Total expected miles from new to retirement.",
-            )
-        }
-    }
-
-    EconomyAccordionRow(
-        title = "Insurance",
-        summary = "\$${"%.3f".format(eco.insuranceCostPerMile)}/mi*",
-        isUserSet = EconomyField.INSURANCE_DELTA in userSet,
-    ) {
-        CurrencyInput(
-            label = "Extra for gig work",
-            value = eco.insuranceDeltaPerMonth,
-            onValueChange = viewModel::setInsurance,
-            suffix = "/mo",
-        )
-    }
-
-    EconomyAccordionRow(
-        title = "Registration",
-        summary = "\$${"%.3f".format(eco.registrationCostPerMile)}/mi*",
-        isUserSet = EconomyField.REGISTRATION_DELTA in userSet,
-    ) {
-        CurrencyInput(
-            label = "Commercial delta",
-            value = eco.registrationDeltaPerYear,
-            onValueChange = viewModel::setRegistration,
-            suffix = "/yr",
-        )
-    }
-
-    EconomyAccordionRow(
-        title = "Phone & data",
-        summary = "\$${"%.3f".format(eco.phoneCostPerMile)}/mi*",
-        isUserSet = EconomyField.PHONE_PLAN_TOTAL in userSet ||
-            EconomyField.PHONE_PLAN_LINES in userSet ||
-            EconomyField.PHONE_DASH_PERCENT in userSet,
-    ) {
-        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            CurrencyInput(
-                label = "Plan total",
-                value = eco.phonePlanTotal,
-                onValueChange = { viewModel.setPhone(it, eco.phonePlanLines, eco.phoneDashPercent) },
-                suffix = "/mo",
-                modifier = Modifier.weight(1f),
-            )
-            IntegerInput(
-                label = "Lines",
-                value = eco.phonePlanLines,
-                onValueChange = { viewModel.setPhone(eco.phonePlanTotal, it, eco.phoneDashPercent) },
-                modifier = Modifier.weight(1f),
-            )
-        }
-        Text("% for gig work: ${eco.phoneDashPercent.toInt()}%")
-        Slider(
-            value = eco.phoneDashPercent.toFloat(),
-            onValueChange = { viewModel.setPhone(eco.phonePlanTotal, eco.phonePlanLines, it.toDouble()) },
-            valueRange = 0f..100f,
-        )
-    }
-
-    EconomyAccordionRow(
-        title = "Expected gig miles / yr",
-        summary = "${eco.expectedAnnualDashMiles.toInt()} mi",
-        isUserSet = EconomyField.EXPECTED_ANNUAL_DASH_MI in userSet,
-    ) {
-        Text(
-            text = "${eco.expectedAnnualDashMiles.toInt()} miles per year",
-            style = MaterialTheme.typography.bodyMedium,
-            fontWeight = FontWeight.Medium,
-        )
-        Slider(
-            value = eco.expectedAnnualDashMiles.toFloat(),
-            onValueChange = { viewModel.setExpectedAnnualDashMiles(it.toDouble()) },
-            valueRange = 500f..30_000f,
-        )
-        Text(
-            text = "Used to amortize fixed costs (insurance, registration, phone) per mile.",
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
     }
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/cards/EconomyCostsCard.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/cards/EconomyCostsCard.kt
@@ -1,9 +1,6 @@
 package cloud.trotter.dashbuddy.ui.main.setup.wizard.cards
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.FlowRow
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -13,42 +10,30 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FilterChip
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Slider
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Switch
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import cloud.trotter.dashbuddy.domain.evaluation.EconomyField
 import cloud.trotter.dashbuddy.domain.evaluation.UserEconomy
 import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleClass
-import cloud.trotter.dashbuddy.ui.components.economy.CurrencyInput
-import cloud.trotter.dashbuddy.ui.components.economy.EconomyAccordionRow
-import cloud.trotter.dashbuddy.ui.components.economy.IntegerInput
-import cloud.trotter.dashbuddy.ui.components.economy.PairedCurrencyAndIntervalInput
+import cloud.trotter.dashbuddy.ui.components.economy.EconomyEditor
+import cloud.trotter.dashbuddy.ui.components.economy.TrueCostFooter
+import cloud.trotter.dashbuddy.ui.components.economy.VehicleClassPicker
+import cloud.trotter.dashbuddy.ui.main.setup.wizard.components.WizardCardHeader
 import cloud.trotter.dashbuddy.ui.main.setup.wizard.model.WizardState
 import cloud.trotter.dashbuddy.ui.main.setup.wizard.model.WizardStep
-import cloud.trotter.dashbuddy.ui.main.setup.wizard.components.WizardCardHeader
 
 /**
- * The ECONOMY_COSTS wizard step. A single scrolling card with:
- * 1. Vehicle class chip picker (drives cost defaults)
- * 2. Accordion of 10 cost sections (collapsed by default; expand to edit)
- * 3. Expected annual gig miles slider (amortizes fixed costs)
- * 4. Live "Your true cost: $X.XX/mi" footer comparing to the IRS standard rate
+ * The ECONOMY_COSTS wizard step. Chrome only: the card, header, scroll, and
+ * the live-economy bridge from [WizardState]. The ten cost sections, vehicle
+ * class picker, and true-cost footer are the shared [EconomyEditor] family
+ * (#357) — also used by the Personal Economy settings screen.
  *
  * Defaults flow from the selected [VehicleClass] for any field not yet user-set;
  * editing a field marks it as user-set so subsequent class changes don't
  * overwrite it.
  */
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun EconomyCostsCard(
     state: WizardState,
@@ -65,9 +50,9 @@ fun EconomyCostsCard(
     onExpectedAnnualDashMilesChange: (Double) -> Unit,
     onTimeConstantsChange: (Double, Double) -> Unit,
 ) {
-    // Build a live UserEconomy from current state so we can show $/mi previews.
+    // Build a live UserEconomy from current state so the editor can show
+    // $/mi summaries without going through the repository.
     val liveEconomy = remember(state) { state.toUserEconomy() }
-    val userSet = state.userSetEconomyFields
 
     Card(
         modifier = Modifier
@@ -84,282 +69,32 @@ fun EconomyCostsCard(
         ) {
             WizardCardHeader(step = WizardStep.ECONOMY_COSTS)
 
-            // Vehicle class chip picker
-            Text(
-                text = "Vehicle class",
-                style = MaterialTheme.typography.titleSmall,
-                modifier = Modifier.padding(top = 12.dp, bottom = 4.dp),
+            Spacer(modifier = Modifier.height(12.dp))
+            VehicleClassPicker(
+                selected = state.vehicleClass,
+                onClassChange = onClassChange,
             )
-            FlowRow(
-                horizontalArrangement = Arrangement.spacedBy(6.dp),
-                verticalArrangement = Arrangement.spacedBy(4.dp),
-            ) {
-                VehicleClass.entries.forEach { vc ->
-                    FilterChip(
-                        selected = state.vehicleClass == vc,
-                        onClick = { onClassChange(vc) },
-                        label = { Text(vc.displayName) },
-                    )
-                }
-            }
 
             Spacer(modifier = Modifier.height(12.dp))
+            EconomyEditor(
+                economy = liveEconomy,
+                onTiresChange = onTiresChange,
+                onOilChange = onOilChange,
+                onBrakesChange = onBrakesChange,
+                onFluidsChange = onFluidsChange,
+                onMiscChange = onMiscChange,
+                onDepreciationChange = onDepreciationChange,
+                onInsuranceChange = onInsuranceChange,
+                onRegistrationChange = onRegistrationChange,
+                onPhoneChange = onPhoneChange,
+                onExpectedAnnualDashMilesChange = onExpectedAnnualDashMilesChange,
+            )
 
-            // -------- Tires --------
-            EconomyAccordionRow(
-                title = "Tires",
-                summary = "%.3f/mi".format(liveEconomy.tireCostPerMile).let { "\$$it" },
-                isUserSet = EconomyField.TIRE_COST in userSet || EconomyField.TIRE_LIFETIME in userSet,
-            ) {
-                PairedCurrencyAndIntervalInput(
-                    costLabel = "Set of 4",
-                    costValue = state.tireSetCost,
-                    onCostChange = { onTiresChange(it, state.tireLifetimeMi) },
-                    intervalLabel = "Lifetime",
-                    intervalValue = state.tireLifetimeMi,
-                    onIntervalChange = { onTiresChange(state.tireSetCost, it) },
-                )
-            }
-
-            // -------- Oil changes --------
-            EconomyAccordionRow(
-                title = "Oil changes",
-                summary = "%.3f/mi".format(liveEconomy.oilCostPerMile).let { "\$$it" },
-                isUserSet = EconomyField.OIL_COST in userSet || EconomyField.OIL_INTERVAL in userSet,
-            ) {
-                PairedCurrencyAndIntervalInput(
-                    costLabel = "Each",
-                    costValue = state.oilCost,
-                    onCostChange = { onOilChange(it, state.oilIntervalMi) },
-                    intervalLabel = "Every",
-                    intervalValue = state.oilIntervalMi,
-                    onIntervalChange = { onOilChange(state.oilCost, it) },
-                )
-            }
-
-            // -------- Brakes --------
-            EconomyAccordionRow(
-                title = "Brakes",
-                summary = "%.3f/mi".format(liveEconomy.brakesCostPerMile).let { "\$$it" },
-                isUserSet = EconomyField.BRAKES_COST in userSet || EconomyField.BRAKES_INTERVAL in userSet,
-            ) {
-                PairedCurrencyAndIntervalInput(
-                    costLabel = "Each",
-                    costValue = state.brakesCost,
-                    onCostChange = { onBrakesChange(it, state.brakesIntervalMi) },
-                    intervalLabel = "Every",
-                    intervalValue = state.brakesIntervalMi,
-                    onIntervalChange = { onBrakesChange(state.brakesCost, it) },
-                )
-            }
-
-            // -------- Fluids --------
-            EconomyAccordionRow(
-                title = "Fluids",
-                summary = "%.3f/mi".format(liveEconomy.fluidsCostPerMile).let { "\$$it" },
-                isUserSet = EconomyField.FLUIDS_COST in userSet || EconomyField.FLUIDS_INTERVAL in userSet,
-            ) {
-                PairedCurrencyAndIntervalInput(
-                    costLabel = "Each",
-                    costValue = state.fluidsCost,
-                    onCostChange = { onFluidsChange(it, state.fluidsIntervalMi) },
-                    intervalLabel = "Every",
-                    intervalValue = state.fluidsIntervalMi,
-                    onIntervalChange = { onFluidsChange(state.fluidsCost, it) },
-                )
-            }
-
-            // -------- Misc repairs --------
-            EconomyAccordionRow(
-                title = "Misc repairs",
-                summary = "%.3f/mi".format(liveEconomy.miscCostPerMile).let { "\$$it" },
-                isUserSet = EconomyField.MISC_YEARLY in userSet || EconomyField.MISC_YEARLY_MI in userSet,
-            ) {
-                PairedCurrencyAndIntervalInput(
-                    costLabel = "Yearly budget",
-                    costValue = state.miscYearly,
-                    onCostChange = { onMiscChange(it, state.miscYearlyMi) },
-                    intervalLabel = "Driving",
-                    intervalValue = state.miscYearlyMi,
-                    onIntervalChange = { onMiscChange(state.miscYearly, it) },
-                    intervalSuffix = "mi/yr",
-                    helperText = "Annual catch-all for repairs not in oil/brakes/fluids.",
-                )
-            }
-
-            // -------- Depreciation --------
-            EconomyAccordionRow(
-                title = "Depreciation",
-                summary = if (state.includeDepreciation)
-                    "%.3f/mi".format(liveEconomy.depreciationCostPerMile).let { "\$$it" }
-                else "off",
-                isUserSet = EconomyField.INCLUDE_DEPRECIATION in userSet ||
-                    EconomyField.PURCHASE_PRICE in userSet ||
-                    EconomyField.TOTAL_LIFETIME_MI in userSet,
-            ) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Text("Include depreciation", modifier = Modifier.weight(1f))
-                    Switch(
-                        checked = state.includeDepreciation,
-                        onCheckedChange = {
-                            onDepreciationChange(it, state.purchasePrice, state.totalLifetimeMi)
-                        },
-                    )
-                }
-                if (state.includeDepreciation) {
-                    PairedCurrencyAndIntervalInput(
-                        costLabel = "Purchase price",
-                        costValue = state.purchasePrice,
-                        onCostChange = {
-                            onDepreciationChange(true, it, state.totalLifetimeMi)
-                        },
-                        intervalLabel = "Lifetime",
-                        intervalValue = state.totalLifetimeMi,
-                        onIntervalChange = {
-                            onDepreciationChange(true, state.purchasePrice, it)
-                        },
-                        helperText = "Total expected miles from new to retirement, " +
-                            "e.g. 200,000 for a typical sedan.",
-                    )
-                }
-            }
-
-            // -------- Insurance --------
-            EconomyAccordionRow(
-                title = "Insurance",
-                summary = "%.3f/mi*".format(liveEconomy.insuranceCostPerMile).let { "\$$it" },
-                isUserSet = EconomyField.INSURANCE_DELTA in userSet,
-            ) {
-                CurrencyInput(
-                    label = "Extra for gig work",
-                    value = state.insuranceDeltaPerMonth,
-                    onValueChange = onInsuranceChange,
-                    suffix = "/mo",
-                )
-                Text(
-                    text = "Monthly add-on for rideshare/delivery rider above your personal policy.",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-
-            // -------- Registration --------
-            EconomyAccordionRow(
-                title = "Registration",
-                summary = "%.3f/mi*".format(liveEconomy.registrationCostPerMile).let { "\$$it" },
-                isUserSet = EconomyField.REGISTRATION_DELTA in userSet,
-            ) {
-                CurrencyInput(
-                    label = "Commercial delta",
-                    value = state.registrationDeltaPerYear,
-                    onValueChange = onRegistrationChange,
-                    suffix = "/yr",
-                )
-                Text(
-                    text = "Annual fee above your personal registration (commercial " +
-                        "registration / inspection / endorsement).",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-
-            // -------- Phone & data --------
-            EconomyAccordionRow(
-                title = "Phone & data",
-                summary = "%.3f/mi*".format(liveEconomy.phoneCostPerMile).let { "\$$it" },
-                isUserSet = EconomyField.PHONE_PLAN_TOTAL in userSet ||
-                    EconomyField.PHONE_PLAN_LINES in userSet ||
-                    EconomyField.PHONE_DASH_PERCENT in userSet,
-            ) {
-                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    CurrencyInput(
-                        label = "Plan total",
-                        value = state.phonePlanTotal,
-                        onValueChange = {
-                            onPhoneChange(it, state.phonePlanLines, state.phoneDashPercent)
-                        },
-                        suffix = "/mo",
-                        modifier = Modifier.weight(1f),
-                    )
-                    IntegerInput(
-                        label = "Lines",
-                        value = state.phonePlanLines,
-                        onValueChange = {
-                            onPhoneChange(state.phonePlanTotal, it, state.phoneDashPercent)
-                        },
-                        modifier = Modifier.weight(1f),
-                    )
-                }
-                Text("% for gig work: ${state.phoneDashPercent.toInt()}%")
-                Slider(
-                    value = state.phoneDashPercent.toFloat(),
-                    onValueChange = {
-                        onPhoneChange(state.phonePlanTotal, state.phonePlanLines, it.toDouble())
-                    },
-                    valueRange = 0f..100f,
-                )
-                Text(
-                    text = "Your line: \$${"%.2f".format(state.phonePlanTotal / state.phonePlanLines.coerceAtLeast(1))}/mo" +
-                        " × ${state.phoneDashPercent.toInt()}%" +
-                        " = \$${"%.2f".format((state.phonePlanTotal / state.phonePlanLines.coerceAtLeast(1)) * state.phoneDashPercent / 100.0)}/mo for gig work",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-
-            // -------- Expected annual gig miles --------
-            EconomyAccordionRow(
-                title = "Expected gig miles / yr",
-                summary = "${state.expectedAnnualDashMiles.toInt().formatWithCommas()} mi",
-                isUserSet = EconomyField.EXPECTED_ANNUAL_DASH_MI in userSet,
-            ) {
-                Text(
-                    text = "${state.expectedAnnualDashMiles.toInt().formatWithCommas()} miles per year",
-                    style = MaterialTheme.typography.bodyMedium,
-                    fontWeight = FontWeight.Medium,
-                )
-                Slider(
-                    value = state.expectedAnnualDashMiles.toFloat(),
-                    onValueChange = { onExpectedAnnualDashMilesChange(it.toDouble()) },
-                    valueRange = 500f..30_000f,
-                    steps = 58, // 500-mile increments
-                )
-                Text(
-                    text = "Used to amortize fixed costs (insurance, registration, phone) into " +
-                        "a per-mile rate. Bigger number → smaller per-mile share.",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-
-            // -------- Footer: live total cost vs IRS standard --------
             Spacer(modifier = Modifier.height(16.dp))
-            Surface(
-                color = MaterialTheme.colorScheme.surfaceContainerHigh,
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                Column(
-                    modifier = Modifier.padding(12.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                ) {
-                    Text(
-                        text = "Your true cost: \$${"%.2f".format(liveEconomy.operatingCostPerMile)}/mi",
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.Bold,
-                    )
-                    Text(
-                        text = "IRS standard mileage rate: \$0.67/mi",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-            }
+            TrueCostFooter(operatingCostPerMile = liveEconomy.operatingCostPerMile)
         }
     }
 }
-
-private fun Int.formatWithCommas(): String =
-    "%,d".format(this)
 
 /**
  * Builds a [UserEconomy] from the wizard state so the card can display live per-mile


### PR DESCRIPTION
Fixes #357.

## What

The ten economy cost accordions now exist **exactly once**: `ui/components/economy/EconomyEditor.kt` — a pure data-in/lambdas-out composable over `UserEconomy`, used by both the wizard's ECONOMY_COSTS card and the Personal Economy settings screen. `VehicleClassPicker` and `TrueCostFooter` are extracted alongside it, since both surfaces rendered them byte-identically. Chrome (Card + WizardCardHeader vs Scaffold + intro + Reset) stays per-caller.

## Divergence reconciled — settings GAINS the richer wizard copy

Per the issue's call ("keep the richer wizard copy"), the settings screen now also gets: misc-repairs helper text, the depreciation "e.g. 200,000 for a typical sedan" helper, insurance/registration explainer lines, the phone per-line math preview, comma-formatted miles, and the 500-mile slider detents (`steps = 58`).

## UDF fix

`EconomyAccordions(eco, viewModel)` is gone — the audit's flagged ViewModel-as-parameter violation. The settings screen hoists state (`collectAsState`) and passes method references; nothing below screen level sees a ViewModel. The editor is preview-able (`EconomyEditorPreview`, the first `@Preview` in `:app`).

## Acceptance

- ✅ Ten sections defined once; both surfaces render via `EconomyEditor`
- ✅ No `viewModel` parameter below screen level
- ✅ Preview exists; **manual pass on wizard + settings still wanted** (alpha bar) — both compile and the full suite is green, but eyes on the two screens before/after is the real check
- ✅ Net **−126 LOC** (388+321 → 123+104+356)

Pre-work for #56/#98/#99/#320 Phase 2. (#57's string extraction deliberately not bundled — judgment call to keep this PR purely structural.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)