### PR TITLE
chore(ui): micro-fix bundle — frozen summary, dashId consistency, memoized sim, lifecycle collection (#367)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -112,6 +112,7 @@ dependencies {
     implementation(libs.androidx.hilt.work)
     implementation(libs.androidx.lifecycle.livedata.ktx)
     implementation(libs.androidx.lifecycle.viewmodel.ktx)
+    implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.material.icons.extended)
     implementation(libs.androidx.material3)
     implementation(libs.androidx.navigation.compose)

--- a/app/src/main/java/cloud/trotter/dashbuddy/log/StateAwareTree.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/log/StateAwareTree.kt
@@ -7,7 +7,6 @@ import timber.log.Timber
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
-import java.util.regex.Pattern
 import javax.inject.Provider
 
 /**
@@ -23,15 +22,17 @@ class StateAwareTree(
     private val stateProvider: Provider<String> // Lazy access to state to avoid circular dependencies
 ) : Timber.Tree() {
 
-    private val anonymousClassPattern = Pattern.compile("(\\$\\d+)+$")
     private val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.US)
 
     override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
         // 1. Check Log Level Gate
         if (priority < devSettingsRepository.minLogLevel.value) return
 
-        // 2. Auto-Generate Tag if missing
-        val finalTag = tag ?: createStackElementTag()
+        // 2. Tag (#367): explicit tags pass through; untagged lines get a fixed
+        // marker. The old per-line Throwable().stackTrace walk cost a stack
+        // capture on EVERY log in ALL builds — logcat (DebugTree) still infers
+        // call-site tags in debug; the file log doesn't need them.
+        val finalTag = tag ?: "App"
 
         val timestamp = dateFormat.format(Date())
 
@@ -66,28 +67,4 @@ class StateAwareTree(
         logRepository.appendLog(logLine.toString())
     }
 
-    /**
-     * Inspects the stack trace to figure out which class called Timber.
-     */
-    private fun createStackElementTag(): String {
-        val stackTrace = Throwable().stackTrace
-        if (stackTrace.size <= 5) return "Unknown"
-
-        // We look for the first stack element that isn't Timber itself.
-        // Usually index 5 or 6 in the trace is the caller.
-        for (element in stackTrace) {
-            val className = element.className
-            if (!className.startsWith("timber.log.Timber") &&
-                !className.startsWith("cloud.trotter.dashbuddy.log.StateAwareTree")
-            ) {
-                var tag = className.substringAfterLast('.')
-                val m = anonymousClassPattern.matcher(tag)
-                if (m.find()) {
-                    tag = m.replaceAll("")
-                }
-                return tag
-            }
-        }
-        return "Unknown"
-    }
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManager.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManager.kt
@@ -36,6 +36,18 @@ class BubbleManager @Inject constructor(
     private val notificationManager: NotificationManager,
     private val chatRepository: ChatRepository
 ) {
+
+    companion object {
+        /** The single bubble/chat notification id. */
+        const val BUBBLE_NOTIFICATION_ID = 1
+
+        /** Bubble expanded-view height (dp). */
+        const val BUBBLE_DESIRED_HEIGHT_DP = 600
+
+        /** PendingIntent request codes for the offer notification actions (#367). */
+        const val REQUEST_CODE_ACCEPT = 10
+        const val REQUEST_CODE_DECLINE = 11
+    }
     // 1. ADDED: CoroutineScope for the suspend database calls
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
@@ -151,7 +163,7 @@ class BubbleManager @Inject constructor(
             bubbleIntent,
             IconCompat.createWithResource(context, persona.getIconResId())
         )
-            .setDesiredHeight(600)
+            .setDesiredHeight(BUBBLE_DESIRED_HEIGHT_DP)
             .setAutoExpandBubble(expand)
             .setSuppressNotification(expand)
             .build()
@@ -180,11 +192,11 @@ class BubbleManager @Inject constructor(
             .setPriority(NotificationCompat.PRIORITY_MAX)
 
         if (offerActionable) {
-            builder.addAction(offerAction("Decline", OfferIntent.DECLINE, 11))
-            builder.addAction(offerAction("Accept", OfferIntent.ACCEPT, 10))
+            builder.addAction(offerAction("Decline", OfferIntent.DECLINE, REQUEST_CODE_DECLINE))
+            builder.addAction(offerAction("Accept", OfferIntent.ACCEPT, REQUEST_CODE_ACCEPT))
         }
 
-        notificationManager.notify(1, builder.build())
+        notificationManager.notify(BUBBLE_NOTIFICATION_ID, builder.build())
     }
 
     /** Post the offer evaluation as a heads-up notification with Accept / Decline action buttons. */

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleScreen.kt
@@ -44,7 +44,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -75,20 +75,22 @@ import cloud.trotter.dashbuddy.ui.formatters.getIconResId
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateMapOf
 import java.util.Date
+import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.runtime.saveable.rememberSaveable
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun BubbleScreen(
     viewModel: BubbleViewModel = hiltViewModel()
 ) {
-    val messages by viewModel.messages.collectAsState()
-    val appState by viewModel.appState.collectAsState()
-    val focusedPlatform by viewModel.focusedPlatform.collectAsState()
-    val focusedRegion by viewModel.focusedRegion.collectAsState()
-    val sessionMiles by viewModel.sessionMiles.collectAsState()
-    val sessionEarnings by viewModel.sessionEarnings.collectAsState()
-    val lastSessionSummary by viewModel.lastSessionSummary.collectAsState()
-    val cardStack by viewModel.cardStack.collectAsState()
+    val messages by viewModel.messages.collectAsStateWithLifecycle()
+    val appState by viewModel.appState.collectAsStateWithLifecycle()
+    val focusedPlatform by viewModel.focusedPlatform.collectAsStateWithLifecycle()
+    val focusedRegion by viewModel.focusedRegion.collectAsStateWithLifecycle()
+    val sessionMiles by viewModel.sessionMiles.collectAsStateWithLifecycle()
+    val sessionEarnings by viewModel.sessionEarnings.collectAsStateWithLifecycle()
+    val lastSessionSummary by viewModel.lastSessionSummary.collectAsStateWithLifecycle()
+    val cardStack by viewModel.cardStack.collectAsStateWithLifecycle()
     var showFullChat by remember { mutableStateOf(false) }
 
     // Collapse the bubble to its head after the user acts on an offer.
@@ -180,7 +182,13 @@ fun DashboardView(
     onAccept: () -> Unit = {},
     onDecline: () -> Unit = {},
 ) {
-    val expandedIds = remember { mutableStateMapOf<String, Boolean>() }
+    // rememberSaveable (#367): expansion state survives rotation/process-restore.
+    val expandedIds = rememberSaveable(
+        saver = listSaver(
+            save = { map -> map.filterValues { it }.keys.toList() },
+            restore = { saved -> mutableStateMapOf<String, Boolean>().apply { saved.forEach { put(it, true) } } },
+        ),
+    ) { mutableStateMapOf<String, Boolean>() }
     val listState = rememberLazyListState()
 
     Column(
@@ -402,10 +410,10 @@ private fun ModeIdle(lastSessionSummary: SessionSummary?) {
                 color = MaterialTheme.colorScheme.primary
             )
             ModeRow(label = "Miles", value = "${DashFormats.decimal(lastSessionSummary.miles)} mi")
-            ModeRow(label = "Duration", value = formatDuration(lastSessionSummary.durationMillis))
-            if (lastSessionSummary.acceptanceRate.isNotBlank()) {
-                ModeRow(label = "Acceptance", value = lastSessionSummary.acceptanceRate)
-            }
+            ModeRow(
+                label = "Duration",
+                value = formatDuration(lastSessionSummary.endedAt - lastSessionSummary.startedAt),
+            )
         }
     } else {
         ModeRow(label = "Status", value = "Offline")
@@ -491,7 +499,7 @@ fun FullChatView(messages: List<ChatMessage>) {
         verticalArrangement = Arrangement.Bottom,
         contentPadding = PaddingValues(bottom = 16.dp)
     ) {
-        items(messages) { msg ->
+        items(messages, key = { it.id }) { msg ->
             ChatBubble(msg)
             Spacer(modifier = Modifier.height(8.dp))
         }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleViewModel.kt
@@ -31,10 +31,12 @@ import kotlinx.coroutines.flow.stateIn
 import javax.inject.Inject
 
 data class SessionSummary(
+    val sessionId: String,
     val earnings: Double,
     val miles: Double,
-    val durationMillis: Long,
-    val acceptanceRate: String
+    /** Anchors (#367): the UI derives duration — the frozen summary can't drift. */
+    val startedAt: Long,
+    val endedAt: Long,
 )
 
 @HiltViewModel
@@ -87,7 +89,13 @@ class BubbleViewModel @Inject constructor(
 
     // Messages scoped to the active dash session
     @OptIn(ExperimentalCoroutinesApi::class)
-    val messages = bubbleManager.activeDashId.flatMapLatest { dashId ->
+    // Chat and cards key off the SAME latched dash id (#367) — the old
+    // split (messages on activeDashId) emptied the ticker post-dash while
+    // the card stack still showed the finished dash.
+    private val displayedDashId = bubbleManager.activeDashId
+        .scan(null as String?) { last, current -> current ?: last }
+
+    val messages = displayedDashId.flatMapLatest { dashId ->
         if (dashId != null) {
             chatRepository.getMessages(dashId)
         } else {
@@ -97,9 +105,6 @@ class BubbleViewModel @Inject constructor(
 
     // Dash whose event log feeds the card stack — the current active dash
     // when one is running, otherwise the most-recently-completed one so the
-    // post-dash review stays visible until the next DASH_START.
-    private val displayedDashId = bubbleManager.activeDashId
-        .scan(null as String?) { last, current -> current ?: last }
 
     /**
      * Bubble HUD flow-card stack (#257). Completed cards are folded from
@@ -137,12 +142,18 @@ class BubbleViewModel @Inject constructor(
             val region = platform?.let { state.regions.platforms[it] }
             val session = region?.session
             // Capture summary when flow is SessionEnded
-            if (state.regions.flow.flow == Flow.SessionEnded && session != null) {
+            if (state.regions.flow.flow == Flow.SessionEnded && session != null &&
+                last?.sessionId != session.sessionId
+            ) {
+                // Captured ONCE per session (#367): the old scan re-stamped a
+                // wall-clock duration on every upstream emission, so the
+                // "frozen" summary grew while idle.
                 SessionSummary(
+                    sessionId = session.sessionId,
                     earnings = session.runningEarnings,
                     miles = miles,
-                    durationMillis = System.currentTimeMillis() - session.startedAt,
-                    acceptanceRate = "" // will populate from SessionEndedFields later
+                    startedAt = session.startedAt,
+                    endedAt = state.timestamp,
                 )
             } else {
                 last

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardScreen.kt
@@ -19,7 +19,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -41,7 +41,7 @@ fun DashboardScreen(
     onNavigateToWizard: () -> Unit
 ) {
     val context = LocalContext.current
-    val isFirstRun by viewModel.isFirstRun.collectAsState()
+    val isFirstRun by viewModel.isFirstRun.collectAsStateWithLifecycle()
 
     // Data State
     var hasPermissions by remember { mutableStateOf<Boolean?>(null) }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/AboutScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/AboutScreen.kt
@@ -19,7 +19,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -41,8 +41,8 @@ fun AboutScreen(
     onBack: () -> Unit,
     viewModel: SettingsMenuViewModel = hiltViewModel()
 ) {
-    val clicks by viewModel.versionClickCount.collectAsState()
-    val isDevUnlocked by viewModel.isDevModeUnlocked.collectAsState(initial = false)
+    val clicks by viewModel.versionClickCount.collectAsStateWithLifecycle()
+    val isDevUnlocked by viewModel.isDevModeUnlocked.collectAsStateWithLifecycle(initialValue = false)
     val context = LocalContext.current
 
     // Hold a reference to the toast so we can cancel it instantly on rapid clicks

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/EconomySettingsScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/EconomySettingsScreen.kt
@@ -18,7 +18,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -40,7 +40,7 @@ fun EconomySettingsScreen(
     onBack: () -> Unit,
     viewModel: EconomySettingsViewModel = hiltViewModel(),
 ) {
-    val eco by viewModel.userEconomy.collectAsState()
+    val eco by viewModel.userEconomy.collectAsStateWithLifecycle()
 
     Scaffold(
         topBar = {

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/EvidenceSettingsScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/EvidenceSettingsScreen.kt
@@ -12,7 +12,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -24,7 +24,7 @@ fun EvidenceSettingsScreen(
     onBack: () -> Unit,
     viewModel: SettingsMenuViewModel = hiltViewModel()
 ) {
-    val config by viewModel.evidenceConfig.collectAsState()
+    val config by viewModel.evidenceConfig.collectAsStateWithLifecycle()
 
     Scaffold(
         topBar = {

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/PlatformSettingsScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/PlatformSettingsScreen.kt
@@ -21,7 +21,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -34,7 +34,7 @@ fun PlatformSettingsScreen(
     onBack: () -> Unit,
     viewModel: PlatformSettingsViewModel = hiltViewModel(),
 ) {
-    val platforms by viewModel.platforms.collectAsState()
+    val platforms by viewModel.platforms.collectAsStateWithLifecycle()
 
     Scaffold(
         topBar = {

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/SettingsHomeScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/SettingsHomeScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import cloud.trotter.dashbuddy.ui.main.navigation.Screen
 import cloud.trotter.dashbuddy.core.designsystem.format.DashFormats
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 
 @Composable
 fun SettingsHomeScreen(
@@ -48,8 +49,8 @@ fun SettingsHomeScreen(
     viewModel: SettingsMenuViewModel = hiltViewModel()
 ) {
     // Relying strictly on the persisted DataStore state now
-    val isDevUnlocked by viewModel.isDevModeUnlocked.collectAsState(initial = false)
-    val userEconomy by viewModel.userEconomy.collectAsState(initial = null)
+    val isDevUnlocked by viewModel.isDevModeUnlocked.collectAsStateWithLifecycle(initialValue = false)
+    val userEconomy by viewModel.userEconomy.collectAsStateWithLifecycle(initialValue = null)
 
     Scaffold(
         topBar = {

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/SettingsViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/SettingsViewModel.kt
@@ -18,6 +18,7 @@ import javax.inject.Inject
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
     private val strategyRepository: StrategyRepository,
+    private val offerEvaluator: OfferEvaluator,
 ) : ViewModel() {
 
     // --- STATE ---
@@ -59,7 +60,9 @@ class SettingsViewModel @Inject constructor(
 
     fun simulateOffer(pay: Double, miles: Double): OfferEvaluation {
         val fakeOffer = ParsedOffer(
-            offerHash = "sim_${System.currentTimeMillis()}",
+            // Stable hash (#367): the screen memoizes on (pay, dist, config) —
+            // a wall-clock hash would defeat structural equality.
+            offerHash = "simulated-offer",
             payAmount = pay,
             distanceMiles = miles,
             itemCount = 5, // Default average workload
@@ -67,7 +70,6 @@ class SettingsViewModel @Inject constructor(
         )
 
         val currentConfig = evaluationConfig.value
-        val evaluator = OfferEvaluator()
-        return evaluator.evaluate(fakeOffer, currentConfig)
+        return offerEvaluator.evaluate(fakeOffer, currentConfig)
     }
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/StrategySettingsScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/StrategySettingsScreen.kt
@@ -23,7 +23,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
@@ -50,13 +50,16 @@ import java.util.Locale
 fun StrategySettingsScreen(
     viewModel: SettingsViewModel = hiltViewModel()
 ) {
-    val config by viewModel.evaluationConfig.collectAsState()
+    val config by viewModel.evaluationConfig.collectAsStateWithLifecycle()
 
     // Local Sim State
     var simPay by remember { mutableFloatStateOf(6.50f) }
     var simDist by remember { mutableFloatStateOf(3.2f) }
 
-    val simulationResult = viewModel.simulateOffer(simPay.toDouble(), simDist.toDouble())
+    // Memoized (#367): this ran an un-remembered evaluation every recomposition.
+    val simulationResult = remember(simPay, simDist, config) {
+        viewModel.simulateOffer(simPay.toDouble(), simDist.toDouble())
+    }
 
     // --- REORDERABLE STATE ---
     val haptic = LocalHapticFeedback.current

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/WizardScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/WizardScreen.kt
@@ -24,7 +24,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -55,13 +55,13 @@ fun WizardScreen(
     viewModel: WizardViewModel = hiltViewModel(),
     onComplete: () -> Unit
 ) {
-    val steps by viewModel.steps.collectAsState()
-    val state by viewModel.state.collectAsState()
+    val steps by viewModel.steps.collectAsStateWithLifecycle()
+    val state by viewModel.state.collectAsStateWithLifecycle()
 
-    val availableYears by viewModel.availableYears.collectAsState()
-    val availableMakes by viewModel.availableMakes.collectAsState()
-    val availableModels by viewModel.availableModels.collectAsState()
-    val availableTrimNames by viewModel.availableTrimNames.collectAsState()
+    val availableYears by viewModel.availableYears.collectAsStateWithLifecycle()
+    val availableMakes by viewModel.availableMakes.collectAsStateWithLifecycle()
+    val availableModels by viewModel.availableModels.collectAsStateWithLifecycle()
+    val availableTrimNames by viewModel.availableTrimNames.collectAsStateWithLifecycle()
 
     val pagerState = rememberPagerState(pageCount = { steps.size })
     val coroutineScope = rememberCoroutineScope()

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/WizardViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/WizardViewModel.kt
@@ -55,7 +55,8 @@ class WizardViewModel @Inject constructor(
     val availableModels = _availableModels.asStateFlow()
 
     private val _availableTrims = MutableStateFlow<List<VehicleOption>>(emptyList())
-    val availableTrimNames = MutableStateFlow<List<String>>(emptyList())
+    private val _availableTrimNames = MutableStateFlow<List<String>>(emptyList())
+    val availableTrimNames = _availableTrimNames.asStateFlow()
 
     init {
         Timber.v("Initializing WizardViewModel")
@@ -279,7 +280,7 @@ class WizardViewModel @Inject constructor(
             )
         }
         _availableMakes.value = emptyList(); _availableModels.value =
-            emptyList(); _availableTrims.value = emptyList(); availableTrimNames.value = emptyList()
+            emptyList(); _availableTrims.value = emptyList(); _availableTrimNames.value = emptyList()
         viewModelScope.launch {
             _availableMakes.value =
                 listOf(VEHICLE_NOT_LISTED) + vehicleRepository.getMakes(year)
@@ -289,7 +290,7 @@ class WizardViewModel @Inject constructor(
     fun onMakeSelected(make: String) {
         _state.update { it.copy(vehicleMake = make, vehicleModel = "", vehicleTrim = "") }
         _availableModels.value = emptyList(); _availableTrims.value =
-            emptyList(); availableTrimNames.value = emptyList()
+            emptyList(); _availableTrimNames.value = emptyList()
 
         // Skip API call if Not Listed
         if (make != VEHICLE_NOT_LISTED) {
@@ -302,7 +303,7 @@ class WizardViewModel @Inject constructor(
 
     fun onModelSelected(model: String) {
         _state.update { it.copy(vehicleModel = model, vehicleTrim = "") }
-        _availableTrims.value = emptyList(); availableTrimNames.value = emptyList()
+        _availableTrims.value = emptyList(); _availableTrimNames.value = emptyList()
 
         // Skip API call if Not Listed
         if (model != VEHICLE_NOT_LISTED) {
@@ -314,7 +315,7 @@ class WizardViewModel @Inject constructor(
                     _state.value.vehicleMake,
                     model,
                 )
-                _availableTrims.value = trims; availableTrimNames.value =
+                _availableTrims.value = trims; _availableTrimNames.value =
                 trims.map { it.displayName }
             }
         }
@@ -359,6 +360,10 @@ class WizardViewModel @Inject constructor(
             // If we have the price, swap instantly!
             if (currentState.isGasPriceAuto && cachedPrice != null) {
                 currentState.copy(fuelType = type, gasPrice = cachedPrice)
+            } else if (type == FuelType.ELECTRICITY && currentState.gasPrice > 1.0f) {
+                // EV snap (#367, moved from GasPriceCard's LaunchedEffect): a
+                // gas-level $/gal makes no sense as $/kWh — drop to a sane default.
+                currentState.copy(fuelType = type, gasPrice = 0.30f)
             } else {
                 // If we DON'T have the price, just update the fuel type for now.
                 currentState.copy(fuelType = type)
@@ -371,8 +376,9 @@ class WizardViewModel @Inject constructor(
                 _state.update { it.copy(isFetchingGasPrice = true) }
                 val result = gasPriceRepository.fetchGasPriceOnly(type)
 
-                if (result.isSuccess) {
-                    val newPrice = result.getOrNull()!!
+                val fetched = result.getOrNull()
+                if (fetched != null) {
+                    val newPrice = fetched
                     _state.update { currentState ->
                         // Update the map AND the current price
                         val newMap = currentState.fetchedGasPrices.toMutableMap()
@@ -405,19 +411,14 @@ class WizardViewModel @Inject constructor(
 
         viewModelScope.launch {
             _state.update { it.copy(isFetchingGasPrice = true) }
-            val pricesMap = mutableMapOf<FuelType, Float>()
-
-            coroutineScope {
+            // awaitAll + associate (#367): the old code mutated a shared map
+            // from parallel async blocks.
+            val pricesMap = coroutineScope {
                 FuelType.entries.map { fuel ->
-                    async {
-                        val result = gasPriceRepository.fetchGasPriceOnly(fuel)
-                        if (result.isSuccess) {
-                            pricesMap[fuel] = result.getOrNull()!!
-                        }
-                    }
+                    async { fuel to gasPriceRepository.fetchGasPriceOnly(fuel).getOrNull() }
                 }.awaitAll()
-                Timber.i("Fetched gas prices: $pricesMap")
-            }
+            }.mapNotNull { (fuel, price) -> price?.let { fuel to it } }.toMap()
+            Timber.i("Fetched gas prices: %s", pricesMap)
 
             _state.update { currentState ->
                 currentState.copy(

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/cards/GasPriceCard.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/cards/GasPriceCard.kt
@@ -42,14 +42,6 @@ fun GasPriceCard(
     onAutoToggle: (Boolean) -> Unit,
     onPriceChange: (Float) -> Unit
 ) {
-    // Edge case: If they switch to Electricity and the price is still at "Gas" levels,
-    // snap it down to a sensible $0.30 default for a better user experience.
-    LaunchedEffect(fuelType) {
-        if (fuelType == FuelType.ELECTRICITY && price > 1.0f) {
-            onPriceChange(0.30f)
-        }
-    }
-
     Column(
         modifier = Modifier
             .fillMaxWidth()

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/cards/VehicleCard.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/cards/VehicleCard.kt
@@ -36,6 +36,7 @@ import cloud.trotter.dashbuddy.ui.main.setup.wizard.components.WizardCardHeader
 import cloud.trotter.dashbuddy.ui.main.setup.wizard.model.WizardStep
 import java.util.Locale
 import cloud.trotter.dashbuddy.ui.main.setup.wizard.VEHICLE_NOT_LISTED
+import android.net.Uri
 
 @Composable
 fun VehicleCard(
@@ -151,14 +152,15 @@ fun VehicleCard(
             ) {
                 OutlinedButton(
                     onClick = {
-                        val queryParts = listOfNotNull(
+                        val query = listOfNotNull(
                             year.takeIf { it.isNotBlank() },
                             make.takeIf { it != VEHICLE_NOT_LISTED && it.isNotBlank() },
-                            model.takeIf { it != VEHICLE_NOT_LISTED && it.isNotBlank() }
-                        ).joinToString("+")
+                            model.takeIf { it != VEHICLE_NOT_LISTED && it.isNotBlank() },
+                            "mpg",
+                        ).joinToString(" ")
 
-                        val searchUrl = "https://www.google.com/search?q=$queryParts+mpg"
-                        uriHandler.openUri(searchUrl)
+                        // Uri.encode (#367): unencoded spaces/specials broke the URL.
+                        uriHandler.openUri("https://www.google.com/search?q=${Uri.encode(query)}")
                     },
                     modifier = Modifier.fillMaxWidth(),
                     colors = ButtonDefaults.outlinedButtonColors(

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -63,7 +63,15 @@ immediately (no second pass needed) so it gets triaged.
 _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **broken** on the
 2026-06-09 dash — moved to that session's log entry below for triage.)_
 
-- **Tree ingestion now bounded — confirm no real screen trips the caps (#363, PR pending).**
+- **Post-dash HUD: frozen summary + consistent chat (#367, PR pending).**
+  Two visible fixes after a dash ends: (a) the "Last session" Duration on the idle bubble is
+  now FROZEN (it used to keep growing while you sat idle — check it shows the real dash length
+  and stays put); (b) the chat ticker and the card stack now both show the finished dash
+  (the ticker used to go empty the moment the dash ended while cards stayed). Also: platform
+  toggles/screens now stop collecting flows while the app is backgrounded — no user-visible
+  change expected, just confirm nothing looks stale when foregrounding.
+  - Confirmed: 0/2.
+- **Tree ingestion now bounded — confirm no real screen trips the caps (#363, PR #391).**
   Accessibility trees deeper than 60 levels or larger than 4,000 nodes truncate with a loud
   log line. The caps carry 2×/10× margin over the corpus, so a normal dash should NEVER hit
   them. Post-dash: grep the log for "Tree ingestion truncated" — any hit means a real DoorDash

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,6 +57,7 @@ androidx-fragment-ktx = { module = "androidx.fragment:fragment-ktx", version.ref
 androidx-hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
 androidx-lifecycle-livedata-ktx = { module = "androidx.lifecycle:lifecycle-livedata-ktx", version.ref = "androidxLifecycle" }
 androidx-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidxLifecycle" }
+androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidxLifecycle" }
 androidx-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }


### PR DESCRIPTION
Fixes #367 — the final issue of the 2026-06-10 design-principles audit campaign.

| Item | Disposition |
|---|---|
| `lastSessionSummary` duration drift | Anchors (`startedAt`/`endedAt` from `state.timestamp`), captured **once per sessionId**; UI derives duration (CLAUDE.md Reactive-UI rule 2). Dead `acceptanceRate` dropped. |
| Chat vs cards dashId | Both key off the latched `displayedDashId` (the cheap consistency patch; #96 owns the deeper refactor). |
| `simulateOffer` unmemoized | Evaluator injected + `remember(simPay, simDist, config)` + stable sim hash. |
| GasPriceCard EV snap | Moved into `WizardViewModel.updateFuelType`. |
| Lookup URL unencoded | `Uri.encode`. |
| `collectAsStateWithLifecycle` | Adopted across 10 files (+ `lifecycle-runtime-compose` dep); incl. the two `initial =` variants. |
| StateAwareTree per-line stack walk | Untagged **file-log** lines get a fixed marker (the issue's "drop per-line tags in the file log" option) — explicit tags pass through, debug logcat still infers via `DebugTree`. |
| WizardViewModel kotlin fixes | private `_availableTrimNames` + `asStateFlow`; both `getOrNull()!!` gone; prefetch via `awaitAll`+associate (no shared-map mutation from parallel `async`). |
| BubbleManager magic numbers | `BUBBLE_NOTIFICATION_ID`/`BUBBLE_DESIRED_HEIGHT_DP`/`REQUEST_CODE_ACCEPT`/`DECLINE`. |
| FullChatView | `items(key = ChatMessage.id)`; `expandedIds` is `rememberSaveable` (listSaver). `rememberFormattedTime` was already fixed by #358. |

Behavior-visible items (summary freeze, post-dash chat) are on the field-testing checklist (`Confirmed: 0/2`); the rest are mechanical. Full suite + release compile green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)