### PR TITLE
fix(network): pin EPA wire-string normalization to Locale.ROOT (#405)

### DIFF
--- a/core/network/src/main/java/cloud/trotter/dashbuddy/core/network/di/GasPriceApiModule.kt
+++ b/core/network/src/main/java/cloud/trotter/dashbuddy/core/network/di/GasPriceApiModule.kt
@@ -19,6 +19,8 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object GasPriceApiModule {
+
+    private const val BASE_URL = "https://api.eia.gov/"
     @Provides
     @Singleton
     fun provideEiaApi(): EiaApi {
@@ -47,7 +49,7 @@ object GasPriceApiModule {
             .build()
 
         return Retrofit.Builder()
-            .baseUrl("https://api.eia.gov/")
+            .baseUrl(BASE_URL)
             .client(client)
             .addConverterFactory(json.asConverterFactory(contentType))
             .build()

--- a/core/network/src/main/java/cloud/trotter/dashbuddy/core/network/vehicle/efficiency/epa/EpaVehicleDataSource.kt
+++ b/core/network/src/main/java/cloud/trotter/dashbuddy/core/network/vehicle/efficiency/epa/EpaVehicleDataSource.kt
@@ -58,7 +58,9 @@ class EpaVehicleDataSource @Inject constructor(
 
     private fun mapFuelType(epaString: String?): FuelType {
         if (epaString == null) return FuelType.REGULAR
-        val lower = epaString.lowercase(Locale.getDefault())
+        // Locale.ROOT (#405): EPA wire strings must not pass through the
+        // device locale (Turkish-I breaks every match).
+        val lower = epaString.lowercase(Locale.ROOT)
         return when {
             lower.contains("electricity") -> FuelType.ELECTRICITY
             lower.contains("premium") -> FuelType.PREMIUM

--- a/core/network/src/main/java/cloud/trotter/dashbuddy/core/network/vehicle/efficiency/epa/VClassMap.kt
+++ b/core/network/src/main/java/cloud/trotter/dashbuddy/core/network/vehicle/efficiency/epa/VClassMap.kt
@@ -22,7 +22,8 @@ import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleClass
  */
 fun mapEpaVClass(raw: String?): VehicleClass? {
     if (raw.isNullOrBlank()) return null
-    val s = raw.lowercase()
+    // Locale.ROOT (#405): EPA wire string — same Turkish-I class.
+    val s = raw.lowercase(java.util.Locale.ROOT)
 
     return when {
         // Pickups before SUVs because some "pickup utility" strings contain both

--- a/core/network/src/test/java/cloud/trotter/dashbuddy/core/network/vehicle/VClassMapLocaleTest.kt
+++ b/core/network/src/test/java/cloud/trotter/dashbuddy/core/network/vehicle/VClassMapLocaleTest.kt
@@ -1,0 +1,38 @@
+package cloud.trotter.dashbuddy.core.network.vehicle
+
+import cloud.trotter.dashbuddy.core.network.vehicle.efficiency.epa.mapEpaVClass
+import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleClass
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.util.Locale
+
+/**
+ * #405 — EPA wire-string normalization must be locale-independent. Under a
+ * Turkish default locale, bare lowercase() maps I → dotless ı and every
+ * contains-match on a capital-I word silently fails.
+ */
+class VClassMapLocaleTest {
+
+    private lateinit var original: Locale
+
+    @Before
+    fun saveLocale() {
+        original = Locale.getDefault()
+    }
+
+    @After
+    fun restoreLocale() {
+        Locale.setDefault(original)
+    }
+
+    @Test
+    fun `EPA vehicle classes map correctly under a Turkish default locale`() {
+        Locale.setDefault(Locale.forLanguageTag("tr-TR"))
+        // "MIDSIZE" / "MINICOMPACT" / "PICKUP" all contain capital I — the bug class.
+        assertEquals(VehicleClass.SEDAN, mapEpaVClass("MIDSIZE CARS"))
+        assertEquals(VehicleClass.COMPACT, mapEpaVClass("MINICOMPACT CARS"))
+        assertEquals(VehicleClass.TRUCK, mapEpaVClass("SMALL PICKUP TRUCKS"))
+    }
+}


### PR DESCRIPTION
Fixes #405. Two missed sites of #362's Turkish-I class: `mapFuelType` (device-locale lowercase) and `mapEpaVClass` (bare lowercase) both normalize EPA wire strings — under tr/az locales every capital-I match (MIDSIZE/MINICOMPACT/PICKUP) silently fails. Pinned ROOT with a tr-TR-default test. Ride-along: EIA base URL → named const (consistency with VehicleNetworkModule). Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)