### PR TITLE
diag(effects): instrument the silent offer-action drop points (#457)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
@@ -216,7 +216,13 @@ class SideEffectEngine @Inject constructor(
                 val throttleKey = "action:${effect.action.wire}:${effect.platform.wire}"
                 val now = System.currentTimeMillis()
                 if ((actionLastFiredAt[throttleKey] ?: 0L) + RULE_ACTION_THROTTLE_MS > now) {
-                    Timber.v("Throttled action: %s", throttleKey)
+                    // .i not .v (#457): a throttled USER offer tap would otherwise be
+                    // invisible under release log filtering — one of the silent drop
+                    // points a shade Accept/Decline could die at.
+                    Timber.i(
+                        "Throttled action %s (%s) — within %dms of the last fire",
+                        throttleKey, effect.trigger, RULE_ACTION_THROTTLE_MS,
+                    )
                     return
                 }
                 if (!permissionTierChecker.isGranted(PermissionTier.ACCESSIBILITY)) {

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
@@ -1016,6 +1016,34 @@ class EffectMapTest {
         )
     }
 
+    @Test
+    fun `UiInput accept when R0 left OfferPresented fires nothing — the #457 shade-drop path`() {
+        // The heads-up notification can outlive the on-screen offer: by the
+        // time a SHADE Accept tap dispatches, R0 may have advanced past
+        // OfferPresented (a UiInput never changes the flow itself). The action
+        // is dropped — pinned here as the documented #457 drop path so a future
+        // fix (and the new diagnostic log) is deliberate, not accidental.
+        val acceptRef = testNodeRef("com.doordash.driverapp:id/accept_button")
+        val offerWithTargets = testPendingOffer.copy(
+            targets = mapOf("acceptButton" to acceptRef),
+            sourceRuleId = "doordash.screen.offer_popup",
+        )
+        // Same offer state, but flow has moved to PostTask (offer left the screen).
+        val flowRegion = FlowRegion(
+            flow = Flow.PostTask,
+            pendingOffer = offerWithTargets,
+            activePlatform = Platform.DoorDash,
+        )
+        val state = AppState(regions = Regions(flow = flowRegion))
+        val obs = Observation.UiInput(timestamp = 2000L, action = OfferIntent.ACCEPT)
+
+        val effects = effectMap.diff(state, state, obs)
+        assertTrue(
+            "off-OfferPresented UiInput must not fire a tap (the #457 silent drop)",
+            effects.filterIsInstance<AppEffect.PerformRuleAction>().isEmpty(),
+        )
+    }
+
     // =========================================================================
     // NOTIFICATION EFFECTS
     // =========================================================================

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -199,32 +199,54 @@ class EffectMap @Inject constructor() {
         // (#425). No binding = action unavailable on this platform (fail to
         // manual). Decline taps the initial decline button; in Native mode the
         // user confirms in DoorDash's own dialog (auto-confirm = #110 2c).
-        if (obs is Observation.UiInput &&
-            (next.flow == Flow.OfferPresented || prev.flow == Flow.OfferPresented)
-        ) {
-            val platform = next.activePlatform ?: prev.activePlatform
-            val offer = next.pendingOffer ?: prev.pendingOffer
+        //
+        // #457 instrumentation: the notification-SHADE Accept/Decline buttons
+        // were found broken in the field while the in-bubble ones work — yet
+        // both dispatch this IDENTICAL UiInput, so the divergence is here or
+        // downstream. A UiInput never changes the flow (it isn't a
+        // FlowObservation), so this gate is purely "was R0 OfferPresented when
+        // the tap dispatched" — and a heads-up notification can outlive the
+        // on-screen offer. Every drop reason now logs (the gate-skip and the
+        // null platform/offer cases were previously silent) so the next field
+        // OR chance-desk occurrence self-documents which gate ate the tap, no
+        // live logcat required. Behavior is unchanged — only logging is added.
+        if (obs is Observation.UiInput) {
             val action = when (obs.action) {
                 OfferIntent.ACCEPT -> RuleAction.ACCEPT_OFFER
                 OfferIntent.DECLINE -> RuleAction.DECLINE_OFFER
                 else -> null
             }
-            if (platform != null && offer != null && action != null) {
-                val target = offer.targets[action.targetBindName]
-                if (target != null) {
-                    // USER trigger: the dasher pressed Accept/Decline — that
-                    // press is the consent for this fire (#417).
-                    add(
-                        AppEffect.PerformRuleAction(
-                            action, platform, target, offer.sourceRuleId,
-                            trigger = ActionTrigger.USER,
-                        ),
+            if (action != null) {
+                val onOfferFlow = next.flow == Flow.OfferPresented || prev.flow == Flow.OfferPresented
+                val platform = next.activePlatform ?: prev.activePlatform
+                val offer = next.pendingOffer ?: prev.pendingOffer
+                val target = offer?.targets?.get(action.targetBindName)
+                when {
+                    !onOfferFlow -> Timber.w(
+                        "Offer action %s dropped (#457): R0 flow is %s, not OfferPresented — " +
+                            "shade tap likely arrived after the offer left the screen",
+                        action.wire, next.flow,
                     )
-                } else {
-                    Timber.w(
-                        "No '%s' target bound for %s — %s unavailable, leaving it to the user",
+                    platform == null || offer == null -> Timber.w(
+                        "Offer action %s dropped (#457): no active platform/pending offer " +
+                            "(platform=%s, offerHash=%s)",
+                        action.wire, platform?.wire, offer?.offerHash,
+                    )
+                    target == null -> Timber.w(
+                        "No '%s' target bound for %s — %s unavailable, leaving it to the user (#457)",
                         action.targetBindName, platform.wire, action.wire,
                     )
+                    else -> {
+                        // USER trigger: the dasher pressed Accept/Decline — that
+                        // press is the consent for this fire (#417).
+                        Timber.i("Offer action %s firing on %s (#457)", action.wire, platform.wire)
+                        add(
+                            AppEffect.PerformRuleAction(
+                                action, platform, target, offer.sourceRuleId,
+                                trigger = ActionTrigger.USER,
+                            ),
+                        )
+                    }
                 }
             }
         }

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -165,9 +165,15 @@ _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **bro
   - ⚠️ **NOTIFICATION-SHADE buttons FOUND BROKEN — 2026-06-12 (DoorDash):** the Accept/Decline buttons
     on the **system shade notification** (NOT the in-bubble buttons) did **NOTHING** (neither worked),
     same dash the in-bubble buttons worked. Dispatch path/wire strings are identical to the bubble;
-    likely the click target isn't reachable from the shade (offer window not foreground). Triaged as
-    2026-06-12 log entry #11 — pull logcat for `OfferActionReceiver: accept_offer/decline_offer` to
-    split broadcast-not-landing vs click-target-absent. In-bubble half still needs a 2nd sighting (esp.
+    likely the click target isn't reachable from the shade (offer window not foreground). Filed as
+    **#457**. **Instrumented (PR pending):** the silent drop points now log durably — next time a shade
+    tap does nothing, the persistent app log self-documents the cause (no live logcat needed). Read the
+    log around the tap and match: `OfferActionReceiver: accept_offer` **absent** = broadcast never landed;
+    `Offer action accept_offer dropped (#457): R0 flow is … not OfferPresented` = the offer left the
+    screen before the tap (most likely); `… no active platform/pending offer` = offer state cleared;
+    `Offer action accept_offer firing` then `Could not find any live node`/`No live windows` = the
+    DoorDash button wasn't reachable from the shade; `Throttled action …` = swallowed by the 1s throttle.
+    Whichever line appears points straight at the fix. In-bubble half still needs a 2nd sighting (esp.
     Decline).
 
 - **Post-dash HUD: frozen summary + consistent chat (#367, PR pending).**


### PR DESCRIPTION
Instrumentation for #457 (notification-shade Accept/Decline do nothing; in-bubble works). Catching a live logcat during an on-screen offer is impractical, so this makes every silent drop point **self-document in the persistent app log** — the next occurrence (field or a chance desk offer) points straight at the cause, no live logcat needed.

## What I found (traced + adversarially verified)
Both surfaces dispatch the **identical** `Observation.UiInput` (`OfferActionReceiver.onReceive` / `BubbleViewModel.onOfferAction`), so the divergence is downstream. A full trace (`StateManagerV2.dispatch` → `EffectMap.diff` → `SideEffectEngine` → `UiInteractionHandler`), independently re-verified by a second agent, found the **only currently-silent** drops are in `EffectMap`'s offer-action block:
- **Flow gate** (`EffectMap.kt:202`): the whole block is skipped when R0 isn't `OfferPresented`. A `UiInput` never changes the flow (it isn't a `FlowObservation`), so this is purely *"was the offer still on screen when the tap dispatched"* — and the heads-up notification can **outlive** the on-screen offer. **Leading hypothesis.**
- **Inner null** platform/offer cases.

Everything downstream already logs (target-not-bound; tier/consent denial; `No live windows`/`Could not find any live node`) — **except** the engine throttle, which was `Timber.v` (release-filtered).

## Changes (logging only — behavior unchanged)
- **EffectMap**: restructure the UiInput offer-action block so every outcome logs with a `#457` tag — `firing`, `R0 flow … not OfferPresented`, `no active platform/pending offer`, or `No 'acceptButton' target bound`. The fire path is unchanged (still requires `OfferPresented` + platform + offer + target).
- **SideEffectEngine**: throttle log `.v` → `.i` (+ trigger), so a throttled USER tap is visible under release filtering.
- **EffectMapTest**: pin the off-`OfferPresented` UiInput drop path so any future fix is deliberate.
- **Field-test checklist** (`#457`): a decode key mapping each log line to its hypothesis.

## Decode key (what the next occurrence will show)
- `OfferActionReceiver: accept_offer` **absent** → broadcast never landed (PendingIntent/registration).
- `Offer action accept_offer dropped (#457): R0 flow is … not OfferPresented` → offer left the screen before the tap (flow gate; most likely).
- `… no active platform/pending offer` → offer state cleared.
- `Offer action accept_offer firing` then `Could not find any live node`/`No live windows` → DoorDash button not reachable from the shade.
- `Throttled action …` → swallowed by the 1s throttle.

## Posture
Effects-layer; no recognition/capture/network/gate change. The actual fix waits on the log identifying which line appears — deliberately not fixing blind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)