### PR TITLE
fix(effects): engine latency + dedupe pack (#436)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
@@ -7,7 +7,6 @@ import cloud.trotter.dashbuddy.core.database.effects.EffectsFiredEntity
 import cloud.trotter.dashbuddy.domain.action.ActionTrigger
 import cloud.trotter.dashbuddy.domain.capability.RuleCapabilityGrants
 import cloud.trotter.dashbuddy.domain.config.EvidenceCategory
-import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
 import cloud.trotter.dashbuddy.domain.model.chat.ChatPersona
 import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.domain.model.state.StateEvent
@@ -21,7 +20,6 @@ import cloud.trotter.dashbuddy.core.state.EffectExecutor
 import cloud.trotter.dashbuddy.core.state.MetadataProvider
 import cloud.trotter.dashbuddy.domain.di.DefaultDispatcher
 import cloud.trotter.dashbuddy.ui.bubble.BubbleManager
-import cloud.trotter.dashbuddy.ui.formatters.toNotificationSummary
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineExceptionHandler
@@ -35,6 +33,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -75,6 +74,10 @@ class SideEffectEngine @Inject constructor(
     // Action throttle tracker: effectKey → last fired timestamp
     private val actionLastFiredAt = ConcurrentHashMap<String, Long>()
 
+    // Offer notifications waiting out their post delay, keyed by offerHash so
+    // an offer-resolved CancelOfferNotification can abort the post (#436).
+    private val pendingOfferNotifications = ConcurrentHashMap<String, Job>()
+
     companion object {
         /** Default throttle between repeated firings of the same action. */
         const val DEFAULT_ACTION_THROTTLE_MS = 500L
@@ -95,6 +98,12 @@ class SideEffectEngine @Inject constructor(
 
         /** Keep effects_fired idempotency rows for 48h (#364). */
         private const val EFFECTS_RETENTION_MS = 48 * 60 * 60 * 1000L
+
+        /** Prune the throttle map past this size (#436) — a slow per-offer leak otherwise. */
+        private const val THROTTLE_MAP_PRUNE_THRESHOLD = 256
+
+        /** Entries older than this can never gate again (≥ any declared throttle window). */
+        private const val THROTTLE_ENTRY_TTL_MS = 10 * 60 * 1000L
     }
 
     /**
@@ -157,13 +166,15 @@ class SideEffectEngine @Inject constructor(
     }
 
     private suspend fun execute(effect: AppEffect, recovering: Boolean, correlationVersion: Long) {
-        // Idempotency: skip keyed effects already fired
+        // Idempotency: skip keyed effects already fired. Consulted on the LIVE
+        // path too (#436) — a non-crash restart used to re-fire keyed external
+        // effects on re-observation because the check was recovery-only. The
+        // table is pruned at 48h, so a key is "already fired" only within that
+        // window (matching the snapshot horizon recovery replays over).
         val key = effect.effectKey
-        if (key != null && recovering) {
-            if (effectsFiredDao.hasBeenFired(key)) {
-                Timber.d("Skipping already-fired effect: %s", key)
-                return
-            }
+        if (key != null && effectsFiredDao.hasBeenFired(key)) {
+            Timber.d("Skipping already-fired effect: %s", key)
+            return
         }
 
         // Suppress external effects during recovery
@@ -221,7 +232,7 @@ class SideEffectEngine @Inject constructor(
                     )
                     return
                 }
-                actionLastFiredAt[throttleKey] = now
+                stampThrottle(throttleKey, now)
                 Timber.i("Performing %s on %s", effect.action.wire, effect.platform.wire)
                 val clicked = uiInteractionHandler.performVerifiedClick(
                     ref = effect.targetRef,
@@ -246,8 +257,12 @@ class SideEffectEngine @Inject constructor(
                     Timber.v("Throttled effect: %s", effectKey)
                     return
                 }
-                actionLastFiredAt[effectKey] = now
-                dispatchRuleEffect(effect.effect)
+                stampThrottle(effectKey, now)
+                // A DENIED effect (tier or evidence gate) must not be marked
+                // fired (#436): once gates are real (#417/#426), marking a
+                // denial would make the effect "already fired" after the user
+                // grants it — skipped on recovery and, now, on the live path.
+                if (!dispatchRuleEffect(effect.effect)) return
             }
 
             is AppEffect.PlayNotificationSound -> { /* Implementation */
@@ -270,7 +285,12 @@ class SideEffectEngine @Inject constructor(
                 // Loopback only: evaluate, then emit the decision back to the state machine. The
                 // notification is posted by the PostOfferNotification effect EffectMap emits once
                 // the evaluation lands on the pending offer — keeps this handler thin.
-                val config = strategyRepository.evaluationConfigFlow.first()
+                // Eagerly-materialized config (#436): a value read after first
+                // load instead of a cold DataStore combine blocking the worker
+                // per offer; filterNotNull means an offer arriving before the
+                // first load WAITS for real economics rather than scoring
+                // against a guessed default.
+                val config = strategyRepository.evaluationConfig.filterNotNull().first()
                 val result = offerEvaluator.evaluate(effect.parsedOffer, config)
                 // Emit the loopback observation directly (#402): the old
                 // OfferEvaluationEvent was a 1:1 shim the bridge re-typed.
@@ -290,14 +310,27 @@ class SideEffectEngine @Inject constructor(
             is AppEffect.PostOfferNotification -> {
                 // The bubble can't auto-expand from the background (#110 field test), so surface the
                 // evaluation as a heads-up notification with Accept/Decline actions. Delayed so it
-                // lands AFTER the offer screenshot's settle + capture (clean frame).
-                val summary = effect.evaluation.toNotificationSummary()
-                val persona = offerPersona(effect.evaluation.action)
-                // Detached: the delay must not block the queue (#351).
-                engineScope.launch {
+                // lands AFTER the offer screenshot's settle + capture (clean frame). Formatting is
+                // BubbleManager's job at the UI edge (#436) — no Android text types here.
+                // Detached: the delay must not block the queue (#351). Tracked
+                // by offerHash with a self-removing completion handler (the
+                // #406 timer pattern) so an offer resolved inside the delay
+                // window cancels the post instead of surfacing an actionable
+                // Accept/Decline for an offer that's already gone (#436).
+                val hashKey = effect.offerHash ?: "no-hash"
+                pendingOfferNotifications[hashKey]?.cancel()
+                val job = engineScope.launch(start = CoroutineStart.LAZY) {
                     delay(OFFER_NOTIFICATION_DELAY_MS)
-                    bubbleManager.postOfferNotification(summary, persona)
+                    bubbleManager.postOfferNotification(effect.evaluation)
                 }
+                job.invokeOnCompletion { pendingOfferNotifications.remove(hashKey, job) }
+                pendingOfferNotifications[hashKey] = job
+                job.start()
+            }
+
+            is AppEffect.CancelOfferNotification -> {
+                // Untracking happens via the job's self-removing completion handler.
+                pendingOfferNotifications[effect.offerHash ?: "no-hash"]?.cancel()
             }
 
             // --- TIMING LOGIC (Pure Coroutines) ---
@@ -337,15 +370,19 @@ class SideEffectEngine @Inject constructor(
     /**
      * Dispatch a [RequestedEffect] to the appropriate handler based on its verb.
      * Permission tier is checked before execution — denied verbs are logged and skipped.
+     *
+     * @return false when a gate (tier or evidence) DENIED the effect — the
+     *   caller must then skip the `markFired` tail (#436): a denial recorded
+     *   as fired would be skipped forever once the user grants the gate.
      */
-    private suspend fun dispatchRuleEffect(e: RequestedEffect) {
+    private suspend fun dispatchRuleEffect(e: RequestedEffect): Boolean {
         if (!permissionTierChecker.isGranted(e.verb.tier)) {
             Timber.w("Denied effect %s — permission tier %s not granted", e.verb, e.verb.tier)
-            return
+            return false
         }
         when (e.verb) {
             // --- Observation-driven verbs ---
-            EffectVerb.SCREENSHOT -> screenshotFromArgs(e.args)
+            EffectVerb.SCREENSHOT -> return screenshotFromArgs(e.args)
             EffectVerb.BUBBLE -> bubbleFromArgs(e.args)
             EffectVerb.LOG -> logFromArgs(e.args)
             // Deliberate no-ops (#359): offer evaluation + speech fire from
@@ -366,11 +403,13 @@ class SideEffectEngine @Inject constructor(
             )
             EffectVerb.CANCEL_TIMEOUT -> cancelTimeoutFromArgs(e.args)
         }
+        return true
     }
 
-    private fun screenshotFromArgs(args: Map<String, String>) {
+    /** @return false when the evidence gate suppressed the capture (#436). */
+    private fun screenshotFromArgs(args: Map<String, String>): Boolean {
         val prefix = args["prefix"] ?: "Rule"
-        captureEvidence(
+        return captureEvidence(
             AppEffect.CaptureScreenshot(
                 filenamePrefix = prefix,
                 // Rule-declared (#426): the rule names its consent bucket via
@@ -386,17 +425,35 @@ class SideEffectEngine @Inject constructor(
      * `EvidenceConfig` allows its category (master toggle AND category
      * toggle; uncategorized → never). The config's startup default is
      * master-off, so the gate also fails closed before DataStore loads.
+     *
+     * @return false when suppressed — a suppression is a denial, never a fire (#436).
      */
-    private fun captureEvidence(effect: AppEffect.CaptureScreenshot) {
+    private fun captureEvidence(effect: AppEffect.CaptureScreenshot): Boolean {
         val config = strategyRepository.evidenceConfig.value
         if (!config.allows(effect.category)) {
             Timber.i(
                 "Evidence capture suppressed (%s, category=%s) — EvidenceConfig denies it",
                 effect.filenamePrefix, effect.category,
             )
-            return
+            return false
         }
         screenShotHandler.capture(engineScope, effect)
+        return true
+    }
+
+    /**
+     * Record a throttle stamp, pruning stale entries first (#436): the map
+     * gains a key per offer/action and previously grew unboundedly over a
+     * long session. Entries older than [THROTTLE_ENTRY_TTL_MS] (≥ any
+     * declared throttle window) can never gate again — drop them once the
+     * map is past [THROTTLE_MAP_PRUNE_THRESHOLD].
+     */
+    private fun stampThrottle(key: String, now: Long) {
+        if (actionLastFiredAt.size > THROTTLE_MAP_PRUNE_THRESHOLD) {
+            val cutoff = now - THROTTLE_ENTRY_TTL_MS
+            actionLastFiredAt.entries.removeIf { it.value < cutoff }
+        }
+        actionLastFiredAt[key] = now
     }
 
     private fun bubbleFromArgs(args: Map<String, String>) {
@@ -490,14 +547,6 @@ class SideEffectEngine @Inject constructor(
         "good_offer" -> ChatPersona.GoodOffer
         "bad_offer" -> ChatPersona.BadOffer
         else -> ChatPersona.Dispatcher
-    }
-
-    /** Map an offer verdict to the persona that voices its notification. */
-    private fun offerPersona(action: OfferAction): ChatPersona = when (action) {
-        OfferAction.ACCEPT -> ChatPersona.GoodOffer
-        OfferAction.DECLINE -> ChatPersona.BadOffer
-        OfferAction.MANUAL_REVIEW -> ChatPersona.Inspector
-        OfferAction.NOTHING -> ChatPersona.Inspector
     }
 
     private fun isExternalEffect(effect: AppEffect): Boolean = when (effect) {

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManager.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManager.kt
@@ -16,9 +16,12 @@ import androidx.core.graphics.drawable.IconCompat
 import cloud.trotter.dashbuddy.R
 import cloud.trotter.dashbuddy.core.data.chat.ChatRepository
 import cloud.trotter.dashbuddy.state.effects.OfferActionReceiver
+import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
 import cloud.trotter.dashbuddy.domain.model.chat.ChatPersona
 import cloud.trotter.dashbuddy.domain.state.OfferIntent
 import cloud.trotter.dashbuddy.ui.formatters.getIconResId // <-- Your new UI Formatter!
+import cloud.trotter.dashbuddy.ui.formatters.notificationPersona
+import cloud.trotter.dashbuddy.ui.formatters.toNotificationSummary
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -199,8 +202,15 @@ class BubbleManager @Inject constructor(
         notificationManager.notify(BUBBLE_NOTIFICATION_ID, builder.build())
     }
 
-    /** Post the offer evaluation as a heads-up notification with Accept / Decline action buttons. */
-    fun postOfferNotification(summary: CharSequence, persona: ChatPersona) {
+    /**
+     * Post the offer evaluation as a heads-up notification with Accept /
+     * Decline action buttons. Formatting (Spannable summary + persona)
+     * happens HERE at the UI edge (#436) — the side-effect engine hands over
+     * the domain evaluation and stays free of Android text types.
+     */
+    fun postOfferNotification(evaluation: OfferEvaluation) {
+        val summary = evaluation.toNotificationSummary()
+        val persona = evaluation.notificationPersona()
         Timber.tag("Chat").i("[${persona.displayName}]: $summary")
         scope.launch { chatRepository.saveMessage(_activeDashId.value, summary.toString(), persona) }
         showNotification(summary, persona, expand = false, offerActionable = true)

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/formatters/OfferFormatters.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/formatters/OfferFormatters.kt
@@ -12,6 +12,15 @@ import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
 import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
 import cloud.trotter.dashbuddy.core.designsystem.format.DashFormats
 import cloud.trotter.dashbuddy.domain.evaluation.OfferQuality
+import cloud.trotter.dashbuddy.domain.model.chat.ChatPersona
+
+/** The persona that voices an offer verdict's notification (moved from the engine, #436). */
+fun OfferEvaluation.notificationPersona(): ChatPersona = when (action) {
+    OfferAction.ACCEPT -> ChatPersona.GoodOffer
+    OfferAction.DECLINE -> ChatPersona.BadOffer
+    OfferAction.MANUAL_REVIEW -> ChatPersona.Inspector
+    OfferAction.NOTHING -> ChatPersona.Inspector
+}
 
 /**
  * Formatted offer summary for the heads-up notification. Built with **Android** text spans — the

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/SettingsViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/SettingsViewModel.kt
@@ -11,6 +11,7 @@ import cloud.trotter.dashbuddy.domain.model.offer.ParsedOffer
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -22,8 +23,10 @@ class SettingsViewModel @Inject constructor(
 ) : ViewModel() {
 
     // --- STATE ---
-    // Combine multiple data sources into one Config object for the UI
-    val evaluationConfig: StateFlow<EvaluationConfig> = strategyRepository.evaluationConfigFlow
+    // The repo materializes the config (#436); the UI just narrows null
+    // (pre-first-load) to a renderable default.
+    val evaluationConfig: StateFlow<EvaluationConfig> = strategyRepository.evaluationConfig
+        .filterNotNull()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), EvaluationConfig())
 
     // --- ACTIONS ---

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
@@ -219,6 +219,8 @@ class EffectMapTest {
         val posts = effects.filterIsInstance<AppEffect.PostOfferNotification>()
         assertEquals("Exactly one PostOfferNotification", 1, posts.size)
         assertEquals("Carries the landed evaluation", testEvaluation, posts[0].evaluation)
+        // Keys the engine's delayed post so an offer-resolved cancel can abort it (#436).
+        assertEquals("Carries the offer hash", "hash-123", posts[0].offerHash)
         // Spoken read also fires on eval-landing, carrying the same evaluation.
         val spoken = effects.filterIsInstance<AppEffect.SpeakOffer>()
         assertEquals("Exactly one SpeakOffer", 1, spoken.size)
@@ -257,6 +259,26 @@ class EffectMapTest {
 
         val effects = effectMap.diff(prev, next, screenObs(flow = Flow.Idle))
         assertTrue(effects.logEventTypes().contains(AppEventType.OFFER_DECLINED))
+    }
+
+    @Test
+    fun `a resolved offer emits CancelOfferNotification for its hash`() {
+        // The heads-up post is delayed ~750ms behind the screenshot settle —
+        // resolving the offer inside that window must abort the post (#436).
+        val prev = AppState(regions = Regions(
+            flow = FlowRegion(
+                flow = Flow.OfferPresented,
+                pendingOffer = testPendingOffer.copy(lastClickIntent = "decline_offer"),
+            ),
+        ))
+        val next = AppState(regions = Regions(
+            flow = FlowRegion(flow = Flow.Idle),
+        ))
+
+        val effects = effectMap.diff(prev, next, screenObs(flow = Flow.Idle))
+        val cancels = effects.filterIsInstance<AppEffect.CancelOfferNotification>()
+        assertEquals(1, cancels.size)
+        assertEquals("hash-123", cancels[0].offerHash)
     }
 
     @Test

--- a/app/src/test/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngineTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngineTest.kt
@@ -11,6 +11,7 @@ import cloud.trotter.dashbuddy.domain.action.RuleAction
 import cloud.trotter.dashbuddy.domain.capability.RuleCapabilityGrants
 import cloud.trotter.dashbuddy.domain.config.EvidenceCategory
 import cloud.trotter.dashbuddy.domain.config.EvidenceConfig
+import cloud.trotter.dashbuddy.domain.evaluation.EvaluationConfig
 import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
 import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluator
 import cloud.trotter.dashbuddy.domain.model.event.AppEvent
@@ -77,12 +78,20 @@ class SideEffectEngineTest {
     private val tipEffectHandler: TipEffectHandler = mock()
     private val bubbleManager: BubbleManager = mock()
     private val offerEvaluator: OfferEvaluator = mock()
+    /** Backs the eval-config read (#436). Non-null so EvaluateOffer never suspends in tests. */
+    private val evaluationConfig =
+        MutableStateFlow<EvaluationConfig?>(EvaluationConfig())
+
     private val strategyRepository: StrategyRepository = mock {
         on { this.evidenceConfig } doReturn this@SideEffectEngineTest.evidenceConfig
+        on { this.evaluationConfig } doReturn this@SideEffectEngineTest.evaluationConfig
     }
     private val screenShotHandler: ScreenShotHandler = mock()
     private val uiInteractionHandler: UiInteractionHandler = mock()
-    private val effectsFiredDao: EffectsFiredDao = mock()
+    /** Live-path dedupe (#436) consults this for every keyed effect — default "not fired". */
+    private val effectsFiredDao: EffectsFiredDao = mock {
+        onBlocking { hasBeenFired(any()) } doReturn false
+    }
     private val ttsEffectHandler: TtsEffectHandler = mock()
 
     /** Default: every tier granted — individual tests stub denial. */
@@ -353,6 +362,95 @@ class SideEffectEngineTest {
         )
         runCurrent()
         verify(screenShotHandler, times(1)).capture(any(), any())
+    }
+
+    // =========================================================================
+    // #436 — engine latency + dedupe pack
+    // =========================================================================
+
+    /** Real evaluation — the summary formatter and persona mapping read its fields. */
+    private fun testEvaluation() = OfferEvaluation(
+        action = cloud.trotter.dashbuddy.domain.evaluation.OfferAction.ACCEPT,
+        score = 74.0,
+        qualityLevel = cloud.trotter.dashbuddy.domain.evaluation.OfferQuality.GOOD,
+        payAmount = 7.50,
+        fuelCostEstimate = 0.50,
+        netPayAmount = 7.00,
+        distanceMiles = 3.2,
+        dollarsPerMile = 2.19,
+        dollarsPerHour = 22.0,
+        estimatedTimeMinutes = 19.0,
+        itemCount = 1.0,
+        merchantName = "Chipotle",
+    )
+
+    @Test
+    fun `a resolved offer cancels the pending notification post`() = runTest {
+        val engine = buildEngine(StandardTestDispatcher(testScheduler))
+
+        engine.process(AppEffect.PostOfferNotification(testEvaluation(), offerHash = "hash-9"))
+        runCurrent()
+        engine.process(AppEffect.CancelOfferNotification(offerHash = "hash-9"))
+        runCurrent()
+        advanceTimeBy(SideEffectEngine.OFFER_NOTIFICATION_DELAY_MS + 100)
+        runCurrent()
+
+        verify(bubbleManager, never()).postOfferNotification(any())
+    }
+
+    @Test
+    fun `an unresolved offer notification still posts after the settle delay`() = runTest {
+        val engine = buildEngine(StandardTestDispatcher(testScheduler))
+
+        engine.process(AppEffect.PostOfferNotification(testEvaluation(), offerHash = "hash-9"))
+        runCurrent()
+        advanceTimeBy(SideEffectEngine.OFFER_NOTIFICATION_DELAY_MS + 100)
+        runCurrent()
+
+        verify(bubbleManager, times(1)).postOfferNotification(any())
+    }
+
+    @Test
+    fun `keyed effects dedupe on the live path - not just during recovery`() = runTest {
+        val engine = buildEngine(StandardTestDispatcher(testScheduler))
+        val effect = AppEffect.StartSession("sess-7", "DoorDash")
+        wheneverBlocking { effectsFiredDao.hasBeenFired(effect.effectKey!!) }
+            .thenReturn(true)
+
+        engine.process(effect, recovering = false)
+        runCurrent()
+
+        verify(bubbleManager, never()).startSession(any(), any())
+        verifyBlocking(effectsFiredDao, never()) { markFired(any()) }
+    }
+
+    @Test
+    fun `a gate-denied rule effect is not marked fired`() = runTest {
+        val engine = buildEngine(StandardTestDispatcher(testScheduler))
+        // Distinct dedupeKeys: a denied fire still consumes the wall-clock
+        // throttle slot, so the granted attempt must not share its key.
+        fun offerShot(key: String) = AppEffect.RequestEffect(
+            RequestedEffect(
+                verb = EffectVerb.SCREENSHOT,
+                ruleId = "doordash.screen.offer_popup",
+                args = mapOf("category" to "offer"),
+                dedupeKey = key,
+            ),
+        )
+
+        evidenceConfig.value = EvidenceConfig(masterEnabled = false)
+        engine.process(offerShot("denied"))
+        runCurrent()
+        verify(screenShotHandler, never()).capture(any(), any())
+        // Denied ≠ fired (#436): marking it would skip the effect forever
+        // (live-path dedupe) once the user enables the Evidence setting.
+        verifyBlocking(effectsFiredDao, never()) { markFired(any()) }
+
+        evidenceConfig.value = EvidenceConfig(masterEnabled = true, saveOffers = true)
+        engine.process(offerShot("granted"))
+        runCurrent()
+        verify(screenShotHandler, times(1)).capture(any(), any())
+        verifyBlocking(effectsFiredDao, times(1)) { markFired(any()) }
     }
 
     // =========================================================================

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/strategy/StrategyRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/strategy/StrategyRepository.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
@@ -156,7 +157,16 @@ class StrategyRepository @Inject constructor(
         declineMinRatio
     )
 
-    val evaluationConfigFlow: Flow<EvaluationConfig> = combine(
+    /**
+     * THE materialized evaluation config (#436): eagerly shared so the
+     * side-effect engine's per-offer read is a value lookup instead of a cold
+     * DataStore combine inside its single serialized worker (head-of-line
+     * latency on every offer). Null until the first DataStore emission —
+     * consumers `filterNotNull()` rather than evaluate against a guessed
+     * default (mirrors [evidenceConfig]'s pattern, but fail-*waiting* instead
+     * of fail-closed: an offer must never be scored with wrong economics).
+     */
+    val evaluationConfig: StateFlow<EvaluationConfig?> = combine(
         scoringRules,
         protectStatsMode,
         allowShopping,
@@ -168,7 +178,7 @@ class StrategyRepository @Inject constructor(
             allowShopping = shop,
             userEconomy = economy,
         )
-    }
+    }.stateIn(scope, SharingStarted.Eagerly, null)
 
 
     suspend fun clearPreferences() {

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/AppEffect.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/AppEffect.kt
@@ -98,7 +98,20 @@ sealed class AppEffect {
      * fired inline from the [EvaluateOffer] loopback handler — so the offer's UI side-effects stay
      * first-class and testable. The app layer formats the summary + persona from the evaluation.
      */
-    data class PostOfferNotification(val evaluation: OfferEvaluation) : AppEffect()
+    data class PostOfferNotification(
+        val evaluation: OfferEvaluation,
+        /** Keys the engine's delayed post so [CancelOfferNotification] can abort it (#436). */
+        val offerHash: String?,
+    ) : AppEffect()
+
+    /**
+     * Abort a pending (not-yet-posted) offer notification (#436). Emitted by
+     * [EffectMap] when the offer resolves (accept/decline/timeout): the post
+     * is delayed ~750ms behind the screenshot settle, so without this an
+     * actionable Accept/Decline heads-up could land AFTER the offer was
+     * already gone.
+     */
+    data class CancelOfferNotification(val offerHash: String?) : AppEffect()
 
     /**
      * Perform an app-owned [RuleAction] on the platform app (#425) — the only

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -164,13 +164,16 @@ class EffectMap @Inject constructor() {
             prevOffer.offerHash == nextOffer.offerHash &&
             prevOffer.evaluation == null
         ) {
-            add(AppEffect.PostOfferNotification(landedEval))
+            add(AppEffect.PostOfferNotification(landedEval, nextOffer.offerHash))
             add(AppEffect.SpeakOffer(landedEval))
         }
 
         // Offer resolved (accepted/declined/timeout)
         if (prevOffer != null && nextOffer == null) {
             val outcome = resolveOfferOutcome(obs, prevOffer)
+            // Abort a notification still waiting out its post delay (#436) —
+            // an Accept/Decline heads-up must not land after the offer is gone.
+            add(AppEffect.CancelOfferNotification(prevOffer.offerHash))
             add(logEffect(sessionId, outcome, obs.timestamp, offerPayload(prevOffer, outcome, obs.timestamp)))
 
             if (outcome == AppEventType.OFFER_TIMEOUT) {

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -63,6 +63,16 @@ immediately (no second pass needed) so it gets triaged.
 _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **broken** on the
 2026-06-09 dash — moved to that session's log entry below for triage.)_
 
+- **Engine latency + dedupe pack (#436).**
+  Four behaviors to watch: (a) accepting/declining an offer FAST (inside ~1s of the verdict
+  landing) should no longer pop a stale Accept/Decline heads-up afterwards; (b) offer verdicts
+  should land a touch quicker (config no longer read cold per offer); (c) relaunching the app
+  mid-dash (non-crash restart) should NOT duplicate session-start bubbles or re-log events on
+  the next screen; (d) nothing else regresses — notifications still post normally when the
+  offer is left alone. Broken = stale heads-up after resolving an offer, duplicated chat
+  entries after an app restart, or a missing offer notification.
+  - Confirmed: 0/2
+
 - **Per-offer dedupe now engages (#427).**
   Offer screenshot/log dedupe keys used to resolve to one shared literal, so a second distinct
   offer within 60s was silently swallowed. Now keyed per-offer via `{parsedHash}`. Watch on a


### PR DESCRIPTION
Closes #436 — all five items from the effects audit.

## What changed

1. **Eval config materialized** — `StrategyRepository.evaluationConfig: StateFlow<EvaluationConfig?>` (`stateIn` Eagerly, null before first load). The engine's per-offer read becomes a value lookup instead of a cold DataStore combine inside the single serialized worker. `filterNotNull().first()` preserves correctness: an offer arriving before the first load *waits* for real economics instead of scoring against a guessed default (deliberately different from `evidenceConfig`'s fail-closed default — wrong economics on a live offer is worse than a short wait).
2. **Stale offer notification cancelled** — `PostOfferNotification` carries `offerHash`; the delayed post is tracked per hash (self-removing completion handler, the #406 timer pattern); EffectMap emits `CancelOfferNotification` when the offer resolves. An Accept/Decline heads-up can no longer post for an offer that's already gone. Formatting (Spannable + persona) moved from the engine into `BubbleManager.postOfferNotification(evaluation)` — UI assembly at the UI edge, engine free of Android text types.
3. **Live-path keyed dedupe** — `effects_fired` is consulted for every keyed effect, not only during recovery: a non-crash restart no longer re-fires keyed external effects on re-observation (duplicate session bubbles / re-logged events). The 48h prune bounds the window.
4. **Throttle map pruned** — `stampThrottle` evicts entries older than 10 min once past 256 keys (per-offer key leak over long sessions).
5. **Denied ≠ fired** — `dispatchRuleEffect` returns false on a tier (#417) or evidence (#426) denial and the `markFired` tail is skipped. Without this, a denied-then-granted effect would be "already fired" forever — on recovery and, with item 3, on the live path too. (The issue flagged this as "coordinate with #417"; both gates are now real, so this closes the loop.)

## Security/privacy posture

Effects-layer only. The denial paths get *stronger*: a gate denial now leaves no fired record, so granting a permission later behaves as the user expects. No new capability surface; recovery suppression and tap verification unchanged.

## Tests

Engine: cancel-aborts-the-pending-post + posts-normally-without-cancel (virtual time), live-path keyed dedupe skips and doesn't re-mark, denied-not-marked / granted-marked through the rule-verb path. EffectMap: `PostOfferNotification` pins its offerHash; offer-pop emits `CancelOfferNotification`. Full `testDebugUnitTest` green.

## Context updates

Field-test item (0/2): no stale heads-up after fast accept/decline, snappier verdicts, no duplicate bubbles/logs after a mid-dash app restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)