### PR TITLE
chore(domain): rename config + economy + evidence dash → session (#469 slice 2)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/components/economy/EconomyEditor.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/components/economy/EconomyEditor.kt
@@ -48,7 +48,7 @@ fun EconomyEditor(
     onInsuranceChange: (perMonth: Double) -> Unit,
     onRegistrationChange: (perYear: Double) -> Unit,
     onPhoneChange: (total: Double, lines: Int, dashPercent: Double) -> Unit,
-    onExpectedAnnualDashMilesChange: (miles: Double) -> Unit,
+    onExpectedAnnualMilesChange: (miles: Double) -> Unit,
 ) {
     val userSet = economy.userSetFields
 
@@ -214,14 +214,14 @@ fun EconomyEditor(
         summary = "${Formats.money3(economy.phoneCostPerMile)}/mi*",
         isUserSet = EconomyField.PHONE_PLAN_TOTAL in userSet ||
             EconomyField.PHONE_PLAN_LINES in userSet ||
-            EconomyField.PHONE_DASH_PERCENT in userSet,
+            EconomyField.PHONE_BUSINESS_PERCENT in userSet,
     ) {
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
             CurrencyInput(
                 label = "Plan total",
                 value = economy.phonePlanTotal,
                 onValueChange = {
-                    onPhoneChange(it, economy.phonePlanLines, economy.phoneDashPercent)
+                    onPhoneChange(it, economy.phonePlanLines, economy.phoneBusinessPercent)
                 },
                 suffix = "/mo",
                 modifier = Modifier.weight(1f),
@@ -230,14 +230,14 @@ fun EconomyEditor(
                 label = "Lines",
                 value = economy.phonePlanLines,
                 onValueChange = {
-                    onPhoneChange(economy.phonePlanTotal, it, economy.phoneDashPercent)
+                    onPhoneChange(economy.phonePlanTotal, it, economy.phoneBusinessPercent)
                 },
                 modifier = Modifier.weight(1f),
             )
         }
-        Text("% for gig work: ${economy.phoneDashPercent.toInt()}%")
+        Text("% for gig work: ${economy.phoneBusinessPercent.toInt()}%")
         Slider(
-            value = economy.phoneDashPercent.toFloat(),
+            value = economy.phoneBusinessPercent.toFloat(),
             onValueChange = {
                 onPhoneChange(economy.phonePlanTotal, economy.phonePlanLines, it.toDouble())
             },
@@ -246,8 +246,8 @@ fun EconomyEditor(
         val perLine = economy.phonePlanTotal / economy.phonePlanLines.coerceAtLeast(1)
         Text(
             text = "Your line: ${Formats.money(perLine)}/mo" +
-                " × ${economy.phoneDashPercent.toInt()}%" +
-                " = ${Formats.money(perLine * economy.phoneDashPercent / 100.0)}/mo for gig work",
+                " × ${economy.phoneBusinessPercent.toInt()}%" +
+                " = ${Formats.money(perLine * economy.phoneBusinessPercent / 100.0)}/mo for gig work",
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
@@ -256,17 +256,17 @@ fun EconomyEditor(
     // -------- Expected annual gig miles --------
     EconomyAccordionRow(
         title = "Expected gig miles / yr",
-        summary = "${Formats.commaInt(economy.expectedAnnualDashMiles.toInt())} mi",
-        isUserSet = EconomyField.EXPECTED_ANNUAL_DASH_MI in userSet,
+        summary = "${Formats.commaInt(economy.expectedAnnualMiles.toInt())} mi",
+        isUserSet = EconomyField.EXPECTED_ANNUAL_MI in userSet,
     ) {
         Text(
-            text = "${Formats.commaInt(economy.expectedAnnualDashMiles.toInt())} miles per year",
+            text = "${Formats.commaInt(economy.expectedAnnualMiles.toInt())} miles per year",
             style = MaterialTheme.typography.bodyMedium,
             fontWeight = FontWeight.Medium,
         )
         Slider(
-            value = economy.expectedAnnualDashMiles.toFloat(),
-            onValueChange = { onExpectedAnnualDashMilesChange(it.toDouble()) },
+            value = economy.expectedAnnualMiles.toFloat(),
+            onValueChange = { onExpectedAnnualMilesChange(it.toDouble()) },
             valueRange = 500f..30_000f,
             steps = 58, // 500-mile increments
         )
@@ -348,7 +348,7 @@ private fun EconomyEditorPreview() = DashBuddyTheme {
                 onInsuranceChange = {},
                 onRegistrationChange = {},
                 onPhoneChange = { _, _, _ -> },
-                onExpectedAnnualDashMilesChange = {},
+                onExpectedAnnualMilesChange = {},
             )
             TrueCostFooter(operatingCostPerMile = economy.operatingCostPerMile)
         }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/EconomySettingsScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/EconomySettingsScreen.kt
@@ -92,7 +92,7 @@ fun EconomySettingsScreen(
                 onInsuranceChange = viewModel::setInsurance,
                 onRegistrationChange = viewModel::setRegistration,
                 onPhoneChange = viewModel::setPhone,
-                onExpectedAnnualDashMilesChange = viewModel::setExpectedAnnualDashMiles,
+                onExpectedAnnualMilesChange = viewModel::setExpectedAnnualMiles,
             )
 
             Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/EconomySettingsViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/EconomySettingsViewModel.kt
@@ -64,8 +64,8 @@ class EconomySettingsViewModel @Inject constructor(
         repo.updateRegistrationDelta(perYear)
     }
 
-    fun setExpectedAnnualDashMiles(miles: Double) = viewModelScope.launch {
-        repo.updateExpectedAnnualDashMi(miles)
+    fun setExpectedAnnualMiles(miles: Double) = viewModelScope.launch {
+        repo.updateExpectedAnnualMi(miles)
     }
 
     fun setPhone(total: Double, lines: Int, dashPercent: Double) = viewModelScope.launch {

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/EvidenceSettingsScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/EvidenceSettingsScreen.kt
@@ -62,7 +62,7 @@ fun EvidenceSettingsScreen(
                     viewModel.updateEvidenceConfig(
                         it,
                         config.saveDeliverySummaries,
-                        config.saveDashSummaries
+                        config.saveSessionSummaries
                     )
                 }
             )
@@ -72,14 +72,14 @@ fun EvidenceSettingsScreen(
                 subtitle = "Track completion stats",
                 checked = config.saveDeliverySummaries,
                 onCheckedChange = {
-                    viewModel.updateEvidenceConfig(config.saveOffers, it, config.saveDashSummaries)
+                    viewModel.updateEvidenceConfig(config.saveOffers, it, config.saveSessionSummaries)
                 }
             )
 
             SwitchRow(
                 label = "Save Dash Summary",
                 subtitle = "End of dash earnings report",
-                checked = config.saveDashSummaries,
+                checked = config.saveSessionSummaries,
                 onCheckedChange = {
                     viewModel.updateEvidenceConfig(
                         config.saveOffers,

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/WizardScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/WizardScreen.kt
@@ -36,7 +36,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import cloud.trotter.dashbuddy.domain.config.DashStrategy
+import cloud.trotter.dashbuddy.domain.config.OfferStrategy
 import cloud.trotter.dashbuddy.ui.main.setup.wizard.cards.EconomyCostsCard
 import cloud.trotter.dashbuddy.ui.main.setup.wizard.cards.GasPriceCard
 import cloud.trotter.dashbuddy.ui.main.setup.wizard.cards.MetricSliderCard
@@ -66,7 +66,7 @@ fun WizardScreen(
     val pagerState = rememberPagerState(pageCount = { steps.size })
     val coroutineScope = rememberCoroutineScope()
 
-    val isCherryPicker = state.strategy == DashStrategy.CHERRY_PICKER
+    val isCherryPicker = state.strategy == OfferStrategy.CHERRY_PICKER
 
     var showCompletionSheet by remember { mutableStateOf(false) }
     // Skip and Finish share the completion sheet but must NOT share a save path:
@@ -160,7 +160,7 @@ fun WizardScreen(
                             onInsuranceChange = viewModel::updateInsuranceDelta,
                             onRegistrationChange = viewModel::updateRegistrationDelta,
                             onPhoneChange = viewModel::updatePhonePlan,
-                            onExpectedAnnualDashMilesChange = viewModel::updateExpectedAnnualDashMiles,
+                            onExpectedAnnualMilesChange = viewModel::updateExpectedAnnualMiles,
                             onTimeConstantsChange = viewModel::updateTimeConstants,
                         )
                     }
@@ -175,16 +175,16 @@ fun WizardScreen(
                             option3Title = "Manual Mode",
                             option3Desc = "Just show me the math. I will make my own decisions.",
                             selectedIndex = when (state.strategy) {
-                                DashStrategy.CHERRY_PICKER -> 0
-                                DashStrategy.PROTECT_PLATINUM -> 1
-                                DashStrategy.MANUAL -> 2
+                                OfferStrategy.CHERRY_PICKER -> 0
+                                OfferStrategy.PROTECT_PLATINUM -> 1
+                                OfferStrategy.MANUAL -> 2
                             },
                             onOptionSelected = { index ->
                                 viewModel.updateStrategy(
                                     when (index) {
-                                        0 -> DashStrategy.CHERRY_PICKER
-                                        1 -> DashStrategy.PROTECT_PLATINUM
-                                        else -> DashStrategy.MANUAL
+                                        0 -> OfferStrategy.CHERRY_PICKER
+                                        1 -> OfferStrategy.PROTECT_PLATINUM
+                                        else -> OfferStrategy.MANUAL
                                     }
                                 )
                             }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/WizardViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/WizardViewModel.kt
@@ -7,7 +7,7 @@ import cloud.trotter.dashbuddy.core.data.settings.AppPreferencesRepository
 import cloud.trotter.dashbuddy.core.data.state.AppStateRepository
 import cloud.trotter.dashbuddy.core.data.strategy.StrategyRepository
 import cloud.trotter.dashbuddy.core.data.vehicle.VehicleRepository
-import cloud.trotter.dashbuddy.domain.config.DashStrategy
+import cloud.trotter.dashbuddy.domain.config.OfferStrategy
 import cloud.trotter.dashbuddy.domain.evaluation.EconomyField
 import cloud.trotter.dashbuddy.domain.evaluation.MetricType
 import cloud.trotter.dashbuddy.domain.evaluation.ScoringRule
@@ -80,7 +80,7 @@ class WizardViewModel @Inject constructor(
 
             val currentProtectMode = strategyRepository.protectStatsMode.first()
             val currentStrategy =
-                if (currentProtectMode) DashStrategy.PROTECT_PLATINUM else DashStrategy.MANUAL
+                if (currentProtectMode) OfferStrategy.PROTECT_PLATINUM else OfferStrategy.MANUAL
 
             val rules = strategyRepository.scoringRules.first()
             val minPayoutRule = rules.filterIsInstance<ScoringRule.MetricRule>()
@@ -133,10 +133,10 @@ class WizardViewModel @Inject constructor(
                     totalLifetimeMi = storedEconomy.totalLifetimeMi,
                     insuranceDeltaPerMonth = storedEconomy.insuranceDeltaPerMonth,
                     registrationDeltaPerYear = storedEconomy.registrationDeltaPerYear,
-                    expectedAnnualDashMiles = storedEconomy.expectedAnnualDashMiles,
+                    expectedAnnualMiles = storedEconomy.expectedAnnualMiles,
                     phonePlanTotal = storedEconomy.phonePlanTotal,
                     phonePlanLines = storedEconomy.phonePlanLines,
-                    phoneDashPercent = storedEconomy.phoneDashPercent,
+                    phoneBusinessPercent = storedEconomy.phoneBusinessPercent,
                     avgMinutesPerMile = storedEconomy.avgMinutesPerMile,
                     basePickupMinutes = storedEconomy.basePickupMinutes,
                     userSetEconomyFields = storedEconomy.userSetFields,
@@ -242,20 +242,20 @@ class WizardViewModel @Inject constructor(
         )
     }
 
-    fun updateExpectedAnnualDashMiles(miles: Double) = _state.update {
+    fun updateExpectedAnnualMiles(miles: Double) = _state.update {
         it.copy(
-            expectedAnnualDashMiles = miles,
-            userSetEconomyFields = it.userSetEconomyFields + EconomyField.EXPECTED_ANNUAL_DASH_MI,
+            expectedAnnualMiles = miles,
+            userSetEconomyFields = it.userSetEconomyFields + EconomyField.EXPECTED_ANNUAL_MI,
         )
     }
 
     fun updatePhonePlan(total: Double, lines: Int, dashPercent: Double) = _state.update {
         it.copy(
-            phonePlanTotal = total, phonePlanLines = lines, phoneDashPercent = dashPercent,
+            phonePlanTotal = total, phonePlanLines = lines, phoneBusinessPercent = dashPercent,
             userSetEconomyFields = it.userSetEconomyFields + setOf(
                 EconomyField.PHONE_PLAN_TOTAL,
                 EconomyField.PHONE_PLAN_LINES,
-                EconomyField.PHONE_DASH_PERCENT,
+                EconomyField.PHONE_BUSINESS_PERCENT,
             ),
         )
     }
@@ -430,7 +430,7 @@ class WizardViewModel @Inject constructor(
         }
     }
 
-    fun updateStrategy(strategy: DashStrategy) {
+    fun updateStrategy(strategy: OfferStrategy) {
         _state.update { it.copy(strategy = strategy) }
     }
 
@@ -515,17 +515,17 @@ class WizardViewModel @Inject constructor(
             if (EconomyField.REGISTRATION_DELTA in userSet) {
                 appPreferencesRepository.updateRegistrationDelta(finalState.registrationDeltaPerYear)
             }
-            if (EconomyField.EXPECTED_ANNUAL_DASH_MI in userSet) {
-                appPreferencesRepository.updateExpectedAnnualDashMi(finalState.expectedAnnualDashMiles)
+            if (EconomyField.EXPECTED_ANNUAL_MI in userSet) {
+                appPreferencesRepository.updateExpectedAnnualMi(finalState.expectedAnnualMiles)
             }
             if (EconomyField.PHONE_PLAN_TOTAL in userSet ||
                 EconomyField.PHONE_PLAN_LINES in userSet ||
-                EconomyField.PHONE_DASH_PERCENT in userSet
+                EconomyField.PHONE_BUSINESS_PERCENT in userSet
             ) {
                 appPreferencesRepository.updatePhonePlan(
                     finalState.phonePlanTotal,
                     finalState.phonePlanLines,
-                    finalState.phoneDashPercent,
+                    finalState.phoneBusinessPercent,
                 )
             }
             if (EconomyField.AVG_MIN_PER_MILE in userSet || EconomyField.BASE_PICKUP_MIN in userSet) {
@@ -553,8 +553,8 @@ class WizardViewModel @Inject constructor(
                 )
             }
 
-            val isCherryPicker = finalState.strategy == DashStrategy.CHERRY_PICKER
-            val isPlatinum = finalState.strategy == DashStrategy.PROTECT_PLATINUM
+            val isCherryPicker = finalState.strategy == OfferStrategy.CHERRY_PICKER
+            val isPlatinum = finalState.strategy == OfferStrategy.PROTECT_PLATINUM
 
             // Only write what the wizard actually collects (#347): the strategy-derived
             // toggles and the SHOPPING step's preference. The threshold values are NOT

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/cards/EconomyCostsCard.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/cards/EconomyCostsCard.kt
@@ -47,7 +47,7 @@ fun EconomyCostsCard(
     onInsuranceChange: (Double) -> Unit,
     onRegistrationChange: (Double) -> Unit,
     onPhoneChange: (Double, Int, Double) -> Unit,
-    onExpectedAnnualDashMilesChange: (Double) -> Unit,
+    onExpectedAnnualMilesChange: (Double) -> Unit,
     onTimeConstantsChange: (Double, Double) -> Unit,
 ) {
     // Build a live UserEconomy from current state so the editor can show
@@ -87,7 +87,7 @@ fun EconomyCostsCard(
                 onInsuranceChange = onInsuranceChange,
                 onRegistrationChange = onRegistrationChange,
                 onPhoneChange = onPhoneChange,
-                onExpectedAnnualDashMilesChange = onExpectedAnnualDashMilesChange,
+                onExpectedAnnualMilesChange = onExpectedAnnualMilesChange,
             )
 
             Spacer(modifier = Modifier.height(16.dp))
@@ -115,9 +115,9 @@ private fun WizardState.toUserEconomy() = UserEconomy(
     purchasePrice = purchasePrice, totalLifetimeMi = totalLifetimeMi,
     insuranceDeltaPerMonth = insuranceDeltaPerMonth,
     registrationDeltaPerYear = registrationDeltaPerYear,
-    expectedAnnualDashMiles = expectedAnnualDashMiles,
+    expectedAnnualMiles = expectedAnnualMiles,
     phonePlanTotal = phonePlanTotal,
     phonePlanLines = phonePlanLines,
-    phoneDashPercent = phoneDashPercent,
+    phoneBusinessPercent = phoneBusinessPercent,
     userSetFields = userSetEconomyFields,
 )

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/model/WizardState.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/model/WizardState.kt
@@ -1,6 +1,6 @@
 package cloud.trotter.dashbuddy.ui.main.setup.wizard.model
 
-import cloud.trotter.dashbuddy.domain.config.DashStrategy
+import cloud.trotter.dashbuddy.domain.config.OfferStrategy
 import cloud.trotter.dashbuddy.domain.evaluation.EconomyField
 import cloud.trotter.dashbuddy.domain.evaluation.UserEconomy
 import cloud.trotter.dashbuddy.domain.model.vehicle.FuelType
@@ -41,16 +41,16 @@ data class WizardState(
     val totalLifetimeMi: Double = VehicleClass.SEDAN.totalLifetimeMi,
     val insuranceDeltaPerMonth: Double = 0.0,
     val registrationDeltaPerYear: Double = 0.0,
-    val expectedAnnualDashMiles: Double = UserEconomy.DEFAULT_ANNUAL_DASH_MI,
+    val expectedAnnualMiles: Double = UserEconomy.DEFAULT_ANNUAL_MI,
     val phonePlanTotal: Double = UserEconomy.DEFAULT_PHONE_PLAN_TOTAL,
     val phonePlanLines: Int = UserEconomy.DEFAULT_PHONE_PLAN_LINES,
-    val phoneDashPercent: Double = UserEconomy.DEFAULT_PHONE_DASH_PERCENT,
+    val phoneBusinessPercent: Double = UserEconomy.DEFAULT_PHONE_BUSINESS_PERCENT,
     val avgMinutesPerMile: Double = UserEconomy.DEFAULT_MINUTES_PER_MILE,
     val basePickupMinutes: Double = UserEconomy.DEFAULT_BASE_PICKUP_MINUTES,
     val userSetEconomyFields: Set<EconomyField> = emptySet(),
 
     // Strategy Variables
-    val strategy: DashStrategy = DashStrategy.MANUAL,
+    val strategy: OfferStrategy = OfferStrategy.MANUAL,
 
     // Targets & Enforcement
     val enforceMinPayout: Boolean = false,

--- a/app/src/test/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngineTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngineTest.kt
@@ -69,7 +69,7 @@ class SideEffectEngineTest {
             masterEnabled = true,
             saveOffers = true,
             saveDeliverySummaries = true,
-            saveDashSummaries = true,
+            saveSessionSummaries = true,
         ),
     )
 
@@ -286,7 +286,7 @@ class SideEffectEngineTest {
 
     private fun dashSummaryShot() = AppEffect.CaptureScreenshot(
         filenamePrefix = "DashSummary - 87.50",
-        category = EvidenceCategory.DASH_SUMMARY,
+        category = EvidenceCategory.SESSION_SUMMARY,
     )
 
     @Test
@@ -306,7 +306,7 @@ class SideEffectEngineTest {
         evidenceConfig.value = EvidenceConfig(
             masterEnabled = true,
             saveOffers = true,
-            saveDashSummaries = false,
+            saveSessionSummaries = false,
         )
 
         engine.process(dashSummaryShot())

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/settings/AppPreferencesRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/settings/AppPreferencesRepository.kt
@@ -93,11 +93,11 @@ class AppPreferencesRepository @Inject constructor(
         combine(
             dataSource.insuranceDeltaPerMonth,
             dataSource.registrationDeltaPerYear,
-            dataSource.expectedAnnualDashMi,
+            dataSource.expectedAnnualMi,
             dataSource.phonePlanTotal,
             dataSource.phonePlanLines,
-        ) { ins, reg, dashMi, phoneTotal, phoneLines ->
-            FixedAndPhoneTuple(ins, reg, dashMi, phoneTotal, phoneLines)
+        ) { ins, reg, annualMi, phoneTotal, phoneLines ->
+            FixedAndPhoneTuple(ins, reg, annualMi, phoneTotal, phoneLines)
         },
     ) { id, maintA, maintB, depr, fixedPhone ->
         val cls = id.vehicleClass
@@ -122,17 +122,17 @@ class AppPreferencesRepository @Inject constructor(
             totalLifetimeMi = depr.lifetimeMi ?: cls.totalLifetimeMi,
             insuranceDeltaPerMonth = fixedPhone.insurance ?: 0.0,
             registrationDeltaPerYear = fixedPhone.registration ?: 0.0,
-            expectedAnnualDashMiles = fixedPhone.dashMi ?: UserEconomy.DEFAULT_ANNUAL_DASH_MI,
+            expectedAnnualMiles = fixedPhone.annualMi ?: UserEconomy.DEFAULT_ANNUAL_MI,
             phonePlanTotal = fixedPhone.phoneTotal ?: UserEconomy.DEFAULT_PHONE_PLAN_TOTAL,
             phonePlanLines = fixedPhone.phoneLines ?: UserEconomy.DEFAULT_PHONE_PLAN_LINES,
-            phoneDashPercent = UserEconomy.DEFAULT_PHONE_DASH_PERCENT, // wired below via separate read
+            phoneBusinessPercent = UserEconomy.DEFAULT_PHONE_BUSINESS_PERCENT, // wired below via separate read
             userSetFields = emptySet(), // populated by mergeUserSetFields below
         )
     }
-    // Wire userSetFields + phoneDashPercent on top — combine has a 5-arg max so we
+    // Wire userSetFields + phoneBusinessPercent on top — combine has a 5-arg max so we
     // do it as a final transform.
-    .combine(dataSource.phoneDashPercent) { eco, phoneDashPct ->
-        eco.copy(phoneDashPercent = phoneDashPct ?: UserEconomy.DEFAULT_PHONE_DASH_PERCENT)
+    .combine(dataSource.phoneBusinessPercent) { eco, phoneBusinessPct ->
+        eco.copy(phoneBusinessPercent = phoneBusinessPct ?: UserEconomy.DEFAULT_PHONE_BUSINESS_PERCENT)
     }
     .combine(dataSource.userSetEconomyFields) { eco, savedNames ->
         eco.copy(userSetFields = parseUserSetFields(savedNames))
@@ -167,19 +167,15 @@ class AppPreferencesRepository @Inject constructor(
     private data class FixedAndPhoneTuple(
         val insurance: Double?,
         val registration: Double?,
-        val dashMi: Double?,
+        val annualMi: Double?,
         val phoneTotal: Double?,
         val phoneLines: Int?,
     )
 
+    // EconomyField owns its own legacy-name aliasing (#469) — see
+    // EconomyField.fromPersistedName.
     private fun parseUserSetFields(names: Set<String>): Set<EconomyField> =
-        names.mapNotNull { name ->
-            try {
-                EconomyField.valueOf(name)
-            } catch (_: IllegalArgumentException) {
-                null
-            }
-        }.toSet()
+        names.mapNotNull(EconomyField::fromPersistedName).toSet()
 
     // ============================================================================================
     // WRITE ACTIONS
@@ -221,8 +217,8 @@ class AppPreferencesRepository @Inject constructor(
     suspend fun updateRegistrationDelta(perYear: Double) =
         dataSource.updateRegistrationDelta(perYear)
 
-    suspend fun updateExpectedAnnualDashMi(miles: Double) =
-        dataSource.updateExpectedAnnualDashMi(miles)
+    suspend fun updateExpectedAnnualMi(miles: Double) =
+        dataSource.updateExpectedAnnualMi(miles)
 
     suspend fun updatePhonePlan(total: Double, lines: Int, dashPercent: Double) =
         dataSource.updatePhonePlan(total, lines, dashPercent)

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/strategy/StrategyRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/strategy/StrategyRepository.kt
@@ -45,7 +45,7 @@ class StrategyRepository @Inject constructor(
     // ============================================================================================
     val evidenceConfig = combine(
         dataSource.evidenceMaster, dataSource.evidenceOffers,
-        dataSource.evidenceDelivery, dataSource.evidenceDash
+        dataSource.evidenceDelivery, dataSource.evidenceSession
     ) { master, offers, delivery, dash ->
         EvidenceConfig(master, offers, delivery, dash)
     }.stateIn(scope, SharingStarted.Eagerly, EvidenceConfig())

--- a/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/settings/AppPreferencesDataSource.kt
+++ b/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/settings/AppPreferencesDataSource.kt
@@ -55,12 +55,12 @@ class AppPreferencesDataSource @Inject constructor(
         // Fixed costs (amortized via expected annual dash miles)
         val INSURANCE_DELTA_PER_MONTH = doublePreferencesKey("insurance_delta_per_month")
         val REGISTRATION_DELTA_PER_YEAR = doublePreferencesKey("registration_delta_per_year")
-        val EXPECTED_ANNUAL_DASH_MI = doublePreferencesKey("expected_annual_dash_mi")
+        val EXPECTED_ANNUAL_MI = doublePreferencesKey("expected_annual_dash_mi")
 
         // Phone & data (not vehicle-driven)
         val PHONE_PLAN_TOTAL = doublePreferencesKey("phone_plan_total")
         val PHONE_PLAN_LINES = intPreferencesKey("phone_plan_lines")
-        val PHONE_DASH_PERCENT = doublePreferencesKey("phone_dash_percent")
+        val PHONE_BUSINESS_PERCENT = doublePreferencesKey("phone_dash_percent")
 
         // Time constants (newly persisted)
         val AVG_MIN_PER_MILE = doublePreferencesKey("avg_min_per_mile")
@@ -114,11 +114,11 @@ class AppPreferencesDataSource @Inject constructor(
 
     val insuranceDeltaPerMonth: Flow<Double?> = ds.data.map { it[Keys.INSURANCE_DELTA_PER_MONTH] }
     val registrationDeltaPerYear: Flow<Double?> = ds.data.map { it[Keys.REGISTRATION_DELTA_PER_YEAR] }
-    val expectedAnnualDashMi: Flow<Double?> = ds.data.map { it[Keys.EXPECTED_ANNUAL_DASH_MI] }
+    val expectedAnnualMi: Flow<Double?> = ds.data.map { it[Keys.EXPECTED_ANNUAL_MI] }
 
     val phonePlanTotal: Flow<Double?> = ds.data.map { it[Keys.PHONE_PLAN_TOTAL] }
     val phonePlanLines: Flow<Int?> = ds.data.map { it[Keys.PHONE_PLAN_LINES] }
-    val phoneDashPercent: Flow<Double?> = ds.data.map { it[Keys.PHONE_DASH_PERCENT] }
+    val phoneBusinessPercent: Flow<Double?> = ds.data.map { it[Keys.PHONE_BUSINESS_PERCENT] }
 
     val avgMinPerMile: Flow<Double?> = ds.data.map { it[Keys.AVG_MIN_PER_MILE] }
     val basePickupMin: Flow<Double?> = ds.data.map { it[Keys.BASE_PICKUP_MIN] }
@@ -240,11 +240,11 @@ class AppPreferencesDataSource @Inject constructor(
         }
     }
 
-    suspend fun updateExpectedAnnualDashMi(miles: Double) {
+    suspend fun updateExpectedAnnualMi(miles: Double) {
         ds.edit {
-            it[Keys.EXPECTED_ANNUAL_DASH_MI] = miles
+            it[Keys.EXPECTED_ANNUAL_MI] = miles
             it[Keys.USER_SET_ECONOMY_FIELDS] = (it[Keys.USER_SET_ECONOMY_FIELDS] ?: emptySet()) +
-                setOf("EXPECTED_ANNUAL_DASH_MI")
+                setOf("EXPECTED_ANNUAL_MI")
         }
     }
 
@@ -252,9 +252,9 @@ class AppPreferencesDataSource @Inject constructor(
         ds.edit {
             it[Keys.PHONE_PLAN_TOTAL] = total
             it[Keys.PHONE_PLAN_LINES] = lines
-            it[Keys.PHONE_DASH_PERCENT] = dashPercent
+            it[Keys.PHONE_BUSINESS_PERCENT] = dashPercent
             it[Keys.USER_SET_ECONOMY_FIELDS] = (it[Keys.USER_SET_ECONOMY_FIELDS] ?: emptySet()) +
-                setOf("PHONE_PLAN_TOTAL", "PHONE_PLAN_LINES", "PHONE_DASH_PERCENT")
+                setOf("PHONE_PLAN_TOTAL", "PHONE_PLAN_LINES", "PHONE_BUSINESS_PERCENT")
         }
     }
 
@@ -280,10 +280,10 @@ class AppPreferencesDataSource @Inject constructor(
             it.remove(Keys.PURCHASE_PRICE); it.remove(Keys.TOTAL_LIFETIME_MI)
             it.remove(Keys.INSURANCE_DELTA_PER_MONTH)
             it.remove(Keys.REGISTRATION_DELTA_PER_YEAR)
-            it.remove(Keys.EXPECTED_ANNUAL_DASH_MI)
+            it.remove(Keys.EXPECTED_ANNUAL_MI)
             it.remove(Keys.PHONE_PLAN_TOTAL)
             it.remove(Keys.PHONE_PLAN_LINES)
-            it.remove(Keys.PHONE_DASH_PERCENT)
+            it.remove(Keys.PHONE_BUSINESS_PERCENT)
             it.remove(Keys.AVG_MIN_PER_MILE)
             it.remove(Keys.BASE_PICKUP_MIN)
         }

--- a/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/strategy/StrategyDataSource.kt
+++ b/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/strategy/StrategyDataSource.kt
@@ -26,7 +26,7 @@ class StrategyDataSource @Inject constructor(
         val EVIDENCE_MASTER = booleanPreferencesKey("evidence_master_enabled")
         val EVIDENCE_OFFERS = booleanPreferencesKey("evidence_save_offers")
         val EVIDENCE_DELIVERY = booleanPreferencesKey("evidence_save_delivery_summary")
-        val EVIDENCE_DASH = booleanPreferencesKey("evidence_save_dash_summary")
+        val EVIDENCE_SESSION = booleanPreferencesKey("evidence_save_dash_summary")
 
         val AUTO_MASTER = booleanPreferencesKey("auto_master_enabled")
 
@@ -46,7 +46,7 @@ class StrategyDataSource @Inject constructor(
     val evidenceMaster: Flow<Boolean> = ds.data.map { it[Keys.EVIDENCE_MASTER] ?: EvidenceConfig.DEFAULT_MASTER }
     val evidenceOffers: Flow<Boolean> = ds.data.map { it[Keys.EVIDENCE_OFFERS] ?: EvidenceConfig.DEFAULT_SAVE_OFFERS }
     val evidenceDelivery: Flow<Boolean> = ds.data.map { it[Keys.EVIDENCE_DELIVERY] ?: EvidenceConfig.DEFAULT_SAVE_DELIVERIES }
-    val evidenceDash: Flow<Boolean> = ds.data.map { it[Keys.EVIDENCE_DASH] ?: EvidenceConfig.DEFAULT_SAVE_DASHES }
+    val evidenceSession: Flow<Boolean> = ds.data.map { it[Keys.EVIDENCE_SESSION] ?: EvidenceConfig.DEFAULT_SAVE_SESSIONS }
 
     val autoMaster: Flow<Boolean> = ds.data.map { it[Keys.AUTO_MASTER] ?: OfferAutomationConfig.DEFAULT_MASTER }
 
@@ -90,7 +90,7 @@ class StrategyDataSource @Inject constructor(
         ds.edit { prefs ->
             prefs[Keys.EVIDENCE_OFFERS] = offers
             prefs[Keys.EVIDENCE_DELIVERY] = delivery
-            prefs[Keys.EVIDENCE_DASH] = dash
+            prefs[Keys.EVIDENCE_SESSION] = dash
         }
     }
 

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -381,7 +381,7 @@ class EffectMap @Inject constructor() {
                         add(
                             AppEffect.CaptureScreenshot(
                                 "DashSummary - ${endParsed.totalEarnings}",
-                                category = EvidenceCategory.DASH_SUMMARY,
+                                category = EvidenceCategory.SESSION_SUMMARY,
                             ),
                         )
                     } else {

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/config/EvidenceConfig.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/config/EvidenceConfig.kt
@@ -4,7 +4,7 @@ data class EvidenceConfig(
     val masterEnabled: Boolean = DEFAULT_MASTER,
     val saveOffers: Boolean = DEFAULT_SAVE_OFFERS,
     val saveDeliverySummaries: Boolean = DEFAULT_SAVE_DELIVERIES,
-    val saveDashSummaries: Boolean = DEFAULT_SAVE_DASHES,
+    val saveSessionSummaries: Boolean = DEFAULT_SAVE_SESSIONS,
 ) {
     /**
      * THE evidence-capture policy (#426): a screenshot fires only when the
@@ -15,7 +15,7 @@ data class EvidenceConfig(
     fun allows(category: EvidenceCategory?): Boolean = masterEnabled && when (category) {
         EvidenceCategory.OFFER -> saveOffers
         EvidenceCategory.DELIVERY_SUMMARY -> saveDeliverySummaries
-        EvidenceCategory.DASH_SUMMARY -> saveDashSummaries
+        EvidenceCategory.SESSION_SUMMARY -> saveSessionSummaries
         null -> false
     }
 
@@ -24,7 +24,7 @@ data class EvidenceConfig(
         const val DEFAULT_MASTER = false
         const val DEFAULT_SAVE_OFFERS = true
         const val DEFAULT_SAVE_DELIVERIES = true
-        const val DEFAULT_SAVE_DASHES = true
+        const val DEFAULT_SAVE_SESSIONS = true
     }
 }
 
@@ -38,7 +38,7 @@ data class EvidenceConfig(
 enum class EvidenceCategory(val wire: String) {
     OFFER("offer"),
     DELIVERY_SUMMARY("delivery_summary"),
-    DASH_SUMMARY("dash_summary"),
+    SESSION_SUMMARY("dash_summary"),
     ;
 
     companion object {

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/config/OfferStrategy.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/config/OfferStrategy.kt
@@ -1,4 +1,4 @@
 package cloud.trotter.dashbuddy.domain.config
 
 /** Defines the core behavior of the DashBuddy automation pipeline. */
-enum class DashStrategy { CHERRY_PICKER, PROTECT_PLATINUM, MANUAL }
+enum class OfferStrategy { CHERRY_PICKER, PROTECT_PLATINUM, MANUAL }

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/EconomyField.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/EconomyField.kt
@@ -30,8 +30,30 @@ enum class EconomyField {
     TOTAL_LIFETIME_MI,
     INSURANCE_DELTA,
     REGISTRATION_DELTA,
-    EXPECTED_ANNUAL_DASH_MI,
+    EXPECTED_ANNUAL_MI,
     PHONE_PLAN_TOTAL,
     PHONE_PLAN_LINES,
-    PHONE_DASH_PERCENT,
+    PHONE_BUSINESS_PERCENT,
+    ;
+
+    companion object {
+        /**
+         * #469: two constants were de-dashed (`EXPECTED_ANNUAL_DASH_MI`,
+         * `PHONE_DASH_PERCENT`). The persisted `USER_SET_ECONOMY_FIELDS` set on
+         * existing installs may still hold those legacy names — map them forward
+         * so the dasher's "user-set" markers don't silently reset.
+         */
+        private val LEGACY_NAMES = mapOf(
+            "EXPECTED_ANNUAL_DASH_MI" to EXPECTED_ANNUAL_MI,
+            "PHONE_DASH_PERCENT" to PHONE_BUSINESS_PERCENT,
+        )
+
+        /**
+         * Resolve a name persisted in `USER_SET_ECONOMY_FIELDS` back to a field,
+         * honoring legacy (pre-#469) names. Returns null for names no current
+         * build knows (forward-compat: a value written by a newer build).
+         */
+        fun fromPersistedName(name: String): EconomyField? =
+            LEGACY_NAMES[name] ?: entries.firstOrNull { it.name == name }
+    }
 }

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/UserEconomy.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/UserEconomy.kt
@@ -12,7 +12,7 @@ import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleClass
  * subtraction: `netPay = grossPay - distance * operatingCostPerMile`.
  *
  * Time-fixed costs (insurance, registration, phone) are amortized via
- * [expectedAnnualDashMiles] — the user's estimate of how many miles per year
+ * [expectedAnnualMiles] — the user's estimate of how many miles per year
  * they expect to dash. Fixed-cost per-mile = (annual cost) / annual dash miles.
  *
  * Defaults come from the selected [vehicleClass]'s preset values. Switching
@@ -51,16 +51,16 @@ data class UserEconomy(
     val purchasePrice: Double = 0.0,
     val totalLifetimeMi: Double = 1.0,
 
-    // Fixed costs (amortized via expectedAnnualDashMiles)
+    // Fixed costs (amortized via expectedAnnualMiles)
     val insuranceDeltaPerMonth: Double = 0.0,
     val registrationDeltaPerYear: Double = 0.0,
-    val expectedAnnualDashMiles: Double = DEFAULT_ANNUAL_DASH_MI,
+    val expectedAnnualMiles: Double = DEFAULT_ANNUAL_MI,
 
     // Phone & data (NOT driven by VehicleClass; stored separately). Domain
     // default is zero plan cost — production populates via repository.
     val phonePlanTotal: Double = 0.0,
     val phonePlanLines: Int = 1,
-    val phoneDashPercent: Double = 0.0,
+    val phoneBusinessPercent: Double = 0.0,
 
     /** Which [EconomyField]s the user has explicitly set. The rest are class defaults. */
     val userSetFields: Set<EconomyField> = emptySet(),
@@ -77,13 +77,13 @@ data class UserEconomy(
     val depreciationCostPerMile: Double =
         if (includeDepreciation) purchasePrice / totalLifetimeMi.coerceAtLeast(1.0) else 0.0
     val insuranceCostPerMile: Double =
-        (insuranceDeltaPerMonth * 12.0) / expectedAnnualDashMiles.coerceAtLeast(1.0)
+        (insuranceDeltaPerMonth * 12.0) / expectedAnnualMiles.coerceAtLeast(1.0)
     val registrationCostPerMile: Double =
-        registrationDeltaPerYear / expectedAnnualDashMiles.coerceAtLeast(1.0)
+        registrationDeltaPerYear / expectedAnnualMiles.coerceAtLeast(1.0)
     val phoneCostPerMile: Double = run {
         val yourLineShare = phonePlanTotal / phonePlanLines.coerceAtLeast(1)
-        val dashingMonthly = yourLineShare * (phoneDashPercent / 100.0)
-        (dashingMonthly * 12.0) / expectedAnnualDashMiles.coerceAtLeast(1.0)
+        val dashingMonthly = yourLineShare * (phoneBusinessPercent / 100.0)
+        (dashingMonthly * 12.0) / expectedAnnualMiles.coerceAtLeast(1.0)
     }
 
     val nonFuelCostPerMile: Double
@@ -104,9 +104,9 @@ data class UserEconomy(
 
         const val DEFAULT_MINUTES_PER_MILE = 2.5
         const val DEFAULT_BASE_PICKUP_MINUTES = 7.0
-        const val DEFAULT_ANNUAL_DASH_MI = 10_000.0
+        const val DEFAULT_ANNUAL_MI = 10_000.0
         const val DEFAULT_PHONE_PLAN_TOTAL = 80.0
         const val DEFAULT_PHONE_PLAN_LINES = 1
-        const val DEFAULT_PHONE_DASH_PERCENT = 30.0
+        const val DEFAULT_PHONE_BUSINESS_PERCENT = 30.0
     }
 }

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/config/EvidenceConfigTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/config/EvidenceConfigTest.kt
@@ -16,7 +16,7 @@ class EvidenceConfigTest {
         masterEnabled = true,
         saveOffers = true,
         saveDeliverySummaries = true,
-        saveDashSummaries = true,
+        saveSessionSummaries = true,
     )
 
     @Test
@@ -41,7 +41,7 @@ class EvidenceConfigTest {
         val config = allOn.copy(saveDeliverySummaries = false)
         assertTrue(config.allows(EvidenceCategory.OFFER))
         assertFalse(config.allows(EvidenceCategory.DELIVERY_SUMMARY))
-        assertTrue(config.allows(EvidenceCategory.DASH_SUMMARY))
+        assertTrue(config.allows(EvidenceCategory.SESSION_SUMMARY))
     }
 
     @Test

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/evaluation/EconomyFieldTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/evaluation/EconomyFieldTest.kt
@@ -1,0 +1,32 @@
+package cloud.trotter.dashbuddy.domain.evaluation
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/** #469: the persisted-name aliasing that keeps a dasher's user-set markers
+ *  alive across the de-dash rename. */
+class EconomyFieldTest {
+
+    @Test
+    fun `current constant names resolve to themselves`() {
+        EconomyField.entries.forEach { field ->
+            assertEquals(field, EconomyField.fromPersistedName(field.name))
+        }
+    }
+
+    @Test
+    fun `legacy pre-469 names map forward to the renamed constants`() {
+        // These two strings were persisted into USER_SET_ECONOMY_FIELDS by
+        // builds before #469. They must still resolve, or the dasher's
+        // "user-set" badge for those fields silently resets to default.
+        assertEquals(EconomyField.EXPECTED_ANNUAL_MI, EconomyField.fromPersistedName("EXPECTED_ANNUAL_DASH_MI"))
+        assertEquals(EconomyField.PHONE_BUSINESS_PERCENT, EconomyField.fromPersistedName("PHONE_DASH_PERCENT"))
+    }
+
+    @Test
+    fun `unknown names resolve to null instead of throwing`() {
+        assertNull(EconomyField.fromPersistedName("SOME_FUTURE_FIELD"))
+        assertNull(EconomyField.fromPersistedName(""))
+    }
+}

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/evaluation/OfferEvaluatorTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/evaluation/OfferEvaluatorTest.kt
@@ -718,9 +718,9 @@ class OfferEvaluatorTest {
             includeDepreciation = true,
             purchasePrice = 28_000.0, totalLifetimeMi = 200_000.0, // depr: $0.14/mi → $1.40
             insuranceDeltaPerMonth = 30.0,
-            expectedAnnualDashMiles = 10_000.0,                    // insurance: $0.036/mi → $0.36
+            expectedAnnualMiles = 10_000.0,                    // insurance: $0.036/mi → $0.36
             registrationDeltaPerYear = 100.0,                      // reg: $0.01/mi → $0.10
-            phonePlanTotal = 80.0, phonePlanLines = 4, phoneDashPercent = 30.0, // phone: $0.0072/mi → $0.072
+            phonePlanTotal = 80.0, phonePlanLines = 4, phoneBusinessPercent = 30.0, // phone: $0.0072/mi → $0.072
         )
         val cfg = EvaluationConfig(rules = listOf(metricRule(MetricType.PAYOUT, 10.0f)), userEconomy = economy)
         val result = evaluator.evaluate(offer(pay = 10.0, dist = 10.0), cfg)
@@ -750,7 +750,7 @@ class OfferEvaluatorTest {
         val economy = UserEconomy(
             vehicleClass = VehicleClass.SEDAN,
             insuranceDeltaPerMonth = 30.0,
-            expectedAnnualDashMiles = 10_000.0,
+            expectedAnnualMiles = 10_000.0,
         )
         val cfg = EvaluationConfig(rules = listOf(metricRule(MetricType.PAYOUT, 10.0f)), userEconomy = economy)
         val result = evaluator.evaluate(offer(pay = 10.0, dist = 5.0), cfg)
@@ -763,7 +763,7 @@ class OfferEvaluatorTest {
         val economy = UserEconomy(
             vehicleClass = VehicleClass.SEDAN,
             registrationDeltaPerYear = 100.0,
-            expectedAnnualDashMiles = 10_000.0,
+            expectedAnnualMiles = 10_000.0,
         )
         val cfg = EvaluationConfig(rules = listOf(metricRule(MetricType.PAYOUT, 10.0f)), userEconomy = economy)
         val result = evaluator.evaluate(offer(pay = 10.0, dist = 5.0), cfg)
@@ -778,8 +778,8 @@ class OfferEvaluatorTest {
             vehicleClass = VehicleClass.SEDAN,
             phonePlanTotal = 80.0,
             phonePlanLines = 4,
-            phoneDashPercent = 30.0,
-            expectedAnnualDashMiles = 10_000.0,
+            phoneBusinessPercent = 30.0,
+            expectedAnnualMiles = 10_000.0,
         )
         val cfg = EvaluationConfig(rules = listOf(metricRule(MetricType.PAYOUT, 10.0f)), userEconomy = economy)
         val result = evaluator.evaluate(offer(pay = 10.0, dist = 10.0), cfg)
@@ -789,20 +789,20 @@ class OfferEvaluatorTest {
     @Test
     fun `operating cost - phone not affected by vehicle class change`() {
         // Same phone setup; only the vehicleClass differs. Phone cost should be identical.
-        val sedanEco = UserEconomy(vehicleClass = VehicleClass.SEDAN, phonePlanTotal = 100.0, phoneDashPercent = 50.0)
-        val truckEco = UserEconomy(vehicleClass = VehicleClass.TRUCK, phonePlanTotal = 100.0, phoneDashPercent = 50.0)
+        val sedanEco = UserEconomy(vehicleClass = VehicleClass.SEDAN, phonePlanTotal = 100.0, phoneBusinessPercent = 50.0)
+        val truckEco = UserEconomy(vehicleClass = VehicleClass.TRUCK, phonePlanTotal = 100.0, phoneBusinessPercent = 50.0)
         assertEquals(sedanEco.phoneCostPerMile, truckEco.phoneCostPerMile, 0.0001)
     }
 
     @Test
     fun `operating cost - zero expected annual dash miles does not divide by zero`() {
-        // expectedAnnualDashMiles = 0 should be coerced; result must be finite.
+        // expectedAnnualMiles = 0 should be coerced; result must be finite.
         val economy = UserEconomy(
             vehicleClass = VehicleClass.SEDAN,
             insuranceDeltaPerMonth = 30.0,
             registrationDeltaPerYear = 100.0,
             phonePlanTotal = 80.0,
-            expectedAnnualDashMiles = 0.0,
+            expectedAnnualMiles = 0.0,
         )
         val cfg = EvaluationConfig(rules = listOf(metricRule(MetricType.PAYOUT, 10.0f)), userEconomy = economy)
         val result = evaluator.evaluate(offer(pay = 10.0, dist = 5.0), cfg)


### PR DESCRIPTION
## Summary

Second #469 slice: the domain **config / economy / evidence** vocabulary. Symbol renames only — every persisted contract is preserved byte-for-byte, and the one persisted-by-name marker set carries a forward-migration.

| Before | After |
|---|---|
| `DashStrategy` | `OfferStrategy` (your pick — it governs offer acceptance) |
| `UserEconomy.expectedAnnualDashMiles` | `expectedAnnualMiles` |
| `UserEconomy.phoneDashPercent` | `phoneBusinessPercent` (your pick) |
| `EconomyField.EXPECTED_ANNUAL_DASH_MI` / `PHONE_DASH_PERCENT` | `EXPECTED_ANNUAL_MI` / `PHONE_BUSINESS_PERCENT` |
| `EvidenceConfig.saveDashSummaries` | `saveSessionSummaries` |
| `evidenceDash` / `EVIDENCE_DASH` | `evidenceSession` / `EVIDENCE_SESSION` |
| `EvidenceCategory.DASH_SUMMARY` | `SESSION_SUMMARY` |

## Persisted contracts preserved (NOT changed)
- DataStore key **strings** `"expected_annual_dash_mi"`, `"phone_dash_percent"`, `"evidence_save_dash_summary"` — only the Kotlin `val` names changed.
- `EvidenceCategory` **wire** `"dash_summary"` — still emitted by the rule JSON and matched by `fromWire()`.
- `OfferStrategy` round-trips through the unchanged boolean strategy keys; the enum is never persisted by type name.

## Migration
Two `EconomyField` constants are persisted **by name** into `USER_SET_ECONOMY_FIELDS` via `valueOf`. `EconomyField.fromPersistedName()` now owns the legacy-name aliasing so a pre-#469 install's "user-set" markers don't silently reset (new writes already use the new names). `EconomyFieldTest` locks this in.

## Verification
Ran a **5-dimension adversarial contract audit** (DataStore key strings, the user-set-fields migration, the evidence wire, the strategy enum, completeness) — all returned **safe**, no must-fix; the two load-bearing claims were independently re-verified against `git show master`. Full `testDebugUnitTest` green.

**#469 stays open** for slice 3 (the `startingDash` parse-field — a rule-output contract that needs the parse golden regenerated in lockstep).