### PR TITLE
fix(pipeline): supervise the sensing upstream + PipelineStats observability (#430)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,7 +128,10 @@ the state machine). Snapshots are attributed to the window's *real* package (not
 our own overlay is dropped (#4 / PR #334). Frame admission is `FrameGate` (identity dedup +
 content-hash rolling suppression of UNKNOWN frames, #360); envelope assembly is the shared
 `CaptureWriter` (#361); `PipelineV2.events` is a HOT `shareIn` stream — one upstream pass feeds
-all collectors, so side effects (captures, dedup state) can never double-run (#361).
+all collectors, so side effects (captures, dedup state) can never double-run (#361). The merged
+upstream is supervised — a crash logs + counts a restart and resubscribes with backoff instead of
+silencing all sensing (#430) — and `PipelineStats` counts every gate decision, mapping failure,
+and restart (periodic summary log line).
 
 ### 2. JSON Rule Engine (`core/pipeline/.../rules/` + `assets/rules/`)
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/di/DispatchersModule.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/di/DispatchersModule.kt
@@ -8,19 +8,20 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import javax.inject.Singleton
 import cloud.trotter.dashbuddy.BuildConfig
 import javax.inject.Named
+import timber.log.Timber
 
 /**
  * Bindings for the injectable dispatchers so coroutine-owning singletons are
  * testable with virtual time (#341/#352), plus the app-lifetime scope for
- * long-lived shared flows (#356). The dispatcher qualifiers live in
- * `:core:state` (`core.state.di`), the scope qualifier in `:core:data`
- * (`core.data.di`); the data-layer hygiene pass (#364) migrates the remaining
+ * long-lived shared flows (#356). The qualifiers all live in `:domain`
+ * (`domain.di`); the data-layer hygiene pass (#364) migrates the remaining
  * hardcoded scopes onto these.
  */
 @Module
@@ -35,11 +36,25 @@ object DispatchersModule {
     @DefaultDispatcher
     fun provideDefaultDispatcher(): CoroutineDispatcher = Dispatchers.Default
 
+    /**
+     * App-lifetime scope hosting the sensing upstream (`PipelineV2.shareIn`)
+     * and rule loading. The exception handler is the last-resort backstop
+     * (#430): the SupervisorJob already isolates child failures from each
+     * other, but without a handler an uncaught one still reaches the default
+     * handler and can kill the process. The pipeline's own `supervised`
+     * retry should make this unreachable for sensing — if this line ever
+     * logs, something escaped supervision.
+     */
     @Provides
     @Singleton
     @ApplicationScope
     fun provideApplicationScope(): CoroutineScope =
-        CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        CoroutineScope(
+            SupervisorJob() + Dispatchers.Default +
+                CoroutineExceptionHandler { _, t ->
+                    Timber.e(t, "ApplicationScope: uncaught coroutine failure (isolated)")
+                },
+        )
 
     /** Build-variant flag for layer modules (#364) — they must not borrow
      *  another module's BuildConfig for it. */

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/PipelineV2ShareTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/PipelineV2ShareTest.kt
@@ -52,6 +52,7 @@ class PipelineV2ShareTest {
         val pipeline = PipelineV2(
             accessibilityPipeline = accessibilityPipeline,
             notificationPipeline = notificationPipeline,
+            stats = PipelineStats(),
             scope = backgroundScope,
         )
 

--- a/core/pipeline/build.gradle.kts
+++ b/core/pipeline/build.gradle.kts
@@ -45,4 +45,5 @@ dependencies {
     ksp(libs.hilt.compiler)
 
     testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/PipelineStats.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/PipelineStats.kt
@@ -1,0 +1,100 @@
+package cloud.trotter.dashbuddy.core.pipeline
+
+import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import timber.log.Timber
+import java.util.concurrent.atomic.AtomicLong
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Production observability for the sensing layer (#430).
+ *
+ * Before this existed, every gate decision, mapping failure, and pipeline
+ * restart was invisible outside Timber verbose lines — "the app observes
+ * nothing" and "the app is working" looked identical. These are cheap atomic
+ * counters incremented at the existing decision points, with a one-line
+ * summary logged every [SUMMARY_EVERY] forwarded observations and on every
+ * supervised restart.
+ *
+ * Counting note: raw ingress drops (the sources' DROP_OLDEST overflow) are
+ * not directly observable — `tryEmit` never fails under DROP_OLDEST — so
+ * loss shows up as the delta between what the listener saw and what the
+ * counters account for, not as its own counter.
+ */
+@Singleton
+class PipelineStats @Inject constructor() {
+
+    private val droppedSensitive = AtomicLong()
+    private val droppedNoise = AtomicLong()
+    private val droppedDisabledPlatform = AtomicLong()
+    private val suppressedDuplicate = AtomicLong()
+    private val droppedUnknown = AtomicLong()
+    private val mappingFailures = AtomicLong()
+    private val restarts = AtomicLong()
+    private val forwarded = AtomicLong()
+
+    val droppedSensitiveCount: Long get() = droppedSensitive.get()
+    val droppedNoiseCount: Long get() = droppedNoise.get()
+    val droppedDisabledPlatformCount: Long get() = droppedDisabledPlatform.get()
+    val suppressedDuplicateCount: Long get() = suppressedDuplicate.get()
+    val droppedUnknownCount: Long get() = droppedUnknown.get()
+    val mappingFailureCount: Long get() = mappingFailures.get()
+    val restartCount: Long get() = restarts.get()
+    val forwardedCount: Long get() = forwarded.get()
+
+    /** A frame the shared content gate dropped (sensitive or noise, #399). */
+    fun onContentGateDrop(parsed: ParsedFields) {
+        if (parsed is ParsedFields.SensitiveFields) {
+            droppedSensitive.incrementAndGet()
+        } else {
+            droppedNoise.incrementAndGet()
+        }
+    }
+
+    fun onDisabledPlatformDrop() {
+        droppedDisabledPlatform.incrementAndGet()
+    }
+
+    /** FrameGate rejected the frame (identity dedup / UNKNOWN suppression, #360). */
+    fun onDuplicateSuppressed() {
+        suppressedDuplicate.incrementAndGet()
+    }
+
+    /** UNKNOWN frame captured for triage but not forwarded to the state machine. */
+    fun onUnknownDropped() {
+        droppedUnknown.incrementAndGet()
+    }
+
+    /** A raw event whose node mapping threw — the event was dropped, not the pipeline. */
+    fun onMappingFailure() {
+        mappingFailures.incrementAndGet()
+    }
+
+    /** The supervised upstream crashed and is resubscribing. Returns the restart ordinal. */
+    fun onPipelineRestart(): Long = restarts.incrementAndGet()
+
+    /** An observation was forwarded to the state machine. */
+    fun onForwarded() {
+        val n = forwarded.incrementAndGet()
+        if (n % SUMMARY_EVERY == 0L) logSummary("periodic")
+    }
+
+    fun logSummary(reason: String) {
+        Timber.i("PipelineStats[%s]: %s", reason, summary())
+    }
+
+    fun summary(): String =
+        "forwarded=${forwarded.get()}" +
+            " dupSuppressed=${suppressedDuplicate.get()}" +
+            " unknownDropped=${droppedUnknown.get()}" +
+            " sensitiveDropped=${droppedSensitive.get()}" +
+            " noiseDropped=${droppedNoise.get()}" +
+            " disabledPlatformDropped=${droppedDisabledPlatform.get()}" +
+            " mappingFailures=${mappingFailures.get()}" +
+            " restarts=${restarts.get()}"
+
+    companion object {
+        /** Forwarded-observation interval between periodic summary log lines. */
+        const val SUMMARY_EVERY = 50L
+    }
+}

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/PipelineSupervision.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/PipelineSupervision.kt
@@ -1,0 +1,49 @@
+package cloud.trotter.dashbuddy.core.pipeline
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.retryWhen
+import timber.log.Timber
+
+/**
+ * Supervision for the hot sensing upstream (#430).
+ *
+ * The whole sensing layer — both sensor pipelines — runs as ONE shared
+ * upstream coroutine (`PipelineV2.events`). Without supervision, a single
+ * uncaught exception anywhere in that chain (mapping, classification,
+ * hashing, envelope building) cancels it permanently: the app looks alive
+ * but observes nothing, with no detection.
+ *
+ * This resubscribes the upstream after a crash, with linear backoff capped
+ * at [MAX_BACKOFF_MULTIPLIER] × [RESTART_BASE_DELAY_MS]. Re-collection is
+ * safe by construction: the raw sources are hot SharedFlows that never
+ * complete, and all dedup state (FrameGate, suppressors, capture dedup)
+ * lives in singletons that survive the resubscribe. Retries are unbounded —
+ * sensing must never stay dead — and each restart is counted and logged
+ * loudly with a stats summary so a crash-looping pipeline is visible.
+ *
+ * Cancellation is never retried: a cancelled scope propagates normally.
+ */
+internal fun <T> Flow<T>.supervised(
+    stats: PipelineStats,
+    tag: String,
+    baseDelayMs: Long = RESTART_BASE_DELAY_MS,
+): Flow<T> = retryWhen { cause, attempt ->
+    if (cause is CancellationException) throw cause
+    val restartNumber = stats.onPipelineRestart()
+    Timber.e(
+        cause,
+        "Pipeline '%s' crashed (restart #%d) — resubscribing after backoff",
+        tag, restartNumber,
+    )
+    stats.logSummary("restart")
+    delay(baseDelayMs * (attempt + 1).coerceAtMost(MAX_BACKOFF_MULTIPLIER))
+    true
+}
+
+/** Base delay before the first resubscribe. */
+internal const val RESTART_BASE_DELAY_MS = 1_000L
+
+/** Backoff cap: delay never exceeds this multiple of the base. */
+internal const val MAX_BACKOFF_MULTIPLIER = 5L

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/PipelineV2.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/PipelineV2.kt
@@ -16,6 +16,7 @@ import javax.inject.Singleton
 class PipelineV2 @Inject constructor(
     accessibilityPipeline: AccessibilityPipeline,
     notificationPipeline: NotificationPipeline,
+    stats: PipelineStats,
     @param:ApplicationScope scope: CoroutineScope,
 ) {
     /**
@@ -25,11 +26,16 @@ class PipelineV2 @Inject constructor(
      * them, double-writing captures and racing the dedup state. One shared
      * upstream collector now feeds all subscribers; both sub-pipelines emit
      * Observation subtypes, which extend StateEvent.
+     *
+     * The merged upstream is [supervised] (#430): a crash anywhere in the
+     * chain logs + counts a restart and resubscribes with backoff instead of
+     * silencing all sensing for the rest of the process.
      */
     val events: SharedFlow<StateEvent> = merge(
         accessibilityPipeline.output(),
         notificationPipeline.output(),
     )
+        .supervised(stats, tag = "sensing")
         // No flowOn: shareIn runs the single upstream collector in [scope],
         // whose dispatcher is Default in production and virtual in tests.
         .shareIn(scope, SharingStarted.WhileSubscribed(5_000), replay = 0)

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/AccessibilityPipeline.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/AccessibilityPipeline.kt
@@ -12,6 +12,7 @@ import cloud.trotter.dashbuddy.core.pipeline.FrameGate
 import cloud.trotter.dashbuddy.core.pipeline.passesContentGates
 import cloud.trotter.dashbuddy.core.pipeline.ObservationClassifier
 import cloud.trotter.dashbuddy.core.pipeline.PipelineEvent
+import cloud.trotter.dashbuddy.core.pipeline.PipelineStats
 import cloud.trotter.dashbuddy.core.pipeline.accessibility.event.type.window.content_changed.ContentChangedPipeline
 import cloud.trotter.dashbuddy.core.pipeline.accessibility.event.type.window.state_changed.StateChangedPipeline
 import cloud.trotter.dashbuddy.core.pipeline.accessibility.event.type.window.windows_changed.WindowsChangedPipeline
@@ -22,6 +23,7 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.onEach
 import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -44,6 +46,7 @@ class AccessibilityPipeline @Inject constructor(
     private val classifier: ObservationClassifier,
     private val captureWriter: CaptureWriter,
     private val platformPreferences: PlatformPreferences,
+    private val stats: PipelineStats,
 ) {
     companion object {
         const val SCREEN_PIPELINE_ID = "accessibility.window"
@@ -71,13 +74,22 @@ class AccessibilityPipeline @Inject constructor(
     private fun clickEvents(): Flow<PipelineEvent.Click> = source.events
         .filter { it.eventType == AccessibilityEvent.TYPE_VIEW_CLICKED }
         .mapNotNull { event ->
-            val sourceNode = event.source ?: return@mapNotNull null
-            val node = sourceNode.toUiNode() ?: return@mapNotNull null
-            PipelineEvent.Click(
-                timestamp = System.currentTimeMillis(),
-                node = node,
-                packageName = event.packageName?.toString(),
-            )
+            try {
+                val sourceNode = event.source ?: return@mapNotNull null
+                val node = sourceNode.toUiNode() ?: return@mapNotNull null
+                PipelineEvent.Click(
+                    timestamp = System.currentTimeMillis(),
+                    node = node,
+                    packageName = event.packageName?.toString(),
+                )
+            } catch (e: Exception) {
+                // A malformed node tree must cost one click, not the whole
+                // sensing upstream (#430) — this was the only unwrapped
+                // mapping call in the chain.
+                stats.onMappingFailure()
+                Timber.w(e, "Click mapping failed — dropping click event")
+                null
+            }
         }
 
     // ── Main pipeline ──────────────────────────────────────────────────
@@ -88,7 +100,11 @@ class AccessibilityPipeline @Inject constructor(
 
         // Gate: drop sensitive/noise observations (pledge: never store or
         // forward) — the shared content gate (#399).
-        .filter { (obs, _) -> passesContentGates(obs) }
+        .filter { (obs, _) ->
+            val passes = passesContentGates(obs)
+            if (!passes) stats.onContentGateDrop(obs.parsed)
+            passes
+        }
 
         // Gate: drop observations from disabled platforms (defense-in-depth)
         .filter { (_, event) ->
@@ -98,8 +114,10 @@ class AccessibilityPipeline @Inject constructor(
                 else -> null
             }
             val platform = Platform.fromPackage(pkg)
-            platform == Platform.Unknown ||
+            val allowed = platform == Platform.Unknown ||
                 platform in platformPreferences.enabledPlatforms.value
+            if (!allowed) stats.onDisabledPlatformDrop()
+            allowed
         }
 
         // Dedup + Capture: write unique observations to disk, skip duplicates.
@@ -114,6 +132,7 @@ class AccessibilityPipeline @Inject constructor(
                 else -> null
             }
             if (!frameGate.admit(obs, contentHash)) {
+                stats.onDuplicateSuppressed()
                 Timber.v("Dedup: suppressed %s", obs.target)
                 return@mapNotNull null
             }
@@ -131,9 +150,13 @@ class AccessibilityPipeline @Inject constructor(
         // Gate: don't forward UNKNOWN observations to state machine
         .filter { obs ->
             val isUnknown = obs.target == UNKNOWN_TARGET
-            if (isUnknown) Timber.v("Unknown gate: captured but not forwarding %s", obs.target)
+            if (isUnknown) {
+                stats.onUnknownDropped()
+                Timber.v("Unknown gate: captured but not forwarding %s", obs.target)
+            }
             !isUnknown
         }
+        .onEach { stats.onForwarded() }
 
 }
 

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/notification/NotificationPipeline.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/notification/NotificationPipeline.kt
@@ -8,6 +8,7 @@ import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.core.pipeline.ObservationClassifier
 import cloud.trotter.dashbuddy.core.pipeline.PipelineEvent
 import cloud.trotter.dashbuddy.core.pipeline.CaptureWriter
+import cloud.trotter.dashbuddy.core.pipeline.PipelineStats
 import cloud.trotter.dashbuddy.core.pipeline.FrameGate
 import cloud.trotter.dashbuddy.core.pipeline.passesContentGates
 import cloud.trotter.dashbuddy.core.pipeline.notification.input.NotificationSource
@@ -16,6 +17,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.onEach
 import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -32,6 +34,7 @@ class NotificationPipeline @Inject constructor(
     private val classifier: ObservationClassifier,
     private val captureWriter: CaptureWriter,
     private val platformPreferences: PlatformPreferences,
+    private val stats: PipelineStats,
 ) {
     companion object {
         const val PIPELINE_ID = "notification"
@@ -50,23 +53,36 @@ class NotificationPipeline @Inject constructor(
         // Gate: drop sensitive/noise observations (pledge: never store or
         // forward) — the shared content gate, symmetric with the
         // accessibility pipeline (#399).
-        .filter { (obs, _) -> passesContentGates(obs) }
+        .filter { (obs, _) ->
+            val passes = passesContentGates(obs)
+            if (!passes) stats.onContentGateDrop(obs.parsed)
+            passes
+        }
         // Gate: drop observations from disabled platforms (defense-in-depth)
         .filter { (_, raw) ->
             val platform = Platform.fromPackage(raw.packageName)
-            platform == Platform.Unknown ||
+            val allowed = platform == Platform.Unknown ||
                 platform in platformPreferences.enabledPlatforms.value
+            if (!allowed) stats.onDisabledPlatformDrop()
+            allowed
         }
         // Dedup + Capture: known notifications dedup by identity; UNKNOWN by
         // content hash in a rolling seen-set (#360).
         .mapNotNull { (obs, raw) ->
-            if (!frameGate.admit(obs, raw.contentHash)) return@mapNotNull null
+            if (!frameGate.admit(obs, raw.contentHash)) {
+                stats.onDuplicateSuppressed()
+                return@mapNotNull null
+            }
             captureWriter.captureNotification(obs, raw)
         }
         // Gate: don't forward UNKNOWN to state machine
         .filter { obs ->
             val isUnknown = obs.target == UNKNOWN_TARGET
-            if (isUnknown) Timber.v("Notification: captured but not forwarding UNKNOWN")
+            if (isUnknown) {
+                stats.onUnknownDropped()
+                Timber.v("Notification: captured but not forwarding UNKNOWN")
+            }
             !isUnknown
         }
+        .onEach { stats.onForwarded() }
 }

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/PipelineStatsTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/PipelineStatsTest.kt
@@ -1,0 +1,47 @@
+package cloud.trotter.dashbuddy.core.pipeline
+
+import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** #430 — gate/restart counters and the summary line. */
+class PipelineStatsTest {
+
+    @Test
+    fun `content gate drops are split by sensitive vs noise`() {
+        val stats = PipelineStats()
+        stats.onContentGateDrop(ParsedFields.SensitiveFields())
+        stats.onContentGateDrop(ParsedFields.SensitiveFields())
+        stats.onContentGateDrop(ParsedFields.NoiseFields())
+
+        assertEquals(2L, stats.droppedSensitiveCount)
+        assertEquals(1L, stats.droppedNoiseCount)
+    }
+
+    @Test
+    fun `counters increment independently and appear in the summary`() {
+        val stats = PipelineStats()
+        stats.onDisabledPlatformDrop()
+        stats.onDuplicateSuppressed()
+        stats.onDuplicateSuppressed()
+        stats.onUnknownDropped()
+        stats.onMappingFailure()
+        assertEquals(1L, stats.onPipelineRestart())
+        assertEquals(2L, stats.onPipelineRestart())
+        stats.onForwarded()
+
+        assertEquals(1L, stats.droppedDisabledPlatformCount)
+        assertEquals(2L, stats.suppressedDuplicateCount)
+        assertEquals(1L, stats.droppedUnknownCount)
+        assertEquals(1L, stats.mappingFailureCount)
+        assertEquals(2L, stats.restartCount)
+        assertEquals(1L, stats.forwardedCount)
+
+        val summary = stats.summary()
+        assertTrue(summary.contains("forwarded=1"))
+        assertTrue(summary.contains("dupSuppressed=2"))
+        assertTrue(summary.contains("restarts=2"))
+        assertTrue(summary.contains("mappingFailures=1"))
+    }
+}

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/PipelineSupervisionTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/PipelineSupervisionTest.kt
@@ -1,0 +1,70 @@
+package cloud.trotter.dashbuddy.core.pipeline
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+/**
+ * #430 — the sensing upstream must survive its own exceptions. A crash
+ * resubscribes (counted + logged); cancellation propagates untouched.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class PipelineSupervisionTest {
+
+    @Test
+    fun `supervised flow resubscribes after upstream crashes and keeps emitting`() = runTest {
+        val stats = PipelineStats()
+        var subscriptions = 0
+        val flaky = flow {
+            subscriptions++
+            emit(subscriptions * 10)
+            if (subscriptions <= 2) throw IllegalStateException("boom #$subscriptions")
+            emit(subscriptions * 10 + 1)
+        }
+
+        val collected = flaky.supervised(stats, tag = "test", baseDelayMs = 10).toList()
+
+        // Two crashes, three subscriptions; emissions before each crash are kept.
+        assertEquals(listOf(10, 20, 30, 31), collected)
+        assertEquals(3, subscriptions)
+        assertEquals(2L, stats.restartCount)
+    }
+
+    @Test
+    fun `backoff delay is applied between resubscribes (virtual time)`() = runTest {
+        val stats = PipelineStats()
+        var subscriptions = 0
+        val start = testScheduler.currentTime
+        val flaky = flow<Int> {
+            subscriptions++
+            if (subscriptions <= 3) throw IllegalStateException("boom")
+            emit(1)
+        }
+
+        flaky.supervised(stats, tag = "test", baseDelayMs = 100).toList()
+
+        // Linear backoff: 100*1 + 100*2 + 100*3 = 600ms of virtual delay.
+        assertEquals(600L, testScheduler.currentTime - start)
+        assertEquals(3L, stats.restartCount)
+    }
+
+    @Test
+    fun `cancellation is never retried - it propagates`() = runTest {
+        val stats = PipelineStats()
+        val cancelling = flow<Int> { throw CancellationException("scope died") }
+
+        try {
+            cancelling.supervised(stats, tag = "test", baseDelayMs = 10).toList()
+            fail("expected CancellationException to propagate")
+        } catch (e: CancellationException) {
+            assertTrue(e.message!!.contains("scope died"))
+        }
+        assertEquals("a cancellation must not count as a restart", 0L, stats.restartCount)
+    }
+}


### PR DESCRIPTION
Closes #430. First P1 from the 2026-06-11 full-architecture validation.

## What

The whole sensing layer runs as ONE shared upstream coroutine (`PipelineV2.events`). Until now it had **no supervision** — a single uncaught exception anywhere in the chain permanently silenced all sensing with zero detection — and **no observability** (every gate decision invisible outside Timber verbose lines).

- **`supervised()` operator** on the merged upstream: crash → log cause + count restart + stats summary → resubscribe with linear backoff (cap 5×1s), unbounded. Cancellation rethrown. Safe by construction: hot SharedFlow sources, singleton dedup state.
- **`CoroutineExceptionHandler` on `@ApplicationScope`** — last-resort backstop; also covers rule loading.
- **Click `toUiNode()` try/caught** — the only unwrapped mapping call; a malformed tree now costs one click, not the pipeline.
- **`PipelineStats`**: atomic counters at the existing decision points in BOTH sensor pipelines (sensitive / noise / disabled-platform / duplicate / UNKNOWN drops, mapping failures, restarts, forwarded) + summary line every 50 forwarded and on every restart. DROP_OLDEST ingress loss isn't directly countable (documented in the class kdoc).

## Security/privacy posture

No recognition, capture, or effect semantics change; gate **order** untouched — counters hook existing decisions. Net effect is strictly reduced silent-failure risk: a dead pipeline was also a dead sensitive-screen gate.

## Tests

New: supervised resubscribe + virtual-time backoff + cancellation passthrough; stats counters/summary. Updated: `PipelineV2ShareTest` (new ctor param). Full suite **1199 tests, 0 failures**. Also adds `kotlinx-coroutines-test` to `core:pipeline` and fixes DispatchersModule's stale qualifier kdoc (one #440 sub-item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
