### PR TITLE
fix(privacy): block the DasherDirect Savings flow as sensitive (#463 — banking slice)

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/DefaultRulesIntegrationTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/DefaultRulesIntegrationTest.kt
@@ -188,6 +188,29 @@ class DefaultRulesIntegrationTest {
         )
     }
 
+    @Test
+    fun `DasherDirect savings transfer screens classify as sensitive (#463)`() {
+        // The three frames that LEAKED plaintext balances to UNKNOWN capture on
+        // the 2026-06-12 dash — each must now hit the priority-0 sensitive rule.
+        fun screen(vararg texts: String) =
+            UiNode(children = texts.map { UiNode(text = it) }).restoreParents()
+
+        // Savings landing: "Savings jar" + "$99.08" + "Transfer $9.06".
+        val landing = screen("Transfer in", "Savings jar", "$99.08", "Transfer $9.06")
+        // Transfer-confirmation: "You transferred $9.06" + "Savings jar".
+        val confirm = screen("You transferred $9.06", "Your transfer should now appear in your Savings jar", "Got it")
+        // Transfer-entry (no "Savings jar"): "Transfer in" + "$9.06 available".
+        val entry = screen("Transfer in", "$9.06 available", "$0", "Continue")
+
+        for ((name, node) in listOf("landing" to landing, "confirm" to confirm, "entry" to entry)) {
+            val r = screenRuleset.matchFirst(node, platformWire = "doordash")
+            assertTrue(
+                "DasherDirect savings $name screen must hit a sensitive rule, got ${r?.ruleId}",
+                r?.ruleId?.contains("sensitive") == true,
+            )
+        }
+    }
+
     // =========================================================================
     // Parse-output regression on real captures (#433)
     // =========================================================================

