### PR TITLE
docs(field-log): 2026-06-12/13 DoorDash offer-copilot dashes — confirmations + 5 new findings

### DIFF
--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -147,10 +147,15 @@ _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **bro
   "Decline") instead of hardcoded view IDs. Working = DoorDash registers the tap. Broken = log
   shows "No 'acceptButton' target bound" (rule didn't bind on that screen variant — capture it!)
   or "NONE passed label verification" (verification too strict for that variant).
-  - Confirmed: 1/2. **2026-06-12 (DoorDash):** dasher tapped **Accept** in the bubble → DoorDash
-    registered the Accept (offer was accepted). First clean live confirmation of the rule-bound tap
-    path that was broken on 06-09. Still need a second sighting — ideally the **Decline** side and
-    the **notification** surface (not just bubble Accept). (See 2026-06-12 log entry #1.)
+  - Confirmed: 1/2 (BUBBLE surface only). **2026-06-12 (DoorDash):** dasher tapped **Accept** in the
+    bubble → DoorDash registered the Accept (offer was accepted). First clean live confirmation of the
+    rule-bound tap path that was broken on 06-09. (See 2026-06-12 log entry #1.)
+  - ⚠️ **NOTIFICATION surface FOUND BROKEN — 2026-06-12 (DoorDash):** tapping **Accept and Decline
+    from the heads-up notification itself did NOTHING** (neither worked), same dash the bubble worked.
+    Dispatch path/wire strings are identical to the bubble; likely the click target isn't reachable
+    from the notification shade (offer window not foreground). Triaged as 2026-06-12 log entry #11 —
+    pull logcat for `OfferActionReceiver: accept_offer/decline_offer` to split broadcast-not-landing
+    vs click-target-absent. Bubble half still needs a 2nd sighting (esp. Decline).
 
 - **Post-dash HUD: frozen summary + consistent chat (#367, PR pending).**
   Two visible fixes after a dash ends: (a) the "Last session" Duration on the idle bubble is
@@ -533,6 +538,34 @@ and asked whether it was already fixed. **It is not.** Desk finding:
   **Hypothesis:** the clean fix routes the bubble copy through the one money formatter rather than a
   local `%.2f`, but where the formatter can live is bound up with #366 — a desk call, not a drop-in.
 
+#### 11. **FOUND BROKEN** — notification Accept/Decline don't work (neither), though the bubble's do
+On a later offer the dasher tapped **Accept and then Decline from the heads-up notification itself**
+— **neither did anything** on DoorDash. This is **distinct from the bubble path (entry #1), which
+worked**: same dash, the bubble's Accept clicked DoorDash, but the notification's buttons don't.
+Moves the notification half of the #425 checklist item to broken.
+
+- **What's the same (so it's not the wire string):** the notification's Accept/Decline send
+  `OfferIntent.ACCEPT`/`DECLINE` = `"accept_offer"`/`"decline_offer"`
+  (`BubbleManager.kt:216-217`, `OfferIntent.kt:10-11`) — the **identical** strings the bubble
+  dispatches — and `OfferActionReceiver` then dispatches the **same** `Observation.UiInput`
+  (`OfferActionReceiver.kt:32-39`). So EffectMap's offer-action handling isn't the divergence.
+- **What's different (the hypothesis):** the receiver is **manifest-registered**
+  (`AndroidManifest.xml:80-81`) and the PendingIntent is an **explicit, same-app broadcast** with
+  `FLAG_IMMUTABLE` (`BubbleManager.kt:238-245`), so it *should* reach `onReceive`. The likely break
+  is **downstream of dispatch**: acting from the **notification shade**, DoorDash's offer button
+  isn't reachable to the accessibility click the way it is when the **bubble overlays the live
+  offer** — the shade (or an advanced/expired offer) is foreground, so `UiInteractionHandler`'s
+  all-windows click finds **no live target** and aborts to manual. Same `Could not find any live
+  node` *class* as the 06-09 bubble bug, but a different cause (wrong foreground window, not
+  wrong-window search).
+- **One log line splits the two hypotheses (desk):** pull logcat around the taps. If
+  `OfferActionReceiver: accept_offer` / `decline_offer` is **absent**, the broadcast never landed
+  (PendingIntent/registration). If it's **present** but followed by a target-resolution failure /
+  `Could not find any live node`, it's the click-target-absent path. Capture which.
+- **Field note for next time:** retry the notification action **while still on the DoorDash offer
+  screen** (notification shade pulled down over the live offer, offer not yet expired) and see if it
+  behaves differently from tapping it after navigating away.
+
 ### Verification TODOs (confirmations this session)
 
 #### 1. Bubble **Accept** clicks DoorDash — #425 rule-bound tap CONFIRMED (1/2)
@@ -579,6 +612,26 @@ feels fully quick — no perceptible delay** (loosely supports #436 (b) "verdict
 quicker"); #436 stays 0/2 since its dedupe/restart sub-cases weren't deliberately tested.
 
 ### Open questions / investigations
+
+#### 12. 7-Eleven alcohol pickup: initial pickup screen UNKNOWN, but self-corrected to drop-off on nav (cross-refs #149/#433)
+On a **7-Eleven alcohol** order (~**19:59 local**), the **initial pickup screen was not recognized**
+(UNKNOWN — no pickup classification). The dasher picked the order up anyway and watched whether it
+would recover: **as soon as the screen changed to the map (drop-off navigation), the app "automatically
+knew" it was on drop-off** and corrected itself.
+
+- **What this tells us:** the **state machine recovered via the nav/flow transition** — even though
+  the pickup-confirm screen itself didn't classify, the drop-off-nav frame did, and the platform
+  region advanced to DROPOFF. Good resilience signal (the missed pickup frame didn't strand the task).
+- **The gap to chase:** the **7-Eleven (alcohol) pickup/confirm screen is an unrecognized variant**.
+  Two ties: #433 notes `pickup_picked_up` had **zero corpus** and could never match before its
+  mojibake fix — this may be exactly that screen failing to classify on a 7-Eleven layout; and #149
+  is the alcohol ID-verify flow. **To confirm:** pull the ~19:59 capture for this task — expect an
+  UNKNOWN around the pickup/confirm step; if so it needs a rule/corpus addition for the 7-Eleven
+  (and possibly alcohol) pickup variant. **Capture is the unblock here** — this screen has little/no
+  corpus.
+- **Did NOT observe:** whether the missed pickup screen cost anything downstream (arrival/confirm
+  timestamps, the pickup card's store/items) — worth checking the event DB for this task vs a clean
+  pickup.
 
 #### 5. Transient **double drop-off card** during the at-door window (cross-refs #297)
 On the **Great Greek Mediterranean** delivery the dasher saw **two drop-off cards** while at the

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -147,15 +147,16 @@ _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **bro
   "Decline") instead of hardcoded view IDs. Working = DoorDash registers the tap. Broken = log
   shows "No 'acceptButton' target bound" (rule didn't bind on that screen variant — capture it!)
   or "NONE passed label verification" (verification too strict for that variant).
-  - Confirmed: 1/2 (BUBBLE surface only). **2026-06-12 (DoorDash):** dasher tapped **Accept** in the
-    bubble → DoorDash registered the Accept (offer was accepted). First clean live confirmation of the
+  - Confirmed: 1/2 (IN-BUBBLE buttons only). **2026-06-12 (DoorDash):** dasher tapped **Accept** in the
+    **expanded bubble** → DoorDash registered the Accept. First clean live confirmation of the
     rule-bound tap path that was broken on 06-09. (See 2026-06-12 log entry #1.)
-  - ⚠️ **NOTIFICATION surface FOUND BROKEN — 2026-06-12 (DoorDash):** tapping **Accept and Decline
-    from the heads-up notification itself did NOTHING** (neither worked), same dash the bubble worked.
-    Dispatch path/wire strings are identical to the bubble; likely the click target isn't reachable
-    from the notification shade (offer window not foreground). Triaged as 2026-06-12 log entry #11 —
-    pull logcat for `OfferActionReceiver: accept_offer/decline_offer` to split broadcast-not-landing
-    vs click-target-absent. Bubble half still needs a 2nd sighting (esp. Decline).
+  - ⚠️ **NOTIFICATION-SHADE buttons FOUND BROKEN — 2026-06-12 (DoorDash):** the Accept/Decline buttons
+    on the **system shade notification** (NOT the in-bubble buttons) did **NOTHING** (neither worked),
+    same dash the in-bubble buttons worked. Dispatch path/wire strings are identical to the bubble;
+    likely the click target isn't reachable from the shade (offer window not foreground). Triaged as
+    2026-06-12 log entry #11 — pull logcat for `OfferActionReceiver: accept_offer/decline_offer` to
+    split broadcast-not-landing vs click-target-absent. In-bubble half still needs a 2nd sighting (esp.
+    Decline).
 
 - **Post-dash HUD: frozen summary + consistent chat (#367, PR pending).**
   Two visible fixes after a dash ends: (a) the "Last session" Duration on the idle bubble is
@@ -538,11 +539,18 @@ and asked whether it was already fixed. **It is not.** Desk finding:
   **Hypothesis:** the clean fix routes the bubble copy through the one money formatter rather than a
   local `%.2f`, but where the formatter can live is bound up with #366 — a desk call, not a drop-in.
 
-#### 11. **FOUND BROKEN** — notification Accept/Decline don't work (neither), though the bubble's do
-On a later offer the dasher tapped **Accept and then Decline from the heads-up notification itself**
-— **neither did anything** on DoorDash. This is **distinct from the bubble path (entry #1), which
-worked**: same dash, the bubble's Accept clicked DoorDash, but the notification's buttons don't.
-Moves the notification half of the #425 checklist item to broken.
+#### 11. **FOUND BROKEN** — the notification-SHADE Accept/Decline buttons don't work (the in-bubble ones do)
+**Surface taxonomy (dasher clarified — investigate the right one):**
+- ✅ **In-bubble buttons** — the Accept/Decline buttons inside the **expanded bubble** (the in-app
+  Compose `OfferActionRow`) **work** (entry #1: bubble Accept clicked DoorDash).
+- ❌ **Notification-shade action buttons** — the Accept/Decline buttons on the **heads-up / shade
+  notification** are what the dasher tapped, and **neither did anything** on DoorDash. **This is the
+  broken surface.** Moves the notification half of the #425 checklist item to broken.
+- ℹ️ Side note: the bubble's own (collapsed/conversation) notification "doesn't have buttons on it" —
+  so the buttons the dasher pressed were unambiguously the **shade notification's action buttons**,
+  not the in-bubble ones.
+
+The two surfaces are NOT the same code path at the click edge even though they share the dispatch:
 
 - **What's the same (so it's not the wire string):** the notification's Accept/Decline send
   `OfferIntent.ACCEPT`/`DECLINE` = `"accept_offer"`/`"decline_offer"`
@@ -552,19 +560,20 @@ Moves the notification half of the #425 checklist item to broken.
 - **What's different (the hypothesis):** the receiver is **manifest-registered**
   (`AndroidManifest.xml:80-81`) and the PendingIntent is an **explicit, same-app broadcast** with
   `FLAG_IMMUTABLE` (`BubbleManager.kt:238-245`), so it *should* reach `onReceive`. The likely break
-  is **downstream of dispatch**: acting from the **notification shade**, DoorDash's offer button
-  isn't reachable to the accessibility click the way it is when the **bubble overlays the live
-  offer** — the shade (or an advanced/expired offer) is foreground, so `UiInteractionHandler`'s
-  all-windows click finds **no live target** and aborts to manual. Same `Could not find any live
-  node` *class* as the 06-09 bubble bug, but a different cause (wrong foreground window, not
-  wrong-window search).
+  is **downstream of dispatch**: acting from the **system notification shade**, DoorDash's offer
+  button isn't reachable to the accessibility click the way it is when the **in-app bubble overlays
+  the live offer** — the shade (or an advanced/expired offer) is foreground, so
+  `UiInteractionHandler`'s all-windows click finds **no live target** and aborts to manual. Same
+  `Could not find any live node` *class* as the 06-09 bubble bug, but a different cause (wrong
+  foreground window, not wrong-window search). The in-bubble buttons working fits this: the bubble is
+  drawn over the live offer, so the target window is present.
 - **One log line splits the two hypotheses (desk):** pull logcat around the taps. If
   `OfferActionReceiver: accept_offer` / `decline_offer` is **absent**, the broadcast never landed
   (PendingIntent/registration). If it's **present** but followed by a target-resolution failure /
   `Could not find any live node`, it's the click-target-absent path. Capture which.
-- **Field note for next time:** retry the notification action **while still on the DoorDash offer
-  screen** (notification shade pulled down over the live offer, offer not yet expired) and see if it
-  behaves differently from tapping it after navigating away.
+- **Field note for next time:** retry the **shade** action **while still on the DoorDash offer
+  screen** (shade pulled down over the live offer, offer not yet expired) and see if it behaves
+  differently from tapping it after navigating away.
 
 ### Verification TODOs (confirmations this session)
 

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -69,7 +69,12 @@ _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **bro
   working = the bubble's chat history and cards are attributed to the SAME dash immediately
   (no orphaned/empty bubble until the next dash starts). Broken = empty chat/card stack after
   a mid-dash restart, or messages landing under a null dash in the DB.
-  - Confirmed: 0/2
+  - Confirmed: 1/2. **2026-06-12 (DoorDash):** force-quit + reload **after resetting the
+    accessibility permission** (a harder restart than a plain force-stop — the service rebinds from
+    scratch) reloaded the bubble with the **current dash still active**. Confirms the dash id derives
+    from restored state, not the crash-suppressed effect. Needs one more clean sighting (ideally
+    confirming the chat history + completed cards re-populate under that same dash, not just that the
+    dash is active). (See 2026-06-12 log entry #6.)
 
 - **Engine latency + dedupe pack (#436).**
   Four behaviors to watch: (a) accepting/declining an offer FAST (inside ~1s of the verdict
@@ -544,6 +549,14 @@ denied capability would have left it collapsed (`Denied expand_earnings — no g
 so the asset-rule auto-grant is covering it. Together with #1 (bubble Accept), both gated automation
 taps fired with no regression. Bumped the #425 expand-earnings and #417 consent-gate checklist items
 to 1/2 each.
+
+#### 6. Bubble survives force-quit + accessibility-permission reset — #437 (1/2)
+Dasher **force-quit and reloaded the app after resetting the accessibility permission** mid-dash —
+a harder restart than a plain force-stop, since the accessibility service rebinds from scratch — and
+the bubble **reloaded with the current dash still active** (not an orphaned/empty bubble). Confirms
+the bubble's dash id derives from restored state rather than the crash-suppressed effect (#437).
+Bumped the checklist item to 1/2; second sighting should confirm the **chat history + completed
+cards** re-populate under that same dash, not just that the dash reads active.
 
 #### 2. Shop & Deliver terminal `total/total` — #302 CONFIRMED (2/2, retired)
 The pickup/shop card read **`shop 25/25 · 0.6/min`** at end of shop — the terminal `total/total`

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -661,29 +661,38 @@ crash. The dasher's read — "maybe it auto-corrected" — matches a desk hypoth
   not closing the Delivery into `completed` until `DELIVERY_CONFIRMED` — but that's a design call for
   the desk, **not** a concluded fix.
 
-#### 8. After a crash with **no active dash**, the bubble cleared instead of showing the last dash (cross-refs #437, #367)
-Distinct from #3: the clean re-attach in #3 was for a restart **while the dash was still active**.
-Separately this session, **after a crash where no dash was active**, the dash did **not** persist as
-the "last dash" — the **bubble cleared out** (empty chat + empty card stack) rather than showing the
-most-recently-completed dash. Flagged by the dasher for the desk/Android Studio agent.
+#### 8. Bubble clears instead of showing the last dash — after a crash AND after a normal dash-end (cross-refs #437, #367)
+Distinct from #3 (which was a re-attach **while the dash was still active**). This item now has **two
+triggers**, and a second sighting makes it look like a **real gap, not just transitional**:
+- **8a — after a crash with no active dash (earlier this session):** the bubble **cleared out**
+  (empty chat + empty card stack) instead of showing the most-recently-completed dash.
+- **8b — after a normal dash END (2026-06-13 ~late):** ending a dash **again cleared the cards**. The
+  dasher's read: "we might be in a state where it's just not displaying the last dash … might just be
+  we're in transition." Desk finding below suggests it's the **same root cause as 8a**, not a benign
+  transition.
 
-- **Likely cause (hypothesis):** the bubble's `displayedDashId` is a purely **in-memory latch** —
-  `bubbleManager.activeDashId.scan(null) { last, current -> current ?: last }`
-  (`BubbleViewModel.kt:95-96`). It holds the last non-null **active** dash id, but a **process death
-  resets the `scan` to null**; on restart, if `activeSessionId()` is null (no active dash), nothing
-  repopulates it. Both downstream flows then key off `null` → `messages` = empty
-  (`BubbleViewModel.kt:98-104`) and `cardStack.completed` = empty (events query returns empty for a
-  null dash id, `:119-122`) — i.e. the bubble empties.
-- **The code comment claims a fallback that isn't implemented for the crash case:**
-  `BubbleViewModel.kt:106-107` says the card stack uses "the current active dash when one is running,
-  **otherwise the most-recently-completed one**" — but there's no **persisted** last-completed-dash-id
-  lookup feeding `displayedDashId`; the only "otherwise" is the in-memory `scan` latch, which a crash
-  wipes. So the documented "review the previous dash" behavior survives a normal idle transition but
-  **not** a process death.
-- **To confirm / one direction to weigh (desk, not a fix):** reproduce by crashing with the dash
-  ended/none-active and check whether `activeDashId` is null at restart. A durable fix would mean
-  sourcing `displayedDashId`'s fallback from a persisted "most-recently-completed dash id" (DB/
-  datastore) rather than an in-memory `scan` — overlaps with the #367 post-dash HUD persistence work.
+- **Likely cause (hypothesis, same for both triggers):** the bubble's `displayedDashId` is a purely
+  **in-memory latch** — `bubbleManager.activeDashId.scan(null) { last, current -> current ?: last }`
+  (`BubbleViewModel.kt:95-96`). `activeDashId` is null whenever there's no live session
+  (`AppState.activeSessionId()` returns a session id only while `session != null`,
+  `AppState.kt:48-52`). The `scan` holds the last **non-null** active id — but it gets **reset to
+  null** two ways: (8a) **process death** wipes the scan; (8b) the downstream `messages`/`cardStack`
+  flows are `SharingStarted.WhileSubscribed(5000)` (`BubbleViewModel.kt:104,128`), so when the bubble
+  is collapsed / has no subscribers for >5s and then **re-subscribes after the dash has ended**, the
+  `scan` chain is torn down and **restarts from `null`** while `activeSessionId()` is already null.
+  Either way `displayedDashId` → null → `messages` empty (`:98-104`) and `cardStack.completed` empty
+  (events query returns empty for a null dash id, `:119-122`) — the bubble empties.
+- **The code comment claims a fallback that isn't implemented:** `BubbleViewModel.kt:106-107` says the
+  card stack uses "the current active dash when one is running, **otherwise the most-recently-completed
+  one**" — but there's **no persisted** last-completed-dash-id feeding `displayedDashId`; the only
+  "otherwise" is the in-memory `scan` latch. So the documented "review the previous dash until you go
+  Online again" behavior holds **only** as long as the scan survives — and it does **not** survive a
+  crash (8a) **nor** a post-dash-end bubble re-subscribe (8b). The 8b sighting **contradicts** the
+  earlier "survives a normal idle transition" assumption.
+- **To confirm / one direction to weigh (desk, not a fix):** for 8b, end a dash, collapse the bubble
+  >5s, reopen → check whether cards/chat are gone and whether `activeDashId.value` is null. A durable
+  fix sources `displayedDashId`'s fallback from a **persisted** "most-recently-completed dash id"
+  (DB/datastore) instead of the in-memory `scan` — overlaps with #367 post-dash HUD persistence.
 
 ### Research / design (improvement ideas — explore, not yet scoped)
 

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -63,19 +63,6 @@ immediately (no second pass needed) so it gets triaged.
 _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **broken** on the
 2026-06-09 dash — moved to that session's log entry below for triage.)_
 
-- **Bubble dash id survives a mid-dash crash/restart (#437).**
-  The bubble's chat + card stack now derive their dash id from restored state instead of an
-  effect that crash recovery suppresses. Mid-dash, force-stop or crash the app and reopen:
-  working = the bubble's chat history and cards are attributed to the SAME dash immediately
-  (no orphaned/empty bubble until the next dash starts). Broken = empty chat/card stack after
-  a mid-dash restart, or messages landing under a null dash in the DB.
-  - Confirmed: 1/2. **2026-06-12 (DoorDash):** force-quit + reload **after resetting the
-    accessibility permission** (a harder restart than a plain force-stop — the service rebinds from
-    scratch) reloaded the bubble with the **current dash still active**. Confirms the dash id derives
-    from restored state, not the crash-suppressed effect. Needs one more clean sighting (ideally
-    confirming the chat history + completed cards re-populate under that same dash, not just that the
-    dash is active). (See 2026-06-12 log entry #6.)
-
 - **Engine latency + dedupe pack (#436).**
   Four behaviors to watch: (a) accepting/declining an offer FAST (inside ~1s of the verdict
   landing) should no longer pop a stale Accept/Decline heads-up afterwards; (b) offer verdicts
@@ -84,7 +71,10 @@ _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **bro
   the next screen; (d) nothing else regresses — notifications still post normally when the
   offer is left alone. Broken = stale heads-up after resolving an offer, duplicated chat
   entries after an app restart, or a missing offer notification.
-  - Confirmed: 0/2
+  - Confirmed: 0/2. **2026-06-12 (DoorDash, partial):** dasher reports offer Accept/Decline feels
+    **fully quick — no perceptible delay** (loosely supports (b) "verdicts land a touch quicker").
+    The (a) stale-heads-up-after-fast-resolve, (c) restart-dedupe, and (d) sub-cases were NOT
+    deliberately exercised — so this stays 0/2 until those are checked. (See 2026-06-12 log entry #10.)
 
 - **Per-offer dedupe now engages (#427).**
   Offer screenshot/log dedupe keys used to resolve to one shared literal, so a second distinct
@@ -113,19 +103,11 @@ _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **bro
   no longer kills the live task — the task card should survive. Broken = double "Saved" bubble,
   a delivery missing from the log, or the bubble's task card stuck on the finished delivery
   well past ~3s after the receipt.
-  - Confirmed: 0/2
-
-- **Consent gate is live — bound-target taps must still fire (#417).**
-  The always-true permission stub is gone: automation taps (the post-delivery expand chevron)
-  now require a granted capability key, and bundled rules are auto-granted at rule load.
-  Working = expand auto-tap and bubble/notification Accept/Decline behave exactly as before
-  (no regression — asset rules auto-grant covers them). Broken = a tap silently stops
-  happening and the log shows `Denied expand_earnings — no granted capability` or
-  `ACCESSIBILITY tier not granted` while the service is clearly running — capture logcat.
-  - Confirmed: 1/2. **2026-06-12 (DoorDash):** both gated automation taps fired as before — the
-    post-delivery **expand auto-tap** worked AND the **bubble Accept** clicked DoorDash (#425), so
-    the asset-rule auto-grant covered them with no regression. Needs one more clean sighting. (See
-    2026-06-12 log entry #5.)
+  - Confirmed: 1/2 (sub-case a). **2026-06-12 (DoorDash):** two separate deliveries → **exactly one
+    "Saved" bubble each** (no double-fire) — confirms (a). Sub-cases (b) stacked-order split and (c)
+    misrecognition-survival not exercised this dash. **NOTE — separate bug found:** the "Saved" bubble
+    omits the `$` sign (renders `Saved: 5.50`, not `Saved: $5.50`) — logged as 2026-06-12 entry #9.
+    (See 2026-06-12 log entry #10.)
 
 - **Uber sensitive screens now blocked + UNKNOWN-capture scrub (#432).**
   Uber finally has matcher-layer sensitive rules (wallet / Instant Pay / cash-out / bank /
@@ -158,16 +140,6 @@ _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **bro
   **capture it** — this intent has zero corpus snapshots.
   - Confirmed: 0/2
 
-- **Expand-earnings auto-tap via the new action path (#425).**
-  The post-delivery pay breakdown should auto-expand ~0.5s after the collapsed summary appears
-  (same behavior as before, but the tap now flows through the app-owned EXPAND_EARNINGS action
-  with package scoping instead of a rule-declared click). Working = breakdown expands on its own
-  and the line items parse. Broken = summary stays collapsed; grep logs for "did not fire —
-  target failed resolution/verification" (verification too strict) or "Throttled action".
-  - Confirmed: 1/2. **2026-06-12 (DoorDash):** post-delivery pay breakdown **auto-expanded** on its
-    own as before — confirms the EXPAND_EARNINGS action path AND (implicitly) the #417 consent gate
-    auto-granting the bundled-rule capability (a denied tap would have left it collapsed). Needs one
-    more clean sighting. (See 2026-06-12 log entry #5.)
 - **Bubble/notification Accept-Decline via rule-bound targets (#425).**
   Tapping Accept or Decline in DashBuddy's offer notification (or bubble) must tap the matching
   DoorDash button. The button is now aimed by the offer rule's `acceptButton`/`declineButton`
@@ -536,9 +508,30 @@ _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **bro
 - **Branch under test:** `master` field offer-copilot build (includes the #425 rule-bound
   Accept/Decline path; the freshest watch-list items reference #437/#436/#427). Exact SHA not
   captured this session — developer to correct if needed.
-- **Field conditions:** live dash with at least one Shop & Deliver order (HEB, 25 items) and at
-  least one offer the dasher **accepted from the bubble**. Observations narrated in real time;
-  everything below is **recorded for triage — hypotheses, not concluded fixes.**
+- **Field conditions:** **two dashes this session** (a first dash, then a second later the same day).
+  At least one Shop & Deliver order (HEB, 25 items), offers accepted from the bubble, and two
+  separate deliveries on the second dash. Observations narrated in real time; everything below is
+  **recorded for triage — hypotheses, not concluded fixes.**
+
+### Bugs
+
+#### 9. "Saved: $X" earnings bubble omits the `$` sign (currency not formatted as dollars)
+Dasher flagged the post-delivery **"Saved"** bubble's amount "doesn't [render] as a dollar amount"
+and asked whether it was already fixed. **It is not.** Desk finding:
+
+- The "Saved" bubble builds its text with a **local** `formatCurrency` in the state layer —
+  `EffectMap.kt:704/710` call `formatCurrency(...)`, defined at `EffectMap.kt:870-871` as
+  `String.format(locale, "%.2f", amount)`. That format **has no `$`** — so the bubble renders
+  `Saved: 5.50`, not `Saved: $5.50`, even though the method's own docstring describes the output as
+  `"Saved: $X"` (`EffectMap.kt:666`).
+- It **does** zero-fill the cents (`%.2f` → `5.5` becomes `5.50`), so if the dasher saw a missing
+  trailing zero that'd point elsewhere — **capture the exact on-screen string** next time to settle
+  which symptom it is. Most likely the perceived defect is the **missing `$`**.
+- **SSOT smell (#358 family):** this is a **separate, divergent currency formatter** from the
+  app-wide `DashFormats.money` (`DashFormats.kt:25`, `"$%.2f"`, which *does* include the `$`). The
+  docstring even flags it as a "known wart" pending #366 (move rendered copy out of the state layer).
+  **Hypothesis:** the clean fix routes the bubble copy through the one money formatter rather than a
+  local `%.2f`, but where the formatter can live is bound up with #366 — a desk call, not a drop-in.
 
 ### Verification TODOs (confirmations this session)
 
@@ -549,30 +542,41 @@ tap path (#425) — the same surface that was **broken on 06-09** (`Could not fi
 wrong-window search). Bumped the checklist item to 1/2; still want a second sighting covering the
 **Decline** side and the **notification** surface (not just bubble Accept).
 
-#### 2. Post-delivery earnings **auto-expand** still works — #425 EXPAND_EARNINGS + #417 gate (both 1/2)
+#### 2. Post-delivery earnings **auto-expand** — #425 EXPAND_EARNINGS + #417 gate CONFIRMED (2/2, both retired)
 The collapsed pay breakdown **auto-expanded on its own** after a delivery, as before. Confirms the
 app-owned EXPAND_EARNINGS action path (#425) AND — implicitly — the live consent gate (#417): a
 denied capability would have left it collapsed (`Denied expand_earnings — no granted capability`),
-so the asset-rule auto-grant is covering it. Together with #1 (bubble Accept), both gated automation
-taps fired with no regression. Bumped the #425 expand-earnings and #417 consent-gate checklist items
-to 1/2 each.
+so the asset-rule auto-grant is covering it. **Dash 1:** expand fired + bubble Accept (#1) fired —
+both gated taps with no regression. **Dash 2 (2026-06-12):** the post-delivery expand auto-tapped
+**again** — second clean sighting. Two independent dashes of gated automation taps firing with zero
+`Denied`/throttle → both the **#425 expand-earnings** and **#417 consent-gate** checklist items moved
+out as validated (the gate reliably auto-grants bundled-rule capabilities).
 
-#### 3. Bubble survives force-quit + accessibility-permission reset — #437 (1/2)
-Dasher **force-quit and reloaded the app after resetting the accessibility permission** mid-dash —
-a harder restart than a plain force-stop, since the accessibility service rebinds from scratch — and
-the bubble **reloaded with the current dash still active** (not an orphaned/empty bubble). Confirms
-the bubble's dash id derives from restored state rather than the crash-suppressed effect (#437).
-Bumped the checklist item to 1/2; second sighting should confirm the **chat history + completed
-cards** re-populate under that same dash, not just that the dash reads active.
-**Caveat (see investigation #8):** this clean re-attach was for a restart **while the dash was
-still active**. A separate moment this session — after a **crash with no active dash** — did **not**
-fall back to the last dash; the bubble **cleared out** entirely. So #437's active-dash re-attach
-holds, but the post-crash "show the last dash" fallback appears not to survive process death.
+#### 3. Bubble re-attaches to the active dash across a restart — #437 CONFIRMED (2/2, retired)
+**Dash 1 (2026-06-12):** force-quit + reload **after resetting the accessibility permission** mid-dash
+— a harder restart than a plain force-stop, since the accessibility service rebinds from scratch —
+reloaded the bubble with the **current dash still active**. **Dash 2 (2026-06-12):** after a restart
+the **completed cards repopulated** (not just the dash reading active) — the missing half of the
+first sighting. Two clean sightings of the mid-dash active-dash re-attach → #437 moved out as
+validated. The bubble's dash id derives from restored state, not the crash-suppressed effect.
+**Caveat — does NOT cover the no-active-dash case (see investigation #8):** both #437 sightings were
+restarts **while a dash was active**. Separately this session, after a **crash with no active dash**,
+the bubble **cleared out** instead of showing the last dash — that's a distinct gap tracked as #8,
+not part of #437's validated scope.
 
 #### 4. Shop & Deliver terminal `total/total` — #302 CONFIRMED (2/2, retired)
 The pickup/shop card read **`shop 25/25 · 0.6/min`** at end of shop — the terminal `total/total`
 frame, no longer the `total−1/total` off-by-one. Second clean sighting → #302 moved out of the
 watch list as validated. (The add-on / second-order-mid-shop case is still tracked under #276.)
+
+#### 10. "Saved" fires once per delivery (#431 sub-case a, 1/2) + offers feel instant (#436 partial)
+**Dash 2** had two separate deliveries and each produced **exactly one "Saved" bubble** — no
+double-fire. Confirms #431 receipt-grace sub-case (a) ("Saved" fires exactly once per delivery);
+bumped that checklist item to 1/2. The (b) stacked-order split and (c) misrecognition-survival
+sub-cases were not exercised. (The bubble's currency formatting is bug #9 above — separate from the
+once-per-delivery behavior, which is correct.) Separately, the dasher reports offer **Accept/Decline
+feels fully quick — no perceptible delay** (loosely supports #436 (b) "verdicts land a touch
+quicker"); #436 stays 0/2 since its dedupe/restart sub-cases weren't deliberately tested.
 
 ### Open questions / investigations
 

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -564,6 +564,10 @@ the bubble **reloaded with the current dash still active** (not an orphaned/empt
 the bubble's dash id derives from restored state rather than the crash-suppressed effect (#437).
 Bumped the checklist item to 1/2; second sighting should confirm the **chat history + completed
 cards** re-populate under that same dash, not just that the dash reads active.
+**Caveat (see investigation #8):** this clean re-attach was for a restart **while the dash was
+still active**. A separate moment this session — after a **crash with no active dash** — did **not**
+fall back to the last dash; the bubble **cleared out** entirely. So #437's active-dash re-attach
+holds, but the post-crash "show the last dash" fallback appears not to survive process death.
 
 #### 4. Shop & Deliver terminal `total/total` — #302 CONFIRMED (2/2, retired)
 The pickup/shop card read **`shop 25/25 · 0.6/min`** at end of shop — the terminal `total/total`
@@ -599,6 +603,30 @@ crash. The dasher's read — "maybe it auto-corrected" — matches a desk hypoth
   would be suppressing the frozen `completed` card whose id matches the current `active` card's id, or
   not closing the Delivery into `completed` until `DELIVERY_CONFIRMED` — but that's a design call for
   the desk, **not** a concluded fix.
+
+#### 8. After a crash with **no active dash**, the bubble cleared instead of showing the last dash (cross-refs #437, #367)
+Distinct from #3: the clean re-attach in #3 was for a restart **while the dash was still active**.
+Separately this session, **after a crash where no dash was active**, the dash did **not** persist as
+the "last dash" — the **bubble cleared out** (empty chat + empty card stack) rather than showing the
+most-recently-completed dash. Flagged by the dasher for the desk/Android Studio agent.
+
+- **Likely cause (hypothesis):** the bubble's `displayedDashId` is a purely **in-memory latch** —
+  `bubbleManager.activeDashId.scan(null) { last, current -> current ?: last }`
+  (`BubbleViewModel.kt:95-96`). It holds the last non-null **active** dash id, but a **process death
+  resets the `scan` to null**; on restart, if `activeSessionId()` is null (no active dash), nothing
+  repopulates it. Both downstream flows then key off `null` → `messages` = empty
+  (`BubbleViewModel.kt:98-104`) and `cardStack.completed` = empty (events query returns empty for a
+  null dash id, `:119-122`) — i.e. the bubble empties.
+- **The code comment claims a fallback that isn't implemented for the crash case:**
+  `BubbleViewModel.kt:106-107` says the card stack uses "the current active dash when one is running,
+  **otherwise the most-recently-completed one**" — but there's no **persisted** last-completed-dash-id
+  lookup feeding `displayedDashId`; the only "otherwise" is the in-memory `scan` latch, which a crash
+  wipes. So the documented "review the previous dash" behavior survives a normal idle transition but
+  **not** a process death.
+- **To confirm / one direction to weigh (desk, not a fix):** reproduce by crashing with the dash
+  ended/none-active and check whether `activeDashId` is null at restart. A durable fix would mean
+  sourcing `displayedDashId`'s fallback from a persisted "most-recently-completed dash id" (DB/
+  datastore) rather than an in-memory `scan` — overlaps with the #367 post-dash HUD persistence work.
 
 ### Research / design (improvement ideas — explore, not yet scoped)
 

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -164,7 +164,10 @@ _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **bro
   "Decline") instead of hardcoded view IDs. Working = DoorDash registers the tap. Broken = log
   shows "No 'acceptButton' target bound" (rule didn't bind on that screen variant — capture it!)
   or "NONE passed label verification" (verification too strict for that variant).
-  - Confirmed: 0/2
+  - Confirmed: 1/2. **2026-06-12 (DoorDash):** dasher tapped **Accept** in the bubble → DoorDash
+    registered the Accept (offer was accepted). First clean live confirmation of the rule-bound tap
+    path that was broken on 06-09. Still need a second sighting — ideally the **Decline** side and
+    the **notification** surface (not just bubble Accept). (See 2026-06-12 log entry #4.)
 
 - **Post-dash HUD: frozen summary + consistent chat (#367, PR pending).**
   Two visible fixes after a dash ends: (a) the "Last session" Duration on the idle bubble is
@@ -384,11 +387,11 @@ _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **bro
   `total−1/total` — and the items/min pace should reflect the full count. This was
   the off-by-one from the 2026-06-05 session, caused by the terminal frame being
   deduped away; the fix makes each shopping count change a distinct observation.
-  - Confirmed: 1/2. **Partial — 2026-06-06 (DoorDash):** developer reported "the
-    item counts are working" (no longer freezing one short). Did not explicitly
-    confirm the terminal `total/total` frame or the add-on case this dash; needs
-    one more clean sighting of the end-of-shop `total/total`. (See 2026-06-06
-    log entry #4.)
+  - Confirmed: 2/2. **2026-06-06 (DoorDash):** developer reported "the item counts
+    are working" (no longer freezing one short). **2026-06-12 (DoorDash):** pickup/shop
+    card read **`shop 25/25 · 0.6/min`** at end of shop — the terminal `total/total`
+    frame, no longer `total−1/total`. Two clean sightings → **validated** (the add-on
+    case is tracked separately under the #276 watch item). (See 2026-06-12 log entry #3.)
 
 - **⚠️ WATCH FOR RECURRENCE — mid-dash "Done Dashing!" + odometer reset (2026-06-06 #5, root cause confirmed, fix NOT yet shipped).** Confirmed once on 06-06: a
   transient **"Start your scheduled dash"** (`idle_scheduled_dash_ready`,
@@ -506,6 +509,73 @@ _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **bro
   - **Status:** Triaged → tracked as #279 (summary attribution fixed in PR; the
     "summary after the idle screen" ordering was the root cause). Field-validate
     via the #279 checklist item above.
+
+---
+
+## 2026-06-12 — DoorDash session (offer-copilot field test)
+
+- **Platform tested:** DoorDash
+- **Branch under test:** `master` field offer-copilot build (includes the #425 rule-bound
+  Accept/Decline path; the freshest watch-list items reference #437/#436/#427). Exact SHA not
+  captured this session — developer to correct if needed.
+- **Field conditions:** live dash with at least one Shop & Deliver order (HEB, 25 items) and at
+  least one offer the dasher **accepted from the bubble**. Observations narrated in real time;
+  everything below is **recorded for triage — hypotheses, not concluded fixes.**
+
+### Verification TODOs (confirmations this session)
+
+#### 1. Bubble **Accept** clicks DoorDash — #425 rule-bound tap CONFIRMED (1/2)
+Dasher tapped **Accept** in the bubble and DoorDash registered the Accept (offer accepted). This
+is the first clean live confirmation of the `acceptButton`/`declineButton` rule-bound, label-verified
+tap path (#425) — the same surface that was **broken on 06-09** (`Could not find any live node`,
+wrong-window search). Bumped the checklist item to 1/2; still want a second sighting covering the
+**Decline** side and the **notification** surface (not just bubble Accept).
+
+#### 2. Shop & Deliver terminal `total/total` — #302 CONFIRMED (2/2, retired)
+The pickup/shop card read **`shop 25/25 · 0.6/min`** at end of shop — the terminal `total/total`
+frame, no longer the `total−1/total` off-by-one. Second clean sighting → #302 moved out of the
+watch list as validated. (The add-on / second-order-mid-shop case is still tracked under #276.)
+
+### Research / design (improvement ideas — explore, not yet scoped)
+
+#### 3. Offer & finished cards under-surface Shop & Deliver (item count + type badge)
+Two related gaps the dasher noticed about the #324 card redesign and the completed-card stack:
+
+- **Item count is buried on the offer card.** Today the count renders only as a small footer
+  caption — `FlowCardItem.kt:392-401` builds `"$store · $itemCount items"` via `Caption(...)`, and
+  only when `itemCount > 1`. For a Shop & Deliver, the dasher wants the item count promoted to the
+  **same visual tier as the $/hr hero and the mi / $/mi line** (the offer hero `Row` at
+  `FlowCardItem.kt:298-340` is score-ring + `$/hr` hero + a secondary `Net · mi · $/mi` line). The
+  data already exists on the snapshot (`FlowCardSnapshot.Offer.itemCount`,
+  `FlowCardSnapshot.kt:57`) — **hypothesis:** this is a pure presentation change (elevate item count
+  into the hero row), no parser/state work needed. Dasher noted there's **space on the right** of
+  the hero row to place it.
+- **No Shop & Deliver indicator / badge, and the finished card doesn't show the type at all.**
+  The offer card has a badge pill row (`FlowCardItem.kt:379-390` + `badgeMeta` `:421-433`), but
+  `badgeMeta` has **no Shop & Deliver / shopping entry**, and the **PostTask (finished) card carries
+  no order-type or activity field whatsoever** — `FlowCardSnapshot.PostTask`
+  (`FlowCardSnapshot.kt:124-135`) has `storeName`/`totalPay`/`parsedPay` but nothing that says "this
+  was a shop." (The `SHOPPING` activity only lives on `FlowCardSnapshot.Pickup.activity`,
+  `:94`.) **Hypothesis:** surfacing "Shop & Deliver" on the finished card would need an order-type/
+  activity field threaded onto `PostTask` (and possibly `Offer`), i.e. it's **not** purely cosmetic
+  — it touches the snapshot model + the mapper (`FlowCardMapper`/`LiveCardBuilder`), not just
+  `FlowCardItem`. Would need to confirm where order type is known at PostTask time. A SHOP badge in
+  `badgeMeta` for the offer card, by contrast, is cheap **if** a shop badge/flag reaches `Offer.badges`.
+
+#### 4. Pickup card not visually upgraded to the redesign + double-"by" wording
+The dasher reads the pickup card as **"still the old style"** next to the redesigned offer card —
+it's the line-based `DeadlineBody` (`FlowCardItem.kt:484-582`): a `HeroBig` countdown + caption rows
+(`HEB · arrived 16:39 · shop 25/25 · 0.6/min`), with none of the offer card's ring/banner/pill
+visual language. Two sub-items:
+
+- **Visual parity.** Pickup (and by extension Delivery, which shares `DeadlineBody`) didn't get a
+  comparable redesign pass. **Hypothesis:** this is a deliberate-or-not gap from the #324 redesign
+  (which targeted the offer card); worth deciding whether the pickup/delivery cards should adopt the
+  same component vocabulary (gauge ring for deadline pressure, etc.) or stay deliberately minimal.
+- **Double "by".** The deadline caption renders **`till pickup-by · by 17:10`** — `deadlineLabel =
+  "till pickup-by"` (`FlowCardItem.kt:454`) concatenated with `Caption("$deadlineLabel · by
+  ${formatTime(deadlineMillis)}")` (`:512`). The two "by"s read awkwardly; trivial wording fix
+  (drop one "by", e.g. `"pickup by 17:10"` or `"till pickup · by 17:10"`).
 
 ---
 

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -117,7 +117,10 @@ _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **bro
   (no regression — asset rules auto-grant covers them). Broken = a tap silently stops
   happening and the log shows `Denied expand_earnings — no granted capability` or
   `ACCESSIBILITY tier not granted` while the service is clearly running — capture logcat.
-  - Confirmed: 0/2
+  - Confirmed: 1/2. **2026-06-12 (DoorDash):** both gated automation taps fired as before — the
+    post-delivery **expand auto-tap** worked AND the **bubble Accept** clicked DoorDash (#425), so
+    the asset-rule auto-grant covered them with no regression. Needs one more clean sighting. (See
+    2026-06-12 log entry #5.)
 
 - **Uber sensitive screens now blocked + UNKNOWN-capture scrub (#432).**
   Uber finally has matcher-layer sensitive rules (wallet / Instant Pay / cash-out / bank /
@@ -156,7 +159,10 @@ _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **bro
   with package scoping instead of a rule-declared click). Working = breakdown expands on its own
   and the line items parse. Broken = summary stays collapsed; grep logs for "did not fire —
   target failed resolution/verification" (verification too strict) or "Throttled action".
-  - Confirmed: 0/2
+  - Confirmed: 1/2. **2026-06-12 (DoorDash):** post-delivery pay breakdown **auto-expanded** on its
+    own as before — confirms the EXPAND_EARNINGS action path AND (implicitly) the #417 consent gate
+    auto-granting the bundled-rule capability (a denied tap would have left it collapsed). Needs one
+    more clean sighting. (See 2026-06-12 log entry #5.)
 - **Bubble/notification Accept-Decline via rule-bound targets (#425).**
   Tapping Accept or Decline in DashBuddy's offer notification (or bubble) must tap the matching
   DoorDash button. The button is now aimed by the offer rule's `acceptButton`/`declineButton`
@@ -530,6 +536,14 @@ is the first clean live confirmation of the `acceptButton`/`declineButton` rule-
 tap path (#425) — the same surface that was **broken on 06-09** (`Could not find any live node`,
 wrong-window search). Bumped the checklist item to 1/2; still want a second sighting covering the
 **Decline** side and the **notification** surface (not just bubble Accept).
+
+#### 5. Post-delivery earnings **auto-expand** still works — #425 EXPAND_EARNINGS + #417 gate (both 1/2)
+The collapsed pay breakdown **auto-expanded on its own** after a delivery, as before. Confirms the
+app-owned EXPAND_EARNINGS action path (#425) AND — implicitly — the live consent gate (#417): a
+denied capability would have left it collapsed (`Denied expand_earnings — no granted capability`),
+so the asset-rule auto-grant is covering it. Together with #1 (bubble Accept), both gated automation
+taps fired with no regression. Bumped the #425 expand-earnings and #417 consent-gate checklist items
+to 1/2 each.
 
 #### 2. Shop & Deliver terminal `total/total` — #302 CONFIRMED (2/2, retired)
 The pickup/shop card read **`shop 25/25 · 0.6/min`** at end of shop — the terminal `total/total`

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -178,7 +178,7 @@ _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **bro
   - Confirmed: 1/2. **2026-06-12 (DoorDash):** dasher tapped **Accept** in the bubble → DoorDash
     registered the Accept (offer was accepted). First clean live confirmation of the rule-bound tap
     path that was broken on 06-09. Still need a second sighting — ideally the **Decline** side and
-    the **notification** surface (not just bubble Accept). (See 2026-06-12 log entry #4.)
+    the **notification** surface (not just bubble Accept). (See 2026-06-12 log entry #1.)
 
 - **Post-dash HUD: frozen summary + consistent chat (#367, PR pending).**
   Two visible fixes after a dash ends: (a) the "Last session" Duration on the idle bubble is
@@ -391,6 +391,13 @@ _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **bro
     2026-06-07 log #1) and the app had **zero crashes** all day. The dedup held: no
     `LazyColumn` duplicate-key crash. Needs one more clean sighting (ideally
     confirming exactly one card per stop visually in the bubble).
+    **2026-06-12 (DoorDash):** crash-free still holds, but the **"exactly one card"**
+    sub-claim got a transient counter-example — a Great Greek (hand-to-customer)
+    dropoff showed **two** delivery cards while at-door, collapsing to one after the
+    paid card. Hypothesis: frozen `completed` Delivery (closed on `DELIVERY_ARRIVED`)
+    + the still-`active` Delivery card overlap, keyed `delivery:id` vs `live:delivery:id`
+    so no crash but two visible cards. Logged as 2026-06-12 entry #5 for investigation;
+    keep watching arrival-bearing dropoffs for the visible duplicate.
 
 - **Shop & Deliver items/min reaches `total/total` at the end (#302).** On a
   Shop & Deliver order, when you finish shopping (add the last item / reach
@@ -402,7 +409,7 @@ _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **bro
     are working" (no longer freezing one short). **2026-06-12 (DoorDash):** pickup/shop
     card read **`shop 25/25 · 0.6/min`** at end of shop — the terminal `total/total`
     frame, no longer `total−1/total`. Two clean sightings → **validated** (the add-on
-    case is tracked separately under the #276 watch item). (See 2026-06-12 log entry #3.)
+    case is tracked separately under the #276 watch item). (See 2026-06-12 log entry #4.)
 
 - **⚠️ WATCH FOR RECURRENCE — mid-dash "Done Dashing!" + odometer reset (2026-06-06 #5, root cause confirmed, fix NOT yet shipped).** Confirmed once on 06-06: a
   transient **"Start your scheduled dash"** (`idle_scheduled_dash_ready`,
@@ -542,7 +549,7 @@ tap path (#425) — the same surface that was **broken on 06-09** (`Could not fi
 wrong-window search). Bumped the checklist item to 1/2; still want a second sighting covering the
 **Decline** side and the **notification** surface (not just bubble Accept).
 
-#### 5. Post-delivery earnings **auto-expand** still works — #425 EXPAND_EARNINGS + #417 gate (both 1/2)
+#### 2. Post-delivery earnings **auto-expand** still works — #425 EXPAND_EARNINGS + #417 gate (both 1/2)
 The collapsed pay breakdown **auto-expanded on its own** after a delivery, as before. Confirms the
 app-owned EXPAND_EARNINGS action path (#425) AND — implicitly — the live consent gate (#417): a
 denied capability would have left it collapsed (`Denied expand_earnings — no granted capability`),
@@ -550,7 +557,7 @@ so the asset-rule auto-grant is covering it. Together with #1 (bubble Accept), b
 taps fired with no regression. Bumped the #425 expand-earnings and #417 consent-gate checklist items
 to 1/2 each.
 
-#### 6. Bubble survives force-quit + accessibility-permission reset — #437 (1/2)
+#### 3. Bubble survives force-quit + accessibility-permission reset — #437 (1/2)
 Dasher **force-quit and reloaded the app after resetting the accessibility permission** mid-dash —
 a harder restart than a plain force-stop, since the accessibility service rebinds from scratch — and
 the bubble **reloaded with the current dash still active** (not an orphaned/empty bubble). Confirms
@@ -558,14 +565,44 @@ the bubble's dash id derives from restored state rather than the crash-suppresse
 Bumped the checklist item to 1/2; second sighting should confirm the **chat history + completed
 cards** re-populate under that same dash, not just that the dash reads active.
 
-#### 2. Shop & Deliver terminal `total/total` — #302 CONFIRMED (2/2, retired)
+#### 4. Shop & Deliver terminal `total/total` — #302 CONFIRMED (2/2, retired)
 The pickup/shop card read **`shop 25/25 · 0.6/min`** at end of shop — the terminal `total/total`
 frame, no longer the `total−1/total` off-by-one. Second clean sighting → #302 moved out of the
 watch list as validated. (The add-on / second-order-mid-shop case is still tracked under #276.)
 
+### Open questions / investigations
+
+#### 5. Transient **double drop-off card** during the at-door window (cross-refs #297)
+On the **Great Greek Mediterranean** delivery the dasher saw **two drop-off cards** while at the
+dropoff; **after** completing it and getting the **paid (PostTask) card, only one remained.** No
+crash. The dasher's read — "maybe it auto-corrected" — matches a desk hypothesis:
+
+- **Likely cause (hypothesis):** the card stack is `completed` (folded from the event log) + one
+  `active` live card. On an **arrival-bearing dropoff** (Great Greek is a hand-it-to-customer
+  restaurant order, so `DELIVERY_ARRIVED` fires), `FlowCardMapper` **closes the delivery into
+  `completed`** on `DELIVERY_ARRIVED` (`FlowCardMapper.kt:216-239`) — a frozen card with id
+  `delivery:<taskId>`. Meanwhile the state machine is still in `TaskDropoffArrived`, so
+  `LiveCardBuilder` **also builds an active Delivery card** for the same task
+  (`LiveCardBuilder.kt:80-92`), same id `delivery:<taskId>`.
+- **Why no crash (and why two cards show):** the active card is keyed `"live:${live.id}"` while the
+  completed card is keyed `it.id` (`BubbleScreen.kt:238` vs `:256`). The `live:` prefix means the two
+  keys **don't collide** — so #297's fatal duplicate-key crash is avoided (good — #297 holds) — but
+  the frozen + active cards for the **same stop render as two visible cards** during the at-door
+  window.
+- **Why it resolves to one:** on payment, `DELIVERY_COMPLETED` adds the PostTask card and the flow
+  moves to `Flow.PostTask`, so `LiveCardBuilder` now emits an **active PostTask** card (not a
+  Delivery). The duplicate active Delivery card disappears, leaving the single frozen Delivery card
+  — exactly the "only one now" the dasher saw.
+- **To confirm:** pull the Jun-12 event DB for the Great Greek task — expect `DELIVERY_ARRIVED`
+  **before** `DELIVERY_CONFIRMED`/`DELIVERY_COMPLETED` (arrival-bearing). If confirmed, this is a
+  **cosmetic transient** (a frozen+live overlap), distinct from #297's crash. One direction to weigh
+  would be suppressing the frozen `completed` card whose id matches the current `active` card's id, or
+  not closing the Delivery into `completed` until `DELIVERY_CONFIRMED` — but that's a design call for
+  the desk, **not** a concluded fix.
+
 ### Research / design (improvement ideas — explore, not yet scoped)
 
-#### 3. Offer & finished cards under-surface Shop & Deliver (item count + type badge)
+#### 6. Offer & finished cards under-surface Shop & Deliver (item count + type badge)
 Two related gaps the dasher noticed about the #324 card redesign and the completed-card stack:
 
 - **Item count is buried on the offer card.** Today the count renders only as a small footer
@@ -589,7 +626,7 @@ Two related gaps the dasher noticed about the #324 card redesign and the complet
   `FlowCardItem`. Would need to confirm where order type is known at PostTask time. A SHOP badge in
   `badgeMeta` for the offer card, by contrast, is cheap **if** a shop badge/flag reaches `Offer.badges`.
 
-#### 4. Pickup card not visually upgraded to the redesign + double-"by" wording
+#### 7. Pickup card not visually upgraded to the redesign + double-"by" wording
 The dasher reads the pickup card as **"still the old style"** next to the redesigned offer card —
 it's the line-based `DeadlineBody` (`FlowCardItem.kt:484-582`): a `HeroBig` countdown + caption rows
 (`HEB · arrived 16:39 · shop 25/25 · 0.6/min`), with none of the offer card's ring/banner/pill


### PR DESCRIPTION
Field-testing log updates from two DoorDash dashes on 2026-06-12 (into 06-13 UTC). Docs-only — `docs/field-testing/README.md` only.

`[skip ci]`

## Confirmations (checklist updated)
- **#425 in-bubble Accept** → 1/2 (bubble Accept clicked DoorDash; the 06-09 break is fixed for the in-bubble surface).
- **#425 expand-earnings auto-tap** → **2/2, retired** (auto-expanded across both dashes).
- **#417 consent gate** → **2/2, retired** (gated taps fired both dashes, zero `Denied`).
- **#437 bubble re-attach on restart** → **2/2, retired** (dash stayed active + completed cards repopulated). Active-dash scope only — see #8.
- **#302 Shop & Deliver `total/total`** → **2/2, retired** (`shop 25/25 · 0.6/min`).
- **#431 receipt grace (a)** → 1/2 (two deliveries → exactly one "Saved" bubble each).
- **#436** partial note (offers feel instant); stays 0/2.

## New findings (recorded as hypotheses, not fixes)
- **#9 Bug** — "Saved: $X" bubble omits the `$` (local `EffectMap.formatCurrency` `%.2f`, diverges from `DashFormats.money`; #358/#366).
- **#11 Bug (FOUND BROKEN)** — the **notification-shade** Accept/Decline buttons do nothing; the **in-bubble** buttons work. Hypothesis: shade isn't the offer's foreground window, so the accessibility click finds no target. Logcat diagnostic noted.
- **#12 Investigation** — 7-Eleven alcohol initial pickup screen UNKNOWN (~19:59 local) but the state machine self-corrected to drop-off on the nav transition; recognition gap for that pickup variant (ties #149/#433); capture is the unblock.
- **#8 Investigation (now two triggers)** — bubble clears the last dash both after a **crash** (8a) and after a **normal dash end** (8b). Same root: `displayedDashId` is an in-memory `scan` latch under `WhileSubscribed(5000)` with no persisted last-dash fallback (overlaps #367).
- **#5 Investigation** — transient double drop-off card on an arrival-bearing dropoff (frozen `completed` + live `active` overlap, keyed `delivery:id` vs `live:delivery:id` so no #297 crash); resolves when PostTask supersedes the active card.
- **#6/#7 Research** — offer card buries Shop & Deliver item count + no type badge on the finished card; pickup card not visually upgraded + double-"by" wording.

Security/privacy posture: docs-only, no code/recognition/capture/network/effects changes.

https://claude.ai/code/session_012QK9LZaC1Txcfp4LVcTQS1

---
_Generated by [Claude Code](https://claude.ai/code/session_012QK9LZaC1Txcfp4LVcTQS1)_