### PR TITLE
chore(domain): rename startingDash parse-field → startingSession (#469 slice 3, final)

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/state/StateMachineTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/state/StateMachineTest.kt
@@ -636,12 +636,12 @@ class StateMachineTest {
         )).newState
         assertNotNull(state.regions.platforms[Platform.DoorDash]!!.pendingDestructive)
 
-        // The set-end-time screen (startingDash) arrives WITHIN the grace window —
+        // The set-end-time screen (startingSession) arrives WITHIN the grace window —
         // the old dash really ended; commit it now (#279-B).
         val t3 = t2 + 1000
         state = machine.step(state, screenObs(
             modeHint = Mode.Offline, flow = Flow.Idle,
-            parsed = ParsedFields.IdleFields(startingDash = true), timestamp = t3,
+            parsed = ParsedFields.IdleFields(startingSession = true), timestamp = t3,
         )).newState
         val afterStart = state.regions.platforms[Platform.DoorDash]!!
         assertNull("the dash-start signal ends the old dash", afterStart.session)

--- a/app/src/test/resources/snapshots/approved-parse-output.json
+++ b/app/src/test/resources/snapshots/approved-parse-output.json
@@ -182,7 +182,7 @@
             "sessionPay": null,
             "sessionType": null,
             "spotSaveDeadline": null,
-            "startingDash": false,
+            "startingSession": false,
             "waitTimeEstimate": null,
             "zoneName": null
         }
@@ -196,7 +196,7 @@
             "sessionPay": null,
             "sessionType": null,
             "spotSaveDeadline": null,
-            "startingDash": false,
+            "startingSession": false,
             "waitTimeEstimate": null,
             "zoneName": null
         }
@@ -210,7 +210,7 @@
             "sessionPay": null,
             "sessionType": null,
             "spotSaveDeadline": null,
-            "startingDash": false,
+            "startingSession": false,
             "waitTimeEstimate": null,
             "zoneName": null
         }
@@ -224,7 +224,7 @@
             "sessionPay": null,
             "sessionType": null,
             "spotSaveDeadline": 1780329420000,
-            "startingDash": false,
+            "startingSession": false,
             "waitTimeEstimate": null,
             "zoneName": null
         }
@@ -238,7 +238,7 @@
             "sessionPay": null,
             "sessionType": null,
             "spotSaveDeadline": 1780329420000,
-            "startingDash": false,
+            "startingSession": false,
             "waitTimeEstimate": null,
             "zoneName": null
         }
@@ -252,7 +252,7 @@
             "sessionPay": null,
             "sessionType": null,
             "spotSaveDeadline": 1780329420000,
-            "startingDash": false,
+            "startingSession": false,
             "waitTimeEstimate": null,
             "zoneName": null
         }
@@ -266,7 +266,7 @@
             "sessionPay": null,
             "sessionType": null,
             "spotSaveDeadline": 1780329420000,
-            "startingDash": false,
+            "startingSession": false,
             "waitTimeEstimate": null,
             "zoneName": null
         }
@@ -280,7 +280,7 @@
             "sessionPay": null,
             "sessionType": null,
             "spotSaveDeadline": 1780329420000,
-            "startingDash": false,
+            "startingSession": false,
             "waitTimeEstimate": null,
             "zoneName": null
         }
@@ -294,7 +294,7 @@
             "sessionPay": null,
             "sessionType": null,
             "spotSaveDeadline": null,
-            "startingDash": false,
+            "startingSession": false,
             "waitTimeEstimate": null,
             "zoneName": null
         }
@@ -308,7 +308,7 @@
             "sessionPay": null,
             "sessionType": null,
             "spotSaveDeadline": 1780331580000,
-            "startingDash": false,
+            "startingSession": false,
             "waitTimeEstimate": null,
             "zoneName": null
         }
@@ -322,7 +322,7 @@
             "sessionPay": null,
             "sessionType": null,
             "spotSaveDeadline": null,
-            "startingDash": false,
+            "startingSession": false,
             "waitTimeEstimate": null,
             "zoneName": null
         }
@@ -336,7 +336,7 @@
             "sessionPay": null,
             "sessionType": null,
             "spotSaveDeadline": 1780331580000,
-            "startingDash": false,
+            "startingSession": false,
             "waitTimeEstimate": null,
             "zoneName": null
         }
@@ -350,7 +350,7 @@
             "sessionPay": null,
             "sessionType": null,
             "spotSaveDeadline": null,
