### PR TITLE
feat(bubble): surface Shop & Deliver on the offer card — item count in hero + SHOP badge (#461 a/b)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardItem.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardItem.kt
@@ -337,6 +337,15 @@ private fun OfferBody(snap: FlowCardSnapshot.Offer, isActive: Boolean) {
                     Text(secondary, style = DashTheme.num.smNum, color = c.text2, maxLines = 1)
                 }
             }
+            // Item count promoted to the hero tier (#461): Shop & Deliver and
+            // multi-item offers surface the count beside the $/hr hero (the
+            // footer caption was easy to miss), using the space on the right.
+            if (snap.itemCount > 1) {
+                Column(horizontalAlignment = Alignment.End) {
+                    Text("${snap.itemCount}", style = DashTheme.num.heroNum, color = c.text, maxLines = 1)
+                    Text("items", style = DashTheme.num.smNum, color = c.text2, maxLines = 1)
+                }
+            }
         }
 
         // Verdict banner — action word + reason + quality chip, tinted by the action.
@@ -389,16 +398,9 @@ private fun OfferBody(snap: FlowCardSnapshot.Offer, isActive: Boolean) {
             }
         }
 
-        // Footer: stores · items.
+        // Footer: stores. (Item count moved up to the hero tier, #461.)
         val storeText = snap.storeNames.joinToString(" & ").ifBlank { null }
-        val footer = buildString {
-            storeText?.let { append(it) }
-            if (snap.itemCount > 1) {
-                if (isNotEmpty()) append(" · ")
-                append("${snap.itemCount} items")
-            }
-        }
-        if (footer.isNotBlank()) Caption(footer)
+        if (storeText != null) Caption(storeText)
     }
 }
 
@@ -420,6 +422,7 @@ private fun OfferCountdownText(expiresAt: Long, countdownSeconds: Int) {
 
 /** Maps a badge enum name to a short label + brand color for the pill row. */
 private fun badgeMeta(name: String, c: DashColors): Pair<String, Color> = when (name) {
+    "SHOP" -> "Shop & Deliver" to c.stPickup
     "HIGH_PAYING" -> "High pay" to c.good
     "PRIORITY_ACCESS" -> "Priority" to c.stOffer
     "RED_CARD" -> "Red Card" to c.bad

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardMapper.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardMapper.kt
@@ -1,5 +1,6 @@
 package cloud.trotter.dashbuddy.ui.bubble.cards
 
+import cloud.trotter.dashbuddy.domain.model.order.OrderType
 import cloud.trotter.dashbuddy.domain.model.event.AppEvent
 import cloud.trotter.dashbuddy.domain.model.cards.FlowCardSnapshot
 import cloud.trotter.dashbuddy.domain.model.event.AppEventType
@@ -99,7 +100,14 @@ object FlowCardMapper {
                             dollarsPerHour = payload.evaluation?.dollarsPerHour,
                             qualityLevel = payload.evaluation?.qualityLevel,
                             badges = (payload.parsedOffer.badges.map { it.name } +
-                                payload.parsedOffer.orders.flatMap { it.badges }.map { it.name }).distinct(),
+                                payload.parsedOffer.orders.flatMap { it.badges }.map { it.name } +
+                                // Synthetic SHOP badge (#461) so a Shop & Deliver offer is
+                                // typed at a glance — orderType is known at offer time.
+                                if (payload.parsedOffer.orders.any { it.orderType == OrderType.SHOP_FOR_ITEMS }) {
+                                    listOf("SHOP")
+                                } else {
+                                    emptyList()
+                                }).distinct(),
                             outcome = payload.outcome,
                         )
                     )

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardMapperTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardMapperTest.kt
@@ -683,4 +683,45 @@ class FlowCardMapperTest {
         val pickup = cards.filterIsInstance<FlowCardSnapshot.Pickup>().single()
         assertEquals(UNKNOWN_STORE, pickup.storeName)
     }
