### PR TITLE
fix(ssot): derive the bubble's activeDashId from AppState (#437)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManager.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManager.kt
@@ -15,10 +15,12 @@ import androidx.core.content.pm.ShortcutManagerCompat
 import androidx.core.graphics.drawable.IconCompat
 import cloud.trotter.dashbuddy.R
 import cloud.trotter.dashbuddy.core.data.chat.ChatRepository
+import cloud.trotter.dashbuddy.core.state.StateManagerV2
 import cloud.trotter.dashbuddy.state.effects.OfferActionReceiver
 import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
 import cloud.trotter.dashbuddy.domain.model.chat.ChatPersona
 import cloud.trotter.dashbuddy.domain.state.OfferIntent
+import cloud.trotter.dashbuddy.domain.state.activeSessionId
 import cloud.trotter.dashbuddy.ui.formatters.getIconResId // <-- Your new UI Formatter!
 import cloud.trotter.dashbuddy.ui.formatters.notificationPersona
 import cloud.trotter.dashbuddy.ui.formatters.toNotificationSummary
@@ -26,8 +28,10 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
@@ -37,7 +41,10 @@ import javax.inject.Singleton
 class BubbleManager @Inject constructor(
     @param:ApplicationContext private val context: Context,
     private val notificationManager: NotificationManager,
-    private val chatRepository: ChatRepository
+    private val chatRepository: ChatRepository,
+    // dagger.Lazy breaks the StateManagerV2 → EffectExecutor → BubbleManager
+    // construction cycle (#437); resolved on first activeDashId access.
+    private val stateManager: dagger.Lazy<StateManagerV2>,
 ) {
 
     companion object {
@@ -57,22 +64,33 @@ class BubbleManager @Inject constructor(
     private val channelId = "bubble_channel"
     private val shortcutId = "DashBuddy_Bubble_Shortcut"
 
-    private val _activeDashId = MutableStateFlow<String?>(null)
-    val activeDashId = _activeDashId.asStateFlow()
+    /**
+     * The dash id chat/cards attribute to — DERIVED from `AppState` (#437),
+     * not a second effect-driven copy. The old `_activeDashId` was set by
+     * StartSession/EndSession, which crash recovery suppresses (external
+     * effects): a restored mid-dash process had a null id and the bubble
+     * showed nothing until the next DASH_START. State restores; this follows.
+     * Lazy so the Hilt graph finishes building before StateManagerV2 resolves.
+     */
+    val activeDashId: StateFlow<String?> by lazy {
+        stateManager.get().state
+            .map { it.activeSessionId() }
+            .stateIn(scope, SharingStarted.Eagerly, null)
+    }
 
     init {
         createChannel()
         pushDynamicShortcut()
     }
 
+    /** Session chat copy only — the dash id derives from state (#437). */
     fun startSession(sessionId: String, platformName: String) {
-        _activeDashId.value = sessionId
         val verb = sessionVerb(platformName)
         postMessage("Started $verb!", ChatPersona.Dispatcher)
     }
 
+    /** Session chat copy only — the dash id derives from state (#437). */
     fun endSession(platformName: String? = null) {
-        _activeDashId.value = null
         val verb = sessionVerb(platformName)
         postMessage("Done $verb!", ChatPersona.Dispatcher)
     }
@@ -94,7 +112,7 @@ class BubbleManager @Inject constructor(
 
         // 2. UPDATED: Launched in a coroutine because the Repository is pure suspend now!
         scope.launch {
-            chatRepository.saveMessage(_activeDashId.value, text.toString(), persona)
+            chatRepository.saveMessage(activeDashId.value, text.toString(), persona)
         }
 
         // Post Notification
@@ -212,7 +230,7 @@ class BubbleManager @Inject constructor(
         val summary = evaluation.toNotificationSummary()
         val persona = evaluation.notificationPersona()
         Timber.tag("Chat").i("[${persona.displayName}]: $summary")
-        scope.launch { chatRepository.saveMessage(_activeDashId.value, summary.toString(), persona) }
+        scope.launch { chatRepository.saveMessage(activeDashId.value, summary.toString(), persona) }
         showNotification(summary, persona, expand = false, offerActionable = true)
     }
 

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -63,6 +63,14 @@ immediately (no second pass needed) so it gets triaged.
 _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **broken** on the
 2026-06-09 dash — moved to that session's log entry below for triage.)_
 
+- **Bubble dash id survives a mid-dash crash/restart (#437).**
+  The bubble's chat + card stack now derive their dash id from restored state instead of an
+  effect that crash recovery suppresses. Mid-dash, force-stop or crash the app and reopen:
+  working = the bubble's chat history and cards are attributed to the SAME dash immediately
+  (no orphaned/empty bubble until the next dash starts). Broken = empty chat/card stack after
+  a mid-dash restart, or messages landing under a null dash in the DB.
+  - Confirmed: 0/2
+
 - **Engine latency + dedupe pack (#436).**
   Four behaviors to watch: (a) accepting/declining an offer FAST (inside ~1s of the verdict
   landing) should no longer pop a stale Accept/Decline heads-up afterwards; (b) offer verdicts

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/AppState.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/AppState.kt
@@ -32,3 +32,21 @@ data class Regions(
     val crossPlatform: CrossPlatformRegion = CrossPlatformRegion(),
     val platforms: Map<Platform, PlatformRegion> = emptyMap(),
 )
+
+/**
+ * THE session id the UI attributes to (#437) — derived from state, never a
+ * second copy. BubbleManager used to mutate its own `activeDashId` from
+ * StartSession/EndSession effects; crash recovery SUPPRESSES StartSession
+ * (external effect), so a restored mid-dash process had a null dash id and
+ * chat/cards attributed to nothing until the next DASH_START. Deriving from
+ * the restored [AppState] makes recovery correct by construction
+ * (principle 5 — the #356 SSOT family).
+ *
+ * Prefers the flow region's active platform; falls back to any platform with
+ * a live session (single-platform alpha: at most one exists).
+ */
+fun AppState.activeSessionId(): String? {
+    val active = regions.flow.activePlatform
+        ?.let { regions.platforms[it]?.session?.sessionId }
+    return active ?: regions.platforms.values.firstNotNullOfOrNull { it.session?.sessionId }
+}

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/state/ActiveSessionIdTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/state/ActiveSessionIdTest.kt
@@ -1,0 +1,61 @@
+package cloud.trotter.dashbuddy.domain.state
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * The dash-id derivation BubbleManager's `activeDashId` reads (#437). The
+ * recovery property follows directly: snapshots restore [AppState], so a
+ * restored mid-dash process derives its session id instead of waiting for a
+ * StartSession effect that recovery suppresses.
+ */
+class ActiveSessionIdTest {
+
+    private fun region(platform: Platform, sessionId: String?) = PlatformRegion(
+        platform = platform,
+        mode = if (sessionId != null) Mode.Online else Mode.Offline,
+        session = sessionId?.let { Session(it, startedAt = 100L) },
+    )
+
+    @Test
+    fun `mid-session state derives the session id - the crash-recovery case`() {
+        val state = AppState(regions = Regions(
+            platforms = mapOf(Platform.DoorDash to region(Platform.DoorDash, "sess-42")),
+        ))
+        assertEquals("sess-42", state.activeSessionId())
+    }
+
+    @Test
+    fun `no live session derives null`() {
+        assertNull(AppState().activeSessionId())
+        val offline = AppState(regions = Regions(
+            platforms = mapOf(Platform.DoorDash to region(Platform.DoorDash, sessionId = null)),
+        ))
+        assertNull(offline.activeSessionId())
+    }
+
+    @Test
+    fun `the flow region's active platform wins when several sessions exist`() {
+        val state = AppState(regions = Regions(
+            flow = FlowRegion(activePlatform = Platform.Uber),
+            platforms = mapOf(
+                Platform.DoorDash to region(Platform.DoorDash, "dd-sess"),
+                Platform.Uber to region(Platform.Uber, "uber-sess"),
+            ),
+        ))
+        assertEquals("uber-sess", state.activeSessionId())
+    }
+
+    @Test
+    fun `an active platform without a session falls back to the live one`() {
+        val state = AppState(regions = Regions(
+            flow = FlowRegion(activePlatform = Platform.Uber),
+            platforms = mapOf(
+                Platform.Uber to region(Platform.Uber, sessionId = null),
+                Platform.DoorDash to region(Platform.DoorDash, "dd-sess"),
+            ),
+        ))
+        assertEquals("dd-sess", state.activeSessionId())
+    }
+}


### PR DESCRIPTION
Closes #437. `BubbleManager` held a second copy of the active dash id, mutated by `StartSession`/`EndSession` effects. Crash recovery suppresses `StartSession` (external effect), so a restored mid-dash process had `activeDashId = null` — chat writes attributed to null and `BubbleViewModel`'s messages/card stack showed nothing until the next DASH_START.

## What changed

- **`AppState.activeSessionId()`** (`:domain`) — THE derivation: the flow region's active platform's session id, falling back to any platform with a live session (at most one in the single-platform alpha). Pure; unit-tested including the multi-platform preference, fallback, and the mid-session crash-recovery case.
- **`BubbleManager.activeDashId`** is now `stateManager.get().state.map { it.activeSessionId() }.stateIn(...)`. `dagger.Lazy<StateManagerV2>` breaks the `StateManagerV2 → EffectExecutor → BubbleManager` construction cycle; the lazy property defers resolution until after the Hilt graph is built. `StartSession`/`EndSession` keep only their chat copy ("Started Dashing!").
- Recovery correctness is now by construction: snapshots restore `AppState`; the id follows. No effect ordering involved.

## Security/privacy posture

UI-attribution plumbing only; no recognition/capture/network/effect-gate surface. One fewer hand-maintained state copy (principle 5).

## Tests

`ActiveSessionIdTest` (`:domain`): mid-session derivation (the recovery case), null when no live session, active-platform preference across two concurrent sessions, fallback when the active platform has no session. Full `testDebugUnitTest` green.

## Context updates

Field-test item (0/2): force-stop mid-dash and reopen — the bubble's chat/cards must attribute to the same dash immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)