### PR TITLE
fix(state): defer PostTask task completion behind the authoritative grace (#431 pt 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,7 +151,7 @@ registry (`:domain`) consumes — see `docs/design/rule-capability-consent.md`.
 
 Observations reduce into `AppState(regions)` (`:domain`): **`FlowRegion`** (R0 — ground-truth
 screen interpretation; holds the pending offer), one **`PlatformRegion`** per platform
-(session/task lifecycle; unified grace via `pendingDestructive` — destructive commits are graced, incl. a short authoritative window for the dash summary, and woken by `GRACE_COMMIT` timers, #431), and **`CrossPlatformRegion`**
+(session/task lifecycle; unified grace via `pendingDestructive` — destructive commits are graced, incl. short authoritative windows for the dash summary AND the delivery receipt, and woken by `GRACE_COMMIT` timers, #431), and **`CrossPlatformRegion`**
 (derived aggregates). The steppers (`FlowRegionStepper`, `PlatformRegionStepper`,
 `CrossPlatformRegionStepper`) are pure and driven by `obs.timestamp` — never a wall clock — so
 crash recovery can replay observations over the last snapshot. `StateManagerV2` hosts the

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
@@ -15,11 +15,13 @@ import cloud.trotter.dashbuddy.domain.pipeline.RequestedEffect
 import cloud.trotter.dashbuddy.domain.pipeline.TimeoutType
 import cloud.trotter.dashbuddy.domain.pipeline.TransitionTrigger
 import cloud.trotter.dashbuddy.domain.state.AppState
+import cloud.trotter.dashbuddy.domain.state.DestructiveKind
 import cloud.trotter.dashbuddy.domain.state.Flow
 import cloud.trotter.dashbuddy.domain.state.FlowRegion
 import cloud.trotter.dashbuddy.domain.state.Mode
 import cloud.trotter.dashbuddy.domain.state.OfferIntent
 import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import cloud.trotter.dashbuddy.domain.state.PendingDestructive
 import cloud.trotter.dashbuddy.domain.state.PendingOffer
 import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.domain.state.PlatformRegion
@@ -712,9 +714,87 @@ class EffectMapTest {
         )
     }
 
+    @Test
+    fun `leaving PostTask with the task still in retire grace emits DELIVERY_COMPLETED for it (#431)`() {
+        // #431 pt 2: the delivered task stays ACTIVE through the receipt grace,
+        // so on PostTask exit recentTasks does NOT yet contain it. The event
+        // must name the still-active task, stamped at the receipt's appearance.
+        val (platform, _) = stateWithPlatform()
+        val session = Session("sess-1", startedAt = 100L)
+        val active = Task(taskId = "task-9", jobId = "job-1", phase = TaskPhase.DROPOFF, storeName = "Chipotle", startedAt = 900L)
+        val pend = PendingDestructive(
+            kind = DestructiveKind.TASK_RETIRE, since = 950L, deadline = 3_450L, authoritative = true,
+        )
+        val prev = AppState(regions = Regions(
+            flow = FlowRegion(flow = Flow.PostTask),
+            platforms = mapOf(platform to PlatformRegion(
+                platform, mode = Mode.Online, session = session,
+                activeTask = active, pendingDestructive = pend,
+            )),
+        ))
+        val next = AppState(regions = Regions(
+            flow = FlowRegion(flow = Flow.Idle),
+            platforms = mapOf(platform to PlatformRegion(
+                platform, mode = Mode.Online, session = session,
+                activeTask = active, pendingDestructive = pend,
+            )),
+        ))
+
+        val effects = effectMap.diff(prev, next, screenObs(flow = Flow.Idle))
+        assertTrue(
+            "DELIVERY_COMPLETED must fire for the deferred (still-active) task",
+            effects.logEventTypes().contains(AppEventType.DELIVERY_COMPLETED),
+        )
+    }
+
     // =========================================================================
     // POST-TASK ANNOUNCEMENT (single-bubble, per-task idempotency)
     // =========================================================================
+
+    @Test
+    fun `deferred receipt announces exactly once across collapsed and expanded frames (#431)`() {
+        // Under the receipt grace the completing task is still ACTIVE on every
+        // PostTask frame. Frame 1 announces; the stepper stamps the gate with
+        // the SAME id the diff resolved, so the expanded re-observation cannot
+        // double-fire (the old recentTasks-only stamp lagged by one frame).
+        val (platform, _) = stateWithPlatform()
+        val session = Session("sess-1", startedAt = 100L)
+        val active = Task(taskId = "task-1", jobId = "job-1", phase = TaskPhase.DROPOFF, storeName = "Chipotle", startedAt = 900L)
+        fun regionWith(announced: String?) = PlatformRegion(
+            platform, mode = Mode.Online, session = session,
+            activeTask = active,
+            pendingDestructive = PendingDestructive(
+                kind = DestructiveKind.TASK_RETIRE, since = 950L, deadline = 3_450L, authoritative = true,
+            ),
+            lastAnnouncedPostTaskTaskId = announced,
+        )
+        val beforeFirst = AppState(regions = Regions(
+            flow = FlowRegion(flow = Flow.PostTask),
+            platforms = mapOf(platform to regionWith(announced = null)),
+        ))
+        val afterFirst = AppState(regions = Regions(
+            flow = FlowRegion(flow = Flow.PostTask),
+            platforms = mapOf(platform to regionWith(announced = "task-1")),
+        ))
+
+        val first = effectMap.diff(beforeFirst, afterFirst, screenObs(
+            flow = Flow.PostTask,
+            parsed = ParsedFields.PostTaskFields(totalPay = 7.50, parsedPay = null),
+        ))
+        assertEquals(
+            "first sighting announces",
+            1, first.filterIsInstance<AppEffect.UpdateBubble>().count { it.text.contains("Saved") },
+        )
+
+        val second = effectMap.diff(afterFirst, afterFirst, screenObs(
+            flow = Flow.PostTask,
+            parsed = ParsedFields.PostTaskFields(totalPay = 7.50, parsedPay = null),
+        ))
+        assertTrue(
+            "the expanded re-observation must NOT re-announce",
+            second.filterIsInstance<AppEffect.UpdateBubble>().none { it.text.contains("Saved") },
+        )
+    }
 
     @Test
     fun `collapsed-only PostTask emits single minimal Saved bubble`() {

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/state/StateMachineTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/state/StateMachineTest.kt
@@ -810,19 +810,50 @@ class StateMachineTest {
     }
 
     @Test
-    fun `task completed on PostTask`() {
+    fun `task completes after the receipt grace - not on the PostTask frame (#431)`() {
         var state = setupOnlineWithPickup()
 
-        // Complete delivery
+        // Complete delivery — the receipt frame arms the short retire grace.
         state = machine.step(state, screenObs(
             flow = Flow.PostTask,
             parsed = ParsedFields.PostTaskFields(totalPay = 7.50),
         )).newState
 
-        val dd = state.regions.platforms[Platform.DoorDash]!!
-        assertNull(dd.activeTask) // task completed
+        var dd = state.regions.platforms[Platform.DoorDash]!!
+        assertNotNull("the task survives the receipt frame", dd.activeTask)
+        assertEquals(DestructiveKind.TASK_RETIRE, dd.pendingDestructive?.kind)
+        assertTrue(dd.pendingDestructive!!.authoritative)
+
+        // Past the deadline (the GRACE_COMMIT timer in production; any later
+        // observation commits via lazy expiry here).
+        state = machine.step(state, screenObs(flow = Flow.Idle, timestamp = tick(3000))).newState
+
+        dd = state.regions.platforms[Platform.DoorDash]!!
+        assertNull("expiry completed the task", dd.activeTask)
+        assertNull(dd.pendingDestructive)
         assertTrue(dd.recentTasks.isNotEmpty())
         assertNotNull(dd.recentTasks.last().completedAt)
+    }
+
+    @Test
+    fun `GRACE_COMMIT timeout commits the pending task retire (#431)`() {
+        var state = setupOnlineWithPickup()
+        state = machine.step(state, screenObs(
+            flow = Flow.PostTask,
+            parsed = ParsedFields.PostTaskFields(totalPay = 7.50),
+        )).newState
+        val deadline = state.regions.platforms[Platform.DoorDash]!!.pendingDestructive!!.deadline
+
+        state = machine.step(state, timeoutObs(
+            type = TimeoutType.GRACE_COMMIT,
+            timestamp = deadline + 1,
+            targetPlatform = Platform.DoorDash,
+        )).newState
+
+        val dd = state.regions.platforms[Platform.DoorDash]!!
+        assertNull("the timer commit retired the task", dd.activeTask)
+        assertNull(dd.pendingDestructive)
+        assertTrue(dd.recentTasks.any { it.completedAt != null })
     }
 
     @Test

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -262,12 +262,21 @@ class EffectMap @Inject constructor() {
                     addAll(taskCompletedOverride)
                 } else {
                     val sessionId = next.session?.sessionId ?: p.session?.sessionId
-                    val completedTask = next.recentTasks.lastOrNull()
+                    // The delivered task may still be ACTIVE on PostTask exit —
+                    // its retire grace commits up to ~2.5s later (#431 pt 2).
+                    // Prefer it (same-id guard: a stacked next-task frame mints
+                    // a NEW activeTask on this same exit, which must not be the
+                    // one we report); fall back to the last committed task.
+                    val completedTask = next.activeTask
+                        ?.takeIf { it.taskId == p.activeTask?.taskId }
+                        ?: next.recentTasks.lastOrNull()
                     if (completedTask != null) {
+                        val retireSince = p.pendingDestructive
+                            ?.takeIf { it.kind == DestructiveKind.TASK_RETIRE }?.since
                         val payload = deliveryCompletedPayload(
                             task = completedTask,
                             jobId = p.activeJob?.jobId,
-                            completedAt = obs.timestamp,
+                            completedAt = completedTask.completedAt ?: retireSince ?: obs.timestamp,
                             postTaskFields = p.lastPostTaskFields,
                             sessionEarnings = next.session?.runningEarnings ?: p.session?.runningEarnings,
                         )
@@ -671,7 +680,12 @@ class EffectMap @Inject constructor() {
         val flowObs = obs as? Observation.FlowObservation ?: return emptyList()
         val parsed = flowObs.parsed as? ParsedFields.PostTaskFields ?: return emptyList()
 
-        val taskId = next.recentTasks.lastOrNull()?.taskId ?: return emptyList()
+        // The completing task stays ACTIVE while its retire grace is pending
+        // (#431 pt 2) — resolve it first, falling back to the last committed
+        // task. Must mirror the stepper's lastAnnouncedPostTaskTaskId stamp.
+        val taskId = next.activeTask?.taskId
+            ?: next.recentTasks.lastOrNull()?.taskId
+            ?: return emptyList()
         if (prev.lastAnnouncedPostTaskTaskId == taskId) return emptyList()
         if (parsed.totalPay <= 0) return emptyList()
 

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
@@ -388,10 +388,14 @@ class PlatformRegionStepper @Inject constructor() {
             is ParsedFields.PostTaskFields -> {
                 val payHash = parsed.parsedPay?.hashCode()
                 // Stamp the per-task announcement gate so EffectMap.diffPostTask
-                // can detect "first time seeing PostTask for this taskId" by
-                // comparing prev region's value to the current taskId. The
-                // currently-completing task is at recentTasks.lastOrNull().
-                val postTaskTaskId = r.recentTasks.lastOrNull()?.taskId
+                // can detect "first time seeing PostTask for this taskId". The
+                // completing task is the still-active one while its retire
+                // grace is pending (#431 pt 2), falling back to the last
+                // committed task. MUST be the same resolution diffPostTask
+                // uses — the old recentTasks-only stamp lagged the commit by
+                // one frame and double-fired the receipt bubble on the
+                // expanded re-observation.
+                val postTaskTaskId = r.activeTask?.taskId ?: r.recentTasks.lastOrNull()?.taskId
                 r = r.copy(
                     lastPostTaskPayHash = payHash,
                     lastPostTaskFields = parsed,
@@ -574,8 +578,14 @@ class PlatformRegionStepper @Inject constructor() {
                 isStackedPickupTransition ||
                 isStackedDropoffTransition
             ) {
-                // New task (different phase, no active task, or stacked-pickup transition)
-                val completedTask = currentTask?.copy(completedAt = obs.timestamp)
+                // New task (different phase, no active task, or stacked-pickup transition).
+                // The displaced task commits inline; if a TASK_RETIRE grace was
+                // pending (receipt or idle already signalled its end, #431 pt 2)
+                // the honest completion time is that signal's appearance, not
+                // this new task's first frame.
+                val retireSince = region.pendingDestructive
+                    ?.takeIf { it.kind == DestructiveKind.TASK_RETIRE }?.since
+                val completedTask = currentTask?.copy(completedAt = retireSince ?: obs.timestamp)
                 val recentTasks = if (completedTask != null) {
                     (region.recentTasks + completedTask).takeLast(MAX_RECENT_TASKS)
                 } else region.recentTasks
@@ -624,15 +634,37 @@ class PlatformRegionStepper @Inject constructor() {
             )
         }
 
-        // PostTask → complete active task (authoritative; clears any pending grace)
+        // PostTask → the receipt is authoritative for "this task is done", but
+        // it no longer completes the task on the spot (#431 pt 2): one
+        // misrecognized receipt frame mid-dropoff used to retire the live task
+        // irrecoverably. Arm (or tighten) a SHORT authoritative TASK_RETIRE
+        // grace instead — a contradicting task-flow frame inside the window
+        // cancels it (misrecognition flap), expiry commits via the GRACE_COMMIT
+        // timer / lazy expiry, and a stacked next-task frame commits it inline
+        // at mint (above). Replacing a pending SESSION_END here preserves the
+        // pre-#431 contract that a receipt-with-active-task reads as "still
+        // dashing" (single-slot pending — noted on the issue).
         val postTask = region.activeTask
         if (nextFlowVal == Flow.PostTask && postTask != null) {
-            val completedTask = postTask.copy(completedAt = obs.timestamp)
-            return region.copy(
-                activeTask = null,
-                recentTasks = (region.recentTasks + completedTask).takeLast(MAX_RECENT_TASKS),
-                pendingDestructive = null,
-            )
+            val newDeadline = obs.timestamp + policy.authoritativeGraceMs
+            val existing = region.pendingDestructive
+            val pend = if (existing?.kind == DestructiveKind.TASK_RETIRE) {
+                // Already armed (idle-grace, or an earlier receipt frame) —
+                // tighten to the short window; the earliest destructive signal
+                // stays the honest completion time.
+                existing.copy(
+                    deadline = minOf(existing.deadline, newDeadline),
+                    authoritative = true,
+                )
+            } else {
+                PendingDestructive(
+                    kind = DestructiveKind.TASK_RETIRE,
+                    since = obs.timestamp,
+                    deadline = newDeadline,
+                    authoritative = true,
+                )
+            }
+            return region.copy(pendingDestructive = pend)
         }
 
         // Leaving a task flow to idle/offer while online → do NOT retire the task

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/TaskLifecycleGuardTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/TaskLifecycleGuardTest.kt
@@ -141,16 +141,84 @@ class TaskLifecycleGuardTest {
     }
 
     @Test
-    fun `PostTask completes the task and clears a pending grace`() {
+    fun `PostTask arms a short authoritative retire grace - not an immediate completion (#431)`() {
         val r0 = region(
             pickupTask("task-A", "H-E-B", arrivedAt = 800L),
             pending = PendingDestructive(DestructiveKind.TASK_RETIRE, since = 800L, deadline = 11_000L),
         )
         val (r1, _) = step(r0, FlowRegion(flow = Flow.Idle), postTaskObs(timestamp = 1_005L))
 
-        assertNull("PostTask is authoritative — the task completes", r1.activeTask)
-        assertNull(r1.pendingDestructive)
-        assertTrue(r1.recentTasks.any { it.taskId == "task-A" && it.completedAt != null })
+        assertNotNull("the task survives the receipt frame (#431 pt 2)", r1.activeTask)
+        assertEquals("task-A", r1.activeTask?.taskId)
+        val pend = r1.pendingDestructive!!
+        assertEquals(DestructiveKind.TASK_RETIRE, pend.kind)
+        assertTrue("receipt arm is authoritative", pend.authoritative)
+        assertEquals(
+            "an existing idle-grace tightens to the short window",
+            1_005L + TransitionPolicy.AUTHORITATIVE_GRACE_MS, pend.deadline,
+        )
+        assertEquals("the earliest destructive signal stays the honest end time", 800L, pend.since)
+        assertTrue("nothing committed yet", r1.recentTasks.isEmpty())
+    }
+
+    @Test
+    fun `fresh PostTask arms TASK_RETIRE stamped at the receipt's appearance`() {
+        val r0 = region(dropoffTask("task-A", customerAddressHash = "cust-1", arrivedAt = 800L))
+        val (r1, _) = step(r0, FlowRegion(flow = Flow.TaskDropoffArrived), postTaskObs(timestamp = 1_005L))
+
+        assertEquals("task-A", r1.activeTask?.taskId)
+        val pend = r1.pendingDestructive!!
+        assertEquals(DestructiveKind.TASK_RETIRE, pend.kind)
+        assertTrue(pend.authoritative)
+        assertEquals(1_005L, pend.since)
+        assertEquals(1_005L + TransitionPolicy.AUTHORITATIVE_GRACE_MS, pend.deadline)
+    }
+
+    @Test
+    fun `a task-flow frame inside the receipt grace cancels the retire (misrecognition flap)`() {
+        val r0 = region(dropoffTask("task-A", customerAddressHash = "cust-1", arrivedAt = 800L))
+        val (r1, f1) = step(r0, FlowRegion(flow = Flow.TaskDropoffArrived), postTaskObs(timestamp = 1_005L))
+        val (r2, _) = step(
+            r1, f1,
+            taskObs(Flow.TaskDropoffArrived, TaskPhase.DROPOFF, TaskSubFlow.ARRIVED, customerAddressHash = "cust-1", timestamp = 1_500L),
+        )
+
+        assertEquals("the same task lives on", "task-A", r2.activeTask?.taskId)
+        assertNull("the flap cancelled the retire", r2.pendingDestructive)
+        assertTrue("nothing committed", r2.recentTasks.isEmpty())
+    }
+
+    @Test
+    fun `receipt grace expiry retires the task at the receipt's timestamp`() {
+        val r0 = region(dropoffTask("task-A", customerAddressHash = "cust-1", arrivedAt = 800L))
+        val (r1, f1) = step(r0, FlowRegion(flow = Flow.TaskDropoffArrived), postTaskObs(timestamp = 1_005L))
+        val deadline = r1.pendingDestructive!!.deadline
+        val (r2, _) = step(r1, f1, idleObs(timestamp = deadline + 1))
+
+        assertNull("expiry retires the task", r2.activeTask)
+        assertNull(r2.pendingDestructive)
+        assertEquals(
+            "completed when the receipt appeared, not when we got around to believing it",
+            1_005L, r2.recentTasks.single { it.taskId == "task-A" }.completedAt,
+        )
+    }
+
+    @Test
+    fun `stacked next-task frame inside the receipt grace commits the old task inline`() {
+        val r0 = region(dropoffTask("task-A", customerAddressHash = "cust-1", arrivedAt = 800L))
+        val (r1, f1) = step(r0, FlowRegion(flow = Flow.TaskDropoffArrived), postTaskObs(timestamp = 1_005L))
+        val (r2, _) = step(
+            r1, f1,
+            taskObs(Flow.TaskPickupNavigation, TaskPhase.PICKUP, TaskSubFlow.NAVIGATION, storeName = "Wingstop", timestamp = 1_500L),
+        )
+
+        assertEquals(TaskPhase.PICKUP, r2.activeTask?.phase)
+        assertNotEquals("task-A", r2.activeTask?.taskId)
+        assertEquals(
+            "the displaced task committed at the receipt's appearance",
+            1_005L, r2.recentTasks.single { it.taskId == "task-A" }.completedAt,
+        )
+        assertNull(r2.pendingDestructive)
     }
 
     // ---- back-to-back transitions ----

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -63,6 +63,17 @@ immediately (no second pass needed) so it gets triaged.
 _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **broken** on the
 2026-06-09 dash — moved to that session's log entry below for triage.)_
 
+- **Receipt grace — delivery completion is now deferred ~2.5s (#431 pt 2).**
+  The delivery-summary (receipt) screen no longer retires the task instantly; it arms a short
+  authoritative grace exactly like the dash summary. Watch: (a) the "Saved: $X" receipt bubble
+  fires exactly ONCE per delivery (the expanded re-observation used to be able to double-fire
+  it); (b) stacked orders still split cleanly — receipt → next pickup must show the new task
+  immediately with the old one logged; (c) a receipt that flashes mid-dropoff (misrecognition)
+  no longer kills the live task — the task card should survive. Broken = double "Saved" bubble,
+  a delivery missing from the log, or the bubble's task card stuck on the finished delivery
+  well past ~3s after the receipt.
+  - Confirmed: 0/2
+
 - **Consent gate is live — bound-target taps must still fire (#417).**
   The always-true permission stub is gone: automation taps (the post-delivery expand chevron)
   now require a granted capability key, and bundled rules are auto-granted at rule load.


### PR DESCRIPTION
Closes #431. Part 1 (PR #444) graced the SessionEnded path and added `GRACE_COMMIT` timers; this lands the remaining half: **PostTask no longer retires the active task on a single frame.**

## What changed

- **Stepper:** a PostTask frame with an active task arms — or tightens an existing `TASK_RETIRE` pending to — the short authoritative grace (`AUTHORITATIVE_GRACE_MS`, 2.5s) instead of completing the task on the spot. Cancel/commit semantics mirror part 1: a contradicting task-flow frame inside the window cancels (misrecognition flap); expiry commits via the existing `GRACE_COMMIT` timer / lazy expiry **stamped at the receipt's appearance** (`pend.since`), not the commit time; a stacked next-task frame commits the displaced task inline at mint with the same honest stamp.
- **Receipt-announce gate fixed by construction:** the stepper's `lastAnnouncedPostTaskTaskId` stamp and `EffectMap.diffPostTask` now resolve the completing task identically (`activeTask` first — it stays active through the grace — falling back to `recentTasks.last`). The old recentTasks-only stamp lagged the commit by one frame, which could **double-fire the "Saved: $X" bubble on the expanded re-observation** — a live bug this PR also fixes (pinned by a new exactly-once test).
- **`DELIVERY_COMPLETED` on PostTask exit** prefers the still-active deferred task, with a same-taskId guard so a stacked mint on the same frame isn't misreported, and `completedAt` honesty (task's own stamp → retire signal's `since` → obs time).

## Single-slot `pendingDestructive` (issue asked this be noted either way)

Still single-slot, deliberately:
- SessionEnded over a pending TASK_RETIRE → safe, `endSession` completes the active task anyway (timestamps stamp at the session signal).
- PostTask over a pending SESSION_END → preserves the pre-#431 contract that a receipt-with-active-task reads as "still dashing" (the old code's unconditional pending clear did the same).
Proper multi-slot pending stays deferred until something needs it.

## Why this matters (audit framing)

R0's "believe the rules" policy is only safe if R2 grace catches misrecognition flaps. PostTask was the last destructive path with zero flap tolerance — one false receipt frame mid-dropoff irrecoverably split the live task. This is also a #192 prereq: community rulesets raise the misrecognition rate, so destructive commits must be flap-tolerant first.

## Tests

- `TaskLifecycleGuardTest`: pinned contract inverted (`PostTask arms a short authoritative retire grace`), + fresh-arm stamp, flap cancel, expiry-commits-at-receipt-time, stacked inline commit.
- `StateMachineTest`: PostTask test inverted to the deferred contract; `GRACE_COMMIT` timeout commits the retire.
- `EffectMapTest`: DELIVERY_COMPLETED for the deferred (still-active) task; exactly-once receipt announce across collapsed → expanded frames.
- Full `testDebugUnitTest` green locally.

## Context updates

- CLAUDE.md state-machine description (both authoritative windows).
- Field-test checklist: #431 pt 2 item (once-only bubble, stacked split, flap survival) at 0/2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)