-            "startingDash": false,
+            "startingSession": false,
             "waitTimeEstimate": null,
             "zoneName": null
         }
@@ -364,7 +364,7 @@
             "sessionPay": null,
             "sessionType": null,
             "spotSaveDeadline": null,
-            "startingDash": false,
+            "startingSession": false,
             "waitTimeEstimate": null,
             "zoneName": null
         }
@@ -378,7 +378,7 @@
             "sessionPay": null,
             "sessionType": null,
             "spotSaveDeadline": 1780331400000,
-            "startingDash": false,
+            "startingSession": false,
             "waitTimeEstimate": null,
             "zoneName": null
         }
@@ -1848,7 +1848,7 @@
             "sessionPay": null,
             "sessionType": "PerOffer",
             "spotSaveDeadline": null,
-            "startingDash": false,
+            "startingSession": false,
             "waitTimeEstimate": null,
             "zoneName": null
         }
@@ -1862,7 +1862,7 @@
             "sessionPay": null,
             "sessionType": "PerOffer",
             "spotSaveDeadline": null,
-            "startingDash": false,
+            "startingSession": false,
             "waitTimeEstimate": null,
             "zoneName": null
         }
@@ -1876,7 +1876,7 @@
             "sessionPay": null,
             "sessionType": "PerOffer",
             "spotSaveDeadline": null,
-            "startingDash": false,
+            "startingSession": false,
             "waitTimeEstimate": null,
             "zoneName": null
         }
@@ -1890,7 +1890,7 @@
             "sessionPay": null,
             "sessionType": "PerOffer",
             "spotSaveDeadline": null,
-            "startingDash": false,
+            "startingSession": false,
             "waitTimeEstimate": null,
             "zoneName": null
         }
@@ -1904,7 +1904,7 @@
             "sessionPay": null,
             "sessionType": "PerOffer",
             "spotSaveDeadline": null,
-            "startingDash": false,
+            "startingSession": false,
             "waitTimeEstimate": null,
             "zoneName": null
         }
@@ -1918,7 +1918,7 @@
             "sessionPay": null,
             "sessionType": "PerOffer",
             "spotSaveDeadline": null,
-            "startingDash": false,
+            "startingSession": false,
             "waitTimeEstimate": null,
             "zoneName": null
         }
@@ -1932,7 +1932,7 @@
             "sessionPay": null,
             "sessionType": "PerOffer",
             "spotSaveDeadline": null,
-            "startingDash": false,
+            "startingSession": false,
             "waitTimeEstimate": null,
             "zoneName": null
         }
@@ -1946,7 +1946,7 @@
             "sessionPay": null,
             "sessionType": "PerOffer",
             "spotSaveDeadline": null,
-            "startingDash": false,
+            "startingSession": false,
             "waitTimeEstimate": null,
             "zoneName": null
         }
@@ -1960,7 +1960,7 @@
             "sessionPay": null,
             "sessionType": "PerOffer",
             "spotSaveDeadline": null,
-            "startingDash": false,
+            "startingSession": false,
             "waitTimeEstimate": null,
             "zoneName": null
         }
@@ -1974,7 +1974,7 @@
             "sessionPay": null,
             "sessionType": "PerOffer",
             "spotSaveDeadline": null,
-            "startingDash": false,
+            "startingSession": false,
             "waitTimeEstimate": null,
             "zoneName": null
         }
@@ -1988,7 +1988,7 @@
             "sessionPay": null,
             "sessionType": "PerOffer",
             "spotSaveDeadline": null,
-            "startingDash": false,
+            "startingSession": false,
             "waitTimeEstimate": null,
             "zoneName": null
         }
@@ -2002,7 +2002,7 @@
             "sessionPay": null,
             "sessionType": "PerOffer",
             "spotSaveDeadline": null,
-            "startingDash": false,
+            "startingSession": false,
             "waitTimeEstimate": null,
             "zoneName": null
         }
@@ -2016,7 +2016,7 @@
             "sessionPay": null,
             "sessionType": "PerOffer",
             "spotSaveDeadline": null,
-            "startingDash": false,
+            "startingSession": false,
             "waitTimeEstimate": null,
             "zoneName": null
         }
@@ -2030,7 +2030,7 @@
             "sessionPay": null,
             "sessionType": null,
             "spotSaveDeadline": null,
-            "startingDash": true,
+            "startingSession": true,
             "waitTimeEstimate": null,
             "zoneName": null
         }
