### PR TITLE
fix(bubble): drop the doubled "by" in the pickup/delivery deadline caption (#460)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardItem.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardItem.kt
@@ -451,7 +451,9 @@ private fun PickupBody(snap: FlowCardSnapshot.Pickup, isActive: Boolean) {
         itemsShopped = snap.itemsShopped,
         itemsRemaining = snap.itemsRemaining,
         activity = snap.activity,
-        deadlineLabel = "till pickup-by",
+        // No "-by": the DeadlineBody caption already appends "· by HH:MM",
+        // so "till pickup-by" read as "till pickup-by · by 17:10" (#460).
+        deadlineLabel = "till pickup",
     )
 }
 
@@ -472,7 +474,7 @@ private fun DeliveryBody(snap: FlowCardSnapshot.Delivery, isActive: Boolean) {
         itemsShopped = null,
         itemsRemaining = null,
         activity = null,
-        deadlineLabel = "till deliver-by",
+        deadlineLabel = "till deliver",
     )
 }
 

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -63,6 +63,12 @@ immediately (no second pass needed) so it gets triaged.
 _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **broken** on the
 2026-06-09 dash — moved to that session's log entry below for triage.)_
 
+- **Pickup/Delivery card deadline reads cleanly — no double "by" (#460).**
+  The deadline caption read `till pickup-by · by 17:10` (two "by"s); now `till pickup · by 17:10`
+  / `till deliver · by 17:10`. Desk- or dash-verifiable on any pickup/delivery card. (The
+  separate pickup/delivery card visual-parity redesign stays tracked in #460.)
+  - Confirmed: 0/2
+
 - **No transient double drop-off card at the door (#458).**
   On an arrival-bearing dropoff (hand-it-to-customer / photo / PIN) the same delivery briefly
   rendered as TWO cards during the at-door window (a frozen completed copy + the live one). The


### PR DESCRIPTION
Addresses the copy-bug half of #460. The deadline caption is built as `"$deadlineLabel · by ${formatTime(...)}"` (FlowCardItem `DeadlineBody:512`), so `PickupBody`'s `deadlineLabel = "till pickup-by"` rendered **"till pickup-by · by 17:10"** — two "by"s (same on delivery: "till deliver-by · by 17:10").

## Fix
Drop `-by` from both labels → `"till pickup"` / `"till deliver"`, so the caption reads **"till pickup · by 17:10"**. Reads cleanly at the label's other two use sites too ("vs till pickup", and the bare label in the frozen state). One-string-each change, contained in `:app`.

## Scope
Copy fix only. The **pickup/delivery visual-parity redesign** (these cards never adopted the #324 offer-card ring/banner/pill vocabulary) is the design half — it stays tracked in **#460** (issue remains open for it). Full suite green; field-test item added (0/2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)