### PR TITLE
feat(rules): recognize the 'Verify items' pickup screen (#462 — first slice)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -78,6 +78,14 @@ android {
         unitTests.all { test ->
             test.jvmArgs("-XX:+EnableDynamicAgentLoading")
 
+            // Forward the parse-output golden regen flag to the forked test JVM
+            // (#433/#462): `-DupdateParseGolden=true` is set on the Gradle JVM,
+            // but the test runs in a fork — without this it never reaches
+            // System.getProperty(...) and the documented regen silently no-ops.
+            System.getProperty("updateParseGolden")?.let {
+                test.systemProperty("updateParseGolden", it)
+            }
+
             // JUnit @Suite aggregators (e.g. AllMatchersSuite) re-run their member
             // classes, so during a broad sweep the members would run twice — once
             // directly, once via the suite. Exclude suites from an unfiltered sweep;

--- a/app/src/test/resources/snapshots/approved-parse-output.json
+++ b/app/src/test/resources/snapshots/approved-parse-output.json
@@ -3639,6 +3639,24 @@
             "subFlow": "ARRIVED"
         }
     },
+    "pickup_verify_items/2026-06-12_19-58-10__doordash__pickup_verify_items__74398e.json": {
+        "ruleId": "doordash.screen.pickup_verify_items",
+        "intent": "pickup_verify_items",
+        "shape": "task",
+        "fields": {
+            "arrivalConfirmed": false,
+            "customerAddressHash": null,
+            "customerNameHash": null,
+            "deadline": null,
+            "itemsRemaining": null,
+            "itemsShopped": null,
+            "phase": "PICKUP",
+            "redCardTotal": null,
+            "storeAddress": null,
+            "storeName": null,
+            "subFlow": "ARRIVED"
+        }
+    },
     "promos/2026-02-02_22-15-05__PROMOS_VIEW__4dd44e49.json": {
         "ruleId": "doordash.screen.promos",
         "intent": "promos",

--- a/app/src/test/resources/snapshots/pickup_verify_items/2026-06-12_19-58-10__doordash__pickup_verify_items__74398e.json
+++ b/app/src/test/resources/snapshots/pickup_verify_items/2026-06-12_19-58-10__doordash__pickup_verify_items__74398e.json
@@ -1,0 +1,604 @@
+{
+    "captureId": "5d8edd61-f8de-455d-a6fa-fef0c9b02aaf",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1781312290458,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 2385,
+            "right": 1080,
+            "bottom": 4785
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 2385,
+                    "right": 1080,
+                    "bottom": 4732
+                },
+                "children": [
+                    {
+                        "id": "android:id/content",
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 2521,
+                            "right": 1080,
+                            "bottom": 4732
+                        },
+                        "children": [
+                            {
+                                "class": "android.view.ViewGroup",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 2521,
+                                    "right": 1080,
+                                    "bottom": 4732
+                                },
+                                "children": [
+                                    {
+                                        "id": "com.doordash.driverapp:id/nav_bar",
+                                        "class": "android.widget.LinearLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 2521,
+                                            "right": 1080,
+                                            "bottom": 2646
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/collapsingToolbar_navBar",
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 2521,
+                                                    "right": 1080,
+                                                    "bottom": 2646
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/imageview_nav_bar_background",
+                                                        "class": "android.widget.ImageView",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 2521,
+                                                            "right": 1080,
+                                                            "bottom": 2521
+                                                        }
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/toolbar_navBar",
+                                                        "class": "android.view.ViewGroup",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 2521,
+                                                            "right": 1080,
+                                                            "bottom": 2646
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "class": "android.widget.ImageButton",
+                                                                "isClickable": true,
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 2521,
+                                                                    "right": 125,
+                                                                    "bottom": 2646
+                                                                }
+                                                            },
+                                                            {
+                                                                "class": "android.view.View",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 125,
+                                                                    "top": 2521,
+                                                                    "right": 1080,
+                                                                    "bottom": 2646
+                                                                }
+                                                            },
+                                                            {
+                                                                "class": "androidx.appcompat.widget.LinearLayoutCompat",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 1080,
+                                                                    "top": 2521,
+                                                                    "right": 1080,
+                                                                    "bottom": 2646
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "text": "Verify items for [name]",
+                                        "id": "com.doordash.driverapp:id/order_verification_checklist_title",
+                                        "class": "android.widget.TextView",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 36,
+                                            "top": 2682,
+                                            "right": 1044,
+                                            "bottom": 2748
+                                        }
+                                    },
+                                    {
+                                        "text": "Do your best to verify visible items. If the bag is sealed, report it can’t be verified.",
+                                        "id": "com.doordash.driverapp:id/order_verification_checklist_subtitle",
+                                        "class": "android.widget.TextView",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 36,
+                                            "top": 2766,
+                                            "right": 1044,
+                                            "bottom": 2868
+                                        }
+                                    },
+                                    {
+                                        "id": "com.doordash.driverapp:id/orderCheckListItemsView",
+                                        "class": "android.view.ViewGroup",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 2868,
+                                            "right": 1080,
+                                            "bottom": 4446
+                                        },
+                                        "children": [
+                                            {
+                                                "desc": ": Do not open sealed bags",
+                                                "id": "com.doordash.driverapp:id/banner",
+                                                "class": "android.view.ViewGroup",
+                                                "isClickable": true,
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 36,
+                                                    "top": 2904,
+                                                    "right": 1044,
+                                                    "bottom": 3032
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/actions_group",
+                                                        "class": "android.view.View",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 36,
+                                                            "top": 2904,
+                                                            "right": 36,
+                                                            "bottom": 2904
+                                                        }
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/subdued_decoration_view",
+                                                        "class": "android.view.View",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 36,
+                                                            "top": 2906,
+                                                            "right": 45,
+                                                            "bottom": 3030
+                                                        }
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/start_icon_image_view",
+                                                        "class": "android.widget.ImageView",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 63,
+                                                            "top": 2931,
+                                                            "right": 134,
+                                                            "bottom": 3002
+                                                        }
+                                                    },
+                                                    {
+                                                        "text": "Do not open sealed bags",
+                                                        "id": "com.doordash.driverapp:id/body_text_view",
+                                                        "class": "android.widget.TextView",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 152,
+                                                            "top": 2939,
+                                                            "right": 909,
+                                                            "bottom": 2997
+                                                        }
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/button_container",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 152,
+                                                            "top": 2997,
+                                                            "right": 909,
+                                                            "bottom": 2997
+                                                        }
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/end_icon_button",
+                                                        "class": "android.widget.Button",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 936,
+                                                            "top": 2931,
+                                                            "right": 1008,
+                                                            "bottom": 3002
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "id": "com.doordash.driverapp:id/items_content_checklist",
+                                                "class": "androidx.recyclerview.widget.RecyclerView",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 36,
+                                                    "top": 3068,
+                                                    "right": 1044,
+                                                    "bottom": 4446
+                                                },
+                                                "children": [
+                                                    {
+                                                        "class": "android.view.ViewGroup",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 36,
+                                                            "top": 3068,
+                                                            "right": 1044,
+                                                            "bottom": 3331
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 36,
+                                                                    "top": 3068,
+                                                                    "right": 1044,
+                                                                    "bottom": 3331
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/item_checklist_view",
+                                                                        "class": "android.view.ViewGroup",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 36,
+                                                                            "top": 3068,
+                                                                            "right": 1044,
+                                                                            "bottom": 3295
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "text": "1 ×",
+                                                                                "id": "com.doordash.driverapp:id/order_item_count",
+                                                                                "class": "android.widget.TextView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 72,
+                                                                                    "top": 3155,
+                                                                                    "right": 125,
+                                                                                    "bottom": 3208
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/container_name_tags",
+                                                                                "class": "android.widget.LinearLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 161,
+                                                                                    "top": 3104,
+                                                                                    "right": 776,
+                                                                                    "bottom": 3259
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "text": "Twisted Tea Raspberry Hard Iced Tea Can (24 fl oz)",
+                                                                                        "id": "com.doordash.driverapp:id/order_item_name",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 161,
+                                                                                            "top": 3104,
+                                                                                            "right": 776,
+                                                                                            "bottom": 3198
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/flowTags",
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 161,
+                                                                                            "top": 3206,
+                                                                                            "right": 776,
+                                                                                            "bottom": 3206
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "text": "21+ ID required",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 161,
+                                                                                            "top": 3206,
+                                                                                            "right": 433,
+                                                                                            "bottom": 3259
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/button_missing",
+                                                                                "class": "android.widget.CompoundButton",
+                                                                                "isClickable": true,
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 812,
+                                                                                    "top": 3137,
+                                                                                    "right": 901,
+                                                                                    "bottom": 3226
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/button_available",
+                                                                                "class": "android.widget.CompoundButton",
+                                                                                "isClickable": true,
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 919,
+                                                                                    "top": 3137,
+                                                                                    "right": 1008,
+                                                                                    "bottom": 3226
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "class": "android.view.ViewGroup",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 36,
+                                                            "top": 3331,
+                                                            "right": 1044,
+                                                            "bottom": 3594
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 36,
+                                                                    "top": 3331,
+                                                                    "right": 1044,
+                                                                    "bottom": 3594
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/item_checklist_view",
+                                                                        "class": "android.view.ViewGroup",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 36,
+                                                                            "top": 3331,
+                                                                            "right": 1044,
+                                                                            "bottom": 3558
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "text": "2 ×",
+                                                                                "id": "com.doordash.driverapp:id/order_item_count",
+                                                                                "class": "android.widget.TextView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 72,
+                                                                                    "top": 3418,
+                                                                                    "right": 125,
+                                                                                    "bottom": 3471
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/container_name_tags",
+                                                                                "class": "android.widget.LinearLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 161,
+                                                                                    "top": 3367,
+                                                                                    "right": 776,
+                                                                                    "bottom": 3522
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "text": "Twisted Tea Peach Hard Iced Tea Can (24 fl oz)",
+                                                                                        "id": "com.doordash.driverapp:id/order_item_name",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 161,
+                                                                                            "top": 3367,
+                                                                                            "right": 776,
+                                                                                            "bottom": 3461
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/flowTags",
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 161,
+                                                                                            "top": 3469,
+                                                                                            "right": 776,
+                                                                                            "bottom": 3469
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "text": "21+ ID required",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 161,
+                                                                                            "top": 3469,
+                                                                                            "right": 433,
+                                                                                            "bottom": 3522
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/button_missing",
+                                                                                "class": "android.widget.CompoundButton",
+                                                                                "isClickable": true,
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 812,
+                                                                                    "top": 3400,
+                                                                                    "right": 901,
+                                                                                    "bottom": 3489
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/button_available",
+                                                                                "class": "android.widget.CompoundButton",
+                                                                                "isClickable": true,
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 919,
+                                                                                    "top": 3400,
+                                                                                    "right": 1008,
+                                                                                    "bottom": 3489
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "desc": "Confirm pickup",
+                                        "id": "com.doordash.driverapp:id/btn_primary_action",
+                                        "class": "android.widget.Button",
+                                        "isClickable": true,
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 36,
+                                            "top": 4464,
+                                            "right": 1044,
+                                            "bottom": 4571
+                                        },
+                                        "children": [
+                                            {
+                                                "text": "Continue",
+                                                "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                "class": "android.widget.TextView",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 445,
+                                                    "top": 4485,
+                                                    "right": 635,
+                                                    "bottom": 4551
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "desc": "Can’t verify items",
+                                        "id": "com.doordash.driverapp:id/btn_secondary_action",
+                                        "class": "android.widget.Button",
+                                        "isClickable": true,
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 36,
+                                            "top": 4589,
+                                            "right": 1044,
+                                            "bottom": 4696
+                                        },
+                                        "children": [
+                                            {
+                                                "text": "Can’t verify items",
+                                                "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                "class": "android.widget.TextView",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 361,
+                                                    "top": 4610,
+                                                    "right": 720,
+                                                    "bottom": 4676
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "id": "android:id/statusBarBackground",
+                "class": "android.view.View",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 2385,
+                    "right": 1080,
+                    "bottom": 2521
+                }
+            },
+            {
+                "id": "android:id/navigationBarBackground",
+                "class": "android.view.View",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 4732,
+                    "right": 1080,
+                    "bottom": 4785
+                }
+            }
+        ]
+    }
+}

