### PR TITLE
refactor(ui): locale-pinned money/time formatting + shared time kit in :core:designsystem (#358)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/TtsEffectHandler.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/TtsEffectHandler.kt
@@ -13,6 +13,7 @@ import timber.log.Timber
 import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
+import cloud.trotter.dashbuddy.core.designsystem.format.DashFormats
 
 @Singleton
 class TtsEffectHandler @Inject constructor(
@@ -86,14 +87,11 @@ class TtsEffectHandler @Inject constructor(
             OfferAction.MANUAL_REVIEW -> "Review"
             else -> "Offer"
         }
-        return "%s. %s. %.0f dollars an hour net. Net %.2f, %.1f miles, score %d.".format(
-            verdict,
-            eval.merchantName.trim(),
-            eval.dollarsPerHour,
-            eval.netPayAmount,
-            eval.distanceMiles,
-            eval.score.toInt(),
-        )
+        return "$verdict. ${eval.merchantName.trim()}. " +
+            "${DashFormats.decimal(eval.dollarsPerHour, 0)} dollars an hour net. " +
+            "Net ${DashFormats.decimal(eval.netPayAmount, 2)}, " +
+            "${DashFormats.decimal(eval.distanceMiles)} miles, " +
+            "score ${eval.score.toInt()}."
     }
 
     fun shutdown() {

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleScreen.kt
@@ -8,6 +8,8 @@ import android.text.format.DateFormat
 import android.widget.TextView
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import cloud.trotter.dashbuddy.core.designsystem.format.DashFormats
+import cloud.trotter.dashbuddy.core.designsystem.time.formatDuration
 import cloud.trotter.dashbuddy.core.designsystem.theme.DashTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -73,7 +75,6 @@ import cloud.trotter.dashbuddy.ui.formatters.getIconResId
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateMapOf
 import java.util.Date
-import java.util.concurrent.TimeUnit
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -337,7 +338,7 @@ private fun SessionMetricsActions(
             MaterialTheme.colorScheme.onSurface
 
         Text(
-            text = "$${String.format("%.2f", displayEarnings)}",
+            text = DashFormats.money(displayEarnings),
             style = MaterialTheme.typography.titleSmall,
             fontWeight = FontWeight.Bold,
             color = textColor
@@ -348,7 +349,7 @@ private fun SessionMetricsActions(
             color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.25f)
         )
         Text(
-            text = "${"%.1f".format(displayMiles)} mi",
+            text = "${DashFormats.decimal(displayMiles)} mi",
             style = MaterialTheme.typography.titleSmall,
             color = textColor
         )
@@ -395,12 +396,12 @@ private fun ModeIdle(lastSessionSummary: SessionSummary?) {
                 color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
             )
             Text(
-                text = "$${String.format("%.2f", lastSessionSummary.earnings)}",
+                text = DashFormats.money(lastSessionSummary.earnings),
                 style = MaterialTheme.typography.headlineMedium,
                 fontWeight = FontWeight.Bold,
                 color = MaterialTheme.colorScheme.primary
             )
-            ModeRow(label = "Miles", value = "${"%.1f".format(lastSessionSummary.miles)} mi")
+            ModeRow(label = "Miles", value = "${DashFormats.decimal(lastSessionSummary.miles)} mi")
             ModeRow(label = "Duration", value = formatDuration(lastSessionSummary.durationMillis))
             if (lastSessionSummary.acceptanceRate.isNotBlank()) {
                 ModeRow(label = "Acceptance", value = lastSessionSummary.acceptanceRate)
@@ -613,17 +614,7 @@ private fun ModeRow(
     }
 }
 
-private fun formatDuration(ms: Long): String {
-    if (ms <= 0) return "0s"
-    val hours = TimeUnit.MILLISECONDS.toHours(ms)
-    val minutes = TimeUnit.MILLISECONDS.toMinutes(ms) % 60
-    val seconds = TimeUnit.MILLISECONDS.toSeconds(ms) % 60
-    return when {
-        hours > 0 -> "${hours}h ${minutes}m"
-        minutes > 0 -> "${minutes}m ${seconds}s"
-        else -> "${seconds}s"
-    }
-}
+
 
 private fun platformShortName(platform: Platform): String = when (platform) {
     Platform.DoorDash -> "DD"

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardItem.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardItem.kt
@@ -1,6 +1,5 @@
 package cloud.trotter.dashbuddy.ui.bubble.cards
 
-import android.text.format.DateFormat
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -24,14 +23,16 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.produceState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
+import cloud.trotter.dashbuddy.core.designsystem.format.DashFormats
 import cloud.trotter.dashbuddy.core.designsystem.theme.DashTheme
+import cloud.trotter.dashbuddy.core.designsystem.time.formatCountdown
+import cloud.trotter.dashbuddy.core.designsystem.time.formatDuration
+import cloud.trotter.dashbuddy.core.designsystem.time.rememberNow
+import cloud.trotter.dashbuddy.core.designsystem.time.rememberTimeFormatter
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -50,9 +51,6 @@ import cloud.trotter.dashbuddy.core.designsystem.theme.DashColors
 import cloud.trotter.dashbuddy.domain.model.cards.FlowCardSnapshot
 import cloud.trotter.dashbuddy.domain.state.PickupActivity
 import cloud.trotter.dashbuddy.domain.model.event.AppEventType
-import kotlinx.coroutines.delay
-import java.util.Date
-import java.util.concurrent.TimeUnit
 
 /**
  * A single flow-phase card in the bubble HUD stack (#257).
@@ -153,16 +151,19 @@ private fun CardHeader(
 
 @Composable
 private fun PhaseChip(snapshot: FlowCardSnapshot, isActive: Boolean) {
-    val (label, color) = when (snapshot) {
-        is FlowCardSnapshot.Awaiting -> "AWAIT" to MaterialTheme.colorScheme.tertiary
-        is FlowCardSnapshot.Offer -> "OFFER" to MaterialTheme.colorScheme.primary
-        is FlowCardSnapshot.Pickup -> "PICKUP" to MaterialTheme.colorScheme.secondary
-        is FlowCardSnapshot.Delivery -> "DROPOFF" to MaterialTheme.colorScheme.secondary
-        is FlowCardSnapshot.PostTask -> "PAID" to MaterialTheme.colorScheme.primary
+    // Semantic brand tokens per DashColors' contract (#358) — the chip now
+    // agrees with statusBadge instead of remapping phases onto M3 roles.
+    val c = DashTheme.colors
+    val (label, color, bg) = when (snapshot) {
+        is FlowCardSnapshot.Awaiting -> Triple("AWAIT", c.neutral, c.neutralBg)
+        is FlowCardSnapshot.Offer -> Triple("OFFER", c.stOffer, c.stOfferBg)
+        is FlowCardSnapshot.Pickup -> Triple("PICKUP", c.stPickup, c.stPickupBg)
+        is FlowCardSnapshot.Delivery -> Triple("DROPOFF", c.stPickup, c.stPickupBg)
+        is FlowCardSnapshot.PostTask -> Triple("PAID", c.good, c.goodBg)
     }
     Surface(
         shape = RoundedCornerShape(4.dp),
-        color = color.copy(alpha = if (isActive) 0.22f else 0.14f),
+        color = if (isActive) bg else bg.copy(alpha = bg.alpha * 0.6f),
     ) {
         Text(
             text = label,
@@ -196,7 +197,7 @@ private fun awaitingSummary(snap: FlowCardSnapshot.Awaiting, isActive: Boolean):
 
 private fun offerSummary(snap: FlowCardSnapshot.Offer): String {
     val store = snap.storeNames.firstOrNull()?.takeIf { it.isNotBlank() } ?: "Offer"
-    val pay = snap.payAmount?.let { " · $%.2f".format(it) } ?: ""
+    val pay = snap.payAmount?.let { " · ${DashFormats.money(it)}" } ?: ""
     // Outcome is rendered as a trailing chip in the header — see
     // CardHeader — so we omit it from the summary text.
     return "$store$pay"
@@ -226,7 +227,7 @@ private fun deliverySummary(snap: FlowCardSnapshot.Delivery, isActive: Boolean):
 
 private fun postTaskSummary(snap: FlowCardSnapshot.PostTask): String {
     val store = snap.storeName?.let { "$it · " } ?: ""
-    return "$store$%.2f".format(snap.totalPay)
+    return store + DashFormats.money(snap.totalPay)
 }
 
 // ---------------------------------------------------------------------------
@@ -318,19 +319,19 @@ private fun OfferBody(snap: FlowCardSnapshot.Offer, isActive: Boolean) {
             Column(modifier = Modifier.weight(1f)) {
                 val hourly = snap.dollarsPerHour
                 when {
-                    hourly != null -> Text("$%.0f/hr".format(hourly), style = DashTheme.num.heroNum, color = c.text, maxLines = 1)
-                    snap.payAmount != null -> Text("$%.2f".format(snap.payAmount), style = DashTheme.num.heroNum, color = c.text, maxLines = 1)
+                    hourly != null -> Text("${DashFormats.money0(hourly)}/hr", style = DashTheme.num.heroNum, color = c.text, maxLines = 1)
+                    snap.payAmount != null -> Text(DashFormats.money(snap.payAmount!!), style = DashTheme.num.heroNum, color = c.text, maxLines = 1)
                 }
                 val net = snap.netPayAmount ?: snap.payAmount
                 val secondary = buildString {
-                    if (net != null) append("Net $%.2f".format(net))
+                    if (net != null) append("Net ${DashFormats.money(net)}")
                     snap.distanceMiles?.let {
                         if (isNotEmpty()) append(" · ")
-                        append("%.1f mi".format(it))
+                        append("${DashFormats.decimal(it)} mi")
                     }
                     snap.dollarsPerMile?.let {
                         if (isNotEmpty()) append(" · ")
-                        append("$%.2f/mi".format(it))
+                        append("${DashFormats.money(it)}/mi")
                     }
                 }
                 if (secondary.isNotBlank()) {
@@ -417,9 +418,8 @@ private fun OfferCountdownText(expiresAt: Long, countdownSeconds: Int) {
         frac > 0.2 -> c.warn
         else -> c.bad
     }
-    val total = secsLeft.toInt()
     Text(
-        text = "%d:%02d".format(total / 60, total % 60),
+        text = formatCountdown((secsLeft * 1000).toLong()),
         style = DashTheme.num.smNum,
         color = col,
         fontWeight = FontWeight.Bold,
@@ -580,7 +580,7 @@ private fun DeadlineBody(
                     val elapsedMs = now - (arrivedAt ?: phaseStartedAt)
                     if (elapsedMs > 0) {
                         val perMin = shopped / (elapsedMs / 60_000.0)
-                        append(" · %.1f/min".format(perMin))
+                        append(" · ${DashFormats.decimal(perMin)}/min")
                     }
                 }
             }
@@ -600,7 +600,7 @@ private fun PostTaskBody(snap: FlowCardSnapshot.PostTask) {
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(2.dp),
     ) {
-        HeroBig("$%.2f".format(snap.totalPay))
+        HeroBig(DashFormats.money(snap.totalPay))
         Caption("delivery total")
         snap.parsedPay?.let { pay ->
             Column(
@@ -608,15 +608,15 @@ private fun PostTaskBody(snap: FlowCardSnapshot.PostTask) {
                 verticalArrangement = Arrangement.spacedBy(2.dp),
             ) {
                 pay.appPayComponents.forEach { item ->
-                    BreakdownRow(item.type, "$%.2f".format(item.amount))
+                    BreakdownRow(item.type, DashFormats.money(item.amount))
                 }
                 pay.customerTips.forEach { tip ->
-                    BreakdownRow("tip · ${tip.type}", "$%.2f".format(tip.amount))
+                    BreakdownRow("tip · ${tip.type}", DashFormats.money(tip.amount))
                 }
             }
         }
         snap.sessionEarningsAtCompletion?.let {
-            Caption("session $%.2f".format(it))
+            Caption("session ${DashFormats.money(it)}")
         }
     }
 }
@@ -651,8 +651,7 @@ private fun OfferActionRow(onAccept: () -> Unit, onDecline: () -> Unit) {
 private fun HeroBig(text: String, color: Color = MaterialTheme.colorScheme.onSurface) {
     Text(
         text = text,
-        fontSize = 30.sp,
-        fontWeight = FontWeight.ExtraBold,
+        style = DashTheme.num.heroNum,
         color = color,
         maxLines = 1,
     )
@@ -715,47 +714,8 @@ private fun deadlineColor(remainingMs: Long): Color {
 }
 
 // ---------------------------------------------------------------------------
-// Time helpers
+// Time helpers — the shared kit lives in :core:designsystem (#358)
 // ---------------------------------------------------------------------------
 
-/** 1Hz tick; scoped to this composable. See CLAUDE.md ▸ Reactive UI Principles. */
 @Composable
-internal fun rememberNow(tickMs: Long = 1000L): State<Long> =
-    produceState(initialValue = System.currentTimeMillis()) {
-        while (true) {
-            delay(tickMs)
-            value = System.currentTimeMillis()
-        }
-    }
-
-@Composable
-internal fun rememberFormattedTime(): (Long) -> String {
-    val ctx = LocalContext.current
-    val use24 = DateFormat.is24HourFormat(ctx)
-    val pattern = if (use24) "HH:mm" else "h:mm a"
-    return { millis -> DateFormat.format(pattern, Date(millis)).toString() }
-}
-
-@Composable
-private fun formatTime(millis: Long): String = rememberFormattedTime().invoke(millis)
-
-internal fun formatDuration(millis: Long): String {
-    val safe = millis.coerceAtLeast(0)
-    val hours = TimeUnit.MILLISECONDS.toHours(safe)
-    val minutes = TimeUnit.MILLISECONDS.toMinutes(safe) % 60
-    val seconds = TimeUnit.MILLISECONDS.toSeconds(safe) % 60
-    return when {
-        hours > 0 -> "%dh %dm".format(hours, minutes)
-        minutes > 0 -> "%dm %ds".format(minutes, seconds)
-        else -> "%ds".format(seconds)
-    }
-}
-
-/** "m:ss" style countdown for the deadline hero. Handles negatives by
- *  returning the absolute magnitude — callers add the "ahead/late" label. */
-internal fun formatCountdown(millis: Long): String {
-    val safe = kotlin.math.abs(millis)
-    val totalMinutes = TimeUnit.MILLISECONDS.toMinutes(safe)
-    val seconds = TimeUnit.MILLISECONDS.toSeconds(safe) % 60
-    return "%d:%02d".format(totalMinutes, seconds)
-}
+private fun formatTime(millis: Long): String = rememberTimeFormatter().invoke(millis)

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/components/economy/EconomyEditor.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/components/economy/EconomyEditor.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import cloud.trotter.dashbuddy.core.designsystem.format.DashFormats
 import cloud.trotter.dashbuddy.core.designsystem.theme.DashBuddyTheme
 import cloud.trotter.dashbuddy.domain.evaluation.EconomyField
 import cloud.trotter.dashbuddy.domain.evaluation.UserEconomy
@@ -54,7 +55,7 @@ fun EconomyEditor(
     // -------- Tires --------
     EconomyAccordionRow(
         title = "Tires",
-        summary = "\$${"%.3f".format(economy.tireCostPerMile)}/mi",
+        summary = "${DashFormats.money3(economy.tireCostPerMile)}/mi",
         isUserSet = EconomyField.TIRE_COST in userSet || EconomyField.TIRE_LIFETIME in userSet,
     ) {
         PairedCurrencyAndIntervalInput(
@@ -70,7 +71,7 @@ fun EconomyEditor(
     // -------- Oil changes --------
     EconomyAccordionRow(
         title = "Oil changes",
-        summary = "\$${"%.3f".format(economy.oilCostPerMile)}/mi",
+        summary = "${DashFormats.money3(economy.oilCostPerMile)}/mi",
         isUserSet = EconomyField.OIL_COST in userSet || EconomyField.OIL_INTERVAL in userSet,
     ) {
         PairedCurrencyAndIntervalInput(
@@ -86,7 +87,7 @@ fun EconomyEditor(
     // -------- Brakes --------
     EconomyAccordionRow(
         title = "Brakes",
-        summary = "\$${"%.3f".format(economy.brakesCostPerMile)}/mi",
+        summary = "${DashFormats.money3(economy.brakesCostPerMile)}/mi",
         isUserSet = EconomyField.BRAKES_COST in userSet || EconomyField.BRAKES_INTERVAL in userSet,
     ) {
         PairedCurrencyAndIntervalInput(
@@ -102,7 +103,7 @@ fun EconomyEditor(
     // -------- Fluids --------
     EconomyAccordionRow(
         title = "Fluids",
-        summary = "\$${"%.3f".format(economy.fluidsCostPerMile)}/mi",
+        summary = "${DashFormats.money3(economy.fluidsCostPerMile)}/mi",
         isUserSet = EconomyField.FLUIDS_COST in userSet || EconomyField.FLUIDS_INTERVAL in userSet,
     ) {
         PairedCurrencyAndIntervalInput(
@@ -118,7 +119,7 @@ fun EconomyEditor(
     // -------- Misc repairs --------
     EconomyAccordionRow(
         title = "Misc repairs",
-        summary = "\$${"%.3f".format(economy.miscCostPerMile)}/mi",
+        summary = "${DashFormats.money3(economy.miscCostPerMile)}/mi",
         isUserSet = EconomyField.MISC_YEARLY in userSet || EconomyField.MISC_YEARLY_MI in userSet,
     ) {
         PairedCurrencyAndIntervalInput(
@@ -137,7 +138,7 @@ fun EconomyEditor(
     EconomyAccordionRow(
         title = "Depreciation",
         summary = if (economy.includeDepreciation) {
-            "\$${"%.3f".format(economy.depreciationCostPerMile)}/mi"
+            "${DashFormats.money3(economy.depreciationCostPerMile)}/mi"
         } else {
             "off"
         },
@@ -171,7 +172,7 @@ fun EconomyEditor(
     // -------- Insurance --------
     EconomyAccordionRow(
         title = "Insurance",
-        summary = "\$${"%.3f".format(economy.insuranceCostPerMile)}/mi*",
+        summary = "${DashFormats.money3(economy.insuranceCostPerMile)}/mi*",
         isUserSet = EconomyField.INSURANCE_DELTA in userSet,
     ) {
         CurrencyInput(
@@ -190,7 +191,7 @@ fun EconomyEditor(
     // -------- Registration --------
     EconomyAccordionRow(
         title = "Registration",
-        summary = "\$${"%.3f".format(economy.registrationCostPerMile)}/mi*",
+        summary = "${DashFormats.money3(economy.registrationCostPerMile)}/mi*",
         isUserSet = EconomyField.REGISTRATION_DELTA in userSet,
     ) {
         CurrencyInput(
@@ -210,7 +211,7 @@ fun EconomyEditor(
     // -------- Phone & data --------
     EconomyAccordionRow(
         title = "Phone & data",
-        summary = "\$${"%.3f".format(economy.phoneCostPerMile)}/mi*",
+        summary = "${DashFormats.money3(economy.phoneCostPerMile)}/mi*",
         isUserSet = EconomyField.PHONE_PLAN_TOTAL in userSet ||
             EconomyField.PHONE_PLAN_LINES in userSet ||
             EconomyField.PHONE_DASH_PERCENT in userSet,
@@ -244,9 +245,9 @@ fun EconomyEditor(
         )
         val perLine = economy.phonePlanTotal / economy.phonePlanLines.coerceAtLeast(1)
         Text(
-            text = "Your line: \$${"%.2f".format(perLine)}/mo" +
+            text = "Your line: ${DashFormats.money(perLine)}/mo" +
                 " × ${economy.phoneDashPercent.toInt()}%" +
-                " = \$${"%.2f".format(perLine * economy.phoneDashPercent / 100.0)}/mo for gig work",
+                " = ${DashFormats.money(perLine * economy.phoneDashPercent / 100.0)}/mo for gig work",
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
@@ -255,11 +256,11 @@ fun EconomyEditor(
     // -------- Expected annual gig miles --------
     EconomyAccordionRow(
         title = "Expected gig miles / yr",
-        summary = "${economy.expectedAnnualDashMiles.toInt().formatWithCommas()} mi",
+        summary = "${DashFormats.commaInt(economy.expectedAnnualDashMiles.toInt())} mi",
         isUserSet = EconomyField.EXPECTED_ANNUAL_DASH_MI in userSet,
     ) {
         Text(
-            text = "${economy.expectedAnnualDashMiles.toInt().formatWithCommas()} miles per year",
+            text = "${DashFormats.commaInt(economy.expectedAnnualDashMiles.toInt())} miles per year",
             style = MaterialTheme.typography.bodyMedium,
             fontWeight = FontWeight.Medium,
         )
@@ -315,7 +316,7 @@ fun TrueCostFooter(operatingCostPerMile: Double) {
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Text(
-                text = "Your true cost: \$${"%.2f".format(operatingCostPerMile)}/mi",
+                text = "Your true cost: ${DashFormats.money(operatingCostPerMile)}/mi",
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
             )
@@ -328,7 +329,6 @@ fun TrueCostFooter(operatingCostPerMile: Double) {
     }
 }
 
-private fun Int.formatWithCommas(): String = "%,d".format(this)
 
 @Preview(showBackground = true, heightDp = 1200)
 @Composable

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/formatters/OfferFormatters.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/formatters/OfferFormatters.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.graphics.toArgb
 import cloud.trotter.dashbuddy.core.designsystem.theme.darkDashColors
 import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
 import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
+import cloud.trotter.dashbuddy.core.designsystem.format.DashFormats
 
 /**
  * Formatted offer summary for the heads-up notification. Built with **Android** text spans — the
@@ -48,15 +49,17 @@ fun OfferEvaluation.toNotificationSummary(): CharSequence {
         setSpan(RelativeSizeSpan(1.2f), start, length, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
 
         append(" · ")
-        append("$%.0f/hr net".format(dollarsPerHour))
+        append("${DashFormats.money0(dollarsPerHour)}/hr net")
         // Whole headline (verdict + rate) bold.
         setSpan(StyleSpan(Typeface.BOLD), start, length, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
 
         append("\n")
         append(
-            "Net $%.2f · %.1f mi · $%.2f/mi · Score %d · %s".format(
-                netPayAmount, distanceMiles, dollarsPerMile, score.toInt(), merchantName,
-            ),
+            "Net ${DashFormats.money(netPayAmount)} · " +
+                "${DashFormats.decimal(distanceMiles)} mi · " +
+                "${DashFormats.money(dollarsPerMile)}/mi · " +
+                "Score ${score.toInt()} · " +
+                merchantName,
         )
     }
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardViewModel.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import cloud.trotter.dashbuddy.core.designsystem.format.DashFormats
 
 @HiltViewModel
 class DashboardViewModel @Inject constructor(
@@ -46,7 +47,7 @@ class DashboardViewModel @Inject constructor(
     val sessionMiles: StateFlow<String> = odometerRepository.sessionMeters
         .map { meters ->
             val miles = meters * 0.000621371
-            "%.1f mi".format(miles)
+            "${DashFormats.decimal(miles)} mi"
         }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), "0.0 mi")
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/SettingsHomeScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/SettingsHomeScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import cloud.trotter.dashbuddy.ui.main.navigation.Screen
+import cloud.trotter.dashbuddy.core.designsystem.format.DashFormats
 
 @Composable
 fun SettingsHomeScreen(
@@ -101,7 +102,7 @@ fun SettingsHomeScreen(
                     val costPerMi = eco.operatingCostPerMile
                     val defaultsCount = cloud.trotter.dashbuddy.domain.evaluation.EconomyField.entries.size -
                         eco.userSetFields.size
-                    "True cost: \$${"%.2f".format(costPerMi)}/mi" +
+                    "True cost: ${DashFormats.money(costPerMi)}/mi" +
                         if (defaultsCount > 0) " · $defaultsCount defaults" else ""
                 } else {
                     "Tires, oil, depreciation, insurance, phone"

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/components/ReorderableRule.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/components/ReorderableRule.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.unit.dp
 import cloud.trotter.dashbuddy.domain.evaluation.MetricType
 import cloud.trotter.dashbuddy.domain.evaluation.ScoringRule
 import java.util.Locale
+import cloud.trotter.dashbuddy.core.designsystem.format.DashFormats
 
 @Composable
 fun DraggableRuleRow(
@@ -107,16 +108,9 @@ fun MetricContent(
         // Value Display (e.g., "$15.00" or "10 mi")
         if (rule.isEnabled) {
             val formatted = when (type) {
-                MetricType.PAYOUT, MetricType.ACTIVE_HOURLY -> "$${
-                    String.format(
-                        Locale.US,
-                        "%.2f",
-                        value
-                    )
-                }"
-
-                MetricType.DOLLAR_PER_MILE -> "$${String.format(Locale.US, "%.2f", value)}/mi"
-                MetricType.MAX_DISTANCE -> "${String.format(Locale.US, "%.1f", value)} mi"
+                MetricType.PAYOUT, MetricType.ACTIVE_HOURLY -> DashFormats.money(value.toDouble())
+                MetricType.DOLLAR_PER_MILE -> "${DashFormats.money(value.toDouble())}/mi"
+                MetricType.MAX_DISTANCE -> "${DashFormats.decimal(value.toDouble())} mi"
                 MetricType.ITEM_COUNT -> "${value.toInt()} items"
             }
             Text(

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/WizardScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/WizardScreen.kt
@@ -47,6 +47,7 @@ import cloud.trotter.dashbuddy.ui.main.setup.wizard.components.WizardTopBar
 import cloud.trotter.dashbuddy.ui.main.setup.wizard.model.WizardStep
 import kotlinx.coroutines.launch
 import java.util.Locale
+import cloud.trotter.dashbuddy.core.designsystem.format.DashFormats
 
 @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 @Composable
@@ -193,13 +194,7 @@ fun WizardScreen(
                     WizardStep.SHOPPING -> {
                         MetricSliderCard(
                             step = currentStep, value = state.maxItems, valueRange = 1f..100f,
-                            valueFormatter = {
-                                String.format(
-                                    Locale.getDefault(),
-                                    "%.0f items",
-                                    it
-                                )
-                            },
+                            valueFormatter = { "${DashFormats.decimal(it.toDouble(), 0)} items" },
                             onValueChange = viewModel::updateMaxItems,
                             footerText = "We'll use this to score shopping offers on the HUD."
                         )
@@ -208,7 +203,7 @@ fun WizardScreen(
                     WizardStep.MIN_PAYOUT -> {
                         MetricSliderCard(
                             step = currentStep, value = state.minPayout, valueRange = 2f..20f,
-                            valueFormatter = { String.format(Locale.getDefault(), "$%.2f", it) },
+                            valueFormatter = { DashFormats.money(it.toDouble()) },
                             onValueChange = viewModel::updateMinPayout,
                             footerText = if (isCherryPicker) "We will auto-decline offers below this amount." else "We will flag offers below this amount in red."
                         )
@@ -217,13 +212,7 @@ fun WizardScreen(
                     WizardStep.TARGET_HOURLY -> {
                         MetricSliderCard(
                             step = currentStep, value = state.targetHourly, valueRange = 10f..40f,
-                            valueFormatter = {
-                                String.format(
-                                    Locale.getDefault(),
-                                    "$%.0f / hr",
-                                    it
-                                )
-                            },
+                            valueFormatter = { "${DashFormats.money0(it.toDouble())} / hr" },
                             onValueChange = viewModel::updateTargetHourly,
                             footerText = if (isCherryPicker) "We will auto-decline offers below this rate." else "We will flag offers below this rate in red."
                         )

--- a/app/src/main/java/cloud/trotter/dashbuddy/util/UtilityFunctions.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/util/UtilityFunctions.kt
@@ -87,7 +87,7 @@ object UtilityFunctions {
         return try {
             val digest = MessageDigest.getInstance("SHA-256")
             val hashBytes = digest.digest(input.toByteArray(Charsets.UTF_8))
-            hashBytes.fold("") { str, it -> str + "%02x".format(it) }
+            hashBytes.fold("") { str, it -> str + String.format(java.util.Locale.ROOT, "%02x", it) }
         } catch (_: Exception) {
             input
         }

--- a/core/designsystem/build.gradle.kts
+++ b/core/designsystem/build.gradle.kts
@@ -34,6 +34,7 @@ android {
 }
 
 dependencies {
+    testImplementation(libs.junit)
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.ui)
     implementation(libs.androidx.ui.graphics)

--- a/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/format/DashFormats.kt
+++ b/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/format/DashFormats.kt
@@ -1,0 +1,40 @@
+package cloud.trotter.dashbuddy.core.designsystem.format
+
+import java.util.Locale
+
+/**
+ * Locale policy for every formatted number in DashBuddy (#358):
+ *
+ *  - **Display strings** (anything a human reads: money, distances, rates,
+ *    counts) format through THIS object, which pins `Locale.getDefault()`
+ *    explicitly. Bare `"%.2f".format(x)` is banned — it picks up the default
+ *    locale *implicitly*, which is the bug pattern this object exists to kill
+ *    (it made the policy invisible and un-greppable).
+ *  - **Machine strings** (hashes, file names, wire values, anything parsed
+ *    back — e.g. editable text fields that round-trip `toDoubleOrNull`) pin
+ *    `Locale.ROOT`/`Locale.US` at their own call site.
+ *
+ * Acceptance grep: `.format(` without `Locale` on the same line should not
+ * appear in ui/ code — everything routes here.
+ */
+object DashFormats {
+
+    private val locale: Locale get() = Locale.getDefault()
+
+    /** "$7.50" — standard money. */
+    fun money(amount: Double): String = String.format(locale, "$%.2f", amount)
+
+    /** "$23" — whole-dollar money (heroes, $/hr). */
+    fun money0(amount: Double): String = String.format(locale, "$%.0f", amount)
+
+    /** "$0.165" — per-mile cost precision. */
+    fun money3(amount: Double): String = String.format(locale, "$%.3f", amount)
+
+    /** "4.2" — bare decimal with [digits] places (callers add units). */
+    fun decimal(value: Double, digits: Int = 1): String =
+        String.format(locale, "%.${digits}f", value)
+
+    /** "12,500" — grouped integer. */
+    fun commaInt(value: Int): String = String.format(locale, "%,d", value)
+
+}

--- a/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/time/TimeKit.kt
+++ b/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/time/TimeKit.kt
@@ -1,0 +1,75 @@
+package cloud.trotter.dashbuddy.core.designsystem.time
+
+import android.text.format.DateFormat
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import kotlinx.coroutines.delay
+import java.util.Date
+import java.util.Locale
+import java.util.concurrent.TimeUnit
+
+/**
+ * The shared time kit (#358): the CLAUDE.md-canonical 1-Hz ticker plus the
+ * duration/countdown/clock formatters that the bubble HUD's glance surfaces
+ * derive from it. One definition repo-wide — the two divergent local copies
+ * (FlowCardItem, BubbleScreen) are gone.
+ *
+ * Digits are pinned to [Locale.ROOT]: durations and countdowns are clock-like
+ * strings ("3m 12s", "7:05") whose digits must not localize to non-ASCII
+ * numerals on a glance surface.
+ */
+
+/** 1-Hz tick, scoped to the calling composable. See CLAUDE.md ▸ Reactive UI Principles. */
+@Composable
+fun rememberNow(tickMs: Long = 1000L): State<Long> =
+    produceState(initialValue = System.currentTimeMillis()) {
+        while (true) {
+            delay(tickMs)
+            value = System.currentTimeMillis()
+        }
+    }
+
+/**
+ * "2h 5m" / "3m 12s" / "45s". Negative inputs floor to "0s" — a duration that
+ * hasn't started reads as zero, never as a negative.
+ */
+fun formatDuration(millis: Long): String {
+    val safe = millis.coerceAtLeast(0)
+    val hours = TimeUnit.MILLISECONDS.toHours(safe)
+    val minutes = TimeUnit.MILLISECONDS.toMinutes(safe) % 60
+    val seconds = TimeUnit.MILLISECONDS.toSeconds(safe) % 60
+    return when {
+        hours > 0 -> String.format(Locale.ROOT, "%dh %dm", hours, minutes)
+        minutes > 0 -> String.format(Locale.ROOT, "%dm %ds", minutes, seconds)
+        else -> String.format(Locale.ROOT, "%ds", seconds)
+    }
+}
+
+/**
+ * "m:ss" countdown for deadline heroes. Negatives format as their absolute
+ * magnitude — the caller renders the ahead/late label and color.
+ */
+fun formatCountdown(millis: Long): String {
+    val safe = kotlin.math.abs(millis)
+    val totalMinutes = TimeUnit.MILLISECONDS.toMinutes(safe)
+    val seconds = TimeUnit.MILLISECONDS.toSeconds(safe) % 60
+    return String.format(Locale.ROOT, "%d:%02d", totalMinutes, seconds)
+}
+
+/**
+ * A remembered wall-clock formatter honoring the device's 12/24-hour setting
+ * (e.g. "3:42 PM" / "15:42"). Remembered per composition — the old private
+ * copy allocated a new lambda every recomposition under a 1-Hz ticker.
+ */
+@Composable
+fun rememberTimeFormatter(): (Long) -> String {
+    val ctx = LocalContext.current
+    val use24 = DateFormat.is24HourFormat(ctx)
+    return remember(use24) {
+        val pattern = if (use24) "HH:mm" else "h:mm a"
+        { millis: Long -> DateFormat.format(pattern, Date(millis)).toString() }
+    }
+}

--- a/core/designsystem/src/test/java/cloud/trotter/dashbuddy/core/designsystem/format/DashFormatsTest.kt
+++ b/core/designsystem/src/test/java/cloud/trotter/dashbuddy/core/designsystem/format/DashFormatsTest.kt
@@ -1,0 +1,43 @@
+package cloud.trotter.dashbuddy.core.designsystem.format
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.util.Locale
+
+/**
+ * #358 locale policy: display formatting follows the DEVICE locale —
+ * explicitly, not as an invisible side effect of bare `.format`.
+ */
+class DashFormatsTest {
+
+    private lateinit var original: Locale
+
+    @Before
+    fun saveLocale() {
+        original = Locale.getDefault()
+    }
+
+    @After
+    fun restoreLocale() {
+        Locale.setDefault(original)
+    }
+
+    @Test
+    fun `US locale formats with dot decimals and comma grouping`() {
+        Locale.setDefault(Locale.US)
+        assertEquals("$7.50", DashFormats.money(7.5))
+        assertEquals("$23", DashFormats.money0(23.4))
+        assertEquals("$0.165", DashFormats.money3(0.1649))
+        assertEquals("4.2", DashFormats.decimal(4.23))
+        assertEquals("12,500", DashFormats.commaInt(12_500))
+    }
+
+    @Test
+    fun `comma-decimal locale renders ITS convention - deliberately`() {
+        Locale.setDefault(Locale.GERMANY)
+        assertEquals("$7,50", DashFormats.money(7.5))
+        assertEquals("12.500", DashFormats.commaInt(12_500))
+    }
+}

--- a/core/designsystem/src/test/java/cloud/trotter/dashbuddy/core/designsystem/time/TimeKitTest.kt
+++ b/core/designsystem/src/test/java/cloud/trotter/dashbuddy/core/designsystem/time/TimeKitTest.kt
@@ -1,0 +1,51 @@
+package cloud.trotter.dashbuddy.core.designsystem.time
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.util.Locale
+
+/**
+ * #358: ONE duration/countdown definition repo-wide, with unified zero/negative
+ * semantics (the two old private copies disagreed) and ASCII digits regardless
+ * of device locale (clock-like glance strings must not localize numerals).
+ */
+class TimeKitTest {
+
+    private lateinit var original: Locale
+
+    @Before
+    fun saveLocale() {
+        original = Locale.getDefault()
+    }
+
+    @After
+    fun restoreLocale() {
+        Locale.setDefault(original)
+    }
+
+    @Test
+    fun `formatDuration tiers and floors`() {
+        assertEquals("45s", formatDuration(45_000))
+        assertEquals("3m 12s", formatDuration(192_000))
+        assertEquals("2h 5m", formatDuration(2 * 3_600_000L + 5 * 60_000L))
+        assertEquals("0s", formatDuration(0))
+        assertEquals("0s", formatDuration(-5_000)) // unified: negatives floor, never render "-5s"
+    }
+
+    @Test
+    fun `formatCountdown is m colon ss with absolute magnitude for negatives`() {
+        assertEquals("1:05", formatCountdown(65_000))
+        assertEquals("0:00", formatCountdown(0))
+        assertEquals("1:05", formatCountdown(-65_000)) // caller adds the late label
+        assertEquals("12:00", formatCountdown(12 * 60_000L))
+    }
+
+    @Test
+    fun `digits stay ASCII under a non-ASCII-numeral locale`() {
+        Locale.setDefault(Locale.forLanguageTag("ar-EG"))
+        assertEquals("3m 12s", formatDuration(192_000))
+        assertEquals("1:05", formatCountdown(65_000))
+    }
+}

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -35,7 +35,6 @@ import cloud.trotter.dashbuddy.domain.state.PlatformRegion
 import cloud.trotter.dashbuddy.domain.state.Task
 import cloud.trotter.dashbuddy.domain.state.TaskPhase
 import cloud.trotter.dashbuddy.domain.state.TaskSubFlow
-import cloud.trotter.dashbuddy.domain.util.formatCurrency
 import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -805,6 +804,14 @@ class EffectMap @Inject constructor() {
     // =========================================================================
     // HELPERS
     // =========================================================================
+
+    /**
+     * Display formatting inside the state layer is a known wart: UpdateBubble
+     * carries rendered copy, so the formatter lives here until #366 moves the
+     * copy out of state. Locale pinned EXPLICITLY per the #358 policy.
+     */
+    private fun formatCurrency(amount: Double): String =
+        String.format(java.util.Locale.getDefault(), "%.2f", amount)
 
     private fun resolveOfferOutcome(obs: Observation, prevOffer: PendingOffer? = null): AppEventType {
         // 1. Stored click intent on PendingOffer — covers the common case where

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -63,7 +63,15 @@ immediately (no second pass needed) so it gets triaged.
 _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **broken** on the
 2026-06-09 dash — moved to that session's log entry below for triage.)_
 
-- **Platform toggles now take effect live — no app restart (#356, PR pending).**
+- **HUD numbers/timers re-plumbed through one shared format/time kit (#358, PR pending).**
+  All bubble-card money, distance, countdown, and duration strings now come from
+  `:core:designsystem` helpers, and the phase chip switched to brand tokens. On a normal dash,
+  glance-check: (a) card money/mi/min strings look exactly as before (en-US should be visually
+  unchanged); (b) the offer countdown and elapsed timers still tick per second; (c) the phase
+  chip color now MATCHES the card's status colors (OFFER chip = same blue family as the offer
+  status badge, PAID = green) instead of the old purple/teal M3 roles.
+  - Confirmed: 0/2.
+- **Platform toggles now take effect live — no app restart (#356, PR #384).**
   All notification/accessibility gating now reads one shared enabled-platforms state. To check:
   mid-session, toggle a platform OFF in DashBuddy settings — its notifications should stop
   reaching the HUD/log immediately (next notification, not next restart); toggle back ON and

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/OfferEvaluator.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/OfferEvaluator.kt
@@ -215,17 +215,17 @@ class OfferEvaluator() {
             val target = rule.targetValue.toDouble()
             when (rule.metricType) {
                 MetricType.DOLLAR_PER_MILE -> if (target > REALISTIC_MAX_DPM)
-                    "Your \$/mile target of \$${"%.2f".format(target)} is above what most DoorDash offers pay. " +
+                    "Your \$/mile target of \$${String.format(java.util.Locale.ROOT, "%.2f", target)} is above what most DoorDash offers pay. " +
                     "Most offers are \$0.80–\$1.50/mi. Setting this high will result in most offers being auto-declined."
                 else null
 
                 MetricType.ACTIVE_HOURLY -> if (target > REALISTIC_MAX_HOURLY)
-                    "Your hourly target of \$${"%.2f".format(target)}/hr is above typical DoorDash earnings. " +
+                    "Your hourly target of \$${String.format(java.util.Locale.ROOT, "%.2f", target)}/hr is above typical DoorDash earnings. " +
                     "Most dashers earn \$15–\$25/hr active. Setting this high will result in most offers being auto-declined."
                 else null
 
                 MetricType.PAYOUT -> if (target > REALISTIC_MAX_PAYOUT)
-                    "Your minimum payout of \$${"%.2f".format(target)} is above what most single orders pay. " +
+                    "Your minimum payout of \$${String.format(java.util.Locale.ROOT, "%.2f", target)} is above what most single orders pay. " +
                     "Most DoorDash orders are under \$10. Setting this high will result in most offers being auto-declined."
                 else null
 

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/util/FormatUtils.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/util/FormatUtils.kt
@@ -1,6 +1,0 @@
-package cloud.trotter.dashbuddy.domain.util
-
-import java.util.Locale
-
-fun formatCurrency(amount: Double): String =
-    String.format(Locale.getDefault(), "%.2f", amount)


### PR DESCRIPTION
Fixes #358.

## New in `:core:designsystem`

- **`format/DashFormats`** — `money` ($7.50), `money0` ($23), `money3` ($0.165/mi), `decimal`, `commaInt`. Pins `Locale.getDefault()` **explicitly**; the KDoc states the policy (display = device locale, machine strings = ROOT/US at their own site). Bare `.format` was the bug pattern — implicit locale, invisible and un-greppable.
- **`time/TimeKit`** — `rememberNow` (the CLAUDE.md-canonical 1-Hz `produceState` ticker), `formatDuration`, `formatCountdown`, `rememberTimeFormatter` (now actually `remember`ed — the old private copy allocated per recomposition under the ticker). Digits pinned to `Locale.ROOT` so countdowns can't render non-ASCII numerals on a glance surface.

## Sweep (acceptance grep is clean)

`grep '.format(' app/src/main core/state/src/main domain/src/main | grep -v Locale` → **empty**. Migrated: FlowCardItem (18 sites + both private time kits deleted), BubbleScreen (4 + divergent `formatDuration` deleted — negative durations now uniformly floor to `0s`), EconomyEditor (13), WizardScreen (3), OfferFormatters (the user-facing notification), SettingsHomeScreen, DashboardViewModel, ReorderableRule (was third strategy: `Locale.US`), TtsEffectHandler, UtilityFunctions hash (`ROOT` pin).

Documented exceptions (explicit locale, deliberately kept): `CurrencyInput`'s edit-friendly trim formatter (parse round-trips `toDoubleOrNull`), `SimpleDateFormat` file/log timestamps (`Locale.US`), `EffectMap`'s private `formatCurrency` (bubble copy lives in state until #366 — domain `FormatUtils` itself is **deleted**), `OfferEvaluator` warning copy pinned `ROOT` pending #366/#57.

## PhaseChip token fix (+ HeroBig)

| Phase | Before (M3 role) | After (DashColors token) |
|---|---|---|
| AWAIT | tertiary | `neutral`/`neutralBg` |
| OFFER | primary | `stOffer`/`stOfferBg` |
| PICKUP / DROPOFF | secondary | `stPickup`/`stPickupBg` |
| PAID | primary | `good`/`goodBg` |

Chip and statusBadge now draw from the same semantic family (no screenshot — no device on this workstation; the field-testing checklist has a chip-color item, and `EconomyEditorPreview`/`DashAccordion` previews cover the components). `HeroBig` 30.sp → `DashTheme.num.heroNum` (#318's site unblocked).

## Tests

`DashFormatsTest` (US + comma-decimal German policy) and `TimeKitTest` (tiering, zero/negative floors, ASCII digits under ar-EG) — 5 new tests. Full suite + release compile green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)