### PR TITLE
fix(pipeline): shared content gate — notifications drop SENSITIVE before capture (#399)

### DIFF
--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/ContentGates.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/ContentGates.kt
@@ -1,0 +1,19 @@
+package cloud.trotter.dashbuddy.core.pipeline
+
+import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import timber.log.Timber
+
+/**
+ * THE content gate (#399): sensitive and noise observations are dropped
+ * before capture and before the state machine — pledge: never store or
+ * forward sensitive screens/notifications. One definition shared by both
+ * sensor pipelines, so the gates can't drift apart again.
+ */
+internal fun passesContentGates(obs: Observation.FlowObservation): Boolean {
+    val isSensitive = obs.parsed is ParsedFields.SensitiveFields
+    val isNoise = obs.parsed is ParsedFields.NoiseFields
+    if (isSensitive) Timber.d("Sensitive gate: dropped %s", obs.target)
+    if (isNoise) Timber.v("Noise gate: dropped %s", obs.target)
+    return !isSensitive && !isNoise
+}

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/AccessibilityPipeline.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/AccessibilityPipeline.kt
@@ -9,6 +9,7 @@ import cloud.trotter.dashbuddy.domain.state.ParsedFields
 import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.core.pipeline.CaptureWriter
 import cloud.trotter.dashbuddy.core.pipeline.FrameGate
+import cloud.trotter.dashbuddy.core.pipeline.passesContentGates
 import cloud.trotter.dashbuddy.core.pipeline.ObservationClassifier
 import cloud.trotter.dashbuddy.core.pipeline.PipelineEvent
 import cloud.trotter.dashbuddy.core.pipeline.accessibility.event.type.window.content_changed.ContentChangedPipeline
@@ -88,15 +89,9 @@ class AccessibilityPipeline @Inject constructor(
         // Classify through the unified rule engine (typed: FlowObservation, #361)
         .map { event -> classifier.classify(event) to event }
 
-        // Gate: drop sensitive/noise observations (pledge: never store or forward)
-        .filter { (obs, _) ->
-            val parsed = obs.parsed
-            val isSensitive = parsed is ParsedFields.SensitiveFields
-            val isNoise = parsed is ParsedFields.NoiseFields
-            if (isSensitive) Timber.d("Sensitive gate: dropped %s", obs.target)
-            if (isNoise) Timber.v("Noise gate: dropped %s", obs.target)
-            !isSensitive && !isNoise
-        }
+        // Gate: drop sensitive/noise observations (pledge: never store or
+        // forward) — the shared content gate (#399).
+        .filter { (obs, _) -> passesContentGates(obs) }
 
         // Gate: drop observations from disabled platforms (defense-in-depth)
         .filter { (_, event) ->

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/notification/NotificationPipeline.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/notification/NotificationPipeline.kt
@@ -9,6 +9,7 @@ import cloud.trotter.dashbuddy.core.pipeline.ObservationClassifier
 import cloud.trotter.dashbuddy.core.pipeline.PipelineEvent
 import cloud.trotter.dashbuddy.core.pipeline.CaptureWriter
 import cloud.trotter.dashbuddy.core.pipeline.FrameGate
+import cloud.trotter.dashbuddy.core.pipeline.passesContentGates
 import cloud.trotter.dashbuddy.core.pipeline.notification.input.NotificationSource
 import cloud.trotter.dashbuddy.core.pipeline.notification.mapper.toDomain
 import kotlinx.coroutines.CoroutineScope
@@ -49,12 +50,10 @@ class NotificationPipeline @Inject constructor(
             val event = PipelineEvent.Notification(raw.postTime, raw)
             classifier.classify(event) to raw
         }
-        // Gate: drop noise observations (known-irrelevant, never capture or forward)
-        .filter { (obs, _) ->
-            val isNoise = obs.parsed is ParsedFields.NoiseFields
-            if (isNoise) Timber.v("Noise gate: dropped notification %s", obs.target)
-            !isNoise
-        }
+        // Gate: drop sensitive/noise observations (pledge: never store or
+        // forward) — the shared content gate, symmetric with the
+        // accessibility pipeline (#399).
+        .filter { (obs, _) -> passesContentGates(obs) }
         // Gate: drop observations from disabled platforms (defense-in-depth)
         .filter { (_, raw) ->
             val platform = Platform.fromPackage(raw.packageName)

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/ContentGatesTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/ContentGatesTest.kt
@@ -1,0 +1,48 @@
+package cloud.trotter.dashbuddy.core.pipeline
+
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
+import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.state.Flow
+import cloud.trotter.dashbuddy.domain.state.Mode
+import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #399 — the shared content gate must drop SENSITIVE and NOISE observations
+ * for BOTH sensor pipelines (the notification chain previously had no
+ * sensitive gate at all; a future rule emitting the shape would have reached
+ * the capture bus and the state machine).
+ */
+class ContentGatesTest {
+
+    private fun notification(parsed: ParsedFields, target: String) = Observation.Notification(
+        timestamp = 1_000L, captureId = null, ruleId = "r",
+        metadata = ReplayMetadata.EMPTY, flow = Flow.Idle, modeHint = Mode.Online,
+        parsed = parsed, target = target,
+    )
+
+    private fun screen(parsed: ParsedFields, target: String) = Observation.Screen(
+        timestamp = 1_000L, captureId = null, ruleId = "r",
+        metadata = ReplayMetadata.EMPTY, flow = Flow.Idle, modeHint = Mode.Online,
+        parsed = parsed, target = target,
+    )
+
+    @Test
+    fun `sensitive observations are dropped — notification and screen alike`() {
+        assertFalse(passesContentGates(notification(ParsedFields.SensitiveFields(), "sensitive.banking")))
+        assertFalse(passesContentGates(screen(ParsedFields.SensitiveFields(), "sensitive.banking")))
+    }
+
+    @Test
+    fun `noise observations are dropped`() {
+        assertFalse(passesContentGates(notification(ParsedFields.NoiseFields(), "noise.ongoing")))
+    }
+
+    @Test
+    fun `ordinary observations pass — including UNKNOWN (captured for triage downstream)`() {
+        assertTrue(passesContentGates(notification(ParsedFields.None, "UNKNOWN")))
+        assertTrue(passesContentGates(screen(ParsedFields.None, "main_map_idle")))
+    }
+}


### PR DESCRIPTION
Fixes #399.

The P1 from the SSOT re-review: `NotificationPipeline` gated noise but never sensitive; `AccessibilityPipeline` gated both. Rather than copy the predicate (the exact drift SSOT forbids), both chains now call one shared `passesContentGates()` — a sensitive-shaped notification can't reach `CaptureWriter` or the state machine, and the two pipelines' gates can never diverge again. `ContentGatesTest` ×3 exercises the production predicate for both observation kinds (sensitive dropped, noise dropped, ordinary + UNKNOWN pass). AllMatchersSuite + full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)