### PR TITLE
feat(security): real fail-closed consent gate at the PerformRuleAction seam (#417)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,8 +100,9 @@ The project uses modular Clean Architecture with a strict dependency graph:
   concrete data layers.
 - **`:core:network`** — Retrofit clients, OkHttp interceptors, EIA gas price API integration.
 - **`:core:location`** — Play Services GPS tracking.
-- **`:core:datastore`** — Preferences DataStore (six single-concern stores behind Hilt
-  qualifiers — app prefs, strategy, dev settings, odometer, app state, platforms).
+- **`:core:datastore`** — Preferences DataStore (seven single-concern stores behind Hilt
+  qualifiers — app prefs, strategy, dev settings, odometer, app state, platforms,
+  rule-capability grants).
 - **`:core:designsystem`** — Brand system (no project deps): fixed dark/light palette (`DashColors`),
   Hanken Grotesk + Space Grotesk fonts (tabular numerals), `DashTheme` + `LocalGlance`, and the
   shared component library (`DashCard`, `DashChip`, `DashStatTile`, `DashGaugeRing`, `DashSegmented`,
@@ -159,8 +160,11 @@ state into `AppEffect`s.
 
 ### 4. Side Effect Engine (`app/.../state/effects/`)
 
-`SideEffectEngine` executes `AppEffect`s with `effects_fired` idempotency dedup (recovery-aware)
-and runs the evaluation loopback (offer eval → `OfferEvaluationEvent` back into the machine).
+`SideEffectEngine` executes `AppEffect`s with `effects_fired` idempotency dedup (recovery-aware),
+runs the evaluation loopback (offer eval → `OfferEvaluationEvent` back into the machine), and owns
+the fail-closed action gates (#417): live `PermissionTierChecker` + the capability consent gate on
+automation-triggered `RuleAction`s (grant store: `RuleCapabilityRepository` over the
+`rule_capability_grants` DataStore; asset rules auto-grant at load).
 Handlers: `OdometerEffectHandler`, `ScreenShotHandler`, `TipEffectHandler`, `TtsEffectHandler`,
 `UiInteractionHandler` (package-scoped, label-verified `RuleAction` taps — the only path that ever
 clicks a third-party app, #425), `OfferActionReceiver` (notification Accept/Decline actions).
@@ -218,10 +222,15 @@ Every new feature or refactor holds to these — they are forefront design input
      `NoOpCaptureBus`, #346).
    - **Secrets never reach logs** (EIA api_key redaction, #348); network logging is debug-gated.
    - **Capability gates fail closed.** An effect whose permission tier isn't granted does not
-     fire. Rules cannot request actuation at all (#425) — taps are app-owned `RuleAction`s aimed
-     by ruleset target bindings and verified at fire time (package scope + label allowlist +
-     strict click); any failed check aborts to manual. (The single-user build still stubs the
-     grant check to always-true — replacing it with the consent-keyed gate is #417.)
+     fire — tiers back onto real OS state (live accessibility-service handle, runtime location
+     grant; #417 removed the always-true stub). Rules cannot request actuation at all (#425) —
+     taps are app-owned `RuleAction`s aimed by ruleset target bindings and verified at fire
+     time (package scope + label allowlist + strict click); any failed check aborts to manual.
+     Automation-initiated taps must additionally be covered by a granted, content-pinned
+     capability key (#417): rule loads enumerate capabilities and reconcile them into the
+     grant store *before* rules go live; bundled (asset) sources auto-grant, remote sources
+     never will. A dasher-pressed Accept/Decline is its own consent (integrity checks still
+     apply). Consent UI = #422 PR 3.
    When a change touches recognition, capture, network, or effects, state its security/privacy
    posture in the PR — what's trusted, what's gated, what's scrubbed.
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/PermissionTierChecker.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/PermissionTierChecker.kt
@@ -1,0 +1,45 @@
+package cloud.trotter.dashbuddy.state.effects
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.core.content.ContextCompat
+import cloud.trotter.dashbuddy.core.pipeline.accessibility.input.AccessibilitySource
+import cloud.trotter.dashbuddy.domain.pipeline.PermissionTier
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Real [PermissionTier] check (#417) — replaces the alpha always-true stub.
+ * Each tier backs onto the OS state that actually carries it, so a denied
+ * tier genuinely blocks the effect (dev principle 6: capability gates fail
+ * closed):
+ *
+ * - [PermissionTier.ACCESSIBILITY] — the live accessibility-service handle.
+ *   Taps and screenshots are dispatched THROUGH the service; if it is not
+ *   connected (user disabled it, system killed it), nothing downstream could
+ *   succeed anyway — deny up front instead of failing deep in a handler.
+ * - [PermissionTier.LOCATION] — the `ACCESS_FINE_LOCATION` runtime grant,
+ *   checked live (the user can revoke it in Settings at any moment).
+ * - [PermissionTier.AUDIO] — structurally granted: Android has no runtime
+ *   permission for TTS/audio output. The user-facing "may DashBuddy speak"
+ *   consent is an app-level setting concern (#422 PR 3 / #428), not an OS
+ *   tier.
+ * - [PermissionTier.NONE] — no requirement by definition.
+ */
+@Singleton
+class PermissionTierChecker @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+    private val accessibilitySource: AccessibilitySource,
+) {
+    fun isGranted(tier: PermissionTier): Boolean = when (tier) {
+        PermissionTier.NONE -> true
+        PermissionTier.ACCESSIBILITY -> accessibilitySource.getService() != null
+        PermissionTier.LOCATION -> ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.ACCESS_FINE_LOCATION,
+        ) == PackageManager.PERMISSION_GRANTED
+        PermissionTier.AUDIO -> true
+    }
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
@@ -4,6 +4,8 @@ import cloud.trotter.dashbuddy.core.data.event.AppEventRepo
 import cloud.trotter.dashbuddy.core.data.strategy.StrategyRepository
 import cloud.trotter.dashbuddy.core.database.effects.EffectsFiredDao
 import cloud.trotter.dashbuddy.core.database.effects.EffectsFiredEntity
+import cloud.trotter.dashbuddy.domain.action.ActionTrigger
+import cloud.trotter.dashbuddy.domain.capability.RuleCapabilityGrants
 import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
 import cloud.trotter.dashbuddy.domain.model.chat.ChatPersona
 import cloud.trotter.dashbuddy.domain.state.Platform
@@ -53,6 +55,8 @@ class SideEffectEngine @Inject constructor(
     private val uiInteractionHandler: UiInteractionHandler,
     private val effectsFiredDao: EffectsFiredDao,
     private val ttsEffectHandler: TtsEffectHandler,
+    private val permissionTierChecker: PermissionTierChecker,
+    private val capabilityGrants: RuleCapabilityGrants,
     private val metadataProvider: MetadataProvider,
     @param:DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher,
 ) : EffectExecutor {
@@ -194,9 +198,10 @@ class SideEffectEngine @Inject constructor(
             is AppEffect.PerformRuleAction -> {
                 // The ONLY path that taps a third-party app (#425). The target
                 // is ruleset data; everything that decides whether/where the
-                // tap lands is app-owned: this throttle, the tier gate (the
-                // #417 grant check lands at this seam, keyed by
-                // (sourceRuleId, action) against the enumerated capabilities),
+                // tap lands is app-owned: this throttle, the live tier check,
+                // the consent gate (#417 — an AUTOMATION fire must be covered
+                // by a granted, content-pinned capability looked up by
+                // (sourceRuleId, action); a USER fire is its own consent),
                 // and the package + label verification in the handler.
                 val throttleKey = "action:${effect.action.wire}:${effect.platform.wire}"
                 val now = System.currentTimeMillis()
@@ -204,8 +209,17 @@ class SideEffectEngine @Inject constructor(
                     Timber.v("Throttled action: %s", throttleKey)
                     return
                 }
-                if (!isPermissionGranted(PermissionTier.ACCESSIBILITY)) {
+                if (!permissionTierChecker.isGranted(PermissionTier.ACCESSIBILITY)) {
                     Timber.w("Denied %s — ACCESSIBILITY tier not granted (fail closed)", effect.action.wire)
+                    return
+                }
+                if (effect.trigger == ActionTrigger.AUTOMATION &&
+                    !capabilityGrants.isActionGranted(effect.sourceRuleId, effect.action)
+                ) {
+                    Timber.w(
+                        "Denied %s — no granted capability for rule '%s' (fail closed)",
+                        effect.action.wire, effect.sourceRuleId,
+                    )
                     return
                 }
                 actionLastFiredAt[throttleKey] = now
@@ -326,7 +340,7 @@ class SideEffectEngine @Inject constructor(
      * Permission tier is checked before execution — denied verbs are logged and skipped.
      */
     private suspend fun dispatchRuleEffect(e: RequestedEffect) {
-        if (!isPermissionGranted(e.verb.tier)) {
+        if (!permissionTierChecker.isGranted(e.verb.tier)) {
             Timber.w("Denied effect %s — permission tier %s not granted", e.verb, e.verb.tier)
             return
         }
@@ -460,16 +474,6 @@ class SideEffectEngine @Inject constructor(
         OfferAction.MANUAL_REVIEW -> ChatPersona.Inspector
         OfferAction.NOTHING -> ChatPersona.Inspector
     }
-
-    /**
-     * Check if the given [PermissionTier] is granted.
-     *
-     * For alpha (single user, all permissions already granted via system settings),
-     * this returns true for all tiers. When multi-user or permission-gated features
-     * are needed, swap in a DataStore-backed implementation.
-     */
-    @Suppress("UNUSED_PARAMETER")
-    private fun isPermissionGranted(tier: PermissionTier): Boolean = true
 
     private fun isExternalEffect(effect: AppEffect): Boolean = when (effect) {
         is AppEffect.UpdateBubble,

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
@@ -1,5 +1,6 @@
 package cloud.trotter.dashbuddy.core.state
 
+import cloud.trotter.dashbuddy.domain.action.ActionTrigger
 import cloud.trotter.dashbuddy.domain.action.RuleAction
 import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
 import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
@@ -867,6 +868,8 @@ class EffectMapTest {
         assertEquals(Platform.DoorDash, actions[0].platform)
         assertEquals("com.example:id/btn", actions[0].targetRef.viewIdSuffix)
         assertEquals("doordash.screen.delivery_summary_collapsed", actions[0].sourceRuleId)
+        // App-decided tap → must pass the engine's capability grant gate (#417).
+        assertEquals(ActionTrigger.AUTOMATION, actions[0].trigger)
     }
 
     @Test
@@ -890,6 +893,8 @@ class EffectMapTest {
         assertEquals(RuleAction.ACCEPT_OFFER, actions[0].action)
         assertEquals(acceptRef, actions[0].targetRef)
         assertEquals("doordash.screen.offer_popup", actions[0].sourceRuleId)
+        // Dasher-pressed → its own consent; the grant gate does not apply (#417).
+        assertEquals(ActionTrigger.USER, actions[0].trigger)
     }
 
     @Test

--- a/app/src/test/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngineTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngineTest.kt
@@ -6,13 +6,17 @@ import cloud.trotter.dashbuddy.core.database.effects.EffectsFiredDao
 import cloud.trotter.dashbuddy.core.database.effects.EffectsFiredEntity
 import cloud.trotter.dashbuddy.core.state.AppEffect
 import cloud.trotter.dashbuddy.core.state.MetadataProvider
+import cloud.trotter.dashbuddy.domain.action.ActionTrigger
 import cloud.trotter.dashbuddy.domain.action.RuleAction
+import cloud.trotter.dashbuddy.domain.capability.RuleCapabilityGrants
 import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
 import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluator
 import cloud.trotter.dashbuddy.domain.model.event.AppEvent
 import cloud.trotter.dashbuddy.domain.model.event.AppEventType
 import cloud.trotter.dashbuddy.domain.model.state.TimeoutEvent
+import cloud.trotter.dashbuddy.domain.pipeline.EffectVerb
 import cloud.trotter.dashbuddy.domain.pipeline.NodeRef
+import cloud.trotter.dashbuddy.domain.pipeline.RequestedEffect
 import cloud.trotter.dashbuddy.domain.pipeline.TimeoutType
 import cloud.trotter.dashbuddy.domain.model.accessibility.BoundingBox
 import cloud.trotter.dashbuddy.domain.state.Platform
@@ -28,7 +32,9 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.inOrder
@@ -38,6 +44,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyBlocking
 import org.mockito.kotlin.whenever
+import org.mockito.kotlin.wheneverBlocking
 
 /**
  * Behavior tests for the SideEffectEngine execution edge:
@@ -63,6 +70,16 @@ class SideEffectEngineTest {
     private val effectsFiredDao: EffectsFiredDao = mock()
     private val ttsEffectHandler: TtsEffectHandler = mock()
 
+    /** Default: every tier granted — individual tests stub denial. */
+    private val permissionTierChecker: PermissionTierChecker = mock {
+        on { isGranted(any()) } doReturn true
+    }
+
+    /** Default: every capability granted — individual tests stub denial. */
+    private val capabilityGrants: RuleCapabilityGrants = mock {
+        onBlocking { isActionGranted(anyOrNull(), any()) } doReturn true
+    }
+
     private fun buildEngine(defaultDispatcher: CoroutineDispatcher) = SideEffectEngine(
         appEventRepo = appEventRepo,
         odometerEffectHandler = odometerEffectHandler,
@@ -74,6 +91,8 @@ class SideEffectEngineTest {
         uiInteractionHandler = uiInteractionHandler,
         effectsFiredDao = effectsFiredDao,
         ttsEffectHandler = ttsEffectHandler,
+        permissionTierChecker = permissionTierChecker,
+        capabilityGrants = capabilityGrants,
         metadataProvider = MetadataProvider { "{}" },
         defaultDispatcher = defaultDispatcher,
     )
@@ -109,18 +128,20 @@ class SideEffectEngineTest {
     // #341/#425 — recovery suppression: PerformRuleAction must never replay a tap
     // =========================================================================
 
-    private fun acceptActionEffect() = AppEffect.PerformRuleAction(
-        action = RuleAction.ACCEPT_OFFER,
-        platform = Platform.DoorDash,
-        targetRef = NodeRef(
-            viewIdSuffix = "com.doordash.driverapp:id/accept_button",
-            text = null,
-            classNameHint = "android.widget.Button",
-            boundsInScreen = BoundingBox(0, 100, 200, 150),
-            pathFingerprint = "View[0]/Button[1]",
-        ),
-        sourceRuleId = "doordash.screen.offer_popup",
-    )
+    private fun acceptActionEffect(trigger: ActionTrigger = ActionTrigger.AUTOMATION) =
+        AppEffect.PerformRuleAction(
+            action = RuleAction.ACCEPT_OFFER,
+            platform = Platform.DoorDash,
+            targetRef = NodeRef(
+                viewIdSuffix = "com.doordash.driverapp:id/accept_button",
+                text = null,
+                classNameHint = "android.widget.Button",
+                boundsInScreen = BoundingBox(0, 100, 200, 150),
+                pathFingerprint = "View[0]/Button[1]",
+            ),
+            sourceRuleId = "doordash.screen.offer_popup",
+            trigger = trigger,
+        )
 
     @Test
     fun `PerformRuleAction is suppressed during recovery and executes live`() = runTest {
@@ -153,6 +174,83 @@ class SideEffectEngineTest {
         // Second fire inside RULE_ACTION_THROTTLE_MS is swallowed — an
         // app-owned bound on automated taps (#425).
         verify(uiInteractionHandler, times(1)).performVerifiedClick(any(), any(), any(), any())
+    }
+
+    // =========================================================================
+    // #417 — consent gate at the PerformRuleAction seam
+    // =========================================================================
+
+    @Test
+    fun `an AUTOMATION fire without a granted capability is denied`() = runTest {
+        val engine = buildEngine(StandardTestDispatcher(testScheduler))
+        wheneverBlocking { capabilityGrants.isActionGranted(anyOrNull(), any()) }
+            .thenReturn(false)
+
+        engine.process(acceptActionEffect(trigger = ActionTrigger.AUTOMATION))
+        runCurrent()
+
+        verify(uiInteractionHandler, never()).performVerifiedClick(any(), any(), any(), any())
+    }
+
+    @Test
+    fun `an AUTOMATION fire with a granted capability fires`() = runTest {
+        val engine = buildEngine(StandardTestDispatcher(testScheduler))
+
+        engine.process(acceptActionEffect(trigger = ActionTrigger.AUTOMATION))
+        runCurrent()
+
+        verify(uiInteractionHandler, times(1)).performVerifiedClick(any(), any(), any(), any())
+        verifyBlocking(capabilityGrants) {
+            isActionGranted(eq("doordash.screen.offer_popup"), eq(RuleAction.ACCEPT_OFFER))
+        }
+    }
+
+    @Test
+    fun `a USER fire is its own consent — the grant store is not consulted`() = runTest {
+        val engine = buildEngine(StandardTestDispatcher(testScheduler))
+        wheneverBlocking { capabilityGrants.isActionGranted(anyOrNull(), any()) }
+            .thenReturn(false)
+
+        engine.process(acceptActionEffect(trigger = ActionTrigger.USER))
+        runCurrent()
+
+        verify(uiInteractionHandler, times(1)).performVerifiedClick(any(), any(), any(), any())
+        verifyBlocking(capabilityGrants, never()) { isActionGranted(anyOrNull(), any()) }
+    }
+
+    @Test
+    fun `a denied ACCESSIBILITY tier blocks even a USER fire`() = runTest {
+        val engine = buildEngine(StandardTestDispatcher(testScheduler))
+        whenever(permissionTierChecker.isGranted(any())).thenReturn(false)
+
+        engine.process(acceptActionEffect(trigger = ActionTrigger.USER))
+        runCurrent()
+
+        verify(uiInteractionHandler, never()).performVerifiedClick(any(), any(), any(), any())
+    }
+
+    @Test
+    fun `rule-verb dispatch consults the real tier checker`() = runTest {
+        val engine = buildEngine(StandardTestDispatcher(testScheduler))
+        // Distinct dedupeKeys: the engine throttles RequestEffect per effectKey
+        // on the wall clock, and a denied fire still consumes the slot.
+        fun screenshot(key: String) = AppEffect.RequestEffect(
+            RequestedEffect(
+                verb = EffectVerb.SCREENSHOT,
+                ruleId = "doordash.screen.offer_popup",
+                dedupeKey = key,
+            ),
+        )
+
+        whenever(permissionTierChecker.isGranted(any())).thenReturn(false)
+        engine.process(screenshot("denied"))
+        runCurrent()
+        verify(screenShotHandler, never()).capture(any(), any())
+
+        whenever(permissionTierChecker.isGranted(any())).thenReturn(true)
+        engine.process(screenshot("granted"))
+        runCurrent()
+        verify(screenShotHandler, times(1)).capture(any(), any())
     }
 
     // =========================================================================

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/capability/RuleCapabilityRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/capability/RuleCapabilityRepository.kt
@@ -1,0 +1,101 @@
+package cloud.trotter.dashbuddy.core.data.capability
+
+import cloud.trotter.dashbuddy.core.datastore.capability.RuleCapabilityDataSource
+import cloud.trotter.dashbuddy.domain.action.RuleAction
+import cloud.trotter.dashbuddy.domain.capability.RuleCapability
+import cloud.trotter.dashbuddy.domain.capability.RuleCapabilityGrants
+import cloud.trotter.dashbuddy.domain.di.ApplicationScope
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.stateIn
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * THE consent SSOT for rule-enabled actions (#417/#422): joins the
+ * capabilities the currently loaded rulesets enumerate (in-memory, replaced
+ * wholesale on every [reconcile]) with the persisted grant set
+ * ([RuleCapabilityDataSource]).
+ *
+ * Grants are NOT pruned when a key drops out of the enumeration: keys are
+ * content-pinned, so a stale grant can never cover a changed binding, and
+ * keeping it means a temporary ruleset swap doesn't cost the user a
+ * re-consent when the original comes back. (Replacement-survival semantics
+ * for remote bundles are #419's scope.)
+ */
+@Singleton
+class RuleCapabilityRepository @Inject constructor(
+    private val dataSource: RuleCapabilityDataSource,
+    @param:ApplicationScope scope: CoroutineScope,
+) : RuleCapabilityGrants {
+
+    /**
+     * Capabilities enabled by the CURRENTLY loaded rulesets, keyed by
+     * (ruleId, action). Set by [reconcile] before the loader swaps the
+     * compiled rules live, so the gate never sees rules without their
+     * enumeration.
+     */
+    private val enumerated =
+        MutableStateFlow<Map<Pair<String, RuleAction>, List<RuleCapability>>>(emptyMap())
+
+    override val grantedKeys: StateFlow<Set<String>> = dataSource.granted
+        .stateIn(scope, SharingStarted.Eagerly, emptySet())
+
+    override suspend fun reconcile(capabilities: List<RuleCapability>) {
+        enumerated.value = capabilities.groupBy { it.ruleId to it.action }
+        dataSource.update { granted, denied ->
+            (granted + autoGrantSelection(capabilities, denied)) to denied
+        }
+        Timber.i(
+            "RuleCapabilityRepository: reconciled %d capabilit(ies) from rule load",
+            capabilities.size,
+        )
+    }
+
+    override suspend fun isActionGranted(ruleId: String?, action: RuleAction): Boolean {
+        if (ruleId == null) return false // no provenance → not consentable
+        val keys = enumerated.value[ruleId to action]?.map { it.key }
+        val granted = try {
+            // Authoritative read at fire time — the persisted store, not a
+            // cached copy, so a revocation suppresses the very next fire.
+            dataSource.granted.first()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.e(e, "Grant read failed — denying %s for '%s' (fail closed)", action.wire, ruleId)
+            return false
+        }
+        return actionKeysCovered(keys, granted)
+    }
+}
+
+/**
+ * Auto-grant policy (#417/#422): bundled (asset-source) capabilities are
+ * granted on load so the single-user alpha has zero consent friction; any
+ * other source (CDN/fork — #192) is NEVER auto-granted and stays pending
+ * until the user approves it. An explicitly denied key is excluded — a
+ * revocation must not be silently undone by the next rule load.
+ *
+ * Pure and top-level so policy is testable without Android.
+ */
+fun autoGrantSelection(capabilities: List<RuleCapability>, denied: Set<String>): Set<String> =
+    capabilities.asSequence()
+        .filter { it.source.startsWith(RuleCapabilityGrants.ASSET_SOURCE_PREFIX) }
+        .map { it.key }
+        .filterNot { it in denied }
+        .toSet()
+
+/**
+ * ALL-keys-granted semantics (#417): when one (rule, action) pair enumerates
+ * to several capability keys (rule-level and branch-level bindings with
+ * different predicates), the fire-time effect cannot prove which definition
+ * aimed its target — so every key must be granted. Unknown pair or empty
+ * enumeration → false (fail closed).
+ */
+fun actionKeysCovered(enumeratedKeys: List<String>?, granted: Set<String>): Boolean =
+    !enumeratedKeys.isNullOrEmpty() && enumeratedKeys.all { it in granted }

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/di/CapabilityBindModule.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/di/CapabilityBindModule.kt
@@ -1,0 +1,25 @@
+package cloud.trotter.dashbuddy.core.data.di
+
+import cloud.trotter.dashbuddy.core.data.capability.RuleCapabilityRepository
+import cloud.trotter.dashbuddy.domain.capability.RuleCapabilityGrants
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+/**
+ * Binds the domain-facing consent contract (#417) to its :core:data
+ * implementation. The rule loader (`:core:pipeline`) reconciles through the
+ * interface; the side-effect engine gates through it at fire time.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class CapabilityBindModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindRuleCapabilityGrants(
+        impl: RuleCapabilityRepository,
+    ): RuleCapabilityGrants
+}

--- a/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/capability/RuleCapabilityPolicyTest.kt
+++ b/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/capability/RuleCapabilityPolicyTest.kt
@@ -1,0 +1,83 @@
+package cloud.trotter.dashbuddy.core.data.capability
+
+import cloud.trotter.dashbuddy.domain.action.RuleAction
+import cloud.trotter.dashbuddy.domain.capability.RuleCapability
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-policy tests for the consent grant store (#417): the source auto-grant
+ * selection and the ALL-keys-granted coverage semantics. The repository glue
+ * (DataStore IO) is exercised through the engine-level gate tests in `:app`.
+ */
+class RuleCapabilityPolicyTest {
+
+    private fun cap(
+        key: String,
+        source: String,
+        ruleId: String = "doordash.screen.delivery_summary_collapsed",
+        action: RuleAction = RuleAction.EXPAND_EARNINGS,
+    ) = RuleCapability(
+        ruleId = ruleId,
+        action = action,
+        targetBindName = action.targetBindName,
+        key = key,
+        source = source,
+    )
+
+    // =========================================================================
+    // autoGrantSelection — the source policy
+    // =========================================================================
+
+    @Test
+    fun `asset capabilities are auto-granted`() {
+        val selected = autoGrantSelection(
+            listOf(cap("k1", "asset:rules/doordash.json"), cap("k2", "asset:rules/uber.json")),
+            denied = emptySet(),
+        )
+        assertEquals(setOf("k1", "k2"), selected)
+    }
+
+    @Test
+    fun `non-asset sources are never auto-granted`() {
+        val selected = autoGrantSelection(
+            listOf(
+                cap("k1", "cdn:https://rules.example.com/doordash.json"),
+                cap("k2", "fork:community-rules"),
+                cap("k3", "unknown"),
+            ),
+            denied = emptySet(),
+        )
+        assertTrue(selected.isEmpty())
+    }
+
+    @Test
+    fun `an explicitly denied key is excluded from auto-grant`() {
+        val selected = autoGrantSelection(
+            listOf(cap("k1", "asset:rules/doordash.json"), cap("k2", "asset:rules/doordash.json")),
+            denied = setOf("k2"),
+        )
+        assertEquals(setOf("k1"), selected)
+    }
+
+    // =========================================================================
+    // actionKeysCovered — ALL-keys-granted semantics
+    // =========================================================================
+
+    @Test
+    fun `coverage requires every enumerated key to be granted`() {
+        // Two binding definitions for the same (rule, action): the fire-time
+        // effect cannot prove which one aimed its target, so both must be
+        // granted before the action may fire.
+        assertFalse(actionKeysCovered(listOf("k1", "k2"), granted = setOf("k1")))
+        assertTrue(actionKeysCovered(listOf("k1", "k2"), granted = setOf("k1", "k2")))
+    }
+
+    @Test
+    fun `unknown or empty enumeration is not covered - fail closed`() {
+        assertFalse(actionKeysCovered(null, granted = setOf("k1")))
+        assertFalse(actionKeysCovered(emptyList(), granted = setOf("k1")))
+    }
+}

--- a/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/capability/RuleCapabilityDataSource.kt
+++ b/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/capability/RuleCapabilityDataSource.kt
@@ -1,0 +1,57 @@
+package cloud.trotter.dashbuddy.core.datastore.capability
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringSetPreferencesKey
+import cloud.trotter.dashbuddy.core.datastore.di.RuleCapabilityPreferences
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Persistence for rule-capability consent (#417/#422): the set of granted
+ * capability keys (`RuleCapability.key` — content-pinned sha256 hashes) and
+ * the set the user has explicitly denied.
+ *
+ * Grants are keyed by content, not rule id, so they survive reloads of an
+ * unchanged ruleset and *stop covering* a rule whose binding definition
+ * changed — that re-consent property is the point of the key (#422). Denials
+ * are stored separately so a future revocation (consent UI, #422 PR 3) is
+ * not silently undone by the next load's auto-grant pass.
+ */
+@Singleton
+class RuleCapabilityDataSource @Inject constructor(
+    @param:RuleCapabilityPreferences private val ds: DataStore<Preferences>,
+) {
+    private object Keys {
+        val GRANTED = stringSetPreferencesKey("granted_capability_keys")
+        val DENIED = stringSetPreferencesKey("denied_capability_keys")
+    }
+
+    /** Granted capability keys; the fire-time gate reads this (fail closed when absent). */
+    val granted: Flow<Set<String>> = ds.data.map { it[Keys.GRANTED] ?: emptySet() }
+
+    /** Explicitly denied capability keys; auto-grant never overrides these. */
+    val denied: Flow<Set<String>> = ds.data.map { it[Keys.DENIED] ?: emptySet() }
+
+    /**
+     * Atomically transform both sets in ONE DataStore edit (#364 lesson:
+     * read-modify-write must happen inside the edit so concurrent updates
+     * can't interleave). [transform] receives the currently-saved sets and
+     * returns the new (granted, denied) pair.
+     */
+    suspend fun update(
+        transform: (granted: Set<String>, denied: Set<String>) -> Pair<Set<String>, Set<String>>,
+    ) {
+        ds.edit { prefs ->
+            val (newGranted, newDenied) = transform(
+                prefs[Keys.GRANTED] ?: emptySet(),
+                prefs[Keys.DENIED] ?: emptySet(),
+            )
+            prefs[Keys.GRANTED] = newGranted
+            prefs[Keys.DENIED] = newDenied
+        }
+    }
+}

--- a/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/di/DataStoreModule.kt
+++ b/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/di/DataStoreModule.kt
@@ -51,4 +51,10 @@ object DataStoreModule {
     @PlatformPreferences
     fun providePlatformDataStore(@ApplicationContext context: Context): DataStore<Preferences> =
         PreferenceDataStoreFactory.create { context.preferencesDataStoreFile("platform_prefs") }
+
+    @Provides
+    @Singleton
+    @RuleCapabilityPreferences
+    fun provideRuleCapabilityDataStore(@ApplicationContext context: Context): DataStore<Preferences> =
+        PreferenceDataStoreFactory.create { context.preferencesDataStoreFile("rule_capability_grants") }
 }

--- a/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/di/DataStoreQualifiers.kt
+++ b/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/di/DataStoreQualifiers.kt
@@ -25,3 +25,7 @@ annotation class StrategyPreferences
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class PlatformPreferences
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class RuleCapabilityPreferences

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/JsonRuleInterpreter.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/JsonRuleInterpreter.kt
@@ -1,10 +1,13 @@
 package cloud.trotter.dashbuddy.core.pipeline.rules
 
 import android.content.Context
+import cloud.trotter.dashbuddy.domain.capability.RuleCapability
+import cloud.trotter.dashbuddy.domain.capability.RuleCapabilityGrants
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
 import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.int
 import kotlinx.serialization.json.jsonArray
@@ -25,10 +28,17 @@ import javax.inject.Singleton
  * - File size ≤ [MAX_FILE_BYTES] (1 MB) per file
  * - [RuleCompiler.MAX_DEPTH] caps nesting depth during compilation
  * - [RuleCompiler.MAX_REGEX_LENGTH] caps regex patterns during compilation
+ *
+ * Consent (#417): each load enumerates the action capabilities the bundle's
+ * target bindings enable and reconciles them into [RuleCapabilityGrants]
+ * BEFORE the compiled rules go live — by the time a frame can classify, the
+ * grant store already reflects the bundle (asset sources auto-grant; remote
+ * sources never do).
  */
 @Singleton
 class JsonRuleInterpreter @Inject constructor(
     @param:ApplicationContext private val context: Context,
+    private val capabilityGrants: RuleCapabilityGrants,
 ) {
 
     /**
@@ -61,7 +71,7 @@ class JsonRuleInterpreter @Inject constructor(
     )
 
     /** Load all bundled rule files from `assets/rules/`. */
-    fun loadDefaults() {
+    suspend fun loadDefaults() {
         try {
             val files = context.assets.list(RULES_DIR)
                 ?.filter { it.endsWith(".json") }
@@ -75,6 +85,7 @@ class JsonRuleInterpreter @Inject constructor(
             val allScreens = mutableListOf<CompiledRule<UiNode>>()
             val allClicks = mutableListOf<CompiledRule<UiNode>>()
             val allNotifications = mutableListOf<CompiledRule<RawNotificationData>>()
+            val perFile = mutableListOf<Pair<String, CompiledRuleBundle>>() // path → bundle
             val seenRuleIds = mutableMapOf<String, String>() // ruleId → first source path
             var lastFormatVersion: Int? = null
 
@@ -82,6 +93,7 @@ class JsonRuleInterpreter @Inject constructor(
                 val path = "$RULES_DIR/$fileName"
                 val json = context.assets.open(path).bufferedReader().readText()
                 val result = loadSingle(json, source = path) ?: continue
+                perFile += path to result
 
                 // Collision detection (C3): warn if any rule ID appears in multiple files
                 val newIds = result.screens.map { it.id } +
@@ -120,6 +132,21 @@ class JsonRuleInterpreter @Inject constructor(
                 )
                 allScreens.filterNot { Platform.fromRuleId(it.id) in uncovered }
             }
+
+            // Consent reconcile (#417), BEFORE the swap goes live. Enumerated
+            // from the EFFECTIVE rules — a platform excluded by the sensitive
+            // check must not have its capabilities granted either. Source is
+            // stamped per file so provenance survives the merge.
+            reconcileCapabilities(
+                perFile.flatMap { (path, bundle) ->
+                    val liveScreens =
+                        bundle.screens.filterNot { Platform.fromRuleId(it.id) in uncovered }
+                    RuleCompiler.enumerateCapabilities(
+                        liveScreens + bundle.clicks + bundle.notifications,
+                        source = "${RuleCapabilityGrants.ASSET_SOURCE_PREFIX}$path",
+                    )
+                },
+            )
 
             current = LoadedRulesets(
                 screens = Ruleset(effectiveScreens),
@@ -190,15 +217,40 @@ class JsonRuleInterpreter @Inject constructor(
     /**
      * Load a single ruleset and replace all current rules.
      * Kept for backward compatibility with CDN hot-reload path.
+     *
+     * [source] is NOT asset-prefixed here, so nothing a remote caller loads
+     * is ever auto-granted (#417) — its capabilities reconcile as pending.
      */
-    fun load(jsonString: String, source: String = "unknown") {
+    suspend fun load(jsonString: String, source: String = "unknown") {
         val result = loadSingle(jsonString, source) ?: return
+        reconcileCapabilities(
+            RuleCompiler.enumerateCapabilities(
+                result.screens + result.clicks + result.notifications,
+                source = source,
+            ),
+        )
         current = LoadedRulesets(
             screens = Ruleset(result.screens),
             clicks = Ruleset(result.clicks),
             notifications = Ruleset(result.notifications),
             formatVersion = result.formatVersion,
         )
+    }
+
+    /**
+     * Reconcile failure degrades ACTUATION only, never recognition: the gate
+     * denies ungranted actions (fail closed) while the rules still load and
+     * classify. Throwing here would instead kill the whole rule load — a
+     * datastore hiccup must not blind the app.
+     */
+    private suspend fun reconcileCapabilities(capabilities: List<RuleCapability>) {
+        try {
+            capabilityGrants.reconcile(capabilities)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.e(e, "JsonRuleInterpreter: capability reconcile failed — automation taps stay denied")
+        }
     }
 
     /** Result of compiling a single rule file. */

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/AppEffect.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/AppEffect.kt
@@ -1,5 +1,6 @@
 package cloud.trotter.dashbuddy.core.state
 
+import cloud.trotter.dashbuddy.domain.action.ActionTrigger
 import cloud.trotter.dashbuddy.domain.action.RuleAction
 import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
 import cloud.trotter.dashbuddy.domain.state.Platform
@@ -99,13 +100,17 @@ sealed class AppEffect {
      * against the live tree scoped to the platform's package and verifies the
      * node against the action's app-owned expectation before clicking.
      * [sourceRuleId] is the rule that supplied the binding — consent-gate
-     * provenance (#422/#417).
+     * provenance (#422/#417). [trigger] records who initiated the fire: an
+     * AUTOMATION fire must be covered by a granted capability at the engine's
+     * consent gate, while a USER fire is its own consent (#417); integrity
+     * checks (tier, package, label, throttle) apply to both.
      */
     data class PerformRuleAction(
         val action: RuleAction,
         val platform: Platform,
         val targetRef: NodeRef,
         val sourceRuleId: String?,
+        val trigger: ActionTrigger,
     ) : AppEffect()
 
     /** A rule-originated side effect. */

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -1,5 +1,6 @@
 package cloud.trotter.dashbuddy.core.state
 
+import cloud.trotter.dashbuddy.domain.action.ActionTrigger
 import cloud.trotter.dashbuddy.domain.action.RuleAction
 import cloud.trotter.dashbuddy.domain.model.chat.ChatPersona
 import cloud.trotter.dashbuddy.domain.model.event.AppEvent
@@ -207,7 +208,14 @@ class EffectMap @Inject constructor() {
             if (platform != null && offer != null && action != null) {
                 val target = offer.targets[action.targetBindName]
                 if (target != null) {
-                    add(AppEffect.PerformRuleAction(action, platform, target, offer.sourceRuleId))
+                    // USER trigger: the dasher pressed Accept/Decline — that
+                    // press is the consent for this fire (#417).
+                    add(
+                        AppEffect.PerformRuleAction(
+                            action, platform, target, offer.sourceRuleId,
+                            trigger = ActionTrigger.USER,
+                        ),
+                    )
                 } else {
                     Timber.w(
                         "No '%s' target bound for %s — %s unavailable, leaving it to the user",
@@ -802,6 +810,9 @@ class EffectMap @Inject constructor() {
                 platform = platform,
                 targetRef = deferred.target,
                 sourceRuleId = deferred.ruleId,
+                // The app decided this tap on its own — it must be covered by
+                // a granted capability at the engine's consent gate (#417).
+                trigger = ActionTrigger.AUTOMATION,
             ),
         )
     }

--- a/docs/design/rule-capability-consent.md
+++ b/docs/design/rule-capability-consent.md
@@ -1,9 +1,13 @@
 # Design: action targets, capabilities + load-time consent
 
 **Status:** layers 1–3 and the capability refit implemented by #425 (2026-06-11);
-the grant store + execution gate remain #417, the consent UI is #422 PR 3.
-Supersedes the original draft of this doc (f9193c7, reconciled 51c58e1) and the
-closed #85 ("GigPlatform interface") — see *History* at the bottom.
+the grant store + execution gate implemented by #417 (2026-06-12): asset
+auto-grant on load, AUTOMATION fires gated by (sourceRuleId, action) →
+all-enumerated-keys-granted lookup, USER fires are their own consent, and the
+OS tier check is real (live service handle / runtime permission). The consent
+UI is #422 PR 3. Supersedes the original draft of this doc (f9193c7,
+reconciled 51c58e1) and the closed #85 ("GigPlatform interface") — see
+*History* at the bottom.
 
 ## The model: three layers
 

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -63,6 +63,15 @@ immediately (no second pass needed) so it gets triaged.
 _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **broken** on the
 2026-06-09 dash — moved to that session's log entry below for triage.)_
 
+- **Consent gate is live — bound-target taps must still fire (#417).**
+  The always-true permission stub is gone: automation taps (the post-delivery expand chevron)
+  now require a granted capability key, and bundled rules are auto-granted at rule load.
+  Working = expand auto-tap and bubble/notification Accept/Decline behave exactly as before
+  (no regression — asset rules auto-grant covers them). Broken = a tap silently stops
+  happening and the log shows `Denied expand_earnings — no granted capability` or
+  `ACCESSIBILITY tier not granted` while the service is clearly running — capture logcat.
+  - Confirmed: 0/2
+
 - **Uber sensitive screens now blocked + UNKNOWN-capture scrub (#432).**
   Uber finally has matcher-layer sensitive rules (wallet / Instant Pay / cash-out / bank /
   identity). On a dash, briefly open Uber's earnings/wallet area: working = the app treats it

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/action/ActionTrigger.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/action/ActionTrigger.kt
@@ -1,0 +1,19 @@
+package cloud.trotter.dashbuddy.domain.action
+
+/**
+ * Who initiated a [RuleAction] fire (#417/#422).
+ *
+ * Consent is asymmetric by design: a tap the dasher just asked for (a bubble
+ * or own-notification button) IS the consent for that fire, while a tap the
+ * app decided to make on its own must be covered by a persisted,
+ * content-pinned capability grant (`RuleCapability.key`). The executor's
+ * integrity checks — OS tier, package scope, label verification, throttle —
+ * apply to BOTH; provenance never skips them.
+ */
+enum class ActionTrigger {
+    /** The dasher explicitly requested this fire (HUD / own-notification tap). */
+    USER,
+
+    /** The app initiated this fire itself (e.g. the deferred expand tap). */
+    AUTOMATION,
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/capability/RuleCapabilityGrants.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/capability/RuleCapabilityGrants.kt
@@ -1,0 +1,62 @@
+package cloud.trotter.dashbuddy.domain.capability
+
+import cloud.trotter.dashbuddy.domain.action.RuleAction
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * The consent state for rule-enabled actions (#417/#422): which
+ * [RuleCapability] keys the user has granted, joined with the capabilities
+ * the currently loaded rulesets enumerate.
+ *
+ * This is the read/reconcile contract the rule loader and the side-effect
+ * engine see; the implementation (`:core:data`) persists grants in
+ * `:core:datastore` and holds the enumeration in memory. The consent UI
+ * (#422 PR 3) builds on the same store.
+ *
+ * Fail-closed posture (dev principle 6): an action whose capability cannot
+ * be positively resolved to a granted key — unknown rule, missing
+ * enumeration, unreadable store — does not fire.
+ */
+interface RuleCapabilityGrants {
+
+    /**
+     * Reactive set of granted capability keys. Revocation (#422 PR 3)
+     * surfaces here immediately; the fire-time gate reads the persisted
+     * store, so a revoked key suppresses the very next fire.
+     */
+    val grantedKeys: StateFlow<Set<String>>
+
+    /**
+     * Publish the capabilities the just-loaded rulesets enable — REPLACING
+     * the previous enumeration — and apply the source auto-grant policy:
+     * capabilities from a bundled asset source ([ASSET_SOURCE_PREFIX]) are
+     * granted unless explicitly denied; any other source (CDN/fork, #192)
+     * is never auto-granted and stays pending until the user approves it.
+     *
+     * Called by the rule loader BEFORE the compiled rules go live, so by the
+     * time a frame can classify (and an action can fire) the grant store
+     * already reflects the bundle.
+     */
+    suspend fun reconcile(capabilities: List<RuleCapability>)
+
+    /**
+     * Fire-time gate lookup (#417), keyed by the `sourceRuleId` + action that
+     * ride the effect — authoritative state, never threaded fields. True iff
+     * the pair resolves to at least one enumerated capability AND every
+     * enumerated key for the pair is granted (the effect cannot prove which
+     * binding definition aimed its target, so all of them must be covered).
+     *
+     * A null [ruleId] (no provenance) is never granted.
+     */
+    suspend fun isActionGranted(ruleId: String?, action: RuleAction): Boolean
+
+    companion object {
+        /**
+         * Source-string prefix marking bundled rule files
+         * (`asset:rules/doordash.json`) — the only source the auto-grant
+         * policy accepts. SSOT for both the loader (which stamps sources)
+         * and the grant policy (which checks them).
+         */
+        const val ASSET_SOURCE_PREFIX = "asset:"
+    }
+}


### PR DESCRIPTION
Closes #417 (the `isPermissionGranted` always-true stub — S2 from the 2026-06-11 rule-engine security audit). Implements the grant-store + execution-gate half of `docs/design/rule-capability-consent.md`; the consent UI remains #422 PR 3.

## What changed

**OS tier check is real.** New `PermissionTierChecker` (`:app`) backs each `PermissionTier` onto the state that actually carries it: ACCESSIBILITY = the live accessibility-service handle, LOCATION = the runtime `ACCESS_FINE_LOCATION` grant checked live, AUDIO/NONE structurally granted (Android has no runtime permission for TTS output — the "may DashBuddy speak" consent is app-level, #422 PR 3/#428). Used by both the `PerformRuleAction` arm and rule-verb dispatch.

**Capability grant gate.** Per the #422/#425 design:
- `:domain` — `RuleCapabilityGrants` contract + `ActionTrigger` (USER / AUTOMATION) provenance enum.
- `:core:datastore` — seventh store `rule_capability_grants`: granted + denied capability-key sets, single atomic edit (#364 pattern).
- `:core:data` — `RuleCapabilityRepository`, the consent SSOT: in-memory enumeration of the currently loaded rulesets × persisted grants. Asset-source auto-grant (denial-aware, so a future revocation is never silently undone); **ALL-keys-granted** coverage when one (rule, action) enumerates several binding definitions (the fire can't prove which definition aimed its target); authoritative store read at fire time so a revocation suppresses the very next fire. Grants are content-pinned, so they're not pruned on reload (a stale grant can't cover a changed binding by construction; replacement semantics for remote bundles stay #419).
- `:core:pipeline` — `JsonRuleInterpreter` enumerates capabilities per file (`asset:rules/<file>`) and reconciles them **before** the volatile ruleset swap goes live, so there is no startup window where a frame can classify before grants land. Platforms excluded by the #432 sensitive-coverage check do not enumerate. Reconcile failure degrades actuation only (gate denies), never recognition. The CDN-path `load()` passes its source through un-prefixed → nothing remote ever auto-grants.
- `:core:state` — `PerformRuleAction` carries `trigger`; EffectMap marks the HUD/own-notification accept-decline site USER and the deferred-expand site AUTOMATION.
- `SideEffectEngine` — the seam: throttle → live tier check → (AUTOMATION only) grant lookup by `(sourceRuleId, action)` → package/label-verified click. Stub deleted.

## Security/privacy posture (principle 6)

- **Trusted:** the app-owned `RuleAction` registry, `PermissionTierChecker`, the grant policy, and tap-time verification — none of it influenced by ruleset content.
- **Untrusted:** ruleset bindings (future-CDN, #192). They can only *aim*; whether a tap fires is now gated by OS tier + content-pinned grant (automation) or explicit dasher input (user), and the resolved node is still package-scoped + label-verified at tap time.
- **Fail closed everywhere:** null `sourceRuleId`, unknown (rule, action), partially granted key sets, unreadable grant store, missing service handle, revoked runtime permission — all deny and log; the dasher acts manually.
- **No behavior change for the bundled build:** asset rules auto-grant at load, so expand auto-tap and Accept/Decline work exactly as before (field-test checklist item added at 0/2).

## Tests

- 5 new `SideEffectEngineTest` gate tests: AUTOMATION denied without grant / fires with grant, USER never consults the grant store, denied tier blocks USER fires too, rule-verb dispatch consults the real checker.
- 5 pure policy tests (`:core:data`): asset-only auto-grant, denial exclusion, ALL-keys coverage, fail-closed empty/unknown enumeration.
- EffectMap tests pin trigger provenance per emission site.
- Full `testDebugUnitTest` green locally.

## Context updates (per CLAUDE.md)

- CLAUDE.md: datastore store count, SideEffectEngine description, principle 6 capability-gates bullet rewritten (stub note removed).
- `docs/design/rule-capability-consent.md` status header updated.
- Field-test checklist: new #417 watch item (taps must keep firing; watch for spurious `Denied … no granted capability`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)