### PR TITLE
refactor(actions): rules expose target bindings; app-owned RuleAction executes verified taps (#425)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,10 @@ Recognition is **data, not code**. Per-platform rule files
 Rules carry a `priority` (sensitive rules are priority 0 and `overrideable: false`, blocking all
 further processing of banking/identity screens), `require` predicates, `bind` blocks, and `parse`
 blocks that produce typed fields via `ParsedFieldsFactory`. There are no Kotlin matcher classes —
-changing recognition means editing rule JSON plus corpus tests.
+changing recognition means editing rule JSON plus corpus tests. **Rules cannot declare actuation**
+(#425): the compiler rejects `click`/gesture effect verbs; rules instead expose well-known *target
+bindings* (`acceptButton`, `declineButton`, `expandButton`) that the app-owned `RuleAction`
+registry (`:domain`) consumes — see `docs/design/rule-capability-consent.md`.
 
 ### 3. Multi-Region State Machine (`core/state/`)
 
@@ -156,8 +159,8 @@ state into `AppEffect`s.
 `SideEffectEngine` executes `AppEffect`s with `effects_fired` idempotency dedup (recovery-aware)
 and runs the evaluation loopback (offer eval → `OfferEvaluationEvent` back into the machine).
 Handlers: `OdometerEffectHandler`, `ScreenShotHandler`, `TipEffectHandler`, `TtsEffectHandler`,
-`UiInteractionHandler` (cross-window accessibility clicks), `OfferActionReceiver` (notification
-Accept/Decline actions).
+`UiInteractionHandler` (package-scoped, label-verified `RuleAction` taps — the only path that ever
+clicks a third-party app, #425), `OfferActionReceiver` (notification Accept/Decline actions).
 
 ## Development Principles
 
@@ -209,9 +212,10 @@ Every new feature or refactor holds to these — they are forefront design input
      `NoOpCaptureBus`, #346).
    - **Secrets never reach logs** (EIA api_key redaction, #348); network logging is debug-gated.
    - **Capability gates fail closed.** An effect whose permission tier isn't granted does not
-     fire; an auto-click or any state-changing effect a rule could request must be gated, not
-     assumed safe. (The current single-user build stubs the grant check to always-true — that
-     stub is the first thing the matchers/multi-user work must replace.)
+     fire. Rules cannot request actuation at all (#425) — taps are app-owned `RuleAction`s aimed
+     by ruleset target bindings and verified at fire time (package scope + label allowlist +
+     strict click); any failed check aborts to manual. (The single-user build still stubs the
+     grant check to always-true — replacing it with the consent-keyed gate is #417.)
    When a change touches recognition, capture, network, or effects, state its security/privacy
    posture in the PR — what's trusted, what's gated, what's scrubbed.
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/OfferActionReceiver.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/OfferActionReceiver.kt
@@ -13,9 +13,10 @@ import timber.log.Timber
 
 /**
  * Handles the offer notification's **Accept / Decline** action buttons. Each fires the same
- * `UiInput` intent the bubble buttons do → EffectMap → `PerformOfferAction` → accessibility
- * click — so the dasher can act straight from the heads-up notification without opening the
- * bubble (which can't auto-expand from the background; see #110 field test 2026-06-09).
+ * `UiInput` intent the bubble buttons do → EffectMap → `PerformRuleAction` (aimed by the offer
+ * rule's bound target, #425) → verified accessibility click — so the dasher can act straight
+ * from the heads-up notification without opening the bubble (which can't auto-expand from the
+ * background; see #110 field test 2026-06-09).
  *
  * Uses [EntryPointAccessors] rather than `@AndroidEntryPoint` so we don't need the Hilt
  * `super.onReceive()` call (which doesn't compile against the abstract receiver in Kotlin).

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
@@ -5,7 +5,6 @@ import cloud.trotter.dashbuddy.core.data.strategy.StrategyRepository
 import cloud.trotter.dashbuddy.core.database.effects.EffectsFiredDao
 import cloud.trotter.dashbuddy.core.database.effects.EffectsFiredEntity
 import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
-import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
 import cloud.trotter.dashbuddy.domain.model.chat.ChatPersona
 import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.domain.model.state.StateEvent
@@ -74,6 +73,14 @@ class SideEffectEngine @Inject constructor(
     companion object {
         /** Default throttle between repeated firings of the same action. */
         const val DEFAULT_ACTION_THROTTLE_MS = 500L
+
+        /**
+         * Throttle between repeated firings of the same `RuleAction` per
+         * platform (#425) — an app-owned bound on automated taps that no
+         * ruleset content can loosen. Carried over from the former expand
+         * click's rule-declared `throttleMs`.
+         */
+        const val RULE_ACTION_THROTTLE_MS = 1000L
 
         /**
          * Delay before posting the offer notification, so it lands AFTER the offer screenshot's
@@ -184,18 +191,36 @@ class SideEffectEngine @Inject constructor(
                 screenShotHandler.capture(engineScope, effect)
             }
 
-            is AppEffect.ClickNode -> {
-                Timber.i("Executing Effect: Clicking Node (${effect.description})")
-                uiInteractionHandler.performClick(effect.node, effect.description)
-            }
-
-            is AppEffect.PerformOfferAction -> {
-                val template = offerActionNode(effect.platform, effect.action)
-                if (template != null) {
-                    Timber.i("Performing offer action: ${effect.action} on ${effect.platform.wire}")
-                    uiInteractionHandler.performClick(template, "Bubble ${effect.action}")
-                } else {
-                    Timber.w("No offer-action node for ${effect.platform.wire}/${effect.action}")
+            is AppEffect.PerformRuleAction -> {
+                // The ONLY path that taps a third-party app (#425). The target
+                // is ruleset data; everything that decides whether/where the
+                // tap lands is app-owned: this throttle, the tier gate (the
+                // #417 grant check lands at this seam, keyed by
+                // (sourceRuleId, action) against the enumerated capabilities),
+                // and the package + label verification in the handler.
+                val throttleKey = "action:${effect.action.wire}:${effect.platform.wire}"
+                val now = System.currentTimeMillis()
+                if ((actionLastFiredAt[throttleKey] ?: 0L) + RULE_ACTION_THROTTLE_MS > now) {
+                    Timber.v("Throttled action: %s", throttleKey)
+                    return
+                }
+                if (!isPermissionGranted(PermissionTier.ACCESSIBILITY)) {
+                    Timber.w("Denied %s — ACCESSIBILITY tier not granted (fail closed)", effect.action.wire)
+                    return
+                }
+                actionLastFiredAt[throttleKey] = now
+                Timber.i("Performing %s on %s", effect.action.wire, effect.platform.wire)
+                val clicked = uiInteractionHandler.performVerifiedClick(
+                    ref = effect.targetRef,
+                    expectedPackage = effect.platform.packageName,
+                    expectation = effect.action.verification,
+                    description = "${effect.action.wire} on ${effect.platform.wire} [${effect.sourceRuleId}]",
+                )
+                if (!clicked) {
+                    Timber.w(
+                        "%s did not fire — target failed resolution/verification (fail closed, user acts manually)",
+                        effect.action.wire,
+                    )
                 }
             }
 
@@ -307,7 +332,6 @@ class SideEffectEngine @Inject constructor(
         }
         when (e.verb) {
             // --- Observation-driven verbs ---
-            EffectVerb.CLICK -> resolveAndClick(e)
             EffectVerb.SCREENSHOT -> screenshotFromArgs(e.args)
             EffectVerb.BUBBLE -> bubbleFromArgs(e.args)
             EffectVerb.LOG -> logFromArgs(e.args)
@@ -328,39 +352,6 @@ class SideEffectEngine @Inject constructor(
                 Platform.fromRuleId(e.ruleId).takeIf { it != Platform.Unknown },
             )
             EffectVerb.CANCEL_TIMEOUT -> cancelTimeoutFromArgs(e.args)
-        }
-    }
-
-    /**
-     * Resolve a [RequestedEffect]'s [NodeRef] against the live UI tree and click.
-     */
-    private fun resolveAndClick(effect: RequestedEffect) {
-        val ref = effect.targetRef ?: run {
-            Timber.w("CLICK effect missing targetRef: %s", effect.ruleId)
-            return
-        }
-        val template = cloud.trotter.dashbuddy.domain.model.accessibility.UiNode(
-            viewIdResourceName = ref.viewIdSuffix,
-            text = ref.text,
-            className = ref.classNameHint,
-            boundsInScreen = ref.boundsInScreen,
-        )
-        Timber.i("Auto-Click [%s]: target id=%s", effect.ruleId, ref.viewIdSuffix)
-        uiInteractionHandler.performClick(template, "Auto-Click [${effect.ruleId}]")
-    }
-
-    /**
-     * Resolve the platform's offer Accept/Decline button to a click template. DoorDash-only
-     * for now; Decline targets the *initial* decline button (its confirm dialog is left to the
-     * user in Native mode — auto-confirm is #110 Stage 2c). See #85 for the GigPlatform interface.
-     */
-    private fun offerActionNode(platform: Platform, action: OfferAction): UiNode? {
-        if (platform != Platform.DoorDash) return null
-        val pkg = platform.packageName ?: return null
-        return when (action) {
-            OfferAction.ACCEPT -> UiNode(viewIdResourceName = "$pkg:id/accept_button", text = "Accept")
-            OfferAction.DECLINE -> UiNode(viewIdResourceName = "$pkg:id/secondary_action_button_dash_plus")
-            else -> null
         }
     }
 
@@ -484,8 +475,7 @@ class SideEffectEngine @Inject constructor(
         is AppEffect.UpdateBubble,
         is AppEffect.PlayNotificationSound,
         is AppEffect.CaptureScreenshot,
-        is AppEffect.ClickNode,
-        is AppEffect.PerformOfferAction,
+        is AppEffect.PerformRuleAction,
         is AppEffect.RequestEffect,
         is AppEffect.StartOdometer,
         is AppEffect.StopOdometer,

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/UiInteractionHandler.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/UiInteractionHandler.kt
@@ -2,8 +2,9 @@ package cloud.trotter.dashbuddy.state.effects
 
 import android.graphics.Rect
 import android.view.accessibility.AccessibilityNodeInfo
+import cloud.trotter.dashbuddy.domain.action.TargetExpectation
 import cloud.trotter.dashbuddy.domain.model.accessibility.BoundingBox
-import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import cloud.trotter.dashbuddy.domain.pipeline.NodeRef
 import cloud.trotter.dashbuddy.core.pipeline.accessibility.input.AccessibilitySource
 import cloud.trotter.dashbuddy.core.pipeline.accessibility.mapper.toBoundingBox
 import cloud.trotter.dashbuddy.util.AccNodeUtils
@@ -11,59 +12,145 @@ import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
 
+/**
+ * Executes app-owned `RuleAction` taps on the platform app (#425).
+ *
+ * The target comes from the (untrusted, future-CDN #192) ruleset as a
+ * [NodeRef] fingerprint, so the tap is verified at fire time against
+ * app-owned anchors the ruleset cannot influence:
+ *
+ * 1. **Package scope** — only windows belonging to the platform's package are
+ *    searched. No expected package → no tap (fail closed).
+ * 2. **Label expectation** — the resolved node's subtree texts must satisfy
+ *    the action's [TargetExpectation] (e.g. DECLINE_OFFER only taps a node
+ *    labeled "Decline"). Platform buttons usually label via a child TextView,
+ *    so collection walks a bounded subtree.
+ * 3. **Strict click** — self-or-ancestor only. The old clickable-*sibling*
+ *    fallback is deliberately absent here: the verified node's sibling can be
+ *    the opposite button (Accept sits beside Decline in the offer footer).
+ *
+ * Any check failing skips the tap and logs — the user acts manually instead.
+ */
 @Singleton
 class UiInteractionHandler @Inject constructor(
     private val accessibilitySource: AccessibilitySource
 ) {
 
-    fun performClick(templateNode: UiNode, description: String) {
-        Timber.i("UiInteractionHandler: Attempting click ($description)")
+    companion object {
+        /** Max subtree depth scanned when collecting a candidate's labels. */
+        private const val LABEL_SCAN_DEPTH = 3
 
+        /** Max nodes visited per label scan — bounded ingestion of third-party UI. */
+        private const val LABEL_SCAN_NODES = 24
+    }
+
+    /**
+     * Re-resolve [ref] in the live tree (scoped to [expectedPackage]), verify
+     * the node against [expectation], and click it.
+     *
+     * @return true if a click action was dispatched to a verified node.
+     */
+    fun performVerifiedClick(
+        ref: NodeRef,
+        expectedPackage: String?,
+        expectation: TargetExpectation,
+        description: String,
+    ): Boolean {
+        Timber.i("UiInteractionHandler: attempting verified click (%s)", description)
+
+        if (expectedPackage.isNullOrEmpty()) {
+            Timber.w("No package scope for %s — refusing to click (fail closed)", description)
+            return false
+        }
         val roots = accessibilitySource.getLiveWindowRoots()
+            .filter { it.packageName?.toString() == expectedPackage }
         if (roots.isEmpty()) {
-            Timber.w("Failed to click: no live windows.")
-            return
+            Timber.w("No live windows for package %s — cannot click (%s)", expectedPackage, description)
+            return false
         }
 
-        val targetId = templateNode.viewIdResourceName
-        val targetText = templateNode.text
-        val targetBounds = templateNode.boundsInScreen
+        val candidates = findCandidates(roots, ref)
+        if (candidates.isEmpty()) {
+            Timber.w(
+                "Could not find any live node for: %s (id=%s, text=%s, bounds=%s)",
+                description, ref.viewIdSuffix, ref.text, ref.boundsInScreen,
+            )
+            return false
+        }
 
-        // Search across ALL windows, strongest strategy first (so a weak bounds match in one
-        // window can't beat a viewId match in another). The target node may live in a window
-        // other than the active one — e.g. DoorDash's offer while the bubble holds focus.
+        val verified = candidates.filter { expectation.matchesLabels(collectLabels(it)) }
+        if (verified.isEmpty()) {
+            Timber.w(
+                "%d candidate(s) for %s but NONE passed label verification (%s) — refusing to click",
+                candidates.size, description, expectation.labelPattern,
+            )
+            return false
+        }
+
+        // Disambiguate: prefer the exact stored-bounds match, else first verified.
+        val exactMatch = verified.find { node ->
+            val liveBounds = Rect()
+            node.getBoundsInScreen(liveBounds)
+            liveBounds.toBoundingBox() == ref.boundsInScreen
+        }
+        val target = exactMatch ?: verified.first()
+        if (exactMatch == null && verified.size > 1) {
+            Timber.w(
+                "No exact bounds match among %d verified candidates for: %s — clicking first",
+                verified.size, description,
+            )
+        }
+        return AccNodeUtils.clickNodeStrict(target)
+    }
+
+    /**
+     * Search the scoped roots, strongest strategy first (so a weak bounds
+     * match in one window can't beat a viewId match in another). The target
+     * may live in a window other than the active one — e.g. DoorDash's offer
+     * while the bubble holds focus.
+     */
+    private fun findCandidates(
+        roots: List<AccessibilityNodeInfo>,
+        ref: NodeRef,
+    ): List<AccessibilityNodeInfo> {
         val candidates = mutableListOf<AccessibilityNodeInfo>()
         // Strategy 1: find by view ID
+        val targetId = ref.viewIdSuffix
         if (!targetId.isNullOrEmpty()) {
             for (root in roots) candidates.addAll(root.findAccessibilityNodeInfosByViewId(targetId))
         }
         // Strategy 2: find by text
+        val targetText = ref.text
         if (candidates.isEmpty() && !targetText.isNullOrEmpty()) {
             for (root in roots) candidates.addAll(root.findAccessibilityNodeInfosByText(targetText))
         }
         // Strategy 3: walk each tree matching by bounds + className
         if (candidates.isEmpty()) {
-            for (root in roots) findNodeByBounds(root, targetBounds, templateNode.className, candidates)
+            for (root in roots) findNodeByBounds(root, ref.boundsInScreen, ref.classNameHint, candidates)
         }
+        return candidates
+    }
 
-        if (candidates.isEmpty()) {
-            Timber.w("Could not find any live node for: %s (id=%s, text=%s, bounds=%s)",
-                description, targetId, targetText, targetBounds)
-            return
+    /**
+     * Collect the candidate's own text/contentDescription plus its bounded
+     * subtree's — platform buttons typically carry their label on a child
+     * TextView (e.g. DoorDash's `textView_prism_button_title`).
+     */
+    private fun collectLabels(node: AccessibilityNodeInfo): List<String> {
+        val labels = mutableListOf<String>()
+        var visited = 0
+        fun visit(n: AccessibilityNodeInfo, depth: Int) {
+            if (depth > LABEL_SCAN_DEPTH || visited >= LABEL_SCAN_NODES) return
+            visited++
+            n.text?.toString()?.takeIf { it.isNotBlank() }?.let { labels.add(it) }
+            n.contentDescription?.toString()?.takeIf { it.isNotBlank() }?.let { labels.add(it) }
+            for (i in 0 until n.childCount) {
+                val child = n.getChild(i) ?: continue
+                visit(child, depth + 1)
+            }
         }
-
-        // Disambiguate: prefer exact bounds match, fall back to first candidate
-        val exactMatch = candidates.find { node ->
-            val liveBounds = Rect()
-            node.getBoundsInScreen(liveBounds)
-            liveBounds.toBoundingBox() == targetBounds
-        }
-        val target = exactMatch ?: candidates.first()
-        if (exactMatch == null && candidates.size > 1) {
-            Timber.w("No exact bounds match among %d candidates for: %s — clicking first",
-                candidates.size, description)
-        }
-        AccNodeUtils.clickNode(target)
+        visit(node, 0)
+        return labels
     }
 
     /**

--- a/app/src/main/java/cloud/trotter/dashbuddy/util/AccNodeUtils.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/util/AccNodeUtils.kt
@@ -9,46 +9,27 @@ import timber.log.Timber
 object AccNodeUtils {
 
     /**
-     * ROBUST CLICK STRATEGY:
-     * 1. Try the node itself.
-     * 2. Try walking up the tree to find a clickable parent (Ancestor Strategy).
-     * 3. Try walking the parent's other children to find a clickable sibling (Lateral Strategy).
+     * STRICT CLICK (#425): self-or-ancestor only — no sibling fallback.
      *
-     * @param node The specific node we want to interact with.
-     * @return `true` if a click action was successfully sent to *some* node.
+     * Used for verified `RuleAction` taps, where label verification ran on
+     * *this* node's subtree: a clickable sibling can be the opposite control
+     * (Accept sits beside Decline in the offer footer), so falling laterally
+     * would tap something the verification never looked at.
      */
-    fun clickNode(node: AccessibilityNodeInfo?): Boolean {
+    fun clickNodeStrict(node: AccessibilityNodeInfo?): Boolean {
         if (node == null) {
             Timber.w("Cannot click: node is null.")
             return false
         }
-
-        // Strategy 1 & 2: Self or Parent
-        val clickableAncestor = findClickableCandidate(node)
-        if (clickableAncestor != null) {
-            Timber.i("Clicking ancestor/self (Class: ${clickableAncestor.className})")
-            return clickableAncestor.performAction(AccessibilityNodeInfo.ACTION_CLICK)
+        val clickable = findClickableCandidate(node)
+        if (clickable == null) {
+            Timber.w("Strict click: no clickable self/ancestor — refusing (no sibling fallback).")
+            return false
         }
-
-        // Strategy 3: Lateral Search (Siblings)
-        // If the text and the container aren't clickable, maybe there is an icon NEXT to the text.
-        Timber.d("Ancestor click failed. Attempting lateral search (siblings)...")
-
-        val parent = node.parent
-        if (parent != null) {
-            for (i in 0 until parent.childCount) {
-                val sibling = parent.getChild(i) ?: continue
-
-                // Don't check the node itself again, only siblings
-                if (sibling != node && sibling.isClickable) {
-                    Timber.i("Found clickable sibling! (Class: ${sibling.className}). Clicking.")
-                    return sibling.performAction(AccessibilityNodeInfo.ACTION_CLICK)
-                }
-            }
+        if (clickable != node) {
+            Timber.i("Strict click: delegating to clickable ancestor (Class: ${clickable.className})")
         }
-
-        Timber.w("Failed to find any clickable candidate (Self, Ancestor, or Sibling).")
-        return false
+        return clickable.performAction(AccessibilityNodeInfo.ACTION_CLICK)
     }
 
     /**

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
@@ -1,5 +1,6 @@
 package cloud.trotter.dashbuddy.core.state
 
+import cloud.trotter.dashbuddy.domain.action.RuleAction
 import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
 import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
 import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
@@ -16,6 +17,7 @@ import cloud.trotter.dashbuddy.domain.state.AppState
 import cloud.trotter.dashbuddy.domain.state.Flow
 import cloud.trotter.dashbuddy.domain.state.FlowRegion
 import cloud.trotter.dashbuddy.domain.state.Mode
+import cloud.trotter.dashbuddy.domain.state.OfferIntent
 import cloud.trotter.dashbuddy.domain.state.ParsedFields
 import cloud.trotter.dashbuddy.domain.state.PendingOffer
 import cloud.trotter.dashbuddy.domain.state.Platform
@@ -784,52 +786,74 @@ class EffectMapTest {
     }
 
     // =========================================================================
-    // CLICK DELAY VIA SETTLE_UI TIMEOUT (UDF round-trip)
+    // APP-OWNED ACTIONS (#425): expand decision + deferred-action round-trip +
+    // UiInput accept/decline aimed by rule-bound targets
     // =========================================================================
 
-    @Test
-    fun `click effect with delayMs emits ScheduleTimeout instead of immediate RequestEffect`() {
-        val nodeRef = cloud.trotter.dashbuddy.domain.pipeline.NodeRef(
-            viewIdSuffix = "com.example:id/btn",
+    private fun testNodeRef(id: String = "com.example:id/btn") =
+        cloud.trotter.dashbuddy.domain.pipeline.NodeRef(
+            viewIdSuffix = id,
             text = null, classNameHint = "android.widget.Button",
             boundsInScreen = cloud.trotter.dashbuddy.domain.model.accessibility.BoundingBox(0, 0, 100, 50),
             pathFingerprint = "fp",
         )
-        val effect = cloud.trotter.dashbuddy.domain.pipeline.RequestedEffect(
-            verb = cloud.trotter.dashbuddy.domain.pipeline.EffectVerb.CLICK,
-            targetRef = nodeRef,
-            delayMs = 500L,
-            ruleId = "test.rule",
-        )
-        val obs = screenObs(flow = Flow.PostTask).copy(effects = listOf(effect))
+
+    @Test
+    fun `collapsed summary with expand target schedules a deferred EXPAND_EARNINGS`() {
+        val obs = screenObs(
+            flow = Flow.PostTask,
+            parsed = ParsedFields.PostTaskFields(totalPay = 25.0, isExpanded = false),
+            ruleId = "doordash.screen.delivery_summary_collapsed",
+        ).copy(targets = mapOf("expandButton" to testNodeRef()))
+
         val effects = effectMap.diff(AppState(), AppState(), obs)
         val scheduled = effects.filterIsInstance<AppEffect.ScheduleTimeout>()
+            .filter { it.type == cloud.trotter.dashbuddy.domain.pipeline.TimeoutType.SETTLE_UI }
         assertEquals(1, scheduled.size)
-        assertEquals(cloud.trotter.dashbuddy.domain.pipeline.TimeoutType.SETTLE_UI, scheduled[0].type)
-        assertEquals(500L, scheduled[0].durationMs)
-        // Payload should carry the typed click context (#366)
-        val click = scheduled[0].payload as ObservationPayload.DeferredClick
-        assertEquals("com.example:id/btn", click.target?.viewIdSuffix)
-        assertEquals("test.rule", click.ruleId)
-        // And NOT emit a RequestEffect for the click directly
+        assertEquals(EffectMap.EXPAND_SETTLE_MS, scheduled[0].durationMs)
+        val deferred = scheduled[0].payload as ObservationPayload.DeferredAction
+        assertEquals(RuleAction.EXPAND_EARNINGS.wire, deferred.action)
+        assertEquals("com.example:id/btn", deferred.target.viewIdSuffix)
+        assertEquals("doordash.screen.delivery_summary_collapsed", deferred.ruleId)
+        // No direct tap effect — the round-trip is mandatory.
+        assertTrue(effects.filterIsInstance<AppEffect.PerformRuleAction>().isEmpty())
+    }
+
+    @Test
+    fun `expanded summary schedules no expand action`() {
+        val obs = screenObs(
+            flow = Flow.PostTask,
+            parsed = ParsedFields.PostTaskFields(totalPay = 25.0, isExpanded = true),
+            ruleId = "doordash.screen.delivery_summary_expanded",
+        ).copy(targets = mapOf("expandButton" to testNodeRef()))
+        val effects = effectMap.diff(AppState(), AppState(), obs)
         assertTrue(
-            "Click should be deferred, not dispatched directly",
-            effects.filterIsInstance<AppEffect.RequestEffect>().isEmpty(),
+            effects.filterIsInstance<AppEffect.ScheduleTimeout>()
+                .none { it.payload is ObservationPayload.DeferredAction },
         )
     }
 
     @Test
-    fun `SETTLE_UI timeout re-emits the click as immediate RequestEffect`() {
-        val payload = ObservationPayload.DeferredClick(
-            verb = "CLICK",
-            ruleId = "test.rule",
-            target = cloud.trotter.dashbuddy.domain.pipeline.NodeRef(
-                viewIdSuffix = "com.example:id/btn",
-                text = null,
-                classNameHint = "android.widget.Button",
-                boundsInScreen = cloud.trotter.dashbuddy.domain.model.accessibility.BoundingBox(0, 0, 100, 50),
-                pathFingerprint = "fp",
-            ),
+    fun `collapsed summary WITHOUT expand target schedules nothing - fail closed`() {
+        val obs = screenObs(
+            flow = Flow.PostTask,
+            parsed = ParsedFields.PostTaskFields(totalPay = 25.0, isExpanded = false),
+            ruleId = "doordash.screen.delivery_summary_collapsed",
+        )
+        val effects = effectMap.diff(AppState(), AppState(), obs)
+        assertTrue(
+            effects.filterIsInstance<AppEffect.ScheduleTimeout>()
+                .none { it.payload is ObservationPayload.DeferredAction },
+        )
+    }
+
+    @Test
+    fun `SETTLE_UI timeout emits the deferred action as immediate PerformRuleAction`() {
+        val payload = ObservationPayload.DeferredAction(
+            action = RuleAction.EXPAND_EARNINGS.wire,
+            platform = Platform.DoorDash.wire,
+            ruleId = "doordash.screen.delivery_summary_collapsed",
+            target = testNodeRef(),
         )
         val timeoutObs = Observation.Timeout(
             timestamp = 1000L,
@@ -837,11 +861,52 @@ class EffectMapTest {
             payload = payload,
         )
         val effects = effectMap.diff(AppState(), AppState(), timeoutObs)
-        val requested = effects.filterIsInstance<AppEffect.RequestEffect>()
-        assertEquals(1, requested.size)
-        assertEquals(cloud.trotter.dashbuddy.domain.pipeline.EffectVerb.CLICK, requested[0].effect.verb)
-        assertEquals("com.example:id/btn", requested[0].effect.targetRef?.viewIdSuffix)
-        assertEquals(null, requested[0].effect.delayMs)  // immediate, not deferred again
+        val actions = effects.filterIsInstance<AppEffect.PerformRuleAction>()
+        assertEquals(1, actions.size)
+        assertEquals(RuleAction.EXPAND_EARNINGS, actions[0].action)
+        assertEquals(Platform.DoorDash, actions[0].platform)
+        assertEquals("com.example:id/btn", actions[0].targetRef.viewIdSuffix)
+        assertEquals("doordash.screen.delivery_summary_collapsed", actions[0].sourceRuleId)
+    }
+
+    @Test
+    fun `UiInput accept fires PerformRuleAction aimed by the offer rule's bound target`() {
+        val acceptRef = testNodeRef("com.doordash.driverapp:id/accept_button")
+        val offerWithTargets = testPendingOffer.copy(
+            targets = mapOf("acceptButton" to acceptRef),
+            sourceRuleId = "doordash.screen.offer_popup",
+        )
+        val flowRegion = FlowRegion(
+            flow = Flow.OfferPresented,
+            pendingOffer = offerWithTargets,
+            activePlatform = Platform.DoorDash,
+        )
+        val state = AppState(regions = Regions(flow = flowRegion))
+        val obs = Observation.UiInput(timestamp = 2000L, action = OfferIntent.ACCEPT)
+
+        val effects = effectMap.diff(state, state, obs)
+        val actions = effects.filterIsInstance<AppEffect.PerformRuleAction>()
+        assertEquals(1, actions.size)
+        assertEquals(RuleAction.ACCEPT_OFFER, actions[0].action)
+        assertEquals(acceptRef, actions[0].targetRef)
+        assertEquals("doordash.screen.offer_popup", actions[0].sourceRuleId)
+    }
+
+    @Test
+    fun `UiInput accept with NO bound target fires nothing - action unavailable`() {
+        val flowRegion = FlowRegion(
+            flow = Flow.OfferPresented,
+            pendingOffer = testPendingOffer, // no targets
+            activePlatform = Platform.DoorDash,
+        )
+        val state = AppState(regions = Regions(flow = flowRegion))
+        val obs = Observation.UiInput(timestamp = 2000L, action = OfferIntent.ACCEPT)
+
+        val effects = effectMap.diff(state, state, obs)
+        assertTrue(
+            "No target bound → no tap (fail closed)",
+            effects.filterIsInstance<AppEffect.PerformRuleAction>().isEmpty(),
+        )
     }
 
     // =========================================================================

--- a/app/src/test/java/cloud/trotter/dashbuddy/state/effects/RuleEffectDispatchTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/state/effects/RuleEffectDispatchTest.kt
@@ -1,7 +1,6 @@
 package cloud.trotter.dashbuddy.state.effects
 
 import cloud.trotter.dashbuddy.domain.pipeline.EffectVerb
-import cloud.trotter.dashbuddy.domain.pipeline.NodeRef
 import cloud.trotter.dashbuddy.domain.pipeline.PermissionTier
 import cloud.trotter.dashbuddy.domain.pipeline.RequestedEffect
 import cloud.trotter.dashbuddy.core.state.AppEffect
@@ -24,10 +23,11 @@ class RuleEffectDispatchTest {
 
     @Test
     fun `every EffectVerb has a defined dispatch path`() {
-        // This test documents that all 14 verbs are handled.
-        // If a verb is added to EffectVerb, the exhaustive when() in
-        // SideEffectEngine.dispatchRuleEffect will fail to compile.
-        assertEquals(14, EffectVerb.entries.size)
+        // This test documents that all 13 verbs are handled (CLICK left the
+        // rule vocabulary in #425). If a verb is added to EffectVerb, the
+        // exhaustive when() in SideEffectEngine.dispatchRuleEffect will fail
+        // to compile.
+        assertEquals(13, EffectVerb.entries.size)
     }
 
     // =========================================================================
@@ -36,40 +36,25 @@ class RuleEffectDispatchTest {
 
     @Test
     fun `effectKey uses dedupeKey when present`() {
-        val effect = makeEffect(EffectVerb.CLICK, dedupeKey = "accept-click")
+        val effect = makeEffect(EffectVerb.SCREENSHOT, dedupeKey = "offer-ss")
         val appEffect = AppEffect.RequestEffect(effect)
-        assertEquals("effect:test.rule:accept-click", appEffect.effectKey)
+        assertEquals("effect:test.rule:offer-ss", appEffect.effectKey)
     }
 
     @Test
-    fun `effectKey uses pathFingerprint when no dedupeKey but targetRef present`() {
-        val ref = NodeRef(
-            viewIdSuffix = "btn_accept",
-            text = "Accept",
-            classNameHint = "android.widget.Button",
-            boundsInScreen = cloud.trotter.dashbuddy.domain.model.accessibility.BoundingBox(0, 100, 200, 150),
-            pathFingerprint = "View[0]/Button[1]",
-        )
-        val effect = makeEffect(EffectVerb.CLICK, targetRef = ref)
-        val appEffect = AppEffect.RequestEffect(effect)
-        assertEquals("effect:test.rule:View[0]/Button[1]", appEffect.effectKey)
-    }
-
-    @Test
-    fun `effectKey falls back to verb wire when no dedupeKey and no targetRef`() {
+    fun `effectKey falls back to verb wire when no dedupeKey`() {
         val effect = makeEffect(EffectVerb.SCREENSHOT)
         val appEffect = AppEffect.RequestEffect(effect)
         assertEquals("effect:test.rule:screenshot", appEffect.effectKey)
     }
 
     @Test
-    fun `effectKey differs per verb for non-target effects`() {
+    fun `effectKey differs per verb`() {
         val keys = EffectVerb.entries
-            .filter { !it.requiresTarget }
             .map { AppEffect.RequestEffect(makeEffect(it)).effectKey }
             .toSet()
         // Each verb should produce a unique key
-        assertEquals(EffectVerb.entries.count { !it.requiresTarget }, keys.size)
+        assertEquals(EffectVerb.entries.size, keys.size)
     }
 
     // =========================================================================
@@ -93,7 +78,7 @@ class RuleEffectDispatchTest {
     @Test
     fun `observation-driven verbs do not have defaults`() {
         val observationVerbs = listOf(
-            EffectVerb.CLICK, EffectVerb.SCREENSHOT, EffectVerb.BUBBLE,
+            EffectVerb.SCREENSHOT, EffectVerb.BUBBLE,
             EffectVerb.LOG, EffectVerb.EVALUATE_OFFER, EffectVerb.SPEAK,
         )
         for (verb in observationVerbs) {
@@ -117,11 +102,6 @@ class RuleEffectDispatchTest {
     // =========================================================================
     // Permission tiers — correct verb assignments
     // =========================================================================
-
-    @Test
-    fun `CLICK requires ACCESSIBILITY tier`() {
-        assertEquals(PermissionTier.ACCESSIBILITY, EffectVerb.CLICK.tier)
-    }
 
     @Test
     fun `SCREENSHOT requires ACCESSIBILITY tier`() {
@@ -163,12 +143,10 @@ class RuleEffectDispatchTest {
     private fun makeEffect(
         verb: EffectVerb,
         args: Map<String, String> = emptyMap(),
-        targetRef: NodeRef? = null,
         dedupeKey: String? = null,
     ) = RequestedEffect(
         verb = verb,
         args = args,
-        targetRef = targetRef,
         dedupeKey = dedupeKey,
         ruleId = "test.rule",
     )

--- a/app/src/test/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngineTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngineTest.kt
@@ -6,13 +6,15 @@ import cloud.trotter.dashbuddy.core.database.effects.EffectsFiredDao
 import cloud.trotter.dashbuddy.core.database.effects.EffectsFiredEntity
 import cloud.trotter.dashbuddy.core.state.AppEffect
 import cloud.trotter.dashbuddy.core.state.MetadataProvider
-import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
+import cloud.trotter.dashbuddy.domain.action.RuleAction
 import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
 import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluator
 import cloud.trotter.dashbuddy.domain.model.event.AppEvent
 import cloud.trotter.dashbuddy.domain.model.event.AppEventType
 import cloud.trotter.dashbuddy.domain.model.state.TimeoutEvent
+import cloud.trotter.dashbuddy.domain.pipeline.NodeRef
 import cloud.trotter.dashbuddy.domain.pipeline.TimeoutType
+import cloud.trotter.dashbuddy.domain.model.accessibility.BoundingBox
 import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.ui.bubble.BubbleManager
 import kotlinx.coroutines.CoroutineDispatcher
@@ -104,21 +106,53 @@ class SideEffectEngineTest {
     }
 
     // =========================================================================
-    // #341 — recovery suppression: PerformOfferAction must never replay a click
+    // #341/#425 — recovery suppression: PerformRuleAction must never replay a tap
     // =========================================================================
 
+    private fun acceptActionEffect() = AppEffect.PerformRuleAction(
+        action = RuleAction.ACCEPT_OFFER,
+        platform = Platform.DoorDash,
+        targetRef = NodeRef(
+            viewIdSuffix = "com.doordash.driverapp:id/accept_button",
+            text = null,
+            classNameHint = "android.widget.Button",
+            boundsInScreen = BoundingBox(0, 100, 200, 150),
+            pathFingerprint = "View[0]/Button[1]",
+        ),
+        sourceRuleId = "doordash.screen.offer_popup",
+    )
+
     @Test
-    fun `PerformOfferAction is suppressed during recovery and executes live`() = runTest {
+    fun `PerformRuleAction is suppressed during recovery and executes live`() = runTest {
         val engine = buildEngine(StandardTestDispatcher(testScheduler))
-        val effect = AppEffect.PerformOfferAction(OfferAction.ACCEPT, Platform.DoorDash)
+        val effect = acceptActionEffect()
 
         engine.process(effect, recovering = true)
         runCurrent()
-        verify(uiInteractionHandler, never()).performClick(any(), any())
+        verify(uiInteractionHandler, never()).performVerifiedClick(any(), any(), any(), any())
 
         engine.process(effect, recovering = false)
         runCurrent()
-        verify(uiInteractionHandler, times(1)).performClick(any(), any())
+        verify(uiInteractionHandler, times(1)).performVerifiedClick(
+            eq(effect.targetRef),
+            eq(Platform.DoorDash.packageName),
+            eq(RuleAction.ACCEPT_OFFER.verification),
+            any(),
+        )
+    }
+
+    @Test
+    fun `PerformRuleAction is throttled per action and platform`() = runTest {
+        val engine = buildEngine(StandardTestDispatcher(testScheduler))
+
+        engine.process(acceptActionEffect())
+        runCurrent()
+        engine.process(acceptActionEffect())
+        runCurrent()
+
+        // Second fire inside RULE_ACTION_THROTTLE_MS is swallowed — an
+        // app-owned bound on automated taps (#425).
+        verify(uiInteractionHandler, times(1)).performVerifiedClick(any(), any(), any(), any())
     }
 
     // =========================================================================

--- a/core/pipeline/src/main/assets/rules/doordash.json
+++ b/core/pipeline/src/main/assets/rules/doordash.json
@@ -299,6 +299,16 @@
         "flow": "offer:presented",
         "modeHint": "online"
       },
+      "bind": {
+        "acceptButton": {
+          "find": { "hasIdSuffix": "accept_button" },
+          "optional": true
+        },
+        "declineButton": {
+          "find": { "hasIdSuffix": "secondary_action_button_dash_plus" },
+          "optional": true
+        }
+      },
       "require": {
         "all": [
           {
@@ -669,18 +679,6 @@
         }
       },
       "effects": [
-        {
-          "click": "$expandButton",
-          "onlyIf": {
-            "fieldEquals": {
-              "field": "isExpanded",
-              "value": false
-            }
-          },
-          "dedupeKey": "expand_pay_breakdown",
-          "throttleMs": 1000,
-          "delayMs": 500
-        },
         {
           "screenshot": {
             "prefix": "Delivery - {totalPay}"

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/ObservationClassifier.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/ObservationClassifier.kt
@@ -3,6 +3,7 @@ package cloud.trotter.dashbuddy.core.pipeline
 import cloud.trotter.dashbuddy.domain.capture.ReplayMetadataProvider
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.pipeline.NodeRef
 import cloud.trotter.dashbuddy.domain.pipeline.RequestedEffect
 import cloud.trotter.dashbuddy.domain.pipeline.TransitionTrigger
 import cloud.trotter.dashbuddy.domain.state.Flow
@@ -109,6 +110,7 @@ class ObservationClassifier @Inject constructor(
             parsed = parsed,
             ruleId = result.ruleId,
             effects = result.effects,
+            targets = result.targets,
             transitionOverrides = result.transitionOverrides,
             expectedOutcomes = result.outcomes,
         )
@@ -129,6 +131,7 @@ class ObservationClassifier @Inject constructor(
         parsed: ParsedFields,
         ruleId: String?,
         effects: List<RequestedEffect> = emptyList(),
+        targets: Map<String, NodeRef> = emptyMap(),
         transitionOverrides: Map<TransitionTrigger, List<RequestedEffect>> = emptyMap(),
         expectedOutcomes: Set<Flow>? = null,
     ) = Observation.Screen(
@@ -141,6 +144,7 @@ class ObservationClassifier @Inject constructor(
         parsed = parsed,
         target = screenName,
         effects = effects,
+        targets = targets,
         transitionOverrides = transitionOverrides,
         expectedOutcomes = expectedOutcomes,
     )

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/CompiledRules.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/CompiledRules.kt
@@ -25,11 +25,16 @@ typealias Bindings = Map<String, UiNode?>
 /**
  * A named binding declaration compiled from a `bind:` block.
  * Bindings are a screen-rule concept; click and notification rules have no bindings.
+ *
+ * [defJson] retains the binding's raw JSON definition (the `bind` entry value:
+ * `find` predicate + flags) so capability enumeration can content-pin consent
+ * keys to it (#422/#425). Null only for programmatically-built bindings.
  */
 data class Binding(
     val name: String,
     val find: (UiNode) -> UiNode?,
     val optional: Boolean = false,
+    val defJson: kotlinx.serialization.json.JsonElement? = null,
 )
 
 /**
@@ -81,6 +86,10 @@ data class CompiledRule<TInput>(
  * Unified result of matching any rule type (screen, click, or notification).
  * The consumer uses [shape] + [fields] with [ParsedFieldsFactory] to produce
  * typed `ParsedFields`.
+ *
+ * [targets] are the rule's resolved bindings as `NodeRef` fingerprints
+ * (#425) — recognition-layer data the app-owned `RuleAction` registry may
+ * later aim a tap with. Only bindings that resolved to a node appear.
  */
 data class RuleMatchResult(
     val ruleId: String,
@@ -91,37 +100,21 @@ data class RuleMatchResult(
     val outcomes: Set<Flow>? = null,
     val fields: Map<String, Any?> = emptyMap(),
     val effects: List<RequestedEffect> = emptyList(),
+    val targets: Map<String, cloud.trotter.dashbuddy.domain.pipeline.NodeRef> = emptyMap(),
     val transitionOverrides: Map<TransitionTrigger, List<RequestedEffect>> = emptyMap(),
 )
 
 /**
  * A compiled effect from a rule's `effects:` (or legacy `actions:`) block.
  *
- * At match time, [targetBindName] is resolved against the current bindings
- * to produce a `NodeRef` on the emitted [RequestedEffect]. For non-target
- * verbs (everything except `EffectVerb.CLICK`), [targetBindName] is null.
+ * Purely observational/app-internal (#425): actuating verbs left the rule
+ * vocabulary, so compiled effects carry no target and no consent key. Taps
+ * are app-owned `RuleAction`s aimed by the rule's *bindings* instead.
  */
 data class CompiledEffect(
     val verb: cloud.trotter.dashbuddy.domain.pipeline.EffectVerb,
-    val targetBindName: String? = null,
     val args: Map<String, String> = emptyMap(),
     val onlyIf: cloud.trotter.dashbuddy.domain.pipeline.ParsedFieldsGate? = null,
     val dedupeKey: String? = null,
     val throttleMs: Long? = null,
-    /**
-     * Optional delay (ms) before the effect fires. When non-null and > 0,
-     * EffectMap routes the effect through a SETTLE_UI timeout so the delay
-     * is state-machine-visible (cancellable / observable). Capped at 5000ms.
-     * Primarily used to let dynamic UI (e.g. RecyclerView pages) settle
-     * before an auto-click.
-     */
-    val delayMs: Long? = null,
-    /**
-     * Content-pinned consent key (#422) for actuating verbs
-     * ([EffectVerb.consentRequired]); null otherwise. Computed once at compile
-     * from `(ruleId, verb, the binding definition this effect targets)` and
-     * carried onto the emitted `RequestedEffect`, so load-time enumeration and
-     * the runtime consent gate compute the same value by construction.
-     */
-    val capabilityKey: String? = null,
 )

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompiler.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompiler.kt
@@ -40,13 +40,6 @@ object RuleCompiler {
     const val MAX_REGEX_LENGTH = 200
     private const val MAX_EACH_SIZE = 50
 
-    /**
-     * Hard cap on per-effect `delayMs` (ms). Prevents rules from holding
-     * deferred side effects indefinitely. Tuned for the longest sensible
-     * UI-settling / countdown window (e.g. auto-accept countdowns).
-     */
-    const val MAX_EFFECT_DELAY_MS = 5000L
-
     // ==========================================================================
     //  Permission introspection
     // ==========================================================================
@@ -77,27 +70,48 @@ object RuleCompiler {
     }
 
     /**
-     * Enumerate the per-rule actuating capabilities a compiled ruleset declares
-     * (#422) — one [RuleCapability] per consent-requiring effect, the unit of
-     * user consent. Deduped by [RuleCapability.key] (a rule declaring the same
-     * click in several branches is one capability). [source] is recorded for
-     * provenance only — consent is uniform regardless of where the rule came
-     * from.
+     * Enumerate the app-owned actions a compiled ruleset's bindings enable
+     * (#422, refit by #425) — one [RuleCapability] per (rule, action) whose
+     * well-known target bind name (`RuleAction.targetBindName`) the rule
+     * binds. The unit of user consent. Deduped by [RuleCapability.key] (the
+     * same binding compiled into several branches is one capability).
+     * [source] is recorded for provenance only — consent is uniform
+     * regardless of where the rule came from.
+     *
+     * The key hashes `(ruleId, action, the CANONICAL binding definition)` —
+     * pinned to the predicate that selects the node, so repointing the
+     * binding (even with the same bind name) forces re-consent. The future
+     * execution gate (#417) looks grants up from this enumeration at fire
+     * time; nothing is threaded through the effect pipeline.
      */
     fun enumerateCapabilities(
         rules: List<CompiledRule<*>>,
         source: String,
     ): List<cloud.trotter.dashbuddy.domain.capability.RuleCapability> {
         val byKey = LinkedHashMap<String, cloud.trotter.dashbuddy.domain.capability.RuleCapability>()
-        fun consider(ruleId: String, effects: List<CompiledEffect>) {
-            for (effect in effects) {
-                if (!effect.verb.consentRequired) continue
-                val key = effect.capabilityKey ?: continue
+        fun consider(ruleId: String, bindings: List<Binding>) {
+            for (binding in bindings) {
+                val action = cloud.trotter.dashbuddy.domain.action.RuleAction
+                    .byTargetBindName[binding.name] ?: continue
+                // Structurally-unambiguous key input (#422): a canonical JSON
+                // object, NOT delimiter-joined fields. Rule ids and bind names
+                // are arbitrary JSON strings (no charset constraint), so JSON
+                // string escaping is what makes the field boundaries exact —
+                // distinct tuples can never collide on the same input.
+                val keyInput = canonicalJson(
+                    buildJsonObject {
+                        put("rule", ruleId)
+                        put("action", action.wire)
+                        put("bind", binding.name)
+                        put("def", binding.defJson ?: JsonNull)
+                    },
+                )
+                val key = sha256OrNull(keyInput) ?: continue // fail closed: unkeyable → not consentable
                 byKey.getOrPut(key) {
                     cloud.trotter.dashbuddy.domain.capability.RuleCapability(
                         ruleId = ruleId,
-                        verb = effect.verb,
-                        targetBindName = effect.targetBindName,
+                        action = action,
+                        targetBindName = binding.name,
                         key = key,
                         source = source,
                     )
@@ -105,45 +119,10 @@ object RuleCompiler {
             }
         }
         for (rule in rules) {
-            for (branch in rule.branches) {
-                consider(rule.id, branch.effects)
-                for ((_, overrideEffects) in branch.transitionOverrides) consider(rule.id, overrideEffects)
-            }
+            consider(rule.id, rule.bindings)
+            for (branch in rule.branches) consider(rule.id, branch.bindings)
         }
         return byKey.values.toList()
-    }
-
-    /**
-     * Stamp the content-pinned consent key (#422) on each consent-requiring
-     * effect. The key hashes `(ruleId, verb, the CANONICAL binding definition
-     * the effect targets)` — pinned to the predicate that selects the node, so
-     * repointing the binding (even with the same bind name) forces re-consent.
-     * Non-actuating effects are returned untouched.
-     */
-    private fun assignCapabilityKeys(
-        effects: List<CompiledEffect>,
-        ruleId: String?,
-        bindObj: JsonObject?,
-    ): List<CompiledEffect> {
-        if (ruleId == null || effects.none { it.verb.consentRequired }) return effects
-        return effects.map { effect ->
-            if (!effect.verb.consentRequired) return@map effect
-            val bindDef = effect.targetBindName?.let { bindObj?.get(it) }
-            // Structurally-unambiguous key input (#422): a canonical JSON
-            // object, NOT delimiter-joined fields. Rule ids and bind names are
-            // arbitrary JSON strings (no charset constraint), so JSON string
-            // escaping is what makes the field boundaries exact — distinct
-            // tuples can never collide on the same input.
-            val keyInput = canonicalJson(
-                buildJsonObject {
-                    put("rule", ruleId)
-                    put("verb", effect.verb.wire)
-                    put("bind", effect.targetBindName ?: "")
-                    put("def", bindDef ?: JsonNull)
-                },
-            )
-            effect.copy(capabilityKey = sha256OrNull(keyInput))
-        }
     }
 
     /** Stable serialization (recursively sorted object keys) so reordering a
@@ -297,14 +276,13 @@ object RuleCompiler {
             compileValidateEntry(entry.jsonObject)
         } ?: emptyList()
 
-        // --- Effects (consent keys assigned for actuating verbs, #422) ---
-        val rawEffects = obj["effects"]?.jsonArray?.map { compileEffectEntry(it.jsonObject) } ?: emptyList()
-        val effects = assignCapabilityKeys(rawEffects, ruleId, effectiveBindObj)
+        // --- Effects (observational/app-internal only; actuation rejected in compileEffectEntry, #425) ---
+        val effects = obj["effects"]?.jsonArray?.map { compileEffectEntry(it.jsonObject) } ?: emptyList()
 
         // --- Transition overrides (screen rules) ---
-        val transitionOverrides = (obj["transitionOverrides"]?.jsonObject?.let {
+        val transitionOverrides = obj["transitionOverrides"]?.jsonObject?.let {
             compileTransitionOverrides(it)
-        } ?: emptyMap()).mapValues { (_, list) -> assignCapabilityKeys(list, ruleId, effectiveBindObj) }
+        } ?: emptyMap()
 
         // --- Click-specific: screenIs ---
         val screenIs = obj["screenIs"]?.jsonPrimitive?.content
@@ -363,7 +341,8 @@ object RuleCompiler {
         val findSpec = specObj["find"] ?: throw RuleCompileException("Binding '$name' has no 'find'")
         val nodePred = compileNodePred(findSpec)
         val find: (UiNode) -> UiNode? = { tree -> tree.findNode(nodePred) }
-        Binding(name, find, optional)
+        // Raw definition retained for capability-key pinning (#422/#425).
+        Binding(name, find, optional, defJson = specObj)
     }
 
     // ==========================================================================
@@ -797,7 +776,17 @@ object RuleCompiler {
         cloud.trotter.dashbuddy.domain.pipeline.EffectVerb.SESSION_END to setOf("platformName"),
     )
 
-    private val effectMetaKeys = setOf("onlyIf", "dedupeKey", "throttleMs", "delayMs")
+    private val effectMetaKeys = setOf("onlyIf", "dedupeKey", "throttleMs")
+
+    /**
+     * Actuating verbs rules may NOT declare (#425). Rejected with a migration
+     * pointer instead of the generic unknown-verb error: rules expose target
+     * *bindings* and the app-owned `RuleAction` registry performs the tap.
+     * Fail closed against future gesture wires too — none of these may ever
+     * silently compile from untrusted rule JSON (#192).
+     */
+    private val rejectedActuationWires =
+        setOf("click", "tap", "swipe", "scroll", "set_text", "long_click")
 
     internal fun compileEffectEntry(obj: JsonObject): CompiledEffect {
         val verbEntries = obj.entries.filter { it.key !in effectMetaKeys }
@@ -809,45 +798,35 @@ object RuleCompiler {
             )
 
         val (wireVerb, verbValue) = verbEntries.single()
+        if (wireVerb in rejectedActuationWires) {
+            throw RuleCompileException(
+                "Rule-declared '$wireVerb' effects were removed (#425): rules expose target " +
+                    "bindings (e.g. bind: { \"declineButton\": { \"find\": ... } }) and the " +
+                    "app-owned RuleAction registry performs taps. " +
+                    "See docs/design/rule-capability-consent.md.",
+            )
+        }
         val verb = cloud.trotter.dashbuddy.domain.pipeline.EffectVerb.fromWire(wireVerb)
             ?: throw RuleCompileException("Unknown effect verb: '$wireVerb'")
 
-        val targetBindName: String?
-        val args: Map<String, String>
-        if (verb.requiresTarget) {
-            targetBindName = verbValue.jsonPrimitive.content.removePrefix("$")
-            args = emptyMap()
-        } else {
-            targetBindName = null
-            val argsObj = verbValue.jsonObject
-            val allowed = allowedArgs[verb] ?: emptySet()
-            val argMap = mutableMapOf<String, String>()
-            for ((key, value) in argsObj) {
-                if (key !in allowed) {
-                    throw RuleCompileException(
-                        "Unknown arg '$key' for verb '$wireVerb'. Allowed: $allowed",
-                    )
-                }
-                argMap[key] = value.jsonPrimitive.content
+        val argsObj = verbValue.jsonObject
+        val allowed = allowedArgs[verb] ?: emptySet()
+        val argMap = mutableMapOf<String, String>()
+        for ((key, value) in argsObj) {
+            if (key !in allowed) {
+                throw RuleCompileException(
+                    "Unknown arg '$key' for verb '$wireVerb'. Allowed: $allowed",
+                )
             }
-            args = argMap.toMap()
-        }
-
-        val delayMs = obj["delayMs"]?.jsonPrimitive?.longOrNull
-        if (delayMs != null && delayMs > MAX_EFFECT_DELAY_MS) {
-            throw RuleCompileException(
-                "Effect delayMs=$delayMs exceeds cap of ${MAX_EFFECT_DELAY_MS}ms",
-            )
+            argMap[key] = value.jsonPrimitive.content
         }
 
         return CompiledEffect(
             verb = verb,
-            targetBindName = targetBindName,
-            args = args,
+            args = argMap.toMap(),
             onlyIf = obj["onlyIf"]?.jsonObject?.let { compileGate(it) },
             dedupeKey = obj["dedupeKey"]?.jsonPrimitive?.content,
             throttleMs = obj["throttleMs"]?.jsonPrimitive?.longOrNull,
-            delayMs = delayMs,
         )
     }
 

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/Ruleset.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/Ruleset.kt
@@ -1,7 +1,6 @@
 package cloud.trotter.dashbuddy.core.pipeline.rules
 
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
-import cloud.trotter.dashbuddy.domain.pipeline.EffectVerb
 import cloud.trotter.dashbuddy.domain.pipeline.NodeRef
 import cloud.trotter.dashbuddy.domain.pipeline.RequestedEffect
 import cloud.trotter.dashbuddy.domain.pipeline.TransitionTrigger
@@ -96,15 +95,23 @@ class Ruleset<TInput>(rules: List<CompiledRule<TInput>>) {
                     effectiveFields
                 }
 
-                // Resolve compiled effects against current bindings + parsed fields
+                // Resolve compiled effects against parsed fields
                 val resolvedEffects = resolveEffects(
-                    branch.effects, allBindings, rule.id, rawFields,
+                    branch.effects, rule.id, rawFields,
                 )
 
                 // Resolve transition overrides
                 val resolvedOverrides = resolveTransitionOverrides(
                     branch.transitionOverrides, rule.id,
                 )
+
+                // Expose resolved bindings as named targets (#425) —
+                // recognition-layer data for the app-owned action registry.
+                val targets = buildMap {
+                    for ((name, node) in allBindings) {
+                        if (node != null) put(name, buildNodeRef(node))
+                    }
+                }
 
                 return RuleMatchResult(
                     ruleId = rule.id,
@@ -115,6 +122,7 @@ class Ruleset<TInput>(rules: List<CompiledRule<TInput>>) {
                     outcomes = branch.outcomes,
                     fields = fieldsWithIntent,
                     effects = resolvedEffects,
+                    targets = targets,
                     transitionOverrides = resolvedOverrides,
                 )
             }
@@ -149,39 +157,24 @@ class Ruleset<TInput>(rules: List<CompiledRule<TInput>>) {
     // =========================================================================
 
     /**
-     * Resolve [CompiledEffect] bind names against current [bindings] to produce
-     * [RequestedEffect]. For target-bound verbs (e.g. [EffectVerb.CLICK]),
-     * effects whose target node is null are silently dropped.
+     * Resolve [CompiledEffect]s to [RequestedEffect]s. All rule effects are
+     * observational/app-internal (#425) — no targets, no consent keys.
      *
      * Template interpolation: `{fieldName}` references in args values and
      * dedupeKey are resolved against [parsedFields].
      */
     private fun resolveEffects(
         effects: List<CompiledEffect>,
-        bindings: Bindings,
         ruleId: String,
         parsedFields: Map<String, Any?> = emptyMap(),
-    ): List<RequestedEffect> = effects.mapNotNull { effect ->
-        val targetRef = if (effect.targetBindName != null) {
-            val node = bindings[effect.targetBindName]
-            if (node == null) {
-                Timber.v("Effect target '${effect.targetBindName}' not bound; skipping effect")
-                return@mapNotNull null
-            }
-            buildNodeRef(node)
-        } else {
-            null
-        }
+    ): List<RequestedEffect> = effects.map { effect ->
         RequestedEffect(
             verb = effect.verb,
             args = resolveTemplateArgs(effect.args, parsedFields),
-            targetRef = targetRef,
             onlyIf = effect.onlyIf,
             dedupeKey = effect.dedupeKey?.let { resolveTemplate(it, parsedFields) },
             throttleMs = effect.throttleMs,
-            delayMs = effect.delayMs,
             ruleId = ruleId,
-            capabilityKey = effect.capabilityKey, // carried unchanged for the consent gate (#422)
         )
     }
 
@@ -205,11 +198,9 @@ class Ruleset<TInput>(rules: List<CompiledRule<TInput>>) {
                 RequestedEffect(
                     verb = effect.verb,
                     args = effect.args,
-                    targetRef = null,
                     onlyIf = effect.onlyIf,
                     dedupeKey = effect.dedupeKey,
                     throttleMs = effect.throttleMs,
-                    delayMs = effect.delayMs,
                     ruleId = ruleId,
                 )
             }

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCapabilityEnumerationTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCapabilityEnumerationTest.kt
@@ -1,67 +1,69 @@
 package cloud.trotter.dashbuddy.core.pipeline.rules
 
+import cloud.trotter.dashbuddy.domain.action.RuleAction
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
-import cloud.trotter.dashbuddy.domain.pipeline.EffectVerb
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Test
 
 /**
- * #422 — per-rule actuating capabilities enumerated at load time, with the
- * consent key content-pinned to the binding DEFINITION (not the rule id or the
- * bind name) so a remote update that repoints a binding forces re-consent.
+ * #422/#425 — capabilities are enumerated at load time from the rules'
+ * *target bindings* (well-known names from the app-owned [RuleAction]
+ * registry), with the consent key content-pinned to the binding DEFINITION
+ * (not the rule id or the bind name) so a remote update that repoints a
+ * binding forces re-consent. Rules cannot declare actuation at all — a
+ * `click` effect is a compile error.
  */
 class RuleCapabilityEnumerationTest {
 
     private fun compile(rulesJson: String): List<CompiledRule<UiNode>> =
         RuleCompiler.compileRules(Json.parseToJsonElement(rulesJson).jsonArray, RuleContext.SCREEN)
 
-    /** A screen rule that auto-clicks a bound button on a recognized screen. */
-    private fun autoClickRule(
-        id: String = "doordash.offer.auto_decline",
+    /** A screen rule that binds the well-known decline target. */
+    private fun declineTargetRule(
+        id: String = "doordash.screen.offer_popup_test",
         bindPredicate: String = """{ "hasText": "Decline" }""",
     ) = """
     [{
       "id": "$id",
       "priority": 10,
       "require": { "exists": { "hasText": "Decline" } },
-      "bind": { "declineButton": { "find": $bindPredicate } },
-      "effects": [ { "click": "${'$'}declineButton" } ]
+      "bind": { "declineButton": { "find": $bindPredicate } }
     }]
     """.trimIndent()
 
     @Test
-    fun `an auto-click rule yields exactly one CLICK capability, keyed and attributed to its source`() {
-        val caps = RuleCompiler.enumerateCapabilities(compile(autoClickRule()), source = "asset:doordash.json")
+    fun `binding a well-known target yields exactly one capability, keyed and attributed to its source`() {
+        val caps = RuleCompiler.enumerateCapabilities(compile(declineTargetRule()), source = "asset:doordash.json")
         assertEquals(1, caps.size)
         val cap = caps.single()
-        assertEquals("doordash.offer.auto_decline", cap.ruleId)
-        assertEquals(EffectVerb.CLICK, cap.verb)
+        assertEquals("doordash.screen.offer_popup_test", cap.ruleId)
+        assertEquals(RuleAction.DECLINE_OFFER, cap.action)
         assertEquals("declineButton", cap.targetBindName)
         assertEquals("asset:doordash.json", cap.source)
         assertTrue(cap.key.isNotBlank())
     }
 
     @Test
-    fun `the same logical action is one capability and the key is stable across compiles`() {
-        val a = RuleCompiler.enumerateCapabilities(compile(autoClickRule()), "asset:doordash.json").single()
-        val b = RuleCompiler.enumerateCapabilities(compile(autoClickRule()), "asset:doordash.json").single()
+    fun `the same logical binding is one capability and the key is stable across compiles`() {
+        val a = RuleCompiler.enumerateCapabilities(compile(declineTargetRule()), "asset:doordash.json").single()
+        val b = RuleCompiler.enumerateCapabilities(compile(declineTargetRule()), "asset:doordash.json").single()
         assertEquals(a.key, b.key)
     }
 
     @Test
     fun `repointing the binding predicate changes the key - silent escalation is caught`() {
-        // Same rule id, same bind name, same click — but the binding now selects
-        // the ACCEPT button. The grant must NOT carry over.
+        // Same rule id, same bind name — but the binding now selects the
+        // ACCEPT button. The grant must NOT carry over.
         val decline = RuleCompiler.enumerateCapabilities(
-            compile(autoClickRule(bindPredicate = """{ "hasText": "Decline" }""")), "s",
+            compile(declineTargetRule(bindPredicate = """{ "hasText": "Decline" }""")), "s",
         ).single()
         val accept = RuleCompiler.enumerateCapabilities(
-            compile(autoClickRule(bindPredicate = """{ "hasText": "Accept" }""")), "s",
+            compile(declineTargetRule(bindPredicate = """{ "hasText": "Accept" }""")), "s",
         ).single()
         assertNotEquals(decline.key, accept.key)
     }
@@ -69,43 +71,84 @@ class RuleCapabilityEnumerationTest {
     @Test
     fun `reordering binding keys does NOT change the key - no spurious re-consent`() {
         val one = RuleCompiler.enumerateCapabilities(
-            compile(autoClickRule(bindPredicate = """{ "hasText": "Decline", "hasIdSuffix": "btn" }""")), "s",
+            compile(declineTargetRule(bindPredicate = """{ "hasText": "Decline", "hasIdSuffix": "btn" }""")), "s",
         ).single()
         val reordered = RuleCompiler.enumerateCapabilities(
-            compile(autoClickRule(bindPredicate = """{ "hasIdSuffix": "btn", "hasText": "Decline" }""")), "s",
+            compile(declineTargetRule(bindPredicate = """{ "hasIdSuffix": "btn", "hasText": "Decline" }""")), "s",
         ).single()
         assertEquals(one.key, reordered.key)
     }
 
     @Test
-    fun `the consent key is carried onto the emitted RequestedEffect for the runtime gate`() {
-        val rules = compile(autoClickRule())
-        val ruleset = Ruleset(rules)
-        // Match the rule against a tree that binds the decline button.
-        val tree = UiNode(children = listOf(UiNode(text = "Decline"))).restoreParents()
-        val result = ruleset.matchFirst(tree, platformWire = "doordash")
-        val clickEffect = result?.effects?.single { it.verb == EffectVerb.CLICK }
-        val cap = RuleCompiler.enumerateCapabilities(rules, "s").single()
+    fun `a rule binding several well-known targets yields one capability per action`() {
+        val caps = RuleCompiler.enumerateCapabilities(
+            compile(
+                """
+                [{
+                  "id": "doordash.screen.offer_popup_test",
+                  "priority": 10,
+                  "require": { "exists": { "hasText": "Decline" } },
+                  "bind": {
+                    "acceptButton": { "find": { "hasIdSuffix": "accept_button" }, "optional": true },
+                    "declineButton": { "find": { "hasText": "Decline" }, "optional": true }
+                  }
+                }]
+                """.trimIndent(),
+            ),
+            "s",
+        )
         assertEquals(
-            "runtime effect carries the same key load-time enumeration produced",
-            cap.key, clickEffect?.capabilityKey,
+            setOf(RuleAction.ACCEPT_OFFER, RuleAction.DECLINE_OFFER),
+            caps.map { it.action }.toSet(),
         )
     }
 
     @Test
-    fun `non-actuating effects produce no capability and no key`() {
+    fun `bindings with non-action names produce no capability`() {
         val rules = compile(
             """
             [{
-              "id": "doordash.offer.notify",
+              "id": "doordash.screen.summary_test",
               "priority": 11,
               "require": { "exists": { "hasText": "Decline" } },
+              "bind": { "payField": { "find": { "hasTextContaining": "$" } } },
               "effects": [ { "bubble": { "text": "offer" } }, { "log": { "type": "OFFER_RECEIVED" } } ]
             }]
             """.trimIndent(),
         )
         assertTrue(RuleCompiler.enumerateCapabilities(rules, "s").isEmpty())
-        val bubble = rules.single().branches.single().effects.first()
-        assertNull(bubble.capabilityKey)
+    }
+
+    @Test
+    fun `rule-declared click effects are rejected at compile time with a migration pointer`() {
+        try {
+            compile(
+                """
+                [{
+                  "id": "doordash.offer.auto_decline",
+                  "priority": 10,
+                  "require": { "exists": { "hasText": "Decline" } },
+                  "bind": { "declineButton": { "find": { "hasText": "Decline" } } },
+                  "effects": [ { "click": "${'$'}declineButton" } ]
+                }]
+                """.trimIndent(),
+            )
+            fail("expected RuleCompileException for rule-declared click")
+        } catch (e: RuleCompileException) {
+            assertTrue(
+                "error should point at the #425 migration: ${e.message}",
+                e.message!!.contains("#425") && e.message!!.contains("bind"),
+            )
+        }
+    }
+
+    @Test
+    fun `matching a rule exposes its resolved bindings as named targets`() {
+        val rules = compile(declineTargetRule())
+        val ruleset = Ruleset(rules)
+        val tree = UiNode(children = listOf(UiNode(text = "Decline"))).restoreParents()
+        val result = ruleset.matchFirst(tree, platformWire = "doordash")
+        val target = result?.targets?.get("declineButton")
+        assertEquals("Decline", target?.text)
     }
 }

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompilerTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompilerTest.kt
@@ -505,13 +505,19 @@ class RuleCompilerTest {
 
     private val compiler = RuleCompiler
 
-    @Test
-    fun `compileEffectEntry accepts valid click verb with target`() {
-        val effect = compiler.compileEffectEntry(
+    @Test(expected = RuleCompileException::class)
+    fun `compileEffectEntry rejects rule-declared click - actuation is app-owned`() {
+        // #425: rules expose target bindings; they can never declare a tap.
+        compiler.compileEffectEntry(
             parseJson("""{"click": "${'$'}acceptBtn"}""").jsonObject
         )
-        assertEquals(cloud.trotter.dashbuddy.domain.pipeline.EffectVerb.CLICK, effect.verb)
-        assertEquals("acceptBtn", effect.targetBindName)
+    }
+
+    @Test(expected = RuleCompileException::class)
+    fun `compileEffectEntry rejects future gesture wires too`() {
+        compiler.compileEffectEntry(
+            parseJson("""{"swipe": {"direction": "up"}}""").jsonObject
+        )
     }
 
     @Test
@@ -520,7 +526,6 @@ class RuleCompilerTest {
             parseJson("""{"screenshot": {"prefix": "Offer"}}""").jsonObject
         )
         assertEquals(cloud.trotter.dashbuddy.domain.pipeline.EffectVerb.SCREENSHOT, effect.verb)
-        assertNull(effect.targetBindName)
         assertEquals("Offer", effect.args["prefix"])
     }
 
@@ -561,14 +566,6 @@ class RuleCompilerTest {
     // compileEffectEntry — format enforcement
     // =========================================================================
 
-    @Test(expected = Exception::class)
-    fun `compileEffectEntry rejects click with object value instead of target string`() {
-        // click requires a string target, not an args object
-        compiler.compileEffectEntry(
-            parseJson("""{"click": {"bad": "value"}}""").jsonObject
-        )
-    }
-
     @Test(expected = RuleCompileException::class)
     fun `compileEffectEntry rejects multiple verb keys`() {
         compiler.compileEffectEntry(
@@ -604,7 +601,7 @@ class RuleCompilerTest {
     @Test
     fun `compileEffectEntry preserves onlyIf gate`() {
         val effect = compiler.compileEffectEntry(
-            parseJson("""{"click": "${'$'}btn", "onlyIf": {"fieldEquals": {"field": "intent", "value": "accept"}}}""").jsonObject
+            parseJson("""{"screenshot": {"prefix": "Offer"}, "onlyIf": {"fieldEquals": {"field": "intent", "value": "accept"}}}""").jsonObject
         )
         assertTrue(effect.onlyIf is cloud.trotter.dashbuddy.domain.pipeline.ParsedFieldsGate.FieldEquals)
     }
@@ -612,9 +609,9 @@ class RuleCompilerTest {
     @Test
     fun `compileEffectEntry preserves dedupeKey and throttleMs`() {
         val effect = compiler.compileEffectEntry(
-            parseJson("""{"click": "${'$'}btn", "dedupeKey": "accept-click", "throttleMs": 1000}""").jsonObject
+            parseJson("""{"screenshot": {"prefix": "Offer"}, "dedupeKey": "offer-ss", "throttleMs": 1000}""").jsonObject
         )
-        assertEquals("accept-click", effect.dedupeKey)
+        assertEquals("offer-ss", effect.dedupeKey)
         assertEquals(1000L, effect.throttleMs)
     }
 
@@ -839,36 +836,15 @@ class RuleCompilerTest {
     }
 
     // =========================================================================
-    // delayMs on effects
+    // effect meta keys
     // =========================================================================
 
     @Test
-    fun `compileEffectEntry accepts delayMs within cap`() {
-        val obj = parseJson("""{"click": "${'$'}btn", "delayMs": 500}""").jsonObject
+    fun `compileEffectEntry treats meta keys as meta - not as a second verb`() {
+        // Regression guard: meta keys alongside a verb must not be flagged
+        // as multiple verb keys.
+        val obj = parseJson("""{"log": {"type": "X"}, "throttleMs": 1000, "dedupeKey": "k"}""").jsonObject
         val effect = RuleCompiler.compileEffectEntry(obj)
-        assertEquals(500L, effect.delayMs)
-    }
-
-    @Test
-    fun `compileEffectEntry omits delayMs when not specified`() {
-        val obj = parseJson("""{"click": "${'$'}btn"}""").jsonObject
-        val effect = RuleCompiler.compileEffectEntry(obj)
-        assertNull(effect.delayMs)
-    }
-
-    @Test(expected = RuleCompileException::class)
-    fun `compileEffectEntry rejects delayMs above 5000ms cap`() {
-        val obj = parseJson("""{"click": "${'$'}btn", "delayMs": 6000}""").jsonObject
-        RuleCompiler.compileEffectEntry(obj)
-    }
-
-    @Test
-    fun `compileEffectEntry treats delayMs as meta-key not verb-key`() {
-        // Regression guard: with delayMs alongside a verb, compileEffectEntry
-        // must not flag it as a second verb.
-        val obj = parseJson("""{"click": "${'$'}btn", "delayMs": 500, "throttleMs": 1000, "dedupeKey": "k"}""").jsonObject
-        val effect = RuleCompiler.compileEffectEntry(obj)
-        assertEquals(500L, effect.delayMs)
         assertEquals(1000L, effect.throttleMs)
         assertEquals("k", effect.dedupeKey)
     }

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/AppEffect.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/AppEffect.kt
@@ -1,13 +1,13 @@
 package cloud.trotter.dashbuddy.core.state
 
-import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
+import cloud.trotter.dashbuddy.domain.action.RuleAction
 import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
-import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
 import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.domain.model.chat.ChatPersona
 import cloud.trotter.dashbuddy.domain.model.event.AppEvent
 import cloud.trotter.dashbuddy.domain.model.offer.ParsedOffer
 import cloud.trotter.dashbuddy.domain.pipeline.TimeoutType
+import cloud.trotter.dashbuddy.domain.pipeline.NodeRef
 import cloud.trotter.dashbuddy.domain.pipeline.RequestedEffect
 import cloud.trotter.dashbuddy.domain.pipeline.ObservationPayload
 
@@ -92,24 +92,26 @@ sealed class AppEffect {
      */
     data class PostOfferNotification(val evaluation: OfferEvaluation) : AppEffect()
 
-    data class ClickNode(
-        val node: UiNode,
-        val description: String = "Auto-Click"
-    ) : AppEffect()
-
     /**
-     * HUD-initiated offer action (bubble Accept/Decline) → perform the platform's offer
-     * click. Platform-agnostic; the app layer resolves the concrete node (see #85 GigPlatform).
+     * Perform an app-owned [RuleAction] on the platform app (#425) — the only
+     * path by which DashBuddy ever taps a third-party UI. [targetRef] is the
+     * ruleset-bound target (recognition data); the executor re-resolves it
+     * against the live tree scoped to the platform's package and verifies the
+     * node against the action's app-owned expectation before clicking.
+     * [sourceRuleId] is the rule that supplied the binding — consent-gate
+     * provenance (#422/#417).
      */
-    data class PerformOfferAction(
-        val action: OfferAction,
+    data class PerformRuleAction(
+        val action: RuleAction,
         val platform: Platform,
+        val targetRef: NodeRef,
+        val sourceRuleId: String?,
     ) : AppEffect()
 
     /** A rule-originated side effect. */
     data class RequestEffect(val effect: RequestedEffect) : AppEffect() {
         override val effectKey: String
-            get() = "effect:${effect.ruleId}:${effect.dedupeKey ?: effect.targetRef?.pathFingerprint ?: effect.verb.wire}"
+            get() = "effect:${effect.ruleId}:${effect.dedupeKey ?: effect.verb.wire}"
     }
 
     data class SequentialEffect(

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -1,5 +1,6 @@
 package cloud.trotter.dashbuddy.core.state
 
+import cloud.trotter.dashbuddy.domain.action.RuleAction
 import cloud.trotter.dashbuddy.domain.model.chat.ChatPersona
 import cloud.trotter.dashbuddy.domain.model.event.AppEvent
 import cloud.trotter.dashbuddy.domain.model.event.AppEventType
@@ -13,12 +14,9 @@ import cloud.trotter.dashbuddy.domain.model.event.payload.SessionPausedPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStartPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStartSource
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStopPayload
-import cloud.trotter.dashbuddy.domain.pipeline.EffectVerb
-import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
 import cloud.trotter.dashbuddy.domain.state.OfferIntent
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
 import cloud.trotter.dashbuddy.domain.pipeline.ParsedFieldsGate
-import cloud.trotter.dashbuddy.domain.pipeline.RequestedEffect
 import cloud.trotter.dashbuddy.domain.pipeline.TimeoutType
 import cloud.trotter.dashbuddy.domain.pipeline.TransitionTrigger
 import cloud.trotter.dashbuddy.domain.state.AppState
@@ -59,11 +57,20 @@ class EffectMap @Inject constructor() {
          * between the parsed timestamp and the actual timer start.
          */
         const val PAUSE_TIMEOUT_BUFFER_MS = 1000L
+
+        /**
+         * Settle delay before the EXPAND_EARNINGS tap (#425) — lets the
+         * post-delivery summary finish animating so the bound chevron's
+         * fingerprint still matches what gets tapped. Carried over from the
+         * former rule-declared click's `delayMs`.
+         */
+        const val EXPAND_SETTLE_MS = 500L
     }
 
 
     fun diff(prev: AppState, next: AppState, obs: Observation): List<AppEffect> = buildList {
         addAll(diffRuleEffects(obs))
+        addAll(diffExpandAction(obs))
         addAll(diffSettleUiTimeout(obs))
         // Offer-resolution events fire in the FlowRegion handler. They need to
         // be scoped to the active platform's session so AppEventDao queries
@@ -181,17 +188,30 @@ class EffectMap @Inject constructor() {
             }
         }
 
-        // HUD-initiated accept/decline (bubble buttons) → perform the platform's offer
-        // click, while an offer is on screen. Decline taps the initial decline button;
-        // in Native mode the user confirms in DoorDash's own dialog (auto-confirm = 2c).
+        // HUD-initiated accept/decline (bubble buttons / own-notification actions) →
+        // perform the app-owned action, aimed by the target the offer rule bound
+        // (#425). No binding = action unavailable on this platform (fail to
+        // manual). Decline taps the initial decline button; in Native mode the
+        // user confirms in DoorDash's own dialog (auto-confirm = #110 2c).
         if (obs is Observation.UiInput &&
             (next.flow == Flow.OfferPresented || prev.flow == Flow.OfferPresented)
         ) {
             val platform = next.activePlatform ?: prev.activePlatform
-            if (platform != null) {
-                when (obs.action) {
-                    OfferIntent.ACCEPT -> add(AppEffect.PerformOfferAction(OfferAction.ACCEPT, platform))
-                    OfferIntent.DECLINE -> add(AppEffect.PerformOfferAction(OfferAction.DECLINE, platform))
+            val offer = next.pendingOffer ?: prev.pendingOffer
+            val action = when (obs.action) {
+                OfferIntent.ACCEPT -> RuleAction.ACCEPT_OFFER
+                OfferIntent.DECLINE -> RuleAction.DECLINE_OFFER
+                else -> null
+            }
+            if (platform != null && offer != null && action != null) {
+                val target = offer.targets[action.targetBindName]
+                if (target != null) {
+                    add(AppEffect.PerformRuleAction(action, platform, target, offer.sourceRuleId))
+                } else {
+                    Timber.w(
+                        "No '%s' target bound for %s — %s unavailable, leaving it to the user",
+                        action.targetBindName, platform.wire, action.wire,
+                    )
                 }
             }
         }
@@ -677,64 +697,69 @@ class EffectMap @Inject constructor() {
     /**
      * Extract rule-declared effects from the observation and emit
      * [AppEffect.RequestEffect] for each that passes its gate.
-     * Runs at top level — NOT inside any region stepper.
+     * Runs at top level — NOT inside any region stepper. All rule effects
+     * are observational/app-internal (#425) — actuation never rides here.
      */
     private fun diffRuleEffects(obs: Observation): List<AppEffect> {
         val flowObs = obs as? Observation.FlowObservation ?: return emptyList()
         if (flowObs.effects.isEmpty()) return emptyList()
         return flowObs.effects
             .filter { evaluateGate(it.onlyIf, flowObs.parsed) }
-            .map { effect ->
-                if (effect.verb == EffectVerb.CLICK && (effect.delayMs ?: 0L) > 0L) {
-                    // Defer the click through the state machine via SETTLE_UI
-                    // timeout — keeps the delay observable + cancellable instead
-                    // of sleeping in a hidden coroutine. Payload carries the
-                    // click context so the timeout handler can reconstruct.
-                    AppEffect.ScheduleTimeout(
-                        durationMs = effect.delayMs!!,
-                        type = TimeoutType.SETTLE_UI,
-                        platform = flowObs.platform.takeIf { it != Platform.Unknown },
-                        payload = deferredClickPayload(effect),
-                    )
-                } else {
-                    AppEffect.RequestEffect(effect)
-                }
-            }
+            .map { AppEffect.RequestEffect(it) }
     }
 
     /**
-     * Catch the SETTLE_UI timeout fired by a deferred click (see
-     * [diffRuleEffects]) and re-emit it as an immediate-fire click.
+     * App-owned EXPAND_EARNINGS decision (#425): when the post-delivery
+     * summary is collapsed and the rule bound an expand target, schedule the
+     * tap behind a SETTLE_UI timeout so the screen finishes animating first
+     * (observable + cancellable, unlike a hidden sleep). Replaces the rule's
+     * former `click` effect — the decision is the app's, the target is data.
+     */
+    private fun diffExpandAction(obs: Observation): List<AppEffect> {
+        val flowObs = obs as? Observation.Screen ?: return emptyList()
+        val action = RuleAction.EXPAND_EARNINGS
+        val target = flowObs.targets[action.targetBindName] ?: return emptyList()
+        // Only when the screen itself reports the breakdown collapsed — the
+        // gate fails closed on an absent/unparseable field (#345).
+        val collapsed = evaluateGate(
+            ParsedFieldsGate.FieldEquals("isExpanded", false), flowObs.parsed,
+        )
+        if (!collapsed) return emptyList()
+        return listOf(
+            AppEffect.ScheduleTimeout(
+                durationMs = EXPAND_SETTLE_MS,
+                type = TimeoutType.SETTLE_UI,
+                platform = flowObs.platform.takeIf { it != Platform.Unknown },
+                payload = ObservationPayload.DeferredAction(
+                    action = action.wire,
+                    platform = flowObs.platform.wire,
+                    ruleId = flowObs.ruleId,
+                    target = target,
+                ),
+            ),
+        )
+    }
+
+    /**
+     * Catch the SETTLE_UI timeout fired by a deferred action (see
+     * [diffExpandAction]) and emit the immediate-fire [AppEffect.PerformRuleAction].
      */
     private fun diffSettleUiTimeout(obs: Observation): List<AppEffect> {
         val timeout = obs as? Observation.Timeout ?: return emptyList()
         if (timeout.type != TimeoutType.SETTLE_UI) return emptyList()
         // Typed payload (#366) — the old per-key Map round-trip is gone.
-        val click = timeout.payload as? ObservationPayload.DeferredClick ?: return emptyList()
-        val verb = runCatching { EffectVerb.valueOf(click.verb) }.getOrNull() ?: return emptyList()
-        if (verb != EffectVerb.CLICK) return emptyList()
-        val targetRef = click.target ?: return emptyList()
-        val effect = RequestedEffect(
-            verb = verb,
-            args = emptyMap(),
-            targetRef = targetRef,
-            onlyIf = null,
-            dedupeKey = click.dedupeKey,
-            throttleMs = click.throttleMs,
-            delayMs = null,  // immediate fire this time
-            ruleId = click.ruleId,
+        val deferred = timeout.payload as? ObservationPayload.DeferredAction ?: return emptyList()
+        val action = RuleAction.fromWire(deferred.action) ?: return emptyList()
+        val platform = Platform.fromWire(deferred.platform) ?: return emptyList()
+        return listOf(
+            AppEffect.PerformRuleAction(
+                action = action,
+                platform = platform,
+                targetRef = deferred.target,
+                sourceRuleId = deferred.ruleId,
+            ),
         )
-        return listOf(AppEffect.RequestEffect(effect))
     }
-
-    private fun deferredClickPayload(effect: RequestedEffect): ObservationPayload.DeferredClick =
-        ObservationPayload.DeferredClick(
-            verb = effect.verb.name,
-            ruleId = effect.ruleId,
-            dedupeKey = effect.dedupeKey,
-            throttleMs = effect.throttleMs,
-            target = effect.targetRef,
-        )
 
     private fun evaluateGate(gate: ParsedFieldsGate?, parsed: ParsedFields): Boolean {
         if (gate == null) return true

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/FlowRegionStepper.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/FlowRegionStepper.kt
@@ -53,9 +53,15 @@ class FlowRegionStepper @Inject constructor() {
             // No offer data → keep existing pending offer if any
             offerFields == null || newHash == null -> existingOffer
 
-            // Same hash → update enrichment fields
+            // Same hash → update enrichment fields; refresh action targets
+            // (#425) when this observation re-bound them (bounds shift as the
+            // screen settles — fresher fingerprints aim better).
             existingOffer != null && existingOffer.offerHash == newHash ->
-                existingOffer.copy(offerFields = offerFields)
+                existingOffer.copy(
+                    offerFields = offerFields,
+                    targets = obs.targets.ifEmpty { existingOffer.targets },
+                    sourceRuleId = obs.ruleId ?: existingOffer.sourceRuleId,
+                )
 
             // New or replaced offer → push (old one is implicitly popped)
             else -> PendingOffer(
@@ -70,6 +76,8 @@ class FlowRegionStepper @Inject constructor() {
                     // Fresh offer: return to whatever we were doing
                     prev.flow
                 },
+                targets = obs.targets,
+                sourceRuleId = obs.ruleId,
             )
         }
 

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/ObservationJournal.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/ObservationJournal.kt
@@ -107,8 +107,8 @@ class ObservationJournal @Inject constructor(
             if (obs.targetPlatform != null || obs.payload != null) {
                 InternalObsPayload(targetPlatform = obs.targetPlatform?.wire, payload = obs.payload)
             } else null
-        // Persisting the REAL action is safe: PerformOfferAction is classified
-        // external (#341), so recovery can never replay an offer click from it.
+        // Persisting the REAL action is safe: PerformRuleAction is classified
+        // external (#341), so recovery can never replay an offer tap from it.
         is Observation.UiInput -> InternalObsPayload(action = obs.action)
         is Observation.Loopback -> InternalObsPayload(effect = obs.effect, payload = obs.payload)
         else -> null

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/ActionTargetsTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/ActionTargetsTest.kt
@@ -1,0 +1,145 @@
+package cloud.trotter.dashbuddy.core.state
+
+import cloud.trotter.dashbuddy.domain.action.RuleAction
+import cloud.trotter.dashbuddy.domain.action.TargetExpectation
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
+import cloud.trotter.dashbuddy.domain.model.accessibility.BoundingBox
+import cloud.trotter.dashbuddy.domain.model.offer.ParsedOffer
+import cloud.trotter.dashbuddy.domain.pipeline.NodeRef
+import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.state.Flow
+import cloud.trotter.dashbuddy.domain.state.FlowRegion
+import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #425 — action targets ride observations into [FlowRegion.pendingOffer], and
+ * the app-owned [TargetExpectation] verification logic holds the line the
+ * ruleset cannot cross.
+ */
+class ActionTargetsTest {
+
+    private val stepper = FlowRegionStepper()
+
+    private fun nodeRef(id: String, text: String? = null) = NodeRef(
+        viewIdSuffix = id,
+        text = text,
+        classNameHint = "android.widget.Button",
+        boundsInScreen = BoundingBox(0, 0, 100, 50),
+        pathFingerprint = "fp/$id",
+    )
+
+    private fun offerObs(
+        hash: String,
+        targets: Map<String, NodeRef> = emptyMap(),
+        ruleId: String = "doordash.screen.offer_popup",
+        timestamp: Long = 1000L,
+    ) = Observation.Screen(
+        timestamp = timestamp,
+        captureId = null,
+        ruleId = ruleId,
+        metadata = ReplayMetadata.EMPTY,
+        flow = Flow.OfferPresented,
+        modeHint = null,
+        parsed = ParsedFields.OfferFields(
+            parsedOffer = ParsedOffer(offerHash = hash, payAmount = 7.5, distanceMiles = 3.2),
+        ),
+        targets = targets,
+    )
+
+    // =========================================================================
+    // FlowRegionStepper — targets land on PendingOffer
+    // =========================================================================
+
+    @Test
+    fun `offer creation copies the observation's targets and source rule onto PendingOffer`() {
+        val targets = mapOf(
+            "acceptButton" to nodeRef("accept_button"),
+            "declineButton" to nodeRef("decline_button"),
+        )
+        val region = stepper.step(FlowRegion(), offerObs("h1", targets))
+        val offer = region.pendingOffer!!
+        assertEquals(targets, offer.targets)
+        assertEquals("doordash.screen.offer_popup", offer.sourceRuleId)
+    }
+
+    @Test
+    fun `same-hash re-observation refreshes targets with the newer fingerprints`() {
+        val first = stepper.step(
+            FlowRegion(),
+            offerObs("h1", mapOf("acceptButton" to nodeRef("accept_button"))),
+        )
+        val moved = nodeRef("accept_button").copy(boundsInScreen = BoundingBox(0, 200, 100, 250))
+        val second = stepper.step(
+            first,
+            offerObs("h1", mapOf("acceptButton" to moved), timestamp = 2000L),
+        )
+        assertEquals(moved, second.pendingOffer!!.targets["acceptButton"])
+    }
+
+    @Test
+    fun `same-hash re-observation with NO targets keeps the previously bound ones`() {
+        val first = stepper.step(
+            FlowRegion(),
+            offerObs("h1", mapOf("acceptButton" to nodeRef("accept_button"))),
+        )
+        val second = stepper.step(first, offerObs("h1", targets = emptyMap(), timestamp = 2000L))
+        assertEquals("accept_button", second.pendingOffer!!.targets["acceptButton"]?.viewIdSuffix)
+    }
+
+    @Test
+    fun `a replacing offer gets ITS OWN targets - never the old offer's`() {
+        val first = stepper.step(
+            FlowRegion(),
+            offerObs("h1", mapOf("acceptButton" to nodeRef("old_accept"))),
+        )
+        val second = stepper.step(first, offerObs("h2", targets = emptyMap(), timestamp = 2000L))
+        assertTrue(
+            "Replaced offer must not inherit stale targets",
+            second.pendingOffer!!.targets.isEmpty(),
+        )
+    }
+
+    // =========================================================================
+    // TargetExpectation — the app-owned tap-time anchor
+    // =========================================================================
+
+    @Test
+    fun `ACCEPT expectation matches Accept and Add to route labels`() {
+        val v = RuleAction.ACCEPT_OFFER.verification
+        assertTrue(v.matchesLabels(listOf("Accept")))
+        assertTrue(v.matchesLabels(listOf("32", "Accept"))) // countdown sibling text
+        assertTrue(v.matchesLabels(listOf("Add to route")))
+        assertFalse("Decline must never satisfy ACCEPT", v.matchesLabels(listOf("Decline")))
+        assertFalse(v.matchesLabels(emptyList()))
+    }
+
+    @Test
+    fun `DECLINE expectation matches Decline and rejects Accept`() {
+        val v = RuleAction.DECLINE_OFFER.verification
+        assertTrue(v.matchesLabels(listOf("Decline")))
+        assertTrue(v.matchesLabels(listOf("Decline offer")))
+        assertFalse("Accept must never satisfy DECLINE", v.matchesLabels(listOf("Accept")))
+        // 'Accepted' contains no standalone 'decline' token — and crucially a
+        // malicious bind pointing decline at the Accept button fails here.
+        assertFalse(v.matchesLabels(listOf("Accepted")))
+    }
+
+    @Test
+    fun `label-free EXPAND expectation passes anything - package scope is its bar`() {
+        val v = RuleAction.EXPAND_EARNINGS.verification
+        assertTrue(v.matchesLabels(emptyList()))
+        assertTrue(v.matchesLabels(listOf("whatever")))
+    }
+
+    @Test
+    fun `well-known bind names map one-to-one onto actions`() {
+        assertEquals(RuleAction.ACCEPT_OFFER, RuleAction.byTargetBindName["acceptButton"])
+        assertEquals(RuleAction.DECLINE_OFFER, RuleAction.byTargetBindName["declineButton"])
+        assertEquals(RuleAction.EXPAND_EARNINGS, RuleAction.byTargetBindName["expandButton"])
+        assertEquals(RuleAction.entries.size, RuleAction.byTargetBindName.size)
+    }
+}

--- a/docs/design/rule-capability-consent.md
+++ b/docs/design/rule-capability-consent.md
@@ -1,148 +1,209 @@
-# Design: per-rule action capabilities + load-time consent
+# Design: action targets, capabilities + load-time consent
 
-**Status:** proposal (2026-06-11). Concrete shape for #417 (make the permission
-gate real) and a safety prerequisite for #192 (matchers split — remote rules).
-Prompted by: "dynamically bundle the rule ACTIONS into a user-permission list at
-load time, if not already granted for that unique rule."
+**Status:** layers 1–3 and the capability refit implemented by #425 (2026-06-11);
+the grant store + execution gate remain #417, the consent UI is #422 PR 3.
+Supersedes the original draft of this doc (f9193c7, reconciled 51c58e1) and the
+closed #85 ("GigPlatform interface") — see *History* at the bottom.
 
-## The problem it solves
+## The model: three layers
 
-A rule can declare **actuating effects** — today `CLICK` (taps the third-party
-app's UI), `SCREENSHOT`, `SPEAK`; tomorrow likely `SWIPE`/`SCROLL`/`SET_TEXT`/
-global actions. Right now `SideEffectEngine.isPermissionGranted(tier)` returns
-`true` for everything, so any rule-declared action fires unconditionally. For
-bundled rules that's a deliberate single-user choice; once rules arrive from a
-forkable CDN (#192), it's **arbitrary UI actuation from untrusted input**.
+The core question is who may ever tap the third-party app, aimed by what, and
+checked by whom. The answer is a strict split:
 
-The blunt fix (#417) is to make the tier check real — "is the accessibility
-service enabled." But that's all-or-nothing: enabling the service to get
-recognition would also bless *every* rule's clicks. The better model, and what
-this design proposes, is **capability consent keyed on the (rule, action) pair**:
-the user approves "rule X may tap the *Accept* button," not "rules may click."
+```
+┌─ RECOGNITION ─────────── the ruleset (untrusted, forkable — #192) ──┐
+│  "What's on screen?"                                                 │
+│  → parses fields (pay $7.50, 3.2 mi)                                 │
+│  → exposes named TARGET BINDINGS:  acceptButton  → NodeRef           │
+│                                    declineButton → NodeRef           │
+│                                    expandButton  → NodeRef           │
+│  Pure observation. No decisions. No actuation. Just DATA.            │
+└───────────────────────────────────────────────────────────────────────┘
+              │ fields + targets (ride the Observation / PendingOffer)
+              ▼
+┌─ DECISION ────────────── the state machine (app-owned) ──────────────┐
+│  Evaluation (OfferEvaluator × user economy) + policy + user input    │
+│  (bubble / own-notification Accept-Decline) decide IF an action      │
+│  fires. EffectMap owns the expand decision (collapsed summary +      │
+│  bound target → settle → act). Rules can never reach in here.        │
+└───────────────────────────────────────────────────────────────────────┘
+              │ AppEffect.PerformRuleAction(action, platform, target, ruleId)
+              ▼
+┌─ ACTUATION ───────────── the executor (app-owned, verified) ─────────┐
+│  RuleAction registry = the app-owned vocabulary (#425):              │
+│    ACCEPT_OFFER / DECLINE_OFFER / EXPAND_EARNINGS                    │
+│  consent gate (#417, pending) → throttle → package scope →           │
+│  label verification → strict click (self/ancestor only)              │
+└───────────────────────────────────────────────────────────────────────┘
+```
 
-## Core model
+**Rules cannot declare actuation at all.** The `click` effect verb was removed
+from the schema and the compiler rejects it (and future gesture wires:
+`swipe`, `scroll`, `set_text`, …) with a migration error. A rule's only way to
+participate in a tap is to *bind a target* — data the app may or may not act
+on.
 
-A **RuleCapability** is the unit of consent — one actuating action a specific
-rule wants to perform:
+**Targets are the platform contract.** `RuleAction.targetBindName` defines
+well-known bind names (`acceptButton`, `declineButton`, `expandButton`). A
+platform supports an action iff its ruleset binds that name on the relevant
+screen; a missing binding means the action is unavailable there (fail to
+manual — e.g. Uber today, whose offer overlay has no binds yet). This is what
+makes "rulesets define platforms" literal: adding offer actions for a new
+platform is a rules change, not an app release. (This supersedes #85's
+per-platform Kotlin interface, which would have been N hardcoded button sets in
+compiled code — the matcher-class pattern ADR-0001 abolished. The old
+`offerActionNode()` hardcoded-ID path is deleted.)
+
+## Consent: a static half and a dynamic half
+
+Both halves are required; each catches what the other cannot.
+
+### Static: the content-pinned capability key (load time)
+
+A **RuleCapability** is one (rule, action) pair a ruleset's bindings enable —
+the unit of user consent:
 
 ```
 RuleCapability(
-    ruleId: String,        // e.g. "doordash.offer.auto_decline"
-    verb: EffectVerb,      // CLICK, SWIPE, SCREENSHOT, SPEAK, …
-    target: String?,       // semantic target signature for UI-targeting verbs
-    source: String,        // "asset:doordash.json" | "cdn:<url>" | "fork:<id>"
+    ruleId: String,          // e.g. "doordash.screen.offer_popup"
+    action: RuleAction,      // ACCEPT_OFFER | DECLINE_OFFER | EXPAND_EARNINGS
+    targetBindName: String,  // display only
+    key: String,             // the grant key — see below
+    source: String,          // "asset:doordash.json" | "cdn:<url>" | "fork:<id>"
 )
-```
 
-**Grant key = a content hash**, not the rule id alone:
-
-```
-capabilityKey = sha256( canonicalJson({
-    "rule": ruleId,
-    "verb": verb.wire,
-    "bind": targetBindName,        // the rule's bind name for the target, e.g. "declineButton"
-    "def":  <the binding DEFINITION that bind name resolves to>
+key = sha256( canonicalJson({
+    "rule":   ruleId,
+    "action": action.wire,
+    "bind":   bindName,
+    "def":    <the binding DEFINITION — its `find` predicate + flags>
 }) )
 ```
 
-This is the load-bearing security property, and the key is pinned to the
-binding **definition** — the matching predicate that *selects* the node the
-rule will act on. Implementation note (this corrects an earlier draft of this
-doc that hashed a resolved `viewId|text` target): click targets are **dynamic**
-— a `click` effect declares a *bind name* (`"$declineButton"`) and the concrete
-`NodeRef` is resolved against the live UI tree only at match time, so the
-resolved node does not exist at load and cannot be the consent key. The binding
-definition *is* known at load (the `bind` block survives compile), so that is
-what we pin to — which is strictly stronger than `viewId|text`: if a remote
-update to a **trusted rule id** keeps the bind name but repoints
-`declineButton`'s predicate at the **Accept** button, the definition changes →
-the key changes → it re-enters consent. Approving a benign `auto_decline` today
-cannot be silently escalated by a malicious update to the same id tomorrow.
+Enumeration (`RuleCompiler.enumerateCapabilities`) walks the compiled rules'
+bind blocks against the `RuleAction` registry. The key pins the binding
+**definition**: a remote update to a trusted rule id that keeps the bind name
+but repoints `declineButton`'s predicate at the Accept button changes the
+definition → changes the key → the old grant no longer covers it and it
+re-enters consent. Robustness (both tested): the key input is a canonical JSON
+object (structurally unambiguous — no in-band delimiters), recursively
+key-sorted (an innocuous reformat must not re-prompt; re-prompt fatigue trains
+click-through).
 
-Two robustness details, both load-bearing for a *security* key and both tested:
+**No key threading.** The original implementation stamped keys onto compiled
+effects and carried them through the pipeline ("the same value by
+construction") — and the carry chain silently dropped them in two places
+(deferred-click reroute, transition overrides). That chain is deleted. The
+future gate (#417) looks grants up at fire time from the enumeration, keyed by
+the `sourceRuleId` + `action` that ride `PerformRuleAction` — authoritative
+state, not threaded fields.
 
-- **Structurally-unambiguous input.** The key input is a *canonical JSON object*
-  (recursively sorted keys), not delimiter-joined fields. Rule ids and bind
-  names are arbitrary JSON strings with no charset constraint, so any in-band
-  delimiter could let distinct tuples collide; JSON string escaping makes the
-  field boundaries exact.
-- **Canonical (sorted-key) serialization.** Reordering a binding's JSON keys
-  must NOT change the key — otherwise an innocuous reformat re-prompts the user,
-  training click-through (a security anti-pattern). `canonicalJson` sorts keys
-  recursively so semantically-identical definitions hash identically.
+### Dynamic: tap-time verification (fire time) — implemented
 
-The key is computed **once at compile** (`RuleCompiler.assignCapabilityKeys`)
-and carried unchanged onto `RequestedEffect.capabilityKey`, so load-time
-enumeration and the runtime consent gate compute the same value by construction.
-Bounds and other live-node attributes are never part of the key (they shift
-constantly).
+The definition pin is necessary but not sufficient: a **byte-stable definition
+can resolve to a different control** after a platform UI update (DoorDash owns
+what `secondary_action_button_dash_plus` is), and the screen can change between
+decision and tap. So the executor (`UiInteractionHandler.performVerifiedClick`)
+re-checks the *live* resolution against anchors the ruleset cannot influence:
 
-## Lifecycle
+1. **Package scope** — only windows of `platform.packageName` are searched.
+   No package → no tap.
+2. **Label expectation** — `RuleAction.verification` is an app-owned pattern
+   the resolved node's bounded subtree texts must satisfy (buttons label via
+   child TextViews): ACCEPT_OFFER ⇒ `accept|add to route`, DECLINE_OFFER ⇒
+   `decline`. EXPAND_EARNINGS is label-free (icon-only chevron) — package
+   scope is its bar, acceptable for a read-only expansion tap. (Patterns track
+   the platform app's display language — en-US alpha; locale work is #428.)
+3. **Strict click** — self-or-ancestor only. The old clickable-*sibling*
+   fallback is gone from this path: Accept sits beside Decline in the offer
+   footer, and verification ran on *this* node's subtree.
+4. **App-owned throttle** — `RULE_ACTION_THROTTLE_MS` per (action, platform)
+   in the engine; ruleset content cannot loosen it.
 
-1. **Enumerate at load.** Generalize the existing
-   `RuleCompiler.enumeratePermissions(rules): Set<PermissionTier>` into
-   `enumerateCapabilities(rules): List<RuleCapability>` — walk every branch's
-   effects, keep the actuating ones (a defined `EffectVerb.isActuating` set:
-   tier ∈ {ACCESSIBILITY, AUDIO} and not app-internal). App-internal effects
-   (`BUBBLE`, `LOG`, `EVALUATE_OFFER`, odometer, timers) never need consent.
-2. **Partition against the grant store.** New persisted set of granted
-   `capabilityHash`es (`RuleCapabilityDataSource` in `:core:datastore` behind a
-   Hilt qualifier → `RuleCapabilityRepository` in `:core:data` exposing
-   `grantedHashes: StateFlow<Set<String>>`, `grant(hash)`, `revoke(hash)` —
-   reactive, per the shared-StateFlow pattern from #356).
-   - `granted` → action allowed.
-   - `pending` → **recognition still runs; the actuating effect is suppressed
-     (fail closed) until granted.** Populates a user-facing list.
-3. **Consent surface.** A review screen (settings + a prompt when *new* pending
-   capabilities appear after a ruleset update) rendering each in human terms —
-   "Rule `…auto_decline` wants to **tap** *Decline offer*" — with allow / deny.
-4. **Execution gate** (this is the real #417 fix). The engine fires an actuating
-   `RequestedEffect` iff **both**:
-   - the OS-level tier is granted (accessibility service enabled / audio
-     allowed), AND
-   - `capabilityHash(effect) ∈ grantedHashes`.
-   Either missing → log + skip (fail closed). Non-actuating effects bypass the
-   capability check entirely.
+Any check failing skips the tap and logs; the user acts manually. This
+restores — in stronger, app-authored form — the runtime grounding the original
+resolved-node key had (see *History*).
 
-## Bundled vs remote: keep the alpha frictionless, make the split safe
+### What the user actually consents to (UI = #422 PR 3)
 
-`loadSingle`/`load` already thread a `source`. Policy:
+"DashBuddy may **tap Decline** for you on **DoorDash**" — per action, per
+platform, pinned to the rule's current binding definition. Consent copy is
+**app-owned string resources** (#428), never rule-supplied text: the rule
+contributes only a bind name and predicate, neither of which is driver-legible
+or trustworthy enough for a consent prompt. Trigger provenance matters for the
+gate: user-initiated taps (bubble / own-notification `UiInput`) express intent
+for that action; the *grant* check is for automation-initiated fires. Target
+verification (the dynamic half) applies to **both** — integrity is never
+skipped.
 
-- **Asset source** (the bundled rules the developer ships) → **auto-grant** on
-  load. They're trusted; no consent friction in the single-user build.
-- **CDN / fork source** (#192) → **never auto-grant**; every actuating
-  capability is pending until the user approves it. This is what makes "rules
-  delivered over CDN" safe *by construction* — a downloaded rule can recognize
-  screens immediately but cannot touch the UI without an explicit, content-
-  pinned grant.
+### Source policy (unchanged)
 
-So this design is shippable in two stages: the enumeration + grant store + gate
-land now (with asset auto-grant, so behavior is unchanged for bundled rules but
-the gate is finally real), and the consent UI + non-auto-grant remote policy
-land with the matchers work.
+- **Asset source** (bundled rules the developer ships) → auto-grant on load;
+  no consent friction in the single-user alpha.
+- **CDN / fork source** (#192) → never auto-grant; every capability pending
+  until approved. A downloaded rule can recognize screens immediately but
+  cannot aim a tap without an explicit, content-pinned grant.
+
+## Lifecycle (current state)
+
+1. **Enumerate at load** — implemented (`enumerateCapabilities`).
+2. **Partition against the grant store** — #417 (`RuleCapabilityDataSource` in
+   `:core:datastore` → repository in `:core:data`, reactive `grantedHashes`).
+   Pending ⇒ recognition still runs; the action is suppressed (fail closed).
+3. **Consent surface** — #422 PR 3 (review screen + new-pending prompt; show a
+   *diff* on re-consent so a legit update reads differently from a repoint).
+4. **Execution gate** — #417, at the `PerformRuleAction` seam in
+   `SideEffectEngine` (the tier check there is still the alpha always-true
+   stub): OS tier AND grant-lookup by (sourceRuleId, action) AND the dynamic
+   verification above. Any missing → log + skip.
+
+## Known gaps / open decisions
+
+1. **The decision surface is wider than the target.** The key pins the binding
+   definition, not the rule's `parse`/`require` blocks — a fork could keep
+   targets byte-identical and misparse $3.50 as $35.00, passing evaluation,
+   policy, and an existing grant while tapping the *genuine* Accept button.
+   Mitigations to choose from when automation policy ships (auto-accept /
+   auto-decline, `OfferAutomationConfig` — currently dormant): widen the pin
+   to the whole rule for automation-feeding intents, plausibility bounds on
+   parsed fields, and/or per-window rate caps beyond the per-fire throttle.
+2. **Multi-step decline** (#110 Stage 2c): today DECLINE_OFFER taps the
+   initial button and leaves the platform's confirm dialog to the user. A full
+   auto-decline is a staged plan over *intents* (offer screen → confirm
+   screen), each step aimed by that screen's own bound target, with in-flight
+   state + timeout + abort-to-manual.
+3. **Asset auto-grant** — keep for the alpha? (recommend yes.)
+4. **Persist explicit denials** vs treat absence as deny (recommend persist).
+5. **Revocation immediacy** — reactive grant flow should suppress immediately
+   (recommend yes).
 
 ## How it composes with the audit findings
 
-- **#417** — this *is* the real gate; `isPermissionGranted` becomes
-  `isCapabilityGranted(ruleId, effect)` = OS tier AND content-hash grant.
-- **#416 (signatures)** — orthogonal and complementary: signatures prove the
-  bundle is *authentic* (from the configured source); capabilities constrain
-  what an authentic-but-untrusted bundle may *do*. Defense in depth — you want
-  both. A signed malicious fork still can't actuate without per-action consent.
-- **#419 (sensitive rules survive replacement)** — capabilities don't replace
-  the sensitive-screen block (that's recognition-layer, not actuation), but the
-  same "remote bundles are untrusted" posture motivates both.
+- **#417** — this design *is* the real gate's shape; what remains is the grant
+  store + the lookup at the `PerformRuleAction` seam.
+- **#416 (signatures)** — orthogonal and complementary: signatures prove a
+  bundle is *authentic*; capabilities + verification constrain what an
+  authentic-but-untrusted bundle may *do*. A signed malicious fork still can't
+  aim a tap at anything that doesn't look like the consented action's control,
+  inside the platform's own package, after the app itself decided to act.
+- **#419 (sensitive rules survive replacement)** — recognition-layer, not
+  actuation; same "remote bundles are untrusted" posture motivates both.
 
-## Open decisions for the developer
+## History (why this shape)
 
-1. Target granularity: semantic vs structural (recommend semantic).
-2. Asset auto-grant: yes for the single-user alpha? (recommend yes.)
-3. Consent UX: load-time modal vs a passive "N rules want new permissions" badge
-   that opens a review screen (recommend the badge — less interrupt, and a modal
-   on every CDN update trains click-through).
-4. Denied vs merely-not-granted: persist explicit denials (so a re-load doesn't
-   re-surface a rejected capability) vs treat absence as deny and let re-loads
-   re-prompt. (Recommend persisting denials.)
-5. Revocation: a granted capability revoked in settings should suppress the
-   effect immediately (reactive grant flow) — confirm that's desired vs
-   next-load.
+- **f9193c7 (original):** keyed consent to the *resolved node* —
+  `sha256(ruleId|verb|viewId|text)`. Right instinct (pin what the button
+  actually IS), fatally incoherent for load-time consent: the resolved node
+  doesn't exist at load, and live-node signatures churn with third-party UI
+  (re-prompt fatigue).
+- **51c58e1 (reconciliation):** moved to the binding-definition key — load-time
+  enumerable and churn-stable, but discarded the runtime half instead of
+  relocating it, and its "strictly stronger" claim was wrong: definition pins
+  catch rule-side repoints, resolved-node checks catch world-side reshuffles.
+  Each alone is insufficient.
+- **#425 (this design):** keeps the definition key for the static half and
+  restores the runtime half as app-authored tap-time verification — stronger
+  than the original's trust-on-first-use signature because it's authored
+  per-action, works on first fire, and never re-prompts (a benign label change
+  fails closed to manual instead of either wrong-tapping or nagging). Also
+  removed actuation from the rule vocabulary entirely, which the original kept.

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -63,6 +63,22 @@ immediately (no second pass needed) so it gets triaged.
 _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **broken** on the
 2026-06-09 dash — moved to that session's log entry below for triage.)_
 
+- **Expand-earnings auto-tap via the new action path (#425).**
+  The post-delivery pay breakdown should auto-expand ~0.5s after the collapsed summary appears
+  (same behavior as before, but the tap now flows through the app-owned EXPAND_EARNINGS action
+  with package scoping instead of a rule-declared click). Working = breakdown expands on its own
+  and the line items parse. Broken = summary stays collapsed; grep logs for "did not fire —
+  target failed resolution/verification" (verification too strict) or "Throttled action".
+  - Confirmed: 0/2
+- **Bubble/notification Accept-Decline via rule-bound targets (#425).**
+  Tapping Accept or Decline in DashBuddy's offer notification (or bubble) must tap the matching
+  DoorDash button. The button is now aimed by the offer rule's `acceptButton`/`declineButton`
+  bindings and label-verified at tap time (accept ⇒ "Accept"/"Add to route", decline ⇒
+  "Decline") instead of hardcoded view IDs. Working = DoorDash registers the tap. Broken = log
+  shows "No 'acceptButton' target bound" (rule didn't bind on that screen variant — capture it!)
+  or "NONE passed label verification" (verification too strict for that variant).
+  - Confirmed: 0/2
+
 - **Post-dash HUD: frozen summary + consistent chat (#367, PR pending).**
   Two visible fixes after a dash ends: (a) the "Last session" Duration on the idle bubble is
   now FROZEN (it used to keep growing while you sat idle — check it shows the real dash length

--- a/docs/rules.schema.json
+++ b/docs/rules.schema.json
@@ -317,7 +317,7 @@
 
     "bindBlock": {
       "type": "object",
-      "description": "Phase 1: Named variable bindings. Keys are binding names; referenced as $name in later phases.",
+      "description": "Phase 1: Named variable bindings. Keys are binding names; referenced as $name in later phases. WELL-KNOWN TARGET NAMES (#425): bindings named 'acceptButton', 'declineButton', or 'expandButton' are exposed to the app as action targets — the app-owned RuleAction registry decides whether/when to tap them (rules cannot declare actuation), each enables a per-rule consent capability content-pinned to this binding's definition (#422), and the tap is verified at fire time against the app's own label/package expectations. A platform supports an action iff its ruleset binds the matching name on the relevant screen.",
       "additionalProperties": { "$ref": "#/$defs/bindEntry" }
     },
 
@@ -1050,7 +1050,7 @@
 
     "effectEntry": {
       "type": "object",
-      "description": "A side effect to execute on successful match. Has exactly one verb key plus optional meta keys (onlyIf, dedupeKey, throttleMs).",
+      "description": "A side effect to execute on successful match. Has exactly one verb key plus optional meta keys (onlyIf, dedupeKey, throttleMs). Effects are observational/app-internal ONLY — actuating verbs ('click', 'swipe', etc.) are rejected at compile time (#425); rules expose target bindings (see bindBlock) and the app-owned RuleAction registry performs taps.",
       "properties": {
         "onlyIf": {
           "$ref": "#/$defs/gateCondition",
@@ -1064,11 +1064,6 @@
           "type": "integer",
           "description": "Minimum milliseconds between firings of the same dedupeKey. Default: 500.",
           "minimum": 0
-        },
-        "click": {
-          "type": "string",
-          "description": "Click a bound node. Value is '$bindName'. Requires ACCESSIBILITY permission.",
-          "pattern": "^\\$"
         },
         "screenshot": {
           "type": "object",

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/action/RuleAction.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/action/RuleAction.kt
@@ -1,0 +1,93 @@
+package cloud.trotter.dashbuddy.domain.action
+
+/**
+ * App-owned vocabulary of actions the state machine may perform on a
+ * third-party platform app (#425, #422 PR 2).
+ *
+ * This is the actuation half of the recognition/actuation split: rulesets
+ * (untrusted, forkable — #192) expose named **target bindings** (pure data —
+ * "this node is the decline button"); the app decides *whether* to act and
+ * executes the tap. A rule can never declare an action — the `click` effect
+ * verb was removed and rejected at compile time. A platform supports an
+ * action iff its ruleset binds [targetBindName] on the relevant screen;
+ * a missing binding means the action is unavailable there (fail to manual).
+ *
+ * [verification] is the app-owned trust anchor for the tap itself: since the
+ * binding definition comes from the (future-CDN, untrusted) ruleset, the
+ * executor re-checks the *resolved live node* against this expectation at
+ * tap time — see `UiInteractionHandler.performVerifiedClick`. Consent
+ * (#422/#417) is keyed per (rule, action, binding definition) via
+ * `RuleCapability`.
+ */
+enum class RuleAction(
+    val wire: String,
+    /** Well-known bind name a platform ruleset exposes for this action. */
+    val targetBindName: String,
+    /** Tap-time expectation the resolved live node must satisfy. */
+    val verification: TargetExpectation,
+) {
+    /**
+     * Tap the offer screen's Accept button. "Add to route" is DoorDash's
+     * stacked-offer variant of the same control.
+     */
+    ACCEPT_OFFER(
+        wire = "accept_offer",
+        targetBindName = "acceptButton",
+        verification = TargetExpectation(labelPattern = Regex("(?i)\\baccept\\b|\\badd to route\\b")),
+    ),
+
+    /**
+     * Tap the offer screen's initial Decline button. The platform's confirm
+     * dialog (if any) is left to the user — auto-confirm is #110 Stage 2c.
+     */
+    DECLINE_OFFER(
+        wire = "decline_offer",
+        targetBindName = "declineButton",
+        verification = TargetExpectation(labelPattern = Regex("(?i)\\bdecline\\b")),
+    ),
+
+    /**
+     * Tap the chevron that expands the post-delivery pay breakdown so the
+     * parser can read the line items. The control carries no text, so the
+     * expectation is package-scope only — acceptable for a read-only,
+     * low-stakes expansion tap.
+     */
+    EXPAND_EARNINGS(
+        wire = "expand_earnings",
+        targetBindName = "expandButton",
+        verification = TargetExpectation(labelPattern = null),
+    ),
+    ;
+
+    companion object {
+        private val byWire: Map<String, RuleAction> = entries.associateBy { it.wire }
+
+        /** Bind-name → action lookup used by capability enumeration (#422). */
+        val byTargetBindName: Map<String, RuleAction> = entries.associateBy { it.targetBindName }
+
+        fun fromWire(wire: String): RuleAction? = byWire[wire]
+    }
+}
+
+/**
+ * App-owned verification an action's resolved target must pass at tap time.
+ *
+ * The binding *definition* is consent-pinned at load (#422), but a
+ * byte-identical definition can resolve to a different control after a
+ * platform UI update — and the screen can change between decision and tap.
+ * This expectation is the runtime check that is independent of the ruleset:
+ * the executor collects the candidate node's own text/contentDescription plus
+ * its descendants' (platform buttons often label via a child TextView) and
+ * requires a [labelPattern] match. `labelPattern == null` means the action is
+ * label-free (e.g. an icon-only chevron) and package scoping is the only bar.
+ *
+ * Note: patterns match the *platform app's* display language (en-US for the
+ * alpha); locale-aware patterns are tracked with the i18n work (#428).
+ */
+data class TargetExpectation(
+    val labelPattern: Regex?,
+) {
+    /** True if [labels] (node + descendant texts) satisfy this expectation. */
+    fun matchesLabels(labels: List<String>): Boolean =
+        labelPattern == null || labels.any { labelPattern.containsMatchIn(it) }
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/capability/RuleCapability.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/capability/RuleCapability.kt
@@ -1,12 +1,18 @@
 package cloud.trotter.dashbuddy.domain.capability
 
-import cloud.trotter.dashbuddy.domain.pipeline.EffectVerb
+import cloud.trotter.dashbuddy.domain.action.RuleAction
 
 /**
- * One actuating action a specific rule wants to perform — the unit of user
- * consent (#422). A rule that declares an automation (today a `click`; future
- * swipes/scrolls/etc.) produces one of these per actuating effect at rule-load
- * time, and the user grants or denies each individually.
+ * One app-owned action a specific rule's target binding enables — the unit of
+ * user consent (#422, refit by #425). A rule that binds a well-known action
+ * target (`acceptButton`, `declineButton`, `expandButton`) produces one of
+ * these per (rule, action) at rule-load time, and the user grants or denies
+ * each individually.
+ *
+ * Rules no longer declare actions at all — they expose target *bindings*
+ * (data), and the app's [RuleAction] registry decides and performs taps. What
+ * the user consents to is therefore "the app may perform [action] on this
+ * platform, aimed by this rule's binding."
  *
  * Driver: Google's accessibility policy requires granular per-automation
  * consent, and once recognition rules are delivered from a forkable source
@@ -15,21 +21,25 @@ import cloud.trotter.dashbuddy.domain.pipeline.EffectVerb
  * consent UI can show provenance.
  *
  * ## Why [key] is content-pinned (the security property)
- * [key] is a hash of `(ruleId, verb, the binding DEFINITION the action targets)`
- * — computed once at compile (see the rule engine) and carried unchanged to the
- * execution gate, so the two always agree. It is pinned to the *matching
- * predicate that selects the node the rule will act on*, not to the rule id or
- * the bind name. So a remote update that keeps the rule id and bind name but
- * quietly repoints `declineButton`'s predicate at the **Accept** button changes
- * the definition → changes [key] → the old grant no longer covers it and it
+ * [key] is a hash of `(ruleId, action, the binding DEFINITION that aims it)` —
+ * pinned to the *matching predicate that selects the node the action will
+ * tap*. A remote update that keeps the rule id and bind name but quietly
+ * repoints `declineButton`'s predicate at the **Accept** button changes the
+ * definition → changes [key] → the old grant no longer covers it and it
  * re-enters consent. This defeats silent escalation via an update to an
  * already-approved rule.
+ *
+ * The definition pin is the *static* half of the defense; the *dynamic* half
+ * is tap-time verification ([RuleAction.verification] + package scoping in
+ * the executor), which checks what the definition actually resolves to on the
+ * live screen. Both are required: a byte-stable definition can land on a
+ * different control after a platform UI update.
  */
 data class RuleCapability(
     val ruleId: String,
-    val verb: EffectVerb,
+    val action: RuleAction,
     /** The rule's bind name for the target (e.g. "declineButton"); display only. */
-    val targetBindName: String?,
+    val targetBindName: String,
     /** Content-pinned consent key — see the class doc. The grant store keys on this. */
     val key: String,
     /** Where the rule was loaded from (asset path, CDN url, fork id); display only. */

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/EffectVerb.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/EffectVerb.kt
@@ -7,46 +7,37 @@ package cloud.trotter.dashbuddy.domain.pipeline
  * is expressed as one of these verbs. Unknown verbs are rejected at rule
  * compile time via [fromWire].
  *
- * @property wire The string used in rule JSON (`"click"`, `"screenshot"`, etc.)
+ * Rules cannot declare actuation (#425): the former `click` verb was removed
+ * from this vocabulary entirely. Rulesets expose target *bindings*; the
+ * app-owned `RuleAction` registry decides and performs taps. Every verb here
+ * is observational, app-internal, or lifecycle.
+ *
+ * @property wire The string used in rule JSON (`"screenshot"`, `"log"`, etc.)
  * @property tier The [PermissionTier] required to execute this verb.
- * @property requiresTarget `true` if the verb operates on a UI node ([NodeRef]).
  * @property hasDefault `true` if the state machine fires this verb automatically
  *   on certain transitions. Rules can override these defaults per-platform.
- * @property consentRequired `true` if a rule requesting this verb is an
- *   *automation that acts on the third-party app* and so needs explicit,
- *   per-rule user consent before it may fire (#422). Google's accessibility
- *   policy requires users to granularly accept each automation, and downloaded
- *   rules (#192) are untrusted — so consent is uniform regardless of the rule's
- *   source. Today only [CLICK]; future gesture verbs (swipe, scroll, set-text,
- *   global actions) join it. Recognition/display verbs (bubble, log, evaluate)
- *   never need it; output/observation verbs gated by their own Android runtime
- *   permission (screenshot, speak, odometer) are not rule-driven *actuations*
- *   and stay off this list.
  */
 enum class EffectVerb(
     val wire: String,
     val tier: PermissionTier,
-    val requiresTarget: Boolean,
     val hasDefault: Boolean,
-    val consentRequired: Boolean = false,
 ) {
     // --- Observation-driven (rule-declared, no built-in default) ---
-    CLICK("click", PermissionTier.ACCESSIBILITY, requiresTarget = true, hasDefault = false, consentRequired = true),
-    SCREENSHOT("screenshot", PermissionTier.ACCESSIBILITY, requiresTarget = false, hasDefault = false),
-    BUBBLE("bubble", PermissionTier.NONE, requiresTarget = false, hasDefault = false),
-    LOG("log", PermissionTier.NONE, requiresTarget = false, hasDefault = false),
-    EVALUATE_OFFER("evaluate_offer", PermissionTier.NONE, requiresTarget = false, hasDefault = false),
-    SPEAK("speak", PermissionTier.AUDIO, requiresTarget = false, hasDefault = false),
+    SCREENSHOT("screenshot", PermissionTier.ACCESSIBILITY, hasDefault = false),
+    BUBBLE("bubble", PermissionTier.NONE, hasDefault = false),
+    LOG("log", PermissionTier.NONE, hasDefault = false),
+    EVALUATE_OFFER("evaluate_offer", PermissionTier.NONE, hasDefault = false),
+    SPEAK("speak", PermissionTier.AUDIO, hasDefault = false),
 
     // --- Lifecycle (built-in defaults on transitions, overridable by rules) ---
-    SESSION_START("session_start", PermissionTier.NONE, requiresTarget = false, hasDefault = true),
-    SESSION_END("session_end", PermissionTier.NONE, requiresTarget = false, hasDefault = true),
-    ODOMETER_START("odometer_start", PermissionTier.LOCATION, requiresTarget = false, hasDefault = true),
-    ODOMETER_STOP("odometer_stop", PermissionTier.LOCATION, requiresTarget = false, hasDefault = true),
-    ODOMETER_PAUSE("odometer_pause", PermissionTier.LOCATION, requiresTarget = false, hasDefault = true),
-    ODOMETER_RESUME("odometer_resume", PermissionTier.LOCATION, requiresTarget = false, hasDefault = true),
-    SCHEDULE_TIMEOUT("schedule_timeout", PermissionTier.NONE, requiresTarget = false, hasDefault = true),
-    CANCEL_TIMEOUT("cancel_timeout", PermissionTier.NONE, requiresTarget = false, hasDefault = true),
+    SESSION_START("session_start", PermissionTier.NONE, hasDefault = true),
+    SESSION_END("session_end", PermissionTier.NONE, hasDefault = true),
+    ODOMETER_START("odometer_start", PermissionTier.LOCATION, hasDefault = true),
+    ODOMETER_STOP("odometer_stop", PermissionTier.LOCATION, hasDefault = true),
+    ODOMETER_PAUSE("odometer_pause", PermissionTier.LOCATION, hasDefault = true),
+    ODOMETER_RESUME("odometer_resume", PermissionTier.LOCATION, hasDefault = true),
+    SCHEDULE_TIMEOUT("schedule_timeout", PermissionTier.NONE, hasDefault = true),
+    CANCEL_TIMEOUT("cancel_timeout", PermissionTier.NONE, hasDefault = true),
     ;
 
     companion object {

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/Observation.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/Observation.kt
@@ -36,6 +36,13 @@ sealed interface Observation : cloud.trotter.dashbuddy.domain.model.state.StateE
         val target: String?
         /** Rule-originated side effects to execute. */
         val effects: List<RequestedEffect>
+        /**
+         * Named UI targets the matched rule's `bind` block resolved on this
+         * screen (#425) — e.g. `"declineButton"` → the decline button's
+         * [NodeRef]. Recognition-layer *data*; the app-owned `RuleAction`
+         * registry decides whether anything is ever done with them.
+         */
+        val targets: Map<String, NodeRef>
         /** Per-trigger overrides that replace built-in transition defaults. */
         val transitionOverrides: Map<TransitionTrigger, List<RequestedEffect>>
         /** Plausible next flows declared by the matched rule's `outcomes` field. */
@@ -53,6 +60,7 @@ sealed interface Observation : cloud.trotter.dashbuddy.domain.model.state.StateE
         override val parsed: ParsedFields,
         override val target: String? = null,
         override val effects: List<RequestedEffect> = emptyList(),
+        override val targets: Map<String, NodeRef> = emptyMap(),
         override val transitionOverrides: Map<TransitionTrigger, List<RequestedEffect>> = emptyMap(),
         override val expectedOutcomes: Set<Flow>? = null,
     ) : FlowObservation
@@ -68,6 +76,7 @@ sealed interface Observation : cloud.trotter.dashbuddy.domain.model.state.StateE
         override val parsed: ParsedFields,
         override val target: String? = null,
         override val effects: List<RequestedEffect> = emptyList(),
+        override val targets: Map<String, NodeRef> = emptyMap(),
         override val transitionOverrides: Map<TransitionTrigger, List<RequestedEffect>> = emptyMap(),
         override val expectedOutcomes: Set<Flow>? = null,
         /** The last classified screen target when this click occurred. */
@@ -85,6 +94,7 @@ sealed interface Observation : cloud.trotter.dashbuddy.domain.model.state.StateE
         override val parsed: ParsedFields,
         override val target: String? = null,
         override val effects: List<RequestedEffect> = emptyList(),
+        override val targets: Map<String, NodeRef> = emptyMap(),
         override val transitionOverrides: Map<TransitionTrigger, List<RequestedEffect>> = emptyMap(),
         override val expectedOutcomes: Set<Flow>? = null,
     ) : FlowObservation

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/ObservationPayload.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/ObservationPayload.kt
@@ -17,18 +17,21 @@ import kotlinx.serialization.Serializable
 sealed interface ObservationPayload {
 
     /**
-     * Context for a rule-declared click deferred through a SETTLE_UI timeout
-     * (see EffectMap's deferred-click round-trip). Carries everything the
-     * timeout handler needs to reconstruct the immediate-fire click.
+     * Context for an app-decided action deferred through a SETTLE_UI timeout
+     * (#425) — e.g. EXPAND_EARNINGS waiting for the summary screen to settle
+     * before tapping. Carries everything the timeout handler needs to emit
+     * the immediate-fire `PerformRuleAction`.
      */
     @Serializable
-    @SerialName("deferredClick")
-    data class DeferredClick(
-        val verb: String,
-        val ruleId: String,
-        val dedupeKey: String? = null,
-        val throttleMs: Long? = null,
-        val target: NodeRef? = null,
+    @SerialName("deferredAction")
+    data class DeferredAction(
+        /** `RuleAction` wire name. */
+        val action: String,
+        /** `Platform` wire name. */
+        val platform: String,
+        /** Rule that supplied the target binding — consent provenance (#422). */
+        val ruleId: String? = null,
+        val target: NodeRef,
     ) : ObservationPayload
 
     /**

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/RequestedEffect.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/RequestedEffect.kt
@@ -7,8 +7,12 @@ import cloud.trotter.dashbuddy.domain.model.accessibility.BoundingBox
  *
  * Effects ride on [Observation.FlowObservation] through the state machine
  * (which treats them as opaque) and are emitted as [AppEffect]s by EffectMap.
- * The side-effect engine resolves the verb and executes it, optionally
- * using [targetRef] for UI-targeted verbs like [EffectVerb.CLICK].
+ * The side-effect engine resolves the verb and executes it.
+ *
+ * Rule effects are purely observational/app-internal (#425): actuation left
+ * this surface — rulesets expose target *bindings* (see
+ * `Observation.FlowObservation.targets`) and the app-owned `RuleAction`
+ * registry decides and performs taps.
  *
  * See ADR-0006 for the original actions design; this generalises it to
  * the full [EffectVerb] vocabulary.
@@ -16,34 +20,21 @@ import cloud.trotter.dashbuddy.domain.model.accessibility.BoundingBox
 data class RequestedEffect(
     val verb: EffectVerb,
     val args: Map<String, String> = emptyMap(),
-    val targetRef: NodeRef? = null,
     val onlyIf: ParsedFieldsGate? = null,
     val dedupeKey: String? = null,
     val throttleMs: Long? = null,
-    /**
-     * Optional delay (ms) before the effect fires. When non-null and > 0,
-     * EffectMap routes the effect through a SETTLE_UI timeout so the delay
-     * is state-machine-visible. See `CompiledEffect.delayMs`.
-     */
-    val delayMs: Long? = null,
     val ruleId: String,
-    /**
-     * Content-pinned consent key for actuating verbs (#422), computed at compile
-     * and carried unchanged so the execution gate matches what the user granted.
-     * Null for verbs that don't require consent ([EffectVerb.consentRequired] ==
-     * false).
-     */
-    val capabilityKey: String? = null,
 )
 
 /**
  * A content fingerprint of a UI node captured at match time.
  *
- * Never a live node reference — the side-effect engine resolves this
- * against the current accessibility tree when executing the action.
- * Carries as many differentiating clues as possible (ID, text, bounds,
- * class name, structural path) so the executor can reliably find the
- * node even on screens where some identifiers are absent.
+ * Never a live node reference — the action executor re-resolves this
+ * against the current accessibility tree (package-scoped, label-verified;
+ * #425) when performing a tap. Carries as many differentiating clues as
+ * possible (ID, text, bounds, class name, structural path) so the executor
+ * can reliably find the node even on screens where some identifiers are
+ * absent.
  */
 @kotlinx.serialization.Serializable
 data class NodeRef(

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/FlowRegion.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/FlowRegion.kt
@@ -29,6 +29,13 @@ data class FlowRegion(
  * pops when leaving it.
  *
  * @param returnFlow The flow to return to on decline/timeout.
+ * @param targets Named UI targets the offer rule bound on this screen
+ *   (#425) — e.g. `"acceptButton"`/`"declineButton"` `NodeRef`s — retained
+ *   so a later `UiInput` accept/decline can resolve the button to tap. The
+ *   app-owned `RuleAction` registry consumes these; an absent name means the
+ *   action is unavailable on this platform.
+ * @param sourceRuleId The rule that matched the offer screen and supplied
+ *   [targets] — consent-gate provenance (#422/#417).
  */
 @Serializable
 data class PendingOffer(
@@ -38,4 +45,6 @@ data class PendingOffer(
     val evaluation: OfferEvaluation? = null,
     val returnFlow: Flow,
     val lastClickIntent: String? = null,
+    val targets: Map<String, cloud.trotter.dashbuddy.domain.pipeline.NodeRef> = emptyMap(),
+    val sourceRuleId: String? = null,
 )

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/pipeline/EffectVerbTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/pipeline/EffectVerbTest.kt
@@ -24,7 +24,10 @@ class EffectVerbTest {
     fun `fromWire returns null for unknown verb`() {
         assertNull(EffectVerb.fromWire("explode"))
         assertNull(EffectVerb.fromWire(""))
-        assertNull(EffectVerb.fromWire("CLICK")) // case-sensitive
+        // Actuation left the rule vocabulary entirely (#425) — the compiler
+        // rejects "click" with a migration error before fromWire is consulted,
+        // and the verb must never silently round-trip.
+        assertNull(EffectVerb.fromWire("click"))
     }
 
     // =========================================================================
@@ -42,15 +45,8 @@ class EffectVerbTest {
     // =========================================================================
 
     @Test
-    fun `CLICK is the only verb requiring a target`() {
-        val targetVerbs = EffectVerb.entries.filter { it.requiresTarget }
-        assertEquals(listOf(EffectVerb.CLICK), targetVerbs)
-    }
-
-    @Test
     fun `observation-driven verbs have hasDefault = false`() {
         val observationDriven = listOf(
-            EffectVerb.CLICK,
             EffectVerb.SCREENSHOT,
             EffectVerb.BUBBLE,
             EffectVerb.LOG,
@@ -85,7 +81,6 @@ class EffectVerbTest {
 
     @Test
     fun `accessibility verbs require ACCESSIBILITY tier`() {
-        assertEquals(PermissionTier.ACCESSIBILITY, EffectVerb.CLICK.tier)
         assertEquals(PermissionTier.ACCESSIBILITY, EffectVerb.SCREENSHOT.tier)
     }
 
@@ -123,6 +118,7 @@ class EffectVerbTest {
     @Test
     fun `verb count matches expected total`() {
         // Update this if verbs are added or removed — forces a conscious review
-        assertEquals("Verb count changed — update this test", 14, EffectVerb.entries.size)
+        // (13 = 14 minus CLICK, which left the rule vocabulary in #425).
+        assertEquals("Verb count changed — update this test", 13, EffectVerb.entries.size)
     }
 }


### PR DESCRIPTION
Closes #425. PR 2 of the #422 capability/consent series (PR 1 = #424; PR 3 = consent UI; gate = #417, now blocked-by #425).

## What this does

**Rules see; the app decides and acts.** The `click` effect verb is removed from the rule vocabulary — the compiler rejects it (and `swipe`/`scroll`/`set_text`/…) with a migration error. Rulesets expose well-known **target bindings** (`acceptButton`, `declineButton`, `expandButton`) as pure recognition data; the new app-owned **`RuleAction` registry** (`:domain`) owns the decision and the tap via `AppEffect.PerformRuleAction`.

- **Offer Accept/Decline** (bubble + own-notification) is no longer aimed by hardcoded DoorDash view IDs (`offerActionNode()` deleted — it was `if (platform != DoorDash) return null` + two literals, duplicating the click-rule predicates; supersedes closed #85's GigPlatform-interface idea). The offer rule now binds the buttons; no binding ⇒ action unavailable on that platform, fail to manual. Platform support for actions is now literally ruleset data.
- **Expand-earnings** moves from a rule-declared click to an EffectMap decision: collapsed summary + bound target → SETTLE_UI deferral → `PerformRuleAction(EXPAND_EARNINGS)`.
- **Tap-time verification** (new `UiInteractionHandler.performVerifiedClick`): window search scoped to the platform's package, app-owned label allowlist over the resolved node's bounded subtree (accept ⇒ `accept|add to route`, decline ⇒ `decline`; expand is label-free), strict self-or-ancestor click (the clickable-**sibling** fallback is gone from this path — Accept sits beside Decline), per-(action, platform) throttle. Any failed check logs and aborts to manual.
- **Capability refit (#422):** `enumerateCapabilities` walks bind blocks × the action registry; key = `sha256(canonicalJson{rule, action, bind, def})`, same recipe, same repoint/reorder properties (tested). The `capabilityKey` carry-chain through `CompiledEffect`/`RequestedEffect` is **deleted** — it silently dropped keys on the deferred-click and transition-override paths; the #417 gate will look grants up at fire time from `(sourceRuleId, action)` instead.
- Targets ride `RuleMatchResult` → `Observation.FlowObservation.targets` → `PendingOffer.targets` (+ `sourceRuleId`); same-hash re-observations refresh fingerprints; a replacing offer never inherits stale targets.

## Security/privacy posture

- **Trusted:** the `RuleAction` registry (action identity, target names, label expectations), the platform→package map, the throttle, the executor. All app-owned; ruleset content cannot influence them.
- **Untrusted:** rule JSON (future-CDN, #192) — it can now *only* contribute recognition data and target bindings. Its worst case is steering a tap to a node **inside the platform's own package whose labels match the app's expectation for that action** — and only after the app-owned state machine decided to act.
- **Fail closed:** rule-declared actuation = compile error; no package = no tap; no verified candidate = no tap; missing binding = action unavailable; recovery replay suppresses `PerformRuleAction`.
- Known residual (documented in the design doc): the consent key pins the binding def, not parse/require blocks — relevant only when automation policy (auto-accept/decline) ships; mitigations enumerated there.

## Docs/context

- `docs/design/rule-capability-consent.md` rewritten (three layers, static+dynamic consent halves, f9193c7/51c58e1 history and why each key design alone was insufficient).
- CLAUDE.md updated (rule engine, side-effect engine, security principle).
- Field-test checklist: 2 new items (expand auto-tap via new path; Accept/Decline via rule-bound targets), each `Confirmed: 0/2`.
- Schema: `click` removed, target-binding contract documented on `bindBlock`.

## Tests

1194 unit tests green, including the golden corpus (`AllMatchersSuite` — offer binds are `optional`, recognition unchanged). New: compile-rejection of `click`/gestures, bind-based enumeration (stability/repoint/reorder/multi-action/dedupe), targets exposure on match, stepper target retention/refresh/no-inheritance, EffectMap expand decision + deferred round-trip + UiInput aiming + fail-closed cases, engine recovery-suppression + throttle for `PerformRuleAction`, `TargetExpectation` allowlists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
