### PR TITLE
fix(state): authoritative grace for SessionEnded + GRACE_COMMIT timers + honest end timestamps (#431, part 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,7 +150,7 @@ registry (`:domain`) consumes — see `docs/design/rule-capability-consent.md`.
 
 Observations reduce into `AppState(regions)` (`:domain`): **`FlowRegion`** (R0 — ground-truth
 screen interpretation; holds the pending offer), one **`PlatformRegion`** per platform
-(session/task lifecycle; unified grace via `pendingDestructive`), and **`CrossPlatformRegion`**
+(session/task lifecycle; unified grace via `pendingDestructive` — destructive commits are graced, incl. a short authoritative window for the dash summary, and woken by `GRACE_COMMIT` timers, #431), and **`CrossPlatformRegion`**
 (derived aggregates). The steppers (`FlowRegionStepper`, `PlatformRegionStepper`,
 `CrossPlatformRegionStepper`) are pure and driven by `obs.timestamp` — never a wall clock — so
 crash recovery can replay observations over the last snapshot. `StateManagerV2` hosts the

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/state/StateMachineTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/state/StateMachineTest.kt
@@ -8,6 +8,9 @@ import cloud.trotter.dashbuddy.domain.pipeline.Observation
 import cloud.trotter.dashbuddy.domain.pipeline.TimeoutType
 import cloud.trotter.dashbuddy.domain.state.AppState
 import cloud.trotter.dashbuddy.domain.state.DestructiveKind
+import cloud.trotter.dashbuddy.domain.model.event.AppEventType
+import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStopPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.SessionEndSource
 import cloud.trotter.dashbuddy.domain.state.Flow
 import cloud.trotter.dashbuddy.domain.state.FlowRegion
 import cloud.trotter.dashbuddy.domain.state.Mode
@@ -91,7 +94,8 @@ class StateMachineTest {
     private fun timeoutObs(
         type: TimeoutType = TimeoutType.SESSION_PAUSED_SAFETY,
         timestamp: Long = tick(),
-    ) = Observation.Timeout(timestamp = timestamp, type = type)
+        targetPlatform: Platform? = null,
+    ) = Observation.Timeout(timestamp = timestamp, type = type, targetPlatform = targetPlatform)
 
     private fun offerFields(storeName: String = "Chipotle", hash: String = "hash-123") =
         ParsedFields.OfferFields(
@@ -437,26 +441,142 @@ class StateMachineTest {
     }
 
     @Test
-    fun `SessionEnded bypasses grace — session ends immediately`() {
+    fun `SessionEnded arms a short authoritative grace - not an immediate end (#431)`() {
         var state = AppState()
 
-        // Get Online
         state = machine.step(state, screenObs(
             flow = Flow.OfferPresented, parsed = offerFields(),
         )).newState
         val sessionId = state.regions.platforms[Platform.DoorDash]!!.session!!.sessionId
         assertNotNull(sessionId)
 
-        // SessionEnded → Offline, session ends immediately (no grace)
-        state = machine.step(state, screenObs(
+        val summaryAt = tick()
+        val transition = machine.step(state, screenObs(
             flow = Flow.SessionEnded,
             parsed = ParsedFields.SessionEndedFields(totalEarnings = 25.0),
-        )).newState
+            timestamp = summaryAt,
+        ))
+        state = transition.newState
 
         val dd = state.regions.platforms[Platform.DoorDash]!!
         assertEquals(Mode.Offline, dd.mode)
-        assertNull(dd.session) // ended immediately — no grace
-        assertNull(dd.pendingDestructive) // no grace set
+        // One frame must never split a live session: it stays alive through
+        // the SHORT authoritative grace, with the summary's data stashed.
+        assertNotNull(dd.session)
+        val pend = dd.pendingDestructive!!
+        assertEquals(DestructiveKind.SESSION_END, pend.kind)
+        assertTrue(pend.authoritative)
+        assertEquals(summaryAt, pend.since)
+        assertEquals(summaryAt + TransitionPolicy.AUTHORITATIVE_GRACE_MS, pend.deadline)
+        assertEquals(25.0, pend.endFields!!.totalEarnings, 0.001)
+        // And the machine armed a wake-up so the commit doesn't wait for the
+        // next observation.
+        val timer = transition.effects.filterIsInstance<AppEffect.ScheduleTimeout>()
+            .single { it.type == TimeoutType.GRACE_COMMIT }
+        assertEquals(Platform.DoorDash, timer.platform)
+    }
+
+    @Test
+    fun `false summary mid-dash - a task flow inside the window cancels the end (#431)`() {
+        var state = AppState()
+
+        // Online and mid-pickup (heal path mints job+task from the task flow).
+        state = machine.step(state, screenObs(
+            flow = Flow.TaskPickupNavigation,
+            parsed = ParsedFields.TaskFields(phase = TaskPhase.PICKUP, subFlow = TaskSubFlow.NAVIGATION, storeName = "Chipotle"),
+        )).newState
+        val sessionId = state.regions.platforms[Platform.DoorDash]!!.session!!.sessionId
+
+        // Misrecognized dash summary.
+        state = machine.step(state, screenObs(
+            flow = Flow.SessionEnded,
+            parsed = ParsedFields.SessionEndedFields(totalEarnings = 99.0),
+        )).newState
+        assertNotNull(state.regions.platforms[Platform.DoorDash]!!.pendingDestructive)
+
+        // The pickup screen is still there 1s later — clearly still dashing.
+        state = machine.step(state, screenObs(
+            flow = Flow.TaskPickupNavigation,
+            parsed = ParsedFields.TaskFields(phase = TaskPhase.PICKUP, subFlow = TaskSubFlow.NAVIGATION, storeName = "Chipotle"),
+        )).newState
+
+        val dd = state.regions.platforms[Platform.DoorDash]!!
+        assertNull("misrecognition cancelled", dd.pendingDestructive)
+        assertEquals("same session survives", sessionId, dd.session!!.sessionId)
+        assertNotNull("task survives", dd.activeTask)
+    }
+
+    @Test
+    fun `real summary commits at the deadline via GRACE_COMMIT - honest endedAt + full payload (#431)`() {
+        var state = AppState()
+        state = machine.step(state, screenObs(
+            flow = Flow.OfferPresented, parsed = offerFields(),
+        )).newState
+
+        val summaryAt = tick()
+        state = machine.step(state, screenObs(
+            flow = Flow.SessionEnded,
+            parsed = ParsedFields.SessionEndedFields(
+                totalEarnings = 25.0,
+                sessionDurationMillis = 3_600_000L,
+                offersAccepted = 5,
+                offersTotal = 8,
+            ),
+            timestamp = summaryAt,
+        )).newState
+
+        // The grace timer fires just past the deadline.
+        val transition = machine.step(state, timeoutObs(
+            type = TimeoutType.GRACE_COMMIT,
+            timestamp = summaryAt + TransitionPolicy.AUTHORITATIVE_GRACE_MS + 100,
+            targetPlatform = Platform.DoorDash,
+        ))
+        state = transition.newState
+
+        assertNull(state.regions.platforms[Platform.DoorDash]!!.session)
+        val stop = transition.effects.filterIsInstance<AppEffect.LogEvent>()
+            .single { it.event.type == AppEventType.DASH_STOP }
+        val payload = stop.event.payload as SessionStopPayload
+        assertEquals(SessionEndSource.SUMMARY_SCREEN, payload.source)
+        assertEquals(25.0, payload.totalEarnings!!, 0.001)
+        assertEquals(3_600_000L, payload.sessionDurationMillis)
+        // endedAt = when the summary appeared, not when the timer got around
+        // to committing it.
+        assertEquals(summaryAt, payload.endedAt)
+    }
+
+    @Test
+    fun `post-summary online flash does NOT resurrect the session (#431)`() {
+        var state = AppState()
+        state = machine.step(state, screenObs(
+            flow = Flow.OfferPresented, parsed = offerFields(),
+        )).newState
+
+        val summaryAt = tick()
+        state = machine.step(state, screenObs(
+            flow = Flow.SessionEnded,
+            parsed = ParsedFields.SessionEndedFields(totalEarnings = 25.0),
+            timestamp = summaryAt,
+        )).newState
+
+        // The idle map flashes "online" right after the summary — the old
+        // immediate-commit existed exactly to stop this resurrecting the
+        // session. The authoritative grace must not cancel on it.
+        state = machine.step(state, screenObs(
+            flow = Flow.Idle, modeHint = Mode.Online,
+        )).newState
+        assertNotNull(
+            "authoritative pending survives an online flash",
+            state.regions.platforms[Platform.DoorDash]!!.pendingDestructive,
+        )
+
+        // Commit still lands at the deadline.
+        state = machine.step(state, timeoutObs(
+            type = TimeoutType.GRACE_COMMIT,
+            timestamp = summaryAt + TransitionPolicy.AUTHORITATIVE_GRACE_MS + 100,
+            targetPlatform = Platform.DoorDash,
+        )).newState
+        assertNull(state.regions.platforms[Platform.DoorDash]!!.session)
     }
 
     @Test

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -20,6 +20,7 @@ import cloud.trotter.dashbuddy.domain.pipeline.ParsedFieldsGate
 import cloud.trotter.dashbuddy.domain.pipeline.TimeoutType
 import cloud.trotter.dashbuddy.domain.pipeline.TransitionTrigger
 import cloud.trotter.dashbuddy.domain.state.AppState
+import cloud.trotter.dashbuddy.domain.state.DestructiveKind
 import cloud.trotter.dashbuddy.domain.state.Flow
 import cloud.trotter.dashbuddy.domain.state.FlowRegion
 import cloud.trotter.dashbuddy.domain.state.Mode
@@ -234,6 +235,7 @@ class EffectMap @Inject constructor() {
 
         return buildList {
             addAll(diffMode(p, next, obs))
+            addAll(diffGraceTimer(p, next, obs))
             addAll(diffTask(p, next, prevFlow, nextFlow, obs))
             addAll(diffPostTask(p, next, nextFlow, obs))
             addAll(diffNotification(obs))
@@ -299,8 +301,19 @@ class EffectMap @Inject constructor() {
                 if (offlineOverride != null) {
                     addAll(offlineOverride)
                 } else {
-                    val endParsed = (obs as? Observation.FlowObservation)?.parsed
-                    if (endParsed is ParsedFields.SessionEndedFields) {
+                    // Summary fields: from the committing observation when it IS
+                    // the summary, else from the grace pending that stashed them
+                    // at arm time (#431) — deferred commits (GRACE_COMMIT timer,
+                    // lazy expiry) keep full payload fidelity. endedAt = when the
+                    // destructive signal appeared, not when we got around to
+                    // believing it.
+                    val pend = prev.pendingDestructive
+                        ?.takeIf { it.kind == DestructiveKind.SESSION_END }
+                    val endParsed = ((obs as? Observation.FlowObservation)?.parsed
+                        as? ParsedFields.SessionEndedFields)
+                        ?: pend?.endFields
+                    val endedAt = pend?.since ?: obs.timestamp
+                    if (endParsed != null) {
                         val earnings = formatCurrency(endParsed.totalEarnings)
                         add(
                             logEffect(
@@ -309,7 +322,7 @@ class EffectMap @Inject constructor() {
                                 obs.timestamp,
                                 SessionStopPayload(
                                     sessionId = sessionId,
-                                    endedAt = obs.timestamp,
+                                    endedAt = endedAt,
                                     source = SessionEndSource.SUMMARY_SCREEN,
                                     totalEarnings = endParsed.totalEarnings,
                                     sessionDurationMillis = endParsed.sessionDurationMillis,
@@ -330,7 +343,7 @@ class EffectMap @Inject constructor() {
                                 obs.timestamp,
                                 SessionStopPayload(
                                     sessionId = sessionId,
-                                    endedAt = obs.timestamp,
+                                    endedAt = endedAt,
                                     source = SessionEndSource.EARLY_OFFLINE,
                                     totalEarnings = prevSession.runningEarnings,
                                 ),
@@ -426,6 +439,38 @@ class EffectMap @Inject constructor() {
                     }
                 }
             }
+        }
+    }
+
+    /**
+     * Schedule/cancel the wake-up timer for a [PendingDestructive] grace
+     * window (#431). Before this, grace commits were only LAZY — they waited
+     * for the next observation, so a session could stay alive in state for
+     * hours after going offline with the app backgrounded. The timer routes
+     * back to this region (platform-scoped, #342); the stepper's lazy expiry
+     * performs the actual commit when the timeout observation arrives.
+     * A commit (pending → null with the destructive applied) also lands in
+     * the cancel branch — harmless, the timer has already fired or no-ops.
+     */
+    private fun diffGraceTimer(
+        prev: PlatformRegion,
+        next: PlatformRegion,
+        obs: Observation,
+    ): List<AppEffect> {
+        val prevPend = prev.pendingDestructive
+        val nextPend = next.pendingDestructive
+        return when {
+            nextPend != null && (prevPend == null || prevPend.deadline != nextPend.deadline) ->
+                listOf(
+                    AppEffect.ScheduleTimeout(
+                        durationMs = (nextPend.deadline - obs.timestamp).coerceAtLeast(1L),
+                        type = TimeoutType.GRACE_COMMIT,
+                        platform = next.platform,
+                    ),
+                )
+            prevPend != null && nextPend == null ->
+                listOf(AppEffect.CancelTimeout(TimeoutType.GRACE_COMMIT))
+            else -> emptyList()
         }
     }
 

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
@@ -78,7 +78,11 @@ class PlatformRegionStepper @Inject constructor() {
         // provisional transition.
         current.pendingDestructive?.let { pend ->
             if (obs.timestamp > pend.deadline) {
-                current = commitDestructive(current, pend.kind, pend.deadline)
+                // Commit stamped at pend.since — the obs.timestamp of the signal
+                // that armed the grace — not the deadline: the dash/task really
+                // ended when the destructive signal appeared, the grace only
+                // delayed our belief in it (#431).
+                current = commitDestructive(current, pend.kind, pend.since)
             }
         }
 
@@ -89,10 +93,13 @@ class PlatformRegionStepper @Inject constructor() {
         // dash-end is pending in its grace window means the old dash really ended
         // and a new one is starting — commit the end now so the next Online mints
         // a fresh session instead of resuming the old one.
-        if (current.pendingDestructive?.kind == DestructiveKind.SESSION_END) {
-            val startParsed = (obs as? Observation.FlowObservation)?.parsed
-            if ((startParsed as? ParsedFields.IdleFields)?.startingDash == true) {
-                current = endSession(current, obs.timestamp)
+        current.pendingDestructive?.let { pend ->
+            if (pend.kind == DestructiveKind.SESSION_END) {
+                val startParsed = (obs as? Observation.FlowObservation)?.parsed
+                if ((startParsed as? ParsedFields.IdleFields)?.startingDash == true) {
+                    // Honest end time = when the destructive signal appeared (#431).
+                    current = endSession(current, pend.since)
+                }
             }
         }
 
@@ -160,10 +167,16 @@ class PlatformRegionStepper @Inject constructor() {
         when {
             prev.mode != Mode.Online && newMode == Mode.Online -> {
                 val pend = region.pendingDestructive
-                if (pend?.kind == DestructiveKind.SESSION_END && region.session != null) {
+                if (pend?.kind == DestructiveKind.SESSION_END && !pend.authoritative &&
+                    region.session != null
+                ) {
                     // Grace active + the same session is still present → a genuine
                     // resume (a transient offline flash). A real new-dash start
                     // would already have committed the end in step() (startingDash).
+                    // An AUTHORITATIVE pending (armed by the dash summary, #431) is
+                    // deliberately NOT cancelled here: a post-summary online flash
+                    // must not resurrect a really-ended session. Only a task-flow
+                    // observation cancels it (updateTaskLifecycle).
                     region = region.copy(pendingDestructive = null)
                 } else if (region.session == null) {
                     // No session — start a fresh one.
@@ -273,12 +286,38 @@ class PlatformRegionStepper @Inject constructor() {
         obs: Observation.FlowObservation,
         policy: TransitionPolicy,
     ): PlatformRegion {
-        // Authoritative session end: a session:ended observation (the dash
-        // summary) ends the session immediately, even when already Offline — the
-        // summary commonly shows AFTER the idle/offline screen, mid-grace. Must
-        // run before the Offline early-return below or that ordering is missed.
+        // Authoritative session end: the dash-summary screen. It no longer ends
+        // the session on the spot (#431) — one misrecognized frame used to split
+        // a live session irrecoverably. Instead it arms (or tightens) a SHORT
+        // authoritative grace: a contradicting task-flow frame inside the window
+        // cancels (misrecognition), anything else lets it commit at the deadline
+        // (GRACE_COMMIT timer or lazy expiry). The summary's parsed fields ride
+        // the pending so the deferred DASH_STOP payload keeps full fidelity.
+        // Runs before the Offline early-return below because the summary commonly
+        // shows AFTER the idle/offline screen, mid-grace.
         if (obs.flow == Flow.SessionEnded && region.session != null) {
-            return endSession(region, obs.timestamp)
+            val endFields = obs.parsed as? ParsedFields.SessionEndedFields
+            val newDeadline = obs.timestamp + policy.authoritativeGraceMs
+            val existing = region.pendingDestructive
+            val pend = if (existing?.kind == DestructiveKind.SESSION_END) {
+                // Offline-grace already armed (idle/offline before summary) —
+                // tighten to the short window, keep the original `since` (the
+                // earliest destructive signal is the honest end time).
+                existing.copy(
+                    deadline = minOf(existing.deadline, newDeadline),
+                    authoritative = true,
+                    endFields = endFields ?: existing.endFields,
+                )
+            } else {
+                PendingDestructive(
+                    kind = DestructiveKind.SESSION_END,
+                    since = obs.timestamp,
+                    deadline = newDeadline,
+                    authoritative = true,
+                    endFields = endFields,
+                )
+            }
+            return region.copy(pendingDestructive = pend)
         }
         if (region.mode == Mode.Offline) {
             // Clear the idle anchor and any TASK_RETIRE pending, but PRESERVE a

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/TransitionPolicy.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/TransitionPolicy.kt
@@ -21,9 +21,19 @@ class TransitionPolicy @Inject constructor() {
 
     companion object {
         const val DEFAULT_GRACE_MS = 10_000L
+
+        /**
+         * Short grace for destructive transitions armed by an authoritative-
+         * looking signal (the dash-summary screen, #431). Long enough for a
+         * contradicting task-flow frame to land and cancel a misrecognition;
+         * short enough that real session ends commit promptly.
+         */
+        const val AUTHORITATIVE_GRACE_MS = 2_500L
     }
 
     val gracePeriodMs: Long = DEFAULT_GRACE_MS
+
+    val authoritativeGraceMs: Long = AUTHORITATIVE_GRACE_MS
 
     /**
      * Determine what mode a flow + modeHint combination implies.

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/IdleAnchorTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/IdleAnchorTest.kt
@@ -13,6 +13,7 @@ import cloud.trotter.dashbuddy.domain.state.Session
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -109,12 +110,21 @@ class IdleAnchorTest {
     }
 
     @Test
-    fun `idleEnteredAt cleared on session end`() {
+    fun `idleEnteredAt cleared when the session-end grace commits (#431)`() {
         val prev = onlineRegion(idleEnteredAt = 800L)
         val prevFlow = FlowRegion(flow = Flow.Idle)
         val obs = screen(flow = Flow.SessionEnded, modeHint = Mode.Offline, timestamp = 1500L)
-        val result = step(prev, obs, prevFlow)
-        assertNull(result.idleEnteredAt)
+        val graced = step(prev, obs, prevFlow)
+        // The summary arms the authoritative grace; the anchor survives until commit.
+        assertNotNull(graced.pendingDestructive)
+
+        val committed = step(
+            graced,
+            screen(flow = Flow.Idle, modeHint = Mode.Offline, timestamp = 1500L + 3_000L),
+            prevFlow,
+        )
+        assertNull(committed.session)
+        assertNull(committed.idleEnteredAt)
     }
 
     @Test
@@ -129,15 +139,32 @@ class IdleAnchorTest {
         assertNotNull("grace armed", offlineGraced.pendingDestructive)
         assertEquals(DestructiveKind.SESSION_END, offlineGraced.pendingDestructive?.kind)
 
-        // dash_summary then arrives while STILL offline (mode unchanged). The
-        // authoritative session:ended end must fire anyway, clearing the session so
-        // the summary attributes to the just-ended dash instead of expiring as thin.
-        val ended = step(
+        // dash_summary then arrives while STILL offline (mode unchanged). It
+        // TIGHTENS the grace to the short authoritative window (#431) — the
+        // session stays alive briefly so a misrecognized summary can still be
+        // cancelled by a task-flow frame — and the commit fires at the
+        // tightened deadline, attributing the summary to the just-ended dash.
+        val tightened = step(
             offlineGraced,
             screen(flow = Flow.SessionEnded, modeHint = Mode.Offline, timestamp = 2000L),
             prevFlow = FlowRegion(flow = Flow.Idle),
         )
-        assertNull("session ended by the summary even though mode stayed offline", ended.session)
+        assertNotNull("session alive through the short grace", tightened.session)
+        val pend = tightened.pendingDestructive!!
+        assertTrue("summary marks the pending authoritative", pend.authoritative)
+        assertEquals(
+            "deadline tightened to summary + short grace",
+            2000L + TransitionPolicy.AUTHORITATIVE_GRACE_MS,
+            pend.deadline,
+        )
+        assertEquals("original offline flash stays the honest end time", 1000L, pend.since)
+
+        val ended = step(
+            tightened,
+            screen(flow = Flow.Idle, modeHint = Mode.Offline, timestamp = pend.deadline + 100),
+            prevFlow = FlowRegion(flow = Flow.Idle),
+        )
+        assertNull("session ended at the tightened deadline", ended.session)
     }
 
     @Test

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -63,6 +63,17 @@ immediately (no second pass needed) so it gets triaged.
 _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **broken** on the
 2026-06-09 dash — moved to that session's log entry below for triage.)_
 
+- **Session-end grace — summary no longer ends the dash instantly (#431).**
+  The dash-summary screen now arms a ~2.5s authoritative grace (cancellable by a task-flow
+  frame) instead of ending the session on the spot, and grace commits fire on a timer instead
+  of waiting for the next event. Watch: (a) the post-dash summary still attributes to the
+  right session (chat/cards/totals) — just ~2.5s later; (b) NO spurious mid-dash session
+  splits (the old failure was one misrecognized frame = split); (c) leaving the app right
+  after going offline still logs DASH_STOP promptly (timer-driven) with endedAt ≈ when you
+  went offline. Broken = duplicate DASH_START/STOP pairs, summary attributed to a new empty
+  session, or a session lingering long after the dash.
+  - Confirmed: 0/2
+
 - **Timeline storeHint now parses + pickup_picked_up rule newly matchable (#433).**
   Two rule fixes from mojibake literals: (a) timeline task rows should now carry store names
   (watch the dash-controls overlay's task chain — logs/cards referencing timeline tasks should

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/Observation.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/Observation.kt
@@ -158,4 +158,12 @@ enum class TimeoutType {
     SETTLE_UI,
     DECLINE_POPUP_WAIT,
     SCREENSHOT_WAIT,
+
+    /**
+     * Wakes the state machine when a [PendingDestructive] grace deadline
+     * lapses (#431), so commits fire on time instead of waiting for the next
+     * observation. Carries no handler logic of its own: the stepper's lazy
+     * expiry (which runs before timeout handling) performs the commit.
+     */
+    GRACE_COMMIT,
 }

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/PlatformRegion.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/PlatformRegion.kt
@@ -79,6 +79,22 @@ data class PendingDestructive(
     /** Once an observation's timestamp passes this, the transition is committed. */
     val deadline: Long,
     val reason: String? = null,
+    /**
+     * Armed by an authoritative-looking signal (the dash-summary screen)
+     * rather than inferred from an offline flash (#431). Authoritative
+     * pendings use the short grace and are NOT cancelled by a mere
+     * online-resume — a post-summary online flash must not resurrect a
+     * really-ended session. Only a task-flow observation (unambiguously
+     * still dashing) cancels them.
+     */
+    val authoritative: Boolean = false,
+    /**
+     * The summary screen's parsed fields, stashed at arm time (#431) so the
+     * deferred commit's DASH_STOP payload keeps full fidelity (earnings,
+     * duration, offer counts) even though the committing observation is a
+     * grace timeout, not the summary itself.
+     */
+    val endFields: ParsedFields.SessionEndedFields? = null,
 )
 
 enum class DestructiveKind {


### PR DESCRIPTION
One misrecognized dash-summary frame used to split a live session
irrecoverably: SessionEnded committed endSession on the spot while
idle/offline flickers got a 10s grace - the highest-cost misrecognition
had the least protection. And grace commits were lazy-only (waited for
the NEXT observation), so a session could stay alive in state for hours
after going offline with the app backgrounded, then log DASH_STOP with
the late observation's time.

- PendingDestructive gains authoritative + endFields (@Serializable
  defaults - snapshot-compatible). The dash summary now ARMS (or, when
  the offline grace is already running - the common summary-after-idle
  ordering - TIGHTENS) a short authoritative grace
  (TransitionPolicy.AUTHORITATIVE_GRACE_MS = 2.5s) instead of committing.
- Cancellation is asymmetric by design: a task-flow frame inside the
  window cancels (unambiguously still dashing - the misrecognition
  case); a mere online flash does NOT (a post-summary flash must not
  resurrect a really-ended session - the reason the old code committed
  immediately). Known residual: a false summary followed only by idle
  still splits after 2.5s - a double-coincidence we accept.
- New TimeoutType.GRACE_COMMIT: EffectMap schedules a platform-routed
  timer when a grace arms (or its deadline tightens) and cancels when it
  clears. Zero new stepper logic: the timeout observation just wakes the
  machine and the existing lazy expiry commits. Applies to TASK_RETIRE
  graces too - task-idle commits also stop waiting for the next event.
- Honest timestamps: commits stamp pend.since (when the destructive
  signal appeared), not the deadline; the DASH_STOP payload's endedAt
  and summary fidelity (earnings/duration/offers) survive deferral via
  endFields stashed on the pending. startingDash early-commits also use
  since.

PostTask grace is deliberately deferred to a follow-up PR (issue #431
stays open): its completion feeds the receipt-announce gate and job
lifecycle with ordering assumptions that need their own test pass.

Tests: new contract suite in StateMachineTest (arm+timer emission, false-
summary-cancelled-by-task-flow, deferred commit with full payload +
endedAt=since via GRACE_COMMIT, online-flash-does-not-resurrect);
IdleAnchorTest's two summary tests rewritten to the tighten+commit
contract. Full suite green.

Security/privacy posture: state-machine semantics only; no recognition,
capture, or effect-execution changes. Strictly reduces the blast radius
of a recognition false-positive (#192 prereq).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)