### PR TITLE
fix(privacy): block alcohol customer-ID/signature capture screens (#463 — identity slice)

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/DefaultRulesIntegrationTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/DefaultRulesIntegrationTest.kt
@@ -211,6 +211,51 @@ class DefaultRulesIntegrationTest {
         }
     }
 
+    @Test
+    fun `alcohol customer-ID and signature CAPTURE screens classify as sensitive (#463)`() {
+        // The identity-CAPTURE surfaces that leaked to UNKNOWN on 2026-06-12 —
+        // each must hit the priority-0 sensitive rule (block, never parse/store).
+        fun screen(vararg texts: String) =
+            UiNode(children = texts.map { UiNode(text = it) }).restoreParents()
+
+        val licenseScan = screen("Driver's License", "Scan barcode on the back of license", "HELP")
+        val idMatch = screen("Identity verification", "2 of 4", "Verify that the ID matches the recipient and they aren't intoxicated.", "Verify", "Can't verify")
+        val signatureHandoff = screen("Hand your phone to the customer so they can provide their signature.", "Got it")
+        val scanResult = screen("Scan Successful", "Now you're ready to start verification.", "Continue")
+
+        for ((name, node) in listOf(
+            "license-scan" to licenseScan, "id-match" to idMatch,
+            "signature-handoff" to signatureHandoff, "scan-result" to scanResult,
+        )) {
+            val r = screenRuleset.matchFirst(node, platformWire = "doordash")
+            assertTrue(
+                "alcohol identity $name screen must hit a sensitive rule, got ${r?.ruleId}",
+                r?.ruleId?.contains("sensitive") == true,
+            )
+        }
+    }
+
+    @Test
+    fun `alcohol delivery instruction CHECKLIST does NOT classify as sensitive — recognize-vs-block boundary (#463 vs #462)`() {
+        // The step-CHECKLIST (instructions, no recipient PII, no scanning) must
+        // stay non-sensitive so #462 can recognize it as a dropoff flow step.
+        // Only the actual capture surfaces are blocked.
+        val checklist = UiNode(
+            children = listOf(
+                UiNode(text = "Follow all of the steps below to complete this delivery."),
+                UiNode(text = "Do NOT hand over items until ID has been verified"),
+                UiNode(text = "Verify recipient's identity"),
+                UiNode(text = "Complete delivery"),
+            ),
+        ).restoreParents()
+
+        val r = screenRuleset.matchFirst(checklist, platformWire = "doordash")
+        assertTrue(
+            "the instruction checklist must NOT be blocked sensitive (got ${r?.ruleId}) — it's a recognizable flow step (#462)",
+            r?.ruleId?.contains("sensitive") != true,
+        )
+    }
+
     // =========================================================================
     // Parse-output regression on real captures (#433)
     // =========================================================================

