### PR TITLE
docs(design): per-rule action capabilities + load-time consent

### DIFF
--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompiler.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompiler.kt
@@ -1215,10 +1215,113 @@ object RuleCompiler {
             throw RuleCompileException(
                 "Regex pattern length ${pattern.length} exceeds MAX_REGEX_LENGTH=$MAX_REGEX_LENGTH",
             )
+        assertNoCatastrophicBacktracking(pattern)
         return try {
             Regex(pattern, RegexOption.IGNORE_CASE)
         } catch (e: Exception) {
             throw RuleCompileException("Invalid regex pattern: '$pattern'", e)
+        }
+    }
+
+    /**
+     * Reject regex prone to catastrophic backtracking at COMPILE time (#418).
+     * Java/Kotlin [Regex] has no match timeout, and recognition runs regex on
+     * the per-event hot path, so one pathological pattern hangs the
+     * classification thread. The dominant exploit class — and the careless-
+     * author footgun — is an UNBOUNDED quantifier applied to a group whose body
+     * already contains an unbounded quantifier: `(a+)+`, `(a*)*`, `(.*)+`,
+     * `(\d+){2,}`. This is a conservative structural check: it accepts linear
+     * patterns like `(\d+)`, `(ab)+`, `\d+\.\d+`, `(?:abc)+` and rejects the
+     * nested-unbounded family.
+     */
+    internal fun assertNoCatastrophicBacktracking(pattern: String) {
+        // Phase 1: neutralize escapes and char classes, so the structural walk
+        // sees only literal atoms, group parens, and quantifiers. Inside a char
+        // class `[...]` the chars `(`, `)`, `+`, `*` are literal, and an escaped
+        // atom (`\d`) is one logical atom — both would confuse the walk.
+        val cleaned = StringBuilder()
+        var i = 0
+        while (i < pattern.length) {
+            when (pattern[i]) {
+                '\\' -> { cleaned.append('a'); i += 2 } // escaped atom → neutral atom
+                '[' -> {
+                    i++
+                    while (i < pattern.length && pattern[i] != ']') {
+                        if (pattern[i] == '\\') i++
+                        i++
+                    }
+                    i++ // past ']'
+                    cleaned.append('a') // the class is one neutral atom
+                }
+                else -> { cleaned.append(pattern[i]); i++ }
+            }
+        }
+
+        // Phase 2: walk the cleaned pattern; per group, track whether its body
+        // (recursively) contains an unbounded quantifier.
+        val s = cleaned.toString()
+        val containsUnbounded = ArrayDeque<Boolean>()
+        containsUnbounded.addLast(false) // top level
+        var j = 0
+        while (j < s.length) {
+            when (s[j]) {
+                '(' -> { containsUnbounded.addLast(false); j++ }
+                ')' -> {
+                    val bodyUnbounded = containsUnbounded.removeLast()
+                    val qEnd = unboundedQuantifierEnd(s, j + 1)
+                    if (qEnd != -1) {
+                        if (bodyUnbounded) {
+                            throw RuleCompileException(
+                                "Regex '$pattern' nests unbounded quantifiers (ReDoS risk) — " +
+                                    "an unbounded quantifier wraps a group that already repeats unboundedly.",
+                            )
+                        }
+                        // This group is itself unbounded → its parent now is too.
+                        if (containsUnbounded.isNotEmpty()) {
+                            containsUnbounded[containsUnbounded.size - 1] = true
+                        }
+                        j = qEnd
+                    } else {
+                        if (bodyUnbounded && containsUnbounded.isNotEmpty()) {
+                            containsUnbounded[containsUnbounded.size - 1] = true
+                        }
+                        j++
+                    }
+                }
+                '*', '+' -> {
+                    containsUnbounded[containsUnbounded.size - 1] = true
+                    j++
+                    if (j < s.length && s[j] == '?') j++ // lazy
+                }
+                '{' -> {
+                    val qEnd = unboundedQuantifierEnd(s, j)
+                    if (qEnd != -1) {
+                        containsUnbounded[containsUnbounded.size - 1] = true
+                        j = qEnd
+                    } else {
+                        // bounded {n} / {n,m} — skip past it
+                        val close = s.indexOf('}', j)
+                        j = if (close == -1) j + 1 else close + 1
+                    }
+                }
+                else -> j++
+            }
+        }
+    }
+
+    /** End index after an UNBOUNDED quantifier at [pos] (`*`, `+`, `{n,}`), or -1. */
+    private fun unboundedQuantifierEnd(s: String, pos: Int): Int {
+        if (pos >= s.length) return -1
+        return when (s[pos]) {
+            '*', '+' -> if (pos + 1 < s.length && s[pos + 1] == '?') pos + 2 else pos + 1
+            '{' -> {
+                val close = s.indexOf('}', pos)
+                if (close == -1) return -1
+                val body = s.substring(pos + 1, close)
+                if (!body.matches(Regex("\\d+,"))) return -1 // {n,} only; {n} / {n,m} are bounded
+                if (close + 1 < s.length && s[close + 1] == '?') close + 2 else close + 1
+            }
+            else -> -1
         }
     }
 }

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RegexReDoSTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RegexReDoSTest.kt
@@ -1,0 +1,62 @@
+package cloud.trotter.dashbuddy.core.pipeline.rules
+
+import org.junit.Assert.fail
+import org.junit.Test
+
+/**
+ * #418 — catastrophic-backtracking regex must be rejected at COMPILE time.
+ * Kotlin [Regex] has no match timeout and recognition runs regex on the
+ * per-event hot path, so a single nested-unbounded pattern would hang the
+ * classification thread. The detector is conservative: it rejects the
+ * nested-unbounded family and accepts the linear patterns the production
+ * rules actually use.
+ */
+class RegexReDoSTest {
+
+    private fun assertRejected(pattern: String) {
+        try {
+            RuleCompiler.compileRegex(pattern)
+            fail("expected RuleCompileException (ReDoS) for: $pattern")
+        } catch (e: RuleCompileException) {
+            // expected
+        }
+    }
+
+    private fun assertAccepted(pattern: String) {
+        // Throws if the detector false-positives or the pattern is invalid.
+        RuleCompiler.compileRegex(pattern)
+    }
+
+    @Test
+    fun `nested unbounded quantifiers are rejected`() {
+        assertRejected("(a+)+")
+        assertRejected("(a*)*")
+        assertRejected("(a+)*")
+        assertRejected("(.*)+")
+        assertRejected("(.+)*")
+        assertRejected("(\\d+){2,}")        // unbounded outer {n,} over unbounded inner
+        assertRejected("(a+)+\$")
+        assertRejected("((a+))+")           // unbounded buried one group deeper
+        assertRejected("(?:a+)+")           // non-capturing group, same risk
+        assertRejected("(a+|b+)+")          // unbounded inside an alternation branch
+        assertRejected("(\\d+\\s*)+")       // the realistic "repeat a padded number" footgun
+    }
+
+    @Test
+    fun `linear patterns are accepted - including every shape the production rules use`() {
+        assertAccepted("(\\d+)")            // group with unbounded inside but NOT quantified
+        assertAccepted("(ab)+")             // quantified group, bounded body
+        assertAccepted("(?:abc)+")
+        assertAccepted("\\d+\\.\\d+")
+        assertAccepted("(a+){2}")           // BOUNDED outer over unbounded inner — not catastrophic
+        assertAccepted("(a+)?")             // optional, bounded
+        // Verbatim from doordash.json / uber.json:
+        assertAccepted("\\\$\\d+\\.\\d{2}")
+        assertAccepted("\\d[\\d.]*\\s*mi")
+        assertAccepted("^Going to (?!\\d)")
+        assertAccepted("To shop \\((\\d+)\\)")
+        assertAccepted("\\bby\\s+\\d{1,2}:\\d{2}")
+        assertAccepted("^\\d{1,5}\\s+\\S")
+        assertAccepted("\\d{5}\$")
+    }
+}