@@ -2044,7 +2044,7 @@
             "sessionPay": null,
             "sessionType": null,
             "spotSaveDeadline": null,
-            "startingDash": true,
+            "startingSession": true,
             "waitTimeEstimate": null,
             "zoneName": null
         }
@@ -2058,7 +2058,7 @@
             "sessionPay": null,
             "sessionType": null,
             "spotSaveDeadline": null,
-            "startingDash": true,
+            "startingSession": true,
             "waitTimeEstimate": null,
             "zoneName": null
         }
@@ -2072,7 +2072,7 @@
             "sessionPay": null,
             "sessionType": null,
             "spotSaveDeadline": null,
-            "startingDash": true,
+            "startingSession": true,
             "waitTimeEstimate": null,
             "zoneName": null
         }
@@ -2086,7 +2086,7 @@
             "sessionPay": null,
             "sessionType": null,
             "spotSaveDeadline": null,
-            "startingDash": true,
+            "startingSession": true,
             "waitTimeEstimate": null,
             "zoneName": null
         }
@@ -4158,7 +4158,7 @@
             "sessionPay": null,
             "sessionType": null,
             "spotSaveDeadline": null,
-            "startingDash": true,
+            "startingSession": true,
             "waitTimeEstimate": null,
             "zoneName": "TX: Northwest San Antonio"
         }
@@ -4172,7 +4172,7 @@
             "sessionPay": null,
             "sessionType": null,
             "spotSaveDeadline": null,
-            "startingDash": true,
+            "startingSession": true,
             "waitTimeEstimate": null,
             "zoneName": null
         }
@@ -4186,7 +4186,7 @@
             "sessionPay": null,
             "sessionType": null,
             "spotSaveDeadline": null,
-            "startingDash": true,
+            "startingSession": true,
             "waitTimeEstimate": null,
             "zoneName": null
         }
@@ -4200,7 +4200,7 @@
             "sessionPay": null,
             "sessionType": null,
             "spotSaveDeadline": null,
-            "startingDash": true,
+            "startingSession": true,
             "waitTimeEstimate": null,
             "zoneName": "TX: Leon Valley"
         }
@@ -4214,7 +4214,7 @@
             "sessionPay": null,
             "sessionType": null,
             "spotSaveDeadline": null,
-            "startingDash": true,
+            "startingSession": true,
             "waitTimeEstimate": null,
             "zoneName": "TX: Northwest San Antonio"
         }
@@ -4228,7 +4228,7 @@
             "sessionPay": null,
             "sessionType": null,
             "spotSaveDeadline": null,
-            "startingDash": true,
+            "startingSession": true,
             "waitTimeEstimate": null,
             "zoneName": "TX: Northwest San Antonio"
         }
@@ -4242,7 +4242,7 @@
             "sessionPay": null,
             "sessionType": null,
             "spotSaveDeadline": null,
-            "startingDash": true,
+            "startingSession": true,
             "waitTimeEstimate": null,
             "zoneName": "TX: Leon Valley"
         }
@@ -4256,7 +4256,7 @@
             "sessionPay": null,
             "sessionType": null,
             "spotSaveDeadline": null,
-            "startingDash": true,
+            "startingSession": true,
             "waitTimeEstimate": null,
             "zoneName": "TX: Leon Valley"
         }
@@ -4270,7 +4270,7 @@
             "sessionPay": null,
             "sessionType": null,
             "spotSaveDeadline": null,
-            "startingDash": true,
+            "startingSession": true,
             "waitTimeEstimate": null,
             "zoneName": null
         }
@@ -4284,7 +4284,7 @@
             "sessionPay": null,
             "sessionType": null,
             "spotSaveDeadline": null,
-            "startingDash": true,
+            "startingSession": true,
             "waitTimeEstimate": null,
             "zoneName": "TX: Leon Valley"
         }
@@ -4298,7 +4298,7 @@
             "sessionPay": null,
             "sessionType": null,
             "spotSaveDeadline": null,
-            "startingDash": true,
+            "startingSession": true,
             "waitTimeEstimate": null,
             "zoneName": "TX: Northwest San Antonio"
         }
@@ -4312,7 +4312,7 @@
             "sessionPay": null,
             "sessionType": null,
             "spotSaveDeadline": null,
-            "startingDash": true,
+            "startingSession": true,
             "waitTimeEstimate": null,
             "zoneName": "TX: North Central"
         }
@@ -4326,7 +4326,7 @@
             "sessionPay": null,
             "sessionType": null,
             "spotSaveDeadline": null,
