### PR TITLE
fix(bubble): durable last-dash fallback so the HUD doesn't empty after a dash (#459)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleViewModel.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
@@ -87,13 +88,21 @@ class BubbleViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 0.0)
 
 
-    // Messages scoped to the active dash session
+    // Messages scoped to the active dash session.
+    //
+    // Chat and cards key off the SAME displayed dash id (#367). The fallback
+    // when no dash is live is now the DURABLE most-recent dash from the event
+    // log (#459), not an in-memory scan latch: the old latch was wiped by
+    // process death AND by a post-dash bubble re-subscribe (>5s collapsed),
+    // emptying the chat/cards. The active dash wins while one is running; the
+    // DB fallback survives both restarts, so the bubble reviews the last dash
+    // until the next one starts (when activeDashId takes over again).
     @OptIn(ExperimentalCoroutinesApi::class)
-    // Chat and cards key off the SAME latched dash id (#367) — the old
-    // split (messages on activeDashId) emptied the ticker post-dash while
-    // the card stack still showed the finished dash.
-    private val displayedDashId = bubbleManager.activeDashId
-        .scan(null as String?) { last, current -> current ?: last }
+    private val displayedDashId = combine(
+        bubbleManager.activeDashId,
+        appEventRepo.getMostRecentDashId(),
+    ) { active, mostRecent -> active ?: mostRecent }
+        .distinctUntilChanged()
 
     val messages = displayedDashId.flatMapLatest { dashId ->
         if (dashId != null) {

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/event/AppEventRepo.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/event/AppEventRepo.kt
@@ -57,6 +57,9 @@ class AppEventRepo @Inject constructor(
     fun getEventsForDash(dashId: String): Flow<List<AppEvent>> =
         dao.getEventsForDash(dashId).map { rows -> rows.map { it.toDomain() } }
 
+    /** Durable "last completed dash" fallback for the bubble HUD (#459). */
+    fun getMostRecentDashId(): Flow<String?> = dao.getMostRecentDashId()
+
     fun getEventsByType(type: AppEventType): Flow<List<AppEvent>> =
         dao.getEventsByType(type).map { rows -> rows.map { it.toDomain() } }
 

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/event/AppEventDao.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/event/AppEventDao.kt
@@ -26,6 +26,17 @@ interface AppEventDao {
     fun getEventsForDash(dashId: String): Flow<List<AppEventEntity>>
 
     /**
+     * The dash ([aggregateId]) of the most recent event, or null if none. The
+     * durable "last completed dash" fallback for the bubble HUD when no session
+     * is live (#459): the in-memory scan latch that fed `displayedDashId` was
+     * wiped by process death (8a) and by a post-dash bubble re-subscribe (8b),
+     * emptying the chat/cards. The event log survives both, so the bubble
+     * reviews the last dash until the next one starts.
+     */
+    @Query("SELECT aggregateId FROM app_events WHERE aggregateId IS NOT NULL ORDER BY sequenceId DESC LIMIT 1")
+    fun getMostRecentDashId(): Flow<String?>
+
+    /**
      * Returns all events of a specific type (e.g., all OFFER_RECEIVED events).
      * Room automatically converts the Enum parameter to a String for the query.
      */

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -63,6 +63,16 @@ immediately (no second pass needed) so it gets triaged.
 _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **broken** on the
 2026-06-09 dash — moved to that session's log entry below for triage.)_
 
+- **Bubble keeps showing the last dash after it ends / after a crash (#459).**
+  The bubble's chat + card stack used to go EMPTY after a dash ended (8b: collapse it >5s then
+  reopen) or after a crash with no active dash (8a) — the fallback dash id was a volatile
+  in-memory latch. It's now sourced durably from the event log (most-recent dash). On a dash:
+  end a dash, collapse the bubble for >5s, reopen → working = the chat + completed cards of the
+  just-finished dash are still shown (not empty); start the next dash → it switches to the new
+  dash. Also force-stop/crash right after a dash and reopen → still shows the last dash. Broken =
+  empty chat/cards after dash-end-then-reopen, or the wrong dash shown.
+  - Confirmed: 0/2
+
 - **Pickup/Delivery card deadline reads cleanly — no double "by" (#460).**
   The deadline caption read `till pickup-by · by 17:10` (two "by"s); now `till pickup · by 17:10`
   / `till deliver · by 17:10`. Desk- or dash-verifiable on any pickup/delivery card. (The


### PR DESCRIPTION
Closes #459. After a dash ended, the bubble's chat + card stack went **empty** instead of showing the just-finished dash — both (8a) after a crash with no active dash and (8b) after a normal dash-end with the bubble collapsed >5s then reopened.

## Cause
`BubbleViewModel.displayedDashId` was an in-memory `scan` latch over `activeDashId` (which derives from `AppState` and is null whenever no session is live). The latch is **wiped by process death** (8a) and **torn down + restarted from null** when the `WhileSubscribed(5000)` downstream loses subscribers >5s and re-subscribes after the dash ended (8b). Either way `displayedDashId → null` → messages empty + the card-stack event query returns nothing. The code even claimed a "most-recently-completed" fallback, but the only "otherwise" was that volatile scan — nothing durable fed it.

## Fix — the issue's option (b): leverage the durable event log
No new datastore key, no write-on-dash-end plumbing — the event log already records every dash.
- **`AppEventDao.getMostRecentDashId()`** — `aggregateId` of the latest event (`ORDER BY sequenceId DESC LIMIT 1`), exposed via `AppEventRepo`.
- **`displayedDashId = combine(activeDashId, mostRecentDashId) { active, recent -> active ?: recent }.distinctUntilChanged()`** — the active dash wins while one runs; the DB fallback survives **both** process death and re-subscribe, so the bubble reviews the last dash until the next one starts (when `activeDashId` takes over and the stack switches to it). `distinctUntilChanged` stops the DB flow's per-event churn from re-triggering the downstream `flatMapLatest`.

## Tests / validation
The resolution is `active ?: recent` (trivial) and the query mirrors the proven `getEventsForDash` pattern. There's **no Room unit-test harness** in the unit path (DAO tests are instrumented-only, not in CI), so this is validated by the **on-dash field item** — appropriate, since the bug is a UI/timing behavior and that's how it surfaced. Full `testDebugUnitTest` green. Field-test item (0/2): end a dash, collapse the bubble >5s, reopen → chat + cards still show the finished dash (not empty); next dash switches over; crash-then-reopen still shows the last dash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)