--- a/docs/design/rule-capability-consent.md
+++ b/docs/design/rule-capability-consent.md
@@ -1,0 +1,134 @@
+# Design: per-rule action capabilities + load-time consent
+
+**Status:** proposal (2026-06-11). Concrete shape for #417 (make the permission
+gate real) and a safety prerequisite for #192 (matchers split — remote rules).
+Prompted by: "dynamically bundle the rule ACTIONS into a user-permission list at
+load time, if not already granted for that unique rule."
+
+## The problem it solves
+
+A rule can declare **actuating effects** — today `CLICK` (taps the third-party
+app's UI), `SCREENSHOT`, `SPEAK`; tomorrow likely `SWIPE`/`SCROLL`/`SET_TEXT`/
+global actions. Right now `SideEffectEngine.isPermissionGranted(tier)` returns
+`true` for everything, so any rule-declared action fires unconditionally. For
+bundled rules that's a deliberate single-user choice; once rules arrive from a
+forkable CDN (#192), it's **arbitrary UI actuation from untrusted input**.
+
+The blunt fix (#417) is to make the tier check real — "is the accessibility
+service enabled." But that's all-or-nothing: enabling the service to get
+recognition would also bless *every* rule's clicks. The better model, and what
+this design proposes, is **capability consent keyed on the (rule, action) pair**:
+the user approves "rule X may tap the *Accept* button," not "rules may click."
+
+## Core model
+
+A **RuleCapability** is the unit of consent — one actuating action a specific
+rule wants to perform:
+
+```
+RuleCapability(
+    ruleId: String,        // e.g. "doordash.offer.auto_decline"
+    verb: EffectVerb,      // CLICK, SWIPE, SCREENSHOT, SPEAK, …
+    target: String?,       // semantic target signature for UI-targeting verbs
+    source: String,        // "asset:doordash.json" | "cdn:<url>" | "fork:<id>"
+)
+```
+
+**Grant key = a content hash**, not the rule id alone:
+
+```
+capabilityHash = sha256("$ruleId|${verb.wire}|${target ?: ""}")
+```
+
+This is the load-bearing security property. The grant is pinned to *what the
+action does*. If a remote update to a **trusted rule id** changes its click
+target — or adds a new click — the hash changes, the old grant no longer
+covers it, and it re-enters the pending list for re-approval. Approving a
+benign `auto_decline` today cannot be silently escalated by a malicious CDN
+update to the same id tomorrow.
+
+### Target signature granularity (a real decision)
+
+For `CLICK`, the `RequestedEffect.targetRef: NodeRef` carries `viewIdSuffix`,
+`text`, `classNameHint`, `pathFingerprint`, `bounds`. Two options:
+
+- **Semantic (recommended):** `target = "${viewIdSuffix}|${text}"` (or a
+  normalized subset). Stable across third-party UI reflows; re-prompts only when
+  the rule genuinely retargets. Slightly coarser — "tap the Accept button"
+  rather than "tap the button at this exact tree path."
+- **Structural:** include `pathFingerprint`. Maximally precise but re-prompts on
+  any third-party redesign (annoying, and trains users to click-through
+  consent — a security anti-pattern).
+
+Recommend semantic; document that bounds are never part of the key (they shift
+constantly).
+
+## Lifecycle
+
+1. **Enumerate at load.** Generalize the existing
+   `RuleCompiler.enumeratePermissions(rules): Set<PermissionTier>` into
+   `enumerateCapabilities(rules): List<RuleCapability>` — walk every branch's
+   effects, keep the actuating ones (a defined `EffectVerb.isActuating` set:
+   tier ∈ {ACCESSIBILITY, AUDIO} and not app-internal). App-internal effects
+   (`BUBBLE`, `LOG`, `EVALUATE_OFFER`, odometer, timers) never need consent.
+2. **Partition against the grant store.** New persisted set of granted
+   `capabilityHash`es (`RuleCapabilityDataSource` in `:core:datastore` behind a
+   Hilt qualifier → `RuleCapabilityRepository` in `:core:data` exposing
+   `grantedHashes: StateFlow<Set<String>>`, `grant(hash)`, `revoke(hash)` —
+   reactive, per the shared-StateFlow pattern from #356).
+   - `granted` → action allowed.
+   - `pending` → **recognition still runs; the actuating effect is suppressed
+     (fail closed) until granted.** Populates a user-facing list.
+3. **Consent surface.** A review screen (settings + a prompt when *new* pending
+   capabilities appear after a ruleset update) rendering each in human terms —
+   "Rule `…auto_decline` wants to **tap** *Decline offer*" — with allow / deny.
+4. **Execution gate** (this is the real #417 fix). The engine fires an actuating
+   `RequestedEffect` iff **both**:
+   - the OS-level tier is granted (accessibility service enabled / audio
+     allowed), AND
+   - `capabilityHash(effect) ∈ grantedHashes`.
+   Either missing → log + skip (fail closed). Non-actuating effects bypass the
+   capability check entirely.
+
+## Bundled vs remote: keep the alpha frictionless, make the split safe
+
+`loadSingle`/`load` already thread a `source`. Policy:
+
+- **Asset source** (the bundled rules the developer ships) → **auto-grant** on
+  load. They're trusted; no consent friction in the single-user build.
+- **CDN / fork source** (#192) → **never auto-grant**; every actuating
+  capability is pending until the user approves it. This is what makes "rules
+  delivered over CDN" safe *by construction* — a downloaded rule can recognize
+  screens immediately but cannot touch the UI without an explicit, content-
+  pinned grant.
+
+So this design is shippable in two stages: the enumeration + grant store + gate
+land now (with asset auto-grant, so behavior is unchanged for bundled rules but
+the gate is finally real), and the consent UI + non-auto-grant remote policy
+land with the matchers work.
+
+## How it composes with the audit findings
+
+- **#417** — this *is* the real gate; `isPermissionGranted` becomes
+  `isCapabilityGranted(ruleId, effect)` = OS tier AND content-hash grant.
+- **#416 (signatures)** — orthogonal and complementary: signatures prove the
+  bundle is *authentic* (from the configured source); capabilities constrain
+  what an authentic-but-untrusted bundle may *do*. Defense in depth — you want
+  both. A signed malicious fork still can't actuate without per-action consent.
+- **#419 (sensitive rules survive replacement)** — capabilities don't replace
+  the sensitive-screen block (that's recognition-layer, not actuation), but the
+  same "remote bundles are untrusted" posture motivates both.
+
+## Open decisions for the developer
+
+1. Target granularity: semantic vs structural (recommend semantic).
+2. Asset auto-grant: yes for the single-user alpha? (recommend yes.)
+3. Consent UX: load-time modal vs a passive "N rules want new permissions" badge
+   that opens a review screen (recommend the badge — less interrupt, and a modal
+   on every CDN update trains click-through).
+4. Denied vs merely-not-granted: persist explicit denials (so a re-load doesn't
+   re-surface a rejected capability) vs treat absence as deny and let re-loads
+   re-prompt. (Recommend persisting denials.)
+5. Revocation: a granted capability revoked in settings should suppress the
+   effect immediately (reactive grant flow) — confirm that's desired vs
+   next-load.


### PR DESCRIPTION
[skip ci]

Design note for #422 — the finer-grained, content-pinned shape of the rule-permission idea: each rule's actuating actions become units of consent enumerated at load, granted via a sha256(ruleId|verb|target) hash so a remote update that changes what an approved rule does forces re-consent. Asset rules auto-grant (frictionless alpha); CDN/fork rules never do (safe-by-construction for #192). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)