--- a/core/pipeline/src/main/assets/rules/doordash.json
+++ b/core/pipeline/src/main/assets/rules/doordash.json
@@ -1211,6 +1211,27 @@
       }
     },
     {
+      "id": "doordash.screen.pickup_verify_items",
+      "priority": 76,
+      "state": {
+        "flow": "task:pickup:arrived",
+        "modeHint": "online"
+      },
+      "require": {
+        "all": [
+          { "exists": { "hasTextContaining": "Verify items for" } },
+          { "exists": { "hasText": "Do not open sealed bags" } }
+        ]
+      },
+      "parse": {
+        "as": "task",
+        "fields": {
+          "phase": "PICKUP",
+          "subFlow": "ARRIVED"
+        }
+      }
+    },
+    {
       "id": "doordash.screen.pickup_shopping",
       "priority": 72,
       "state": {

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -63,6 +63,16 @@ immediately (no second pass needed) so it gets triaged.
 _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **broken** on the
 2026-06-09 dash — moved to that session's log entry below for triage.)_
 
+- **7-Eleven / alcohol "Verify items" pickup screen now recognized (#462, first slice).**
+  The store "Verify items for <name>" screen (with "Do not open sealed bags" / "Can't verify
+  items" / the item list) classified UNKNOWN — the 7-Eleven alcohol pickup from the 2026-06-12
+  dash (field-log #12). It's now a recognized `pickup_verify_items` screen mapped to
+  pickup-arrived (no customer-name parsing). On a retail/alcohol pickup: working = the bubble/log
+  shows a pickup screen (not UNKNOWN) on the verify-items step and the flow stays on pickup.
+  Broken = still UNKNOWN, or it mis-steps the flow. (**#462 stays open** — this is one of ~30
+  recognition gaps from that dash; the rest are a larger effort.)
+  - Confirmed: 0/2
+
 - **Pickup/Delivery card deadline reads cleanly — no double "by" (#460).**
   The deadline caption read `till pickup-by · by 17:10` (two "by"s); now `till pickup · by 17:10`
   / `till deliver · by 17:10`. Desk- or dash-verifiable on any pickup/delivery card. (The


### PR DESCRIPTION
First slice of #462 — the headline gap (field-log #12). The store **"Verify items for &lt;name&gt;"** screen (`Do not open sealed bags` / `Can't verify items` / item list / `21+ ID required`) classified UNKNOWN, so the 7-Eleven alcohol pickup-confirm step fell to UNKNOWN and the state machine only recovered on the later drop-off-nav frame.

## Change
- **`doordash.json`**: new `pickup_verify_items` screen rule (priority 76), keyed on the distinctive, stable `Verify items for` + `Do not open sealed bags` text, mapped to `task:pickup:arrived`. **Recognition only** — parses just `phase`/`subFlow`, **not** the customer name (the regenerated `approved-parse-output.json` entry confirms every PII field stays `null`).
- **Corpus**: a redacted snapshot under `snapshots/pickup_verify_items/` (customer name → `[name]`, product names kept) so the golden guard + #433 coverage ratchet cover the new intent.
- **No collision with #463**: the verify-**items** screen has none of `sensitive.id_verification`'s predicates, so it recognizes as a pickup screen while the actual ID-scan / signature **capture** surfaces stay blocked.

## Bonus: fixes a latent #433 harness bug
The documented `-DupdateParseGolden=true` regen never reached the forked test JVM (Gradle sets `-D` on its own JVM only), so the approval file could only ever be first-generated via the `!exists` path. `app/build.gradle.kts` now forwards the property — the regen command actually works now.

## Scope
**#462 stays open** — this is 1 of ~30 recognition gaps from the dash. The rest (shopping sub-flow, more pickup/dropoff steps, idle/schedule, stacked/restricted offers) are a larger recognition effort best done as focused follow-ups. Full `testDebugUnitTest` green; field-test item added (0/2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)