-            "startingDash": true,
+            "startingSession": true,
             "waitTimeEstimate": null,
             "zoneName": null
         }
@@ -4340,7 +4340,7 @@
             "sessionPay": null,
             "sessionType": null,
             "spotSaveDeadline": null,
-            "startingDash": true,
+            "startingSession": true,
             "waitTimeEstimate": null,
             "zoneName": "TX: Leon Valley"
         }
@@ -4354,7 +4354,7 @@
             "sessionPay": null,
             "sessionType": null,
             "spotSaveDeadline": null,
-            "startingDash": true,
+            "startingSession": true,
             "waitTimeEstimate": null,
             "zoneName": "TX: Leon Valley"
         }
@@ -4710,7 +4710,7 @@
             "sessionPay": 0.0,
             "sessionType": null,
             "spotSaveDeadline": null,
-            "startingDash": false,
+            "startingSession": false,
             "waitTimeEstimate": "1-4 min",
             "zoneName": null
         }
@@ -4724,7 +4724,7 @@
             "sessionPay": null,
             "sessionType": null,
             "spotSaveDeadline": null,
-            "startingDash": false,
+            "startingSession": false,
             "waitTimeEstimate": null,
             "zoneName": null
         }
@@ -4738,7 +4738,7 @@
             "sessionPay": 12.15,
             "sessionType": null,
             "spotSaveDeadline": null,
-            "startingDash": false,
+            "startingSession": false,
             "waitTimeEstimate": "1-4 min",
             "zoneName": null
         }
@@ -4752,7 +4752,7 @@
             "sessionPay": 12.15,
             "sessionType": null,
             "spotSaveDeadline": null,
-            "startingDash": false,
+            "startingSession": false,
             "waitTimeEstimate": "1-4 min",
             "zoneName": null
         }
@@ -4766,7 +4766,7 @@
             "sessionPay": 12.15,
             "sessionType": null,
             "spotSaveDeadline": null,
-            "startingDash": false,
+            "startingSession": false,
             "waitTimeEstimate": "1-5 min",
             "zoneName": null
         }
@@ -4780,7 +4780,7 @@
             "sessionPay": 12.15,
             "sessionType": null,
             "spotSaveDeadline": null,
-            "startingDash": false,
+            "startingSession": false,
             "waitTimeEstimate": "1-5 min",
             "zoneName": null
         }
@@ -4794,7 +4794,7 @@
             "sessionPay": null,
             "sessionType": null,
             "spotSaveDeadline": null,
-            "startingDash": false,
+            "startingSession": false,
             "waitTimeEstimate": null,
             "zoneName": null
         }
@@ -4808,7 +4808,7 @@
             "sessionPay": null,
             "sessionType": null,
             "spotSaveDeadline": null,
-            "startingDash": false,
+            "startingSession": false,
             "waitTimeEstimate": null,
             "zoneName": null
         }
@@ -4822,7 +4822,7 @@
             "sessionPay": 0.0,
             "sessionType": null,
             "spotSaveDeadline": null,
-            "startingDash": false,
+            "startingSession": false,
             "waitTimeEstimate": "2-6 min",
             "zoneName": null
         }
@@ -4836,7 +4836,7 @@
             "sessionPay": null,
             "sessionType": null,
             "spotSaveDeadline": null,
-            "startingDash": false,
+            "startingSession": false,
             "waitTimeEstimate": null,
             "zoneName": null
         }
@@ -4850,7 +4850,7 @@
             "sessionPay": 0.0,
             "sessionType": null,
             "spotSaveDeadline": null,
-            "startingDash": false,
+            "startingSession": false,
             "waitTimeEstimate": null,
             "zoneName": null
         }
@@ -4864,7 +4864,7 @@
             "sessionPay": 0.0,
             "sessionType": null,
             "spotSaveDeadline": null,
-            "startingDash": false,
+            "startingSession": false,
             "waitTimeEstimate": "2-6 min",
             "zoneName": null
         }
@@ -4878,7 +4878,7 @@
             "sessionPay": 0.0,
             "sessionType": null,
             "spotSaveDeadline": null,
-            "startingDash": false,
+            "startingSession": false,
             "waitTimeEstimate": null,
             "zoneName": null
         }
@@ -4892,7 +4892,7 @@
             "sessionPay": null,
             "sessionType": null,
             "spotSaveDeadline": null,
