### PR TITLE
fix(bubble): drop the frozen twin of the active card (#458)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleViewModel.kt
@@ -121,7 +121,9 @@ class BubbleViewModel @Inject constructor(
             else flowOf(emptyList())
         },
     ) { state, events ->
-        CardStack(
+        // CardStack.of drops a frozen completed card that duplicates the active
+        // card's id — the at-door frozen+live overlap (#458).
+        CardStack.of(
             completed = FlowCardMapper.fold(events),
             active = LiveCardBuilder.build(state),
         )

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -63,6 +63,14 @@ immediately (no second pass needed) so it gets triaged.
 _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **broken** on the
 2026-06-09 dash — moved to that session's log entry below for triage.)_
 
+- **No transient double drop-off card at the door (#458).**
+  On an arrival-bearing dropoff (hand-it-to-customer / photo / PIN) the same delivery briefly
+  rendered as TWO cards during the at-door window (a frozen completed copy + the live one). The
+  stack now drops the frozen twin when it shares the active card's id. On a dash: working = at
+  the customer's door you see exactly ONE delivery card (then the single frozen card + the live
+  "Saved" receipt after you complete). Broken = two identical delivery cards stacked at the door.
+  - Confirmed: 0/2
+
 - **"Saved: $X" bubble shows the dollar sign now (#456).**
   The post-delivery earnings bubble rendered `Saved: 5.50` (no `$`) because the state layer had
   its own money formatter that omitted it. Both local formatters are gone — money now formats

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/cards/FlowCardSnapshot.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/cards/FlowCardSnapshot.kt
@@ -148,5 +148,23 @@ data class CardStack(
 
     companion object {
         val Empty = CardStack()
+
+        /**
+         * Assemble the stack from the folded [completed] history + the current
+         * [active] card, dropping any frozen completed card whose id matches
+         * the active one (#458). On an arrival-bearing dropoff the mapper
+         * closes the Delivery into `completed` on DELIVERY_ARRIVED while the
+         * live builder still emits an active Delivery for the same task — same
+         * id `delivery:<taskId>` — which would render as TWO cards during the
+         * at-door window (no crash: #297's `live:` key prefix holds). Suppress
+         * the frozen twin so exactly one card shows; it resolves on
+         * DELIVERY_COMPLETED anyway when the active card becomes a PostTask.
+         */
+        fun of(completed: List<FlowCardSnapshot>, active: FlowCardSnapshot?): CardStack =
+            CardStack(
+                completed = if (active == null) completed
+                else completed.filterNot { it.id == active.id },
+                active = active,
+            )
     }
 }

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/model/cards/CardStackTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/model/cards/CardStackTest.kt
@@ -1,0 +1,60 @@
+package cloud.trotter.dashbuddy.domain.model.cards
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** #458 — CardStack.of drops the frozen completed card that duplicates the active card. */
+class CardStackTest {
+
+    private fun delivery(taskId: String, ended: Long? = null) = FlowCardSnapshot.Delivery(
+        phaseStartedAt = 0L, phaseEndedAt = ended, taskId = taskId, jobId = "job-1",
+    )
+
+    private fun postTask(jobId: String) = FlowCardSnapshot.PostTask(
+        phaseStartedAt = 0L, jobId = jobId,
+    )
+
+    @Test
+    fun `frozen completed card with the same id as active is suppressed - the at-door overlap`() {
+        // The mapper froze delivery:task-A into completed on DELIVERY_ARRIVED
+        // while the live builder still emits an active delivery:task-A.
+        val frozen = delivery("task-A", ended = 100L)
+        val active = delivery("task-A")
+        assertEquals("frozen.id == active.id", frozen.id, active.id)
+
+        val stack = CardStack.of(completed = listOf(frozen), active = active)
+
+        assertTrue("the frozen twin is dropped", stack.completed.none { it.id == active.id })
+        assertEquals("exactly the active card remains", active, stack.active)
+        assertTrue(stack.completed.isEmpty())
+    }
+
+    @Test
+    fun `distinct completed cards are kept`() {
+        val older = delivery("task-A", ended = 100L)
+        val active = delivery("task-B")
+        val stack = CardStack.of(completed = listOf(older), active = active)
+        assertEquals(listOf(older), stack.completed)
+        assertEquals(active, stack.active)
+    }
+
+    @Test
+    fun `null active keeps all completed`() {
+        val cards = listOf(delivery("task-A", ended = 1L), postTask("job-1"))
+        val stack = CardStack.of(completed = cards, active = null)
+        assertEquals(cards, stack.completed)
+    }
+
+    @Test
+    fun `the overlap resolves once active becomes a PostTask (different id)`() {
+        // On DELIVERY_COMPLETED the live card becomes posttask:job-1 while the
+        // frozen delivery:task-A stays — different ids, both shown (the single
+        // frozen delivery + the live receipt), which is the correct end state.
+        val frozen = delivery("task-A", ended = 100L)
+        val active = postTask("job-1")
+        val stack = CardStack.of(completed = listOf(frozen), active = active)
+        assertEquals(listOf(frozen), stack.completed)
+        assertEquals(active, stack.active)
+    }
+}


### PR DESCRIPTION
Closes #458. On an arrival-bearing dropoff (hand-to-customer / photo / PIN), the same delivery briefly rendered as **two cards** during the at-door window.

## Cause (verified on current master)
On `DELIVERY_ARRIVED`, `FlowCardMapper` closes the Delivery into the `completed` list (frozen, id `delivery:<taskId>`) while `LiveCardBuilder` still emits an **active** Delivery for the same task (same id, because flow is `TaskDropoffArrived`). `BubbleViewModel.cardStack` put the fold in `completed` and the live build in `active`, so the delivery showed in **both**. No crash — #297's `live:` key prefix holds — purely cosmetic, and it self-resolved on `DELIVERY_COMPLETED` (active becomes a PostTask card with a different id).

## Fix
At the assembly edge, where it belongs — new pure **`CardStack.of(completed, active)`** factory (`:domain`) drops any completed card whose id equals the active card's id; `BubbleViewModel.cardStack` routes through it. Generalises to any frozen/live id overlap; no state-machine or mapper change. (The riskier alternative — not freezing the Delivery until `DELIVERY_CONFIRMED` — changes arrival-vs-receipt semantics; avoided.)

## Tests
`CardStackTest` (`:domain`, pure — no heavy ViewModel needed): same-id frozen card suppressed; distinct cards kept; null active keeps all; and the post-`DELIVERY_COMPLETED` state (`active` = `posttask:<jobId>`, different id) correctly shows both the frozen delivery and the live receipt. Full suite green. Field-test item added (0/2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)