### PR TITLE
feat(pipeline): content-bearing UNKNOWN identity + rolling suppression (#360)

### DIFF
--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/FrameGate.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/FrameGate.kt
@@ -1,0 +1,87 @@
+package cloud.trotter.dashbuddy.core.pipeline
+
+import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.pipeline.ObservationIdentity
+import cloud.trotter.dashbuddy.domain.pipeline.identity
+import timber.log.Timber
+
+/**
+ * Per-pipeline frame admission (#360). Combines the existing identity dedup
+ * with content-bearing suppression for UNKNOWN frames.
+ *
+ * The two layers solve different problems:
+ *  - **Identity dedup** (`lastIdentity`) suppresses the same RECOGNIZED screen
+ *    re-observed back-to-back. It is deliberately NOT updated by UNKNOWN
+ *    frames, so a known screen re-forwards after an UNKNOWN interlude even if
+ *    its own identity didn't change.
+ *  - **UNKNOWN suppression** ([UnknownSuppressor]): UNKNOWN identity is
+ *    contentless (constant target + ParsedFields.None), so consecutive
+ *    *distinct* unknown screens were indistinguishable and every noisy frame
+ *    re-captured — ~66% of May's capture volume. UNKNOWN frames are now keyed
+ *    by a content hash (tree `stableHash` / notification `contentHash`) in a
+ *    rolling seen-set, separate from `lastIdentity`.
+ */
+internal class FrameGate(
+    private val unknownSuppressor: UnknownSuppressor = UnknownSuppressor(),
+) {
+    private var lastIdentity: ObservationIdentity? = null
+
+    /**
+     * @param contentHash content-bearing hash for UNKNOWN frames (null = no
+     *   content available; the frame is then admitted — never silently lose a
+     *   triage-able capture for want of a hash).
+     * @return true if the frame should be captured (and, for known targets,
+     *   forwarded onward).
+     */
+    fun admit(obs: Observation, contentHash: Int?): Boolean {
+        val identity = obs.identity()
+        if (identity == lastIdentity) return false
+
+        val target = (obs as? Observation.FlowObservation)?.target
+        if (target != "UNKNOWN") {
+            lastIdentity = identity
+            return true
+        }
+        if (contentHash == null) return true
+        return unknownSuppressor.shouldCapture(contentHash)
+    }
+}
+
+/**
+ * Rolling LRU seen-set + per-process cap for UNKNOWN captures (#360).
+ * Re-seeing a recent hash refreshes its recency, so an animation alternating
+ * between two frames suppresses both after the first sighting of each.
+ */
+internal class UnknownSuppressor(
+    private val capacity: Int = 32,
+    private val processCap: Int = 200,
+) {
+    private val seen = object : LinkedHashMap<Int, Unit>(capacity, 0.75f, true) {
+        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<Int, Unit>): Boolean =
+            size > capacity
+    }
+    private var captured = 0
+    private var capLogged = false
+
+    @Synchronized
+    fun shouldCapture(contentHash: Int): Boolean {
+        if (seen.containsKey(contentHash)) {
+            seen[contentHash] = Unit // refresh recency
+            return false
+        }
+        if (captured >= processCap) {
+            // No silent truncation: say so, once.
+            if (!capLogged) {
+                capLogged = true
+                Timber.w(
+                    "UNKNOWN capture cap (%d) reached — suppressing further unknown captures this process",
+                    processCap,
+                )
+            }
+            return false
+        }
+        seen[contentHash] = Unit
+        captured++
+        return true
+    }
+}

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/AccessibilityPipeline.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/AccessibilityPipeline.kt
@@ -9,11 +9,11 @@ import cloud.trotter.dashbuddy.domain.capture.schema.ClickContextSchema
 import cloud.trotter.dashbuddy.domain.capture.schema.UiNodeSchema
 import cloud.trotter.dashbuddy.domain.settings.PlatformPreferences
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
-import cloud.trotter.dashbuddy.domain.pipeline.ObservationIdentity
 import cloud.trotter.dashbuddy.domain.pipeline.identity
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
 import cloud.trotter.dashbuddy.domain.state.ParsedFields
 import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.core.pipeline.FrameGate
 import cloud.trotter.dashbuddy.core.pipeline.ObservationClassifier
 import cloud.trotter.dashbuddy.core.pipeline.PipelineEvent
 import cloud.trotter.dashbuddy.core.pipeline.accessibility.event.type.window.content_changed.ContentChangedPipeline
