### PR TITLE
fix(rules): per-offer dedupe via reserved {parsedHash} dedupeKey token (#427)

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/DefaultRulesIntegrationTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/DefaultRulesIntegrationTest.kt
@@ -223,6 +223,58 @@ class DefaultRulesIntegrationTest {
     }
 
     // =========================================================================
+    // Per-offer dedupe keys (#427)
+    // =========================================================================
+
+    @Test
+    fun `distinct offers resolve distinct dedupe keys via the parsedHash token`() {
+        // The old 'offer-ss-{offerHash}' template stayed literal (offerHash is
+        // computed in ParsedFieldsFactory, not a raw parse field), so every
+        // offer shared ONE dedupe key and the second offer inside the 60s
+        // throttle window was silently swallowed. The reserved {parsedHash}
+        // token resolves post-factory (DedupeTokens — same call the classifier
+        // makes) to the typed parse's content identity.
+        val snapshots = TestResourceLoader.loadSnapshots("snapshots/offer_popup")
+        assertTrue("offer corpus must not be empty", snapshots.isNotEmpty())
+
+        val keysByFile = snapshots.mapNotNull { (fn, tree, _) ->
+            val result = screenRuleset.matchFirst(tree, platformWire = "doordash")
+                ?: return@mapNotNull null
+            if (result.intent != "offer_popup") return@mapNotNull null
+            val parsed = ParsedFieldsFactory.create(result.shape, result.fields)
+            val resolved = DedupeTokens.resolve(result.effects, parsed)
+            val key = resolved.firstNotNullOfOrNull { e ->
+                e.dedupeKey?.takeIf { it.startsWith("offer-ss-") }
+            } ?: return@mapNotNull null
+            fn to key
+        }
+
+        assertTrue("expected offer screenshots with dedupe keys", keysByFile.size >= 2)
+        assertTrue(
+            "no unresolved template tokens may survive resolution: $keysByFile",
+            keysByFile.none { (_, k) -> k.contains('{') },
+        )
+        assertTrue(
+            "distinct offers must resolve DISTINCT dedupe keys (was one literal for all): $keysByFile",
+            keysByFile.map { it.second }.toSet().size > 1,
+        )
+    }
+
+    @Test
+    fun `the same offer resolves the same dedupe key on re-observation`() {
+        val (_, tree, _) = TestResourceLoader.loadSnapshots("snapshots/offer_popup").first()
+        fun resolveOnce(): String? {
+            val result = screenRuleset.matchFirst(tree, platformWire = "doordash") ?: return null
+            val parsed = ParsedFieldsFactory.create(result.shape, result.fields)
+            return DedupeTokens.resolve(result.effects, parsed)
+                .firstNotNullOfOrNull { e -> e.dedupeKey?.takeIf { it.startsWith("offer-ss-") } }
+        }
+        val first = resolveOnce()
+        assertNotNull("offer snapshot must resolve a screenshot dedupe key", first)
+        assertEquals("re-observation must dedupe against the same key", first, resolveOnce())
+    }
+
+    // =========================================================================
     // Helpers
     // =========================================================================
 

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/ParseOutputGoldenTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/ParseOutputGoldenTest.kt
@@ -227,18 +227,20 @@ class ParseOutputGoldenTest {
 
     /**
      * Dead dedupeKey templates already known (ratchet — may only shrink):
-     * - `offer_popup:offerHash` — the literal-`{offerHash}` bug, #427's scope.
      * - `delivery_summary_expanded:sessionEarnings` — never parses non-null on
      *   any expanded-summary capture; either the screen stopped showing it or
-     *   the extractor regressed. Triage with #427.
+     *   the extractor regressed. The expanded key still differentiates per
+     *   delivery via its `{totalPay}` half, so dedupe works; clean up the dead
+     *   half when the summary rules are next touched.
      * - `delivery_summary_collapsed:totalPay` — the mirror image: collapsed
      *   receipts parse sessionEarnings but never the per-delivery totalPay
-     *   (it's behind the expand), so that half of the key never substitutes.
-     *   Triage with #427.
+     *   (it's behind the expand); the `{sessionEarnings}` half differentiates.
+     * (The third original entry, `offer_popup:offerHash`, was the #427 bug —
+     * fixed by the reserved `{parsedHash}` token, resolved post-factory by the
+     * classifier via [DedupeTokens].)
      * Entries are "ruleId:field".
      */
     private val knownDeadDedupeTemplates = setOf(
-        "doordash.screen.offer_popup:offerHash",
         "doordash.screen.delivery_summary_expanded:sessionEarnings",
         "doordash.screen.delivery_summary_collapsed:totalPay",
     )
@@ -265,6 +267,9 @@ class ParseOutputGoldenTest {
                     val dk = effect.dedupeKey ?: continue
                     for (m in template.findAll(dk)) {
                         val field = m.groupValues[1]
+                        // Reserved tokens resolve post-factory in the
+                        // classifier (DedupeTokens, #427) — never raw fields.
+                        if (field in DedupeTokens.RESERVED_FIELD_NAMES) continue
                         val key = result.ruleId to field
                         seen[key] = (seen[key] ?: false) || (result.fields[field] != null)
                         exampleKey.putIfAbsent(key, dk)

--- a/core/pipeline/src/main/assets/rules/doordash.json
+++ b/core/pipeline/src/main/assets/rules/doordash.json
@@ -486,7 +486,7 @@
             "prefix": "Offer - {storeName}",
             "category": "offer"
           },
-          "dedupeKey": "offer-ss-{offerHash}",
+          "dedupeKey": "offer-ss-{parsedHash}",
           "throttleMs": 60000
         },
         {
@@ -494,7 +494,7 @@
             "type": "OFFER_RECEIVED",
             "payload": "pay={payAmount} dist={distance}"
           },
-          "dedupeKey": "offer-log-{offerHash}",
+          "dedupeKey": "offer-log-{parsedHash}",
           "throttleMs": 60000
         }
       ]

