### PR TITLE
chore(ssot): config defaults — domain companions own them, datasources reference them (#401)

### DIFF
--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/settings/AppPreferencesRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/settings/AppPreferencesRepository.kt
@@ -104,7 +104,7 @@ class AppPreferencesRepository @Inject constructor(
         UserEconomy(
             vehicleClass = cls,
             vehicleMpg = id.mpg ?: cls.defaultMpg.coerceAtLeast(1.0),
-            gasPricePerGallon = id.gasPrice ?: 3.50,
+            gasPricePerGallon = id.gasPrice ?: UserEconomy.DEFAULT_GAS_PRICE_PER_GALLON,
             avgMinutesPerMile = id.avgMinPerMi ?: UserEconomy.DEFAULT_MINUTES_PER_MILE,
             basePickupMinutes = id.basePickupMin ?: UserEconomy.DEFAULT_BASE_PICKUP_MINUTES,
             tireSetCost = maintA.tireCost ?: cls.tireSetCost,

--- a/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/strategy/StrategyDataSource.kt
+++ b/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/strategy/StrategyDataSource.kt
@@ -15,6 +15,8 @@ import kotlinx.serialization.json.Json
 import javax.inject.Inject
 import javax.inject.Singleton
 import timber.log.Timber
+import cloud.trotter.dashbuddy.domain.config.EvidenceConfig
+import cloud.trotter.dashbuddy.domain.config.OfferAutomationConfig
 
 @Singleton
 class StrategyDataSource @Inject constructor(
@@ -41,20 +43,20 @@ class StrategyDataSource @Inject constructor(
         val ALLOW_SHOPPING = booleanPreferencesKey("allow_shopping")
     }
 
-    val evidenceMaster: Flow<Boolean> = ds.data.map { it[Keys.EVIDENCE_MASTER] ?: false }
-    val evidenceOffers: Flow<Boolean> = ds.data.map { it[Keys.EVIDENCE_OFFERS] ?: true }
-    val evidenceDelivery: Flow<Boolean> = ds.data.map { it[Keys.EVIDENCE_DELIVERY] ?: true }
-    val evidenceDash: Flow<Boolean> = ds.data.map { it[Keys.EVIDENCE_DASH] ?: true }
+    val evidenceMaster: Flow<Boolean> = ds.data.map { it[Keys.EVIDENCE_MASTER] ?: EvidenceConfig.DEFAULT_MASTER }
+    val evidenceOffers: Flow<Boolean> = ds.data.map { it[Keys.EVIDENCE_OFFERS] ?: EvidenceConfig.DEFAULT_SAVE_OFFERS }
+    val evidenceDelivery: Flow<Boolean> = ds.data.map { it[Keys.EVIDENCE_DELIVERY] ?: EvidenceConfig.DEFAULT_SAVE_DELIVERIES }
+    val evidenceDash: Flow<Boolean> = ds.data.map { it[Keys.EVIDENCE_DASH] ?: EvidenceConfig.DEFAULT_SAVE_DASHES }
 
-    val autoMaster: Flow<Boolean> = ds.data.map { it[Keys.AUTO_MASTER] ?: false }
+    val autoMaster: Flow<Boolean> = ds.data.map { it[Keys.AUTO_MASTER] ?: OfferAutomationConfig.DEFAULT_MASTER }
 
-    val autoAccept: Flow<Boolean> = ds.data.map { it[Keys.AUTO_ACCEPT] ?: false }
-    val autoAcceptMinPay: Flow<Double> = ds.data.map { it[Keys.AUTO_ACCEPT_MIN_PAY] ?: 10.0 }
-    val autoAcceptMinRatio: Flow<Double> = ds.data.map { it[Keys.AUTO_ACCEPT_MIN_RATIO] ?: 2.0 }
+    val autoAccept: Flow<Boolean> = ds.data.map { it[Keys.AUTO_ACCEPT] ?: OfferAutomationConfig.DEFAULT_AUTO_ACCEPT }
+    val autoAcceptMinPay: Flow<Double> = ds.data.map { it[Keys.AUTO_ACCEPT_MIN_PAY] ?: OfferAutomationConfig.DEFAULT_ACCEPT_MIN_PAY }
+    val autoAcceptMinRatio: Flow<Double> = ds.data.map { it[Keys.AUTO_ACCEPT_MIN_RATIO] ?: OfferAutomationConfig.DEFAULT_ACCEPT_MIN_RATIO }
 
-    val autoDecline: Flow<Boolean> = ds.data.map { it[Keys.AUTO_DECLINE] ?: false }
-    val autoDeclineMaxPay: Flow<Double> = ds.data.map { it[Keys.AUTO_DECLINE_MAX_PAY] ?: 3.50 }
-    val autoDeclineMinRatio: Flow<Double> = ds.data.map { it[Keys.AUTO_DECLINE_MIN_RATIO] ?: 0.50 }
+    val autoDecline: Flow<Boolean> = ds.data.map { it[Keys.AUTO_DECLINE] ?: OfferAutomationConfig.DEFAULT_AUTO_DECLINE }
+    val autoDeclineMaxPay: Flow<Double> = ds.data.map { it[Keys.AUTO_DECLINE_MAX_PAY] ?: OfferAutomationConfig.DEFAULT_DECLINE_MAX_PAY }
+    val autoDeclineMinRatio: Flow<Double> = ds.data.map { it[Keys.AUTO_DECLINE_MIN_RATIO] ?: OfferAutomationConfig.DEFAULT_DECLINE_MIN_RATIO }
 
     @OptIn(InternalSerializationApi::class)
     val scoringRules: Flow<List<ScoringRuleDto>> = ds.data.map { prefs ->

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/config/EvidenceConfig.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/config/EvidenceConfig.kt
@@ -1,8 +1,16 @@
 package cloud.trotter.dashbuddy.domain.config
 
 data class EvidenceConfig(
-    val masterEnabled: Boolean = false,
-    val saveOffers: Boolean = true,
-    val saveDeliverySummaries: Boolean = true,
-    val saveDashSummaries: Boolean = true
-)
+    val masterEnabled: Boolean = DEFAULT_MASTER,
+    val saveOffers: Boolean = DEFAULT_SAVE_OFFERS,
+    val saveDeliverySummaries: Boolean = DEFAULT_SAVE_DELIVERIES,
+    val saveDashSummaries: Boolean = DEFAULT_SAVE_DASHES,
+) {
+    companion object {
+        // ONE owner for every default (#401).
+        const val DEFAULT_MASTER = false
+        const val DEFAULT_SAVE_OFFERS = true
+        const val DEFAULT_SAVE_DELIVERIES = true
+        const val DEFAULT_SAVE_DASHES = true
+    }
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/config/OfferAutomationConfig.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/config/OfferAutomationConfig.kt
@@ -5,15 +5,27 @@ package cloud.trotter.dashbuddy.domain.config
  * Read by the side-effect engine's evaluation loopback to decide instant actions.
  */
 data class OfferAutomationConfig(
-    val masterAutoPilotEnabled: Boolean = false,
+    val masterAutoPilotEnabled: Boolean = DEFAULT_MASTER,
 
     // Auto-Accept
-    val autoAcceptEnabled: Boolean = false,
-    val autoAcceptMinPay: Double = 10.0,
-    val autoAcceptMinRatio: Double = 2.0, // $/mi
+    val autoAcceptEnabled: Boolean = DEFAULT_AUTO_ACCEPT,
+    val autoAcceptMinPay: Double = DEFAULT_ACCEPT_MIN_PAY,
+    val autoAcceptMinRatio: Double = DEFAULT_ACCEPT_MIN_RATIO, // $/mi
 
     // Auto-Decline
-    val autoDeclineEnabled: Boolean = false,
-    val autoDeclineMaxPay: Double = 3.50,
-    val autoDeclineMinRatio: Double = 0.50
-)
+    val autoDeclineEnabled: Boolean = DEFAULT_AUTO_DECLINE,
+    val autoDeclineMaxPay: Double = DEFAULT_DECLINE_MAX_PAY,
+    val autoDeclineMinRatio: Double = DEFAULT_DECLINE_MIN_RATIO,
+) {
+    companion object {
+        // ONE owner for every default (#401): the DataStore fallbacks
+        // reference these instead of restating literals.
+        const val DEFAULT_MASTER = false
+        const val DEFAULT_AUTO_ACCEPT = false
+        const val DEFAULT_ACCEPT_MIN_PAY = 10.0
+        const val DEFAULT_ACCEPT_MIN_RATIO = 2.0
+        const val DEFAULT_AUTO_DECLINE = false
+        const val DEFAULT_DECLINE_MAX_PAY = 3.50
+        const val DEFAULT_DECLINE_MIN_RATIO = 0.50
+    }
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/UserEconomy.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/UserEconomy.kt
@@ -21,8 +21,10 @@ import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleClass
  */
 data class UserEconomy(
     val vehicleClass: VehicleClass = VehicleClass.SEDAN,
-    val vehicleMpg: Double = 30.0,
-    val gasPricePerGallon: Double = 3.50,
+    /** Derives from the class (#401) — the old 30.0 literal silently
+     *  duplicated SEDAN.defaultMpg. */
+    val vehicleMpg: Double = vehicleClass.defaultMpg,
+    val gasPricePerGallon: Double = DEFAULT_GAS_PRICE_PER_GALLON,
 
     /** Minutes per mile of driving — default 2.5 (urban average). */
     val avgMinutesPerMile: Double = DEFAULT_MINUTES_PER_MILE,
@@ -97,6 +99,9 @@ data class UserEconomy(
     val isUsingDefaults: Boolean get() = userSetFields.size < EconomyField.entries.size
 
     companion object {
+        /** Fallback price-per-gallon when no fetched price exists (#401). */
+        const val DEFAULT_GAS_PRICE_PER_GALLON = 3.50
+
         const val DEFAULT_MINUTES_PER_MILE = 2.5
         const val DEFAULT_BASE_PICKUP_MINUTES = 7.0
         const val DEFAULT_ANNUAL_DASH_MI = 10_000.0


### PR DESCRIPTION
Fixes #401. Eleven DataStore fallback literals + the matching data-class defaults collapse onto `DEFAULT_*` companions (`OfferAutomationConfig`, `EvidenceConfig`, `UserEconomy.DEFAULT_GAS_PRICE_PER_GALLON`); `UserEconomy.vehicleMpg` now derives from `vehicleClass.defaultMpg` instead of restating SEDAN's 30.0. Each default exists exactly once. Full suite + release compile green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)