### PR TITLE
fix(privacy): block signature canvas + alcohol-arrival sensitive surfaces (#463)

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/DefaultRulesIntegrationTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/DefaultRulesIntegrationTest.kt
@@ -222,10 +222,15 @@ class DefaultRulesIntegrationTest {
         val idMatch = screen("Identity verification", "2 of 4", "Verify that the ID matches the recipient and they aren't intoxicated.", "Verify", "Can't verify")
         val signatureHandoff = screen("Hand your phone to the customer so they can provide their signature.", "Got it")
         val scanResult = screen("Scan Successful", "Now you're ready to start verification.", "Continue")
+        // Found in the #462 sweep — were leaking to UNKNOWN (the arrival banner
+        // with recipient name+address). Both must block.
+        val signatureCanvas = screen("3 of 4", "A recipient signature is required for this order", "I have received this order", "Clear")
+        val alcoholArrival = screen("I've arrived at recipient", "Verify the recipient's identity and collect a signature at dropoff", "Remember, you’re required by law to confirm the recipient's identity before handing over the order.", "Hand it to recipient")
 
         for ((name, node) in listOf(
             "license-scan" to licenseScan, "id-match" to idMatch,
             "signature-handoff" to signatureHandoff, "scan-result" to scanResult,
+            "signature-canvas" to signatureCanvas, "alcohol-arrival" to alcoholArrival,
         )) {
             val r = screenRuleset.matchFirst(node, platformWire = "doordash")
             assertTrue(

--- a/app/src/test/resources/snapshots/SENSITIVE/2026-06-12_17-29-59__doordash__recipient_signature__f9848f.json
+++ b/app/src/test/resources/snapshots/SENSITIVE/2026-06-12_17-29-59__doordash__recipient_signature__f9848f.json
@@ -1,0 +1,384 @@
+{
+    "captureId": "7380bcf3-4e87-4b84-aa49-e673ada21c12",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1781303399784,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 0,
+                            "right": 1080,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 0,
+                                    "right": 1080,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 0,
+                                            "right": 1080,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/container",
+                                                "class": "android.widget.ScrollView",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 0,
+                                                    "right": 1080,
+                                                    "bottom": 2347
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/toolbar_container",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 278
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/toolbar",
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 136,
+                                                                    "right": 1080,
+                                                                    "bottom": 278
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "desc": "Navigate up",
+                                                                        "class": "android.widget.ImageButton",
+                                                                        "isClickable": true,
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 144,
+                                                                            "right": 125,
+                                                                            "bottom": 269
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "class": "androidx.appcompat.widget.LinearLayoutCompat",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 973,
+                                                                            "top": 144,
+                                                                            "right": 1080,
+                                                                            "bottom": 269
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "desc": "Help",
+                                                                                "id": "com.doordash.driverapp:id/action_self_help",
+                                                                                "class": "android.widget.Button",
+                                                                                "isClickable": true,
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 973,
+                                                                                    "top": 153,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 260
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 278,
+                                                            "right": 1080,
+                                                            "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/fragment",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 278,
+                                                                    "right": 1080,
+                                                                    "bottom": 2347
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.widget.ScrollView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 278,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 45,
+                                                                                    "top": 278,
+                                                                                    "right": 1035,
+                                                                                    "bottom": 2347
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "text": "A recipient signature is required for this order",
+                                                                                        "id": "com.doordash.driverapp:id/signature_instruction_label",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 45,
+                                                                                            "top": 340,
+                                                                                            "right": 1035,
+                                                                                            "bottom": 471
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/step_flow_progressbar",
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 45,
+                                                                                            "top": 507,
+                                                                                            "right": 1035,
+                                                                                            "bottom": 578
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "3 of 4",
+                                                                                                "id": "com.doordash.driverapp:id/step_title",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 45,
+                                                                                                    "top": 507,
+                                                                                                    "right": 1035,
+                                                                                                    "bottom": 554
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/step_container",
+                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 45,
+                                                                                                    "top": 562,
+                                                                                                    "right": 1035,
+                                                                                                    "bottom": 578
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 45,
+                                                                                                            "top": 570,
+                                                                                                            "right": 284,
+                                                                                                            "bottom": 578
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 292,
+                                                                                                            "top": 570,
+                                                                                                            "right": 531,
+                                                                                                            "bottom": 578
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 539,
+                                                                                                            "top": 570,
+                                                                                                            "right": 778,
+                                                                                                            "bottom": 578
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 786,
+                                                                                                            "top": 570,
+                                                                                                            "right": 1025,
+                                                                                                            "bottom": 578
+                                                                                                        }
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/signature_drawing_view",
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 45,
+                                                                                            "top": 614,
+                                                                                            "right": 1035,
+                                                                                            "bottom": 961
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "state": "in progress",
+                                                                                        "id": "com.doordash.driverapp:id/progress_bar",
+                                                                                        "class": "android.widget.ProgressBar",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 487,
+                                                                                            "top": 734,
+                                                                                            "right": 594,
+                                                                                            "bottom": 841
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "android.widget.ImageView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 45,
+                                                                                            "top": 903,
+                                                                                            "right": 85,
+                                                                                            "bottom": 943
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/signature_drawing_line",
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 45,
+                                                                                            "top": 957,
+                                                                                            "right": 1035,
+                                                                                            "bottom": 961
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "text": "Clear",
+                                                                                        "id": "com.doordash.driverapp:id/signature_clear_button",
+                                                                                        "class": "android.widget.Button",
+                                                                                        "isClickable": true,
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 884,
+                                                                                            "top": 854,
+                                                                                            "right": 1035,
+                                                                                            "bottom": 961
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "text": "This is not a receipt. By submitting, you agree to DoorDash's E-Sign Consent",
+                                                                                        "id": "com.doordash.driverapp:id/signature_disclaimer",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 45,
+                                                                                            "top": 961,
+                                                                                            "right": 1035,
+                                                                                            "bottom": 1056
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "text": "I have received this order",
+                                                                                        "id": "com.doordash.driverapp:id/received_order_button",
+                                                                                        "class": "android.widget.Button",
+                                                                                        "isClickable": true,
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 81,
+                                                                                            "top": 2204,
+                                                                                            "right": 999,
+                                                                                            "bottom": 2311
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/core/pipeline/src/main/assets/rules/doordash.json
+++ b/core/pipeline/src/main/assets/rules/doordash.json
@@ -63,7 +63,10 @@
               { "exists": { "hasTextContaining": "matches the recipient" } }
             ] },
             { "exists": { "hasTextContaining": "provide their signature" } },
-            { "exists": { "hasTextContaining": "ready to start verification" } }
+            { "exists": { "hasTextContaining": "ready to start verification" } },
+            { "exists": { "hasTextContaining": "A recipient signature is required" } },
+            { "exists": { "hasTextContaining": "collect a signature at dropoff" } },
+            { "exists": { "hasTextContaining": "required by law to confirm the recipient" } }
           ] }
         },
         {

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/SensitiveTextMarkers.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/SensitiveTextMarkers.kt
@@ -62,6 +62,11 @@ object SensitiveTextMarkers {
         "Driver's License",
         "Identity verification",
         "provide their signature",
+        // The signature canvas + the alcohol-arrival identity/signature banner
+        // (the latter leaks recipient name+address) — found in the #462 sweep.
+        "A recipient signature is required",
+        "collect a signature at dropoff",
+        "required by law to confirm the recipient",
     )
 
     /**

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/SensitiveTextMarkersTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/SensitiveTextMarkersTest.kt
@@ -27,6 +27,10 @@ class SensitiveTextMarkersTest {
         assertEquals("Driver's License", SensitiveTextMarkers.findMarker(tree("Driver's License")))
         assertEquals("Identity verification", SensitiveTextMarkers.findMarker(tree("Identity verification")))
         assertEquals("provide their signature", SensitiveTextMarkers.findMarker(tree("Hand your phone to the customer so they can provide their signature.")))
+        // Signature canvas + the alcohol-arrival identity/signature banner (#462 sweep).
+        assertEquals("A recipient signature is required", SensitiveTextMarkers.findMarker(tree("A recipient signature is required for this order")))
+        assertEquals("collect a signature at dropoff", SensitiveTextMarkers.findMarker(tree("Verify the recipient's identity and collect a signature at dropoff")))
+        assertEquals("required by law to confirm the recipient", SensitiveTextMarkers.findMarker(tree("you're required by law to confirm the recipient's identity")))
     }
 
     @Test


### PR DESCRIPTION
## Summary

Reopens #463. The #462 recognition sweep surfaced two more identity/signature **capture** surfaces that the original #463 identity slice missed and that were leaking to `UNKNOWN` on 2026-06-12 — one of them (the alcohol arrival banner) carries the recipient's **full name and street address**:

- the e-signature canvas (`"A recipient signature is required for this order"` / `"I have received this order"`), and
- the alcohol-arrival identity+signature banner (`"Verify the recipient's identity and collect a signature at dropoff"` / `"required by law to confirm the recipient's identity"`).

Both must be blocked at the matcher layer, never parsed or stored.

## Security / privacy posture

- **Rule side:** extends the priority-0 `sensitive.id_verification` rule (`overrideable: false`) with three new text predicates — blocks before any flow processing.
- **Backstop:** adds the same three markers to `SensitiveTextMarkers` (the rules-independent SSOT shared with the test scanner) so `UNKNOWN` captures are scrubbed even without rule coverage.
- **Boundary preserved:** the alcohol delivery instruction CHECKLIST (`"Verify recipient's identity"` step text) stays recognizable as flow (#462) — only the actual capture surfaces are blocked.

## Tests

- `DefaultRulesIntegrationTest` asserts both screens hit a sensitive rule (synthetic nodes for the PII-heavy alcohol banner).
- `SensitiveTextMarkersTest` covers the three new markers and confirms the checklist boundary stays clean.
- The clean signature canvas is added to the `SENSITIVE/` corpus (no redaction needed — carries no PII) so the golden guard asserts it stays caught.

Closes #463.