### PR TITLE
fix(privacy): EvidenceConfig actually gates evidence screenshots (#426)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,7 +219,9 @@ Every new feature or refactor holds to these — they are forefront design input
      scanner shares). A recognition change must not be able to downgrade any of that.
    - **PII is hashed at the edge before it is persisted or could be uploaded** (`sha256`,
      fail-closed — never echo plaintext on failure, #362). Captures are debug-only (release binds
-     `NoOpCaptureBus`, #346).
+     `NoOpCaptureBus`, #346). Evidence screenshots are gated by `EvidenceConfig` at the engine
+     edge (#426): master toggle AND per-category toggle, and an uncategorized capture never
+     fires — the master default is OFF.
    - **Secrets never reach logs** (EIA api_key redaction, #348); network logging is debug-gated.
    - **Capability gates fail closed.** An effect whose permission tier isn't granted does not
      fire — tiers back onto real OS state (live accessibility-service handle, runtime location

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
@@ -6,6 +6,7 @@ import cloud.trotter.dashbuddy.core.database.effects.EffectsFiredDao
 import cloud.trotter.dashbuddy.core.database.effects.EffectsFiredEntity
 import cloud.trotter.dashbuddy.domain.action.ActionTrigger
 import cloud.trotter.dashbuddy.domain.capability.RuleCapabilityGrants
+import cloud.trotter.dashbuddy.domain.config.EvidenceCategory
 import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
 import cloud.trotter.dashbuddy.domain.model.chat.ChatPersona
 import cloud.trotter.dashbuddy.domain.state.Platform
@@ -191,9 +192,7 @@ class SideEffectEngine @Inject constructor(
                 bubbleManager.postMessage(effect.text, effect.persona, effect.expand)
             }
 
-            is AppEffect.CaptureScreenshot -> {
-                screenShotHandler.capture(engineScope, effect)
-            }
+            is AppEffect.CaptureScreenshot -> captureEvidence(effect)
 
             is AppEffect.PerformRuleAction -> {
                 // The ONLY path that taps a third-party app (#425). The target
@@ -371,7 +370,33 @@ class SideEffectEngine @Inject constructor(
 
     private fun screenshotFromArgs(args: Map<String, String>) {
         val prefix = args["prefix"] ?: "Rule"
-        screenShotHandler.capture(engineScope, AppEffect.CaptureScreenshot(filenamePrefix = prefix))
+        captureEvidence(
+            AppEffect.CaptureScreenshot(
+                filenamePrefix = prefix,
+                // Rule-declared (#426): the rule names its consent bucket via
+                // the `category` arg; unknown or missing maps to null → denied.
+                category = EvidenceCategory.fromWire(args["category"]),
+            ),
+        )
+    }
+
+    /**
+     * THE evidence gate (#426): every screenshot — EffectMap-emitted or
+     * rule-declared — passes through here, and fires only when the user's
+     * `EvidenceConfig` allows its category (master toggle AND category
+     * toggle; uncategorized → never). The config's startup default is
+     * master-off, so the gate also fails closed before DataStore loads.
+     */
+    private fun captureEvidence(effect: AppEffect.CaptureScreenshot) {
+        val config = strategyRepository.evidenceConfig.value
+        if (!config.allows(effect.category)) {
+            Timber.i(
+                "Evidence capture suppressed (%s, category=%s) — EvidenceConfig denies it",
+                effect.filenamePrefix, effect.category,
+            )
+            return
+        }
+        screenShotHandler.capture(engineScope, effect)
     }
 
     private fun bubbleFromArgs(args: Map<String, String>) {

--- a/app/src/test/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngineTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngineTest.kt
@@ -9,6 +9,8 @@ import cloud.trotter.dashbuddy.core.state.MetadataProvider
 import cloud.trotter.dashbuddy.domain.action.ActionTrigger
 import cloud.trotter.dashbuddy.domain.action.RuleAction
 import cloud.trotter.dashbuddy.domain.capability.RuleCapabilityGrants
+import cloud.trotter.dashbuddy.domain.config.EvidenceCategory
+import cloud.trotter.dashbuddy.domain.config.EvidenceConfig
 import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
 import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluator
 import cloud.trotter.dashbuddy.domain.model.event.AppEvent
@@ -23,6 +25,7 @@ import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.ui.bubble.BubbleManager
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -59,12 +62,24 @@ import org.mockito.kotlin.wheneverBlocking
 @OptIn(ExperimentalCoroutinesApi::class)
 class SideEffectEngineTest {
 
+    /** Backs the evidence gate (#426). Default: everything allowed — individual tests stub denial. */
+    private val evidenceConfig = MutableStateFlow(
+        EvidenceConfig(
+            masterEnabled = true,
+            saveOffers = true,
+            saveDeliverySummaries = true,
+            saveDashSummaries = true,
+        ),
+    )
+
     private val appEventRepo: AppEventRepo = mock()
     private val odometerEffectHandler: OdometerEffectHandler = mock()
     private val tipEffectHandler: TipEffectHandler = mock()
     private val bubbleManager: BubbleManager = mock()
     private val offerEvaluator: OfferEvaluator = mock()
-    private val strategyRepository: StrategyRepository = mock()
+    private val strategyRepository: StrategyRepository = mock {
+        on { this.evidenceConfig } doReturn this@SideEffectEngineTest.evidenceConfig
+    }
     private val screenShotHandler: ScreenShotHandler = mock()
     private val uiInteractionHandler: UiInteractionHandler = mock()
     private val effectsFiredDao: EffectsFiredDao = mock()
@@ -234,10 +249,13 @@ class SideEffectEngineTest {
         val engine = buildEngine(StandardTestDispatcher(testScheduler))
         // Distinct dedupeKeys: the engine throttles RequestEffect per effectKey
         // on the wall clock, and a denied fire still consumes the slot.
+        // Category present + evidence fully allowed (defaults), so the TIER is
+        // the only gate under test here.
         fun screenshot(key: String) = AppEffect.RequestEffect(
             RequestedEffect(
                 verb = EffectVerb.SCREENSHOT,
                 ruleId = "doordash.screen.offer_popup",
+                args = mapOf("category" to "offer"),
                 dedupeKey = key,
             ),
         )
@@ -249,6 +267,90 @@ class SideEffectEngineTest {
 
         whenever(permissionTierChecker.isGranted(any())).thenReturn(true)
         engine.process(screenshot("granted"))
+        runCurrent()
+        verify(screenShotHandler, times(1)).capture(any(), any())
+    }
+
+    // =========================================================================
+    // #426 — evidence gate on screenshots
+    // =========================================================================
+
+    private fun dashSummaryShot() = AppEffect.CaptureScreenshot(
+        filenamePrefix = "DashSummary - 87.50",
+        category = EvidenceCategory.DASH_SUMMARY,
+    )
+
+    @Test
+    fun `master off suppresses an EffectMap-emitted screenshot`() = runTest {
+        val engine = buildEngine(StandardTestDispatcher(testScheduler))
+        evidenceConfig.value = EvidenceConfig(masterEnabled = false)
+
+        engine.process(dashSummaryShot())
+        runCurrent()
+
+        verify(screenShotHandler, never()).capture(any(), any())
+    }
+
+    @Test
+    fun `a disabled category suppresses its screenshot while others fire`() = runTest {
+        val engine = buildEngine(StandardTestDispatcher(testScheduler))
+        evidenceConfig.value = EvidenceConfig(
+            masterEnabled = true,
+            saveOffers = true,
+            saveDashSummaries = false,
+        )
+
+        engine.process(dashSummaryShot())
+        runCurrent()
+        verify(screenShotHandler, never()).capture(any(), any())
+
+        engine.process(
+            AppEffect.CaptureScreenshot("Offer - Chipotle", category = EvidenceCategory.OFFER),
+        )
+        runCurrent()
+        verify(screenShotHandler, times(1)).capture(any(), any())
+    }
+
+    @Test
+    fun `an uncategorized screenshot never fires - fail closed`() = runTest {
+        val engine = buildEngine(StandardTestDispatcher(testScheduler))
+
+        // Everything enabled — the missing category alone must deny it.
+        engine.process(AppEffect.CaptureScreenshot("Mystery", category = null))
+        runCurrent()
+
+        verify(screenShotHandler, never()).capture(any(), any())
+    }
+
+    @Test
+    fun `a rule-declared screenshot is gated by its category arg`() = runTest {
+        val engine = buildEngine(StandardTestDispatcher(testScheduler))
+        evidenceConfig.value = EvidenceConfig(masterEnabled = true, saveOffers = false)
+
+        engine.process(
+            AppEffect.RequestEffect(
+                RequestedEffect(
+                    verb = EffectVerb.SCREENSHOT,
+                    ruleId = "doordash.screen.offer_popup",
+                    args = mapOf("prefix" to "Offer - Chipotle", "category" to "offer"),
+                    dedupeKey = "offer-gated",
+                ),
+            ),
+        )
+        runCurrent()
+        verify(screenShotHandler, never()).capture(any(), any())
+
+        evidenceConfig.value = EvidenceConfig(masterEnabled = true, saveOffers = true)
+        engine.process(
+            AppEffect.RequestEffect(
+                RequestedEffect(
+                    verb = EffectVerb.SCREENSHOT,
+                    ruleId = "doordash.screen.offer_popup",
+                    args = mapOf("prefix" to "Offer - Chipotle", "category" to "offer"),
+                    dedupeKey = "offer-allowed",
+                ),
+            ),
+        )
         runCurrent()
         verify(screenShotHandler, times(1)).capture(any(), any())
     }

--- a/core/pipeline/src/main/assets/rules/doordash.json
+++ b/core/pipeline/src/main/assets/rules/doordash.json
@@ -483,7 +483,8 @@
       "effects": [
         {
           "screenshot": {
-            "prefix": "Offer - {storeName}"
+            "prefix": "Offer - {storeName}",
+            "category": "offer"
           },
           "dedupeKey": "offer-ss-{offerHash}",
           "throttleMs": 60000
@@ -600,7 +601,8 @@
       "effects": [
         {
           "screenshot": {
-            "prefix": "DeliveryBreakdown - {totalPay}"
+            "prefix": "DeliveryBreakdown - {totalPay}",
+            "category": "delivery_summary"
           },
           "dedupeKey": "delivery-ss-expanded-{totalPay}-{sessionEarnings}",
           "throttleMs": 60000
@@ -681,7 +683,8 @@
       "effects": [
         {
           "screenshot": {
-            "prefix": "Delivery - {totalPay}"
+            "prefix": "Delivery - {totalPay}",
+            "category": "delivery_summary"
           },
           "dedupeKey": "delivery-ss-collapsed-{totalPay}-{sessionEarnings}",
           "throttleMs": 60000
@@ -2366,7 +2369,8 @@
       "effects": [
         {
           "screenshot": {
-            "prefix": "DashSummary - {totalEarnings}"
+            "prefix": "DashSummary - {totalEarnings}",
+            "category": "dash_summary"
           },
           "dedupeKey": "dash-summary-ss-{totalEarnings}-{sessionDurationMillis}",
           "throttleMs": 60000

--- a/core/pipeline/src/main/assets/rules/uber.json
+++ b/core/pipeline/src/main/assets/rules/uber.json
@@ -234,7 +234,8 @@
           "effects": [
             {
               "screenshot": {
-                "prefix": "Offer - {storeName}"
+                "prefix": "Offer - {storeName}",
+                "category": "offer"
               },
               "dedupeKey": "offer-ss-{offerHash}",
               "throttleMs": 60000

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompiler.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompiler.kt
@@ -766,7 +766,9 @@ object RuleCompiler {
     // ==========================================================================
 
     private val allowedArgs: Map<cloud.trotter.dashbuddy.domain.pipeline.EffectVerb, Set<String>> = mapOf(
-        cloud.trotter.dashbuddy.domain.pipeline.EffectVerb.SCREENSHOT to setOf("prefix"),
+        // `category` names the evidence consent bucket the engine's #426 gate
+        // checks against EvidenceConfig; a screenshot without one never fires.
+        cloud.trotter.dashbuddy.domain.pipeline.EffectVerb.SCREENSHOT to setOf("prefix", "category"),
         cloud.trotter.dashbuddy.domain.pipeline.EffectVerb.BUBBLE to setOf("text", "persona"),
         cloud.trotter.dashbuddy.domain.pipeline.EffectVerb.LOG to setOf("type", "payload"),
         cloud.trotter.dashbuddy.domain.pipeline.EffectVerb.SPEAK to setOf("text", "platform"),

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/AppEffect.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/AppEffect.kt
@@ -2,6 +2,7 @@ package cloud.trotter.dashbuddy.core.state
 
 import cloud.trotter.dashbuddy.domain.action.ActionTrigger
 import cloud.trotter.dashbuddy.domain.action.RuleAction
+import cloud.trotter.dashbuddy.domain.config.EvidenceCategory
 import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
 import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.domain.model.chat.ChatPersona
@@ -42,8 +43,14 @@ sealed class AppEffect {
     // 3. System Commands (e.g. "Keep Screen On", "Play Sound")
     data object PlayNotificationSound : AppEffect()
 
+    /**
+     * Capture an evidence screenshot. [category] is the user-consent bucket
+     * the engine's evidence gate (#426) checks against `EvidenceConfig` —
+     * null (an effect that never declared one) never fires.
+     */
     data class CaptureScreenshot(
         val filenamePrefix: String, // e.g. "offer" or "payout"
+        val category: EvidenceCategory?,
         val metadata: String? = null // Optional context
     ) : AppEffect()
 

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -2,6 +2,7 @@ package cloud.trotter.dashbuddy.core.state
 
 import cloud.trotter.dashbuddy.domain.action.ActionTrigger
 import cloud.trotter.dashbuddy.domain.action.RuleAction
+import cloud.trotter.dashbuddy.domain.config.EvidenceCategory
 import cloud.trotter.dashbuddy.domain.model.chat.ChatPersona
 import cloud.trotter.dashbuddy.domain.model.event.AppEvent
 import cloud.trotter.dashbuddy.domain.model.event.AppEventType
@@ -351,7 +352,12 @@ class EffectMap @Inject constructor() {
                         )
                         add(AppEffect.StopOdometer)
                         add(AppEffect.UpdateBubble("Session Ended. Total: $earnings", ChatPersona.Dispatcher))
-                        add(AppEffect.CaptureScreenshot("DashSummary - ${endParsed.totalEarnings}"))
+                        add(
+                            AppEffect.CaptureScreenshot(
+                                "DashSummary - ${endParsed.totalEarnings}",
+                                category = EvidenceCategory.DASH_SUMMARY,
+                            ),
+                        )
                     } else {
                         add(
                             logEffect(

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -63,6 +63,15 @@ immediately (no second pass needed) so it gets triaged.
 _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **broken** on the
 2026-06-09 dash — moved to that session's log entry below for triage.)_
 
+- **Evidence Locker settings are now real (#426).**
+  Screenshots (offer / delivery / dash-summary PNGs in Pictures/DashBuddy) previously fired
+  unconditionally; they are now gated on the Evidence settings, whose master toggle defaults
+  OFF. On a dash with settings untouched: working = NO new PNGs appear at all. Then flip
+  Master Record + a category on mid-dash: working = only that category's screenshots appear.
+  Broken = PNGs appear with master off, or an enabled category stops capturing (look for
+  "Evidence capture suppressed" in logs with an unexpected category).
+  - Confirmed: 0/2
+
 - **Receipt grace — delivery completion is now deferred ~2.5s (#431 pt 2).**
   The delivery-summary (receipt) screen no longer retires the task instantly; it arms a short
   authoritative grace exactly like the dash summary. Watch: (a) the "Saved: $X" receipt bubble

--- a/docs/rules.schema.json
+++ b/docs/rules.schema.json
@@ -1067,11 +1067,16 @@
         },
         "screenshot": {
           "type": "object",
-          "description": "Capture the current screen. Requires ACCESSIBILITY permission.",
+          "description": "Capture the current screen. Requires ACCESSIBILITY permission, and fires only when the user's Evidence Locker settings allow the declared category (#426) — an effect without a category never fires.",
           "properties": {
             "prefix": {
               "type": "string",
               "description": "Screenshot filename prefix. Supports {fieldName} templates."
+            },
+            "category": {
+              "type": "string",
+              "enum": ["offer", "delivery_summary", "dash_summary"],
+              "description": "Evidence consent bucket the capture is gated on (EvidenceConfig toggle). Required in practice: omitting it means the screenshot is always suppressed."
             }
           },
           "additionalProperties": false

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/config/EvidenceConfig.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/config/EvidenceConfig.kt
@@ -6,11 +6,44 @@ data class EvidenceConfig(
     val saveDeliverySummaries: Boolean = DEFAULT_SAVE_DELIVERIES,
     val saveDashSummaries: Boolean = DEFAULT_SAVE_DASHES,
 ) {
+    /**
+     * THE evidence-capture policy (#426): a screenshot fires only when the
+     * master toggle AND the matching category toggle are on. A null category
+     * (an effect that never declared one) is DENIED — fail closed, so a new
+     * screenshot source cannot bypass the user's settings by omission.
+     */
+    fun allows(category: EvidenceCategory?): Boolean = masterEnabled && when (category) {
+        EvidenceCategory.OFFER -> saveOffers
+        EvidenceCategory.DELIVERY_SUMMARY -> saveDeliverySummaries
+        EvidenceCategory.DASH_SUMMARY -> saveDashSummaries
+        null -> false
+    }
+
     companion object {
         // ONE owner for every default (#401).
         const val DEFAULT_MASTER = false
         const val DEFAULT_SAVE_OFFERS = true
         const val DEFAULT_SAVE_DELIVERIES = true
         const val DEFAULT_SAVE_DASHES = true
+    }
+}
+
+/**
+ * The user-consentable kinds of evidence screenshot (#426) — one per toggle in
+ * the Evidence Locker settings. Rule-declared `screenshot` effects name theirs
+ * via the `category` arg (wire values below); app-emitted screenshots set it
+ * directly. No "other" bucket on purpose: an uncategorized capture has no
+ * toggle the user could turn off, so it is not allowed to exist.
+ */
+enum class EvidenceCategory(val wire: String) {
+    OFFER("offer"),
+    DELIVERY_SUMMARY("delivery_summary"),
+    DASH_SUMMARY("dash_summary"),
+    ;
+
+    companion object {
+        private val byWire = entries.associateBy { it.wire }
+
+        fun fromWire(wire: String?): EvidenceCategory? = wire?.let { byWire[it] }
     }
 }

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/config/EvidenceConfigTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/config/EvidenceConfigTest.kt
@@ -1,0 +1,60 @@
+package cloud.trotter.dashbuddy.domain.config
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The evidence-capture policy truth table (#426): master AND category, with
+ * uncategorized captures denied unconditionally.
+ */
+class EvidenceConfigTest {
+
+    private val allOn = EvidenceConfig(
+        masterEnabled = true,
+        saveOffers = true,
+        saveDeliverySummaries = true,
+        saveDashSummaries = true,
+    )
+
+    @Test
+    fun `master off denies every category`() {
+        val config = allOn.copy(masterEnabled = false)
+        EvidenceCategory.entries.forEach { category ->
+            assertFalse("master off must deny $category", config.allows(category))
+        }
+    }
+
+    @Test
+    fun `the factory default denies everything - the app's own default-off promise`() {
+        val config = EvidenceConfig()
+        EvidenceCategory.entries.forEach { category ->
+            assertFalse("default config must deny $category", config.allows(category))
+        }
+        assertFalse(config.allows(null))
+    }
+
+    @Test
+    fun `master on gates per category`() {
+        val config = allOn.copy(saveDeliverySummaries = false)
+        assertTrue(config.allows(EvidenceCategory.OFFER))
+        assertFalse(config.allows(EvidenceCategory.DELIVERY_SUMMARY))
+        assertTrue(config.allows(EvidenceCategory.DASH_SUMMARY))
+    }
+
+    @Test
+    fun `uncategorized capture is denied even with everything on - fail closed`() {
+        assertFalse(allOn.allows(null))
+    }
+
+    @Test
+    fun `category wire mapping round-trips and rejects unknowns`() {
+        EvidenceCategory.entries.forEach { category ->
+            assertEquals(category, EvidenceCategory.fromWire(category.wire))
+        }
+        assertNull(EvidenceCategory.fromWire("selfie"))
+        assertNull(EvidenceCategory.fromWire(null))
+    }
+}


### PR DESCRIPTION
Closes #426. The Evidence Locker settings (master default **OFF**) were displayed and persisted but gated nothing — evidence screenshots fired unconditionally, including in release, writing PNGs of third-party screens to public `Pictures/DashBuddy`. The app violated its own default.

## What changed

Gate at the engine edge (the issue's recommended placement — reducers stay pure):

- **`:domain`** — `EvidenceCategory` (`offer` / `delivery_summary` / `dash_summary`, exactly one per settings toggle) + `EvidenceConfig.allows()`: master AND category, **null category denied unconditionally**. No "other" bucket on purpose: an uncategorized capture has no toggle the user could turn off, so it isn't allowed to exist.
- **`AppEffect.CaptureScreenshot`** carries its category (no default — every emitter must declare); EffectMap's dash-summary emission is `DASH_SUMMARY`.
- **Rule JSON** — the five `screenshot` effects (DoorDash offer / delivery expanded / delivery collapsed / dash summary, Uber offer) declare `"category"`; `RuleCompiler`'s per-verb arg allowlist admits the new key (it correctly rejected it until allowlisted); `docs/rules.schema.json` updated for editors.
- **`SideEffectEngine`** — both screenshot paths (EffectMap-emitted effect and rule-declared verb) funnel through one `captureEvidence()` gate reading `StrategyRepository.evidenceConfig`.

## Security/privacy posture (principle 6)

- **Fail closed everywhere:** master off → nothing; category off → that kind suppressed; missing/unknown category (e.g. a future CDN rule omitting it, #192) → never fires, loudly logged; before DataStore loads, the StateFlow's startup default is master-off → suppressed.
- **Untrusted input:** a ruleset can *request* a screenshot and *label* it, but cannot widen consent — the label only selects which user toggle gates it, and an unlabeled request is dead.
- **Behavior change is the fix:** with factory defaults, evidence screenshots stop entirely (they were firing against the user's displayed default). The tier check (ACCESSIBILITY, #417) still applies on the rule-verb path.
- Unrelated capture system (`CaptureBus` UI hierarchies) unchanged — already debug-only (#346).

## Tests

- `:domain` `EvidenceConfigTest` — the policy truth table, including "the factory default denies everything" (the app's own promise) and unknown-wire rejection.
- Engine tests: master-off suppression, per-category gating, uncategorized fail-closed, rule-declared `category` arg gating end-to-end through the verb dispatcher.
- Full `testDebugUnitTest` green (the compiler allowlist initially rejected the new arg corpus-wide — caught by the suite, fixed by allowlisting).

## Context updates

- CLAUDE.md principle-6 PII bullet now records the evidence gate.
- Field-test checklist: #426 item (no PNGs by default; per-category capture when enabled) at 0/2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)