### PR TITLE
feat(bubble): redesign pickup/dropoff task cards to the co-hero design (#460/#324)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardItem.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardItem.kt
@@ -35,6 +35,7 @@ import cloud.trotter.dashbuddy.core.designsystem.time.rememberNow
 import cloud.trotter.dashbuddy.core.designsystem.time.rememberTimeFormatter
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
@@ -435,155 +436,247 @@ private fun badgeMeta(name: String, c: AppColors): Pair<String, Color> = when (n
     else -> name.lowercase().replace('_', ' ').replaceFirstChar { it.uppercase() } to c.neutral
 }
 
-/**
- * Pickup body: hero is the **countdown to pickup-by deadline**, colored
- * green/amber/red. When no deadline is parsed, falls back to elapsed time.
- * Frozen cards show a "+Xm ahead" / "Xm late" delta vs the deadline plus
- * arrival info.
- */
+/** Pickup body — the #324/#460 task-card vocabulary (co-hero pair). */
 @Composable
 private fun PickupBody(snap: FlowCardSnapshot.Pickup, isActive: Boolean) {
-    DeadlineBody(
+    TaskBody(
         phaseStartedAt = snap.phaseStartedAt,
         arrivedAt = snap.arrivedAt,
         deadlineMillis = snap.deadlineMillis,
         phaseEndedAt = snap.phaseEndedAt,
         isActive = isActive,
+        isDrop = false,
         primary = snap.storeName,
+        netPay = snap.netPay,
+        estMinutes = snap.estMinutes,
         confirmedAt = snap.confirmedAt,
         itemsShopped = snap.itemsShopped,
         itemsRemaining = snap.itemsRemaining,
         activity = snap.activity,
-        // No "-by": the DeadlineBody caption already appends "· by HH:MM",
-        // so "till pickup-by" read as "till pickup-by · by 17:10" (#460).
-        deadlineLabel = "till pickup",
     )
 }
 
-/**
- * Delivery body: same shape as Pickup but with deliver-by deadline and
- * customer hash instead of store name.
- */
+/** Delivery body — same co-hero shape as Pickup, deliver-by deadline + customer. */
 @Composable
 private fun DeliveryBody(snap: FlowCardSnapshot.Delivery, isActive: Boolean) {
-    DeadlineBody(
+    TaskBody(
         phaseStartedAt = snap.phaseStartedAt,
         arrivedAt = snap.arrivedAt,
         deadlineMillis = snap.deadlineMillis,
         phaseEndedAt = snap.phaseEndedAt,
         isActive = isActive,
+        isDrop = true,
         primary = customerDisplayName(snap.customerHash),
+        netPay = snap.netPay,
+        estMinutes = snap.estMinutes,
         confirmedAt = null,
         itemsShopped = null,
         itemsRemaining = null,
         activity = null,
-        deadlineLabel = "till deliver",
     )
 }
 
 /**
- * Shared body for Pickup + Delivery — both have a deadline + arrival
- * lifecycle. Hero is countdown-to-deadline while active; "+Xm ahead" /
- * "Xm late" once frozen.
+ * Shared task-card body for Pickup + Delivery (#324/#460). Two co-heroes:
+ * the phase timer (To-go countdown → Dwell count-up once arrived) and the
+ * live "Running at $/hr" realized rate (holds until the deadline, then erodes
+ * — the drop-it signal). Below: an arrival/deadline caption, the drop-it
+ * floor banner, shop pace, and a store/customer detail line. All time-derived
+ * values tick off `rememberNow()` while the card is live.
  */
 @Composable
-private fun DeadlineBody(
+private fun TaskBody(
     phaseStartedAt: Long,
     arrivedAt: Long?,
     deadlineMillis: Long?,
     phaseEndedAt: Long?,
     isActive: Boolean,
+    isDrop: Boolean,
     primary: String,
+    netPay: Double?,
+    estMinutes: Double?,
     confirmedAt: Long?,
     itemsShopped: Int?,
     itemsRemaining: Int?,
     activity: String?,
-    deadlineLabel: String,
 ) {
+    val c = AppTheme.colors
+    val now = if (isActive) rememberNow().value else (phaseEndedAt ?: phaseStartedAt)
+    val arrived = arrivedAt != null
+    val verb = if (isDrop) "deliver" else "pickup"
+    val overdue = deadlineMillis != null && now > deadlineMillis
+    val hourly = projectedHourly(netPay, estMinutes, deadlineMillis, now)
+
     Column(
         modifier = Modifier.fillMaxWidth(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(2.dp),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
     ) {
-        val now = if (isActive) rememberNow().value else (phaseEndedAt ?: phaseStartedAt)
-
-        if (isActive) {
-            if (deadlineMillis != null) {
-                val remaining = deadlineMillis - now
-                HeroBig(text = formatCountdown(remaining), color = deadlineColor(remaining))
-                // Caption is `${deadlineLabel} · by HH:MM` — the wall-clock anchor
-                // lets the dasher cross-check the countdown against what DoorDash
-                // itself is showing on screen (field log 2026-05-19 #1 / 2026-05-17 #2).
-                Caption("$deadlineLabel · by ${formatTime(deadlineMillis)}")
-            } else {
-                // No deadline parsed — fall back to elapsed time
-                HeroBig(formatDuration(now - phaseStartedAt))
-                Caption(if (arrivedAt == null) "en route" else "at stop")
-            }
-        } else {
-            // Frozen card. Three cases:
-            //   (a) arrivedAt + deadlineMillis → delta vs deadline ("+Xm ahead" / "Xm late")
-            //   (b) arrivedAt null but phaseEndedAt set → drop-off completed without
-            //       an observed arrival sub-state (typical DoorDash no-contact flow).
-            //       Show total phase duration with started/completed times in
-            //       the tertiary row instead of the "—" placeholder.
-            //   (c) nothing useful → placeholder
-            val arrivalRemaining = if (deadlineMillis != null && arrivedAt != null)
-                deadlineMillis - arrivedAt else null
+        // ---- Co-hero pair: phase timer + live realized $/hr ----
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            // LEFT — phase timer.
+            val timerLabel: String
+            val timerValue: String
+            val timerSub: String?
+            val timerColor: Color
             when {
-                arrivalRemaining != null -> {
-                    val deltaLabel = if (arrivalRemaining >= 0)
-                        "+${formatCountdown(arrivalRemaining)} ahead"
-                    else
-                        "${formatCountdown(-arrivalRemaining)} late"
-                    HeroBig(text = deltaLabel, color = deadlineColor(arrivalRemaining))
-                    Caption("vs $deadlineLabel")
+                arrived -> {
+                    timerLabel = "Dwell"
+                    timerValue = formatCountdown(now - arrivedAt)
+                    timerSub = if (isDrop) "at door" else "at store"
+                    timerColor = deadlineMillis?.let { deadlineColor(it - arrivedAt) } ?: c.text
                 }
-                phaseEndedAt != null -> {
-                    HeroBig(formatDuration(phaseEndedAt - phaseStartedAt))
-                    Caption("duration")
+                deadlineMillis != null -> {
+                    timerLabel = if (overdue) "Overdue" else "To go"
+                    timerValue = formatCountdown(deadlineMillis - now)
+                    timerSub = null
+                    timerColor = deadlineColor(deadlineMillis - now)
                 }
                 else -> {
-                    HeroBig("—")
-                    Caption(deadlineLabel)
+                    timerLabel = "Elapsed"
+                    timerValue = formatDuration(now - phaseStartedAt)
+                    timerSub = "en route"
+                    timerColor = c.text
+                }
+            }
+            TaskMetric(
+                modifier = Modifier.weight(1f),
+                live = isActive,
+                label = timerLabel,
+                value = timerValue,
+                sub = timerSub,
+                color = timerColor,
+            )
+            Box(Modifier.size(width = 1.dp, height = 36.dp).background(c.line))
+            // RIGHT — Running at $/hr (erodes past the deadline).
+            TaskMetric(
+                modifier = Modifier.weight(1f),
+                live = isActive && hourly != null,
+                label = "Running at",
+                value = if (hourly != null) "${Formats.money0(hourly)}/hr${if (overdue) " ↓" else ""}" else "—",
+                sub = if (hourly == null) null else if (overdue) "dropping" else "on track",
+                color = hourly?.let { hourlyColor(it, c) } ?: c.text3,
+            )
+        }
+
+        // ---- arrival / deadline caption ----
+        val caption = buildString {
+            if (arrived && deadlineMillis != null) {
+                val margin = deadlineMillis - arrivedAt
+                append("arrived ${formatCountdown(kotlin.math.abs(margin))} ${if (margin >= 0) "early" else "late"} · ")
+            }
+            when {
+                deadlineMillis == null -> append(if (arrived) "at stop" else "en route")
+                overdue -> append("${formatCountdown(now - deadlineMillis)} past $verb-by")
+                else -> append("$verb by ${formatTime(deadlineMillis)}")
+            }
+        }
+        Caption(caption)
+
+        // ---- drop-it floor banner: overdue AND the rate has eroded below the floor ----
+        if (isActive && overdue && hourly != null && hourly < DROP_FLOOR_HOURLY) {
+            Surface(shape = MaterialTheme.shapes.small, color = c.badBg) {
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp, vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Icon(Icons.Default.Close, contentDescription = null, tint = c.bad, modifier = Modifier.size(16.dp))
+                    Text(
+                        "Below your floor — no longer worth the wait.",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = c.bad,
+                        fontWeight = FontWeight.SemiBold,
+                    )
                 }
             }
         }
 
-        // Tertiary row — store/customer + lifecycle times + items
-        val tertiary = buildString {
-            append(primary)
-            arrivedAt?.let {
-                append(" · arrived ${formatTime(it)}")
-            }
-            confirmedAt?.let {
-                append(" · picked up ${formatTime(it)}")
-            }
-            // When we don't have an arrival (no-contact-delivery case),
-            // surface the started/completed wall-clock so the dasher can
-            // read what happened — paralleling Pickup's "arrived · picked up".
-            if (arrivedAt == null && phaseEndedAt != null && !isActive) {
-                append(" · started ${formatTime(phaseStartedAt)}")
-                append(" · completed ${formatTime(phaseEndedAt)}")
-            }
-            // Shop & Deliver: show progress + a live items/min pace (derived off
-            // `now`, so it ticks while shopping and freezes with the card). The bare
-            // "items left" count alone isn't useful; pace + shopped/total is.
-            if (activity == PickupActivity.SHOPPING) {
-                val shopped = itemsShopped ?: 0
-                val total = shopped + (itemsRemaining ?: 0)
-                if (total > 0) {
-                    append(" · shop $shopped/$total")
-                    val elapsedMs = now - (arrivedAt ?: phaseStartedAt)
-                    if (elapsedMs > 0) {
-                        val perMin = shopped / (elapsedMs / 60_000.0)
-                        append(" · ${Formats.decimal(perMin)}/min")
+        // ---- shop progress (Shop & Deliver): shopped/total + live pace ----
+        if (activity == PickupActivity.SHOPPING) {
+            val shopped = itemsShopped ?: 0
+            val total = shopped + (itemsRemaining ?: 0)
+            if (total > 0) {
+                val elapsedMs = now - (arrivedAt ?: phaseStartedAt)
+                val pace = if (elapsedMs > 0) shopped / (elapsedMs / 60_000.0) else 0.0
+                Surface(shape = MaterialTheme.shapes.small, color = c.stPickup.copy(alpha = 0.12f)) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp, vertical = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        Text("shop $shopped/$total", style = AppTheme.num.smNum, color = c.text, fontWeight = FontWeight.Bold, modifier = Modifier.weight(1f))
+                        Text("${Formats.decimal(pace)}/min", style = AppTheme.num.smNum, color = c.stPickup, fontWeight = FontWeight.Bold)
                     }
                 }
             }
         }
-        Caption(tertiary)
+
+        // ---- detail line — store/customer + lifecycle times ----
+        val detail = buildString {
+            append(primary)
+            arrivedAt?.let { append(" · arrived ${formatTime(it)}") }
+            confirmedAt?.let { append(" · picked up ${formatTime(it)}") }
+            if (arrivedAt == null && phaseEndedAt != null && !isActive) {
+                append(" · ${formatDuration(phaseEndedAt - phaseStartedAt)}")
+            }
+        }
+        Caption(detail)
     }
+}
+
+/** One co-hero metric — a label (with a live dot), a big value, and an optional sub. */
+@Composable
+private fun TaskMetric(
+    modifier: Modifier = Modifier,
+    live: Boolean,
+    label: String,
+    value: String,
+    sub: String?,
+    color: Color,
+) {
+    val c = AppTheme.colors
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            if (live) Box(Modifier.size(6.dp).clip(RoundedCornerShape(3.dp)).background(color))
+            Text(label.uppercase(), style = MaterialTheme.typography.labelSmall, color = c.text3, fontWeight = FontWeight.Bold)
+        }
+        // 24sp — a co-hero size (vs the 30sp single hero) so the two metrics fit
+        // side by side in the bubble's width without clipping.
+        Text(value, style = AppTheme.num.heroNum.copy(fontSize = 24.sp), color = color, maxLines = 1)
+        if (sub != null) Text(sub, style = MaterialTheme.typography.labelSmall, color = c.text3, maxLines = 1)
+    }
+}
+
+/** The drop-it floor (#460): once overdue and the realized rate falls below
+ *  this, the card flags the wait as no longer worth it. */
+private const val DROP_FLOOR_HOURLY = 12.0
+
+/**
+ * Live realized $/hr on a task (#460). Pay is fixed; the offer's time estimate
+ * has slack up to the deadline — once past it, every extra minute erodes the
+ * rate (the drop-it signal). Null when no accepted-offer economics are known.
+ */
+private fun projectedHourly(netPay: Double?, estMinutes: Double?, deadlineMillis: Long?, now: Long): Double? {
+    if (netPay == null || estMinutes == null || estMinutes <= 0.0) return null
+    val pastMin = if (deadlineMillis != null) ((now - deadlineMillis) / 60_000.0).coerceAtLeast(0.0) else 0.0
+    return netPay / ((estMinutes + pastMin) / 60.0)
+}
+
+/** $/hr color tiers for the task co-hero (#460): ≥16 good, ≥10 amber, else red. */
+private fun hourlyColor(hourly: Double, c: AppColors): Color = when {
+    hourly >= 16.0 -> c.good
+    hourly >= 10.0 -> c.warn
+    else -> c.bad
 }
 
 /**

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardMapper.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardMapper.kt
@@ -35,6 +35,11 @@ object FlowCardMapper {
         var openPickup: FlowCardSnapshot.Pickup? = null
         var openDelivery: FlowCardSnapshot.Delivery? = null
         var lastDeliveryArrivedAt: Long? = null
+        // The accepted offer's economics, carried onto the task cards for the
+        // "Running at $/hr" co-hero (#460). v1 tracks a single job in flight; a
+        // stacked add-on overwrites (the live card uses the accurate Job.blended).
+        var acceptedNetPay: Double? = null
+        var acceptedEstMin: Double? = null
 
         for (event in events) {
             when (event.type) {
@@ -45,6 +50,8 @@ object FlowCardMapper {
                     openPickup = null
                     openDelivery = null
                     lastDeliveryArrivedAt = null
+                    acceptedNetPay = null
+                    acceptedEstMin = null
 
                     val payload = event.payload as? SessionStartPayload
                     openAwaiting = FlowCardSnapshot.Awaiting(
@@ -111,6 +118,12 @@ object FlowCardMapper {
                             outcome = payload.outcome,
                         )
                     )
+                    // On accept, capture the offer's economics for the upcoming
+                    // task cards' live $/hr co-hero (#460).
+                    if (payload.outcome == AppEventType.OFFER_ACCEPTED) {
+                        acceptedNetPay = payload.evaluation?.netPayAmount
+                        acceptedEstMin = payload.evaluation?.estimatedTimeMinutes
+                    }
                     // Re-open Awaiting if the dasher returned to the
                     // waiting-for-offer state (declined / timeout). Accept
                     // skips this — they're going into pickup.
@@ -145,6 +158,8 @@ object FlowCardMapper {
                             phaseStartedAt = payload.phaseStartedAt,
                             taskId = payload.taskId,
                             jobId = payload.jobId,
+                            netPay = acceptedNetPay,
+                            estMinutes = acceptedEstMin,
                             storeName = payload.storeName.ifBlank { UNKNOWN_STORE },
                             deadlineMillis = payload.deadlineMillis,
                             itemsRemaining = payload.itemsRemaining,
@@ -168,6 +183,8 @@ object FlowCardMapper {
                             phaseStartedAt = payload.phaseStartedAt,
                             taskId = payload.taskId,
                             jobId = payload.jobId,
+                            netPay = acceptedNetPay,
+                            estMinutes = acceptedEstMin,
                             storeName = payload.storeName.ifBlank { UNKNOWN_STORE },
                             arrivedAt = payload.arrivedAt ?: event.occurredAt,
                             deadlineMillis = payload.deadlineMillis,
@@ -192,6 +209,8 @@ object FlowCardMapper {
                             phaseEndedAt = payload.confirmedAt ?: event.occurredAt,
                             taskId = payload.taskId,
                             jobId = payload.jobId,
+                            netPay = acceptedNetPay,
+                            estMinutes = acceptedEstMin,
                             storeName = payload.storeName.ifBlank { UNKNOWN_STORE },
                             arrivedAt = payload.arrivedAt,
                             confirmedAt = payload.confirmedAt ?: event.occurredAt,
@@ -214,6 +233,8 @@ object FlowCardMapper {
                             phaseStartedAt = payload.phaseStartedAt,
                             taskId = payload.taskId,
                             jobId = payload.jobId,
+                            netPay = acceptedNetPay,
+                            estMinutes = acceptedEstMin,
                             storeName = payload.storeName,
                             customerHash = payload.customerHash,
                             deadlineMillis = payload.deadlineMillis,
@@ -235,6 +256,8 @@ object FlowCardMapper {
                             phaseEndedAt = payload.arrivedAt ?: event.occurredAt,
                             taskId = payload.taskId,
                             jobId = payload.jobId,
+                            netPay = acceptedNetPay,
+                            estMinutes = acceptedEstMin,
                             storeName = payload.storeName,
                             customerHash = payload.customerHash,
                             arrivedAt = payload.arrivedAt ?: event.occurredAt,
@@ -260,6 +283,8 @@ object FlowCardMapper {
                             phaseEndedAt = event.occurredAt,
                             taskId = payload.taskId,
                             jobId = payload.jobId,
+                            netPay = acceptedNetPay,
+                            estMinutes = acceptedEstMin,
                             storeName = payload.storeName,
                             customerHash = payload.customerHash,
                             arrivedAt = payload.arrivedAt,

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/LiveCardBuilder.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/LiveCardBuilder.kt
@@ -74,6 +74,8 @@ object LiveCardBuilder {
                     itemsRemaining = task.itemsRemaining,
                     itemsShopped = task.itemsShopped,
                     activity = task.activity,
+                    netPay = region.activeJob?.blendedNetPay,
+                    estMinutes = region.activeJob?.blendedEstMinutes,
                 )
             }
 
@@ -88,6 +90,8 @@ object LiveCardBuilder {
                     customerHash = task.customerNameHash,
                     arrivedAt = task.arrivedAt,
                     deadlineMillis = task.deadlineMillis,
+                    netPay = region.activeJob?.blendedNetPay,
+                    estMinutes = region.activeJob?.blendedEstMinutes,
                 )
             }
 

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardMapperTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardMapperTest.kt
@@ -724,4 +724,30 @@ class FlowCardMapperTest {
         val offer = FlowCardMapper.fold(events).filterIsInstance<FlowCardSnapshot.Offer>().single()
         assertTrue("plain pickup must not carry SHOP", !offer.badges.contains("SHOP"))
     }
+
+    @Test
+    fun `accepted offer economics thread onto the pickup and delivery cards (#460)`() {
+        // The "Running at $/hr" co-hero needs netPay + estMinutes on the task
+        // cards. They come from the accepted offer's evaluation (netPayAmount
+        // 6.50, estimatedTimeMinutes 18.0 in the test fixture).
+        val events = listOf(
+            event(AppEventType.DASH_START,
+                SessionStartPayload("s1", "DoorDash", 1000L, "interaction", "WaitingForOffer"), 1000L),
+            event(AppEventType.OFFER_ACCEPTED,
+                offerPayload("o1", AppEventType.OFFER_ACCEPTED, 2000L, 2500L), 2500L),
+            event(AppEventType.PICKUP_NAV_STARTED, pickupPayload("T1", "J1", "Wendy's", 2500L), 2500L),
+            event(AppEventType.PICKUP_CONFIRMED,
+                pickupPayload("T1", "J1", "Wendy's", 2500L, arrived = 3000L, confirmed = 3500L), 3500L),
+            event(AppEventType.DELIVERY_NAV_STARTED, deliveryPayload("T2", "J1", 3500L), 3500L),
+            event(AppEventType.DELIVERY_ARRIVED, deliveryPayload("T2", "J1", 3500L, arrived = 4000L), 4000L),
+        )
+        val cards = FlowCardMapper.fold(events)
+        val pickup = cards.filterIsInstance<FlowCardSnapshot.Pickup>().single()
+        val delivery = cards.filterIsInstance<FlowCardSnapshot.Delivery>().single()
+
+        assertEquals(6.50, pickup.netPay!!, 0.001)
+        assertEquals(18.0, pickup.estMinutes!!, 0.001)
+        assertEquals(6.50, delivery.netPay!!, 0.001)
+        assertEquals(18.0, delivery.estMinutes!!, 0.001)
+    }
 }

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/JobEconomicsTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/JobEconomicsTest.kt
@@ -19,6 +19,7 @@ import cloud.trotter.dashbuddy.domain.state.TaskPhase
 import cloud.trotter.dashbuddy.domain.state.TaskSubFlow
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Test
 import cloud.trotter.dashbuddy.domain.evaluation.OfferQuality
 
@@ -151,5 +152,18 @@ class JobEconomicsTest {
         assertNotNull(job)
         assertEquals("offer-1 already counted → no duplicate", 1, job!!.acceptedOffers.size)
         assertEquals(6.0, job.totalNetPay, 0.001)
+    }
+
+    @Test
+    fun `blended economics are null with no accepted offers, summed otherwise (#460)`() {
+        // The task card's $/hr co-hero shows "—" (null), never a misleading $0,
+        // when no accepted-offer economics exist yet.
+        val empty = Job(jobId = "j0", offerStoreHint = emptyList(), parentOfferHash = "o0", startedAt = 0L)
+        assertNull(empty.blendedNetPay)
+        assertNull(empty.blendedEstMinutes)
+
+        val seeded = jobWith("o1", net = 6.5, est = 18.0, dist = 4.2, pay = 7.5)
+        assertEquals(6.5, seeded.blendedNetPay!!, 0.001)
+        assertEquals(18.0, seeded.blendedEstMinutes!!, 0.001)
     }
 }

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -97,6 +97,20 @@ _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **bro
   stacked offer variants, idle/navigate-to-zone, and transient frames.)
   - Confirmed: 0/2
 
+- **Pickup/Delivery task cards redesigned to the co-hero design (#460/#324).** The task cards
+  no longer show a single countdown + caption — they now have the **dual co-hero**: LEFT = the
+  phase timer (counts DOWN to the deadline as "To go", then flips to "Dwell" counting UP once you
+  arrive, with "at store"/"at door"), RIGHT = **"Running at $X/hr"** — the live realized rate from
+  the accepted offer's net pay ÷ time, which **holds until the deadline then erodes** (shows a ↓
+  and "dropping"). Below: an "arrived N early/late · deliver by H:MM" caption, a red **"Below your
+  floor"** banner once overdue + the rate drops under $12/hr, the shop pace block (Shop & Deliver),
+  and the store/customer detail line. On a dash: working = during pickup/dropoff the live card
+  shows both heroes ticking; the $/hr roughly matches the accepted offer's $/hr and drops if you
+  run late; "Running at —" only when the offer had no economics. Broken = $/hr shows "—" on a
+  normal accepted offer, the timer doesn't flip to Dwell on arrival, values clip/overflow the
+  bubble width, or the $/hr doesn't erode past the deadline.
+  - Confirmed: 0/2
+
 - **Bubble keeps showing the last dash after it ends / after a crash (#459).**
   The bubble's chat + card stack used to go EMPTY after a dash ended (8b: collapse it >5s then
   reopen) or after a crash with no active dash (8a) — the fallback dash id was a volatile

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/cards/FlowCardSnapshot.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/cards/FlowCardSnapshot.kt
@@ -92,6 +92,12 @@ sealed class FlowCardSnapshot {
         val itemsRemaining: Int? = null,
         val itemsShopped: Int? = null,
         val activity: String? = null,
+        /** The job's blended net pay — the numerator for the live "Running at $/hr"
+         *  co-hero (#460). Null until an accepted offer's economics are known. */
+        val netPay: Double? = null,
+        /** The job's blended estimated minutes — the $/hr denominator (erodes past
+         *  the deadline, the drop-it signal). */
+        val estMinutes: Double? = null,
     ) : FlowCardSnapshot() {
         override val id: String get() = "pickup:$taskId"
     }
@@ -112,6 +118,10 @@ sealed class FlowCardSnapshot {
         val customerHash: String? = null,
         val arrivedAt: Long? = null,
         val deadlineMillis: Long? = null,
+        /** Blended net pay for the live "Running at $/hr" co-hero (#460). */
+        val netPay: Double? = null,
+        /** Blended estimated minutes — the $/hr denominator (erodes past deadline). */
+        val estMinutes: Double? = null,
     ) : FlowCardSnapshot() {
         override val id: String get() = "delivery:$taskId"
     }

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/Job.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/Job.kt
@@ -54,6 +54,18 @@ data class Job(
     /** Total estimated minutes across all offers — the denominator for the job's blended $/hr. */
     val totalEstMinutes: Double get() = acceptedOffers.sumOf { it.estMinutes ?: 0.0 }
 
+    /**
+     * Net pay for the live task-card "Running at $/hr" co-hero (#460) — null when
+     * no accepted offer has carried economics yet, so the card shows "—" rather
+     * than a misleading $0.
+     */
+    val blendedNetPay: Double?
+        get() = acceptedOffers.mapNotNull { it.netPay }.takeIf { it.isNotEmpty() }?.sum()
+
+    /** Estimated minutes denominator for the blended $/hr — null until known, must be > 0. */
+    val blendedEstMinutes: Double?
+        get() = acceptedOffers.mapNotNull { it.estMinutes }.takeIf { it.isNotEmpty() }?.sum()?.takeIf { it > 0.0 }
+
     /** Total quoted distance in miles across all offers. */
     val totalDistanceMiles: Double get() = acceptedOffers.sumOf { it.distanceMiles ?: 0.0 }
 


### PR DESCRIPTION
## Summary

The Pickup/Delivery flow cards never adopted the #324 task-card vocabulary — they used a single countdown hero + caption (the old `DeadlineBody`). This brings them to the design's dual **co-hero** layout (handoff "1c Task card"), which the #317 `Job.acceptedOffers` economics finally make possible.

**Co-hero pair** (`TaskMetric` ×2):
- **LEFT — phase timer:** counts DOWN to the deadline ("To go"), flips to **"Dwell"** counting UP once arrived ("at store"/"at door"). Colored by margin.
- **RIGHT — "Running at $X/hr":** the live realized rate (net pay ÷ time). Holds until the deadline, then **erodes** as every late minute grows the denominator — the drop signal (↓ / "dropping"). `"—"` when no economics are known.

Plus an "arrived N early/late · deliver by H:MM" caption, a red **"Below your floor"** banner once overdue and the rate falls under $12/hr, the Shop & Deliver pace block, and a store/customer detail line. All time-derived values tick off `rememberNow()` while the card is live (the bubble's strict reactivity bar).

## Data threading
- `FlowCardSnapshot.Pickup`/`Delivery` gain `netPay` + `estMinutes`.
- `Job.blendedNetPay` / `blendedEstMinutes` (SSOT, **null** when no economics → the card shows "—", never a misleading $0).
- `LiveCardBuilder` reads `region.activeJob.blended*` for the live card; `FlowCardMapper` captures the accepted offer's evaluation economics and stamps them onto completed Pickup/Delivery cards (v1 single-job; the live card stays accurate for stacked).
- `projectedHourly()` / `hourlyColor()` replicate the design's erosion + color tiers.

## Tests
- `FlowCardMapperTest` asserts the economics thread onto both task cards.
- `JobEconomicsTest` covers `blended*` (null when empty, summed otherwise).
- Full `testDebugUnitTest` green.

## Reactive-UI / privacy posture
- The $/hr + timer are derived from anchors (`netPay`, `estMinutes`, `arrivedAt`, `deadlineMillis`) + the 1 Hz ticker — they re-render continuously, never frozen at the last reducer emission.
- No new data captured; the customer hash is rendered via `customerDisplayName` exactly as before.

Closes #460. **Needs field validation** (added to the field-test checklist).