### PR TITLE
refactor(state): replace EffectMap's reflection gate with sealed ParsedFields.toFieldMap() (#434)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -52,6 +52,14 @@ android {
 
     buildTypes {
         release {
+            // R8 posture (#434): minify stays OFF until the remaining
+            // reflective surfaces are keep-ruled or removed — Gson over
+            // EventMetadata in DashBuddyApplication.createMetadata(), and
+            // kotlinx-serialization's generated serializers are safe but
+            // unaudited under shrinking. The hot-path reflection that made
+            // this dangerous (EffectMap's gate extraction) was replaced by
+            // sealed ParsedFields.toFieldMap() in #434. Flipping this on
+            // without that audit silently breaks reflective code paths.
             isMinifyEnabled = false
             signingConfig = signingConfigs.getByName("release")
             proguardFiles(

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -763,9 +763,12 @@ class EffectMap @Inject constructor() {
 
     private fun evaluateGate(gate: ParsedFieldsGate?, parsed: ParsedFields): Boolean {
         if (gate == null) return true
-        // Fail CLOSED: if fields can't be extracted we can't prove the condition,
-        // and a gated action (potentially an auto-click) must not fire (#345).
-        val fieldsMap = parsedFieldsToMap(parsed) ?: return false
+        // Explicit per-subtype field maps (#434) replace the old Java
+        // reflection here — exhaustive over the sealed hierarchy, so
+        // extraction can never fail, and rename-proof under R8. The #345
+        // fail-closed posture is preserved by the absent-field semantics
+        // below: a field the subtype doesn't carry proves nothing.
+        val fieldsMap = parsed.toFieldMap()
         return when (gate) {
             is ParsedFieldsGate.FieldEquals -> fieldsMap[gate.field] == gate.value
             // An ABSENT field (wrong name, or ParsedFields.None) proves nothing —
@@ -773,31 +776,6 @@ class EffectMap @Inject constructor() {
             is ParsedFieldsGate.FieldNotEquals ->
                 gate.field in fieldsMap && fieldsMap[gate.field] != gate.value
             is ParsedFieldsGate.FieldNotNull -> fieldsMap[gate.field] != null
-        }
-    }
-
-    /**
-     * Extract named fields from a [ParsedFields] subtype into a flat map
-     * for gate evaluation. Uses Java reflection on data class fields.
-     *
-     * `activity` is excluded because it is a classification tag inherited
-     * from the sealed parent — rules gate on structural fields, not the
-     * activity discriminator. Returns null on extraction failure so the
-     * caller rejects (fail closed) instead of evaluating against an empty
-     * map, where FieldNotEquals would spuriously fire (#345).
-     */
-    private fun parsedFieldsToMap(parsed: ParsedFields): Map<String, Any?>? {
-        if (parsed is ParsedFields.None) return emptyMap()
-        return try {
-            parsed::class.java.declaredFields
-                .filter { it.name != "activity" }
-                .associate { field ->
-                    field.isAccessible = true
-                    field.name to field.get(parsed)
-                }
-        } catch (e: Exception) {
-            Timber.w(e, "Gate field extraction failed for %s", parsed::class.simpleName)
-            null
         }
     }
 

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/ParsedFields.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/ParsedFields.kt
@@ -33,10 +33,23 @@ sealed class ParsedFields {
      */
     open fun dedupeHash(): Int = 0
 
+    /**
+     * Structural fields for effect-gate evaluation (`onlyIf`, #345/#434) —
+     * every constructor property EXCEPT the open [activity] discriminator
+     * (rules gate on structural fields, not the classification tag).
+     *
+     * Hand-written and exhaustive over the sealed hierarchy, replacing the
+     * old Java reflection in EffectMap: rename-proof under R8/minification
+     * and cheaper on the hot diff path. `ParsedFieldsFieldMapTest` asserts
+     * every subtype's map stays in sync with its constructor.
+     */
+    abstract fun toFieldMap(): Map<String, Any?>
+
     @Serializable
 
     data object None : ParsedFields() {
         override val activity: String? = null
+        override fun toFieldMap(): Map<String, Any?> = emptyMap()
     }
 
     @Serializable
@@ -57,6 +70,16 @@ sealed class ParsedFields {
          */
         val startingDash: Boolean = false,
     ) : ParsedFields() {
+        override fun toFieldMap(): Map<String, Any?> = mapOf(
+            "zoneName" to zoneName,
+            "sessionType" to sessionType,
+            "sessionPay" to sessionPay,
+            "waitTimeEstimate" to waitTimeEstimate,
+            "isHeadingBackToZone" to isHeadingBackToZone,
+            "spotSaveDeadline" to spotSaveDeadline,
+            "startingDash" to startingDash,
+        )
+
         override fun dedupeHash(): Int {
             var h = zoneName.hashCode()
             h = 31 * h + sessionType.hashCode()
@@ -71,6 +94,10 @@ sealed class ParsedFields {
         override val activity: String? = null,
         val parsedOffer: ParsedOffer,
     ) : ParsedFields() {
+        override fun toFieldMap(): Map<String, Any?> = mapOf(
+            "parsedOffer" to parsedOffer,
+        )
+
         override fun dedupeHash(): Int = parsedOffer.offerHash.hashCode()
     }
 
@@ -90,6 +117,20 @@ sealed class ParsedFields {
         val redCardTotal: Double? = null,
         val arrivalConfirmed: Boolean = false,
     ) : ParsedFields() {
+        override fun toFieldMap(): Map<String, Any?> = mapOf(
+            "phase" to phase,
+            "subFlow" to subFlow,
+            "storeName" to storeName,
+            "storeAddress" to storeAddress,
+            "customerNameHash" to customerNameHash,
+            "customerAddressHash" to customerAddressHash,
+            "deadline" to deadline,
+            "itemsRemaining" to itemsRemaining,
+            "itemsShopped" to itemsShopped,
+            "redCardTotal" to redCardTotal,
+            "arrivalConfirmed" to arrivalConfirmed,
+        )
+
         override fun dedupeHash(): Int {
             var h = phase.hashCode()
             h = 31 * h + subFlow.hashCode()
@@ -122,6 +163,18 @@ sealed class ParsedFields {
         val offersAccepted: Int? = null,
         val offersTotal: Int? = null,
     ) : ParsedFields() {
+        override fun toFieldMap(): Map<String, Any?> = mapOf(
+            "totalPay" to totalPay,
+            "appPay" to appPay,
+            "customerTips" to customerTips,
+            "parsedPay" to parsedPay,
+            "isExpanded" to isExpanded,
+            "expandButtonId" to expandButtonId,
+            "sessionEarnings" to sessionEarnings,
+            "offersAccepted" to offersAccepted,
+            "offersTotal" to offersTotal,
+        )
+
         override fun dedupeHash(): Int {
             var h = totalPay.hashCode()
             h = 31 * h + appPay.hashCode()
@@ -140,6 +193,14 @@ sealed class ParsedFields {
         val offersTotal: Int? = null,
         val weeklyEarnings: Double? = null,
     ) : ParsedFields() {
+        override fun toFieldMap(): Map<String, Any?> = mapOf(
+            "totalEarnings" to totalEarnings,
+            "sessionDurationMillis" to sessionDurationMillis,
+            "offersAccepted" to offersAccepted,
+            "offersTotal" to offersTotal,
+            "weeklyEarnings" to weeklyEarnings,
+        )
+
         override fun dedupeHash(): Int = totalEarnings.hashCode()
     }
 
@@ -150,6 +211,11 @@ sealed class ParsedFields {
         val remainingText: String? = null,
         val remainingMillis: Long? = null,
     ) : ParsedFields() {
+        override fun toFieldMap(): Map<String, Any?> = mapOf(
+            "remainingText" to remainingText,
+            "remainingMillis" to remainingMillis,
+        )
+
         // Paused is a single state — identity is just "paused".
         override fun dedupeHash(): Int = "paused".hashCode()
     }
@@ -164,6 +230,14 @@ sealed class ParsedFields {
         val endsAtMillis: Long? = null,
         val tasks: List<TimelineTaskEntry> = emptyList(),
     ) : ParsedFields() {
+        override fun toFieldMap(): Map<String, Any?> = mapOf(
+            "sessionEarnings" to sessionEarnings,
+            "offerEarnings" to offerEarnings,
+            "endsAtText" to endsAtText,
+            "endsAtMillis" to endsAtMillis,
+            "tasks" to tasks,
+        )
+
         override fun dedupeHash(): Int {
             var h = sessionEarnings.hashCode()
             h = 31 * h + tasks.size
@@ -188,6 +262,21 @@ sealed class ParsedFields {
         val itemsWrongOrMissingRate: Double? = null,
         val lifetimeShoppingOrders: Int? = null,
     ) : ParsedFields() {
+        override fun toFieldMap(): Map<String, Any?> = mapOf(
+            "acceptanceRate" to acceptanceRate,
+            "completionRate" to completionRate,
+            "onTimeRate" to onTimeRate,
+            "customerRating" to customerRating,
+            "deliveriesLast30Days" to deliveriesLast30Days,
+            "lifetimeDeliveries" to lifetimeDeliveries,
+            "originalItemsFoundRate" to originalItemsFoundRate,
+            "totalItemsFoundRate" to totalItemsFoundRate,
+            "substitutionIssuesRate" to substitutionIssuesRate,
+            "itemsWithQualityIssuesRate" to itemsWithQualityIssuesRate,
+            "itemsWrongOrMissingRate" to itemsWrongOrMissingRate,
+            "lifetimeShoppingOrders" to lifetimeShoppingOrders,
+        )
+
         override fun dedupeHash(): Int {
             var h = customerRating.hashCode()
             h = 31 * h + lifetimeDeliveries.hashCode()
@@ -199,13 +288,17 @@ sealed class ParsedFields {
 
     data class SensitiveFields(
         override val activity: String? = null,
-    ) : ParsedFields()
+    ) : ParsedFields() {
+        override fun toFieldMap(): Map<String, Any?> = emptyMap()
+    }
 
     @Serializable
 
     data class NoiseFields(
         override val activity: String? = null,
-    ) : ParsedFields()
+    ) : ParsedFields() {
+        override fun toFieldMap(): Map<String, Any?> = emptyMap()
+    }
 
     @Serializable
 
@@ -215,6 +308,12 @@ sealed class ParsedFields {
         val nodeId: String? = null,
         val nodeText: String? = null,
     ) : ParsedFields() {
+        override fun toFieldMap(): Map<String, Any?> = mapOf(
+            "intent" to intent,
+            "nodeId" to nodeId,
+            "nodeText" to nodeText,
+        )
+
         // Every click is unique — identity() returns null for ClickFields
         // observations (#366), an explicit never-dedupe signal.
     }
@@ -229,6 +328,14 @@ sealed class ParsedFields {
         val deliveredAt: String? = null,
         val rawText: String? = null,
     ) : ParsedFields() {
+        override fun toFieldMap(): Map<String, Any?> = mapOf(
+            "intent" to intent,
+            "amount" to amount,
+            "storeName" to storeName,
+            "deliveredAt" to deliveredAt,
+            "rawText" to rawText,
+        )
+
         override fun dedupeHash(): Int {
             var h = intent.hashCode()
             h = 31 * h + amount.hashCode()

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/state/ParsedFieldsFieldMapTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/state/ParsedFieldsFieldMapTest.kt
@@ -1,0 +1,70 @@
+package cloud.trotter.dashbuddy.domain.state
+
+import cloud.trotter.dashbuddy.domain.model.offer.ParsedOffer
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import kotlin.reflect.full.primaryConstructor
+
+/**
+ * #434 — toFieldMap() replaced EffectMap's Java-reflection gate extraction.
+ * The hand-written maps must never drift from the constructors: a field
+ * added to a subtype but not its map would silently vanish from `onlyIf`
+ * gate evaluation. Reflection is fine HERE (test-only, never minified).
+ */
+class ParsedFieldsFieldMapTest {
+
+    private val samples: List<ParsedFields> = listOf(
+        ParsedFields.IdleFields(),
+        ParsedFields.OfferFields(parsedOffer = ParsedOffer(offerHash = "h", payAmount = 1.0)),
+        ParsedFields.TaskFields(phase = TaskPhase.PICKUP, subFlow = TaskSubFlow.NAVIGATION),
+        ParsedFields.PostTaskFields(totalPay = 1.0),
+        ParsedFields.SessionEndedFields(totalEarnings = 1.0),
+        ParsedFields.PausedFields(),
+        ParsedFields.TimelineFields(),
+        ParsedFields.RatingsFields(),
+        ParsedFields.SensitiveFields(),
+        ParsedFields.NoiseFields(),
+        ParsedFields.ClickFields(intent = "x"),
+        ParsedFields.NotificationFields(intent = "x"),
+    )
+
+    private fun expectedKeys(instance: ParsedFields): Set<String> =
+        instance::class.primaryConstructor!!.parameters
+            .mapNotNull { it.name }
+            .filter { it != "activity" }
+            .toSet()
+
+    @Test
+    fun `every subtype's field map covers exactly its constructor properties minus activity`() {
+        for (sample in samples) {
+            assertEquals(
+                "toFieldMap drifted from the constructor for ${sample::class.simpleName}",
+                expectedKeys(sample),
+                sample.toFieldMap().keys,
+            )
+        }
+    }
+
+    @Test
+    fun `None maps to empty`() {
+        assertEquals(emptyMap<String, Any?>(), ParsedFields.None.toFieldMap())
+    }
+
+    @Test
+    fun `field map values are the instance's values`() {
+        val parsed = ParsedFields.PostTaskFields(totalPay = 12.5, isExpanded = false)
+        val map = parsed.toFieldMap()
+        assertEquals(12.5, map["totalPay"])
+        assertEquals(false, map["isExpanded"])
+        assertEquals(null, map["sessionEarnings"])
+    }
+
+    @Test
+    fun `sealed hierarchy is fully sampled - update samples when adding a subtype`() {
+        assertEquals(
+            "new ParsedFields subtype? add it to [samples] above",
+            samples.size + 1, // +1 = the None object, asserted separately
+            ParsedFields::class.sealedSubclasses.size,
+        )
+    }
+}


### PR DESCRIPTION
EffectMap.parsedFieldsToMap evaluated onlyIf gates via Java reflection
over ParsedFields field names - the only reflection on the hot diff
path, and one isMinifyEnabled flip away from silent death: R8 renames
the fields, FieldEquals never matches, every gated effect (including
the EXPAND_EARNINGS auto-tap) fails closed with no crash and no log.

- ParsedFields gains abstract toFieldMap(): every constructor property
  except the open `activity` discriminator, hand-written per subtype
  (13 overrides) - exhaustive by the sealed hierarchy, rename-proof,
  and cheaper than declaredFields + setAccessible per gate evaluation.
- evaluateGate consumes it directly; the reflection helper and its
  can-fail null path are deleted. Absent-field semantics are byte-for-
  byte preserved (FieldEquals matches null on absent only when the gate
  value is null; FieldNotEquals requires presence; #345 fail-closed
  posture intact - existing EvalDiffCorrectnessTest gate tests pass
  unchanged).
- ParsedFieldsFieldMapTest pins every subtype's map to its primary
  constructor via kotlin-reflect (test-only): a field added to a
  subtype but not its map fails the build, and a new subtype must be
  added to the sample list. Values + None + count guards included.
- R8 posture written down at app/build.gradle.kts isMinifyEnabled:
  minify stays OFF until the remaining reflective surfaces (Gson
  EventMetadata) are keep-ruled or removed; the hot-path hazard this
  comment used to guard is now gone.

Security/privacy posture: no behavior change - gate semantics
identical, verified by existing fail-closed tests. Removes a latent
silent-failure mode in the effect-gating path that #417's consent gate
will sit on top of.

Full suite green; ParsedFieldsFieldMapTest 4/4.

Closes #434.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)