### PR TITLE
refactor(domain): typing cleanup — OfferQuality enum, typed observation payloads, honest evaluator, explicit clocks (#366)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
@@ -233,7 +233,14 @@ class SideEffectEngine @Inject constructor(
                 // the evaluation lands on the pending offer — keeps this handler thin.
                 val config = strategyRepository.evaluationConfigFlow.first()
                 val result = offerEvaluator.evaluate(effect.parsedOffer, config)
-                _events.emit(OfferEvaluationEvent(result.action, result, offerHash = effect.offerHash))
+                _events.emit(
+                    OfferEvaluationEvent(
+                        action = result.action,
+                        evaluation = result,
+                        offerHash = effect.offerHash,
+                        timestamp = System.currentTimeMillis(),
+                    )
+                )
             }
 
             is AppEffect.PostOfferNotification -> {
@@ -265,7 +272,12 @@ class SideEffectEngine @Inject constructor(
 
                     // Emit Timeout Event back to State Machine
                     _events.emit(
-                        TimeoutEvent(type = effect.type, platform = effect.platform, payload = effect.payload)
+                        TimeoutEvent(
+                            timestamp = System.currentTimeMillis(),
+                            type = effect.type,
+                            platform = effect.platform,
+                            payload = effect.payload,
+                        )
                     )
                 }
                 job.invokeOnCompletion { activeTimers.remove(effect.type, job) }
@@ -416,7 +428,13 @@ class SideEffectEngine @Inject constructor(
         val job = engineScope.launch(start = CoroutineStart.LAZY) {
             delay(durationMs)
             Timber.w("Timer Expired (rule): %s", type)
-            _events.emit(TimeoutEvent(type = type, platform = platform))
+            _events.emit(
+                TimeoutEvent(
+                    timestamp = System.currentTimeMillis(),
+                    type = type,
+                    platform = platform,
+                )
+            )
         }
         job.invokeOnCompletion { activeTimers.remove(type, job) }
         activeTimers[type] = job

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardItem.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardItem.kt
@@ -51,6 +51,7 @@ import cloud.trotter.dashbuddy.core.designsystem.theme.DashColors
 import cloud.trotter.dashbuddy.domain.model.cards.FlowCardSnapshot
 import cloud.trotter.dashbuddy.domain.state.PickupActivity
 import cloud.trotter.dashbuddy.domain.model.event.AppEventType
+import cloud.trotter.dashbuddy.ui.formatters.displayLabel
 
 /**
  * A single flow-phase card in the bubble HUD stack (#257).
@@ -371,11 +372,8 @@ private fun OfferBody(snap: FlowCardSnapshot.Offer, isActive: Boolean) {
                             fontWeight = FontWeight.ExtraBold,
                             color = vColor,
                         )
-                        snap.recommendationText?.let {
-                            Text(it, style = MaterialTheme.typography.bodySmall, color = c.text2, maxLines = 2)
-                        }
                     }
-                    snap.qualityLevel?.let { DashChip(it, color = c.text3, container = c.surface3) }
+                    snap.qualityLevel?.let { DashChip(it.displayLabel(), color = c.text3, container = c.surface3) }
                 }
             }
         }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardMapper.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardMapper.kt
@@ -97,7 +97,6 @@ object FlowCardMapper {
                             dollarsPerMile = payload.evaluation?.dollarsPerMile,
                             dollarsPerHour = payload.evaluation?.dollarsPerHour,
                             qualityLevel = payload.evaluation?.qualityLevel,
-                            recommendationText = payload.evaluation?.recommendationText,
                             badges = (payload.parsedOffer.badges.map { it.name } +
                                 payload.parsedOffer.orders.flatMap { it.badges }.map { it.name }).distinct(),
                             outcome = payload.outcome,

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/LiveCardBuilder.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/LiveCardBuilder.kt
@@ -52,7 +52,6 @@ object LiveCardBuilder {
                     dollarsPerMile = pending.evaluation?.dollarsPerMile,
                     dollarsPerHour = pending.evaluation?.dollarsPerHour,
                     qualityLevel = pending.evaluation?.qualityLevel,
-                    recommendationText = pending.evaluation?.recommendationText,
                     badges = (offer.badges.map { it.name } +
                         offer.orders.flatMap { it.badges }.map { it.name }).distinct(),
                     expiresAt = offer.initialCountdownSeconds?.let { pending.presentedAt + it * 1000L },

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/formatters/OfferFormatters.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/formatters/OfferFormatters.kt
@@ -11,6 +11,7 @@ import cloud.trotter.dashbuddy.core.designsystem.theme.darkDashColors
 import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
 import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
 import cloud.trotter.dashbuddy.core.designsystem.format.DashFormats
+import cloud.trotter.dashbuddy.domain.evaluation.OfferQuality
 
 /**
  * Formatted offer summary for the heads-up notification. Built with **Android** text spans — the
@@ -62,4 +63,25 @@ fun OfferEvaluation.toNotificationSummary(): CharSequence {
                 merchantName,
         )
     }
+}
+
+
+/** UI label for a typed [OfferQuality] (#366) — display copy stays out of :domain. */
+fun OfferQuality.displayLabel(): String = when (this) {
+    OfferQuality.AWESOME -> "AWESOME OFFER"
+    OfferQuality.GREAT -> "GREAT OFFER"
+    OfferQuality.GOOD -> "GOOD OFFER"
+    OfferQuality.DECENT -> "DECENT OFFER"
+    OfferQuality.BAD -> "BAD OFFER"
+    OfferQuality.PROTECTED -> "Protected!"
+    OfferQuality.BLOCKED -> "Blocked"
+    OfferQuality.UNKNOWN -> "No verdict"
+}
+
+/** UI recommendation line derived from the typed [OfferAction] (#366). */
+fun OfferAction.recommendationLabel(): String = when (this) {
+    OfferAction.ACCEPT -> "Recommended: ACCEPT"
+    OfferAction.DECLINE -> "Recommended: DECLINE"
+    OfferAction.MANUAL_REVIEW -> "Recommended: REVIEW"
+    else -> "Recommended: DECIDE"
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/components/FakeOfferCard.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/components/FakeOfferCard.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.unit.dp
 import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
 import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
 import java.util.Locale
+import cloud.trotter.dashbuddy.ui.formatters.recommendationLabel
 
 @Composable
 fun FakeOfferCard(
@@ -71,7 +72,7 @@ fun FakeOfferCard(
             ) {
                 // --- Recommendation + Score ---
                 Text(
-                    text = "${evaluation.recommendationText}  ·  ${evaluation.score.toInt()}pts",
+                    text = "${evaluation.action.recommendationLabel()}  ·  ${evaluation.score.toInt()}pts",
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.Bold,
                     color = borderColor

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/WizardViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/WizardViewModel.kt
@@ -292,7 +292,7 @@ class WizardViewModel @Inject constructor(
             emptyList(); availableTrimNames.value = emptyList()
 
         // Skip API call if Not Listed
-        if (make != "Not Listed") {
+        if (make != VEHICLE_NOT_LISTED) {
             viewModelScope.launch {
                 _availableModels.value =
                     listOf(VEHICLE_NOT_LISTED) + vehicleRepository.getModels(_state.value.vehicleYear, make)
@@ -305,12 +305,14 @@ class WizardViewModel @Inject constructor(
         _availableTrims.value = emptyList(); availableTrimNames.value = emptyList()
 
         // Skip API call if Not Listed
-        if (model != "Not Listed") {
+        if (model != VEHICLE_NOT_LISTED) {
             viewModelScope.launch {
-                val trims = vehicleRepository.getVehicleOptions(
+                val trims = listOf(
+                    VehicleOption(id = "NOT_LISTED", displayName = VEHICLE_NOT_LISTED),
+                ) + vehicleRepository.getVehicleOptions(
                     _state.value.vehicleYear,
                     _state.value.vehicleMake,
-                    model
+                    model,
                 )
                 _availableTrims.value = trims; availableTrimNames.value =
                 trims.map { it.displayName }
@@ -322,7 +324,7 @@ class WizardViewModel @Inject constructor(
         _state.update { it.copy(vehicleTrim = trimName) }
 
         // Escape hatch! Don't look up MPG if Not Listed.
-        if (trimName == "Not Listed") return
+        if (trimName == VEHICLE_NOT_LISTED) return
 
         viewModelScope.launch {
             val vehicleId =

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
@@ -28,6 +28,8 @@ import cloud.trotter.dashbuddy.domain.state.TaskSubFlow
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import cloud.trotter.dashbuddy.domain.pipeline.ObservationPayload
+import cloud.trotter.dashbuddy.domain.evaluation.OfferQuality
 
 /**
  * Tests for [EffectMap.diff] — verifies correct effects are emitted
@@ -121,8 +123,7 @@ class EffectMapTest {
     private val testEvaluation = OfferEvaluation(
         action = OfferAction.ACCEPT,
         score = 74.0,
-        qualityLevel = "Good",
-        recommendationText = "Take it",
+        qualityLevel = OfferQuality.GOOD,
         payAmount = 7.50,
         fuelCostEstimate = 0.50,
         netPayAmount = 7.00,
@@ -806,9 +807,10 @@ class EffectMapTest {
         assertEquals(1, scheduled.size)
         assertEquals(cloud.trotter.dashbuddy.domain.pipeline.TimeoutType.SETTLE_UI, scheduled[0].type)
         assertEquals(500L, scheduled[0].durationMs)
-        // Payload should carry the click context
-        assertEquals("com.example:id/btn", scheduled[0].payload["target.viewIdSuffix"])
-        assertEquals("test.rule", scheduled[0].payload["ruleId"])
+        // Payload should carry the typed click context (#366)
+        val click = scheduled[0].payload as ObservationPayload.DeferredClick
+        assertEquals("com.example:id/btn", click.target?.viewIdSuffix)
+        assertEquals("test.rule", click.ruleId)
         // And NOT emit a RequestEffect for the click directly
         assertTrue(
             "Click should be deferred, not dispatched directly",
@@ -818,16 +820,16 @@ class EffectMapTest {
 
     @Test
     fun `SETTLE_UI timeout re-emits the click as immediate RequestEffect`() {
-        val payload = mapOf<String, Any?>(
-            "verb" to "CLICK",
-            "ruleId" to "test.rule",
-            "target.viewIdSuffix" to "com.example:id/btn",
-            "target.classNameHint" to "android.widget.Button",
-            "target.pathFingerprint" to "fp",
-            "target.bounds.left" to 0,
-            "target.bounds.top" to 0,
-            "target.bounds.right" to 100,
-            "target.bounds.bottom" to 50,
+        val payload = ObservationPayload.DeferredClick(
+            verb = "CLICK",
+            ruleId = "test.rule",
+            target = cloud.trotter.dashbuddy.domain.pipeline.NodeRef(
+                viewIdSuffix = "com.example:id/btn",
+                text = null,
+                classNameHint = "android.widget.Button",
+                boundsInScreen = cloud.trotter.dashbuddy.domain.model.accessibility.BoundingBox(0, 0, 100, 50),
+                pathFingerprint = "fp",
+            ),
         )
         val timeoutObs = Observation.Timeout(
             timestamp = 1000L,

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardMapperTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardMapperTest.kt
@@ -23,6 +23,7 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import cloud.trotter.dashbuddy.domain.evaluation.OfferQuality
 
 class FlowCardMapperTest {
 
@@ -54,8 +55,7 @@ class FlowCardMapperTest {
     private fun evaluation(score: Double = 80.0) = OfferEvaluation(
         action = OfferAction.ACCEPT,
         score = score,
-        qualityLevel = "Good",
-        recommendationText = "Recommended: ACCEPT",
+        qualityLevel = OfferQuality.GOOD,
         payAmount = 7.50,
         fuelCostEstimate = 0.5,
         nonFuelCostEstimate = 0.5,

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/vehicle/VehicleRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/vehicle/VehicleRepository.kt
@@ -10,24 +10,24 @@ import javax.inject.Singleton
 class VehicleRepository @Inject constructor(
     private val dataSource: VehicleEfficiencyDataSource
 ) {
-    suspend fun getYears(): List<String> = dataSource.getYears()
+    // Result unwrapped at this boundary (#366) — the UI sees the same
+    // empty-on-failure shape as before; failures were logged at the source.
+    suspend fun getYears(): List<String> = dataSource.getYears().getOrElse { emptyList() }
 
     // The "Not Listed" sentinel is a UI concern — the wizard layer prepends
     // it (#364); data results stay pure EPA values.
-    suspend fun getMakes(year: String): List<String> = dataSource.getMakes(year)
+    suspend fun getMakes(year: String): List<String> =
+        dataSource.getMakes(year).getOrElse { emptyList() }
 
     suspend fun getModels(year: String, make: String): List<String> =
-        dataSource.getModels(year, make)
+        dataSource.getModels(year, make).getOrElse { emptyList() }
 
-    suspend fun getVehicleOptions(year: String, make: String, model: String): List<VehicleOption> {
-        val list = dataSource.getVehicleOptions(year, make, model).toMutableList()
-        list.add(0, VehicleOption(id = "NOT_LISTED", displayName = "Not Listed"))
-        return list
-    }
+    suspend fun getVehicleOptions(year: String, make: String, model: String): List<VehicleOption> =
+        dataSource.getVehicleOptions(year, make, model).getOrElse { emptyList() }
 
     suspend fun getVehicleDetails(vehicleId: String): VehicleDetails? =
-        dataSource.getVehicleDetails(vehicleId)
+        dataSource.getVehicleDetails(vehicleId).getOrNull()
 
     suspend fun getCombinedMpg(vehicleId: String): Float? =
-        dataSource.getVehicleDetails(vehicleId)?.combinedMpg
+        dataSource.getVehicleDetails(vehicleId).getOrNull()?.combinedMpg
 }

--- a/core/network/src/main/java/cloud/trotter/dashbuddy/core/network/vehicle/efficiency/epa/EpaVehicleDataSource.kt
+++ b/core/network/src/main/java/cloud/trotter/dashbuddy/core/network/vehicle/efficiency/epa/EpaVehicleDataSource.kt
@@ -19,40 +19,28 @@ class EpaVehicleDataSource @Inject constructor(
     private val api: EpaApi
 ) : VehicleEfficiencyDataSource {
 
-    override suspend fun getYears(): List<String> = try {
+    override suspend fun getYears(): Result<List<String>> = runCatching {
         api.getYears().menuItem.map { it.text }.sortedDescending()
-    } catch (e: Exception) {
-        Timber.e(e, "Failed to fetch vehicle years")
-        emptyList()
-    }
+    }.onFailure { Timber.e(it, "Failed to fetch vehicle years") }
 
-    override suspend fun getMakes(year: String): List<String> = try {
+    override suspend fun getMakes(year: String): Result<List<String>> = runCatching {
         api.getMakes(year = year).menuItem.map { it.text }.sorted()
-    } catch (e: Exception) {
-        Timber.e(e, "Failed to fetch vehicle makes for year: $year")
-        emptyList()
-    }
+    }.onFailure { Timber.e(it, "Failed to fetch vehicle makes for year: $year") }
 
-    override suspend fun getModels(year: String, make: String): List<String> = try {
+    override suspend fun getModels(year: String, make: String): Result<List<String>> = runCatching {
         api.getModels(year = year, make = make).menuItem.map { it.text }.sorted()
-    } catch (e: Exception) {
-        Timber.e(e, "Failed to fetch vehicle models for $year $make")
-        emptyList()
-    }
+    }.onFailure { Timber.e(it, "Failed to fetch vehicle models for $year $make") }
 
     override suspend fun getVehicleOptions(
         year: String,
         make: String,
         model: String
-    ): List<VehicleOption> = try {
+    ): Result<List<VehicleOption>> = runCatching {
         api.getVehicleOptions(year = year, make = make, model = model).menuItem
             .map { VehicleOption(id = it.value, displayName = it.text) }
-    } catch (e: Exception) {
-        Timber.e(e, "Failed to fetch vehicle options for $year $make $model")
-        emptyList()
-    }
+    }.onFailure { Timber.e(it, "Failed to fetch vehicle options for $year $make $model") }
 
-    override suspend fun getVehicleDetails(vehicleId: String): VehicleDetails? = try {
+    override suspend fun getVehicleDetails(vehicleId: String): Result<VehicleDetails> = runCatching {
         val response = api.getVehicleDetails(vehicleId = vehicleId)
         val fuel = mapFuelType(response.fuelType1)
         // EVs are detected via fuel type; otherwise infer class from EPA VClass.
@@ -66,10 +54,7 @@ class EpaVehicleDataSource @Inject constructor(
             fuelType = fuel,
             vehicleClass = vClass,
         )
-    } catch (e: Exception) {
-        Timber.e(e, "Failed to fetch vehicle details for ID $vehicleId")
-        null
-    }
+    }.onFailure { Timber.e(it, "Failed to fetch vehicle details for ID $vehicleId") }
 
     private fun mapFuelType(epaString: String?): FuelType {
         if (epaString == null) return FuelType.REGULAR

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/FrameGate.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/FrameGate.kt
@@ -34,8 +34,11 @@ internal class FrameGate(
      *   forwarded onward).
      */
     fun admit(obs: Observation, contentHash: Int?): Boolean {
+        // Null identity = never dedup (#366: clicks). It still CLEARS
+        // lastIdentity below, preserving the old behavior where a click's
+        // unique hash reset screen dedup (same screen re-forwards after it).
         val identity = obs.identity()
-        if (identity == lastIdentity) return false
+        if (identity != null && identity == lastIdentity) return false
 
         val target = (obs as? Observation.FlowObservation)?.target
         if (target != "UNKNOWN") {

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/AppEffect.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/AppEffect.kt
@@ -9,6 +9,7 @@ import cloud.trotter.dashbuddy.domain.model.event.AppEvent
 import cloud.trotter.dashbuddy.domain.model.offer.ParsedOffer
 import cloud.trotter.dashbuddy.domain.pipeline.TimeoutType
 import cloud.trotter.dashbuddy.domain.pipeline.RequestedEffect
+import cloud.trotter.dashbuddy.domain.pipeline.ObservationPayload
 
 sealed class AppEffect {
 
@@ -62,11 +63,11 @@ sealed class AppEffect {
          */
         val platform: Platform? = null,
         /**
-         * Opaque payload carried through the timer back into [Observation.Timeout].
-         * Used to thread effect context (e.g. click target NodeRef fields) through
-         * the UDF round-trip when the firing of a downstream effect must be deferred.
+         * Typed payload carried through the timer back into [Observation.Timeout]
+         * (#366) — e.g. the deferred-click context when a downstream effect's
+         * firing must wait for the UI to settle.
          */
-        val payload: Map<String, Any?> = emptyMap(),
+        val payload: ObservationPayload? = null,
     ) : AppEffect()
     data class CancelTimeout(val type: TimeoutType) : AppEffect()
 

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -11,10 +11,9 @@ import cloud.trotter.dashbuddy.domain.model.event.payload.OfferReceivedPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.PickupPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionPausedPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStartPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStartSource
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStopPayload
-import cloud.trotter.dashbuddy.domain.model.accessibility.BoundingBox
 import cloud.trotter.dashbuddy.domain.pipeline.EffectVerb
-import cloud.trotter.dashbuddy.domain.pipeline.NodeRef
 import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
 import cloud.trotter.dashbuddy.domain.state.OfferIntent
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
@@ -38,6 +37,7 @@ import cloud.trotter.dashbuddy.domain.state.TaskSubFlow
 import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
+import cloud.trotter.dashbuddy.domain.pipeline.ObservationPayload
 
 /**
  * Replaces 9 reducers + 8 factories. Diffs each region before/after
@@ -331,7 +331,11 @@ class EffectMap @Inject constructor() {
                             sessionId = nextSession.sessionId,
                             platform = next.platform.name,
                             startedAt = nextSession.startedAt,
-                            source = if (next.lastTransitionKind == TransitionKind.Unexpected) "recovery" else "interaction",
+                            source = if (next.lastTransitionKind == TransitionKind.Unexpected) {
+                                SessionStartSource.RECOVERY
+                            } else {
+                                SessionStartSource.INTERACTION
+                            },
                             startScreen = "WaitingForOffer",
                         )
                         add(logEffect(nextSession.sessionId, AppEventType.DASH_START, obs.timestamp, payload))
@@ -688,7 +692,7 @@ class EffectMap @Inject constructor() {
                         durationMs = effect.delayMs!!,
                         type = TimeoutType.SETTLE_UI,
                         platform = flowObs.platform.takeIf { it != Platform.Unknown },
-                        payload = serializeClickContext(effect),
+                        payload = deferredClickPayload(effect),
                     )
                 } else {
                     AppEffect.RequestEffect(effect)
@@ -703,63 +707,32 @@ class EffectMap @Inject constructor() {
     private fun diffSettleUiTimeout(obs: Observation): List<AppEffect> {
         val timeout = obs as? Observation.Timeout ?: return emptyList()
         if (timeout.type != TimeoutType.SETTLE_UI) return emptyList()
-        val verb = (timeout.payload["verb"] as? String)
-            ?.let { runCatching { EffectVerb.valueOf(it) }.getOrNull() }
-            ?: return emptyList()
+        // Typed payload (#366) — the old per-key Map round-trip is gone.
+        val click = timeout.payload as? ObservationPayload.DeferredClick ?: return emptyList()
+        val verb = runCatching { EffectVerb.valueOf(click.verb) }.getOrNull() ?: return emptyList()
         if (verb != EffectVerb.CLICK) return emptyList()
-        val ruleId = timeout.payload["ruleId"] as? String ?: return emptyList()
-        val targetRef = deserializeNodeRef(timeout.payload) ?: return emptyList()
+        val targetRef = click.target ?: return emptyList()
         val effect = RequestedEffect(
             verb = verb,
             args = emptyMap(),
             targetRef = targetRef,
             onlyIf = null,
-            dedupeKey = timeout.payload["dedupeKey"] as? String,
-            throttleMs = (timeout.payload["throttleMs"] as? Number)?.toLong(),
+            dedupeKey = click.dedupeKey,
+            throttleMs = click.throttleMs,
             delayMs = null,  // immediate fire this time
-            ruleId = ruleId,
+            ruleId = click.ruleId,
         )
         return listOf(AppEffect.RequestEffect(effect))
     }
 
-    private fun serializeClickContext(effect: RequestedEffect): Map<String, Any?> {
-        val ref = effect.targetRef
-        val map = mutableMapOf<String, Any?>(
-            "verb" to effect.verb.name,
-            "ruleId" to effect.ruleId,
+    private fun deferredClickPayload(effect: RequestedEffect): ObservationPayload.DeferredClick =
+        ObservationPayload.DeferredClick(
+            verb = effect.verb.name,
+            ruleId = effect.ruleId,
+            dedupeKey = effect.dedupeKey,
+            throttleMs = effect.throttleMs,
+            target = effect.targetRef,
         )
-        if (effect.dedupeKey != null) map["dedupeKey"] = effect.dedupeKey
-        if (effect.throttleMs != null) map["throttleMs"] = effect.throttleMs
-        if (ref != null) {
-            map["target.viewIdSuffix"] = ref.viewIdSuffix
-            map["target.text"] = ref.text
-            map["target.classNameHint"] = ref.classNameHint
-            map["target.pathFingerprint"] = ref.pathFingerprint
-            map["target.bounds.left"] = ref.boundsInScreen.left
-            map["target.bounds.top"] = ref.boundsInScreen.top
-            map["target.bounds.right"] = ref.boundsInScreen.right
-            map["target.bounds.bottom"] = ref.boundsInScreen.bottom
-        }
-        return map
-    }
-
-    private fun deserializeNodeRef(payload: Map<String, Any?>): NodeRef? {
-        val pathFingerprint = payload["target.pathFingerprint"] as? String ?: return null
-        val viewIdSuffix = payload["target.viewIdSuffix"] as? String
-        val text = payload["target.text"] as? String
-        val classNameHint = payload["target.classNameHint"] as? String
-        val left = (payload["target.bounds.left"] as? Number)?.toInt() ?: 0
-        val top = (payload["target.bounds.top"] as? Number)?.toInt() ?: 0
-        val right = (payload["target.bounds.right"] as? Number)?.toInt() ?: 0
-        val bottom = (payload["target.bounds.bottom"] as? Number)?.toInt() ?: 0
-        return NodeRef(
-            viewIdSuffix = viewIdSuffix,
-            text = text,
-            classNameHint = classNameHint,
-            boundsInScreen = BoundingBox(left, top, right, bottom),
-            pathFingerprint = pathFingerprint,
-        )
-    }
 
     private fun evaluateGate(gate: ParsedFieldsGate?, parsed: ParsedFields): Boolean {
         if (gate == null) return true

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/FlowRegionStepper.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/FlowRegionStepper.kt
@@ -8,6 +8,7 @@ import cloud.trotter.dashbuddy.domain.state.ParsedFields
 import cloud.trotter.dashbuddy.domain.state.PendingOffer
 import javax.inject.Inject
 import javax.inject.Singleton
+import cloud.trotter.dashbuddy.domain.pipeline.ObservationPayload
 
 /**
  * Region 0 stepper — ground-truth screen interpretation.
@@ -130,13 +131,14 @@ class FlowRegionStepper @Inject constructor() {
         val offer = prev.pendingOffer ?: return prev
         if (obs.effect != "offer_evaluated") return prev
 
-        val evaluation = obs.payload["evaluation"] as? OfferEvaluation
+        val result = obs.payload as? ObservationPayload.EvaluationResult
+        val evaluation = result?.evaluation
             ?: return prev.copy(lastObservedAt = obs.timestamp)
 
         // Correlate by hash: an evaluation computed for a since-replaced offer must not
         // land on the current one (the notification/TTS would speak the wrong economics,
         // #345). A null hash (legacy replayed stubs) is accepted as-before.
-        val evalHash = obs.payload["offerHash"] as? String
+        val evalHash = result.offerHash
         if (evalHash != null && evalHash != offer.offerHash) {
             return prev.copy(lastObservedAt = obs.timestamp)
         }

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/ObservationJournal.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/ObservationJournal.kt
@@ -3,7 +3,7 @@ package cloud.trotter.dashbuddy.core.state
 import cloud.trotter.dashbuddy.core.database.observation.ObservationDao
 import cloud.trotter.dashbuddy.core.database.observation.ObservationEntity
 import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
-import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
+import cloud.trotter.dashbuddy.domain.pipeline.ObservationPayload
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
 import cloud.trotter.dashbuddy.domain.pipeline.TimeoutType
 import cloud.trotter.dashbuddy.domain.state.AppState
@@ -23,18 +23,16 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * Typed projection of the non-flow observations' payloads (#352). FlowObservations
- * persist their ParsedFields; Timeout/UiInput/Loopback used to replay as STUBS —
- * notably the `offer_evaluated` loopback, so replayed state never carried its
- * evaluations. Map-payload entries beyond these fields are #366's typed-payload work.
+ * Persisted projection of the non-flow observations (#352, folded by #366):
+ * the payload itself is now the TYPED sealed [ObservationPayload], serialized
+ * polymorphically — no per-key map rebuilding on replay.
  */
 @Serializable
 internal data class InternalObsPayload(
     val action: String? = null,
     val effect: String? = null,
-    val offerHash: String? = null,
-    val evaluation: OfferEvaluation? = null,
     val targetPlatform: String? = null,
+    val payload: ObservationPayload? = null,
 )
 
 /**
@@ -105,17 +103,14 @@ class ObservationJournal @Inject constructor(
     }
 
     private fun internalPayloadOf(obs: Observation): InternalObsPayload? = when (obs) {
-        is Observation.Timeout -> obs.targetPlatform?.let {
-            InternalObsPayload(targetPlatform = it.wire)
-        }
+        is Observation.Timeout ->
+            if (obs.targetPlatform != null || obs.payload != null) {
+                InternalObsPayload(targetPlatform = obs.targetPlatform?.wire, payload = obs.payload)
+            } else null
         // Persisting the REAL action is safe: PerformOfferAction is classified
         // external (#341), so recovery can never replay an offer click from it.
         is Observation.UiInput -> InternalObsPayload(action = obs.action)
-        is Observation.Loopback -> InternalObsPayload(
-            effect = obs.effect,
-            offerHash = obs.payload["offerHash"] as? String,
-            evaluation = obs.payload["evaluation"] as? OfferEvaluation,
-        )
+        is Observation.Loopback -> InternalObsPayload(effect = obs.effect, payload = obs.payload)
         else -> null
     }
 
@@ -169,6 +164,7 @@ class ObservationJournal @Inject constructor(
                     runCatching { enumValueOf<TimeoutType>(it) }.getOrNull()
                 } ?: TimeoutType.SETTLE_UI,
                 targetPlatform = payload?.targetPlatform?.let(Platform::fromWire),
+                payload = payload?.payload,
             )
 
             "internal.ui" -> Observation.UiInput(
@@ -179,15 +175,9 @@ class ObservationJournal @Inject constructor(
             "internal.loopback" -> Observation.Loopback(
                 timestamp = occurredAt,
                 effect = payload?.effect ?: "replay",
-                // Rebuild the exact keys FlowRegionStepper.handleLoopback reads, so
-                // a replayed offer_evaluated LANDS its evaluation (#352).
-                payload = buildMap {
-                    payload?.offerHash?.let { put("offerHash", it) }
-                    payload?.evaluation?.let {
-                        put("evaluation", it)
-                        put("action", it.action.name)
-                    }
-                },
+                // Typed payload round-trips losslessly (#366) — a replayed
+                // offer_evaluated lands its evaluation with no key rebuilding.
+                payload = payload?.payload,
             )
 
             else -> Observation.Loopback(

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/StateManagerV2.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/StateManagerV2.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
+import cloud.trotter.dashbuddy.domain.pipeline.ObservationPayload
 
 @Singleton
 class StateManagerV2 @Inject constructor(
@@ -173,12 +174,12 @@ class StateManagerV2 @Inject constructor(
             )
 
             is OfferEvaluationEvent -> Observation.Loopback(
-                timestamp = System.currentTimeMillis(),
+                timestamp = event.timestamp,
                 effect = "offer_evaluated",
-                payload = mapOf(
-                    "action" to event.action.name,
-                    "evaluation" to event.evaluation,
-                    "offerHash" to event.offerHash,
+                payload = ObservationPayload.EvaluationResult(
+                    action = event.action.name,
+                    offerHash = event.offerHash,
+                    evaluation = event.evaluation,
                 ),
             )
 

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapPayloadTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapPayloadTest.kt
@@ -36,6 +36,7 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import cloud.trotter.dashbuddy.domain.evaluation.OfferQuality
 
 /**
  * Verifies that EffectMap.diff() emits rich JSON payloads at every
@@ -88,8 +89,7 @@ class EffectMapPayloadTest {
     private fun evaluation(score: Double = 75.0, netPay: Double = 6.50) = OfferEvaluation(
         action = OfferAction.ACCEPT,
         score = score,
-        qualityLevel = "Good",
-        recommendationText = "Recommended: ACCEPT",
+        qualityLevel = OfferQuality.GOOD,
         payAmount = 7.50,
         fuelCostEstimate = 0.5,
         nonFuelCostEstimate = 0.5,

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/EvalDiffCorrectnessTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/EvalDiffCorrectnessTest.kt
@@ -31,6 +31,8 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import cloud.trotter.dashbuddy.domain.evaluation.OfferQuality
+import cloud.trotter.dashbuddy.domain.pipeline.ObservationPayload
 
 /**
  * #345 — eval/diff correctness pack:
@@ -66,8 +68,7 @@ class EvalDiffCorrectnessTest {
     private fun evaluation() = OfferEvaluation(
         action = OfferAction.ACCEPT,
         score = 75.0,
-        qualityLevel = "Good",
-        recommendationText = "Recommended: ACCEPT",
+        qualityLevel = OfferQuality.GOOD,
         payAmount = 7.50,
         fuelCostEstimate = 0.5,
         netPayAmount = 6.50,
@@ -82,10 +83,10 @@ class EvalDiffCorrectnessTest {
     private fun loopback(evalForHash: String?) = Observation.Loopback(
         timestamp = 2_000L,
         effect = "offer_evaluated",
-        payload = mapOf(
-            "action" to OfferAction.ACCEPT.name,
-            "evaluation" to evaluation(),
-            "offerHash" to evalForHash,
+        payload = ObservationPayload.EvaluationResult(
+            action = OfferAction.ACCEPT.name,
+            offerHash = evalForHash,
+            evaluation = evaluation(),
         ),
     )
 

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/JobEconomicsTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/JobEconomicsTest.kt
@@ -20,6 +20,7 @@ import cloud.trotter.dashbuddy.domain.state.TaskSubFlow
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
+import cloud.trotter.dashbuddy.domain.evaluation.OfferQuality
 
 /**
  * Accepted-offer economics on the [Job] (issue #317). A first accept seeds the job's
@@ -45,8 +46,7 @@ class JobEconomicsTest {
     private fun eval(net: Double, est: Double, dist: Double, pay: Double) = OfferEvaluation(
         action = OfferAction.ACCEPT,
         score = 75.0,
-        qualityLevel = "Good",
-        recommendationText = "Accept",
+        qualityLevel = OfferQuality.GOOD,
         payAmount = pay,
         fuelCostEstimate = 0.0,
         netPayAmount = net,

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/ObservationJournalTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/ObservationJournalTest.kt
@@ -26,6 +26,8 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import cloud.trotter.dashbuddy.domain.evaluation.OfferQuality
+import cloud.trotter.dashbuddy.domain.pipeline.ObservationPayload
 
 /**
  * #352 — the observation journal's fidelity guarantees:
@@ -67,8 +69,7 @@ class ObservationJournalTest {
     private fun state(cv: Long) = AppState(timestamp = cv, correlationVersion = cv)
 
     private fun evaluation() = OfferEvaluation(
-        action = OfferAction.ACCEPT, score = 74.0, qualityLevel = "Good",
-        recommendationText = "Recommended: ACCEPT", payAmount = 7.50,
+        action = OfferAction.ACCEPT, score = 74.0, qualityLevel = OfferQuality.GOOD, payAmount = 7.50,
         fuelCostEstimate = 0.5, netPayAmount = 6.50, distanceMiles = 3.2,
         dollarsPerMile = 2.03, dollarsPerHour = 22.0, estimatedTimeMinutes = 18.0,
         itemCount = 3.0, merchantName = "HEB",
@@ -95,10 +96,10 @@ class ObservationJournalTest {
         val loopback = Observation.Loopback(
             timestamp = 2_000L,
             effect = "offer_evaluated",
-            payload = mapOf(
-                "action" to eval.action.name,
-                "evaluation" to eval,
-                "offerHash" to "offer-A",
+            payload = ObservationPayload.EvaluationResult(
+                action = eval.action.name,
+                offerHash = "offer-A",
+                evaluation = eval,
             ),
         )
 
@@ -107,8 +108,9 @@ class ObservationJournalTest {
         val replayed = journal.tailAfter(0).single() as Observation.Loopback
 
         assertEquals("offer_evaluated", replayed.effect)
-        assertEquals("offer-A", replayed.payload["offerHash"])
-        assertEquals(eval, replayed.payload["evaluation"])
+        val result = replayed.payload as ObservationPayload.EvaluationResult
+        assertEquals("offer-A", result.offerHash)
+        assertEquals(eval, result.evaluation)
 
         // And the replayed loopback LANDS on a pending offer — the fidelity gap
         // this issue exists for.

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/SerializationRoundTripTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/SerializationRoundTripTest.kt
@@ -29,6 +29,7 @@ import kotlinx.serialization.encodeToString
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import cloud.trotter.dashbuddy.domain.evaluation.OfferQuality
 
 /**
  * #353 — the Gson→kotlinx.serialization migration's safety net.
@@ -114,8 +115,7 @@ class SerializationRoundTripTest {
     @Test
     fun `a fully-populated AppState snapshot round-trips losslessly`() {
         val evaluation = OfferEvaluation(
-            action = OfferAction.ACCEPT, score = 74.0, qualityLevel = "Good",
-            recommendationText = "Recommended: ACCEPT", payAmount = 7.50,
+            action = OfferAction.ACCEPT, score = 74.0, qualityLevel = OfferQuality.GOOD, payAmount = 7.50,
             fuelCostEstimate = 0.5, netPayAmount = 6.50, distanceMiles = 3.2,
             dollarsPerMile = 2.03, dollarsPerHour = 22.0, estimatedTimeMinutes = 18.0,
             itemCount = 3.0, merchantName = "HEB", warnings = listOf("target high"),

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/capture/ReplayMetadataProvider.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/capture/ReplayMetadataProvider.kt
@@ -2,7 +2,7 @@ package cloud.trotter.dashbuddy.domain.capture
 
 /**
  * Provides live [ReplayMetadata] for the current engine/ruleset/pipeline state.
- * Interface in `:domain`, implementation in `:app` (needs Android context + BuildConfig).
+ * Interface in `:domain`; the implementation lives in `:core:pipeline` with the capture flow.
  */
 interface ReplayMetadataProvider {
     fun current(): ReplayMetadata

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/config/OfferAutomationConfig.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/config/OfferAutomationConfig.kt
@@ -2,7 +2,7 @@ package cloud.trotter.dashbuddy.domain.config
 
 /**
  * Rules for the "Offer Robot".
- * Used by DefaultEffectHandler/Reducer to decide instant actions.
+ * Read by the side-effect engine's evaluation loopback to decide instant actions.
  */
 data class OfferAutomationConfig(
     val masterAutoPilotEnabled: Boolean = false,

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/OfferEvaluation.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/OfferEvaluation.kt
@@ -7,8 +7,7 @@ import kotlinx.serialization.Serializable
 data class OfferEvaluation(
     val action: OfferAction,
     val score: Double,
-    val qualityLevel: String,
-    val recommendationText: String,
+    val qualityLevel: OfferQuality,
     /** Gross pay as shown on the offer screen. */
     val payAmount: Double,
     /** Estimated fuel cost for this offer's route. Zero for non-fuel vehicle classes. */

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/OfferEvaluator.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/OfferEvaluator.kt
@@ -38,8 +38,7 @@ class OfferEvaluator() {
             return OfferEvaluation(
                 action = OfferAction.ACCEPT,
                 score = 100.0,
-                qualityLevel = "Protected!",
-                recommendationText = "Protected: Accept!",
+                qualityLevel = OfferQuality.PROTECTED,
                 payAmount = grossPay,
                 fuelCostEstimate = fuelCost,
                 nonFuelCostEstimate = nonFuelCost,
@@ -57,22 +56,28 @@ class OfferEvaluator() {
         }
 
         // --- 3. Filter Active Rules ---
+        // No rules enabled is NOT a parse error (#366): parsing succeeded, so
+        // return the REAL economics with an explicit no-verdict quality —
+        // the old branch zeroed everything and claimed "Error Parsing Offer".
         val activeRules = config.rules.filter { it.isEnabled }
         if (activeRules.isEmpty()) {
             return OfferEvaluation(
                 action = OfferAction.NOTHING,
                 score = 0.0,
-                qualityLevel = "UNKNOWN",
-                recommendationText = "Error Parsing Offer",
-                payAmount = 0.0,
-                fuelCostEstimate = 0.0,
-                netPayAmount = 0.0,
-                distanceMiles = 0.0,
-                dollarsPerMile = 0.0,
-                dollarsPerHour = 0.0,
-                estimatedTimeMinutes = 0.0,
-                itemCount = 0.0,
-                merchantName = "UNKNOWN"
+                qualityLevel = OfferQuality.UNKNOWN,
+                payAmount = grossPay,
+                fuelCostEstimate = fuelCost,
+                nonFuelCostEstimate = nonFuelCost,
+                totalOperatingCost = operatingCost,
+                operatingCostPerMile = economy.operatingCostPerMile,
+                netPayAmount = netPay,
+                distanceMiles = dist,
+                dollarsPerMile = dpm,
+                dollarsPerHour = activeHourly,
+                estimatedTimeMinutes = estTimeMinutes,
+                itemCount = items,
+                merchantName = merchants,
+                isUsingDefaults = economy.isUsingDefaults,
             )
         }
 
@@ -89,8 +94,7 @@ class OfferEvaluator() {
             return OfferEvaluation(
                 action = OfferAction.DECLINE,
                 score = 0.0,
-                qualityLevel = "Blocked",
-                recommendationText = "Recommended: DECLINE",
+                qualityLevel = OfferQuality.BLOCKED,
                 payAmount = grossPay,
                 fuelCostEstimate = fuelCost,
                 nonFuelCostEstimate = nonFuelCost,
@@ -143,16 +147,9 @@ class OfferEvaluator() {
         // --- 7. Decision ---
         val action = when {
             requiresManualReview -> OfferAction.MANUAL_REVIEW
-            finalScore >= 70 -> OfferAction.ACCEPT
-            finalScore <= 30 -> OfferAction.DECLINE
+            finalScore >= ACCEPT_THRESHOLD -> OfferAction.ACCEPT
+            finalScore <= DECLINE_THRESHOLD -> OfferAction.DECLINE
             else -> OfferAction.NOTHING
-        }
-
-        val recText = when (action) {
-            OfferAction.ACCEPT -> "Recommended: ACCEPT"
-            OfferAction.DECLINE -> "Recommended: DECLINE"
-            OfferAction.MANUAL_REVIEW -> "Recommended: REVIEW"
-            else -> "Recommended: DECIDE"
         }
 
         val quality = ScoringUtils.determineOfferQuality(finalScore)
@@ -164,7 +161,6 @@ class OfferEvaluator() {
             action = action,
             score = finalScore,
             qualityLevel = quality,
-            recommendationText = recText,
             payAmount = grossPay,
             fuelCostEstimate = fuelCost,
             nonFuelCostEstimate = nonFuelCost,
@@ -234,6 +230,12 @@ class OfferEvaluator() {
         }
 
     companion object {
+        /** Score at or above which the verdict is ACCEPT. */
+        const val ACCEPT_THRESHOLD = 70.0
+
+        /** Score at or below which the verdict is DECLINE. */
+        const val DECLINE_THRESHOLD = 30.0
+
         private const val REALISTIC_MAX_DPM = 2.00
         private const val REALISTIC_MAX_HOURLY = 35.00
         private const val REALISTIC_MAX_PAYOUT = 15.00

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/OfferQuality.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/OfferQuality.kt
@@ -1,0 +1,25 @@
+package cloud.trotter.dashbuddy.domain.evaluation
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Quality tier of an evaluated offer (#366). A typed verdict, not UI copy —
+ * display labels live in the UI layer (which #57 can localize).
+ */
+@Serializable
+enum class OfferQuality {
+    AWESOME,
+    GREAT,
+    GOOD,
+    DECENT,
+    BAD,
+
+    /** Protect-stats mode forced an accept; scoring was bypassed. */
+    PROTECTED,
+
+    /** A merchant BLOCK rule hard-declined the offer before scoring. */
+    BLOCKED,
+
+    /** No verdict — e.g. no scoring rules are enabled. */
+    UNKNOWN,
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/ScoringUtils.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/ScoringUtils.kt
@@ -9,13 +9,13 @@ object ScoringUtils {
     private const val AWESOME = 70.0
 
 
-    fun determineOfferQuality(score: Double): String {
+    fun determineOfferQuality(score: Double): OfferQuality {
         return when {
-            score >= AWESOME -> "AWESOME OFFER"
-            score >= GREAT -> "GREAT OFFER"
-            score >= GOOD -> "GOOD OFFER"
-            score >= DECENT -> "DECENT OFFER"
-            else -> "BAD OFFER"
+            score >= AWESOME -> OfferQuality.AWESOME
+            score >= GREAT -> OfferQuality.GREAT
+            score >= GOOD -> OfferQuality.GOOD
+            score >= DECENT -> OfferQuality.DECENT
+            else -> OfferQuality.BAD
         }
     }
 }

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/accessibility/BoundingBox.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/accessibility/BoundingBox.kt
@@ -1,5 +1,6 @@
 package cloud.trotter.dashbuddy.domain.model.accessibility
 
+@kotlinx.serialization.Serializable
 data class BoundingBox(
     val left: Int,
     val top: Int,

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/cards/FlowCardSnapshot.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/cards/FlowCardSnapshot.kt
@@ -1,5 +1,6 @@
 package cloud.trotter.dashbuddy.domain.model.cards
 
+import cloud.trotter.dashbuddy.domain.evaluation.OfferQuality
 import cloud.trotter.dashbuddy.domain.model.event.AppEventType
 import cloud.trotter.dashbuddy.domain.model.pay.ParsedPay
 
@@ -61,9 +62,7 @@ sealed class FlowCardSnapshot {
         val dollarsPerMile: Double? = null,
         val dollarsPerHour: Double? = null,
         /** Evaluator quality level ("Great offer", "Bad offer", …) for the verdict chip. */
-        val qualityLevel: String? = null,
-        /** One-line reason from the evaluator, shown under the verdict action word. */
-        val recommendationText: String? = null,
+        val qualityLevel: OfferQuality? = null,
         /** Offer + order badge enum names (e.g. HIGH_PAYING, RED_CARD, ALCOHOL) for the pill row. */
         val badges: List<String> = emptyList(),
         /** When the DoorDash offer countdown expires (presentedAt + initialCountdown). Null if unparsed. */

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/payload/AppEventPayloads.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/payload/AppEventPayloads.kt
@@ -114,13 +114,22 @@ data class DeliveryPayload(
     val sessionEarningsAtCompletion: Double? = null,
 ) : AppEventPayload
 
+/** Wire values for [SessionStartPayload.source] (#366) — mirrors [SessionEndSource]. */
+object SessionStartSource {
+    /** Normal user-initiated start. */
+    const val INTERACTION = "interaction"
+
+    /** Session resurrected by crash recovery. */
+    const val RECOVERY = "recovery"
+}
+
 /** Payload for `DASH_START`. */
 @Serializable
 data class SessionStartPayload(
     val sessionId: String,
     val platform: String,
     val startedAt: Long,
-    /** "interaction" (normal user start) | "recovery" (crash recovery). */
+    /** One of [SessionStartSource]. */
     val source: String,
     val startScreen: String,
 ) : AppEventPayload

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/notification/RawNotificationData.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/notification/RawNotificationData.kt
@@ -3,7 +3,7 @@ package cloud.trotter.dashbuddy.domain.model.notification
 /**
  * Raw notification payload extracted from a [android.service.notification.StatusBarNotification].
  * Analogous to [cloud.trotter.dashbuddy.domain.model.accessibility.UiNode] — this is the
- * uninterpreted source data; [NotificationInfo] carries the typed, parsed result.
+ * uninterpreted source data; [cloud.trotter.dashbuddy.domain.state.ParsedFields.NotificationFields] carries the typed, parsed result.
  */
 data class RawNotificationData(
     val title: String?,

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/ratings/RatingsSnapshot.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/ratings/RatingsSnapshot.kt
@@ -4,12 +4,13 @@ import kotlinx.serialization.Serializable
 
 /**
  * A point-in-time snapshot of the dasher's performance metrics, captured when the Ratings
- * screen is observed. Stored on [AppStateV2.IdleOffline] so the bubble HUD can display it
+ * screen is observed. Carried in app state so the bubble HUD can display it
  * on the idle card without re-observing the ratings screen.
  */
 @Serializable
 data class RatingsSnapshot(
-    val capturedAt: Long = System.currentTimeMillis(),
+    /** Explicit (#366): callers stamp the capture instant at the edge. */
+    val capturedAt: Long,
     val acceptanceRate: Double? = null,
     val completionRate: Double? = null,
     val onTimeRate: Double? = null,

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/state/OfferEvaluationEvent.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/state/OfferEvaluationEvent.kt
@@ -8,5 +8,6 @@ data class OfferEvaluationEvent(
     val evaluation: OfferEvaluation? = null,
     /** Hash of the offer this evaluation was computed FOR — correlated by the stepper (#345). */
     val offerHash: String? = null,
-    override val timestamp: Long = System.currentTimeMillis()
+    /** Explicit (#366): the engine stamps the loopback time at the edge. */
+    override val timestamp: Long
 ) : StateEvent

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/state/TimeoutEvent.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/state/TimeoutEvent.kt
@@ -2,11 +2,13 @@ package cloud.trotter.dashbuddy.domain.model.state
 
 import cloud.trotter.dashbuddy.domain.pipeline.TimeoutType
 import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.domain.pipeline.ObservationPayload
 
 data class TimeoutEvent(
-    override val timestamp: Long = System.currentTimeMillis(),
+    /** Explicit (#366): the engine stamps the fire time at the edge. */
+    override val timestamp: Long,
     val type: TimeoutType = TimeoutType.SESSION_PAUSED_SAFETY,
     /** Platform region the timer belongs to — threads through to Observation.Timeout (#342). */
     val platform: Platform? = null,
-    val payload: Map<String, Any?> = emptyMap(),
+    val payload: ObservationPayload? = null,
 ) : StateEvent

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/Observation.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/Observation.kt
@@ -104,11 +104,11 @@ sealed interface Observation : cloud.trotter.dashbuddy.domain.model.state.StateE
          */
         val targetPlatform: Platform? = null,
         /**
-         * Carries opaque context from the original [AppEffect.ScheduleTimeout]'s
-         * payload back into the state machine. Used for deferred-effect patterns
-         * like click-after-settle where the timer fire needs to know what to do.
+         * Typed context from the original ScheduleTimeout (#366) — e.g. the
+         * deferred-click target for click-after-settle. Serializable, so the
+         * journal replays it losslessly.
          */
-        val payload: Map<String, Any?> = emptyMap(),
+        val payload: ObservationPayload? = null,
     ) : Observation {
         override val platform: Platform get() = targetPlatform ?: Platform.fromRuleId(ruleId)
     }
@@ -120,7 +120,6 @@ sealed interface Observation : cloud.trotter.dashbuddy.domain.model.state.StateE
         override val ruleId: String? = null,
         override val metadata: ReplayMetadata = ReplayMetadata.EMPTY,
         val action: String,
-        val payload: Map<String, Any?> = emptyMap(),
     ) : Observation
 
     /** A loopback event from the side-effect engine back into the state machine. */
@@ -130,7 +129,8 @@ sealed interface Observation : cloud.trotter.dashbuddy.domain.model.state.StateE
         override val ruleId: String? = null,
         override val metadata: ReplayMetadata = ReplayMetadata.EMPTY,
         val effect: String,
-        val payload: Map<String, Any?> = emptyMap(),
+        /** Typed loopback context (#366) — e.g. the landed offer evaluation. */
+        val payload: ObservationPayload? = null,
     ) : Observation
 }
 

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/ObservationIdentity.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/ObservationIdentity.kt
@@ -1,6 +1,7 @@
 package cloud.trotter.dashbuddy.domain.pipeline
 
 import cloud.trotter.dashbuddy.domain.state.Mode
+import cloud.trotter.dashbuddy.domain.state.ParsedFields
 
 /**
  * Semantic identity of an observation for post-classification dedup.
@@ -25,11 +26,17 @@ data class ObservationIdentity(
  * ensures that a screen whose UI changes between online/offline states
  * is not suppressed as a duplicate.
  */
-fun Observation.identity(): ObservationIdentity = when (this) {
+/**
+ * Null = never dedup (#366): clicks with parsed ClickFields are always unique —
+ * previously expressed as a nanoTime-salted hash, now an explicit signal.
+ */
+fun Observation.identity(): ObservationIdentity? = when (this) {
     is Observation.Screen -> ObservationIdentity("screen", target, parsed.dedupeHash(), modeHint)
-    is Observation.Click -> ObservationIdentity("click", target, parsed.dedupeHash(), modeHint)
+    is Observation.Click ->
+        if (parsed is ParsedFields.ClickFields) null
+        else ObservationIdentity("click", target, parsed.dedupeHash(), modeHint)
     is Observation.Notification -> ObservationIdentity("notification", target, parsed.dedupeHash(), modeHint)
     is Observation.Timeout -> ObservationIdentity("timeout", type.name, 0)
-    is Observation.UiInput -> ObservationIdentity("ui_input", action, payload.hashCode())
+    is Observation.UiInput -> ObservationIdentity("ui_input", action, 0)
     is Observation.Loopback -> ObservationIdentity("loopback", effect, payload.hashCode())
 }

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/ObservationPayload.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/ObservationPayload.kt
@@ -1,0 +1,46 @@
+package cloud.trotter.dashbuddy.domain.pipeline
+
+import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Typed payloads for the internal observation types (#366). Replaces the
+ * `Map<String, Any?>` bags on Timeout/Loopback that bypassed both type safety
+ * (live objects stuffed in, cast back out) and journal/replay fidelity
+ * (#352's `InternalObsPayload` shim existed only to re-type them).
+ *
+ * Serializable as a sealed hierarchy, so the observation journal persists and
+ * replays these losslessly with no per-key rebuilding.
+ */
+@Serializable
+sealed interface ObservationPayload {
+
+    /**
+     * Context for a rule-declared click deferred through a SETTLE_UI timeout
+     * (see EffectMap's deferred-click round-trip). Carries everything the
+     * timeout handler needs to reconstruct the immediate-fire click.
+     */
+    @Serializable
+    @SerialName("deferredClick")
+    data class DeferredClick(
+        val verb: String,
+        val ruleId: String,
+        val dedupeKey: String? = null,
+        val throttleMs: Long? = null,
+        val target: NodeRef? = null,
+    ) : ObservationPayload
+
+    /**
+     * Result of an async offer evaluation, looped back into the machine.
+     * [offerHash] correlates the result to the offer it was computed FOR
+     * (#345); [action] mirrors `evaluation.action` for stepper convenience.
+     */
+    @Serializable
+    @SerialName("evaluationResult")
+    data class EvaluationResult(
+        val action: String,
+        val offerHash: String? = null,
+        val evaluation: OfferEvaluation? = null,
+    ) : ObservationPayload
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/RequestedEffect.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/RequestedEffect.kt
@@ -38,6 +38,7 @@ data class RequestedEffect(
  * class name, structural path) so the executor can reliably find the
  * node even on screens where some identifiers are absent.
  */
+@kotlinx.serialization.Serializable
 data class NodeRef(
     val viewIdSuffix: String?,
     val text: String?,

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/provider/VehicleEfficiencyDataSource.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/provider/VehicleEfficiencyDataSource.kt
@@ -7,11 +7,14 @@ import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleOption
  * The standard contract for fetching vehicle efficiency data.
  * Any future provider (EPA, NHTSA, CarQuery) must implement this interface.
  * All return types are pure :domain models — no network DTOs leak upstream.
+ *
+ * Result-typed (#366), matching [FuelPriceDataSource] — one provider error
+ * idiom; callers decide how to degrade.
  */
 interface VehicleEfficiencyDataSource {
-    suspend fun getYears(): List<String>
-    suspend fun getMakes(year: String): List<String>
-    suspend fun getModels(year: String, make: String): List<String>
-    suspend fun getVehicleOptions(year: String, make: String, model: String): List<VehicleOption>
-    suspend fun getVehicleDetails(vehicleId: String): VehicleDetails?
+    suspend fun getYears(): Result<List<String>>
+    suspend fun getMakes(year: String): Result<List<String>>
+    suspend fun getModels(year: String, make: String): Result<List<String>>
+    suspend fun getVehicleOptions(year: String, make: String, model: String): Result<List<VehicleOption>>
+    suspend fun getVehicleDetails(vehicleId: String): Result<VehicleDetails>
 }

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/AppState.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/AppState.kt
@@ -14,7 +14,8 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class AppState(
     val regions: Regions = Regions(),
-    val timestamp: Long = System.currentTimeMillis(),
+    /** Explicit (#366): 0 for the pre-restore initial state; obs-driven after. */
+    val timestamp: Long = 0L,
     val correlationVersion: Long = 0L,
 )
 

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/Flow.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/Flow.kt
@@ -8,6 +8,12 @@ package cloud.trotter.dashbuddy.domain.state
  * observation log. The enum is the Kotlin-side source of truth; any rule
  * emitting a wire value not in this set is rejected at load time.
  *
+ * NAMING (#366, decided): this enum collides with `kotlinx.coroutines.flow.Flow`
+ * and stays that way. The handful of files needing both use a fully-qualified
+ * coroutines import; renaming (~21 consumers + the wire-format mental model)
+ * buys nothing behavioral. Revisit only if the collision starts causing real
+ * bugs rather than import friction.
+ *
  * @see Mode for the orthogonal availability axis.
  */
 enum class Flow(val wire: String) {

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/ParsedFields.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/ParsedFields.kt
@@ -14,7 +14,7 @@ object PickupActivity {
 
 /**
  * Typed parsed data produced by rules and consumed by the state machine.
- * Each subtype corresponds to a [Flow] family — the [FieldsFactory]
+ * Each subtype corresponds to a [Flow] family — ParsedFieldsFactory (:core:pipeline)
  * validates that rule output conforms to the contract at load time.
  *
  * All subtypes carry an optional [activity] tag for platform-specific
@@ -215,8 +215,8 @@ sealed class ParsedFields {
         val nodeId: String? = null,
         val nodeText: String? = null,
     ) : ParsedFields() {
-        // Every click is unique — always passes dedup.
-        override fun dedupeHash(): Int = System.nanoTime().hashCode()
+        // Every click is unique — identity() returns null for ClickFields
+        // observations (#366), an explicit never-dedupe signal.
     }
 
     @Serializable

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/evaluation/OfferEvaluatorTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/evaluation/OfferEvaluatorTest.kt
@@ -107,7 +107,7 @@ class OfferEvaluatorTest {
         val result = evaluator.evaluate(offer(pay = 1.0), cfg)
         assertEquals(OfferAction.ACCEPT, result.action)
         assertEquals(100.0, result.score, 0.0001)
-        assertEquals("Protected!", result.qualityLevel)
+        assertEquals(OfferQuality.PROTECTED, result.qualityLevel)
     }
 
     @Test
@@ -433,7 +433,7 @@ class OfferEvaluatorTest {
         val result = evaluator.evaluate(offer(pay = 20.0, storeName = "Taco Bell"), cfg)
         assertEquals(OfferAction.DECLINE, result.action)
         assertEquals(0.0, result.score, 0.0001)
-        assertEquals("Blocked", result.qualityLevel)
+        assertEquals(OfferQuality.BLOCKED, result.qualityLevel)
     }
 
     @Test
@@ -468,7 +468,6 @@ class OfferEvaluatorTest {
         // pay=10 → score=100, but MANUAL_REVIEW overrides to MANUAL_REVIEW action
         val result = evaluator.evaluate(offer(pay = 10.0, storeName = "Chipotle"), cfg)
         assertEquals(OfferAction.MANUAL_REVIEW, result.action)
-        assertEquals("Recommended: REVIEW", result.recommendationText)
     }
 
     @Test

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/evaluation/ScoringUtilsTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/evaluation/ScoringUtilsTest.kt
@@ -3,6 +3,7 @@ package cloud.trotter.dashbuddy.domain.evaluation
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import cloud.trotter.dashbuddy.domain.evaluation.OfferQuality
 
 class ScoringUtilsTest {
 
@@ -12,40 +13,40 @@ class ScoringUtilsTest {
 
     @Test
     fun `quality - score below 40 is BAD OFFER`() {
-        assertEquals("BAD OFFER", ScoringUtils.determineOfferQuality(0.0))
-        assertEquals("BAD OFFER", ScoringUtils.determineOfferQuality(39.9))
+        assertEquals(OfferQuality.BAD, ScoringUtils.determineOfferQuality(0.0))
+        assertEquals(OfferQuality.BAD, ScoringUtils.determineOfferQuality(39.9))
     }
 
     @Test
     fun `quality - score 40 to 49 is DECENT OFFER`() {
-        assertEquals("DECENT OFFER", ScoringUtils.determineOfferQuality(40.0))
-        assertEquals("DECENT OFFER", ScoringUtils.determineOfferQuality(49.9))
+        assertEquals(OfferQuality.DECENT, ScoringUtils.determineOfferQuality(40.0))
+        assertEquals(OfferQuality.DECENT, ScoringUtils.determineOfferQuality(49.9))
     }
 
     @Test
     fun `quality - score 50 to 59 is GOOD OFFER`() {
-        assertEquals("GOOD OFFER", ScoringUtils.determineOfferQuality(50.0))
-        assertEquals("GOOD OFFER", ScoringUtils.determineOfferQuality(59.9))
+        assertEquals(OfferQuality.GOOD, ScoringUtils.determineOfferQuality(50.0))
+        assertEquals(OfferQuality.GOOD, ScoringUtils.determineOfferQuality(59.9))
     }
 
     @Test
     fun `quality - score 60 to 69 is GREAT OFFER`() {
-        assertEquals("GREAT OFFER", ScoringUtils.determineOfferQuality(60.0))
-        assertEquals("GREAT OFFER", ScoringUtils.determineOfferQuality(69.9))
+        assertEquals(OfferQuality.GREAT, ScoringUtils.determineOfferQuality(60.0))
+        assertEquals(OfferQuality.GREAT, ScoringUtils.determineOfferQuality(69.9))
     }
 
     @Test
     fun `quality - score 70 and above is AWESOME OFFER`() {
-        assertEquals("AWESOME OFFER", ScoringUtils.determineOfferQuality(70.0))
-        assertEquals("AWESOME OFFER", ScoringUtils.determineOfferQuality(100.0))
+        assertEquals(OfferQuality.AWESOME, ScoringUtils.determineOfferQuality(70.0))
+        assertEquals(OfferQuality.AWESOME, ScoringUtils.determineOfferQuality(100.0))
     }
 
     @Test
     fun `quality - boundary values are correctly assigned`() {
         // Exact boundaries fall into the higher band
-        assertTrue(ScoringUtils.determineOfferQuality(40.0) != "BAD OFFER")
-        assertTrue(ScoringUtils.determineOfferQuality(50.0) != "DECENT OFFER")
-        assertTrue(ScoringUtils.determineOfferQuality(60.0) != "GOOD OFFER")
-        assertTrue(ScoringUtils.determineOfferQuality(70.0) != "GREAT OFFER")
+        assertTrue(ScoringUtils.determineOfferQuality(40.0) != OfferQuality.BAD)
+        assertTrue(ScoringUtils.determineOfferQuality(50.0) != OfferQuality.DECENT)
+        assertTrue(ScoringUtils.determineOfferQuality(60.0) != OfferQuality.GOOD)
+        assertTrue(ScoringUtils.determineOfferQuality(70.0) != OfferQuality.GREAT)
     }
 }

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/model/event/AppEventCodecTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/model/event/AppEventCodecTest.kt
@@ -18,6 +18,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.fail
 import org.junit.Test
+import cloud.trotter.dashbuddy.domain.evaluation.OfferQuality
 
 /**
  * The event-payload wire codec (#354): every payload type round-trips through
@@ -39,8 +40,7 @@ class AppEventCodecTest {
         val evaluation = OfferEvaluation(
             action = OfferAction.ACCEPT,
             score = 80.0,
-            qualityLevel = "Good",
-            recommendationText = "Recommended: ACCEPT",
+            qualityLevel = OfferQuality.GOOD,
             payAmount = 7.5,
             fuelCostEstimate = 0.5,
             nonFuelCostEstimate = 0.5,


### PR DESCRIPTION
Fixes #366. Item-by-item:

| Item | Disposition |
|---|---|
| Evaluator emits presentation strings | `OfferQuality` enum (with PROTECTED/BLOCKED tiers the audit's 5-tier list missed); `recommendationText` deleted — UI derives copy via `displayLabel()`/`recommendationLabel()` in `ui/formatters` (#57 can localize there). |
| No-rules branch lies | Returns **real economics** + explicit `UNKNOWN` verdict (was: zeroed fields + "Error Parsing Offer" for a successful parse). `ACCEPT_THRESHOLD`/`DECLINE_THRESHOLD` named. |
| `Map<String,Any?>` payloads | Typed sealed `ObservationPayload` (`DeferredClick`, `EvaluationResult`), serializable — **the #352 `InternalObsPayload` shim folds onto it** (journal round-trips losslessly, zero key rebuilding) and it carries platform via the existing #342 field, as the three-issue coordination wanted. `UiInput.payload` had no consumers — deleted. EffectMap's 8-key map↔NodeRef round-trip is typed construction now. |
| `SessionStartSource` consts | Mirrors `SessionEndSource`; EffectMap literals swept. |
| Wall-clock ctor defaults | Removed from `TimeoutEvent`/`OfferEvaluationEvent`/`AppState`(0L initial)/`RatingsSnapshot`; the engine stamps explicitly at the edge; the eval-loopback bridge uses `event.timestamp` instead of a second wall-clock read. `ClickFields`' nanoTime dedupe hash → **null identity** (explicit never-dedup; FrameGate preserves click-clears-dedup semantics). |
| `Flow` name collision | **Decided: keep + documented in KDoc.** FQN imports in a handful of files vs ~21-consumer rename churn with zero behavioral payoff. |
| Stale kdocs ×5 | Fixed. |
| Provider error idiom | `VehicleEfficiencyDataSource` → `Result` (matches `FuelPriceDataSource`); EPA impl `runCatching` + source logging; repo unwraps so UI signatures are unchanged. Bonus: the trim-picker "Not Listed" sentinel the #364 sweep missed moves to the wizard. |

**Documented exception** to the no-copy-in-domain grep: `buildCaveatWarnings`' English warning strings remain (pinned `Locale.ROOT` since #358) — copy extraction is #57's, per its note there.

**Persistence note (alpha):** pre-existing journal/app_events rows embedding the string-typed evaluation decode as stubs/null payloads — loud at the edge, tolerated by all consumers, and the v8 wipe (#359) means few such rows exist.

Full suite + release compile/KSP green; golden corpus unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)