@@ -57,8 +57,8 @@ class AccessibilityPipeline @Inject constructor(
         const val CLICK_PIPELINE_ID = "accessibility.click"
     }
 
-    /** Last emitted observation identity — for post-classification dedup. */
-    private var lastIdentity: ObservationIdentity? = null
+    /** Identity dedup + content-bearing UNKNOWN suppression (#360). */
+    private val frameGate = FrameGate()
 
     // ── Source flows ────────────────────────────────────────────────────
 
@@ -115,18 +115,21 @@ class AccessibilityPipeline @Inject constructor(
                 platform in platformPreferences.enabledPlatforms.value
         }
 
-        // Dedup + Capture: write unique observations to disk, skip duplicates
+        // Dedup + Capture: write unique observations to disk, skip duplicates.
+        // Known screens dedup by identity; UNKNOWN frames dedup by tree/node
+        // content hash in a rolling seen-set (#360) — lastIdentity semantics
+        // (known-after-UNKNOWN re-forwarding) are preserved inside FrameGate.
         .mapNotNull { (obs, event) ->
-            val identity = obs.identity()
-            if (identity == lastIdentity) {
-                Timber.v("Dedup: skipped %s (same identity)", (obs as? Observation.FlowObservation)?.target)
+            val contentHash = when (event) {
+                is PipelineEvent.Screen -> event.tree.stableHash
+                is PipelineEvent.Click ->
+                    clickDedupHash(event.node, classifier.lastScreenTarget)
+                else -> null
+            }
+            if (!frameGate.admit(obs, contentHash)) {
+                Timber.v("Dedup: suppressed %s", (obs as? Observation.FlowObservation)?.target)
                 return@mapNotNull null
             }
-            // Only update lastIdentity for known observations — UNKNOWN observations
-            // get captured below but shouldn't reset dedup state, otherwise the next
-            // known screen after an UNKNOWN re-forwards even if nothing changed.
-            val target = (obs as? Observation.FlowObservation)?.target
-            if (target != "UNKNOWN") lastIdentity = identity
             captureObservation(obs, event)
         }
 

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/notification/NotificationPipeline.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/notification/NotificationPipeline.kt
@@ -5,12 +5,12 @@ import cloud.trotter.dashbuddy.domain.capture.EnvelopeBuilder
 import cloud.trotter.dashbuddy.domain.capture.schema.RawNotificationSchema
 import cloud.trotter.dashbuddy.domain.settings.PlatformPreferences
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
-import cloud.trotter.dashbuddy.domain.pipeline.ObservationIdentity
 import cloud.trotter.dashbuddy.domain.pipeline.identity
 import cloud.trotter.dashbuddy.domain.state.ParsedFields
 import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.core.pipeline.ObservationClassifier
 import cloud.trotter.dashbuddy.core.pipeline.PipelineEvent
+import cloud.trotter.dashbuddy.core.pipeline.FrameGate
 import cloud.trotter.dashbuddy.core.pipeline.notification.input.NotificationSource
 import cloud.trotter.dashbuddy.core.pipeline.notification.mapper.toDomain
 import kotlinx.coroutines.CoroutineScope
@@ -41,7 +41,8 @@ class NotificationPipeline @Inject constructor(
         const val PIPELINE_ID = "notification"
     }
 
-    private var lastIdentity: ObservationIdentity? = null
+    /** Identity dedup + content-bearing UNKNOWN suppression (#360). */
+    private val frameGate = FrameGate()
 
     fun output(): Flow<Observation.Notification> = source.events
         .mapNotNull { sbn -> sbn.toDomain() }
@@ -63,11 +64,10 @@ class NotificationPipeline @Inject constructor(
             platform == Platform.Unknown ||
                 platform in platformPreferences.enabledPlatforms.value
         }
-        // Dedup + Capture
+        // Dedup + Capture: known notifications dedup by identity; UNKNOWN by
+        // content hash in a rolling seen-set (#360).
         .mapNotNull { (obs, raw) ->
-            val identity = obs.identity()
-            if (identity == lastIdentity) return@mapNotNull null
-            if (obs.target != "UNKNOWN") lastIdentity = identity
+            if (!frameGate.admit(obs, raw.contentHash)) return@mapNotNull null
 
             // Derive platform from the source package, not from the matched rule
             val platform = Platform.fromPackage(raw.packageName).wire

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/FrameGateTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/FrameGateTest.kt
@@ -1,0 +1,116 @@
+package cloud.trotter.dashbuddy.core.pipeline
+
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
+import cloud.trotter.dashbuddy.domain.state.Flow
+import cloud.trotter.dashbuddy.domain.state.Mode
+import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #360 acceptance: identical UNKNOWN frames capture once; distinct unknowns
+ * each capture; the recognized-screen-after-UNKNOWN re-forward behavior
+ * (lastIdentity is never reset by UNKNOWN) is preserved; the rolling set and
+ * the process cap bound capture volume.
+ */
+class FrameGateTest {
+
+    private fun screen(target: String, ruleId: String? = "doordash.screen.$target", t: Long = 1_000L) =
+        Observation.Screen(
+            timestamp = t,
+            captureId = null,
+            ruleId = ruleId,
+            metadata = ReplayMetadata.EMPTY,
+            flow = Flow.Idle,
+            modeHint = Mode.Online,
+            parsed = ParsedFields.None,
+            target = target,
+        )
+
+    private fun unknown(t: Long = 1_000L) =
+        screen(target = "UNKNOWN", ruleId = null, t = t)
+
+    @Test
+    fun `identical UNKNOWN frames capture exactly once`() {
+        val gate = FrameGate()
+        assertTrue(gate.admit(unknown(), contentHash = 111))
+        assertFalse(gate.admit(unknown(), contentHash = 111))
+        assertFalse(gate.admit(unknown(), contentHash = 111))
+    }
+
+    @Test
+    fun `alternating distinct unknowns each capture once, then suppress`() {
+        val gate = FrameGate()
+        assertTrue(gate.admit(unknown(), contentHash = 1))
+        assertTrue(gate.admit(unknown(), contentHash = 2))
+        // The animation loop: A-B-A-B never re-captures.
+        assertFalse(gate.admit(unknown(), contentHash = 1))
+        assertFalse(gate.admit(unknown(), contentHash = 2))
+    }
+
+    @Test
+    fun `a genuinely new unknown still captures after suppression`() {
+        val gate = FrameGate()
+        assertTrue(gate.admit(unknown(), contentHash = 1))
+        assertFalse(gate.admit(unknown(), contentHash = 1))
+        assertTrue(gate.admit(unknown(), contentHash = 99))
+    }
+
+    @Test
+    fun `lastIdentity semantics survive an UNKNOWN interlude`() {
+        val gate = FrameGate()
+        assertTrue(gate.admit(screen("main_map_idle"), contentHash = null))
+        // Same recognized screen again — identity dedup suppresses.
+        assertFalse(gate.admit(screen("main_map_idle"), contentHash = null))
+        // UNKNOWN interlude (captured) must NOT reset identity state ...
+        assertTrue(gate.admit(unknown(), contentHash = 7))
+        // ... so the UNCHANGED known screen stays suppressed (the original
+        // design: an UNKNOWN between two identical sightings is not a change) ...
+        assertFalse(gate.admit(screen("main_map_idle"), contentHash = null))
+        // ... while a recognized screen with a NEW identity still forwards.
+        assertTrue(gate.admit(screen("offer_popup"), contentHash = null))
+    }
+
+    @Test
+    fun `UNKNOWN with no content hash is admitted - never silently lost`() {
+        val gate = FrameGate()
+        assertTrue(gate.admit(unknown(), contentHash = null))
+        assertTrue(gate.admit(unknown(), contentHash = null))
+    }
+
+    @Test
+    fun `rolling capacity evicts oldest - an evicted hash can capture again`() {
+        val suppressor = UnknownSuppressor(capacity = 2, processCap = 1_000)
+        assertTrue(suppressor.shouldCapture(1))
+        assertTrue(suppressor.shouldCapture(2))
+        assertTrue(suppressor.shouldCapture(3)) // evicts 1
+        assertTrue(suppressor.shouldCapture(1)) // 1 was evicted → captures again
+        assertFalse(suppressor.shouldCapture(3)) // still resident
+    }
+
+    @Test
+    fun `re-seeing a hash refreshes its recency`() {
+        val suppressor = UnknownSuppressor(capacity = 2, processCap = 1_000)
+        assertTrue(suppressor.shouldCapture(1))
+        assertTrue(suppressor.shouldCapture(2))
+        assertFalse(suppressor.shouldCapture(1)) // touch 1 → 2 is now eldest
+        assertTrue(suppressor.shouldCapture(3))  // evicts 2, not 1
+        assertFalse(suppressor.shouldCapture(1))
+        assertTrue(suppressor.shouldCapture(2))  // 2 was evicted
+    }
+
+    @Test
+    fun `process cap stops captures but suppression of seen hashes continues`() {
+        val suppressor = UnknownSuppressor(capacity = 8, processCap = 2)
+        assertTrue(suppressor.shouldCapture(1))
+        assertTrue(suppressor.shouldCapture(2))
+        assertFalse(suppressor.shouldCapture(3)) // cap reached
+        assertFalse(suppressor.shouldCapture(1)) // seen — still suppressed
+        var capped = 0
+        for (h in 10..20) if (!suppressor.shouldCapture(h)) capped++
+        assertEquals(11, capped)
+    }
+}

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -63,7 +63,16 @@ immediately (no second pass needed) so it gets triaged.
 _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **broken** on the
 2026-06-09 dash — moved to that session's log entry below for triage.)_
 
-- **HUD numbers/timers re-plumbed through one shared format/time kit (#358, PR pending).**
+- **UNKNOWN capture volume should drop materially (#360, PR pending).**
+  UNKNOWN frames now dedup by content hash in a rolling seen-set (animations/list churn
+  capture once instead of per frame), with a 200-per-process cap (logged loudly when hit).
+  Post-dash check: count files in the capture INBOX vs a May session of similar length —
+  the May baseline was ~66% UNKNOWN; expect a large drop. Also confirm genuinely NEW
+  unknown screens (any screen you visited that DashBuddy doesn't know) still produce a
+  capture, and grep the log for the cap warning — hitting 200 on a normal dash would mean
+  the suppressor is too weak.
+  - Confirmed: 0/2.
+- **HUD numbers/timers re-plumbed through one shared format/time kit (#358, PR #386).**
   All bubble-card money, distance, countdown, and duration strings now come from
   `:core:designsystem` helpers, and the phase chip switched to brand tokens. On a normal dash,
   glance-check: (a) card money/mi/min strings look exactly as before (en-US should be visually


### PR DESCRIPTION
Fixes #360.

## What

New `FrameGate` (one instance per pipeline) extracts the previously-inline dedup decision and adds the missing layer:

- **Known frames**: identity dedup, semantics bit-identical to before — `lastIdentity` is still never touched by UNKNOWN, so an UNKNOWN interlude neither re-forwards an unchanged known screen nor blocks a new one (pinned by test; my first draft of that test asserted the inverse and the existing behavior caught it).
- **UNKNOWN frames**: keyed by a content hash — `tree.stableHash` (screens), `clickDedupHash(node, screenTarget)` (clicks), `raw.contentHash` (notifications) — in a 32-entry access-ordered LRU (`UnknownSuppressor`). An A-B-A-B animation loop captures A and B once each, then suppresses both. A `null` hash **admits** — never silently lose a triage-able capture for want of a hash.
- **Backstop**: 200 UNKNOWN captures per process; when hit, a loud `Timber.w` (no silent truncation), and seen-hash suppression keeps working.

Both `AccessibilityPipeline` and `NotificationPipeline` now share the gate; their hand-rolled `lastIdentity` fields are gone.

## Acceptance

- ✅ `FrameGateTest` (8 tests): identical UNKNOWNs → 1 capture; alternating distinct unknowns → each captured once; genuinely new unknown after suppression → captured; lastIdentity semantics across UNKNOWN interludes; LRU eviction + recency refresh; cap behavior.
- ⏳ Field validation: checklist item added — compare INBOX volume to May baselines (~66% UNKNOWN), confirm new unknowns still land, grep for the cap warning.
- ✅ InboxProcessor triage unaffected: distinct screens still capture (suppression only ever drops content-hash repeats).

Helps #192 (less noise → better community corpus). Full suite + release compile green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)