### PR TITLE
chore(ssot): display-fallback unification + card divergence fix (#403)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardItem.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardItem.kt
@@ -53,6 +53,7 @@ import cloud.trotter.dashbuddy.domain.state.PickupActivity
 import cloud.trotter.dashbuddy.domain.model.event.AppEventType
 import cloud.trotter.dashbuddy.ui.formatters.displayLabel
 import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluator
+import cloud.trotter.dashbuddy.domain.state.customerDisplayName
 
 /**
  * A single flow-phase card in the bubble HUD stack (#257).
@@ -218,7 +219,7 @@ private fun pickupSummary(snap: FlowCardSnapshot.Pickup, isActive: Boolean): Str
 
 @Composable
 private fun deliverySummary(snap: FlowCardSnapshot.Delivery, isActive: Boolean): String {
-    val customer = snap.customerHash?.take(6) ?: "Customer"
+    val customer = customerDisplayName(snap.customerHash)
     val arrivedAt = snap.arrivedAt
     return when {
         isActive -> customer
@@ -475,7 +476,7 @@ private fun DeliveryBody(snap: FlowCardSnapshot.Delivery, isActive: Boolean) {
         deadlineMillis = snap.deadlineMillis,
         phaseEndedAt = snap.phaseEndedAt,
         isActive = isActive,
-        primary = snap.customerHash?.take(6) ?: "Customer",
+        primary = customerDisplayName(snap.customerHash),
         confirmedAt = null,
         itemsShopped = null,
         itemsRemaining = null,

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardMapper.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardMapper.kt
@@ -9,6 +9,7 @@ import cloud.trotter.dashbuddy.domain.model.event.payload.OfferReceivedPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.PickupPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStartPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStopPayload
+import cloud.trotter.dashbuddy.domain.state.UNKNOWN_STORE
 
 /**
  * Pure fold from the AppEvent log to the completed-card list for the bubble
@@ -124,7 +125,7 @@ object FlowCardMapper {
                     val current = openPickup
                     if (current?.taskId == payload.taskId) {
                         openPickup = current.copy(
-                            storeName = payload.storeName,
+                            storeName = payload.storeName.ifBlank { current.storeName },
                             itemsRemaining = payload.itemsRemaining ?: current.itemsRemaining,
                             itemsShopped = payload.itemsShopped ?: current.itemsShopped,
                             deadlineMillis = payload.deadlineMillis ?: current.deadlineMillis,
@@ -136,7 +137,7 @@ object FlowCardMapper {
                             phaseStartedAt = payload.phaseStartedAt,
                             taskId = payload.taskId,
                             jobId = payload.jobId,
-                            storeName = payload.storeName,
+                            storeName = payload.storeName.ifBlank { UNKNOWN_STORE },
                             deadlineMillis = payload.deadlineMillis,
                             itemsRemaining = payload.itemsRemaining,
                             itemsShopped = payload.itemsShopped,
@@ -159,7 +160,7 @@ object FlowCardMapper {
                             phaseStartedAt = payload.phaseStartedAt,
                             taskId = payload.taskId,
                             jobId = payload.jobId,
-                            storeName = payload.storeName,
+                            storeName = payload.storeName.ifBlank { UNKNOWN_STORE },
                             arrivedAt = payload.arrivedAt ?: event.occurredAt,
                             deadlineMillis = payload.deadlineMillis,
                             itemsRemaining = payload.itemsRemaining,
@@ -183,7 +184,7 @@ object FlowCardMapper {
                             phaseEndedAt = payload.confirmedAt ?: event.occurredAt,
                             taskId = payload.taskId,
                             jobId = payload.jobId,
-                            storeName = payload.storeName,
+                            storeName = payload.storeName.ifBlank { UNKNOWN_STORE },
                             arrivedAt = payload.arrivedAt,
                             confirmedAt = payload.confirmedAt ?: event.occurredAt,
                             deadlineMillis = payload.deadlineMillis,

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/LiveCardBuilder.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/LiveCardBuilder.kt
@@ -5,6 +5,7 @@ import cloud.trotter.dashbuddy.domain.state.AppState
 import cloud.trotter.dashbuddy.domain.state.Flow
 import cloud.trotter.dashbuddy.domain.state.Mode
 import cloud.trotter.dashbuddy.domain.state.TaskPhase
+import cloud.trotter.dashbuddy.domain.state.UNKNOWN_STORE
 
 /**
  * Constructs the live (active) flow card from the current [AppState].
@@ -67,7 +68,7 @@ object LiveCardBuilder {
                     phaseStartedAt = task.startedAt,
                     taskId = task.taskId,
                     jobId = task.jobId,
-                    storeName = task.storeName ?: "Unknown",
+                    storeName = task.storeName ?: UNKNOWN_STORE,
                     arrivedAt = task.arrivedAt,
                     deadlineMillis = task.deadlineMillis,
                     itemsRemaining = task.itemsRemaining,

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardMapperTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardMapperTest.kt
@@ -24,6 +24,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import cloud.trotter.dashbuddy.domain.evaluation.OfferQuality
+import cloud.trotter.dashbuddy.domain.state.UNKNOWN_STORE
 
 class FlowCardMapperTest {
 
@@ -666,5 +667,20 @@ class FlowCardMapperTest {
         // Stale Offer card is dropped by the DASH_START reset; the new
         // Awaiting card is still open (no end-time yet).
         assertEquals(0, cards.size)
+    }
+
+    // ── #403: blank store names render the same fallback as the live card ──
+
+    @Test
+    fun `a blank store name on PICKUP_NAV_STARTED falls back to Unknown like the live card`() {
+        val events = listOf(
+            event(AppEventType.PICKUP_NAV_STARTED,
+                pickupPayload(taskId = "t1", jobId = "j1", store = "", started = 1000L), 1000L),
+            event(AppEventType.PICKUP_CONFIRMED,
+                pickupPayload(taskId = "t1", jobId = "j1", store = "", started = 1000L, confirmed = 2000L), 2000L),
+        )
+        val cards = FlowCardMapper.fold(events)
+        val pickup = cards.filterIsInstance<FlowCardSnapshot.Pickup>().single()
+        assertEquals(UNKNOWN_STORE, pickup.storeName)
     }
 }

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -38,6 +38,8 @@ import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
 import cloud.trotter.dashbuddy.domain.pipeline.ObservationPayload
+import cloud.trotter.dashbuddy.domain.state.UNKNOWN_STORE
+import cloud.trotter.dashbuddy.domain.state.customerDisplayName
 
 /**
  * Replaces 9 reducers + 8 factories. Diffs each region before/after
@@ -108,7 +110,7 @@ class EffectMap @Inject constructor() {
         // across platforms (#257 design discussion).
         if (prevOffer == null && nextOffer != null) {
             val offer = nextOffer.offerFields
-            val platform = next.activePlatform?.name ?: "Unknown"
+            val platform = (next.activePlatform ?: Platform.Unknown).name
 
             // Log OFFER_RECEIVED with the full parsed offer. Evaluation
             // hasn't run yet at this point (it fires async via the
@@ -438,7 +440,7 @@ class EffectMap @Inject constructor() {
                 if (taskStartOverride != null) {
                     addAll(taskStartOverride)
                 } else {
-                    val storeName = nextTask.storeName ?: "Unknown"
+                    val storeName = nextTask.storeName ?: UNKNOWN_STORE
                     val payload = pickupPayload(nextTask, storeName)
                     add(logEffect(sessionId, AppEventType.PICKUP_NAV_STARTED, obs.timestamp, payload))
                     add(AppEffect.ResumeOdometer)
@@ -475,7 +477,7 @@ class EffectMap @Inject constructor() {
                 val customerHash = nextTask.customerNameHash
                 val pickupConfirmed = pickupPayload(
                     task = prevTask,
-                    storeName = prevTask.storeName ?: "Unknown",
+                    storeName = prevTask.storeName ?: UNKNOWN_STORE,
                     confirmedAt = obs.timestamp,
                 )
                 val deliveryStart = deliveryPhasePayload(
@@ -486,7 +488,7 @@ class EffectMap @Inject constructor() {
                 add(logEffect(sessionId, AppEventType.DELIVERY_NAV_STARTED, obs.timestamp, deliveryStart))
                 add(AppEffect.ResumeOdometer)
 
-                val customer = customerHash?.take(6) ?: "Customer"
+                val customer = customerDisplayName(customerHash)
                 add(AppEffect.UpdateBubble("Heading to $customer", ChatPersona.Customer(customer)))
             }
 
@@ -506,7 +508,7 @@ class EffectMap @Inject constructor() {
                                 sessionId, AppEventType.PICKUP_ARRIVED, obs.timestamp,
                                 pickupPayload(
                                     task = nextTask,
-                                    storeName = nextTask.storeName ?: "Unknown",
+                                    storeName = nextTask.storeName ?: UNKNOWN_STORE,
                                 ),
                             )
                         )
@@ -531,11 +533,11 @@ class EffectMap @Inject constructor() {
                 val prevName = prevTask.storeName?.trim()
                 val nextName = nextTask.storeName?.trim()
                 val storeChanged = nextName != prevName &&
-                    nextName != null && nextName != "Unknown"
+                    nextName != null && nextName != UNKNOWN_STORE
                 val activityChanged = nextTask.activity != prevTask.activity
 
                 if (storeChanged || activityChanged) {
-                    val storeName = nextTask.storeName ?: "Unknown"
+                    val storeName = nextTask.storeName ?: UNKNOWN_STORE
                     val persona = determinePickupPersona(
                         nextTask.activity,
                         nextTask.arrivedAt != null,
@@ -550,7 +552,7 @@ class EffectMap @Inject constructor() {
                 // PICKUP_NAV_STARTED per task as canonical, so this is the
                 // store name the Pickup card will render.
                 if (storeChanged) {
-                    val storeName = nextTask.storeName ?: "Unknown"
+                    val storeName = nextTask.storeName ?: UNKNOWN_STORE
                     add(
                         logEffect(
                             sessionId, AppEventType.PICKUP_NAV_STARTED, obs.timestamp,
@@ -814,7 +816,7 @@ class EffectMap @Inject constructor() {
     ): ChatPersona {
         return when {
             activity == PickupActivity.SHOPPING -> ChatPersona.Shopper
-            activity == PickupActivity.CONFIRMED -> ChatPersona.Customer(customerHash?.take(6) ?: "Customer")
+            activity == PickupActivity.CONFIRMED -> ChatPersona.Customer(customerDisplayName(customerHash))
             arrived -> ChatPersona.Merchant(storeName)
             else -> ChatPersona.Navigator
         }

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
@@ -20,6 +20,7 @@ import cloud.trotter.dashbuddy.domain.state.TaskSubFlow
 import cloud.trotter.dashbuddy.domain.state.TransitionKind
 import javax.inject.Inject
 import javax.inject.Singleton
+import cloud.trotter.dashbuddy.domain.state.UNKNOWN_STORE
 
 /**
  * Region 2+ stepper — per-platform durable state.
@@ -512,7 +513,7 @@ class PlatformRegionStepper @Inject constructor() {
                 currentTask.arrivedAt != null &&
                 taskSubFlow == TaskSubFlow.NAVIGATION &&
                 taskFields?.storeName != null &&
-                !taskFields.storeName.equals("Unknown", ignoreCase = true) &&
+                !taskFields.storeName.equals(UNKNOWN_STORE, ignoreCase = true) &&
                 taskFields.storeName != currentTask.storeName
 
             // Stacked-dropoff transition: symmetric to the pickup case but keyed

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/DisplayNames.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/DisplayNames.kt
@@ -1,0 +1,17 @@
+package cloud.trotter.dashbuddy.domain.state
+
+/**
+ * Shared display-name sentinels and derivations (#403). Each existed as
+ * scattered matching literals across the state layer and the bubble UI —
+ * one owner now, so the fallbacks can't drift.
+ */
+
+/** Store-name sentinel for a task whose store hasn't resolved yet. */
+const val UNKNOWN_STORE = "Unknown"
+
+/** Customer display fallback when no name hash is available. */
+const val CUSTOMER_FALLBACK = "Customer"
+
+/** The ONE derivation of a short customer display name from the privacy hash. */
+fun customerDisplayName(customerHash: String?): String =
+    customerHash?.take(6) ?: CUSTOMER_FALLBACK


### PR DESCRIPTION
Fixes #403. `domain/state/DisplayNames.kt` owns `UNKNOWN_STORE`, `CUSTOMER_FALLBACK`, and the one `customerDisplayName(hash)` derivation (was 7 + 4 scattered literals across EffectMap, the stepper guard, and FlowCardItem). The live-vs-completed divergence is fixed: the mapper's Pickup paths normalize blank store names to `UNKNOWN_STORE` like the live card, and a follow-up event with a blank name keeps the current name instead of erasing it. Bonus: EffectMap's platform fallback uses `Platform.Unknown.name` instead of a string. Test pins the blank-store path. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)