### PR TITLE
chore(domain): rename dashId-family symbols dash → session (#469 slice 1)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManager.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManager.kt
@@ -43,7 +43,7 @@ class BubbleManager @Inject constructor(
     private val notificationManager: NotificationManager,
     private val chatRepository: ChatRepository,
     // dagger.Lazy breaks the StateManagerV2 → EffectExecutor → BubbleManager
-    // construction cycle (#437); resolved on first activeDashId access.
+    // construction cycle (#437); resolved on first activeSessionId access.
     private val stateManager: dagger.Lazy<StateManagerV2>,
 ) {
 
@@ -72,7 +72,7 @@ class BubbleManager @Inject constructor(
      * showed nothing until the next DASH_START. State restores; this follows.
      * Lazy so the Hilt graph finishes building before StateManagerV2 resolves.
      */
-    val activeDashId: StateFlow<String?> by lazy {
+    val activeSessionId: StateFlow<String?> by lazy {
         stateManager.get().state
             .map { it.activeSessionId() }
             .stateIn(scope, SharingStarted.Eagerly, null)
@@ -112,7 +112,7 @@ class BubbleManager @Inject constructor(
 
         // 2. UPDATED: Launched in a coroutine because the Repository is pure suspend now!
         scope.launch {
-            chatRepository.saveMessage(activeDashId.value, text.toString(), persona)
+            chatRepository.saveMessage(activeSessionId.value, text.toString(), persona)
         }
 
         // Post Notification
@@ -230,7 +230,7 @@ class BubbleManager @Inject constructor(
         val summary = evaluation.toNotificationSummary()
         val persona = evaluation.notificationPersona()
         Timber.tag("Chat").i("[${persona.displayName}]: $summary")
-        scope.launch { chatRepository.saveMessage(activeDashId.value, summary.toString(), persona) }
+        scope.launch { chatRepository.saveMessage(activeSessionId.value, summary.toString(), persona) }
         showNotification(summary, persona, expand = false, offerActionable = true)
     }
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleViewModel.kt
@@ -96,15 +96,15 @@ class BubbleViewModel @Inject constructor(
     // process death AND by a post-dash bubble re-subscribe (>5s collapsed),
     // emptying the chat/cards. The active dash wins while one is running; the
     // DB fallback survives both restarts, so the bubble reviews the last dash
-    // until the next one starts (when activeDashId takes over again).
+    // until the next one starts (when activeSessionId takes over again).
     @OptIn(ExperimentalCoroutinesApi::class)
-    private val displayedDashId = combine(
-        bubbleManager.activeDashId,
-        appEventRepo.getMostRecentDashId(),
+    private val displayedSessionId = combine(
+        bubbleManager.activeSessionId,
+        appEventRepo.getMostRecentSessionId(),
     ) { active, mostRecent -> active ?: mostRecent }
         .distinctUntilChanged()
 
-    val messages = displayedDashId.flatMapLatest { dashId ->
+    val messages = displayedSessionId.flatMapLatest { dashId ->
         if (dashId != null) {
             chatRepository.getMessages(dashId)
         } else {
@@ -117,7 +117,7 @@ class BubbleViewModel @Inject constructor(
 
     /**
      * Bubble HUD flow-card stack (#257). Completed cards are folded from
-     * the AppEvent log scoped to [displayedDashId]; the live card is built
+     * the AppEvent log scoped to [displayedSessionId]; the live card is built
      * from current [appState]. A new dash clears the stack via DASH_START's
      * fold logic, so the user can review the previous dash's cards until
      * they go Online again.
@@ -125,8 +125,8 @@ class BubbleViewModel @Inject constructor(
     @OptIn(ExperimentalCoroutinesApi::class)
     val cardStack = combine(
         stateManager.state,
-        displayedDashId.flatMapLatest { dashId ->
-            if (dashId != null) appEventRepo.getEventsForDash(dashId)
+        displayedSessionId.flatMapLatest { dashId ->
+            if (dashId != null) appEventRepo.getEventsForSession(dashId)
             else flowOf(emptyList())
         },
     ) { state, events ->

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardViewModel.kt
@@ -31,7 +31,7 @@ class DashboardViewModel @Inject constructor(
 ) : AndroidViewModel(application) {
 
     // 1. Am I Dashing?
-    val isDashing: StateFlow<Boolean> = stateManager.state
+    val isInSession: StateFlow<Boolean> = stateManager.state
         .map { state ->
             val dd = state.regions.platforms[Platform.DoorDash]
             dd != null && dd.mode != Mode.Offline

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/chat/ChatRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/chat/ChatRepository.kt
@@ -17,7 +17,7 @@ class ChatRepository @Inject constructor(
 ) {
     // Queries specific dash messages and maps them to pure Domain models
     fun getMessages(dashId: String): Flow<List<ChatMessage>> {
-        return chatDao.getMessagesForDash(dashId).map { entities ->
+        return chatDao.getMessagesForSession(dashId).map { entities ->
             entities.map { it.toDomain() }
         }
     }
@@ -34,7 +34,7 @@ class ChatRepository @Inject constructor(
         chatDao.insertMessage(domainMessage.toEntity())
     }
 
-    fun getAllDashIds(): Flow<List<String>> {
-        return chatDao.getAllDashIds()
+    fun getAllSessionIds(): Flow<List<String>> {
+        return chatDao.getAllSessionIds()
     }
 }

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/event/AppEventRepo.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/event/AppEventRepo.kt
@@ -54,11 +54,11 @@ class AppEventRepo @Inject constructor(
     fun getAllEvents(): Flow<List<AppEvent>> =
         dao.getAllEvents().map { rows -> rows.map { it.toDomain() } }
 
-    fun getEventsForDash(dashId: String): Flow<List<AppEvent>> =
-        dao.getEventsForDash(dashId).map { rows -> rows.map { it.toDomain() } }
+    fun getEventsForSession(dashId: String): Flow<List<AppEvent>> =
+        dao.getEventsForSession(dashId).map { rows -> rows.map { it.toDomain() } }
 
     /** Durable "last completed dash" fallback for the bubble HUD (#459). */
-    fun getMostRecentDashId(): Flow<String?> = dao.getMostRecentDashId()
+    fun getMostRecentSessionId(): Flow<String?> = dao.getMostRecentSessionId()
 
     fun getEventsByType(type: AppEventType): Flow<List<AppEvent>> =
         dao.getEventsByType(type).map { rows -> rows.map { it.toDomain() } }

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/chat/ChatDao.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/chat/ChatDao.kt
@@ -12,9 +12,9 @@ interface ChatDao {
 
     // Live stream for the current active dash
     @Query("SELECT * FROM chat_messages WHERE dashId = :dashId ORDER BY timestamp ASC")
-    fun getMessagesForDash(dashId: String): Flow<List<ChatMessageEntity>>
+    fun getMessagesForSession(dashId: String): Flow<List<ChatMessageEntity>>
 
     // The "Poor Man's Join": Get a list of all unique Dash IDs to build the history list later
     @Query("SELECT DISTINCT dashId FROM chat_messages WHERE dashId IS NOT NULL ORDER BY timestamp DESC")
-    fun getAllDashIds(): Flow<List<String>>
+    fun getAllSessionIds(): Flow<List<String>>
 }

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/event/AppEventDao.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/event/AppEventDao.kt
@@ -23,18 +23,18 @@ interface AppEventDao {
      * Returns all events for a specific Dash session.
      */
     @Query("SELECT * FROM app_events WHERE aggregateId = :dashId ORDER BY sequenceId ASC")
-    fun getEventsForDash(dashId: String): Flow<List<AppEventEntity>>
+    fun getEventsForSession(dashId: String): Flow<List<AppEventEntity>>
 
     /**
      * The dash ([aggregateId]) of the most recent event, or null if none. The
      * durable "last completed dash" fallback for the bubble HUD when no session
-     * is live (#459): the in-memory scan latch that fed `displayedDashId` was
+     * is live (#459): the in-memory scan latch that fed `displayedSessionId` was
      * wiped by process death (8a) and by a post-dash bubble re-subscribe (8b),
      * emptying the chat/cards. The event log survives both, so the bubble
      * reviews the last dash until the next one starts.
      */
     @Query("SELECT aggregateId FROM app_events WHERE aggregateId IS NOT NULL ORDER BY sequenceId DESC LIMIT 1")
-    fun getMostRecentDashId(): Flow<String?>
+    fun getMostRecentSessionId(): Flow<String?>
 
     /**
      * Returns all events of a specific type (e.g., all OFFER_RECEIVED events).

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapPayloadTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapPayloadTest.kt
@@ -169,7 +169,7 @@ class EffectMapPayloadTest {
         assertEquals(1, logs.size)
 
         // Regression: aggregateId must match sessionId so the bubble HUD's
-        // getEventsForDash(dashId) query sees it.
+        // getEventsForSession(dashId) query sees it.
         assertEquals("dash-7", logs[0].event.sessionId)
 
         val payload = (logs[0].event.payload as OfferReceivedPayload)
@@ -209,7 +209,7 @@ class EffectMapPayloadTest {
         val logs = logEvents(prev, next, click, AppEventType.OFFER_ACCEPTED)
         assertEquals(1, logs.size)
 
-        // Regression: AppEventDao.getEventsForDash(dashId) filters by
+        // Regression: AppEventDao.getEventsForSession(dashId) filters by
         // aggregateId. Offer events with null aggregateId are invisible
         // to the bubble HUD's flow-card stack (#257).
         assertEquals("dash-42", logs[0].event.sessionId)

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/AppState.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/AppState.kt
@@ -35,7 +35,7 @@ data class Regions(
 
 /**
  * THE session id the UI attributes to (#437) — derived from state, never a
- * second copy. BubbleManager used to mutate its own `activeDashId` from
+ * second copy. BubbleManager used to mutate its own `activeSessionId` from
  * StartSession/EndSession effects; crash recovery SUPPRESSES StartSession
  * (external effect), so a restored mid-dash process had a null dash id and
  * chat/cards attributed to nothing until the next DASH_START. Deriving from

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/state/ActiveSessionIdTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/state/ActiveSessionIdTest.kt
@@ -5,7 +5,7 @@ import org.junit.Assert.assertNull
 import org.junit.Test
 
 /**
- * The dash-id derivation BubbleManager's `activeDashId` reads (#437). The
+ * The dash-id derivation BubbleManager's `activeSessionId` reads (#437). The
  * recovery property follows directly: snapshots restore [AppState], so a
  * restored mid-dash process derives its session id instead of waiting for a
  * StartSession effect that recovery suppresses.


### PR DESCRIPTION
## Summary

First slice of the dash→session migration (#469): the session-identifier accessors and the "is a session active" flag. These map cleanly onto the already-established `Session` vocabulary (`AppState.activeSessionId()`, #437), so there's no naming ambiguity. **Code-only — no persisted schema touched.**

| Before | After | Where |
|---|---|---|
| `activeDashId` | `activeSessionId` | `BubbleManager` StateFlow (#437 SSOT) |
| `displayedDashId` | `displayedSessionId` | `BubbleViewModel` UI state |
| `getEventsForDash` | `getEventsForSession` | `AppEventDao`/Repo method |
| `getMessagesForDash` | `getMessagesForSession` | `ChatDao`/Repo method |
| `getAllDashIds` | `getAllSessionIds` | `ChatDao` method |
| `getMostRecentDashId` | `getMostRecentSessionId` | `AppEventDao` method |
| `isDashing` | `isInSession` | `DashboardViewModel` StateFlow |

## Persistence untouched (the #469 caution)

The Room `dashId` **column** on `chat_messages`, the `:dashId` **bind parameters**, and every `@Query` string are left exactly as-is — only Kotlin method/property identifiers changed. `DashBuddy` (app name) untouched.

## Deferred to later #469 slices

These need a naming decision and/or persisted-key care, so they're intentionally not in this slice:
- `DashStrategy` (enum type → `SessionStrategy`?)
- `UserEconomy.expectedAnnualDashMiles` / `phoneDashPercent` (+ their DataStore key symbols)
- `EvidenceConfig.saveDashSummaries` / `evidenceDash` / `EVIDENCE_DASH` / `EvidenceCategory.DASH_SUMMARY` (persisted key `"evidence_save_dash_summary"` must stay)
- the `startingDash` parse-field (a rule-output contract / parse golden)

**#469 stays open** for those.

Full `testDebugUnitTest` green.