### PR TITLE
fix(rules): repair mojibake literals — timeline separators + never-matching pickup_picked_up (#433)

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/DefaultRulesIntegrationTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/DefaultRulesIntegrationTest.kt
@@ -9,6 +9,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import cloud.trotter.dashbuddy.test.util.TestResourceLoader
 import cloud.trotter.dashbuddy.test.util.TestRulesetFactory
 import org.junit.Before
 import org.junit.Test
@@ -143,6 +144,40 @@ class DefaultRulesIntegrationTest {
         assertTrue(screenRuleset.ruleCount > 0)
         assertTrue(clickRuleset.ruleCount > 0)
         assertTrue(notificationRuleset.ruleCount > 0)
+    }
+
+    // =========================================================================
+    // Parse-output regression on real captures (#433)
+    // =========================================================================
+
+    @Test
+    fun `timeline task rows parse storeHint and deadline from the real bullet separator`() {
+        // The rule's extractBefore/extractAfter separator was double-encoded
+        // mojibake (" ï¿½ ") instead of the real bullet (" • ") the captures
+        // contain — extractAfter returned null, so storeHint silently parsed
+        // null on EVERY timeline screen while the intent-only golden guard
+        // stayed green (#433). This pins the parse OUTPUT on real snapshots.
+        val snapshots = TestResourceLoader.loadSnapshots("snapshots/timeline")
+        assertTrue("timeline corpus must not be empty", snapshots.isNotEmpty())
+
+        val taskEntries = snapshots.mapNotNull { (_, tree, _) ->
+            val result = screenRuleset.matchFirst(tree, platformWire = "doordash")
+                ?: return@mapNotNull null
+            if (result.intent != "timeline") return@mapNotNull null
+            val parsed = ParsedFieldsFactory.create(result.shape, result.fields)
+                as? cloud.trotter.dashbuddy.domain.state.ParsedFields.TimelineFields
+            parsed?.tasks
+        }.flatten()
+
+        assertTrue("expected parsed timeline task entries across the corpus", taskEntries.isNotEmpty())
+        assertTrue(
+            "at least one task row must parse a storeHint (null on every row before #433)",
+            taskEntries.any { it.storeHint != null },
+        )
+        assertTrue(
+            "at least one task row must parse a deadline",
+            taskEntries.any { it.deadline != null },
+        )
     }
 
     // =========================================================================

--- a/core/pipeline/src/main/assets/rules/doordash.json
+++ b/core/pipeline/src/main/assets/rules/doordash.json
@@ -221,7 +221,7 @@
                 "navigate": "sibling(1)",
                 "read": "text",
                 "transform": {
-                  "extractBefore": " ï¿½ "
+                  "extractBefore": " • "
                 }
               },
               "deadlineMillis": {
@@ -242,7 +242,7 @@
                 "read": "text",
                 "transform": [
                   {
-                    "extractBefore": " ï¿½ "
+                    "extractBefore": " • "
                   },
                   "parseDeadline"
                 ]
@@ -264,7 +264,7 @@
                 "navigate": "sibling(1)",
                 "read": "text",
                 "transform": {
-                  "extractAfter": " ï¿½ "
+                  "extractAfter": " • "
                 }
               },
               "isCurrent": {
@@ -1825,7 +1825,7 @@
       "require": {
         "allTextContainsAll": [
           "confirm pickup",
-          "loadingï¿½"
+          "loading"
         ]
       }
     },

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -63,6 +63,15 @@ immediately (no second pass needed) so it gets triaged.
 _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **broken** on the
 2026-06-09 dash — moved to that session's log entry below for triage.)_
 
+- **Timeline storeHint now parses + pickup_picked_up rule newly matchable (#433).**
+  Two rule fixes from mojibake literals: (a) timeline task rows should now carry store names
+  (watch the dash-controls overlay's task chain — logs/cards referencing timeline tasks should
+  name the store, not blank); (b) the `pickup_picked_up` screen rule could NEVER match before
+  (its require contained a mangled literal) — on the confirm-pickup/loading screen, watch
+  whether it now classifies (bubble/log shows pickup_picked_up instead of UNKNOWN) and
+  **capture it** — this intent has zero corpus snapshots.
+  - Confirmed: 0/2
+
 - **Expand-earnings auto-tap via the new action path (#425).**
   The post-delivery pay breakdown should auto-expand ~0.5s after the collapsed summary appears
   (same behavior as before, but the tap now flows through the app-owned EXPAND_EARNINGS action


### PR DESCRIPTION
Bug half of #433 (the issue stays open for the corpus-wide expected-fields harness).

## What

Four rule-JSON literals were double-encoded U+FFFD mojibake (`ï¿½`, bytes `c3af c2bf c2bd`), present since the rules' first commit:

- **timeline** `extractBefore`/`extractAfter` separator → `" • "` (3 sites). Real captures contain the bullet, so `storeHint` parsed **null on every timeline screen** while the intent-only golden guard stayed green; deadlines worked only because `extractBefore` falls through to the whole string.
- **pickup_picked_up** `require` contained `"loadingï¿½"` — a literal that cannot occur in live text, so the rule was **dead** (never matched once). Relaxed to `"loading"`: the original glyph is unrecoverable (zero corpus snapshots for this intent), and golden corpus confirms the broader require steals no other folder's matches.

## Tests

New regression test in `DefaultRulesIntegrationTest` — the project's first parse-**output** assertion on real captures: timeline corpus must yield task entries with non-null `storeHint` + `deadline`. Verified to fail against the mojibake version via `--rerun` and pass with the fix. (Side-finding for the harness work: rule JSON is read from the filesystem, not declared as a Gradle test input, so local task caching can mask rule-only changes — CI's fresh checkout is unaffected.)

Full suite: **1200 tests, 0 failures** (golden corpus included).

## Security/privacy posture

Recognition-only change; no effects, capture, or gate semantics touched. `pickup_picked_up` is a flow-state rule (`task:pickup:arrived`) — broader matching affects state interpretation only, and a field-test checklist item (0/2) watches it on the next dash with a capture request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