--- a/core/pipeline/src/main/assets/rules/uber.json
+++ b/core/pipeline/src/main/assets/rules/uber.json
@@ -237,7 +237,7 @@
                 "prefix": "Offer - {storeName}",
                 "category": "offer"
               },
-              "dedupeKey": "offer-ss-{offerHash}",
+              "dedupeKey": "offer-ss-{parsedHash}",
               "throttleMs": 60000
             },
             {
@@ -245,7 +245,7 @@
                 "type": "OFFER_RECEIVED",
                 "payload": "pay={payAmount} dist={distance}"
               },
-              "dedupeKey": "offer-log-{offerHash}",
+              "dedupeKey": "offer-log-{parsedHash}",
               "throttleMs": 60000
             }
           ]

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/ObservationClassifier.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/ObservationClassifier.kt
@@ -10,6 +10,7 @@ import cloud.trotter.dashbuddy.domain.state.Flow
 import cloud.trotter.dashbuddy.domain.state.Mode
 import cloud.trotter.dashbuddy.domain.state.ParsedFields
 import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.core.pipeline.rules.DedupeTokens
 import cloud.trotter.dashbuddy.core.pipeline.rules.JsonRuleInterpreter
 import cloud.trotter.dashbuddy.core.pipeline.rules.ParsedFieldsFactory
 import cloud.trotter.dashbuddy.core.pipeline.rules.TransformRegistry
