### PR TITLE
chore(rules): dedupe id-derivation + assertion-name list (#404)

### DIFF
--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompiler.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompiler.kt
@@ -813,8 +813,9 @@ object RuleCompiler {
     // ==========================================================================
 
     /**
-     * Derive a classification name from a rule ID by stripping the platform prefix.
-     * "doordash.screen.idle_map" → "idle_map"
+     * THE id→name derivation (#404): strips the platform prefix.
+     * "doordash.screen.idle_map" → "idle_map". Used for classification
+     * targets here and intent fallbacks in [Ruleset] — one rule, one owner.
      */
     internal fun deriveTargetFromId(id: String): String {
         val parts = id.split(".", limit = 3)

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/Ruleset.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/Ruleset.kt
@@ -108,7 +108,7 @@ class Ruleset<TInput>(rules: List<CompiledRule<TInput>>) {
 
                 return RuleMatchResult(
                     ruleId = rule.id,
-                    intent = branch.intent ?: deriveIntentFromId(rule.id),
+                    intent = branch.intent ?: RuleCompiler.deriveTargetFromId(rule.id),
                     shape = branch.shape,
                     flow = branch.flow,
                     modeHint = branch.modeHint,
@@ -224,14 +224,6 @@ class Ruleset<TInput>(rules: List<CompiledRule<TInput>>) {
         const val MAX_TEMPLATE_VALUE_LENGTH = 256
         private val TEMPLATE_PATTERN = Regex("""\{(\w+)\}""")
 
-        /**
-         * Derive intent from a rule ID by stripping the platform prefix.
-         * "doordash.screen.idle_map" → "idle_map"
-         */
-        private fun deriveIntentFromId(id: String): String {
-            val parts = id.split(".", limit = 3)
-            return if (parts.size >= 3) parts[2] else id
-        }
     }
 
     private fun resolveTemplateArgs(

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/TransformRegistry.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/TransformRegistry.kt
@@ -224,15 +224,21 @@ object TransformRegistry {
     //  Validate assertions
     // ========================================================================
 
+    // ONE owner for the assertion vocabulary (#404): the dispatch map drives
+    // both validate() and the compile-time name check — adding an assertion
+    // is exactly one entry here plus its implementation.
+    private val knownAssertions: Map<String, (JsonObject, Map<String, Any?>) -> ValidateOutcome> = mapOf(
+        "sumApproxEquals" to ::validateSumApproxEquals,
+        "fieldsLe" to ::validateFieldsLe,
+        "fieldsGe" to ::validateFieldsGe,
+        "fieldNotNull" to ::validateFieldNotNull,
+        "fieldEquals" to ::validateFieldEquals,
+    )
+
     fun validate(name: String, args: JsonObject, parsed: Map<String, Any?>): ValidateOutcome {
-        return when (name) {
-            "sumApproxEquals" -> validateSumApproxEquals(args, parsed)
-            "fieldsLe" -> validateFieldsLe(args, parsed)
-            "fieldsGe" -> validateFieldsGe(args, parsed)
-            "fieldNotNull" -> validateFieldNotNull(args, parsed)
-            "fieldEquals" -> validateFieldEquals(args, parsed)
-            else -> throw RuleCompileException("Unknown validate assertion: '$name'")
-        }
+        val assertion = knownAssertions[name]
+            ?: throw RuleCompileException("Unknown validate assertion: '$name'")
+        return assertion(args, parsed)
     }
 
     // ========================================================================
@@ -320,10 +326,7 @@ object TransformRegistry {
     }
 
     fun validateAssertionName(name: String) {
-        val known = setOf(
-            "sumApproxEquals", "fieldsLe", "fieldsGe", "fieldNotNull", "fieldEquals",
-        )
-        if (name !in known) throw RuleCompileException("Unknown validate assertion: '$name'")
+        if (name !in knownAssertions) throw RuleCompileException("Unknown validate assertion: '$name'")
     }
 
     // ========================================================================


### PR DESCRIPTION
Fixes #404. One `deriveTargetFromId` (Ruleset's twin deleted); one `knownAssertions` dispatch map driving both `validate()` and `validateAssertionName()` — a sixth assertion is now one entry + its implementation, compile-time check included for free. Diffs kept surgical per the #293 sequencing note. AllMatchersSuite + full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)