+
+    // ── #461: Shop & Deliver gets a SHOP badge ──
+
+    @Test
+    fun `a Shop & Deliver offer gets a synthetic SHOP badge`() {
+        val shopOffer = ParsedOffer(
+            offerHash = "shop-1", payAmount = 22.0, distanceMiles = 3.0, itemCount = 18,
+            orders = listOf(
+                ParsedOrder(
+                    orderIndex = 0, orderType = OrderType.SHOP_FOR_ITEMS, storeName = "H-E-B",
+                    itemCount = 18, isItemCountEstimated = false, badges = emptySet(),
+                ),
+            ),
+        )
+        val events = listOf(
+            event(
+                AppEventType.OFFER_ACCEPTED,
+                OfferPayload(
+                    offerHash = "shop-1", parsedOffer = shopOffer, evaluation = evaluation(),
+                    outcome = AppEventType.OFFER_ACCEPTED, presentedAt = 2000L, decidedAt = 2500L,
+                    returnFlow = Flow.Idle,
+                ),
+                occurredAt = 2500L,
+            ),
+        )
+        val offer = FlowCardMapper.fold(events).filterIsInstance<FlowCardSnapshot.Offer>().single()
+        assertTrue("Shop & Deliver offer must carry the SHOP badge", offer.badges.contains("SHOP"))
+    }
+
+    @Test
+    fun `a plain pickup offer does NOT get a SHOP badge`() {
+        val events = listOf(
+            event(
+                AppEventType.OFFER_ACCEPTED,
+                offerPayload("plain-1", AppEventType.OFFER_ACCEPTED, 2000L, 2500L),
+                occurredAt = 2500L,
+            ),
+        )
+        val offer = FlowCardMapper.fold(events).filterIsInstance<FlowCardSnapshot.Offer>().single()
+        assertTrue("plain pickup must not carry SHOP", !offer.badges.contains("SHOP"))
+    }
 }

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -63,6 +63,15 @@ immediately (no second pass needed) so it gets triaged.
 _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **broken** on the
 2026-06-09 dash — moved to that session's log entry below for triage.)_
 
+- **Offer card surfaces Shop & Deliver: item count in the hero row + a SHOP badge (#461 a/b).**
+  The item count moved from a small footer caption up to the hero row (beside the score ring /
+  $/hr), and a Shop & Deliver offer now shows a "Shop & Deliver" badge pill. On a shop offer:
+  working = the item count is prominent in the hero and a "Shop & Deliver" pill shows; a plain
+  pickup offer shows NO shop pill. Broken = item count missing/duplicated, or the shop pill on a
+  non-shop offer. (**#461 stays open** for part (c) — the finished/PostTask card showing the
+  order type, which needs offer→job→delivery data flow.)
+  - Confirmed: 0/2
+
 - **7-Eleven / alcohol "Verify items" pickup screen now recognized (#462, first slice).**
   The store "Verify items for <name>" screen (with "Do not open sealed bags" / "Can't verify
   items" / the item list) classified UNKNOWN — the 7-Eleven alcohol pickup from the 2026-06-12


### PR DESCRIPTION
Addresses sub-tasks (a) and (b) of #461 — the high-value presentation gaps the dasher flagged.

## Changes
- **(a) Item count → hero row**: moved from a small footer caption up to the offer hero `Row` (beside the score ring / `$/hr`), since it was easy to miss on a Shop & Deliver. Removed the duplicate footer `N items`; the footer is now just store names.
- **(b) SHOP badge**: a synthetic `"SHOP"` badge derived in `FlowCardMapper` from `orderType == SHOP_FOR_ITEMS` (known at offer time), rendered as a **"Shop & Deliver"** pill via `badgeMeta`.

## Tests
`FlowCardMapperTest`: a `SHOP_FOR_ITEMS` offer gets the SHOP badge; a plain pickup does not. Full `testDebugUnitTest` green.

## Scope — (c) deferred
The finished/**PostTask** card showing the order type (sub-task c) needs the shop flag threaded **offer → job → delivery** — it isn't on the dropoff task at `DELIVERY_COMPLETED` time, so it's a real data-flow change, not cosmetic plumbing. **#461 stays open** for it. Field-test item added (0/2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)