### PR TITLE
security(privacy): close the sensitive fail-open paths (#432)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,8 +208,11 @@ Every new feature or refactor holds to these — they are forefront design input
      validation, and — for any remote rule source — **signature/integrity verification before
      compile**, which does not exist yet and is a hard prerequisite for that path.
    - **Sensitive screens are blocked, never parsed or stored** (banking/identity/payment), at the
-     matcher layer, in both sensor pipelines (#399). A recognition change must not be able to
-     downgrade that.
+     matcher layer, in both sensor pipelines (#399) — and the gate fails CLOSED beyond rule
+     coverage (#432): frames are dropped entirely until rulesets load, every platform shipping
+     screen rules must ship sensitive rules (load-time check), and UNKNOWN captures are scrubbed
+     by a rules-independent text-marker backstop (`SensitiveTextMarkers`, the SSOT the test
+     scanner shares). A recognition change must not be able to downgrade any of that.
    - **PII is hashed at the edge before it is persisted or could be uploaded** (`sha256`,
      fail-closed — never echo plaintext on failure, #362). Captures are debug-only (release binds
      `NoOpCaptureBus`, #346).

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/DefaultRulesIntegrationTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/DefaultRulesIntegrationTest.kt
@@ -147,6 +147,48 @@ class DefaultRulesIntegrationTest {
     }
 
     // =========================================================================
+    // Sensitive coverage (#432)
+    // =========================================================================
+
+    @Test
+    fun `every platform shipping screen rules ships a sensitive rule`() {
+        // Recompile the production files and assert no platform is uncovered —
+        // the load-time check in JsonRuleInterpreter excludes uncovered
+        // platforms (fail closed); this pins that the SHIPPED bundles never
+        // trip it.
+        val dir = File(TestRulesetFactory.rulesDir)
+        val allScreens = mutableListOf<CompiledRule<UiNode>>()
+        dir.listFiles { f -> f.extension == "json" }?.forEach { file ->
+            val root = Json.parseToJsonElement(file.readText()).jsonObject
+            root["screens"]?.jsonArray
+                ?.let { allScreens += RuleCompiler.compileRules<UiNode>(it, RuleContext.SCREEN) }
+        }
+        assertTrue(
+            "platforms missing sensitive rules: ${missingSensitivePlatforms(allScreens)}",
+            missingSensitivePlatforms(allScreens).isEmpty(),
+        )
+    }
+
+    @Test
+    fun `uber wallet and cashout screens classify as sensitive`() {
+        val wallet = UiNode(children = listOf(UiNode(text = "Available balance"), UiNode(text = "Set up Instant Pay")))
+            .restoreParents()
+        val walletResult = screenRuleset.matchFirst(wallet, platformWire = "uber")
+        assertTrue(
+            "wallet screen must hit a sensitive rule, got ${walletResult?.ruleId}",
+            walletResult?.ruleId?.contains("sensitive") == true,
+        )
+
+        val cashout = UiNode(children = listOf(UiNode(text = "Cash out"), UiNode(text = "Transfer to bank account")))
+            .restoreParents()
+        val cashoutResult = screenRuleset.matchFirst(cashout, platformWire = "uber")
+        assertTrue(
+            "cashout screen must hit a sensitive rule, got ${cashoutResult?.ruleId}",
+            cashoutResult?.ruleId?.contains("sensitive") == true,
+        )
+    }
+
+    // =========================================================================
     // Parse-output regression on real captures (#433)
     // =========================================================================
 

--- a/app/src/test/java/cloud/trotter/dashbuddy/test/util/SnapshotSecurityScanner.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/test/util/SnapshotSecurityScanner.kt
@@ -1,38 +1,19 @@
 package cloud.trotter.dashbuddy.test.util
 
+import cloud.trotter.dashbuddy.core.pipeline.SensitiveTextMarkers
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
 
 /**
  * Scans a [UiNode] tree for sensitive keywords (PII, financial data).
  *
  * Used by [InboxProcessorTest] to prevent accidental commits of raw
- * banking/identity data in snapshot files. Keywords are inlined from
- * the production sensitive screen rules in `rules.default.json`.
+ * banking/identity data in snapshot files. The keyword list is the
+ * production [SensitiveTextMarkers] SSOT (#432) — test toxicity and the
+ * runtime UNKNOWN-capture scrub agree by construction.
  */
 object SnapshotSecurityScanner {
 
-    /** Combined keywords from both sensitive screen rules. */
-    private val SENSITIVE_KEYWORDS = listOf(
-        // doordash.screen.sensitive.known
-        "Bank Account",
-        "Routing Number",
-        "Social Security",
-        "Direct Deposit",
-        "Visa",
-        "Mastercard",
-        "ending in",
-        "Linked accounts",
-        "Statements & documents",
-        "Emergency contact details",
-        // doordash.screen.sensitive.catchall
-        "Crimson",
-        "Biometric",
-        "Available Balance",
-        "Tax Form",
-        "Expiry",
-        "Enter the code we sent",
-        "t=completed_view",
-    )
+    private val SENSITIVE_KEYWORDS = SensitiveTextMarkers.KEYWORDS
 
     data class ScanResult(
         val isToxic: Boolean,

--- a/core/pipeline/build.gradle.kts
+++ b/core/pipeline/build.gradle.kts
@@ -46,4 +46,5 @@ dependencies {
 
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.mockito.kotlin)
 }

--- a/core/pipeline/src/main/assets/rules/uber.json
+++ b/core/pipeline/src/main/assets/rules/uber.json
@@ -4,6 +4,108 @@
   "platform_id": "uber.driver",
   "screens": [
     {
+      "id": "uber.screen.sensitive.known",
+      "priority": 0,
+      "overrideable": false,
+      "parse": {
+        "as": "sensitive"
+      },
+      "branches": [
+        {
+          "intent": "sensitive.wallet",
+          "require": {
+            "exists": {
+              "any": [
+                {
+                  "hasTextContaining": "Instant Pay"
+                },
+                {
+                  "hasTextContaining": "Uber Pro Card"
+                },
+                {
+                  "hasTextContaining": "Available balance"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "intent": "sensitive.cashout",
+          "require": {
+            "exists": {
+              "any": [
+                {
+                  "hasTextContaining": "Cash out"
+                },
+                {
+                  "hasTextContaining": "Transfer to bank"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "intent": "sensitive.bank",
+          "require": {
+            "exists": {
+              "any": [
+                {
+                  "hasTextContaining": "bank account"
+                },
+                {
+                  "hasTextContaining": "Routing number"
+                },
+                {
+                  "hasTextContaining": "Direct deposit"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "intent": "sensitive.identity",
+          "require": {
+            "exists": {
+              "any": [
+                {
+                  "hasTextContaining": "Social Security"
+                },
+                {
+                  "hasTextContaining": "Tax information"
+                },
+                {
+                  "hasTextContaining": "Enter the code we sent"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "uber.screen.sensitive.catchall",
+      "priority": 998,
+      "overrideable": false,
+      "parse": {
+        "as": "sensitive"
+      },
+      "require": {
+        "allTextContainsAny": [
+          "routing number",
+          "social security",
+          "bank account",
+          "available balance",
+          "instant pay",
+          "cash out",
+          "tax form",
+          "direct deposit",
+          "card number",
+          "cvv",
+          "expiry"
+        ]
+      }
+    },
+    {
       "id": "uber.screen.offer",
       "priority": 15,
       "branches": [
@@ -631,7 +733,9 @@
         "titleMatchesRegex": "^Going to (?!\\d)"
       },
       "intent": "trip_en_route_pickup",
-      "parse": { "as": "notification" },
+      "parse": {
+        "as": "notification"
+      },
       "effects": [
         {
           "log": {
@@ -648,7 +752,9 @@
         "titleContains": "Arrived at "
       },
       "intent": "trip_arrived_pickup",
-      "parse": { "as": "notification" },
+      "parse": {
+        "as": "notification"
+      },
       "effects": [
         {
           "log": {
@@ -665,7 +771,9 @@
         "titleMatchesRegex": "^Going to \\d"
       },
       "intent": "trip_en_route_dropoff",
-      "parse": { "as": "notification" },
+      "parse": {
+        "as": "notification"
+      },
       "effects": [
         {
           "log": {
@@ -682,7 +790,9 @@
         "titleMatchesRegex": "(Leave the order at|Meet at door for)"
       },
       "intent": "trip_at_dropoff",
-      "parse": { "as": "notification" },
+      "parse": {
+        "as": "notification"
+      },
       "effects": [
         {
           "log": {
@@ -699,7 +809,9 @@
         "titleMatchesRegex": "received a \\$\\d"
       },
       "intent": "tip_received",
-      "parse": { "as": "notification" },
+      "parse": {
+        "as": "notification"
+      },
       "effects": [
         {
           "log": {
@@ -715,7 +827,9 @@
       "require": {
         "titleContains": "currently online"
       },
-      "parse": { "as": "noise" }
+      "parse": {
+        "as": "noise"
+      }
     },
     {
       "id": "uber.notification.quest_promo",
@@ -724,7 +838,9 @@
         "titleContains": "Quest awaits"
       },
       "intent": "quest_promo",
-      "parse": { "as": "notification" },
+      "parse": {
+        "as": "notification"
+      },
       "effects": [
         {
           "log": {
@@ -748,7 +864,9 @@
         ]
       },
       "intent": "quest_deadline",
-      "parse": { "as": "notification" },
+      "parse": {
+        "as": "notification"
+      },
       "effects": [
         {
           "log": {

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CaptureWriter.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CaptureWriter.kt
@@ -12,6 +12,7 @@ import cloud.trotter.dashbuddy.domain.capture.schema.RawNotificationSchema
 import cloud.trotter.dashbuddy.domain.capture.schema.UiNodeSchema
 import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.pipeline.UNKNOWN_TARGET
 import cloud.trotter.dashbuddy.domain.state.Platform
 import timber.log.Timber
 import javax.inject.Inject
@@ -29,12 +30,27 @@ import javax.inject.Singleton
 @Singleton
 class CaptureWriter @Inject constructor(
     private val captureBus: CaptureBus,
+    private val stats: PipelineStats,
 ) {
 
     fun captureScreen(
         obs: Observation.Screen,
         event: PipelineEvent.Screen,
     ): Observation.Screen {
+        // Fail-closed backstop (#432): the sensitive gate upstream only sees
+        // screens a RULE recognized as sensitive. An UNRECOGNIZED sensitive
+        // screen classifies UNKNOWN and would be captured verbatim for triage
+        // — scan its text and drop the capture on any sensitive marker. The
+        // observation still flows (it dies at the UNKNOWN gate downstream);
+        // only the disk write is suppressed.
+        if (obs.target == UNKNOWN_TARGET) {
+            val marker = SensitiveTextMarkers.findMarker(event.tree)
+            if (marker != null) {
+                stats.onScrubbedUnknownCapture()
+                Timber.w("Capture scrubbed: UNKNOWN screen hit sensitive marker '%s'", marker)
+                return obs
+            }
+        }
         val platform = Platform.fromPackage(event.packageName).wire
         val winCtx = event.snapshot.windowContext?.let { wc ->
             WindowContextDto(
@@ -108,6 +124,16 @@ class CaptureWriter @Inject constructor(
         obs: Observation.Notification,
         raw: RawNotificationData,
     ): Observation.Notification {
+        // Same fail-closed backstop as captureScreen (#432) for UNKNOWN
+        // notification bodies.
+        if (obs.target == UNKNOWN_TARGET) {
+            val marker = SensitiveTextMarkers.findMarker(raw.toFullString())
+            if (marker != null) {
+                stats.onScrubbedUnknownCapture()
+                Timber.w("Capture scrubbed: UNKNOWN notification hit sensitive marker '%s'", marker)
+                return obs
+            }
+        }
         val platform = Platform.fromPackage(raw.packageName).wire
         val capture = EnvelopeBuilder.build(
             pipelineId = NotificationPipeline.PIPELINE_ID,

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/ObservationClassifier.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/ObservationClassifier.kt
@@ -39,6 +39,9 @@ class ObservationClassifier @Inject constructor(
     var lastScreenTarget: String? = null
         private set
 
+    /** True once rulesets are published — pipelines drop frames until then (#432). */
+    val isReady: Boolean get() = interpreter.isLoaded
+
 
     // Typed entry points (#361): each event subtype returns its observation
     // subtype, so pipelines never downcast classify results.

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/PipelineStats.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/PipelineStats.kt
@@ -32,6 +32,8 @@ class PipelineStats @Inject constructor() {
     private val mappingFailures = AtomicLong()
     private val restarts = AtomicLong()
     private val forwarded = AtomicLong()
+    private val droppedAwaitingRules = AtomicLong()
+    private val scrubbedUnknownCaptures = AtomicLong()
 
     val droppedSensitiveCount: Long get() = droppedSensitive.get()
     val droppedNoiseCount: Long get() = droppedNoise.get()
@@ -41,6 +43,8 @@ class PipelineStats @Inject constructor() {
     val mappingFailureCount: Long get() = mappingFailures.get()
     val restartCount: Long get() = restarts.get()
     val forwardedCount: Long get() = forwarded.get()
+    val droppedAwaitingRulesCount: Long get() = droppedAwaitingRules.get()
+    val scrubbedUnknownCaptureCount: Long get() = scrubbedUnknownCaptures.get()
 
     /** A frame the shared content gate dropped (sensitive or noise, #399). */
     fun onContentGateDrop(parsed: ParsedFields) {
@@ -70,6 +74,17 @@ class PipelineStats @Inject constructor() {
         mappingFailures.incrementAndGet()
     }
 
+    /** A frame dropped because no ruleset is loaded yet — the sensitive gate
+     *  is rule-driven, so pre-rules frames are never classified or captured (#432). */
+    fun onDroppedAwaitingRules() {
+        droppedAwaitingRules.incrementAndGet()
+    }
+
+    /** An UNKNOWN capture dropped by the fail-closed text-marker backstop (#432). */
+    fun onScrubbedUnknownCapture() {
+        scrubbedUnknownCaptures.incrementAndGet()
+    }
+
     /** The supervised upstream crashed and is resubscribing. Returns the restart ordinal. */
     fun onPipelineRestart(): Long = restarts.incrementAndGet()
 
@@ -91,6 +106,8 @@ class PipelineStats @Inject constructor() {
             " noiseDropped=${droppedNoise.get()}" +
             " disabledPlatformDropped=${droppedDisabledPlatform.get()}" +
             " mappingFailures=${mappingFailures.get()}" +
+            " awaitingRulesDropped=${droppedAwaitingRules.get()}" +
+            " unknownScrubbed=${scrubbedUnknownCaptures.get()}" +
             " restarts=${restarts.get()}"
 
     companion object {

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/SensitiveTextMarkers.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/SensitiveTextMarkers.kt
@@ -1,0 +1,84 @@
+package cloud.trotter.dashbuddy.core.pipeline
+
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+
+/**
+ * App-owned fail-closed backstop for the sensitive-screen pledge (#432).
+ *
+ * The matcher-layer block (priority-0 sensitive rules) fails OPEN for
+ * screens no rule recognizes: an unmatched banking screen classifies
+ * UNKNOWN and — in debug builds — its full tree text is captured to disk
+ * for triage. These markers scan an UNKNOWN frame's text before capture;
+ * a hit drops the capture entirely. They are deliberately independent of
+ * the (forkable, future-CDN #192) rulesets — a bundle that loses its
+ * sensitive rules cannot disable this guard.
+ *
+ * The keyword list is the SSOT shared with the test-side
+ * `SnapshotSecurityScanner` (golden-corpus toxicity guard), so production
+ * and test agree on what "toxic" means.
+ */
+object SensitiveTextMarkers {
+
+    /**
+     * Keywords inlined from the production sensitive screen rules.
+     * Case-insensitive substring match.
+     */
+    val KEYWORDS: List<String> = listOf(
+        // doordash.screen.sensitive.known
+        "Bank Account",
+        "Routing Number",
+        "Social Security",
+        "Direct Deposit",
+        "Visa",
+        "Mastercard",
+        "ending in",
+        "Linked accounts",
+        "Statements & documents",
+        "Emergency contact details",
+        // doordash.screen.sensitive.catchall
+        "Crimson",
+        "Biometric",
+        "Available Balance",
+        "Tax Form",
+        "Expiry",
+        "Enter the code we sent",
+        "t=completed_view",
+        // platform-agnostic payout/identity surfaces (#432)
+        "Instant Pay",
+        "Cash out",
+        "CVV",
+    )
+
+    /**
+     * Shaped-value patterns no keyword list can cover: SSNs and card PANs.
+     * Conservative shapes to avoid flagging ordinary money/IDs.
+     */
+    private val SHAPE_PATTERNS: List<Regex> = listOf(
+        // SSN: 123-45-6789
+        Regex("""\b\d{3}-\d{2}-\d{4}\b"""),
+        // Card PAN: 4 groups of 4 separated by space/dash (16 digits)
+        Regex("""\b\d{4}[ -]\d{4}[ -]\d{4}[ -]\d{4}\b"""),
+    )
+
+    /**
+     * Scan the tree's text for a sensitive marker. Returns the first
+     * matched marker (for logging) or null when clean.
+     */
+    fun findMarker(tree: UiNode): String? {
+        for (text in tree.allText) {
+            val keyword = KEYWORDS.firstOrNull { text.contains(it, ignoreCase = true) }
+            if (keyword != null) return keyword
+            val shape = SHAPE_PATTERNS.firstOrNull { it.containsMatchIn(text) }
+            if (shape != null) return "shape:${shape.pattern}"
+        }
+        return null
+    }
+
+    /** Scan a flat text blob (notification body) for a sensitive marker. */
+    fun findMarker(text: String): String? {
+        val keyword = KEYWORDS.firstOrNull { text.contains(it, ignoreCase = true) }
+        if (keyword != null) return keyword
+        return SHAPE_PATTERNS.firstOrNull { it.containsMatchIn(text) }
+            ?.let { "shape:${it.pattern}" }
+    }
+}

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/AccessibilityPipeline.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/AccessibilityPipeline.kt
@@ -95,6 +95,17 @@ class AccessibilityPipeline @Inject constructor(
     // ── Main pipeline ──────────────────────────────────────────────────
 
     fun output(): Flow<Observation> = merge(screenEvents(), clickEvents())
+        // Gate: drop everything until rulesets load (#432). The sensitive gate
+        // below is RULE-driven — a frame classified before rules exist would
+        // bypass it straight into the UNKNOWN capture path.
+        .filter { event ->
+            val ready = classifier.isReady
+            if (!ready) {
+                stats.onDroppedAwaitingRules()
+                Timber.w("Dropping %s — rulesets not loaded yet", event::class.simpleName)
+            }
+            ready
+        }
         // Classify through the unified rule engine (typed: FlowObservation, #361)
         .map { event -> classifier.classify(event) to event }
 

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/notification/NotificationPipeline.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/notification/NotificationPipeline.kt
@@ -45,6 +45,13 @@ class NotificationPipeline @Inject constructor(
 
     fun output(): Flow<Observation.Notification> = source.events
         .mapNotNull { sbn -> sbn.toDomain() }
+        // Gate: drop everything until rulesets load (#432) — symmetric with
+        // the accessibility pipeline.
+        .filter { raw ->
+            val ready = classifier.isReady
+            if (!ready) stats.onDroppedAwaitingRules()
+            ready
+        }
         .filter { raw -> filter.isRelevant(raw) }
         .map { raw ->
             val event = PipelineEvent.Notification(raw.postTime, raw)

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/JsonRuleInterpreter.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/JsonRuleInterpreter.kt
@@ -2,6 +2,7 @@ package cloud.trotter.dashbuddy.core.pipeline.rules
 
 import android.content.Context
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.serialization.json.Json
@@ -43,6 +44,14 @@ class JsonRuleInterpreter @Inject constructor(
     val clickRuleset: Ruleset<UiNode>? get() = current.clicks
     val notificationRuleset: Ruleset<RawNotificationData>? get() = current.notifications
     val loadedFormatVersion: Int? get() = current.formatVersion
+
+    /**
+     * True once a ruleset bundle has been published. The pipelines drop (not
+     * capture) every frame until this flips (#432): the sensitive-screen gate
+     * is rule-driven, so a frame classified before rules load would bypass it
+     * and land in the UNKNOWN capture path.
+     */
+    val isLoaded: Boolean get() = current.screens != null
 
     private data class LoadedRulesets(
         val screens: Ruleset<UiNode>? = null,
@@ -94,8 +103,26 @@ class JsonRuleInterpreter @Inject constructor(
                 result.formatVersion?.let { lastFormatVersion = it }
             }
 
+            // Sensitive-coverage check (#432, complements #419): every platform
+            // that ships screen rules MUST ship at least one sensitive rule —
+            // the matcher-layer block is only as real as its coverage. A
+            // platform without one has its SCREEN rules excluded (fail closed:
+            // its frames classify UNKNOWN, where the capture-scrub backstop
+            // applies) rather than loaded blind.
+            val uncovered = missingSensitivePlatforms(allScreens)
+            val effectiveScreens = if (uncovered.isEmpty()) {
+                allScreens
+            } else {
+                Timber.e(
+                    "JsonRuleInterpreter: platform(s) %s ship screen rules but NO sensitive rule — " +
+                        "excluding their screen rules (fail closed)",
+                    uncovered.joinToString { it.wire },
+                )
+                allScreens.filterNot { Platform.fromRuleId(it.id) in uncovered }
+            }
+
             current = LoadedRulesets(
-                screens = Ruleset(allScreens),
+                screens = Ruleset(effectiveScreens),
                 clicks = Ruleset(allClicks),
                 notifications = Ruleset(allNotifications),
                 formatVersion = lastFormatVersion,
@@ -186,4 +213,19 @@ class JsonRuleInterpreter @Inject constructor(
         private const val RULES_DIR = "rules"
         private const val MAX_FILE_BYTES = 1_000_000  // 1 MB
     }
+}
+
+/**
+ * Platforms whose screen-rule set lacks ANY sensitive-shaped branch
+ * (`parse.as == "sensitive"`) — #432. Pure and top-level so it's testable
+ * without an Android Context (public: the app-module integration test pins
+ * that the shipped bundles never trip it).
+ */
+fun missingSensitivePlatforms(screens: List<CompiledRule<UiNode>>): Set<Platform> {
+    val byPlatform = screens.groupBy { Platform.fromRuleId(it.id) }
+    return byPlatform.filterKeys { it != Platform.Unknown }
+        .filterValues { rules ->
+            rules.none { r -> r.branches.any { it.shape == "sensitive" } }
+        }
+        .keys
 }

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureScrubTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureScrubTest.kt
@@ -1,0 +1,80 @@
+package cloud.trotter.dashbuddy.core.pipeline
+
+import cloud.trotter.dashbuddy.core.pipeline.accessibility.AccessibilityPipeline
+import cloud.trotter.dashbuddy.core.pipeline.accessibility.TreeSnapshot
+import cloud.trotter.dashbuddy.domain.capture.CaptureBus
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.pipeline.UNKNOWN_TARGET
+import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+
+/**
+ * #432 — UNKNOWN captures are scrubbed by the fail-closed text backstop:
+ * an unrecognized sensitive screen must never reach the CaptureBus, while
+ * benign UNKNOWNs still capture for triage.
+ */
+class CaptureScrubTest {
+
+    private val captureBus: CaptureBus = mock()
+    private val stats = PipelineStats()
+    private val writer = CaptureWriter(captureBus, stats)
+
+    private fun screenEvent(tree: UiNode) = PipelineEvent.Screen(
+        timestamp = 1_000L,
+        tree = tree,
+        snapshot = TreeSnapshot(
+            tree = tree,
+            packageName = "com.doordash.driverapp",
+            source = TreeSnapshot.Source.STATE_CHANGED,
+        ),
+        packageName = "com.doordash.driverapp",
+    )
+
+    private fun unknownObs() = Observation.Screen(
+        timestamp = 1_000L,
+        captureId = null,
+        ruleId = null,
+        metadata = ReplayMetadata.EMPTY,
+        flow = null,
+        modeHint = null,
+        parsed = ParsedFields.None,
+        target = UNKNOWN_TARGET,
+    )
+
+    @Test
+    fun `UNKNOWN screen with sensitive text is never offered to the capture bus`() {
+        val toxic = UiNode(children = listOf(UiNode(text = "Available balance: \$152.10")))
+        writer.captureScreen(unknownObs(), screenEvent(toxic))
+
+        verify(captureBus, never()).offer(any(), any(), any(), any(), any(), any())
+        assertEquals(1L, stats.scrubbedUnknownCaptureCount)
+    }
+
+    @Test
+    fun `benign UNKNOWN screen still captures for triage`() {
+        val benign = UiNode(children = listOf(UiNode(text = "Some new promo screen")))
+        writer.captureScreen(unknownObs(), screenEvent(benign))
+
+        verify(captureBus, times(1)).offer(any(), any(), any(), any(), any(), any())
+        assertEquals(0L, stats.scrubbedUnknownCaptureCount)
+    }
+
+    @Test
+    fun `recognized screens are not scrubbed - the rule gate already vetted them`() {
+        val tree = UiNode(children = listOf(UiNode(text = "ending in 1234")))
+        val recognized = unknownObs().copy(ruleId = "doordash.screen.test", target = "idle_map")
+        writer.captureScreen(recognized, screenEvent(tree))
+
+        verify(captureBus, times(1)).offer(any(), any(), any(), any(), any(), any())
+        assertTrue(stats.scrubbedUnknownCaptureCount == 0L)
+    }
+}

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/SensitiveTextMarkersTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/SensitiveTextMarkersTest.kt
@@ -1,0 +1,47 @@
+package cloud.trotter.dashbuddy.core.pipeline
+
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/** #432 — the fail-closed text backstop for UNKNOWN captures. */
+class SensitiveTextMarkersTest {
+
+    private fun tree(vararg texts: String) = UiNode(
+        children = texts.map { UiNode(text = it) },
+    )
+
+    @Test
+    fun `keyword markers hit case-insensitively`() {
+        assertEquals("Routing Number", SensitiveTextMarkers.findMarker(tree("Your routing number is below")))
+        assertEquals("Available Balance", SensitiveTextMarkers.findMarker(tree("available balance: \$52.10")))
+        assertEquals("Instant Pay", SensitiveTextMarkers.findMarker(tree("Set up instant pay")))
+        assertEquals("CVV", SensitiveTextMarkers.findMarker(tree("Enter CVV")))
+    }
+
+    @Test
+    fun `shaped values hit - SSN and card PAN`() {
+        assertNotNull(SensitiveTextMarkers.findMarker(tree("ID 123-45-6789 on file")))
+        assertNotNull(SensitiveTextMarkers.findMarker(tree("4111 1111 1111 1111")))
+        assertNotNull(SensitiveTextMarkers.findMarker(tree("4111-1111-1111-1111")))
+    }
+
+    @Test
+    fun `ordinary dash screens stay clean`() {
+        assertNull(
+            SensitiveTextMarkers.findMarker(
+                tree("Pickup from Chipotle", "Deliver by 7:45 PM", "\$7.50", "3.2 mi", "Accept"),
+            ),
+        )
+        // Plain money, dates, and phone-shaped strings must not trip the shapes.
+        assertNull(SensitiveTextMarkers.findMarker(tree("Total: \$1,234.56", "ETA 12-45")))
+    }
+
+    @Test
+    fun `flat text overload works for notification bodies`() {
+        assertNotNull(SensitiveTextMarkers.findMarker("Your bank account transfer was initiated"))
+        assertNull(SensitiveTextMarkers.findMarker("New order: Chipotle, \$8.25 total"))
+    }
+}

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/SensitiveCoverageTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/SensitiveCoverageTest.kt
@@ -1,0 +1,46 @@
+package cloud.trotter.dashbuddy.core.pipeline.rules
+
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import cloud.trotter.dashbuddy.domain.state.Platform
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #432 — every platform that ships screen rules must ship a sensitive rule;
+ * the matcher-layer block is only as real as its coverage.
+ */
+class SensitiveCoverageTest {
+
+    private fun rule(id: String, shape: String? = null) = CompiledRule<UiNode>(
+        id = id,
+        priority = id.hashCode() and 0xFFFF,
+        branches = listOf(CompiledBranch(intent = "x", shape = shape)),
+    )
+
+    @Test
+    fun `platform without a sensitive-shaped rule is reported`() {
+        val screens = listOf(
+            rule("doordash.screen.sensitive.known", shape = "sensitive"),
+            rule("doordash.screen.idle", shape = "idle"),
+            rule("uber.screen.offer", shape = "offer"), // no sensitive rule!
+        )
+        assertEquals(setOf(Platform.Uber), missingSensitivePlatforms(screens))
+    }
+
+    @Test
+    fun `all covered - nothing reported`() {
+        val screens = listOf(
+            rule("doordash.screen.sensitive.known", shape = "sensitive"),
+            rule("uber.screen.sensitive.known", shape = "sensitive"),
+            rule("uber.screen.offer", shape = "offer"),
+        )
+        assertTrue(missingSensitivePlatforms(screens).isEmpty())
+    }
+
+    @Test
+    fun `unknown-platform rules are ignored`() {
+        val screens = listOf(rule("mystery.screen.thing", shape = "idle"))
+        assertTrue(missingSensitivePlatforms(screens).isEmpty())
+    }
+}

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -63,6 +63,17 @@ immediately (no second pass needed) so it gets triaged.
 _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **broken** on the
 2026-06-09 dash — moved to that session's log entry below for triage.)_
 
+- **Uber sensitive screens now blocked + UNKNOWN-capture scrub (#432).**
+  Uber finally has matcher-layer sensitive rules (wallet / Instant Pay / cash-out / bank /
+  identity). On a dash, briefly open Uber's earnings/wallet area: working = the app treats it
+  as sensitive (no capture, no state change, log shows the sensitive gate) and normal offer
+  recognition is unaffected. Also new: UNKNOWN screens whose text contains sensitive markers
+  are no longer captured for triage (PipelineStats logs `unknownScrubbed`), and the pipeline
+  drops all frames until rulesets finish loading at startup. Broken = an Uber wallet screen
+  shows up in captures/, or offer screens misclassify as sensitive (keywords too broad —
+  capture the screen text).
+  - Confirmed: 0/2
+
 - **Session-end grace — summary no longer ends the dash instantly (#431).**
   The dash-summary screen now arms a ~2.5s authoritative grace (cancellable by a task-flow
   frame) instead of ending the session on the spot, and grace commits fire on a timer instead


### PR DESCRIPTION
The sensitive-screen pledge failed OPEN three ways: frames classified
before rulesets loaded (startup race) went to the UNKNOWN capture path;
an UNRECOGNIZED sensitive screen's full tree text was captured verbatim
for triage (debug); and Uber had zero sensitive rules - the matcher-layer
block was DoorDash-only by convention.

- Startup gate: both sensor pipelines drop (never classify, never
  capture) every frame until JsonRuleInterpreter.isLoaded flips - the
  sensitive gate is rule-driven, so pre-rules frames must not exist.
  Counted (PipelineStats.droppedAwaitingRules).
- UNKNOWN-capture scrub: SensitiveTextMarkers (keywords from the
  production sensitive rules + SSN/card-PAN shape patterns) scans every
  UNKNOWN screen/notification before the CaptureBus offer; a hit drops
  the capture and counts (scrubbedUnknownCaptures). Deliberately
  independent of the (forkable, #192) rulesets - a bundle that loses its
  sensitive rules cannot disable this guard. The keyword list is now the
  SSOT shared with the test-side SnapshotSecurityScanner.
- Uber sensitive rules: priority-0 uber.screen.sensitive.known (wallet /
  Instant Pay / cash-out / bank / identity branches) + priority-998
  catchall, mirroring the DoorDash structure. Payment surfaces are
  blocked even for the dasher's own earnings, per the standing policy.
- Load-time coverage check: every platform that ships screen rules must
  ship >=1 sensitive-shaped rule; an uncovered platform's screen rules
  are EXCLUDED from the bundle (fail closed - its frames then classify
  UNKNOWN where the scrub applies) with a loud error.
  missingSensitivePlatforms is pure + pinned against the shipped bundles
  by an integration test.

Tests: SensitiveTextMarkersTest (keywords, shapes, benign-clean),
CaptureScrubTest (toxic UNKNOWN never reaches the bus; benign UNKNOWN
still captures; recognized screens untouched), SensitiveCoverageTest,
DefaultRulesIntegrationTest gains shipped-coverage + Uber
wallet/cashout-classify-sensitive cases. core:pipeline gains
mockito-kotlin. Full suite green.

Security/privacy posture: pure hardening of the pledge surface. No new
data collection; strictly fewer captures. Blocks-#192 prerequisite:
"sensitive = whatever the bundle matches" now has app-owned fail-closed
backstops at load (coverage check), classify (startup gate), and capture
(text scrub).

Closes #432.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)