### PR TITLE
refactor(domain): immutable UiNode + bounded tree ingestion (#363)

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/model/UiNodeTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/model/UiNodeTest.kt
@@ -30,15 +30,15 @@ class UiNodeTest {
 
     @Test
     fun `equals does NOT cause StackOverflowError on circular references`() {
-        val parent1 = createBaseNode().copy(viewIdResourceName = "parent")
         val child1 = createBaseNode().copy(viewIdResourceName = "child")
-        parent1.children.add(child1)
-        child1.parent = parent1 // Circular Reference!
+        val parent1 = createBaseNode()
+            .copy(viewIdResourceName = "parent", children = listOf(child1))
+            .restoreParents() // wires the circular parent reference
 
-        val parent2 = createBaseNode().copy(viewIdResourceName = "parent")
         val child2 = createBaseNode().copy(viewIdResourceName = "child")
-        parent2.children.add(child2)
-        child2.parent = parent2 // Circular Reference!
+        val parent2 = createBaseNode()
+            .copy(viewIdResourceName = "parent", children = listOf(child2))
+            .restoreParents()
 
         // THE TEST: If the bug exists, this will crash with StackOverflowError
         val areEqual = parent1 == parent2

--- a/app/src/test/java/cloud/trotter/dashbuddy/test/LogToUiNodeParser.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/test/LogToUiNodeParser.kt
@@ -1,22 +1,23 @@
 package cloud.trotter.dashbuddy.test
 
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
-import java.lang.reflect.Field
 
 object LogToUiNodeParser {
 
     private val nodeRegex = Regex("""^(\s*)UiNode\((.*)\)$""")
 
+    /** Mutable scaffolding while parsing; materialized into the immutable tree at the end (#363). */
+    private class Scaffold(val proto: UiNode, val kids: MutableList<Scaffold> = mutableListOf())
+
     fun parseLog(logContent: String): UiNode? {
         val lines = logContent.lines().filter { it.isNotBlank() }
         if (lines.isEmpty()) return null
 
-        val rootLine = lines.first()
-        val rootNode = parseLine(rootLine) ?: return null
+        val root = parseLine(lines.first())?.let(::Scaffold) ?: return null
 
-        // Stack: Pair(IndentLevel, Node)
-        val stack = ArrayDeque<Pair<Int, UiNode>>()
-        stack.addFirst(0 to rootNode)
+        // Stack: Pair(IndentLevel, Scaffold)
+        val stack = ArrayDeque<Pair<Int, Scaffold>>()
+        stack.addFirst(0 to root)
 
         for (i in 1 until lines.size) {
             val line = lines[i]
@@ -24,39 +25,24 @@ object LogToUiNodeParser {
 
             val indentSpaces = match.groupValues[1].length
             val indentLevel = indentSpaces / 2
-            val node = parseLine(line) ?: continue
+            val node = parseLine(line)?.let(::Scaffold) ?: continue
 
             // 1. Pop stack until we find the parent
             while (stack.isNotEmpty() && stack.first().first >= indentLevel) {
                 stack.removeFirst()
             }
 
-            // 2. Link Parent <-> Child
-            val parent = stack.firstOrNull()?.second
-            if (parent != null) {
-                parent.children.add(node)
-
-                // --- CRITICAL FIX: Set the parent reference using Reflection ---
-                setParent(node, parent)
-            }
+            // 2. Link parent <- child in the scaffolding
+            stack.firstOrNull()?.second?.kids?.add(node)
 
             stack.addFirst(indentLevel to node)
         }
 
-        return rootNode
+        return materialize(root).restoreParents()
     }
 
-    // Helper to set immutable 'val parent' using reflection
-    private fun setParent(child: UiNode, parent: UiNode) {
-        try {
-            val parentField: Field = UiNode::class.java.getDeclaredField("parent")
-            parentField.isAccessible = true
-            parentField.set(child, parent)
-        } catch (e: Exception) {
-            e.printStackTrace()
-            // Fallback: If reflection fails, tests relying on .parent will fail.
-        }
-    }
+    private fun materialize(s: Scaffold): UiNode =
+        s.proto.copy(children = s.kids.map(::materialize))
 
     private fun parseLine(line: String): UiNode? {
         val match = nodeRegex.find(line) ?: return null

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/mapper/AccessibilityNodeMapper.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/mapper/AccessibilityNodeMapper.kt
@@ -7,36 +7,76 @@ import cloud.trotter.dashbuddy.core.pipeline.BuildConfig
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
 import timber.log.Timber
 
-fun AccessibilityNodeInfo?.toUiNode(parentUiNode: UiNode? = null, depth: Int = 0): UiNode? {
+/**
+ * Per-tree ingestion budget (#363). Third-party trees are untrusted input:
+ * every `getChild(i)` is a binder IPC and the converted tree is serialized
+ * into the capture envelope, so a pathological/redesigned target UI must not
+ * be able to stack-overflow the accessibility service or balloon captures.
+ *
+ * Limits carry ~2×/10× margin over the golden corpus (max depth 27, max
+ * nodes 327). Truncation is LOUD — one warning per tree, never silent.
+ */
+internal class TreeBudget(
+    private val maxDepth: Int = MAX_TREE_DEPTH,
+    private val maxNodes: Int = MAX_TREE_NODES,
+) {
+    private var nodes = 0
+    var truncated = false
+        private set
+
+    /** True if a node at [depth] may be ingested; flags truncation otherwise. */
+    fun admit(depth: Int): Boolean {
+        if (depth > maxDepth || nodes >= maxNodes) {
+            truncated = true
+            return false
+        }
+        nodes++
+        return true
+    }
+
+    fun logIfTruncated(rootClassName: CharSequence?) {
+        if (truncated) {
+            Timber.w(
+                "Tree ingestion truncated (maxDepth=%d, maxNodes=%d) — root class=%s. " +
+                    "Captured subtree is partial.",
+                maxDepth, maxNodes, rootClassName,
+            )
+        }
+    }
+
+    companion object {
+        const val MAX_TREE_DEPTH = 60
+        const val MAX_TREE_NODES = 4_000
+    }
+}
+
+/**
+ * Convert an Android accessibility node into the immutable [UiNode] tree
+ * (#363): children are built bottom-up into a read-only list, parents are
+ * wired once at the root, and ingestion is bounded by [TreeBudget].
+ */
+fun AccessibilityNodeInfo?.toUiNode(): UiNode? {
     if (this == null) return null
+    val budget = TreeBudget()
+    val root = convert(this, depth = 0, budget = budget) ?: return null
+    budget.logIfTruncated(className)
+    return root.restoreParents()
+}
 
-    val bounds = Rect()
-    this.getBoundsInScreen(bounds)
+private fun convert(
+    node: AccessibilityNodeInfo,
+    depth: Int,
+    budget: TreeBudget,
+): UiNode? {
+    if (!budget.admit(depth)) return null
 
-    val currentUiNode = UiNode(
-        text = this.text?.toString(),
-        contentDescription = this.contentDescription?.toString(),
-        stateDescription = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            this.stateDescription?.toString()
-        } else null,
-        viewIdResourceName = this.viewIdResourceName,
-        className = this.className?.toString(),
-        isClickable = this.isClickable,
-        isEnabled = this.isEnabled,
-        isChecked = this.checked,
-        boundsInScreen = bounds.toBoundingBox(),
-        parent = parentUiNode
-    )
-
-    val childCount = this.childCount
+    val childCount = node.childCount
     var nullChildren = 0
-
+    val children = ArrayList<UiNode>(childCount)
     for (i in 0 until childCount) {
-        val childAccNode = this.getChild(i)
+        val childAccNode = node.getChild(i)
         if (childAccNode != null) {
-            childAccNode.toUiNode(currentUiNode, depth + 1)?.let { childUiNode ->
-                currentUiNode.children.add(childUiNode)
-            }
+            convert(childAccNode, depth + 1, budget)?.let(children::add)
         } else {
             nullChildren++
         }
@@ -47,9 +87,25 @@ fun AccessibilityNodeInfo?.toUiNode(parentUiNode: UiNode? = null, depth: Int = 0
         Timber.w(
             "👻 NULL CHILDREN: %d/%d null at depth=%d class=%s id=%s",
             nullChildren, childCount, depth,
-            this.className, this.viewIdResourceName
+            node.className, node.viewIdResourceName,
         )
     }
 
-    return currentUiNode
+    val bounds = Rect()
+    node.getBoundsInScreen(bounds)
+
+    return UiNode(
+        text = node.text?.toString(),
+        contentDescription = node.contentDescription?.toString(),
+        stateDescription = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            node.stateDescription?.toString()
+        } else null,
+        viewIdResourceName = node.viewIdResourceName,
+        className = node.className?.toString(),
+        isClickable = node.isClickable,
+        isEnabled = node.isEnabled,
+        isChecked = node.checked,
+        boundsInScreen = bounds.toBoundingBox(),
+        children = children,
+    )
 }

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/mapper/TreeBudgetTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/mapper/TreeBudgetTest.kt
@@ -1,0 +1,48 @@
+package cloud.trotter.dashbuddy.core.pipeline.accessibility.mapper
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #363 — bounded ingestion of untrusted third-party trees. The budget is the
+ * pure decision core the AccessibilityNodeMapper applies during conversion
+ * (the mapper itself needs live AccessibilityNodeInfo binder objects, so the
+ * cap LOGIC is what unit tests pin).
+ */
+class TreeBudgetTest {
+
+    @Test
+    fun `admits everything inside both limits`() {
+        val budget = TreeBudget(maxDepth = 5, maxNodes = 10)
+        repeat(10) { assertTrue(budget.admit(depth = it % 6)) }
+        assertFalse(budget.truncated)
+    }
+
+    @Test
+    fun `rejects past max depth and flags truncation`() {
+        val budget = TreeBudget(maxDepth = 3, maxNodes = 100)
+        assertTrue(budget.admit(depth = 3))
+        assertFalse(budget.admit(depth = 4))
+        assertTrue(budget.truncated)
+        // Shallower siblings continue to be admitted — only the deep branch is cut.
+        assertTrue(budget.admit(depth = 2))
+    }
+
+    @Test
+    fun `rejects past max nodes and flags truncation`() {
+        val budget = TreeBudget(maxDepth = 100, maxNodes = 3)
+        assertTrue(budget.admit(0))
+        assertTrue(budget.admit(1))
+        assertTrue(budget.admit(1))
+        assertFalse(budget.admit(1))
+        assertTrue(budget.truncated)
+    }
+
+    @Test
+    fun `production limits carry margin over the golden corpus`() {
+        // Corpus stats at cap-selection time: max depth 27, max nodes 327.
+        assertTrue(TreeBudget.MAX_TREE_DEPTH >= 27 * 2)
+        assertTrue(TreeBudget.MAX_TREE_NODES >= 327 * 10)
+    }
+}

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -63,7 +63,13 @@ immediately (no second pass needed) so it gets triaged.
 _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **broken** on the
 2026-06-09 dash — moved to that session's log entry below for triage.)_
 
-- **UNKNOWN capture volume should drop materially (#360, PR pending).**
+- **Tree ingestion now bounded — confirm no real screen trips the caps (#363, PR pending).**
+  Accessibility trees deeper than 60 levels or larger than 4,000 nodes truncate with a loud
+  log line. The caps carry 2×/10× margin over the corpus, so a normal dash should NEVER hit
+  them. Post-dash: grep the log for "Tree ingestion truncated" — any hit means a real DoorDash
+  screen is bigger than the corpus suggested and the caps need raising (file it).
+  - Confirmed: 0/2.
+- **UNKNOWN capture volume should drop materially (#360, PR #388).**
   UNKNOWN frames now dedup by content hash in a rolling seen-set (animations/list churn
   capture once instead of per frame), with a 200-per-process cap (logged loudly when hit).
   Post-dash check: count files in the capture INBOX vs a May session of similar length —

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/capture/UiNodeMapper.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/capture/UiNodeMapper.kt
@@ -26,25 +26,19 @@ fun UiNode.toDto(): UiNodeDto {
 }
 
 // --- JSON DTO -> Domain (Reading from disk) ---
-fun UiNodeDto.toDomain(parentUiNode: UiNode? = null): UiNode {
-    val domainNode = UiNode(
-        text = this.text,
-        contentDescription = this.contentDescription,
-        stateDescription = this.stateDescription,
-        viewIdResourceName = this.viewIdResourceName,
-        className = this.className,
-        isClickable = this.isClickable,
-        isEnabled = this.isEnabled,
-        isChecked = this.isChecked,
-        boundsInScreen = this.boundsInScreen.toDomain(),
-        parent = parentUiNode,
-        children = mutableListOf()
-    )
+// Bottom-up construction into the immutable tree (#363); parents are wired
+// once at the root via restoreParents().
+fun UiNodeDto.toDomain(): UiNode = toDomainNode().restoreParents()
 
-    // Recursively build children, passing the current node as the new parent
-    domainNode.children.addAll(
-        this.children.map { childDto -> childDto.toDomain(parentUiNode = domainNode) }
-    )
-
-    return domainNode
-}
+private fun UiNodeDto.toDomainNode(): UiNode = UiNode(
+    text = this.text,
+    contentDescription = this.contentDescription,
+    stateDescription = this.stateDescription,
+    viewIdResourceName = this.viewIdResourceName,
+    className = this.className,
+    isClickable = this.isClickable,
+    isEnabled = this.isEnabled,
+    isChecked = this.isChecked,
+    boundsInScreen = this.boundsInScreen.toDomain(),
+    children = this.children.map { it.toDomainNode() },
+)

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/accessibility/UiNode.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/accessibility/UiNode.kt
@@ -5,6 +5,11 @@ package cloud.trotter.dashbuddy.domain.model.accessibility
  * Optimized for both efficient recursive searching (Clicks) and full-text collection (Screen Analysis).
  * Essentially a pared-down serialization for AccessibilityNode in Android.
  *
+ * IMMUTABLE after construction (#363): [children] is a read-only List built
+ * bottom-up by the mappers, so the lazy hash/text caches can never go stale.
+ * `equals`/`hashCode` deliberately compare THIS node's identity fields only —
+ * never the recursive tree (that's what the hash properties are for).
+ *
  * If properties are edited, ensure you update the following to match:
  *  In this file
  *    - the equals function
@@ -31,20 +36,31 @@ data class UiNode(
 
     val boundsInScreen: BoundingBox = BoundingBox(0, 0, 0, 0),
 
-    var parent: UiNode? = null,
-
-    val children: MutableList<UiNode> = mutableListOf(),
+    val children: List<UiNode> = emptyList(),
 ) {
 
     /**
-     * Call this immediately after deserializing from JSON to re-populate
-     * the 'parent' fields for the entire tree.
+     * Back-reference up the tree. Read-only to consumers (#363): the ONLY
+     * writer is [restoreParents], which can never wire anything but the true
+     * containing node. Excluded from equals/hashCode/copy by living outside
+     * the primary constructor.
      */
-    fun restoreParents() {
+    var parent: UiNode? = null
+        private set
+
+    /**
+     * Wire the parent back-references for the whole tree (#363). The single
+     * mutation point on an otherwise-immutable tree — called once by the
+     * construction/deserialization factories before the tree is shared.
+     * Idempotent; returns this for chaining. The lazy hash/text caches are
+     * safe because they never include [parent].
+     */
+    fun restoreParents(): UiNode {
         for (child in children) {
             child.parent = this
             child.restoreParents() // Recurse down
         }
+        return this
     }
 
     override fun equals(other: Any?): Boolean {

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/capture/UiNodeMapperTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/capture/UiNodeMapperTest.kt
@@ -111,8 +111,8 @@ class UiNodeMapperTest {
     }
 
     @Test
-    fun `toDomain with no parent sets parent to null`() {
-        val node = sampleDto().toDomain(parentUiNode = null)
+    fun `toDomain root has null parent`() {
+        val node = sampleDto().toDomain()
         assertNull(node.parent)
     }
 
@@ -168,12 +168,15 @@ class UiNodeMapperTest {
     }
 
     @Test
-    fun `toDomain with explicit parent wires correctly`() {
-        val parentNode = sampleNode(text = "parent")
-        val childDto = sampleDto(text = "child")
-        val childNode = childDto.toDomain(parentUiNode = parentNode)
+    fun `toDomain wires every level of a nested tree`() {
+        val dto = sampleDto(
+            children = listOf(sampleDto(text = "child", children = listOf(sampleDto(text = "grandchild"))))
+        )
+        val root = dto.toDomain()
+        val child = root.children.single()
+        val grandchild = child.children.single()
 
-        assertNotNull(childNode.parent)
-        assertSame(parentNode, childNode.parent)
+        assertSame(root, child.parent)
+        assertSame(child, grandchild.parent)
     }
 }

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/model/accessibility/UiNodeImmutabilityTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/model/accessibility/UiNodeImmutabilityTest.kt
@@ -1,0 +1,95 @@
+package cloud.trotter.dashbuddy.domain.model.accessibility
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+/**
+ * #363 — the lazy hash/text caches assume a frozen tree. With children now an
+ * immutable List built at construction, hashes must be identical across
+ * (a) repeated access, (b) interleaved use of other lazy caches, and
+ * (c) independent re-parses of the same structure.
+ */
+class UiNodeImmutabilityTest {
+
+    private fun tree(): UiNode = UiNode(
+        className = "android.widget.FrameLayout",
+        children = listOf(
+            UiNode(
+                viewIdResourceName = "app:id/title",
+                className = "android.widget.TextView",
+                text = "Pickup from Wendy's",
+            ),
+            UiNode(
+                className = "android.view.View", // anonymous wrapper
+                children = listOf(
+                    UiNode(
+                        viewIdResourceName = "app:id/pay",
+                        className = "android.widget.TextView",
+                        text = "$7.50",
+                    ),
+                ),
+            ),
+        ),
+    ).restoreParents()
+
+    @Test
+    fun `hashes are stable across repeated access and other lazy caches`() {
+        val node = tree()
+        val first = Triple(node.stableHash, node.structuralHash, node.contentHash)
+        // Interleave the other lazy caches — they must not perturb anything.
+        assertEquals(listOf("Pickup from Wendy's", "$7.50"), node.allText)
+        val second = Triple(node.stableHash, node.structuralHash, node.contentHash)
+        assertEquals(first, second)
+    }
+
+    @Test
+    fun `independent constructions of the same structure hash identically`() {
+        assertEquals(tree().stableHash, tree().stableHash)
+        assertEquals(tree().structuralHash, tree().structuralHash)
+        assertEquals(tree().contentHash, tree().contentHash)
+    }
+
+    @Test
+    fun `stableHash ignores anonymous wrappers, structuralHash does not`() {
+        val withWrapper = tree()
+        val withoutWrapper = UiNode(
+            className = "android.widget.FrameLayout",
+            children = listOf(
+                withWrapper.children[0],
+                UiNode(
+                    viewIdResourceName = "app:id/pay",
+                    className = "android.widget.TextView",
+                    text = "$7.50",
+                ),
+            ),
+        ).restoreParents()
+
+        assertEquals(withWrapper.stableHash, withoutWrapper.stableHash)
+        // structuralHash IS wrapper-sensitive by design.
+        assert(withWrapper.structuralHash != withoutWrapper.structuralHash)
+    }
+
+    @Test
+    fun `restoreParents wires every level and is idempotent`() {
+        val root = tree()
+        val wrapper = root.children[1]
+        val pay = wrapper.children[0]
+        assertSame(root, wrapper.parent)
+        assertSame(wrapper, pay.parent)
+
+        root.restoreParents() // second call must be harmless
+        assertSame(root, wrapper.parent)
+        assertSame(wrapper, pay.parent)
+    }
+
+    @Test
+    fun `parent is excluded from equality so wired and unwired trees compare equal`() {
+        val wired = tree()
+        val unwired = UiNode(
+            className = "android.widget.FrameLayout",
+            children = wired.children,
+        )
+        assertEquals(wired, unwired)
+    }
+}


### PR DESCRIPTION
Fixes #363.

## Immutability

- `children: MutableList` → **`List`**, built bottom-up by both mappers; `var parent` leaves the primary constructor for a **`private set`** body property (so `equals`/`hashCode`/`copy` exclude it by construction — the custom equals already skipped it, now the shape enforces it).
- `restoreParents()` is the single wiring point: idempotent, can only wire the true containing node, returns `this` for chaining, called once at the root by `AccessibilityNodeMapper` / `UiNodeDto.toDomain` / test factories. Public mutation of the tree is gone — the lazy `allText`/hash caches can't go stale because nothing they read can change.
- `LogToUiNodeParser` (test util) kept its top-down parse via mutable *scaffolding*, materialized into the immutable tree at the end — its reflection-based `parent` writes are deleted.

## Bounded ingestion

`TreeBudget` (`MAX_TREE_DEPTH=60`, `MAX_TREE_NODES=4_000`) guards `AccessibilityNodeMapper`'s recursion — measured corpus max is depth 27 / 327 nodes, so the caps carry 2×/10× margin (a corpus-margin assertion is in the tests so cap edits confront the data). Truncation logs loudly, once per tree; deep branches are cut while shallow siblings continue. Every `getChild(i)` is a binder IPC and the tree serializes into the capture envelope — a redesigned/pathological target UI can no longer stack-overflow the accessibility service process.

## Verification

- `UiNodeImmutabilityTest` ×5 — hash stability across repeated access, lazy-cache interleaving, and independent re-parses; `stableHash` wrapper-transparency pinned; idempotent wiring; parent-excluded equality.
- `TreeBudgetTest` ×4 — the pure cap logic (the mapper itself needs live binder objects; the decision core is what's unit-testable).
- Golden corpus (AllMatchersSuite) green — **no hash drift on real snapshots** (the re-parse-stability test guards the regression class without pinning brittle constants).
- 49 UiNode consumers compile untouched except the two mappers and three test utils.

The 328-loc file split (model / search DSL / hashes / printer) is deliberately NOT done here — tracked under #237's umbrella, per the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)