@@ -112,7 +113,9 @@ class ObservationClassifier @Inject constructor(
             modeHint = result.modeHint,
             parsed = parsed,
             ruleId = result.ruleId,
-            effects = result.effects,
+            // Reserved tokens ({parsedHash}) resolve HERE — after the factory,
+            // against the typed parse's identity (#427).
+            effects = DedupeTokens.resolve(result.effects, parsed),
             targets = result.targets,
             transitionOverrides = result.transitionOverrides,
             expectedOutcomes = result.outcomes,
@@ -163,6 +166,7 @@ class ObservationClassifier @Inject constructor(
         if (ruleset != null) {
             val result = ruleset.matchFirst(event.node, platformWire, lastScreenTarget)
             if (result != null) {
+                val parsed = ParsedFields.ClickFields(intent = result.intent)
                 return Observation.Click(
                     timestamp = now,
                     captureId = null,
@@ -170,9 +174,9 @@ class ObservationClassifier @Inject constructor(
                     metadata = metadataProvider.current(),
                     flow = result.flow,
                     modeHint = result.modeHint,
-                    parsed = ParsedFields.ClickFields(intent = result.intent),
+                    parsed = parsed,
                     target = result.intent,
-                    effects = result.effects,
+                    effects = DedupeTokens.resolve(result.effects, parsed),
                     transitionOverrides = result.transitionOverrides,
                     expectedOutcomes = result.outcomes,
                     screenTarget = lastScreenTarget,
@@ -221,7 +225,7 @@ class ObservationClassifier @Inject constructor(
                     modeHint = result.modeHint,
                     parsed = parsed,
                     target = result.intent,
-                    effects = result.effects,
+                    effects = DedupeTokens.resolve(result.effects, parsed),
                     transitionOverrides = result.transitionOverrides,
                     expectedOutcomes = result.outcomes,
                 )

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/DedupeTokens.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/DedupeTokens.kt
@@ -1,0 +1,46 @@
+package cloud.trotter.dashbuddy.core.pipeline.rules
+
+import cloud.trotter.dashbuddy.domain.pipeline.RequestedEffect
+import cloud.trotter.dashbuddy.domain.state.ParsedFields
+
+/**
+ * Reserved dedupeKey tokens resolved AFTER typed parsing (#427).
+ *
+ * `{field}` templates resolve at match time against the branch's RAW parse
+ * fields ([Ruleset.matchFirst]) — but identity fields computed by
+ * [ParsedFieldsFactory] (the offer hash, derived from pay/distance/stores)
+ * don't exist in the raw map, so a key like `offer-ss-{offerHash}` stayed a
+ * literal constant: every offer shared one `effects_fired` row and one
+ * throttle bucket, and the second offer inside the 60s window was silently
+ * swallowed.
+ *
+ * [PARSED_HASH] is the shape-agnostic fix: the classifier resolves it from
+ * [ParsedFields.dedupeHash] — the typed parse's content identity — once the
+ * factory has run. Deterministic across runs and replay (String/Double
+ * hashCode are specified), so recovery dedupe keys match the live run's.
+ */
+object DedupeTokens {
+
+    /** Resolves to `ParsedFields.dedupeHash()` of the observation's typed parse. */
+    const val PARSED_HASH = "{parsedHash}"
+
+    /** Names treated as reserved (never raw parse fields) — lint/tooling SSOT. */
+    val RESERVED_FIELD_NAMES = setOf("parsedHash")
+
+    /**
+     * Resolve reserved tokens in [effects]' dedupe keys against [parsed].
+     * No-op (same list instance) when nothing references a token.
+     */
+    fun resolve(effects: List<RequestedEffect>, parsed: ParsedFields): List<RequestedEffect> {
+        if (effects.none { it.dedupeKey?.contains(PARSED_HASH) == true }) return effects
+        val hash = parsed.dedupeHash().toString()
+        return effects.map { effect ->
+            val key = effect.dedupeKey
+            if (key != null && key.contains(PARSED_HASH)) {
+                effect.copy(dedupeKey = key.replace(PARSED_HASH, hash))
+            } else {
+                effect
+            }
+        }
+    }
+}

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -63,6 +63,15 @@ immediately (no second pass needed) so it gets triaged.
 _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **broken** on the
 2026-06-09 dash — moved to that session's log entry below for triage.)_
 
+- **Per-offer dedupe now engages (#427).**
+  Offer screenshot/log dedupe keys used to resolve to one shared literal, so a second distinct
+  offer within 60s was silently swallowed. Now keyed per-offer via `{parsedHash}`. Watch on a
+  busy dash (with Evidence master + offers enabled, see #426 item): two different offers
+  arriving close together should BOTH capture; the same offer re-rendering (collapse/expand,
+  re-observation) should still capture only once. Broken = missing capture for a distinct
+  second offer, or duplicate captures of one offer inside the same minute.
+  - Confirmed: 0/2
+
 - **Evidence Locker settings are now real (#426).**
   Screenshots (offer / delivery / dash-summary PNGs in Pictures/DashBuddy) previously fired
   unconditionally; they are now gated on the Evidence settings, whose master toggle defaults

--- a/docs/rules.schema.json
+++ b/docs/rules.schema.json
@@ -1058,7 +1058,7 @@
         },
         "dedupeKey": {
           "type": "string",
-          "description": "Stable key for deduplication. Supports {fieldName} template interpolation."
+          "description": "Stable key for deduplication. Supports {fieldName} template interpolation against the branch's RAW parse fields, plus the reserved {parsedHash} token, resolved after typed parsing to the parse's content identity (ParsedFields.dedupeHash) — use it for per-offer/per-parse dedupe of fields the rule itself doesn't parse (#427)."
         },
         "throttleMs": {
           "type": "integer",


### PR DESCRIPTION
Closes #427. Offer dedupe keys resolved to one shared literal (`offer-ss-{offerHash}`) because `offerHash` is computed in `ParsedFieldsFactory`, after match-time template resolution against raw fields — so per-offer dedupe never engaged and the 60s throttle swallowed the second distinct offer. #433's new lint surfaced this corpus-wide.

## The fix

Of the issue's three options, this takes "resolve after ParsedFieldsFactory" — but scoped to a **reserved token** instead of re-resolving arbitrary fields, so raw-field template semantics are untouched:

- **`DedupeTokens`** (`:core:pipeline`): `{parsedHash}` → `ParsedFields.dedupeHash()`, the typed parse's content identity (base-class contract, every subtype overrides — for offers it's the offerHash). Deterministic across runs and crash-recovery replay (spec'd `hashCode`s), so `effects_fired` keys match between live and replay.
- **`ObservationClassifier`** resolves the token at all three classify sites immediately after the factory runs.
- **Rule JSON**: the four offer keys (DD + Uber, screenshot + log) switch to `{parsedHash}`; `docs/rules.schema.json` documents the token.
- **#433 lint integration**: `DedupeTokens.RESERVED_FIELD_NAMES` is the lint's SSOT for non-raw tokens; `offer_popup:offerHash` leaves the dead-template pin (fixed). The two delivery-summary dead halves stay pinned with explanatory notes — each summary variant's key still differentiates per delivery via its other (parsing) half, so dedupe works there; the dead halves are cleanup for whenever those rules are next touched.

## Security/privacy posture

Recognition-layer only; no new capability surface. The token can't widen what a rule may do — it only makes dedupe keys honest. The resolved hash is an `Int` of already-edge-hashed/derived content (no PII). Untrusted-rules posture unchanged: an unknown `{token}` still resolves to nothing and stays literal.

## Tests

- Distinct corpus offers → distinct resolved keys, zero surviving `{` (fails against the old rules by construction — the old keys keep their braces).
- Same offer re-resolved → same key (recovery idempotency contract).
- Full `testDebugUnitTest` green, `AllMatchersSuite` re-run with `--rerun` (rule JSON isn't a declared test input).

## Context updates

- Field-test item (0/2): two distinct offers back-to-back both capture; one offer re-rendering captures once.
- Editor schema + lint pin notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)