--- a/app/src/test/resources/snapshots/SENSITIVE/2026-06-12_17-29-47__doordash__id_verification__007cce.json
+++ b/app/src/test/resources/snapshots/SENSITIVE/2026-06-12_17-29-47__doordash__id_verification__007cce.json
@@ -1,0 +1,390 @@
+{
+    "captureId": "6bbecd7f-f0a7-4024-9a3f-566242cb7e84",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1781303387482,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 136,
+                            "right": 1080,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 136,
+                                    "right": 1080,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 136,
+                                            "right": 1080,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/container",
+                                                "class": "android.widget.LinearLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 136,
+                                                    "right": 1080,
+                                                    "bottom": 2347
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/navbar",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 261
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "desc": "",
+                                                                "id": "com.doordash.driverapp:id/collapsingToolbar_navBar",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 136,
+                                                                    "right": 1080,
+                                                                    "bottom": 261
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/imageview_nav_bar_background",
+                                                                        "class": "android.widget.ImageView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 136,
+                                                                            "right": 1080,
+                                                                            "bottom": 136
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/toolbar_navBar",
+                                                                        "class": "android.view.ViewGroup",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 136,
+                                                                            "right": 1080,
+                                                                            "bottom": 261
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "desc": "Navigate up",
+                                                                                "class": "android.widget.ImageButton",
+                                                                                "isClickable": true,
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 136,
+                                                                                    "right": 125,
+                                                                                    "bottom": 261
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "class": "android.view.View",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 125,
+                                                                                    "top": 136,
+                                                                                    "right": 938,
+                                                                                    "bottom": 261
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "class": "androidx.appcompat.widget.LinearLayoutCompat",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 938,
+                                                                                    "top": 136,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 261
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "text": "HELP",
+                                                                                        "id": "com.doordash.driverapp:id/action_self_help",
+                                                                                        "class": "android.widget.Button",
+                                                                                        "isClickable": true,
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 938,
+                                                                                            "top": 145,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 252
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/fragment",
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 261,
+                                                            "right": 1080,
+                                                            "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 261,
+                                                                    "right": 1080,
+                                                                    "bottom": 2347
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "text": "Identity verification",
+                                                                        "id": "com.doordash.driverapp:id/verify_id_confirmation_title",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 36,
+                                                                            "top": 297,
+                                                                            "right": 1044,
+                                                                            "bottom": 363
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/verify_id_confirmation_flow_progressbar",
+                                                                        "class": "android.view.ViewGroup",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 36,
+                                                                            "top": 399,
+                                                                            "right": 1044,
+                                                                            "bottom": 470
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "text": "2 of 4",
+                                                                                "id": "com.doordash.driverapp:id/step_title",
+                                                                                "class": "android.widget.TextView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 36,
+                                                                                    "top": 399,
+                                                                                    "right": 1044,
+                                                                                    "bottom": 446
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/step_container",
+                                                                                "class": "android.widget.LinearLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 36,
+                                                                                    "top": 454,
+                                                                                    "right": 1044,
+                                                                                    "bottom": 470
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 36,
+                                                                                            "top": 462,
+                                                                                            "right": 280,
+                                                                                            "bottom": 470
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 288,
+                                                                                            "top": 462,
+                                                                                            "right": 532,
+                                                                                            "bottom": 470
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 540,
+                                                                                            "top": 462,
+                                                                                            "right": 784,
+                                                                                            "bottom": 470
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 792,
+                                                                                            "top": 462,
+                                                                                            "right": 1036,
+                                                                                            "bottom": 470
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "text": "Verify that the ID matches the recipient and they aren't intoxicated.     ",
+                                                                        "id": "com.doordash.driverapp:id/verify_id_confirmation_subtitle",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 36,
+                                                                            "top": 506,
+                                                                            "right": 1044,
+                                                                            "bottom": 624
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/verify_id_confirmation_image",
+                                                                        "class": "android.widget.ImageView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 255,
+                                                                            "top": 1101,
+                                                                            "right": 825,
+                                                                            "bottom": 1508
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "desc": "Verify",
+                                                                        "id": "com.doordash.driverapp:id/verify_id_confirm_btn",
+                                                                        "class": "android.widget.Button",
+                                                                        "isClickable": true,
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 36,
+                                                                            "top": 2097,
+                                                                            "right": 1044,
+                                                                            "bottom": 2204
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "text": "Verify",
+                                                                                "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                "class": "android.widget.TextView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 479,
+                                                                                    "top": 2118,
+                                                                                    "right": 601,
+                                                                                    "bottom": 2184
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "desc": "Can't verify",
+                                                                        "id": "com.doordash.driverapp:id/verify_id_no_confirm_btn",
+                                                                        "class": "android.widget.Button",
+                                                                        "isClickable": true,
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 36,
+                                                                            "top": 2222,
+                                                                            "right": 1044,
+                                                                            "bottom": 2329
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "text": "Can't verify",
+                                                                                "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                "class": "android.widget.TextView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 422,
+                                                                                    "top": 2243,
+                                                                                    "right": 658,
+                                                                                    "bottom": 2309
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/core/pipeline/src/main/assets/rules/doordash.json
+++ b/core/pipeline/src/main/assets/rules/doordash.json
@@ -54,6 +54,19 @@
           ] }
         },
         {
+          "intent": "sensitive.id_verification",
+          "require": { "any": [
+            { "exists": { "hasTextContaining": "Scan barcode on the back" } },
+            { "exists": { "hasTextContaining": "Driver's License" } },
+            { "all": [
+              { "exists": { "hasTextContaining": "Identity verification" } },
+              { "exists": { "hasTextContaining": "matches the recipient" } }
+            ] },
+            { "exists": { "hasTextContaining": "provide their signature" } },
+            { "exists": { "hasTextContaining": "ready to start verification" } }
+          ] }
+        },
+        {
           "intent": "sensitive.otp",
           "require": { "exists": { "hasTextContaining": "Enter the code we sent" } }
         },

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/SensitiveTextMarkers.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/SensitiveTextMarkers.kt
@@ -52,6 +52,16 @@ object SensitiveTextMarkers {
         // sensitive.savings branch, these markers are the fail-closed backstop.
         "Savings jar",
         "You transferred",
+        // Customer ID / signature capture during alcohol delivery (#463) — the
+        // license-scan, identity-match, and signature-handoff surfaces.
+        // Rule-side block is sensitive.id_verification; markers are the backstop.
+        // NB: the alcohol delivery instruction CHECKLIST ("Verify recipient's
+        // identity" step text) is deliberately NOT here — that's recognized as
+        // flow (#462); only the actual capture surfaces are blocked.
+        "Scan barcode on the back",
+        "Driver's License",
+        "Identity verification",
+        "provide their signature",
     )
 
     /**

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/SensitiveTextMarkersTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/SensitiveTextMarkersTest.kt
@@ -22,6 +22,26 @@ class SensitiveTextMarkersTest {
         // DasherDirect Savings flow (#463) — the markers that leaked on 2026-06-12.
         assertEquals("Savings jar", SensitiveTextMarkers.findMarker(tree("Your transfer should now appear in your Savings jar")))
         assertEquals("You transferred", SensitiveTextMarkers.findMarker(tree("You transferred \$9.06")))
+        // Alcohol customer-ID / signature capture (#463 identity slice).
+        assertEquals("Scan barcode on the back", SensitiveTextMarkers.findMarker(tree("Scan barcode on the back of license")))
+        assertEquals("Driver's License", SensitiveTextMarkers.findMarker(tree("Driver's License")))
+        assertEquals("Identity verification", SensitiveTextMarkers.findMarker(tree("Identity verification")))
+        assertEquals("provide their signature", SensitiveTextMarkers.findMarker(tree("Hand your phone to the customer so they can provide their signature.")))
+    }
+
+    @Test
+    fun `alcohol delivery instruction checklist stays clean — recognize-vs-block boundary (#463)`() {
+        // The step-CHECKLIST text (no actual ID/signature capture) must NOT be
+        // scrubbed — it's a recognizable flow step (#462), not a sensitive surface.
+        assertNull(
+            SensitiveTextMarkers.findMarker(
+                tree(
+                    "Follow all of the steps below to complete this delivery.",
+                    "Verify recipient's identity",
+                    "Complete delivery",
+                ),
+            ),
+        )
     }
 
     @Test

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -80,16 +80,20 @@ _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **bro
   doubled `$`, or a wrong decimal.
   - Confirmed: 0/2
 
-- **DasherDirect Savings screens now blocked as sensitive (#463, partial — banking slice).**
-  On the 2026-06-12 dash the DasherDirect **Savings jar** flow (balance + "Transfer $X" + "You
-  transferred $X") leaked plaintext dollar balances to UNKNOWN capture — the redesigned savings
-  UI no rule covered. Now caught by a priority-0 `sensitive.savings` rule + `SensitiveTextMarkers`
-  backstop. On a dash, open DasherDirect → Savings and do a small transfer: working = the screen
-  produces NO capture (matcher-layer block, log shows the sensitive gate / "Capture scrubbed"),
-  and normal flow recognition is unaffected. Broken = a Savings/Transfer screen with a dollar
-  balance shows up in captures/, or a non-banking screen gets wrongly blocked. **Still open in
-  #463:** the identity/ID-scan slice (license-scan, identity-verify, signature-canvas) is a
-  separate follow-up.
+- **Sensitive screens now blocked: DasherDirect Savings + alcohol customer-ID/signature (#463, complete).**
+  On the 2026-06-12 dash two sensitive surfaces leaked to UNKNOWN capture: the DasherDirect
+  **Savings jar** flow (plaintext balances — "Transfer $X" / "You transferred $X") and the
+  **alcohol customer-ID/signature capture** screens (license-scan, the "Identity verification"
+  ID-match, the "hand your phone … signature" handoff, the "Scan Successful" confirmation). Both
+  are now blocked at the matcher layer (priority-0 `sensitive.savings` / `sensitive.id_verification`)
+  + `SensitiveTextMarkers` backstop. On a dash:
+  - **Banking:** open DasherDirect → Savings, do a small transfer → the screen produces NO capture
+    (log shows the sensitive gate / "Capture scrubbed").
+  - **Alcohol ID:** on a 21+ delivery, the license-scan / ID-verify / signature screens should
+    produce NO capture, while the *instruction checklist* ("Verify recipient's identity" steps)
+    and the rest of the dropoff flow still recognize normally (the recognize-vs-block boundary).
+  Broken = a Savings/Transfer balance OR a license-scan / ID-match / signature screen shows up in
+  captures/, or the alcohol delivery flow stops advancing (over-blocked the instruction steps).
   - Confirmed: 0/2
 
 - **Engine latency + dedupe pack (#436).**


### PR DESCRIPTION
Completes #463 (the banking slice landed in PR #464). The 2026-06-12 dash also leaked the alcohol-delivery **identity-capture** surfaces to UNKNOWN capture. Per the Pledges these are identity-sensitive and must be blocked at the matcher layer.

## Blocked (priority-0 `sensitive.id_verification`, `overrideable: false`)
- **License barcode scan** — `Driver's License` / `Scan barcode on the back of license`
- **ID-match** — `Identity verification` + `Verify that the ID matches the recipient`
- **Signature handoff** — `Hand your phone to the customer … provide their signature`
- **Post-scan confirmation** — `Now you're ready to start verification`

## The recognize-vs-block judgment (the #463 call)
Only the actual ID/signature **capture** surfaces are blocked. The alcohol-delivery instruction **checklist** (`Follow all of the steps below` / `Verify recipient's identity` / `Complete delivery` — instructions, **no recipient PII, no scanning**) stays **non-sensitive** so it remains a recognizable dropoff flow step (#462). The block predicates key on the capture-screen text, never the checklist text, so they can't over-block the flow — pinned by an explicit boundary test in **both** the ruleset and the markers test.

## Two layers (the #432 pattern)
- `doordash.json`: the `sensitive.id_verification` branch.
- `SensitiveTextMarkers` backstop: `Scan barcode on the back`, `Driver's License`, `Identity verification`, `provide their signature` (SSOT-shared with `SnapshotSecurityScanner`; verified no non-sensitive corpus collision).

## Tests
The 4 capture screens classify sensitive; the instruction checklist does **not** (boundary pinned twice); a SENSITIVE corpus snapshot of the real ID-match screen added (no text PII — the license image is in the camera, not the a11y tree) so the golden guard ratchets it. Full `testDebugUnitTest` green.

## Security/privacy posture (principle 6)
Trusted = nothing (third-party UI); gated = these capture frames dropped at the matcher layer in both sensor pipelines; scrubbed = any residual UNKNOWN capture via `SensitiveTextMarkers`. The recognize-vs-block split keeps the alcohol delivery flow trackable **without** capturing the customer's ID.

With this, **#463 is fully resolved** (banking + identity).

## Field validation
Checklist item updated (0/2): on a 21+ delivery the license-scan / ID-verify / signature screens produce no capture, while the instruction checklist + the rest of the dropoff flow still recognize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)