### PR TITLE
fix(recognition): branch dropoff_pre_arrival to match the "Delivery for" arrival card (#462/#460)

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/DefaultRulesIntegrationTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/DefaultRulesIntegrationTest.kt
@@ -261,6 +261,47 @@ class DefaultRulesIntegrationTest {
         )
     }
 
+    @Test
+    fun `7-Eleven 'Delivery for' dropoff arrival card is a dropoff_pre_arrival branch — but the alcohol variant stays blocked (#462 vs #463)`() {
+        // The arrival detail card uses "Delivery for" (name in a sibling node) +
+        // "Hand it to recipient", not the "Deliver to <name>" form the rule
+        // originally keyed on, so it fell to UNKNOWN. It must now branch into
+        // dropoff_pre_arrival.
+        val arrivalCard = UiNode(
+            children = listOf(
+                UiNode(text = "Deliver by 20:04"),
+                UiNode(text = "Delivery for"),
+                UiNode(text = "Sample C"),
+                UiNode(text = "100 Sample St, San Antonio, TX 78000, USA"),
+                UiNode(text = "Directions"),
+                UiNode(text = "Hand it to recipient"),
+            ),
+        ).restoreParents()
+        val card = screenRuleset.matchFirst(arrivalCard, platformWire = "doordash")
+        assertEquals(
+            "the 'Delivery for' dropoff arrival card must branch into dropoff_pre_arrival (got ${card?.ruleId})",
+            "doordash.screen.dropoff_pre_arrival", card?.ruleId,
+        )
+
+        // The alcohol variant of the SAME card carries the priority-0 identity/
+        // signature banner — it must stay blocked, never reach the dropoff branch.
+        val alcoholVariant = UiNode(
+            children = listOf(
+                UiNode(text = "Deliver by 20:04"),
+                UiNode(text = "Delivery for"),
+                UiNode(text = "Sample C"),
+                UiNode(text = "Hand it to recipient"),
+                UiNode(text = "Verify the recipient's identity and collect a signature at dropoff"),
+                UiNode(text = "Remember, you’re required by law to confirm the recipient's identity before handing over the order."),
+            ),
+        ).restoreParents()
+        val blocked = screenRuleset.matchFirst(alcoholVariant, platformWire = "doordash")
+        assertTrue(
+            "the alcohol arrival variant must stay sensitive-blocked (got ${blocked?.ruleId})",
+            blocked?.ruleId?.contains("sensitive") == true,
+        )
+    }
+
     // =========================================================================
     // Parse-output regression on real captures (#433)
     // =========================================================================

--- a/app/src/test/resources/snapshots/approved-parse-output.json
+++ b/app/src/test/resources/snapshots/approved-parse-output.json
@@ -1488,6 +1488,27 @@
         "shape": null,
         "fields": {}
     },
