### PR TITLE
fix(format): one :domain money formatter SSOT; "Saved: $X" gets its $ (#456)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,8 +87,10 @@ The project uses modular Clean Architecture with a strict dependency graph:
 ```
 
 - **`:domain`** — Pure Kotlin library. Domain models, state regions, evaluation logic,
-  pipeline/provider contracts, and the capture contracts (`CaptureBus`, `EnvelopeBuilder`,
-  capture schemas/DTOs) plus the `PlatformPreferences` read interface (#355). No Android
+  pipeline/provider contracts, the capture contracts (`CaptureBus`, `EnvelopeBuilder`,
+  capture schemas/DTOs), the `PlatformPreferences` read interface (#355), and the
+  number/money formatting SSOT (`format.Formats` — the locale policy, #358/#456; lives here
+  so both the UI and the state layer route through one definition). No Android
   dependencies. (Repository *implementations* and Hilt bindings live in `:core:data`.)
 - **`:core:pipeline`** — Accessibility pipeline, notification pipeline, JSON rule engine
   (RuleCompiler, Ruleset, JsonRuleInterpreter), observation classifier. Reads third-party UI.

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/TtsEffectHandler.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/TtsEffectHandler.kt
@@ -13,7 +13,7 @@ import timber.log.Timber
 import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
-import cloud.trotter.dashbuddy.core.designsystem.format.DashFormats
+import cloud.trotter.dashbuddy.domain.format.Formats
 
 @Singleton
 class TtsEffectHandler @Inject constructor(
@@ -88,9 +88,9 @@ class TtsEffectHandler @Inject constructor(
             else -> "Offer"
         }
         return "$verdict. ${eval.merchantName.trim()}. " +
-            "${DashFormats.decimal(eval.dollarsPerHour, 0)} dollars an hour net. " +
-            "Net ${DashFormats.decimal(eval.netPayAmount, 2)}, " +
-            "${DashFormats.decimal(eval.distanceMiles)} miles, " +
+            "${Formats.decimal(eval.dollarsPerHour, 0)} dollars an hour net. " +
+            "Net ${Formats.decimal(eval.netPayAmount, 2)}, " +
+            "${Formats.decimal(eval.distanceMiles)} miles, " +
             "score ${eval.score.toInt()}."
     }
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleScreen.kt
@@ -8,7 +8,7 @@ import android.text.format.DateFormat
 import android.widget.TextView
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import cloud.trotter.dashbuddy.core.designsystem.format.DashFormats
+import cloud.trotter.dashbuddy.domain.format.Formats
 import cloud.trotter.dashbuddy.core.designsystem.time.formatDuration
 import cloud.trotter.dashbuddy.core.designsystem.theme.DashTheme
 import androidx.compose.foundation.layout.Arrangement
@@ -346,7 +346,7 @@ private fun SessionMetricsActions(
             MaterialTheme.colorScheme.onSurface
 
         Text(
-            text = DashFormats.money(displayEarnings),
+            text = Formats.money(displayEarnings),
             style = MaterialTheme.typography.titleSmall,
             fontWeight = FontWeight.Bold,
             color = textColor
@@ -357,7 +357,7 @@ private fun SessionMetricsActions(
             color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.25f)
         )
         Text(
-            text = "${DashFormats.decimal(displayMiles)} mi",
+            text = "${Formats.decimal(displayMiles)} mi",
             style = MaterialTheme.typography.titleSmall,
             color = textColor
         )
@@ -404,12 +404,12 @@ private fun ModeIdle(lastSessionSummary: SessionSummary?) {
                 color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
             )
             Text(
-                text = DashFormats.money(lastSessionSummary.earnings),
+                text = Formats.money(lastSessionSummary.earnings),
                 style = MaterialTheme.typography.headlineMedium,
                 fontWeight = FontWeight.Bold,
                 color = MaterialTheme.colorScheme.primary
             )
-            ModeRow(label = "Miles", value = "${DashFormats.decimal(lastSessionSummary.miles)} mi")
+            ModeRow(label = "Miles", value = "${Formats.decimal(lastSessionSummary.miles)} mi")
             ModeRow(
                 label = "Duration",
                 value = formatDuration(lastSessionSummary.endedAt - lastSessionSummary.startedAt),

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardItem.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardItem.kt
@@ -27,7 +27,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import cloud.trotter.dashbuddy.core.designsystem.format.DashFormats
+import cloud.trotter.dashbuddy.domain.format.Formats
 import cloud.trotter.dashbuddy.core.designsystem.theme.DashTheme
 import cloud.trotter.dashbuddy.core.designsystem.time.formatCountdown
 import cloud.trotter.dashbuddy.core.designsystem.time.formatDuration
@@ -199,7 +199,7 @@ private fun awaitingSummary(snap: FlowCardSnapshot.Awaiting, isActive: Boolean):
 
 private fun offerSummary(snap: FlowCardSnapshot.Offer): String {
     val store = snap.storeNames.firstOrNull()?.takeIf { it.isNotBlank() } ?: "Offer"
-    val pay = snap.payAmount?.let { " · ${DashFormats.money(it)}" } ?: ""
+    val pay = snap.payAmount?.let { " · ${Formats.money(it)}" } ?: ""
     // Outcome is rendered as a trailing chip in the header — see
     // CardHeader — so we omit it from the summary text.
     return "$store$pay"
@@ -229,7 +229,7 @@ private fun deliverySummary(snap: FlowCardSnapshot.Delivery, isActive: Boolean):
 
 private fun postTaskSummary(snap: FlowCardSnapshot.PostTask): String {
     val store = snap.storeName?.let { "$it · " } ?: ""
-    return store + DashFormats.money(snap.totalPay)
+    return store + Formats.money(snap.totalPay)
 }
 
 // ---------------------------------------------------------------------------
@@ -318,19 +318,19 @@ private fun OfferBody(snap: FlowCardSnapshot.Offer, isActive: Boolean) {
             Column(modifier = Modifier.weight(1f)) {
                 val hourly = snap.dollarsPerHour
                 when {
-                    hourly != null -> Text("${DashFormats.money0(hourly)}/hr", style = DashTheme.num.heroNum, color = c.text, maxLines = 1)
-                    snap.payAmount != null -> Text(DashFormats.money(snap.payAmount!!), style = DashTheme.num.heroNum, color = c.text, maxLines = 1)
+                    hourly != null -> Text("${Formats.money0(hourly)}/hr", style = DashTheme.num.heroNum, color = c.text, maxLines = 1)
+                    snap.payAmount != null -> Text(Formats.money(snap.payAmount!!), style = DashTheme.num.heroNum, color = c.text, maxLines = 1)
                 }
                 val net = snap.netPayAmount ?: snap.payAmount
                 val secondary = buildString {
-                    if (net != null) append("Net ${DashFormats.money(net)}")
+                    if (net != null) append("Net ${Formats.money(net)}")
                     snap.distanceMiles?.let {
                         if (isNotEmpty()) append(" · ")
-                        append("${DashFormats.decimal(it)} mi")
+                        append("${Formats.decimal(it)} mi")
                     }
                     snap.dollarsPerMile?.let {
                         if (isNotEmpty()) append(" · ")
-                        append("${DashFormats.money(it)}/mi")
+                        append("${Formats.money(it)}/mi")
                     }
                 }
                 if (secondary.isNotBlank()) {
@@ -572,7 +572,7 @@ private fun DeadlineBody(
                     val elapsedMs = now - (arrivedAt ?: phaseStartedAt)
                     if (elapsedMs > 0) {
                         val perMin = shopped / (elapsedMs / 60_000.0)
-                        append(" · ${DashFormats.decimal(perMin)}/min")
+                        append(" · ${Formats.decimal(perMin)}/min")
                     }
                 }
             }
@@ -592,7 +592,7 @@ private fun PostTaskBody(snap: FlowCardSnapshot.PostTask) {
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(2.dp),
     ) {
-        HeroBig(DashFormats.money(snap.totalPay))
+        HeroBig(Formats.money(snap.totalPay))
         Caption("delivery total")
         snap.parsedPay?.let { pay ->
             Column(
@@ -600,15 +600,15 @@ private fun PostTaskBody(snap: FlowCardSnapshot.PostTask) {
                 verticalArrangement = Arrangement.spacedBy(2.dp),
             ) {
                 pay.appPayComponents.forEach { item ->
-                    BreakdownRow(item.type, DashFormats.money(item.amount))
+                    BreakdownRow(item.type, Formats.money(item.amount))
                 }
                 pay.customerTips.forEach { tip ->
-                    BreakdownRow("tip · ${tip.type}", DashFormats.money(tip.amount))
+                    BreakdownRow("tip · ${tip.type}", Formats.money(tip.amount))
                 }
             }
         }
         snap.sessionEarningsAtCompletion?.let {
-            Caption("session ${DashFormats.money(it)}")
+            Caption("session ${Formats.money(it)}")
         }
     }
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/components/economy/EconomyEditor.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/components/economy/EconomyEditor.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import cloud.trotter.dashbuddy.core.designsystem.format.DashFormats
+import cloud.trotter.dashbuddy.domain.format.Formats
 import cloud.trotter.dashbuddy.core.designsystem.theme.DashBuddyTheme
 import cloud.trotter.dashbuddy.domain.evaluation.EconomyField
 import cloud.trotter.dashbuddy.domain.evaluation.UserEconomy
@@ -55,7 +55,7 @@ fun EconomyEditor(
     // -------- Tires --------
     EconomyAccordionRow(
         title = "Tires",
-        summary = "${DashFormats.money3(economy.tireCostPerMile)}/mi",
+        summary = "${Formats.money3(economy.tireCostPerMile)}/mi",
         isUserSet = EconomyField.TIRE_COST in userSet || EconomyField.TIRE_LIFETIME in userSet,
     ) {
         PairedCurrencyAndIntervalInput(
@@ -71,7 +71,7 @@ fun EconomyEditor(
     // -------- Oil changes --------
     EconomyAccordionRow(
         title = "Oil changes",
-        summary = "${DashFormats.money3(economy.oilCostPerMile)}/mi",
+        summary = "${Formats.money3(economy.oilCostPerMile)}/mi",
         isUserSet = EconomyField.OIL_COST in userSet || EconomyField.OIL_INTERVAL in userSet,
     ) {
         PairedCurrencyAndIntervalInput(
@@ -87,7 +87,7 @@ fun EconomyEditor(
     // -------- Brakes --------
     EconomyAccordionRow(
         title = "Brakes",
-        summary = "${DashFormats.money3(economy.brakesCostPerMile)}/mi",
+        summary = "${Formats.money3(economy.brakesCostPerMile)}/mi",
         isUserSet = EconomyField.BRAKES_COST in userSet || EconomyField.BRAKES_INTERVAL in userSet,
     ) {
         PairedCurrencyAndIntervalInput(
@@ -103,7 +103,7 @@ fun EconomyEditor(
     // -------- Fluids --------
     EconomyAccordionRow(
         title = "Fluids",
-        summary = "${DashFormats.money3(economy.fluidsCostPerMile)}/mi",
+        summary = "${Formats.money3(economy.fluidsCostPerMile)}/mi",
         isUserSet = EconomyField.FLUIDS_COST in userSet || EconomyField.FLUIDS_INTERVAL in userSet,
     ) {
         PairedCurrencyAndIntervalInput(
@@ -119,7 +119,7 @@ fun EconomyEditor(
     // -------- Misc repairs --------
     EconomyAccordionRow(
         title = "Misc repairs",
-        summary = "${DashFormats.money3(economy.miscCostPerMile)}/mi",
+        summary = "${Formats.money3(economy.miscCostPerMile)}/mi",
         isUserSet = EconomyField.MISC_YEARLY in userSet || EconomyField.MISC_YEARLY_MI in userSet,
     ) {
         PairedCurrencyAndIntervalInput(
@@ -138,7 +138,7 @@ fun EconomyEditor(
     EconomyAccordionRow(
         title = "Depreciation",
         summary = if (economy.includeDepreciation) {
-            "${DashFormats.money3(economy.depreciationCostPerMile)}/mi"
+            "${Formats.money3(economy.depreciationCostPerMile)}/mi"
         } else {
             "off"
         },
@@ -172,7 +172,7 @@ fun EconomyEditor(
     // -------- Insurance --------
     EconomyAccordionRow(
         title = "Insurance",
-        summary = "${DashFormats.money3(economy.insuranceCostPerMile)}/mi*",
+        summary = "${Formats.money3(economy.insuranceCostPerMile)}/mi*",
         isUserSet = EconomyField.INSURANCE_DELTA in userSet,
     ) {
         CurrencyInput(
@@ -191,7 +191,7 @@ fun EconomyEditor(
     // -------- Registration --------
     EconomyAccordionRow(
         title = "Registration",
-        summary = "${DashFormats.money3(economy.registrationCostPerMile)}/mi*",
+        summary = "${Formats.money3(economy.registrationCostPerMile)}/mi*",
         isUserSet = EconomyField.REGISTRATION_DELTA in userSet,
     ) {
         CurrencyInput(
@@ -211,7 +211,7 @@ fun EconomyEditor(
     // -------- Phone & data --------
     EconomyAccordionRow(
         title = "Phone & data",
-        summary = "${DashFormats.money3(economy.phoneCostPerMile)}/mi*",
+        summary = "${Formats.money3(economy.phoneCostPerMile)}/mi*",
         isUserSet = EconomyField.PHONE_PLAN_TOTAL in userSet ||
             EconomyField.PHONE_PLAN_LINES in userSet ||
             EconomyField.PHONE_DASH_PERCENT in userSet,
@@ -245,9 +245,9 @@ fun EconomyEditor(
         )
         val perLine = economy.phonePlanTotal / economy.phonePlanLines.coerceAtLeast(1)
         Text(
-            text = "Your line: ${DashFormats.money(perLine)}/mo" +
+            text = "Your line: ${Formats.money(perLine)}/mo" +
                 " × ${economy.phoneDashPercent.toInt()}%" +
-                " = ${DashFormats.money(perLine * economy.phoneDashPercent / 100.0)}/mo for gig work",
+                " = ${Formats.money(perLine * economy.phoneDashPercent / 100.0)}/mo for gig work",
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
@@ -256,11 +256,11 @@ fun EconomyEditor(
     // -------- Expected annual gig miles --------
     EconomyAccordionRow(
         title = "Expected gig miles / yr",
-        summary = "${DashFormats.commaInt(economy.expectedAnnualDashMiles.toInt())} mi",
+        summary = "${Formats.commaInt(economy.expectedAnnualDashMiles.toInt())} mi",
         isUserSet = EconomyField.EXPECTED_ANNUAL_DASH_MI in userSet,
     ) {
         Text(
-            text = "${DashFormats.commaInt(economy.expectedAnnualDashMiles.toInt())} miles per year",
+            text = "${Formats.commaInt(economy.expectedAnnualDashMiles.toInt())} miles per year",
             style = MaterialTheme.typography.bodyMedium,
             fontWeight = FontWeight.Medium,
         )
@@ -316,7 +316,7 @@ fun TrueCostFooter(operatingCostPerMile: Double) {
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Text(
-                text = "Your true cost: ${DashFormats.money(operatingCostPerMile)}/mi",
+                text = "Your true cost: ${Formats.money(operatingCostPerMile)}/mi",
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
             )

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/formatters/OfferFormatters.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/formatters/OfferFormatters.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.graphics.toArgb
 import cloud.trotter.dashbuddy.core.designsystem.theme.darkDashColors
 import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
 import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
-import cloud.trotter.dashbuddy.core.designsystem.format.DashFormats
+import cloud.trotter.dashbuddy.domain.format.Formats
 import cloud.trotter.dashbuddy.domain.evaluation.OfferQuality
 import cloud.trotter.dashbuddy.domain.model.chat.ChatPersona
 
@@ -59,15 +59,15 @@ fun OfferEvaluation.toNotificationSummary(): CharSequence {
         setSpan(RelativeSizeSpan(1.2f), start, length, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
 
         append(" · ")
-        append("${DashFormats.money0(dollarsPerHour)}/hr net")
+        append("${Formats.money0(dollarsPerHour)}/hr net")
         // Whole headline (verdict + rate) bold.
         setSpan(StyleSpan(Typeface.BOLD), start, length, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
 
         append("\n")
         append(
-            "Net ${DashFormats.money(netPayAmount)} · " +
-                "${DashFormats.decimal(distanceMiles)} mi · " +
-                "${DashFormats.money(dollarsPerMile)}/mi · " +
+            "Net ${Formats.money(netPayAmount)} · " +
+                "${Formats.decimal(distanceMiles)} mi · " +
+                "${Formats.money(dollarsPerMile)}/mi · " +
                 "Score ${score.toInt()} · " +
                 merchantName,
         )

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardViewModel.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-import cloud.trotter.dashbuddy.core.designsystem.format.DashFormats
+import cloud.trotter.dashbuddy.domain.format.Formats
 
 @HiltViewModel
 class DashboardViewModel @Inject constructor(
@@ -47,7 +47,7 @@ class DashboardViewModel @Inject constructor(
     val sessionMiles: StateFlow<String> = odometerRepository.sessionMeters
         .map { meters ->
             val miles = meters * 0.000621371
-            "${DashFormats.decimal(miles)} mi"
+            "${Formats.decimal(miles)} mi"
         }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), "0.0 mi")
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/SettingsHomeScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/SettingsHomeScreen.kt
@@ -38,7 +38,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import cloud.trotter.dashbuddy.ui.main.navigation.Screen
-import cloud.trotter.dashbuddy.core.designsystem.format.DashFormats
+import cloud.trotter.dashbuddy.domain.format.Formats
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 
 @Composable
@@ -102,7 +102,7 @@ fun SettingsHomeScreen(
                     val costPerMi = eco.operatingCostPerMile
                     val defaultsCount = cloud.trotter.dashbuddy.domain.evaluation.EconomyField.entries.size -
                         eco.userSetFields.size
-                    "True cost: ${DashFormats.money(costPerMi)}/mi" +
+                    "True cost: ${Formats.money(costPerMi)}/mi" +
                         if (defaultsCount > 0) " · $defaultsCount defaults" else ""
                 } else {
                     "Tires, oil, depreciation, insurance, phone"

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/components/ReorderableRule.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/components/ReorderableRule.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.unit.dp
 import cloud.trotter.dashbuddy.domain.evaluation.MetricType
 import cloud.trotter.dashbuddy.domain.evaluation.ScoringRule
 import java.util.Locale
-import cloud.trotter.dashbuddy.core.designsystem.format.DashFormats
+import cloud.trotter.dashbuddy.domain.format.Formats
 
 @Composable
 fun DraggableRuleRow(
@@ -108,9 +108,9 @@ fun MetricContent(
         // Value Display (e.g., "$15.00" or "10 mi")
         if (rule.isEnabled) {
             val formatted = when (type) {
-                MetricType.PAYOUT, MetricType.ACTIVE_HOURLY -> DashFormats.money(value.toDouble())
-                MetricType.DOLLAR_PER_MILE -> "${DashFormats.money(value.toDouble())}/mi"
-                MetricType.MAX_DISTANCE -> "${DashFormats.decimal(value.toDouble())} mi"
+                MetricType.PAYOUT, MetricType.ACTIVE_HOURLY -> Formats.money(value.toDouble())
+                MetricType.DOLLAR_PER_MILE -> "${Formats.money(value.toDouble())}/mi"
+                MetricType.MAX_DISTANCE -> "${Formats.decimal(value.toDouble())} mi"
                 MetricType.ITEM_COUNT -> "${value.toInt()} items"
             }
             Text(

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/WizardScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/WizardScreen.kt
@@ -47,7 +47,7 @@ import cloud.trotter.dashbuddy.ui.main.setup.wizard.components.WizardTopBar
 import cloud.trotter.dashbuddy.ui.main.setup.wizard.model.WizardStep
 import kotlinx.coroutines.launch
 import java.util.Locale
-import cloud.trotter.dashbuddy.core.designsystem.format.DashFormats
+import cloud.trotter.dashbuddy.domain.format.Formats
 
 @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 @Composable
@@ -194,7 +194,7 @@ fun WizardScreen(
                     WizardStep.SHOPPING -> {
                         MetricSliderCard(
                             step = currentStep, value = state.maxItems, valueRange = 1f..100f,
-                            valueFormatter = { "${DashFormats.decimal(it.toDouble(), 0)} items" },
+                            valueFormatter = { "${Formats.decimal(it.toDouble(), 0)} items" },
                             onValueChange = viewModel::updateMaxItems,
                             footerText = "We'll use this to score shopping offers on the HUD."
                         )
@@ -203,7 +203,7 @@ fun WizardScreen(
                     WizardStep.MIN_PAYOUT -> {
                         MetricSliderCard(
                             step = currentStep, value = state.minPayout, valueRange = 2f..20f,
-                            valueFormatter = { DashFormats.money(it.toDouble()) },
+                            valueFormatter = { Formats.money(it.toDouble()) },
                             onValueChange = viewModel::updateMinPayout,
                             footerText = if (isCherryPicker) "We will auto-decline offers below this amount." else "We will flag offers below this amount in red."
                         )
@@ -212,7 +212,7 @@ fun WizardScreen(
                     WizardStep.TARGET_HOURLY -> {
                         MetricSliderCard(
                             step = currentStep, value = state.targetHourly, valueRange = 10f..40f,
-                            valueFormatter = { "${DashFormats.money0(it.toDouble())} / hr" },
+                            valueFormatter = { "${Formats.money0(it.toDouble())} / hr" },
                             onValueChange = viewModel::updateTargetHourly,
                             footerText = if (isCherryPicker) "We will auto-decline offers below this rate." else "We will flag offers below this rate in red."
                         )

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -3,6 +3,7 @@ package cloud.trotter.dashbuddy.core.state
 import cloud.trotter.dashbuddy.domain.action.ActionTrigger
 import cloud.trotter.dashbuddy.domain.action.RuleAction
 import cloud.trotter.dashbuddy.domain.config.EvidenceCategory
+import cloud.trotter.dashbuddy.domain.format.Formats
 import cloud.trotter.dashbuddy.domain.model.chat.ChatPersona
 import cloud.trotter.dashbuddy.domain.model.event.AppEvent
 import cloud.trotter.dashbuddy.domain.model.event.AppEventType
@@ -357,7 +358,7 @@ class EffectMap @Inject constructor() {
                         ?: pend?.endFields
                     val endedAt = pend?.since ?: obs.timestamp
                     if (endParsed != null) {
-                        val earnings = formatCurrency(endParsed.totalEarnings)
+                        val earnings = Formats.money(endParsed.totalEarnings)
                         add(
                             logEffect(
                                 sessionId,
@@ -723,13 +724,13 @@ class EffectMap @Inject constructor() {
         val payData = parsed.parsedPay
         val text = if (payData != null) {
             buildString {
-                append("Saved: ${formatCurrency(payData.total)}")
+                append("Saved: ${Formats.money(payData.total)}")
                 payData.customerTips.forEach { item ->
-                    append("\nTip: ${item.type} • ${formatCurrency(item.amount)}")
+                    append("\nTip: ${item.type} • ${Formats.money(item.amount)}")
                 }
             }
         } else {
-            "Saved: ${formatCurrency(parsed.totalPay)}"
+            "Saved: ${Formats.money(parsed.totalPay)}"
         }
         return listOf(AppEffect.UpdateBubble(text, ChatPersona.Earnings))
     }
@@ -883,14 +884,6 @@ class EffectMap @Inject constructor() {
     // =========================================================================
     // HELPERS
     // =========================================================================
-
-    /**
-     * Display formatting inside the state layer is a known wart: UpdateBubble
-     * carries rendered copy, so the formatter lives here until #366 moves the
-     * copy out of state. Locale pinned EXPLICITLY per the #358 policy.
-     */
-    private fun formatCurrency(amount: Double): String =
-        String.format(java.util.Locale.getDefault(), "%.2f", amount)
 
     private fun resolveOfferOutcome(obs: Observation, prevOffer: PendingOffer? = null): AppEventType {
         // 1. Stored click intent on PendingOffer — covers the common case where

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -63,6 +63,15 @@ immediately (no second pass needed) so it gets triaged.
 _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **broken** on the
 2026-06-09 dash — moved to that session's log entry below for triage.)_
 
+- **"Saved: $X" bubble shows the dollar sign now (#456).**
+  The post-delivery earnings bubble rendered `Saved: 5.50` (no `$`) because the state layer had
+  its own money formatter that omitted it. Both local formatters are gone — money now formats
+  through one `:domain` `Formats.money` SSOT. On a dash, after a delivery: working = the "Saved"
+  bubble reads `Saved: $5.50` (with the `$`); the dash-summary "Session Ended. Total: $X" and
+  the offer notification's `$/hr`/`$/mi` should all still read correctly. Broken = a missing or
+  doubled `$`, or a wrong decimal.
+  - Confirmed: 0/2
+
 - **DasherDirect Savings screens now blocked as sensitive (#463, partial — banking slice).**
   On the 2026-06-12 dash the DasherDirect **Savings jar** flow (balance + "Transfer $X" + "You
   transferred $X") leaked plaintext dollar balances to UNKNOWN capture — the redesigned savings

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/OfferEvaluator.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/OfferEvaluator.kt
@@ -1,5 +1,6 @@
 package cloud.trotter.dashbuddy.domain.evaluation
 
+import cloud.trotter.dashbuddy.domain.format.Formats
 import cloud.trotter.dashbuddy.domain.model.offer.ParsedOffer
 import cloud.trotter.dashbuddy.domain.model.order.ParsedOrder
 
@@ -211,17 +212,17 @@ class OfferEvaluator() {
             val target = rule.targetValue.toDouble()
             when (rule.metricType) {
                 MetricType.DOLLAR_PER_MILE -> if (target > REALISTIC_MAX_DPM)
-                    "Your \$/mile target of \$${String.format(java.util.Locale.ROOT, "%.2f", target)} is above what most DoorDash offers pay. " +
+                    "Your \$/mile target of ${Formats.money(target)} is above what most DoorDash offers pay. " +
                     "Most offers are \$0.80–\$1.50/mi. Setting this high will result in most offers being auto-declined."
                 else null
 
                 MetricType.ACTIVE_HOURLY -> if (target > REALISTIC_MAX_HOURLY)
-                    "Your hourly target of \$${String.format(java.util.Locale.ROOT, "%.2f", target)}/hr is above typical DoorDash earnings. " +
+                    "Your hourly target of ${Formats.money(target)}/hr is above typical DoorDash earnings. " +
                     "Most dashers earn \$15–\$25/hr active. Setting this high will result in most offers being auto-declined."
                 else null
 
                 MetricType.PAYOUT -> if (target > REALISTIC_MAX_PAYOUT)
-                    "Your minimum payout of \$${String.format(java.util.Locale.ROOT, "%.2f", target)} is above what most single orders pay. " +
+                    "Your minimum payout of ${Formats.money(target)} is above what most single orders pay. " +
                     "Most DoorDash orders are under \$10. Setting this high will result in most offers being auto-declined."
                 else null
 

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/format/Formats.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/format/Formats.kt
@@ -1,9 +1,9 @@
-package cloud.trotter.dashbuddy.core.designsystem.format
+package cloud.trotter.dashbuddy.domain.format
 
 import java.util.Locale
 
 /**
- * Locale policy for every formatted number in DashBuddy (#358):
+ * Locale policy for every formatted number in DashBuddy (#358, #456):
  *
  *  - **Display strings** (anything a human reads: money, distances, rates,
  *    counts) format through THIS object, which pins `Locale.getDefault()`
@@ -14,10 +14,18 @@ import java.util.Locale
  *    back — e.g. editable text fields that round-trip `toDoubleOrNull`) pin
  *    `Locale.ROOT`/`Locale.US` at their own call site.
  *
+ * Lives in `:domain` (pure Kotlin, no Android) so BOTH the UI (`:app`) and the
+ * state layer (`:core:state`) route through the one definition. EffectMap used
+ * to carry a private `formatCurrency` that omitted the `$` — the "Saved: $X"
+ * bubble rendered `Saved: 5.50` (#456) — because `:core:state` can't reach the
+ * old designsystem `DashFormats`. Pulling the formatter down to `:domain`
+ * removes that divergence (and the platform-flavoured "Dash" name). Formatting
+ * is platform-neutral; the name is too.
+ *
  * Acceptance grep: `.format(` without `Locale` on the same line should not
- * appear in ui/ code — everything routes here.
+ * appear in ui/ or rendered-copy code — everything routes here.
  */
-object DashFormats {
+object Formats {
 
     private val locale: Locale get() = Locale.getDefault()
 
@@ -36,5 +44,4 @@ object DashFormats {
 
     /** "12,500" — grouped integer. */
     fun commaInt(value: Int): String = String.format(locale, "%,d", value)
-
 }

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/format/FormatsTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/format/FormatsTest.kt
@@ -1,4 +1,4 @@
-package cloud.trotter.dashbuddy.core.designsystem.format
+package cloud.trotter.dashbuddy.domain.format
 
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -10,7 +10,7 @@ import java.util.Locale
  * #358 locale policy: display formatting follows the DEVICE locale —
  * explicitly, not as an invisible side effect of bare `.format`.
  */
-class DashFormatsTest {
+class FormatsTest {
 
     private lateinit var original: Locale
 
@@ -27,17 +27,17 @@ class DashFormatsTest {
     @Test
     fun `US locale formats with dot decimals and comma grouping`() {
         Locale.setDefault(Locale.US)
-        assertEquals("$7.50", DashFormats.money(7.5))
-        assertEquals("$23", DashFormats.money0(23.4))
-        assertEquals("$0.165", DashFormats.money3(0.1649))
-        assertEquals("4.2", DashFormats.decimal(4.23))
-        assertEquals("12,500", DashFormats.commaInt(12_500))
+        assertEquals("$7.50", Formats.money(7.5))
+        assertEquals("$23", Formats.money0(23.4))
+        assertEquals("$0.165", Formats.money3(0.1649))
+        assertEquals("4.2", Formats.decimal(4.23))
+        assertEquals("12,500", Formats.commaInt(12_500))
     }
 
     @Test
     fun `comma-decimal locale renders ITS convention - deliberately`() {
         Locale.setDefault(Locale.GERMANY)
-        assertEquals("$7,50", DashFormats.money(7.5))
-        assertEquals("12.500", DashFormats.commaInt(12_500))
+        assertEquals("$7,50", Formats.money(7.5))
+        assertEquals("12.500", Formats.commaInt(12_500))
     }
 }


### PR DESCRIPTION
Closes #456. The post-delivery **"Saved: $X"** bubble rendered `Saved: 5.50` — no `$` — because `EffectMap` (`:core:state`) carried a **private** `formatCurrency` (`"%.2f"`, no `$`), since `:core:state` can't reach `DashFormats.money` over in `:core:designsystem`. Two divergent money formatters, one of them wrong (the #358 twin-formatter family).

## Fix
Pull the formatter down to **`:domain`** (pure Kotlin, reachable by both the UI and the state layer) and remove **both** local copies, per your direction:

- **New `domain/.../format/Formats.kt`** — the locale-policy SSOT (`money`/`money0`/`money3`/`decimal`/`commaInt`). **Renamed** from `DashFormats`: dropped the platform-flavoured "Dash" (formatting is platform-neutral).
- **Deleted** `DashFormats` from `:core:designsystem`; its test moved to `:domain` as `FormatsTest`.
- **Deleted** EffectMap's private `formatCurrency`; the "Saved"/"Tip"/session-end copy now calls `Formats.money`, which carries the `$` → **#456 fixed by construction**.
- Repointed all **52 call sites across 9 `:app` files** (`DashFormats.` → `Formats.`).
- Also folded in **OfferEvaluator's 3 inline advice-copy money formatters** (they re-implemented `$` + `"%.2f"` on `Locale.ROOT`) → `Formats.money`. They're in the same `:domain` module, it's the same SSOT, and `Locale.getDefault()` is the display-correct choice. (Slightly beyond the two formatters #456 named, but exactly the "no re-implemented formatter" rule from principle 5 — easy to drop if you'd rather keep this PR to the two.)

## Why `:domain`
`:core:designsystem` has no project deps and no internal component used `DashFormats` (only `:app` and EffectMap did), and `:domain` is pure-Kotlin JVM — so the formatter belongs there, where both layers can route through one definition. Module graph respected (no new edges; `:core:designsystem` loses a file rather than gaining a dep).

## Scope / safety
- No behavior change except the intended one: `$` restored; en-US output otherwise byte-identical (the locale formats are the same).
- Brand names elsewhere — `DashColors`, `DashTheme`, `DashCard`, … — **untouched**; only the formatter carried a platform-flavoured name.
- Full `testDebugUnitTest` green (incl. the moved `FormatsTest`).

## Field validation
Checklist item (0/2): after a delivery the "Saved" bubble reads `Saved: $5.50`; session-end total and the offer notification's `$/hr`·`$/mi` still read correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)