### PR TITLE
chore(build): robolectric scope, JVM 21 alignment, FGS permission decision (#365)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -128,7 +128,7 @@ dependencies {
     implementation(libs.material)
     implementation(libs.play.services.location)
     implementation(libs.reorderable)
-    implementation(libs.robolectric)
+    testImplementation(libs.robolectric)
     implementation(libs.timber)
     implementation(platform(libs.androidx.compose.bom))
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,12 +9,9 @@
         <package android:name="com.walmart.spark" />
     </queries>
 
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
 
     <application
         android:name=".DashBuddyApplication"
@@ -69,10 +66,6 @@
                 android:name="android.accessibilityservice"
                 android:resource="@xml/accessibility_service_config" />
         </service>
-
-        <!--        <service-->
-        <!--            android:name=".data.location.LocationService"-->
-        <!--            android:foregroundServiceType="location" />-->
 
         <service
             android:name="cloud.trotter.dashbuddy.core.pipeline.notification.input.NotificationListener"

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -28,8 +28,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
 }
 

--- a/core/datastore/build.gradle.kts
+++ b/core/datastore/build.gradle.kts
@@ -28,8 +28,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
 }
 


### PR DESCRIPTION
Fixes #365.

| Item | Disposition |
|---|---|
| Robolectric in the APK | → `testImplementation`. Acceptance: `:app:dependencies --configuration debugRuntimeClasspath` contains **zero** robolectric entries (R8 is off, so the dep-graph check is the definitive one). |
| JVM-target drift | `:core:data` + `:core:datastore` Java 11 → **21**; `grep VERSION_11` over all build files is clean, so the CLAUDE.md "JVM 21" statement is now true. Convention plugin deliberately skipped — the issue allows the copy-paste fix, and two lines per module didn't justify new build machinery. |
| Vestigial FGS permissions | **Decision: removed** (`FOREGROUND_SERVICE`, `_SPECIAL_USE`, `_LOCATION` + the commented `LocationService` block). Rationale: the app declares no foreground service; GPS rides on accessibility-process priority; permissions claiming a nonexistent capability are pure liability (alpha posture now, Play review later — #122/#84). The alternative (commit to a real location FGS) is #163's call to make — if it lands, restoring the permission alongside an actual `foregroundServiceType="location"` service is one edit. `OdometerEffectHandler`'s `setOngoing` notification is untouched: it's informational, and making it honest *is* #163. |

Full `testDebugUnitTest` + `:domain:test` + release compile green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)