+    "dropoff_pre_arrival/2026-06-12__doordash__dropoff_pre_arrival_711__335996.json": {
+        "ruleId": "doordash.screen.dropoff_pre_arrival",
+        "intent": "dropoff_pre_arrival",
+        "shape": "task",
+        "fields": {
+            "arrivalConfirmed": false,
+            "customerAddressHash": null,
+            "customerNameHash": "75adb7969770f4910879f8d929335ac1f2b5c66adc3574bccaa4cdab310f690d",
+            "deadline": {
+                "text": "20:04",
+                "time": 1780344240000
+            },
+            "itemsRemaining": null,
+            "itemsShopped": null,
+            "phase": "DROPOFF",
+            "redCardTotal": null,
+            "storeAddress": null,
+            "storeName": null,
+            "subFlow": "NAVIGATION"
+        }
+    },
     "dropoff_pre_arrival/20260128_180652_578_DROPOFF_DETAILS_PRE_ARRIVAL.json": {
         "ruleId": "doordash.screen.dropoff_pre_arrival",
         "intent": "dropoff_pre_arrival",

--- a/app/src/test/resources/snapshots/dropoff_pre_arrival/2026-06-12__doordash__dropoff_pre_arrival_711__335996.json
+++ b/app/src/test/resources/snapshots/dropoff_pre_arrival/2026-06-12__doordash__dropoff_pre_arrival_711__335996.json
@@ -1,0 +1,699 @@
+{
+    "captureId": "9b357537-864d-4ea6-aa0d-d0a1d357ce61",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1781312726209,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 136,
+                            "right": 1080,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 136,
+                                    "right": 1080,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 136,
+                                            "right": 1080,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/container",
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 136,
+                                                    "right": 1080,
+                                                    "bottom": 2347
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/toolbar_container",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 278
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/toolbar",
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 136,
+                                                                    "right": 1080,
+                                                                    "bottom": 278
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "desc": "Current dash",
+                                                                        "class": "android.widget.ImageButton",
+                                                                        "isClickable": true,
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 144,
+                                                                            "right": 125,
+                                                                            "bottom": 269
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "text": "Deliver by 20:04",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 133,
+                                                                            "top": 182,
+                                                                            "right": 442,
+                                                                            "bottom": 232
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "class": "androidx.appcompat.widget.LinearLayoutCompat",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 866,
+                                                                            "top": 144,
+                                                                            "right": 1080,
+                                                                            "bottom": 269
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "desc": "Safety",
+                                                                                "id": "com.doordash.driverapp:id/action_dasher_safety",
+                                                                                "class": "android.widget.Button",
+                                                                                "isClickable": true,
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 866,
+                                                                                    "top": 153,
+                                                                                    "right": 973,
+                                                                                    "bottom": 260
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "desc": "Help",
+                                                                                "id": "com.doordash.driverapp:id/action_self_help",
+                                                                                "class": "android.widget.Button",
+                                                                                "isClickable": true,
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 973,
+                                                                                    "top": 153,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 260
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 278,
+                                                            "right": 1080,
+                                                            "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/fragment",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 278,
+                                                                    "right": 1080,
+                                                                    "bottom": 2347
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/drop_off_container",
+                                                                        "class": "android.view.ViewGroup",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 278,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/main_view_container",
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 278,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2347
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/map_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 278,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2347
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 278,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2347
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.TextureView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 278,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2347
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 278,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2347
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "class": "android.widget.ImageView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 1496,
+                                                                                                            "right": 189,
+                                                                                                            "bottom": 1543
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "class": "android.widget.ImageView",
+                                                                                                        "isClickable": true,
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 195,
+                                                                                                            "top": 1496,
+                                                                                                            "right": 242,
+                                                                                                            "bottom": 1543
+                                                                                                        }
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/dash_total_pay",
+                                                                                        "class": "android.widget.LinearLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 844,
+                                                                                            "top": 296,
+                                                                                            "right": 1062,
+                                                                                            "bottom": 430
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "$0.00",
+                                                                                                "id": "com.doordash.driverapp:id/running_total_pay",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 880,
+                                                                                                    "top": 314,
+                                                                                                    "right": 1026,
+                                                                                                    "bottom": 366
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "this dash",
+                                                                                                "id": "com.doordash.driverapp:id/text_pay",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 880,
+                                                                                                    "top": 370,
+                                                                                                    "right": 1026,
+                                                                                                    "bottom": 412
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/drop_off_bottom_sheet_container",
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 428,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2347
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/bottom_sheet_handle",
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 482,
+                                                                                            "top": 446,
+                                                                                            "right": 562,
+                                                                                            "bottom": 455
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/drop_off_recycler_view",
+                                                                                        "class": "androidx.recyclerview.widget.RecyclerView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 473,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2347
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 473,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 624
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "text": "Delivery for",
+                                                                                                        "id": "com.doordash.driverapp:id/user_name_label",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 36,
+                                                                                                            "top": 475,
+                                                                                                            "right": 246,
+                                                                                                            "bottom": 522
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "text": "Sample C",
+                                                                                                        "id": "com.doordash.driverapp:id/user_name",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 36,
+                                                                                                            "top": 522,
+                                                                                                            "right": 767,
+                                                                                                            "bottom": 588
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/call_button",
+                                                                                                        "class": "android.widget.ImageButton",
+                                                                                                        "isClickable": true,
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 803,
+                                                                                                            "top": 487,
+                                                                                                            "right": 892,
+                                                                                                            "bottom": 576
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/text_button",
+                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                        "isClickable": true,
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 928,
+                                                                                                            "top": 447,
+                                                                                                            "right": 1044,
+                                                                                                            "bottom": 563
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.doordash.driverapp:id/chat_button_internal",
+                                                                                                                "class": "android.widget.ImageButton",
+                                                                                                                "isClickable": true,
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 943,
+                                                                                                                    "top": 462,
+                                                                                                                    "right": 1030,
+                                                                                                                    "bottom": 549
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 624,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 1006
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/address_divider",
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 599,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 601
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/address_spacing",
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 579,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 615
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/ic_address",
+                                                                                                        "class": "android.widget.ImageView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 36,
+                                                                                                            "top": 615,
+                                                                                                            "right": 89,
+                                                                                                            "bottom": 668
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "text": "Sample Complex",
+                                                                                                        "id": "com.doordash.driverapp:id/address_line_1",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 125,
+                                                                                                            "top": 615,
+                                                                                                            "right": 937,
+                                                                                                            "bottom": 657
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "text": "100 Sample St, San Antonio, TX 78000, USA",
+                                                                                                        "id": "com.doordash.driverapp:id/address_line_2",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 125,
+                                                                                                            "top": 639,
+                                                                                                            "right": 955,
+                                                                                                            "bottom": 741
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/expand_button",
+                                                                                                        "class": "android.widget.ImageView",
+                                                                                                        "isClickable": true,
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 973,
+                                                                                                            "top": 597,
+                                                                                                            "right": 1062,
+                                                                                                            "bottom": 650
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "text": "Apt/Suite: 0000",
+                                                                                                        "id": "com.doordash.driverapp:id/address_subpremise_line",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 125,
+                                                                                                            "top": 728,
+                                                                                                            "right": 1044,
+                                                                                                            "bottom": 775
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/directions_button",
+                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                        "isClickable": true,
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 125,
+                                                                                                            "top": 811,
+                                                                                                            "right": 490,
+                                                                                                            "bottom": 892
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.doordash.driverapp:id/action_icon",
+                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 179,
+                                                                                                                    "top": 829,
+                                                                                                                    "right": 224,
+                                                                                                                    "bottom": 874
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "Directions",
+                                                                                                                "id": "com.doordash.driverapp:id/action_text",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 242,
+                                                                                                                    "top": 811,
+                                                                                                                    "right": 436,
+                                                                                                                    "bottom": 892
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "androidx.recyclerview.widget.RecyclerView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 892,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 980
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 124,
+                                                                                                            "top": 916,
+                                                                                                            "right": 195,
+                                                                                                            "bottom": 969
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.doordash.driverapp:id/icon",
+                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 124,
+                                                                                                                    "top": 916,
+                                                                                                                    "right": 177,
+                                                                                                                    "bottom": 969
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 969,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 1016
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "text": "More information available",
+                                                                                                        "id": "com.doordash.driverapp:id/additional_info_text",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 125,
+                                                                                                            "top": 952,
+                                                                                                            "right": 955,
+                                                                                                            "bottom": 999
+                                                                                                        }
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 996,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 1187
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/dasher_instructions_tags",
+                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 125,
+                                                                                                            "top": 1061,
+                                                                                                            "right": 125,
+                                                                                                            "bottom": 1061
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/ic_instructions",
+                                                                                                        "class": "android.widget.ImageView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 36,
+                                                                                                            "top": 1074,
+                                                                                                            "right": 89,
+                                                                                                            "bottom": 1127
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "text": "Hand it to recipient",
+                                                                                                        "id": "com.doordash.driverapp:id/instructions_title",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 125,
+                                                                                                            "top": 1079,
+                                                                                                            "right": 1044,
+                                                                                                            "bottom": 1122
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "text": "Hand it to me: ",
+                                                                                                        "id": "com.doordash.driverapp:id/dasher_instruction_content_collapsed",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 125,
+                                                                                                            "top": 1140,
+                                                                                                            "right": 938,
+                                                                                                            "bottom": 1187
+                                                                                                        }
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/core/pipeline/src/main/assets/rules/doordash.json
+++ b/core/pipeline/src/main/assets/rules/doordash.json
@@ -1306,34 +1306,53 @@
         "flow": "task:dropoff:navigation",
         "modeHint": "online"
       },