-            "startingDash": false,
+            "startingSession": false,
             "waitTimeEstimate": null,
             "zoneName": null
         }
@@ -4906,7 +4906,7 @@
             "sessionPay": 0.0,
             "sessionType": null,
             "spotSaveDeadline": null,
-            "startingDash": false,
+            "startingSession": false,
             "waitTimeEstimate": "2-6 min",
             "zoneName": null
         }

--- a/core/pipeline/src/main/assets/rules/doordash.json
+++ b/core/pipeline/src/main/assets/rules/doordash.json
@@ -2209,7 +2209,7 @@
             },
             "read": "text"
           },
-          "startingDash": {
+          "startingSession": {
             "literal": true
           }
         }
@@ -2234,7 +2234,7 @@
       "parse": {
         "as": "idle",
         "fields": {
-          "startingDash": {
+          "startingSession": {
             "literal": true
           }
         }

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/ParsedFieldsFactory.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/ParsedFieldsFactory.kt
@@ -114,7 +114,7 @@ object ParsedFieldsFactory {
         waitTimeEstimate = f.str("waitTimeEstimate"),
         isHeadingBackToZone = f.bool("isHeadingBackToZone") ?: false,
         spotSaveDeadline = f.long("spotSaveDeadline"),
-        startingDash = f.bool("startingDash") ?: false,
+        startingSession = f.bool("startingSession") ?: false,
     )
 
     private fun buildTask(f: Map<String, Any?>) = ParsedFields.TaskFields(

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
@@ -96,7 +96,7 @@ class PlatformRegionStepper @Inject constructor() {
         current.pendingDestructive?.let { pend ->
             if (pend.kind == DestructiveKind.SESSION_END) {
                 val startParsed = (obs as? Observation.FlowObservation)?.parsed
-                if ((startParsed as? ParsedFields.IdleFields)?.startingDash == true) {
+                if ((startParsed as? ParsedFields.IdleFields)?.startingSession == true) {
                     // Honest end time = when the destructive signal appeared (#431).
                     current = endSession(current, pend.since)
                 }
@@ -172,7 +172,7 @@ class PlatformRegionStepper @Inject constructor() {
                 ) {
                     // Grace active + the same session is still present → a genuine
                     // resume (a transient offline flash). A real new-dash start
-                    // would already have committed the end in step() (startingDash).
+                    // would already have committed the end in step() (startingSession).
                     // An AUTHORITATIVE pending (armed by the dash summary, #431) is
                     // deliberately NOT cancelled here: a post-summary online flash
                     // must not resurrect a really-ended session. Only a task-flow

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/ParsedFields.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/ParsedFields.kt
@@ -68,7 +68,7 @@ sealed class ParsedFields {
          * still in its grace window and start a fresh one rather than resuming.
          * Transient signal — excluded from [dedupeHash].
          */
-        val startingDash: Boolean = false,
+        val startingSession: Boolean = false,
     ) : ParsedFields() {
         override fun toFieldMap(): Map<String, Any?> = mapOf(
             "zoneName" to zoneName,
@@ -77,7 +77,7 @@ sealed class ParsedFields {
             "waitTimeEstimate" to waitTimeEstimate,
             "isHeadingBackToZone" to isHeadingBackToZone,
             "spotSaveDeadline" to spotSaveDeadline,
-            "startingDash" to startingDash,
+            "startingSession" to startingSession,
         )
 
         override fun dedupeHash(): Int {


### PR DESCRIPTION
## Summary

The last dash→session holdout: the `startingDash` idle parse-field (the set-end-time screen that signals a session is starting). Renamed in lockstep across its **whole contract** so nothing diverges:
- the rule JSON parse-field key (`doordash.json`, ×2),
- `ParsedFieldsFactory.bool("startingSession")`,
- `ParsedFields.IdleFields.startingSession` + its `toFieldMap` key,
- `PlatformRegionStepper` + `StateMachineTest` usages.

**Not persisted at runtime** — the field is a transient parse output consumed by the stepper; the only on-disk copy is the test parse-output golden. So no migration is needed. `approved-parse-output.json` regenerated — the diff is exactly **63 `"startingDash"` → `"startingSession"`**, no other key changed. Full `testDebugUnitTest` green.

## This completes the #469 migration
- slice 1 (#480) — the `dashId` family + `isDashing`
- slice 2 (#481) — config / economy / evidence (+ the `EconomyField` legacy-name migration)
- slice 3 (this) — the `startingDash` parse-field

Closes #469.