### PR TITLE
chore(format): move duration/countdown formatters to :domain; disambiguate input formatter (#467)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,8 +89,10 @@ The project uses modular Clean Architecture with a strict dependency graph:
 - **`:domain`** — Pure Kotlin library. Domain models, state regions, evaluation logic,
   pipeline/provider contracts, the capture contracts (`CaptureBus`, `EnvelopeBuilder`,
   capture schemas/DTOs), the `PlatformPreferences` read interface (#355), and the
-  number/money formatting SSOT (`format.Formats` — the locale policy, #358/#456; lives here
-  so both the UI and the state layer route through one definition). No Android
+  number/money/duration formatting SSOT (`format.Formats` money/decimal + `format.TimeFormats`
+  `formatDuration`/`formatCountdown` — the locale policy, #358/#456/#467; lives here so both the
+  UI and the state layer route through one definition; the Compose time helpers
+  `rememberNow`/`rememberTimeFormatter` stay in `:core:designsystem`). No Android
   dependencies. (Repository *implementations* and Hilt bindings live in `:core:data`.)
 - **`:core:pipeline`** — Accessibility pipeline, notification pipeline, JSON rule engine
   (RuleCompiler, Ruleset, JsonRuleInterpreter), observation classifier. Reads third-party UI.

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleScreen.kt
@@ -9,7 +9,7 @@ import android.widget.TextView
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import cloud.trotter.dashbuddy.domain.format.Formats
-import cloud.trotter.dashbuddy.core.designsystem.time.formatDuration
+import cloud.trotter.dashbuddy.domain.format.formatDuration
 import cloud.trotter.dashbuddy.core.designsystem.theme.DashTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardItem.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardItem.kt
@@ -29,8 +29,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import cloud.trotter.dashbuddy.domain.format.Formats
 import cloud.trotter.dashbuddy.core.designsystem.theme.DashTheme
-import cloud.trotter.dashbuddy.core.designsystem.time.formatCountdown
-import cloud.trotter.dashbuddy.core.designsystem.time.formatDuration
+import cloud.trotter.dashbuddy.domain.format.formatCountdown
+import cloud.trotter.dashbuddy.domain.format.formatDuration
 import cloud.trotter.dashbuddy.core.designsystem.time.rememberNow
 import cloud.trotter.dashbuddy.core.designsystem.time.rememberTimeFormatter
 import androidx.compose.ui.text.font.FontWeight

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/components/economy/CurrencyInput.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/components/economy/CurrencyInput.kt
@@ -35,9 +35,9 @@ fun CurrencyInput(
     suffix: String? = null,
 ) {
     var isFocused by remember { mutableStateOf(false) }
-    var text by remember { mutableStateOf(formatCurrency(value)) }
+    var text by remember { mutableStateOf(editableAmount(value)) }
     LaunchedEffect(value, isFocused) {
-        if (!isFocused) text = formatCurrency(value)
+        if (!isFocused) text = editableAmount(value)
     }
 
     OutlinedTextField(
@@ -92,5 +92,9 @@ fun IntegerInput(
     )
 }
 
-private fun formatCurrency(value: Double): String =
+// Input-field machine string (#467): the editable amount the field round-trips
+// via toDoubleOrNull — Locale.US, trailing zeros trimmed ("5.5", "0"), NOT the
+// display money SSOT (Formats.money, which renders "$5.50"). Renamed from
+// formatCurrency to avoid confusion with the removed display formatter.
+private fun editableAmount(value: Double): String =
     if (value == 0.0) "0" else String.format(Locale.US, "%.2f", value).trimEnd('0').trimEnd('.')

--- a/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/time/TimeKit.kt
+++ b/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/time/TimeKit.kt
@@ -8,18 +8,15 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import kotlinx.coroutines.delay
 import java.util.Date
-import java.util.Locale
-import java.util.concurrent.TimeUnit
 
 /**
  * The shared time kit (#358): the CLAUDE.md-canonical 1-Hz ticker plus the
- * duration/countdown/clock formatters that the bubble HUD's glance surfaces
- * derive from it. One definition repo-wide — the two divergent local copies
- * (FlowCardItem, BubbleScreen) are gone.
+ * device-aware wall-clock formatter for the bubble HUD's glance surfaces.
  *
- * Digits are pinned to [Locale.ROOT]: durations and countdowns are clock-like
- * strings ("3m 12s", "7:05") whose digits must not localize to non-ASCII
- * numerals on a glance surface.
+ * The pure duration/countdown formatters (`formatDuration`/`formatCountdown`)
+ * moved to `:domain` (`format.TimeFormats`, #467) so the formatting SSOT is
+ * colocated with [cloud.trotter.dashbuddy.domain.format.Formats] and reachable
+ * from every layer; only the Compose-bound helpers remain here.
  */
 
 /** 1-Hz tick, scoped to the calling composable. See CLAUDE.md ▸ Reactive UI Principles. */
@@ -31,33 +28,6 @@ fun rememberNow(tickMs: Long = 1000L): State<Long> =
             value = System.currentTimeMillis()
         }
     }
-
-/**
- * "2h 5m" / "3m 12s" / "45s". Negative inputs floor to "0s" — a duration that
- * hasn't started reads as zero, never as a negative.
- */
-fun formatDuration(millis: Long): String {
-    val safe = millis.coerceAtLeast(0)
-    val hours = TimeUnit.MILLISECONDS.toHours(safe)
-    val minutes = TimeUnit.MILLISECONDS.toMinutes(safe) % 60
-    val seconds = TimeUnit.MILLISECONDS.toSeconds(safe) % 60
-    return when {
-        hours > 0 -> String.format(Locale.ROOT, "%dh %dm", hours, minutes)
-        minutes > 0 -> String.format(Locale.ROOT, "%dm %ds", minutes, seconds)
-        else -> String.format(Locale.ROOT, "%ds", seconds)
-    }
-}
-
-/**
- * "m:ss" countdown for deadline heroes. Negatives format as their absolute
- * magnitude — the caller renders the ahead/late label and color.
- */
-fun formatCountdown(millis: Long): String {
-    val safe = kotlin.math.abs(millis)
-    val totalMinutes = TimeUnit.MILLISECONDS.toMinutes(safe)
-    val seconds = TimeUnit.MILLISECONDS.toSeconds(safe) % 60
-    return String.format(Locale.ROOT, "%d:%02d", totalMinutes, seconds)
-}
 
 /**
  * A remembered wall-clock formatter honoring the device's 12/24-hour setting

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/format/TimeFormats.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/format/TimeFormats.kt
@@ -1,0 +1,43 @@
+package cloud.trotter.dashbuddy.domain.format
+
+import java.util.Locale
+import java.util.concurrent.TimeUnit
+
+/**
+ * Duration / countdown formatters (#358, #467) — the pure half of the former
+ * `:core:designsystem` TimeKit. Lives in `:domain` alongside [Formats] so the
+ * formatting SSOT is colocated and reachable by every layer (the Compose
+ * helpers `rememberNow`/`rememberTimeFormatter` stay in designsystem — they
+ * need Compose/Android).
+ *
+ * Digits are pinned to [Locale.ROOT]: durations and countdowns are clock-like
+ * strings ("3m 12s", "7:05") whose digits must not localize to non-ASCII
+ * numerals on a glance surface.
+ */
+
+/**
+ * "2h 5m" / "3m 12s" / "45s". Negative inputs floor to "0s" — a duration that
+ * hasn't started reads as zero, never as a negative.
+ */
+fun formatDuration(millis: Long): String {
+    val safe = millis.coerceAtLeast(0)
+    val hours = TimeUnit.MILLISECONDS.toHours(safe)
+    val minutes = TimeUnit.MILLISECONDS.toMinutes(safe) % 60
+    val seconds = TimeUnit.MILLISECONDS.toSeconds(safe) % 60
+    return when {
+        hours > 0 -> String.format(Locale.ROOT, "%dh %dm", hours, minutes)
+        minutes > 0 -> String.format(Locale.ROOT, "%dm %ds", minutes, seconds)
+        else -> String.format(Locale.ROOT, "%ds", seconds)
+    }
+}
+
+/**
+ * "m:ss" countdown for deadline heroes. Negatives format as their absolute
+ * magnitude — the caller renders the ahead/late label and color.
+ */
+fun formatCountdown(millis: Long): String {
+    val safe = kotlin.math.abs(millis)
+    val totalMinutes = TimeUnit.MILLISECONDS.toMinutes(safe)
+    val seconds = TimeUnit.MILLISECONDS.toSeconds(safe) % 60
+    return String.format(Locale.ROOT, "%d:%02d", totalMinutes, seconds)
+}

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/format/TimeFormatsTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/format/TimeFormatsTest.kt
@@ -1,4 +1,4 @@
-package cloud.trotter.dashbuddy.core.designsystem.time
+package cloud.trotter.dashbuddy.domain.format
 
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -7,11 +7,11 @@ import org.junit.Test
 import java.util.Locale
 
 /**
- * #358: ONE duration/countdown definition repo-wide, with unified zero/negative
+ * #358/#467: ONE duration/countdown definition repo-wide, with unified zero/negative
  * semantics (the two old private copies disagreed) and ASCII digits regardless
  * of device locale (clock-like glance strings must not localize numerals).
  */
-class TimeKitTest {
+class TimeFormatsTest {
 
     private lateinit var original: Locale
 


### PR DESCRIPTION
Closes #467. Follows #456 (money → `:domain` `Formats`) — consolidates the remaining formatters so the formatting SSOT is colocated and reachable from every layer.

## Changes
- **Duration/countdown → `:domain`**: moved TimeKit's pure `formatDuration`/`formatCountdown` (`Locale.ROOT`) to `domain/format/TimeFormats.kt` alongside `Formats`. The **Compose-bound** helpers `rememberNow`/`rememberTimeFormatter` stay in `:core:designsystem` (they need Compose/Android). The 2 callers (`BubbleScreen`, `FlowCardItem`) repoint their import; `TimeKitTest` → `:domain` as `TimeFormatsTest`.
- **Input-field formatter disambiguated**: `CurrencyInput`'s private `formatCurrency` → `editableAmount`. It's an input-field **machine** string (`Locale.US`, trailing zeros trimmed, round-trips via `toDoubleOrNull` → `"5.5"`/`"0"`), intentionally separate from the display SSOT — but the name made it look like the (now-removed) display formatter. `formatInterval` keeps its already-descriptive name.
- **Date/filename machine formatters** (`StateAwareTree`, `ScreenShotHandler`, `DiskCaptureBus`) are log/filename strings, already correctly `Locale.US` — left as-is (noted in #467).

No behavior change (locales preserved). CLAUDE.md `:domain` bullet updated. Full `testDebugUnitTest` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)