+      "comment": "Two dropoff layouts (#462/#460): the en-route nav card ('Deliver to <name>' + Directions/Call/Message) and the arrival detail card ('Delivery for' label with the name in a sibling node + 'Hand it to recipient'). The arrival card was dropping to UNKNOWN — its first text is 'Delivery for'/'Deliver by', neither of which startsWith 'Deliver to'. 'Hand it to recipient' is the dropoff-specific discriminator (the pickup card also carries 'Delivery for', so keying on that alone would steal it). The alcohol variant of the arrival card additionally carries the priority-0 sensitive id/signature banner (#463), so it is blocked before reaching here.",
       "require": {
-        "all": [
+        "any": [
           {
-            "exists": {
-              "any": [
-                {
-                  "hasTextStartsWith": "Deliver to"
-                },
-                {
-                  "hasTextStartsWith": "Heading to"
+            "all": [
+              {
+                "exists": {
+                  "any": [
+                    {
+                      "hasTextStartsWith": "Deliver to"
+                    },
+                    {
+                      "hasTextStartsWith": "Heading to"
+                    }
+                  ]
                 }
-              ]
-            }
+              },
+              {
+                "exists": {
+                  "any": [
+                    {
+                      "hasText": "Directions"
+                    },
+                    {
+                      "hasText": "Call"
+                    },
+                    {
+                      "hasText": "Message"
+                    }
+                  ]
+                }
+              }
+            ]
           },
           {
-            "exists": {
-              "any": [
-                {
-                  "hasText": "Directions"
-                },
-                {
-                  "hasText": "Call"
-                },
-                {
-                  "hasText": "Message"
+            "all": [
+              {
+                "exists": {
+                  "hasTextContaining": "Delivery for"
                 }
-              ]
-            }
+              },
+              {
+                "exists": {
+                  "hasText": "Hand it to recipient"
+                }
+              }
+            ]
           }
         ]
       },
@@ -1343,26 +1362,41 @@
           "phase": "DROPOFF",
           "subFlow": "NAVIGATION",
           "customerNameHash": {
-            "find": {
-              "any": [
-                {
-                  "hasTextStartsWith": "Deliver to"
-                },
-                {
-                  "hasTextStartsWith": "Heading to"
-                }
-              ]
-            },
-            "read": "text",
-            "transform": [
+            "coalesce": [
               {
-                "stripPrefixes": [
-                  "Deliver to ",
-                  "Heading to "
+                "find": {
+                  "any": [
+                    {
+                      "hasTextStartsWith": "Deliver to"
+                    },
+                    {
+                      "hasTextStartsWith": "Heading to"
+                    }
+                  ]
+                },
+                "read": "text",
+                "transform": [
+                  {
+                    "stripPrefixes": [
+                      "Deliver to ",
+                      "Heading to "
+                    ]
+                  },
+                  "trim",
+                  "sha256"
                 ]
               },
-              "trim",
-              "sha256"
+              {
+                "find": {
+                  "hasTextContaining": "Delivery for"
+                },
+                "navigate": "sibling(1)",
+                "read": "text",
+                "transform": [
+                  "trim",
+                  "sha256"
+                ]
+              }
             ]
           },
           "customerAddressHash": {

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -82,6 +82,19 @@ _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **bro
   recognition gaps from that dash; the rest are a larger effort.)
   - Confirmed: 0/2
 
+- **"Delivery for <name>" dropoff arrival card now recognized as dropoff_pre_arrival (#462/#460).**
+  The dropoff arrival/detail card (the one with "Delivery for", the customer name, the address,
+  "Directions", and "Hand it to recipient" — e.g. the 7-Eleven order to Adam C) was falling to
+  UNKNOWN: its first text is "Delivery for"/"Deliver by", neither of which the rule's "Deliver to"
+  predicate matched. It's now a branch of `dropoff_pre_arrival` (flow = task:dropoff:navigation),
+  keyed on "Delivery for" + "Hand it to recipient" (dropoff-specific so it won't steal the pickup
+  card). On a dropoff: working = arriving at the customer shows a recognized dropoff screen (not
+  UNKNOWN) and the flow is on dropoff; the customer name + deadline are captured (name hashed).
+  **Critical to verify on an ALCOHOL dropoff:** the identity/signature-banner variant must STILL be
+  blocked (no recognition, no parse) — only the plain arrival card recognizes. Broken = still
+  UNKNOWN, mis-steps the flow, or the alcohol variant leaks recipient PII.
+  - Confirmed: 0/2
+
 - **Batch-1 recognition gaps from 2026-06-12 now recognized (#462).** Twelve more screens that
   fell to UNKNOWN are now recognized (mostly recognize-only — no flow change): pickup steps
   (`Pickup steps` / `Take receipt photo`), pickup "what's causing your wait" survey, pickup


### PR DESCRIPTION
## Summary

The dropoff **arrival/detail card** — "Delivery for" label with the customer name in a **sibling** node, plus the address, "Directions", and "Hand it to recipient" (e.g. the 7-Eleven order to Adam C from the 2026-06-12 dash) — was falling to `UNKNOWN`.

**Root cause (the diagnosis):** `dropoff_pre_arrival`'s `require` keyed its first predicate on `hasTextStartsWith "Deliver to"` / `"Heading to"`. This card's leading texts are **"Delivery for"** and **"Deliver by 20:04"** — neither *starts with* "Deliver to", so the predicate failed and the screen dropped to UNKNOWN.

## Fix — a branch of the existing rule (it's the same dropoff intent)
- **`require`** wrapped in `any` with a second layout: `all["Delivery for", "Hand it to recipient"]`. `"Hand it to recipient"` is the **dropoff-specific discriminator** — the *pickup* card also carries "Delivery for", so keying on that alone would steal it; the pickup card has no "Hand it to recipient".
- **`customerNameHash`** wrapped in `coalesce`, so the name still hashes in the new layout: the second strategy finds "Delivery for" and reads its `sibling(1)` (the name node) → `sha256`. Address + deadline already parse via the regex / by-time finds.

## Security / privacy posture
- Recognition only; recipient name + address are **hashed at the edge** (never stored raw), exactly like the existing dropoff card.
- The **alcohol variant** of this same card additionally carries the priority-0 identity/signature banner (`"collect a signature at dropoff"` / `"required by law to confirm the recipient"`, #463), so it is **blocked before reaching this branch**. A new `DefaultRulesIntegrationTest` locks in both halves: plain arrival card → `dropoff_pre_arrival`, alcohol variant → sensitive-blocked.

## Tests
- Redacted corpus snapshot under `snapshots/dropoff_pre_arrival/` (classifies via `GoldenSnapshotRegressionTest`; `customerNameHash` + `deadline` parse, `customerAddressHash` null — consistent with most existing `dropoff_pre_arrival` corpus).
- `approved-parse-output.json` regenerated (one added entry).
- Full `testDebugUnitTest` green.

Part of #462; also addresses the dropoff-card recognition noted in #460.