### PR TITLE
chore(designsystem): rename brand identifiers Dash* → App* (#468)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,11 +107,14 @@ The project uses modular Clean Architecture with a strict dependency graph:
 - **`:core:datastore`** — Preferences DataStore (seven single-concern stores behind Hilt
   qualifiers — app prefs, strategy, dev settings, odometer, app state, platforms,
   rule-capability grants).
-- **`:core:designsystem`** — Brand system (no project deps): fixed dark/light palette (`DashColors`),
-  Hanken Grotesk + Space Grotesk fonts (tabular numerals), `DashTheme` + `LocalGlance`, and the
-  shared component library (`DashCard`, `DashChip`, `DashStatTile`, `DashGaugeRing`, `DashSegmented`,
-  `DashSlider`, `DashBarChart`, `DashAccordion`). No M3 dynamic color. Feature-specific composables
-  stay with their feature (Package by Feature); only generic, data-in/lambdas-out components live here.
+- **`:core:designsystem`** — Brand system (no project deps): fixed dark/light palette (`AppColors`),
+  Hanken Grotesk + Space Grotesk fonts (tabular numerals), `AppTheme` + `LocalGlance` (the public
+  theme wrapper is `DashBuddyTheme`, the only `Dash`-named symbol kept — it's the app name, not a
+  platform term), and the shared component library (`AppCard`, `AppChip`, `AppStatTile`,
+  `AppGaugeRing`, `AppSegmented`, `AppSlider`, `AppBarChart`, `AppAccordion`). The design-system
+  brand vocabulary is `App*`, not `Dash*` (#468) — no platform-flavoured names. No M3 dynamic
+  color. Feature-specific composables stay with their feature (Package by Feature); only generic,
+  data-in/lambdas-out components live here.
 - **`:app`** — UI (Compose + overlays), side effect handlers (SideEffectEngine, odometer, screenshots,
   TTS, tips), Hilt DI wiring, and the `DashBuddyApplication` entry point.
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleScreen.kt
@@ -10,7 +10,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import cloud.trotter.dashbuddy.domain.format.Formats
 import cloud.trotter.dashbuddy.domain.format.formatDuration
-import cloud.trotter.dashbuddy.core.designsystem.theme.DashTheme
+import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -366,7 +366,7 @@ private fun SessionMetricsActions(
 
 @Composable
 private fun statusBadge(region: PlatformRegion?, flow: Flow): Pair<String, Color> {
-    val c = DashTheme.colors
+    val c = AppTheme.colors
     val green = c.good
     val amber = c.warn
     val blue = c.stOffer
@@ -531,7 +531,7 @@ fun ChatBubble(message: ChatMessage) {
             modifier = Modifier
                 .fillMaxWidth()
                 // Deliberate 12dp chat-bubble radius — between the small/medium
-                // shape tokens; revisit if DashShapes grows a chat variant (#406).
+                // shape tokens; revisit if AppShapes grows a chat variant (#406).
                 .clip(RoundedCornerShape(12.dp))
                 .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
                 .padding(12.dp)

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardItem.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardItem.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import cloud.trotter.dashbuddy.domain.format.Formats
-import cloud.trotter.dashbuddy.core.designsystem.theme.DashTheme
+import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
 import cloud.trotter.dashbuddy.domain.format.formatCountdown
 import cloud.trotter.dashbuddy.domain.format.formatDuration
 import cloud.trotter.dashbuddy.core.designsystem.time.rememberNow
@@ -44,9 +44,9 @@ import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.ui.draw.clip
-import cloud.trotter.dashbuddy.core.designsystem.component.DashChip
-import cloud.trotter.dashbuddy.core.designsystem.component.DashGaugeRing
-import cloud.trotter.dashbuddy.core.designsystem.theme.DashColors
+import cloud.trotter.dashbuddy.core.designsystem.component.AppChip
+import cloud.trotter.dashbuddy.core.designsystem.component.AppGaugeRing
+import cloud.trotter.dashbuddy.core.designsystem.theme.AppColors
 import cloud.trotter.dashbuddy.domain.model.cards.FlowCardSnapshot
 import cloud.trotter.dashbuddy.domain.state.PickupActivity
 import cloud.trotter.dashbuddy.domain.model.event.AppEventType
@@ -153,9 +153,9 @@ private fun CardHeader(
 
 @Composable
 private fun PhaseChip(snapshot: FlowCardSnapshot, isActive: Boolean) {
-    // Semantic brand tokens per DashColors' contract (#358) — the chip now
+    // Semantic brand tokens per AppColors' contract (#358) — the chip now
     // agrees with statusBadge instead of remapping phases onto M3 roles.
-    val c = DashTheme.colors
+    val c = AppTheme.colors
     val (label, color, bg) = when (snapshot) {
         is FlowCardSnapshot.Awaiting -> Triple("AWAIT", c.neutral, c.neutralBg)
         is FlowCardSnapshot.Offer -> Triple("OFFER", c.stOffer, c.stOfferBg)
@@ -273,7 +273,7 @@ private fun AwaitingBody(snap: FlowCardSnapshot.Awaiting, isActive: Boolean) {
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun OfferBody(snap: FlowCardSnapshot.Offer, isActive: Boolean) {
-    val c = DashTheme.colors
+    val c = AppTheme.colors
     Column(
         modifier = Modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -307,7 +307,7 @@ private fun OfferBody(snap: FlowCardSnapshot.Offer, isActive: Boolean) {
                     score <= OfferEvaluator.DECLINE_THRESHOLD -> c.bad
                     else -> c.warn
                 }
-                DashGaugeRing(
+                AppGaugeRing(
                     progress = (score / 100.0).toFloat(),
                     value = score.toInt().toString(),
                     label = "Score",
@@ -318,8 +318,8 @@ private fun OfferBody(snap: FlowCardSnapshot.Offer, isActive: Boolean) {
             Column(modifier = Modifier.weight(1f)) {
                 val hourly = snap.dollarsPerHour
                 when {
-                    hourly != null -> Text("${Formats.money0(hourly)}/hr", style = DashTheme.num.heroNum, color = c.text, maxLines = 1)
-                    snap.payAmount != null -> Text(Formats.money(snap.payAmount!!), style = DashTheme.num.heroNum, color = c.text, maxLines = 1)
+                    hourly != null -> Text("${Formats.money0(hourly)}/hr", style = AppTheme.num.heroNum, color = c.text, maxLines = 1)
+                    snap.payAmount != null -> Text(Formats.money(snap.payAmount!!), style = AppTheme.num.heroNum, color = c.text, maxLines = 1)
                 }
                 val net = snap.netPayAmount ?: snap.payAmount
                 val secondary = buildString {
@@ -334,7 +334,7 @@ private fun OfferBody(snap: FlowCardSnapshot.Offer, isActive: Boolean) {
                     }
                 }
                 if (secondary.isNotBlank()) {
-                    Text(secondary, style = DashTheme.num.smNum, color = c.text2, maxLines = 1)
+                    Text(secondary, style = AppTheme.num.smNum, color = c.text2, maxLines = 1)
                 }
             }
             // Item count promoted to the hero tier (#461): Shop & Deliver and
@@ -342,8 +342,8 @@ private fun OfferBody(snap: FlowCardSnapshot.Offer, isActive: Boolean) {
             // footer caption was easy to miss), using the space on the right.
             if (snap.itemCount > 1) {
                 Column(horizontalAlignment = Alignment.End) {
-                    Text("${snap.itemCount}", style = DashTheme.num.heroNum, color = c.text, maxLines = 1)
-                    Text("items", style = DashTheme.num.smNum, color = c.text2, maxLines = 1)
+                    Text("${snap.itemCount}", style = AppTheme.num.heroNum, color = c.text, maxLines = 1)
+                    Text("items", style = AppTheme.num.smNum, color = c.text2, maxLines = 1)
                 }
             }
         }
@@ -380,7 +380,7 @@ private fun OfferBody(snap: FlowCardSnapshot.Offer, isActive: Boolean) {
                             color = vColor,
                         )
                     }
-                    snap.qualityLevel?.let { DashChip(it.displayLabel(), color = c.text3, container = c.surface3) }
+                    snap.qualityLevel?.let { AppChip(it.displayLabel(), color = c.text3, container = c.surface3) }
                 }
             }
         }
@@ -393,7 +393,7 @@ private fun OfferBody(snap: FlowCardSnapshot.Offer, isActive: Boolean) {
             ) {
                 snap.badges.forEach { b ->
                     val (label, col) = badgeMeta(b, c)
-                    DashChip(label, color = col, container = c.surface3)
+                    AppChip(label, color = col, container = c.surface3)
                 }
             }
         }
@@ -407,21 +407,21 @@ private fun OfferBody(snap: FlowCardSnapshot.Offer, isActive: Boolean) {
 /** Live m:ss offer-expiry countdown for the active offer card header. */
 @Composable
 private fun OfferCountdownText(expiresAt: Long, countdownSeconds: Int) {
-    val c = DashTheme.colors
+    val c = AppTheme.colors
     val now by rememberNow()
     val secsLeft = ((expiresAt - now) / 1000.0).coerceAtLeast(0.0)
     val frac = if (countdownSeconds > 0) (secsLeft / countdownSeconds).coerceIn(0.0, 1.0) else 0.0
     val col = offerExpiryColor(frac, c)
     Text(
         text = formatCountdown((secsLeft * 1000).toLong()),
-        style = DashTheme.num.smNum,
+        style = AppTheme.num.smNum,
         color = col,
         fontWeight = FontWeight.Bold,
     )
 }
 
 /** Maps a badge enum name to a short label + brand color for the pill row. */
-private fun badgeMeta(name: String, c: DashColors): Pair<String, Color> = when (name) {
+private fun badgeMeta(name: String, c: AppColors): Pair<String, Color> = when (name) {
     "SHOP" -> "Shop & Deliver" to c.stPickup
     "HIGH_PAYING" -> "High pay" to c.good
     "PRIORITY_ACCESS" -> "Priority" to c.stOffer
@@ -625,7 +625,7 @@ private fun PostTaskBody(snap: FlowCardSnapshot.PostTask) {
 /** Manual Accept / Decline buttons on the active offer card (#110 Stage 2b). */
 @Composable
 private fun OfferActionRow(onAccept: () -> Unit, onDecline: () -> Unit) {
-    val c = DashTheme.colors
+    val c = AppTheme.colors
     Row(
         modifier = Modifier.fillMaxWidth().padding(top = 4.dp),
         horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -648,7 +648,7 @@ private fun OfferActionRow(onAccept: () -> Unit, onDecline: () -> Unit) {
 private fun HeroBig(text: String, color: Color = MaterialTheme.colorScheme.onSurface) {
     Text(
         text = text,
-        style = DashTheme.num.heroNum,
+        style = AppTheme.num.heroNum,
         color = color,
         maxLines = 1,
     )
@@ -677,7 +677,7 @@ private fun BreakdownRow(label: String, value: String) {
 
 @Composable
 private fun OutcomeChip(outcome: AppEventType) {
-    val c = DashTheme.colors
+    val c = AppTheme.colors
     val (text, color) = when (outcome) {
         AppEventType.OFFER_ACCEPTED -> "Accepted" to c.good
         AppEventType.OFFER_DECLINED -> "Declined" to c.bad
@@ -701,7 +701,7 @@ private fun OutcomeChip(outcome: AppEventType) {
 @Composable
 private fun deadlineColor(remainingMs: Long): Color {
     val mins = remainingMs / 60_000L
-    val c = DashTheme.colors
+    val c = AppTheme.colors
     return when {
         remainingMs < 0 -> c.bad              // past — red
         mins < 5 -> c.bad                     // <5m — red
@@ -715,7 +715,7 @@ private fun deadlineColor(remainingMs: Long): Color {
 // ---------------------------------------------------------------------------
 
 /** THE offer-expiry color tiers (#406) — previously written twice in this file. */
-private fun offerExpiryColor(frac: Double, c: DashColors): Color = when {
+private fun offerExpiryColor(frac: Double, c: AppColors): Color = when {
     frac > 0.45 -> c.good
     frac > 0.2 -> c.warn
     else -> c.bad

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/formatters/OfferFormatters.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/formatters/OfferFormatters.kt
@@ -7,7 +7,7 @@ import android.text.style.ForegroundColorSpan
 import android.text.style.RelativeSizeSpan
 import android.text.style.StyleSpan
 import androidx.compose.ui.graphics.toArgb
-import cloud.trotter.dashbuddy.core.designsystem.theme.darkDashColors
+import cloud.trotter.dashbuddy.core.designsystem.theme.darkAppColors
 import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
 import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
 import cloud.trotter.dashbuddy.domain.format.Formats
@@ -38,7 +38,7 @@ fun OfferEvaluation.notificationPersona(): ChatPersona = when (action) {
  * it. `toString()` yields the plain text used for chat storage.
  */
 fun OfferEvaluation.toNotificationSummary(): CharSequence {
-    val colors = darkDashColors()
+    val colors = darkAppColors()
     val verdict = when (action) {
         OfferAction.ACCEPT -> "ACCEPT"
         OfferAction.DECLINE -> "DECLINE"

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/AboutScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/AboutScreen.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import cloud.trotter.dashbuddy.core.designsystem.theme.DashTheme
+import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -109,7 +109,7 @@ fun AboutScreen(
                 Text(
                     text = "Build ${BuildConfig.VERSION_CODE}",
                     style = MaterialTheme.typography.bodySmall,
-                    color = DashTheme.colors.text3
+                    color = AppTheme.colors.text3
                 )
             }
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/StrategySettingsScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/StrategySettingsScreen.kt
@@ -32,7 +32,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
-import cloud.trotter.dashbuddy.core.designsystem.theme.DashTheme
+import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.font.FontWeight
@@ -184,7 +184,7 @@ fun StrategySettingsScreen(
                 Text(
                     "Drag to reorder. Top rules matter most.",
                     style = MaterialTheme.typography.bodySmall,
-                    color = DashTheme.colors.text3
+                    color = AppTheme.colors.text3
                 )
                 Spacer(Modifier.height(16.dp))
             }
@@ -234,7 +234,7 @@ fun SwitchRow(
     ) {
         Column(Modifier.weight(1f)) {
             Text(label, style = MaterialTheme.typography.titleMedium)
-            Text(subtitle, style = MaterialTheme.typography.bodySmall, color = DashTheme.colors.text3)
+            Text(subtitle, style = MaterialTheme.typography.bodySmall, color = AppTheme.colors.text3)
         }
         Switch(checked = checked, onCheckedChange = onCheckedChange)
     }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/components/FakeOfferCard.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/components/FakeOfferCard.kt
@@ -21,7 +21,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
-import cloud.trotter.dashbuddy.core.designsystem.theme.DashTheme
+import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
 import androidx.compose.ui.unit.dp
 import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
 import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
@@ -33,7 +33,7 @@ fun FakeOfferCard(
     evaluation: OfferEvaluation,
     modifier: Modifier = Modifier
 ) {
-    val c = DashTheme.colors
+    val c = AppTheme.colors
 
     val targetContainerColor = when (evaluation.action) {
         OfferAction.ACCEPT -> c.goodBg

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/components/ReorderableRule.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/components/ReorderableRule.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
-import cloud.trotter.dashbuddy.core.designsystem.theme.DashTheme
+import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
 import androidx.compose.ui.unit.dp
 import cloud.trotter.dashbuddy.domain.evaluation.MetricType
 import cloud.trotter.dashbuddy.domain.evaluation.ScoringRule
@@ -102,7 +102,7 @@ fun MetricContent(
         Text(
             text = type.label,
             style = MaterialTheme.typography.titleMedium,
-            color = if (rule.isEnabled) MaterialTheme.colorScheme.onSurface else DashTheme.colors.neutral
+            color = if (rule.isEnabled) MaterialTheme.colorScheme.onSurface else AppTheme.colors.neutral
         )
 
         // Value Display (e.g., "$15.00" or "10 mi")

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/permissions/PermissionCard.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/permissions/PermissionCard.kt
@@ -33,7 +33,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
-import cloud.trotter.dashbuddy.core.designsystem.theme.DashTheme
+import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -119,15 +119,15 @@ fun PermissionCard(
             modifier = Modifier
                 .fillMaxWidth()
                 .clip(RoundedCornerShape(8.dp))
-                .background(DashTheme.colors.goodBg) // Soft Green
+                .background(AppTheme.colors.goodBg) // Soft Green
                 .padding(12.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Icon(Icons.Default.Security, contentDescription = "Privacy", tint = DashTheme.colors.good)
+            Icon(Icons.Default.Security, contentDescription = "Privacy", tint = AppTheme.colors.good)
             Text(
                 text = stringResource(id = R.string.perm_privacy_guarantee),
                 style = MaterialTheme.typography.bodySmall,
-                color = DashTheme.colors.good,
+                color = AppTheme.colors.good,
                 modifier = Modifier.padding(start = 8.dp)
             )
         }

--- a/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/component/AppAccordion.kt
+++ b/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/component/AppAccordion.kt
@@ -28,14 +28,14 @@ import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import cloud.trotter.dashbuddy.core.designsystem.theme.DashBuddyTheme
-import cloud.trotter.dashbuddy.core.designsystem.theme.DashTheme
+import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
 
 /**
  * Expandable row with a `$/mi`-style [trailing] summary — Personal Economy cost accordions.
  * Caller owns the [expanded] state and the [onToggle] lambda (hoisted, pure).
  */
 @Composable
-fun DashAccordion(
+fun AppAccordion(
     title: String,
     expanded: Boolean,
     onToggle: () -> Unit,
@@ -43,7 +43,7 @@ fun DashAccordion(
     trailing: String? = null,
     content: @Composable ColumnScope.() -> Unit,
 ) {
-    val c = DashTheme.colors
+    val c = AppTheme.colors
     Surface(
         modifier = modifier,
         shape = MaterialTheme.shapes.medium,
@@ -60,7 +60,7 @@ fun DashAccordion(
                 horizontalArrangement = Arrangement.spacedBy(10.dp),
             ) {
                 Text(title, Modifier.weight(1f), style = MaterialTheme.typography.titleMedium, color = c.text)
-                if (trailing != null) Text(trailing, style = DashTheme.num.smNum, color = c.text2)
+                if (trailing != null) Text(trailing, style = AppTheme.num.smNum, color = c.text2)
                 Chevron(expanded, c.text3)
             }
             if (expanded) {
@@ -87,17 +87,17 @@ private fun Chevron(expanded: Boolean, tint: Color) {
 
 @Preview
 @Composable
-private fun DashAccordionPreview() = DashBuddyTheme {
+private fun AppAccordionPreview() = DashBuddyTheme {
     Surface(color = MaterialTheme.colorScheme.background) {
         var open by remember { mutableStateOf(true) }
-        DashAccordion(
+        AppAccordion(
             title = "Tires",
             expanded = open,
             onToggle = { open = !open },
             trailing = "$0.016/mi",
             modifier = Modifier.padding(16.dp),
         ) {
-            Text("Set cost ÷ lifetime miles.", style = MaterialTheme.typography.bodySmall, color = DashTheme.colors.text3)
+            Text("Set cost ÷ lifetime miles.", style = MaterialTheme.typography.bodySmall, color = AppTheme.colors.text3)
         }
     }
 }

--- a/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/component/AppCard.kt
+++ b/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/component/AppCard.kt
@@ -13,20 +13,20 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import cloud.trotter.dashbuddy.core.designsystem.theme.DashBuddyTheme
-import cloud.trotter.dashbuddy.core.designsystem.theme.DashTheme
+import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
 
 /**
  * Card surface — the `.db-card` / `.db-card-active` tokens. `active` raises elevation tone
  * (surface-2 + stronger hairline) for the pinned/active HUD card. Content is a [ColumnScope].
  */
 @Composable
-fun DashCard(
+fun AppCard(
     modifier: Modifier = Modifier,
     active: Boolean = false,
     contentPadding: Boolean = true,
     content: @Composable ColumnScope.() -> Unit,
 ) {
-    val c = DashTheme.colors
+    val c = AppTheme.colors
     Surface(
         modifier = modifier,
         shape = MaterialTheme.shapes.medium,
@@ -45,31 +45,31 @@ fun DashCard(
  * (e.g. accentDim / goodBg / warnBg / badBg).
  */
 @Composable
-fun DashCallout(
+fun AppCallout(
     text: String,
     modifier: Modifier = Modifier,
-    container: Color = DashTheme.colors.accentDim,
+    container: Color = AppTheme.colors.accentDim,
 ) {
     Surface(modifier = modifier, shape = MaterialTheme.shapes.small, color = container) {
         Text(
             text = text,
             modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
             style = MaterialTheme.typography.bodySmall,
-            color = DashTheme.colors.text2,
+            color = AppTheme.colors.text2,
         )
     }
 }
 
 @Preview
 @Composable
-private fun DashCardPreview() = DashBuddyTheme {
+private fun AppCardPreview() = DashBuddyTheme {
     Surface(color = MaterialTheme.colorScheme.background) {
         Column(Modifier.padding(16.dp)) {
-            DashCard(active = true) {
-                Text("Active card", style = MaterialTheme.typography.titleMedium, color = DashTheme.colors.text)
+            AppCard(active = true) {
+                Text("Active card", style = MaterialTheme.typography.titleMedium, color = AppTheme.colors.text)
             }
             Column(Modifier.padding(top = 12.dp)) {
-                DashCallout("You kept $612 of $812 gross — a 75% true margin.")
+                AppCallout("You kept $612 of $812 gross — a 75% true margin.")
             }
         }
     }

--- a/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/component/AppCharts.kt
+++ b/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/component/AppCharts.kt
@@ -33,16 +33,16 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import cloud.trotter.dashbuddy.core.designsystem.theme.DashBuddyTheme
-import cloud.trotter.dashbuddy.core.designsystem.theme.DashTheme
+import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
 import kotlin.math.roundToInt
 
 /** A single bar. [highlight] paints it in the brand accent (e.g. a "hot" day/zone). */
-data class DashBar(val label: String, val value: Float, val highlight: Boolean = false)
+data class AppBar(val label: String, val value: Float, val highlight: Boolean = false)
 
 /** Simple labelled bar chart — earnings-by-period, etc. */
 @Composable
-fun DashBarChart(bars: List<DashBar>, modifier: Modifier = Modifier, height: Dp = 96.dp) {
-    val c = DashTheme.colors
+fun AppBarChart(bars: List<AppBar>, modifier: Modifier = Modifier, height: Dp = 96.dp) {
+    val c = AppTheme.colors
     val max = bars.maxOfOrNull { it.value }?.takeIf { it > 0f } ?: 1f
     Column(modifier) {
         Row(
@@ -79,15 +79,15 @@ fun DashBarChart(bars: List<DashBar>, modifier: Modifier = Modifier, height: Dp 
 
 /** Circular progress gauge with a centred value + caption — ratings, on-time scorecard. */
 @Composable
-fun DashGaugeRing(
+fun AppGaugeRing(
     progress: Float,
     value: String,
     label: String,
     modifier: Modifier = Modifier,
-    color: Color = DashTheme.colors.accent,
+    color: Color = AppTheme.colors.accent,
     diameter: Dp = 88.dp,
 ) {
-    val c = DashTheme.colors
+    val c = AppTheme.colors
     val track = c.surface3
     Column(
         modifier,
@@ -105,18 +105,18 @@ fun DashGaugeRing(
                     topLeft, arcSize, style = Stroke(stroke, cap = StrokeCap.Round),
                 )
             }
-            Text(value, style = DashTheme.num.lgNum, color = c.text)
+            Text(value, style = AppTheme.num.lgNum, color = c.text)
         }
         Text(label, style = MaterialTheme.typography.bodySmall, color = c.text2)
     }
 }
 
 /** A proportion in a stacked bar / legend. */
-data class DashSegment(val label: String, val value: Float, val color: Color, val note: String? = null)
+data class AppSegment(val label: String, val value: Float, val color: Color, val note: String? = null)
 
 /** Stacked proportion bar — offer funnel, time split, deadhead ratio. */
 @Composable
-fun DashStackBar(segments: List<DashSegment>, modifier: Modifier = Modifier, height: Dp = 12.dp) {
+fun AppStackBar(segments: List<AppSegment>, modifier: Modifier = Modifier, height: Dp = 12.dp) {
     val total = segments.sumOf { it.value.toDouble() }.toFloat().takeIf { it > 0f } ?: 1f
     Row(modifier.clip(CircleShape).fillMaxWidth().height(height)) {
         segments.forEach { s ->
@@ -125,11 +125,11 @@ fun DashStackBar(segments: List<DashSegment>, modifier: Modifier = Modifier, hei
     }
 }
 
-/** Legend for a [DashStackBar]. Shows each key + its `note` (or computed percent). */
+/** Legend for a [AppStackBar]. Shows each key + its `note` (or computed percent). */
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
-fun DashLegend(segments: List<DashSegment>, modifier: Modifier = Modifier) {
-    val c = DashTheme.colors
+fun AppLegend(segments: List<AppSegment>, modifier: Modifier = Modifier) {
+    val c = AppTheme.colors
     val total = segments.sumOf { it.value.toDouble() }.toFloat().takeIf { it > 0f } ?: 1f
     FlowRow(
         modifier,
@@ -142,7 +142,7 @@ fun DashLegend(segments: List<DashSegment>, modifier: Modifier = Modifier) {
                 Text(s.label, style = MaterialTheme.typography.bodySmall, color = c.text2)
                 Text(
                     s.note ?: "${(s.value / total * 100f).roundToInt()}%",
-                    style = DashTheme.num.smNum,
+                    style = AppTheme.num.smNum,
                     color = c.text,
                 )
             }
@@ -152,23 +152,23 @@ fun DashLegend(segments: List<DashSegment>, modifier: Modifier = Modifier) {
 
 @Preview
 @Composable
-private fun DashChartsPreview() = DashBuddyTheme {
+private fun AppChartsPreview() = DashBuddyTheme {
     Surface(color = MaterialTheme.colorScheme.background) {
         Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
-            DashBarChart(
+            AppBarChart(
                 listOf(
-                    DashBar("M", 96f), DashBar("T", 110f), DashBar("W", 88f),
-                    DashBar("T", 132f, highlight = true), DashBar("F", 158f, highlight = true),
+                    AppBar("M", 96f), AppBar("T", 110f), AppBar("W", 88f),
+                    AppBar("T", 132f, highlight = true), AppBar("F", 158f, highlight = true),
                 ),
             )
-            DashGaugeRing(progress = 0.96f, value = "96%", label = "Before deadline", color = DashTheme.colors.good)
+            AppGaugeRing(progress = 0.96f, value = "96%", label = "Before deadline", color = AppTheme.colors.good)
             val segs = listOf(
-                DashSegment("Accepted", 54f, DashTheme.colors.good),
-                DashSegment("Declined", 32f, DashTheme.colors.bad),
-                DashSegment("Timed out", 5f, DashTheme.colors.neutral),
+                AppSegment("Accepted", 54f, AppTheme.colors.good),
+                AppSegment("Declined", 32f, AppTheme.colors.bad),
+                AppSegment("Timed out", 5f, AppTheme.colors.neutral),
             )
-            DashStackBar(segs, height = 14.dp)
-            DashLegend(segs)
+            AppStackBar(segs, height = 14.dp)
+            AppLegend(segs)
         }
     }
 }

--- a/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/component/AppChip.kt
+++ b/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/component/AppChip.kt
@@ -13,23 +13,23 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import cloud.trotter.dashbuddy.core.designsystem.theme.DashBuddyTheme
-import cloud.trotter.dashbuddy.core.designsystem.theme.DashTheme
+import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
 
 /**
  * Uppercase pill / badge — the `.db-chip` token. Phase chips, status badges, outcome chips,
  * analytics legend keys. Pure data + tokens.
  */
 @Composable
-fun DashChip(
+fun AppChip(
     text: String,
     modifier: Modifier = Modifier,
-    color: Color = DashTheme.colors.neutral,
-    container: Color = DashTheme.colors.neutralBg,
+    color: Color = AppTheme.colors.neutral,
+    container: Color = AppTheme.colors.neutralBg,
     uppercase: Boolean = true,
 ) {
     Text(
         text = if (uppercase) text.uppercase() else text,
-        style = DashTheme.num.chip,
+        style = AppTheme.num.chip,
         color = color,
         modifier = modifier
             .clip(CircleShape)
@@ -40,12 +40,12 @@ fun DashChip(
 
 @Preview
 @Composable
-private fun DashChipPreview() = DashBuddyTheme {
+private fun AppChipPreview() = DashBuddyTheme {
     Surface(color = MaterialTheme.colorScheme.background) {
-        DashChip(
+        AppChip(
             "Offer",
-            color = DashTheme.colors.stOffer,
-            container = DashTheme.colors.stOfferBg,
+            color = AppTheme.colors.stOffer,
+            container = AppTheme.colors.stOfferBg,
             modifier = Modifier.padding(16.dp),
         )
     }

--- a/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/component/AppSegmented.kt
+++ b/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/component/AppSegmented.kt
@@ -18,20 +18,20 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import cloud.trotter.dashbuddy.core.designsystem.theme.DashBuddyTheme
-import cloud.trotter.dashbuddy.core.designsystem.theme.DashTheme
+import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
 
 /**
  * Pill segmented control — analytics tabs / period switches. Selected segment fills with the
  * brand accent. Pure data + an `onSelect` lambda.
  */
 @Composable
-fun DashSegmented(
+fun AppSegmented(
     options: List<String>,
     selected: String,
     onSelect: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val c = DashTheme.colors
+    val c = AppTheme.colors
     Row(
         modifier = modifier
             .clip(CircleShape)
@@ -62,9 +62,9 @@ fun DashSegmented(
 
 @Preview
 @Composable
-private fun DashSegmentedPreview() = DashBuddyTheme {
+private fun AppSegmentedPreview() = DashBuddyTheme {
     Surface(color = MaterialTheme.colorScheme.background) {
-        DashSegmented(
+        AppSegmented(
             options = listOf("Money", "Patterns", "Decisions", "Time"),
             selected = "Money",
             onSelect = {},

--- a/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/component/AppSlider.kt
+++ b/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/component/AppSlider.kt
@@ -19,14 +19,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import cloud.trotter.dashbuddy.core.designsystem.theme.DashBuddyTheme
-import cloud.trotter.dashbuddy.core.designsystem.theme.DashTheme
+import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
 
 /**
  * Slider with a min / value / max readout below (the live value in the brand accent, numeric).
  * Economy costs, strategy targets, wizard steps. [format] turns the raw float into display text.
  */
 @Composable
-fun DashSlider(
+fun AppSlider(
     value: Float,
     onValueChange: (Float) -> Unit,
     valueRange: ClosedFloatingPointRange<Float>,
@@ -34,7 +34,7 @@ fun DashSlider(
     steps: Int = 0,
     format: (Float) -> String = { it.toString() },
 ) {
-    val c = DashTheme.colors
+    val c = AppTheme.colors
     Column(modifier) {
         Slider(
             value = value,
@@ -49,7 +49,7 @@ fun DashSlider(
         )
         Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
             Text(format(valueRange.start), style = MaterialTheme.typography.bodySmall, color = c.text3)
-            Text(format(value), style = DashTheme.num.smNum, color = c.accent)
+            Text(format(value), style = AppTheme.num.smNum, color = c.accent)
             Text(format(valueRange.endInclusive), style = MaterialTheme.typography.bodySmall, color = c.text3)
         }
     }
@@ -57,10 +57,10 @@ fun DashSlider(
 
 @Preview
 @Composable
-private fun DashSliderPreview() = DashBuddyTheme {
+private fun AppSliderPreview() = DashBuddyTheme {
     Surface(color = MaterialTheme.colorScheme.background) {
         var v by remember { mutableFloatStateOf(22f) }
-        DashSlider(
+        AppSlider(
             value = v,
             onValueChange = { v = it },
             valueRange = 10f..40f,

--- a/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/component/AppStatTile.kt
+++ b/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/component/AppStatTile.kt
@@ -15,22 +15,22 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import cloud.trotter.dashbuddy.core.designsystem.theme.DashBuddyTheme
-import cloud.trotter.dashbuddy.core.designsystem.theme.DashTheme
+import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
 
 /**
  * Mini stat cell — uppercase label (+ optional [leading] slot), a numeric value, optional sub.
  * Dashboard "Today" glance, analytics tiles, ratings counts.
  */
 @Composable
-fun DashStatTile(
+fun AppStatTile(
     label: String,
     value: String,
     modifier: Modifier = Modifier,
     sub: String? = null,
-    valueColor: Color = DashTheme.colors.text,
+    valueColor: Color = AppTheme.colors.text,
     leading: (@Composable () -> Unit)? = null,
 ) {
-    DashCard(modifier = modifier) {
+    AppCard(modifier = modifier) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(6.dp),
@@ -39,27 +39,27 @@ fun DashStatTile(
             Text(
                 text = label.uppercase(),
                 style = MaterialTheme.typography.labelMedium,
-                color = DashTheme.colors.text3,
+                color = AppTheme.colors.text3,
             )
         }
         Spacer(Modifier.height(6.dp))
-        Text(text = value, style = DashTheme.num.xlNum, color = valueColor)
+        Text(text = value, style = AppTheme.num.xlNum, color = valueColor)
         if (sub != null) {
             Spacer(Modifier.height(4.dp))
-            Text(text = sub, style = MaterialTheme.typography.bodySmall, color = DashTheme.colors.text3)
+            Text(text = sub, style = MaterialTheme.typography.bodySmall, color = AppTheme.colors.text3)
         }
     }
 }
 
 @Preview
 @Composable
-private fun DashStatTilePreview() = DashBuddyTheme {
+private fun AppStatTilePreview() = DashBuddyTheme {
     Surface(color = MaterialTheme.colorScheme.background) {
-        DashStatTile(
+        AppStatTile(
             label = "Net/hr",
             value = "$19.40",
             sub = "after real costs",
-            valueColor = DashTheme.colors.good,
+            valueColor = AppTheme.colors.good,
             modifier = Modifier.padding(16.dp),
         )
     }

--- a/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/theme/AppColors.kt
+++ b/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/theme/AppColors.kt
@@ -10,13 +10,13 @@ import androidx.compose.ui.graphics.Color
  *
  * Design-specific semantics (phase chips, status badges, good/warn/bad, offer/pickup)
  * read from [LocalDashColors] — NOT Material 3 roles — so they stay meaningful and fixed,
- * never wallpaper-derived. Material 3 roles are still mapped (see DashTheme) so stock M3
+ * never wallpaper-derived. Material 3 roles are still mapped (see AppTheme) so stock M3
  * components render on-brand.
  *
  * `*Bg` tokens are the base color at 14% (dark) / 12% (light) alpha.
  */
 @Immutable
-data class DashColors(
+data class AppColors(
     val bg: Color,
     val surface: Color,
     val surface2: Color,
@@ -47,7 +47,7 @@ data class DashColors(
 )
 
 /** Dark theme — primary. */
-fun darkDashColors(): DashColors = DashColors(
+fun darkAppColors(): AppColors = AppColors(
     bg = Color(0xFF0C1014),
     surface = Color(0xFF141A21),
     surface2 = Color(0xFF1B2530),
@@ -78,7 +78,7 @@ fun darkDashColors(): DashColors = DashColors(
 )
 
 /** Light theme — follows system; semantic tokens stay meaningful. */
-fun lightDashColors(): DashColors = DashColors(
+fun lightAppColors(): AppColors = AppColors(
     bg = Color(0xFFEEF2F4),
     surface = Color(0xFFFFFFFF),
     surface2 = Color(0xFFF3F6F8),
@@ -108,5 +108,5 @@ fun lightDashColors(): DashColors = DashColors(
     isDark = false,
 )
 
-/** Brand semantic tokens. Provided by [DashBuddyTheme]; read via `DashTheme.colors`. */
-val LocalDashColors = staticCompositionLocalOf { darkDashColors() }
+/** Brand semantic tokens. Provided by [DashBuddyTheme]; read via `AppTheme.colors`. */
+val LocalDashColors = staticCompositionLocalOf { darkAppColors() }

--- a/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/theme/AppShapes.kt
+++ b/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/theme/AppShapes.kt
@@ -5,7 +5,7 @@ import androidx.compose.material3.Shapes
 import androidx.compose.ui.unit.dp
 
 /** Radii (M3-ish): xs 6 · sm 10 · md 14 · lg 20 · xl 28. Pills use a full/circle shape at the call site. */
-val DashShapes = Shapes(
+val AppShapes = Shapes(
     extraSmall = RoundedCornerShape(6.dp),
     small = RoundedCornerShape(10.dp),
     medium = RoundedCornerShape(14.dp),

--- a/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/theme/AppTheme.kt
+++ b/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/theme/AppTheme.kt
@@ -10,7 +10,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
 
 /** Maps the fixed brand palette onto Material 3 roles so stock M3 components render on-brand. */
-private fun dashColorScheme(c: DashColors): ColorScheme {
+private fun dashColorScheme(c: AppColors): ColorScheme {
     val base = if (c.isDark) darkColorScheme() else lightColorScheme()
     return base.copy(
         primary = c.accent,
@@ -56,7 +56,7 @@ fun DashBuddyTheme(
     glance: Float = 1f,
     content: @Composable () -> Unit,
 ) {
-    val dash = if (darkTheme) darkDashColors() else lightDashColors()
+    val dash = if (darkTheme) darkAppColors() else lightAppColors()
     CompositionLocalProvider(
         LocalDashColors provides dash,
         LocalDashTextStyles provides dashTextStyles(),
@@ -64,18 +64,18 @@ fun DashBuddyTheme(
     ) {
         MaterialTheme(
             colorScheme = dashColorScheme(dash),
-            typography = DashTypography,
-            shapes = DashShapes,
+            typography = AppTypography,
+            shapes = AppShapes,
             content = content,
         )
     }
 }
 
-/** Ergonomic accessors for the brand tokens: `DashTheme.colors.good`, `DashTheme.num.heroNum`. */
-object DashTheme {
-    val colors: DashColors
+/** Ergonomic accessors for the brand tokens: `AppTheme.colors.good`, `AppTheme.num.heroNum`. */
+object AppTheme {
+    val colors: AppColors
         @Composable @ReadOnlyComposable get() = LocalDashColors.current
-    val num: DashTextStyles
+    val num: AppTextStyles
         @Composable @ReadOnlyComposable get() = LocalDashTextStyles.current
     val glance: Float
         @Composable @ReadOnlyComposable get() = LocalGlance.current

--- a/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/theme/AppType.kt
+++ b/core/designsystem/src/main/java/cloud/trotter/dashbuddy/core/designsystem/theme/AppType.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 
 /** Glanceability-tuned type scale (px → sp): hero 30 · xl 22 · lg 18 · md 15 · sm 13 · xs 11 · micro 10. */
-object DashTypeScale {
+object AppTypeScale {
     val hero = 30.sp
     val xl = 22.sp
     val lg = 18.sp
@@ -26,7 +26,7 @@ object DashTypeScale {
  * uses one of these styles. Plus the uppercase `chip` label style.
  */
 @Immutable
-data class DashTextStyles(
+data class AppTextStyles(
     val heroNum: TextStyle,
     val xlNum: TextStyle,
     val lgNum: TextStyle,
@@ -45,17 +45,17 @@ private fun num(size: TextUnit, weight: FontWeight = FontWeight.Bold, ls: Double
         fontFeatureSettings = "tnum",
     )
 
-fun dashTextStyles(): DashTextStyles = DashTextStyles(
-    heroNum = num(DashTypeScale.hero, FontWeight.Bold, -0.02),
-    xlNum = num(DashTypeScale.xl),
-    lgNum = num(DashTypeScale.lg),
-    mdNum = num(DashTypeScale.md),
-    smNum = num(DashTypeScale.sm),
-    xsNum = num(DashTypeScale.xs),
+fun dashTextStyles(): AppTextStyles = AppTextStyles(
+    heroNum = num(AppTypeScale.hero, FontWeight.Bold, -0.02),
+    xlNum = num(AppTypeScale.xl),
+    lgNum = num(AppTypeScale.lg),
+    mdNum = num(AppTypeScale.md),
+    smNum = num(AppTypeScale.sm),
+    xsNum = num(AppTypeScale.xs),
     chip = TextStyle(
         fontFamily = HankenGrotesk,
         fontWeight = FontWeight.Bold,
-        fontSize = DashTypeScale.xs,
+        fontSize = AppTypeScale.xs,
         letterSpacing = 0.06.em,
     ),
 )
@@ -63,23 +63,23 @@ fun dashTextStyles(): DashTextStyles = DashTextStyles(
 val LocalDashTextStyles = staticCompositionLocalOf { dashTextStyles() }
 
 /** Material 3 Typography — Hanken Grotesk across the board, sized to the design scale. */
-val DashTypography: Typography = Typography().let { b ->
+val AppTypography: Typography = Typography().let { b ->
     val ui = HankenGrotesk
     b.copy(
         displayLarge = b.displayLarge.copy(fontFamily = ui),
         displayMedium = b.displayMedium.copy(fontFamily = ui),
         displaySmall = b.displaySmall.copy(fontFamily = ui),
         headlineLarge = b.headlineLarge.copy(fontFamily = ui),
-        headlineMedium = b.headlineMedium.copy(fontFamily = ui, fontSize = DashTypeScale.xl, fontWeight = FontWeight.SemiBold),
-        headlineSmall = b.headlineSmall.copy(fontFamily = ui, fontSize = DashTypeScale.lg, fontWeight = FontWeight.SemiBold),
-        titleLarge = b.titleLarge.copy(fontFamily = ui, fontSize = DashTypeScale.lg),
-        titleMedium = b.titleMedium.copy(fontFamily = ui, fontSize = DashTypeScale.md, fontWeight = FontWeight.SemiBold),
-        titleSmall = b.titleSmall.copy(fontFamily = ui, fontSize = DashTypeScale.sm, fontWeight = FontWeight.SemiBold),
-        bodyLarge = b.bodyLarge.copy(fontFamily = ui, fontSize = DashTypeScale.md),
-        bodyMedium = b.bodyMedium.copy(fontFamily = ui, fontSize = DashTypeScale.sm),
-        bodySmall = b.bodySmall.copy(fontFamily = ui, fontSize = DashTypeScale.xs),
-        labelLarge = b.labelLarge.copy(fontFamily = ui, fontSize = DashTypeScale.sm, fontWeight = FontWeight.SemiBold),
-        labelMedium = b.labelMedium.copy(fontFamily = ui, fontSize = DashTypeScale.xs, fontWeight = FontWeight.Medium),
-        labelSmall = b.labelSmall.copy(fontFamily = ui, fontSize = DashTypeScale.micro, fontWeight = FontWeight.Medium),
+        headlineMedium = b.headlineMedium.copy(fontFamily = ui, fontSize = AppTypeScale.xl, fontWeight = FontWeight.SemiBold),
+        headlineSmall = b.headlineSmall.copy(fontFamily = ui, fontSize = AppTypeScale.lg, fontWeight = FontWeight.SemiBold),
+        titleLarge = b.titleLarge.copy(fontFamily = ui, fontSize = AppTypeScale.lg),
+        titleMedium = b.titleMedium.copy(fontFamily = ui, fontSize = AppTypeScale.md, fontWeight = FontWeight.SemiBold),
+        titleSmall = b.titleSmall.copy(fontFamily = ui, fontSize = AppTypeScale.sm, fontWeight = FontWeight.SemiBold),
+        bodyLarge = b.bodyLarge.copy(fontFamily = ui, fontSize = AppTypeScale.md),
+        bodyMedium = b.bodyMedium.copy(fontFamily = ui, fontSize = AppTypeScale.sm),
+        bodySmall = b.bodySmall.copy(fontFamily = ui, fontSize = AppTypeScale.xs),
+        labelLarge = b.labelLarge.copy(fontFamily = ui, fontSize = AppTypeScale.sm, fontWeight = FontWeight.SemiBold),
+        labelMedium = b.labelMedium.copy(fontFamily = ui, fontSize = AppTypeScale.xs, fontWeight = FontWeight.Medium),
+        labelSmall = b.labelSmall.copy(fontFamily = ui, fontSize = AppTypeScale.micro, fontWeight = FontWeight.Medium),
     )
 }


### PR DESCRIPTION
## Summary

Pure mechanical rename of the `:core:designsystem` **brand/component** vocabulary `Dash*` → `App*` — same "no platform-flavoured names" reasoning as #456 (`DashFormats` → `Formats`). No behavior change.

Renamed (identifiers **and** their files, word-boundary scoped): `DashTheme`→`AppTheme`, `DashColors`→`AppColors` (+ `dark`/`lightDashColors`), `DashTypography`/`TypeScale`/`TextStyles`, `DashShapes`, `DashCard`, `DashChip`, `DashStatTile`, `DashGaugeRing`, `DashSegmented`/`DashSegment`, `DashSlider`, `DashBar`/`DashBarChart`/`DashStackBar`/`DashLegend`, `DashAccordion`, `DashCallout`, and all `*Preview` variants.

## Explicitly NOT renamed
- **`DashBuddyTheme`** — the public theme wrapper; it carries the app name, not a platform term (the only `Dash`-named symbol kept in the module).
- **Domain "dash = work session" terms** (`DashStrategy`, `DashSummary`, `activeDashId`, `isDashing`, …) — those are the separate dash→session chore (#469), not `App*`.

## Scope
19 files (`:core:designsystem` + 8 `:app` UI call sites). `CLAUDE.md` `:core:designsystem` bullet updated to the new names. Full `testDebugUnitTest` green.

Closes #468.