### PR TITLE
chore: post-campaign stragglers sweep (#406)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
@@ -264,32 +264,8 @@ class SideEffectEngine @Inject constructor(
 
             // --- TIMING LOGIC (Pure Coroutines) ---
 
-            is AppEffect.ScheduleTimeout -> {
-                // Cancel existing timer of this type
-                activeTimers[effect.type]?.cancel()
-
-                // LAZY start so the map entry exists before the body can run; the completion
-                // handler removes only ITSELF (two-arg remove), so an expiring timer can never
-                // untrack a replacement scheduled for the same type (#341). Detached onto the
-                // engine scope — never blocks the queue (#351).
-                val job = engineScope.launch(start = CoroutineStart.LAZY) {
-                    delay(effect.durationMs)
-                    Timber.w("Timer Expired: ${effect.type}")
-
-                    // Emit Timeout Event back to State Machine
-                    _events.emit(
-                        TimeoutEvent(
-                            timestamp = System.currentTimeMillis(),
-                            type = effect.type,
-                            platform = effect.platform,
-                            payload = effect.payload,
-                        )
-                    )
-                }
-                job.invokeOnCompletion { activeTimers.remove(effect.type, job) }
-                activeTimers[effect.type] = job
-                job.start()
-            }
+            is AppEffect.ScheduleTimeout ->
+                scheduleTimer(effect.type, effect.durationMs, effect.platform, effect.payload)
 
             is AppEffect.CancelTimeout -> {
                 // Untracking happens via the job's self-removing completion handler.
@@ -428,17 +404,32 @@ class SideEffectEngine @Inject constructor(
             return
         }
         val durationMs = args["durationMs"]?.toLongOrNull() ?: return
+        scheduleTimer(type, durationMs, platform, payload = null)
+    }
 
+    /**
+     * THE timer pattern (#406): LAZY start so the map entry exists before the
+     * body can run; the completion handler removes only ITSELF (two-arg
+     * remove), so an expiring timer can never untrack a replacement of the
+     * same type (#341). Detached onto the engine scope — never blocks the
+     * queue (#351). Previously hand-rolled twice in this file.
+     */
+    private fun scheduleTimer(
+        type: TimeoutType,
+        durationMs: Long,
+        platform: Platform?,
+        payload: ObservationPayload?,
+    ) {
         activeTimers[type]?.cancel()
-        // Same LAZY + self-removing pattern as AppEffect.ScheduleTimeout (#341).
         val job = engineScope.launch(start = CoroutineStart.LAZY) {
             delay(durationMs)
-            Timber.w("Timer Expired (rule): %s", type)
+            Timber.w("Timer Expired: %s", type)
             _events.emit(
                 TimeoutEvent(
                     timestamp = System.currentTimeMillis(),
                     type = type,
                     platform = platform,
+                    payload = payload,
                 )
             )
         }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleScreen.kt
@@ -530,6 +530,8 @@ fun ChatBubble(message: ChatMessage) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
+                // Deliberate 12dp chat-bubble radius — between the small/medium
+                // shape tokens; revisit if DashShapes grows a chat variant (#406).
                 .clip(RoundedCornerShape(12.dp))
                 .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
                 .padding(12.dp)
@@ -558,9 +560,10 @@ fun ChatBubble(message: ChatMessage) {
 
                 Text(
                     text = timeString,
+                    // labelSmall already maps to the micro (10sp) token —
+                    // the explicit override duplicated it invisibly (#406).
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
-                    fontSize = 10.sp
                 )
             }
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardItem.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardItem.kt
@@ -35,7 +35,6 @@ import cloud.trotter.dashbuddy.core.designsystem.time.rememberNow
 import cloud.trotter.dashbuddy.core.designsystem.time.rememberTimeFormatter
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
@@ -286,11 +285,7 @@ private fun OfferBody(snap: FlowCardSnapshot.Offer, isActive: Boolean) {
             val now by rememberNow()
             val secsLeft = ((expiresAt - now) / 1000f).coerceAtLeast(0f)
             val frac = (secsLeft / countdownSeconds).coerceIn(0f, 1f)
-            val barColor = when {
-                frac > 0.45f -> c.good
-                frac > 0.2f -> c.warn
-                else -> c.bad
-            }
+            val barColor = offerExpiryColor(frac.toDouble(), c)
             Box(
                 Modifier.fillMaxWidth().height(4.dp)
                     .clip(RoundedCornerShape(2.dp)).background(c.line),
@@ -414,11 +409,7 @@ private fun OfferCountdownText(expiresAt: Long, countdownSeconds: Int) {
     val now by rememberNow()
     val secsLeft = ((expiresAt - now) / 1000.0).coerceAtLeast(0.0)
     val frac = if (countdownSeconds > 0) (secsLeft / countdownSeconds).coerceIn(0.0, 1.0) else 0.0
-    val col = when {
-        frac > 0.45 -> c.good
-        frac > 0.2 -> c.warn
-        else -> c.bad
-    }
+    val col = offerExpiryColor(frac, c)
     Text(
         text = formatCountdown((secsLeft * 1000).toLong()),
         style = DashTheme.num.smNum,
@@ -717,6 +708,13 @@ private fun deadlineColor(remainingMs: Long): Color {
 // ---------------------------------------------------------------------------
 // Time helpers — the shared kit lives in :core:designsystem (#358)
 // ---------------------------------------------------------------------------
+
+/** THE offer-expiry color tiers (#406) — previously written twice in this file. */
+private fun offerExpiryColor(frac: Double, c: DashColors): Color = when {
+    frac > 0.45 -> c.good
+    frac > 0.2 -> c.warn
+    else -> c.bad
+}
 
 @Composable
 private fun formatTime(millis: Long): String = rememberTimeFormatter().invoke(millis)

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/SettingsHomeScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/SettingsHomeScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/capture/DiskCaptureBus.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/capture/DiskCaptureBus.kt
@@ -4,7 +4,6 @@ import cloud.trotter.dashbuddy.domain.capture.CaptureBus
 import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import timber.log.Timber

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/location/OdometerRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/location/OdometerRepository.kt
@@ -4,7 +4,6 @@ import cloud.trotter.dashbuddy.core.datastore.odometer.OdometerLocalDataSource
 import cloud.trotter.dashbuddy.core.location.LocationDataSource
 import cloud.trotter.dashbuddy.domain.model.location.Coordinates
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/log/LogRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/log/LogRepository.kt
@@ -3,12 +3,12 @@ package cloud.trotter.dashbuddy.core.data.log
 import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import java.io.File
-import java.text.SimpleDateFormat
-import java.util.Date
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -54,7 +54,10 @@ class LogRepository @Inject constructor(
     private val rotationPrefix = "app_log_rotated_"
 
     // Format for log rotation: app_log_rotated_20260127_143000.log
-    private val logRotationFormat = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US)
+    // DateTimeFormatter (#406): thread-safe, consistent with DiskCaptureBus.
+    private val logRotationFormat = DateTimeFormatter
+        .ofPattern("yyyyMMdd_HHmmss", Locale.US)
+        .withZone(ZoneId.systemDefault())
 
     /**
      * Appends a pre-formatted line to the main log file.
@@ -69,7 +72,7 @@ class LogRepository @Inject constructor(
      */
     private fun rotateLogFile() {
         try {
-            val timestamp = logRotationFormat.format(Date())
+            val timestamp = logRotationFormat.format(Instant.now())
             val rotatedName = "${rotationPrefix}${timestamp}.log"
             val rotatedFile = File(logDir, rotatedName)
 

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/settings/DevSettingsRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/settings/DevSettingsRepository.kt
@@ -3,7 +3,6 @@ package cloud.trotter.dashbuddy.core.data.settings
 import android.util.Log
 import cloud.trotter.dashbuddy.core.datastore.settings.DevSettingsDataSource
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/strategy/StrategyRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/strategy/StrategyRepository.kt
@@ -10,12 +10,10 @@ import cloud.trotter.dashbuddy.domain.evaluation.MerchantAction
 import cloud.trotter.dashbuddy.domain.evaluation.MetricType
 import cloud.trotter.dashbuddy.domain.evaluation.ScoringRule
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.serialization.InternalSerializationApi

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/AccessibilityPipeline.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/AccessibilityPipeline.kt
@@ -17,15 +17,11 @@ import cloud.trotter.dashbuddy.core.pipeline.accessibility.event.type.window.sta
 import cloud.trotter.dashbuddy.core.pipeline.accessibility.event.type.window.windows_changed.WindowsChangedPipeline
 import cloud.trotter.dashbuddy.core.pipeline.accessibility.input.AccessibilitySource
 import cloud.trotter.dashbuddy.core.pipeline.accessibility.mapper.toUiNode
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.merge
-import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/notification/NotificationPipeline.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/notification/NotificationPipeline.kt
@@ -12,14 +12,10 @@ import cloud.trotter.dashbuddy.core.pipeline.FrameGate
 import cloud.trotter.dashbuddy.core.pipeline.passesContentGates
 import cloud.trotter.dashbuddy.core.pipeline.notification.input.NotificationSource
 import cloud.trotter.dashbuddy.core.pipeline.notification.mapper.toDomain
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
-import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
@@ -134,7 +134,7 @@ class PlatformRegionStepper @Inject constructor() {
         }
 
         // Update session/job/task lifecycle based on flow changes
-        return updateLifecycle(afterMode, prevFlow, nextFlow, flowObs)
+        return updateLifecycle(afterMode, prevFlow, nextFlow, flowObs, policy)
     }
 
     // =========================================================================
@@ -271,6 +271,7 @@ class PlatformRegionStepper @Inject constructor() {
         prevFlow: FlowRegion,
         nextFlow: FlowRegion,
         obs: Observation.FlowObservation,
+        policy: TransitionPolicy,
     ): PlatformRegion {
         // Authoritative session end: a session:ended observation (the dash
         // summary) ends the session immediately, even when already Offline — the
@@ -316,7 +317,7 @@ class PlatformRegionStepper @Inject constructor() {
         r = updateJobLifecycle(r, prev, next, prevFlow, nextFlow, obs)
 
         // Task lifecycle
-        r = updateTaskLifecycle(r, prev, next, obs)
+        r = updateTaskLifecycle(r, prev, next, obs, policy)
 
         // Idle anchor: track when we started waiting for offers
         r = when {
@@ -469,7 +470,7 @@ class PlatformRegionStepper @Inject constructor() {
         // Post-task: keep job alive through PostTask for payout capture
         // Job ends when we leave PostTask for non-task flow
         if (prevFlowVal == Flow.PostTask && !nextFlowVal.isTaskFlow() && nextFlowVal != Flow.PostTask && nextFlowVal != Flow.OfferPresented) {
-            return completeActiveJob(region, obs)
+            return completeActiveJob(region)
         }
 
         return region
@@ -480,6 +481,7 @@ class PlatformRegionStepper @Inject constructor() {
         prevFlowVal: Flow,
         nextFlowVal: Flow,
         obs: Observation.FlowObservation,
+        policy: TransitionPolicy,
     ): PlatformRegion {
         val parsed = obs.parsed
 
@@ -605,7 +607,8 @@ class PlatformRegionStepper @Inject constructor() {
                     pendingDestructive = PendingDestructive(
                         kind = DestructiveKind.TASK_RETIRE,
                         since = obs.timestamp,
-                        deadline = obs.timestamp + TransitionPolicy.DEFAULT_GRACE_MS,
+                        // Through the injected policy (#406): the static constant ignored overrides.
+                        deadline = obs.timestamp + policy.gracePeriodMs,
                     ),
                 )
             }
@@ -662,7 +665,7 @@ class PlatformRegionStepper @Inject constructor() {
         )
     }
 
-    private fun completeActiveJob(region: PlatformRegion, obs: Observation): PlatformRegion {
+    private fun completeActiveJob(region: PlatformRegion): PlatformRegion {
         val job = region.activeJob ?: return region
         return region.copy(
             activeJob = null,


### PR DESCRIPTION
Fixes #406 — the last issue from the SSOT re-review. Every checklist item done, none deferred: one `scheduleTimer()` helper in the engine; `TipEffectHandler`/`BubbleManager` on injected dispatchers; `TransitionPolicy` threaded so BOTH grace windows honor overrides (+ dead param dropped); `LogRepository` on `DateTimeFormatter`; odometer notification consts; the redundant `10.sp` dropped and the 12dp chat radius documented; the twin offer-expiry color tiers unified; dead imports pruned across 9 files (each verified unused). Full suite + release compile green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)