### PR TITLE
docs(audit): stamp the design-principles audit complete

### DIFF
--- a/docs/audits/2026-06-10-design-principles-audit.md
+++ b/docs/audits/2026-06-10-design-principles-audit.md
@@ -1,5 +1,11 @@
 # Design-Principles Audit — 2026-06-10
 
+> **STATUS (2026-06-11): COMPLETE.** All 27 issues filed from this audit (#341–#367)
+> are fixed and merged — PRs #368–#395. Three pre-existing issues (#300, #119, plus the
+> #346 family) closed with them; #96 and #192 are unblocked. Remaining adjacent work is
+> tracked on #293, #237, #57, and #244. Field validation for the on-dash-visible changes
+> is on the checklist in `docs/field-testing/README.md`.
+
 Full-codebase audit against the CLAUDE.md **Development Principles** (UDF, MAD, clean
 code / single responsibility, Kotlin/Android best practices), at master `3872684`
 (post-PR #339). Method: 7 parallel auditors, one per module slice; **every main-source


### PR DESCRIPTION
[skip ci]

Adds a completion banner to the 2026-06-10 audit report: all 27 filed issues (#341–#367) merged via PRs #368–#395; #300/#119 closed with them; #96/#192 unblocked; adjacent work pointers (#293/#237/#57/#244). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)