--- a/app/src/test/resources/snapshots/SENSITIVE/2026-06-12_18-27-01__doordash__savings_transfer__4c5484.json
+++ b/app/src/test/resources/snapshots/SENSITIVE/2026-06-12_18-27-01__doordash__savings_transfer__4c5484.json
@@ -1,0 +1,334 @@
+{
+    "captureId": "6856febf-884c-4f0d-943a-a0ec99d88055",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1781306821845,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.FrameLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2400
+                },
+                "children": [
+                    {
+                        "id": "android:id/content",
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 0,
+                            "right": 1080,
+                            "bottom": 2400
+                        },
+                        "children": [
+                            {
+                                "class": "android.view.ViewGroup",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 0,
+                                    "right": 1080,
+                                    "bottom": 2400
+                                },
+                                "children": [
+                                    {
+                                        "class": "android.view.View",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 0,
+                                            "right": 1080,
+                                            "bottom": 2400
+                                        },
+                                        "children": [
+                                            {
+                                                "class": "android.view.View",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 0,
+                                                    "right": 1080,
+                                                    "bottom": 2400
+                                                },
+                                                "children": [
+                                                    {
+                                                        "class": "android.view.View",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 0,
+                                                            "right": 1080,
+                                                            "bottom": 2400
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "desc": "Close sheet",
+                                                                "class": "android.view.View",
+                                                                "isClickable": true,
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 0,
+                                                                    "right": 1080,
+                                                                    "bottom": 2400
+                                                                }
+                                                            },
+                                                            {
+                                                                "class": "android.view.View",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 1767,
+                                                                    "right": 1080,
+                                                                    "bottom": 2380
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.view.View",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 1767,
+                                                                            "right": 1080,
+                                                                            "bottom": 2380
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "class": "android.view.View",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 505,
+                                                                                    "top": 1767,
+                                                                                    "right": 576,
+                                                                                    "bottom": 1874
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isClickable": true,
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 487,
+                                                                                            "top": 1767,
+                                                                                            "right": 594,
+                                                                                            "bottom": 1874
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "desc": "Drag handle",
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 505,
+                                                                                                    "top": 1816,
+                                                                                                    "right": 576,
+                                                                                                    "bottom": 1825
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "text": "Transfer in",
+                                                                                "class": "android.widget.TextView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 36,
+                                                                                    "top": 1910,
+                                                                                    "right": 1044,
+                                                                                    "bottom": 1976
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "class": "android.view.View",
+                                                                                "isClickable": true,
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 2012,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2156
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 36,
+                                                                                            "top": 2031,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2137
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "desc": "",
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 36,
+                                                                                                    "top": 2058,
+                                                                                                    "right": 89,
+                                                                                                    "bottom": 2111
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 125,
+                                                                                                    "top": 2039,
+                                                                                                    "right": 981,
+                                                                                                    "bottom": 2129
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "text": "Savings jar",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 125,
+                                                                                                            "top": 2039,
+                                                                                                            "right": 981,
+                                                                                                            "bottom": 2086
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "text": "$0.00",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 125,
+                                                                                                            "top": 2086,
+                                                                                                            "right": 981,
+                                                                                                            "bottom": 2129
+                                                                                                        }
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "desc": "",
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 1008,
+                                                                                                    "top": 2066,
+                                                                                                    "right": 1044,
+                                                                                                    "bottom": 2102
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "text": "",
+                                                                                "class": "android.widget.TextView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 36,
+                                                                                    "top": 2183,
+                                                                                    "right": 1044,
+                                                                                    "bottom": 2219
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "class": "android.view.View",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 27,
+                                                                                    "top": 2246,
+                                                                                    "right": 1053,
+                                                                                    "bottom": 2353
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 27,
+                                                                                            "top": 2223,
+                                                                                            "right": 1053,
+                                                                                            "bottom": 2330
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.widget.Button",
+                                                                                                "isClickable": true,
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 27,
+                                                                                                    "top": 2218,
+                                                                                                    "right": 1053,
+                                                                                                    "bottom": 2325
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "text": "Transfer $0.00",
+                                                                                                        "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 392,
+                                                                                                            "top": 2239,
+                                                                                                            "right": 689,
+                                                                                                            "bottom": 2305
+                                                                                                        }
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/core/pipeline/src/main/assets/rules/doordash.json
+++ b/core/pipeline/src/main/assets/rules/doordash.json
@@ -43,6 +43,17 @@
           "require": { "exists": { "hasTextContaining": "transfer was initiated" } }
         },
         {
+          "intent": "sensitive.savings",
+          "require": { "any": [
+            { "exists": { "hasTextContaining": "Savings jar" } },
+            { "exists": { "hasTextContaining": "You transferred" } },
+            { "all": [
+              { "exists": { "hasText": "Transfer in" } },
+              { "exists": { "hasTextContaining": "available" } }
+            ] }
+          ] }
+        },
+        {
           "intent": "sensitive.otp",
           "require": { "exists": { "hasTextContaining": "Enter the code we sent" } }
         },

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/SensitiveTextMarkers.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/SensitiveTextMarkers.kt
@@ -47,6 +47,11 @@ object SensitiveTextMarkers {
         "Instant Pay",
         "Cash out",
         "CVV",
+        // DasherDirect Savings flow (#463) — leaked dollar balances to UNKNOWN
+        // capture on the 2026-06-12 dash; the rule-side block is the
+        // sensitive.savings branch, these markers are the fail-closed backstop.
+        "Savings jar",
+        "You transferred",
     )
 
     /**

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/SensitiveTextMarkersTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/SensitiveTextMarkersTest.kt
@@ -19,6 +19,9 @@ class SensitiveTextMarkersTest {
         assertEquals("Available Balance", SensitiveTextMarkers.findMarker(tree("available balance: \$52.10")))
         assertEquals("Instant Pay", SensitiveTextMarkers.findMarker(tree("Set up instant pay")))
         assertEquals("CVV", SensitiveTextMarkers.findMarker(tree("Enter CVV")))
+        // DasherDirect Savings flow (#463) — the markers that leaked on 2026-06-12.
+        assertEquals("Savings jar", SensitiveTextMarkers.findMarker(tree("Your transfer should now appear in your Savings jar")))
+        assertEquals("You transferred", SensitiveTextMarkers.findMarker(tree("You transferred \$9.06")))
     }
 
     @Test

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -63,6 +63,18 @@ immediately (no second pass needed) so it gets triaged.
 _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **broken** on the
 2026-06-09 dash — moved to that session's log entry below for triage.)_
 
+- **DasherDirect Savings screens now blocked as sensitive (#463, partial — banking slice).**
+  On the 2026-06-12 dash the DasherDirect **Savings jar** flow (balance + "Transfer $X" + "You
+  transferred $X") leaked plaintext dollar balances to UNKNOWN capture — the redesigned savings
+  UI no rule covered. Now caught by a priority-0 `sensitive.savings` rule + `SensitiveTextMarkers`
+  backstop. On a dash, open DasherDirect → Savings and do a small transfer: working = the screen
+  produces NO capture (matcher-layer block, log shows the sensitive gate / "Capture scrubbed"),
+  and normal flow recognition is unaffected. Broken = a Savings/Transfer screen with a dollar
+  balance shows up in captures/, or a non-banking screen gets wrongly blocked. **Still open in
+  #463:** the identity/ID-scan slice (license-scan, identity-verify, signature-canvas) is a
+  separate follow-up.
+  - Confirmed: 0/2
+
 - **Engine latency + dedupe pack (#436).**
   Four behaviors to watch: (a) accepting/declining an offer FAST (inside ~1s of the verdict
   landing) should no longer pop a stale Accept/Decline heads-up afterwards; (b) offer verdicts


### PR DESCRIPTION
Partial fix for #463 (the banking slice). The 2026-06-12 dash leaked **plaintext dollar balances** to UNKNOWN capture — the DasherDirect **Savings jar** flow (`Savings jar`, `$99.08` balance, `Transfer $9.06`, `You transferred $9.06`, `Transfer in` + `$X available`). A non-negotiable Pledge violation: sensitive banking screens must be blocked at the matcher layer, never parsed or stored.

## Root cause
The redesigned DasherDirect Savings UI is an uncovered variant. The existing `doordash.screen.sensitive.known` branches want exact `"Available Balance"` / `"Withdraw"` / `"transfer was initiated"` wording — the **06-01** corpus frame literally said *"Your $51.26 transfer was initiated"* and **was** caught. The **06-12** "Savings jar" / "You transferred $X" wording matched none of them, so the screen classified UNKNOWN and its balance was written to the capture folder in the clear. (The `SensitiveTextMarkers` scrub backstop didn't cover it either, since it's the SSOT shared with — and equal to — the test scanner, which also lacked these terms.)

## Fix (two layers, the #432 pattern)
- **Matcher-layer block** — new priority-0 `sensitive.savings` branch (`overrideable: false`) on `doordash.screen.sensitive.known`: matches `Savings jar` / `You transferred`, or `Transfer in` **and** a dollar-`available` balance (the transfer-entry frame that lacks "Savings jar"). All three leaked frames now classify sensitive and are dropped before parse/storage.
- **Rules-independent backstop** — added `Savings jar` / `You transferred` to `SensitiveTextMarkers` (the UNKNOWN-capture scrub, SSOT-shared with `SnapshotSecurityScanner`). Covers the forkable-rules future (#192) where a downloaded bundle might lack the savings rule.

## Tests
- `DefaultRulesIntegrationTest`: all three leaked frames (savings landing / transfer-confirmation / transfer-entry) classify sensitive.
- `SensitiveTextMarkersTest`: the two new markers hit.
- A **redacted device capture** of the new variant added to `snapshots/SENSITIVE/` — dollar amounts neutralized to `$0.00`, the screen-identity trigger text preserved — so `GoldenSnapshotRegressionTest` ratchets it.
- Full `testDebugUnitTest` green.

## Security/privacy posture (principle 6)
- **Trusted:** nothing (third-party UI).
- **Gated:** these frames dropped at the matcher layer (priority 0, `overrideable: false`) in both sensor pipelines; over-blocking is the correct fail-closed direction for sensitive.
- **Scrubbed:** any residual UNKNOWN capture via `SensitiveTextMarkers`.
- A recognition change cannot downgrade this — the #432 load-time sensitive-coverage check still holds.

## Scope
Banking slice only. **Still open in #463:** the identity/ID-scan slice (license-scan, identity-verify 2-of-4, signature-canvas) — a separate, more nuanced follow-up that must distinguish the alcohol delivery *flow steps* (recognize) from the actual ID-capture *surfaces* (block).

## Field validation
Checklist item added (0/2): open DasherDirect → Savings, do a small transfer — the screen should produce no capture (matcher-layer block / "Capture scrubbed" log), normal flow recognition unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)