### PR TITLE
chore: clear all 22 Kotlin build warnings

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleViewModel.kt
@@ -97,13 +97,13 @@ class BubbleViewModel @Inject constructor(
     // emptying the chat/cards. The active dash wins while one is running; the
     // DB fallback survives both restarts, so the bubble reviews the last dash
     // until the next one starts (when activeSessionId takes over again).
-    @OptIn(ExperimentalCoroutinesApi::class)
     private val displayedSessionId = combine(
         bubbleManager.activeSessionId,
         appEventRepo.getMostRecentSessionId(),
     ) { active, mostRecent -> active ?: mostRecent }
         .distinctUntilChanged()
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     val messages = displayedSessionId.flatMapLatest { dashId ->
         if (dashId != null) {
             chatRepository.getMessages(dashId)

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/event/type/view/clicked/ClickClassifierTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/event/type/view/clicked/ClickClassifierTest.kt
@@ -46,7 +46,7 @@ class ClickClassifierTest {
             isAccessible = true
             set(classifier, screenTarget)
         }
-        return classifier.classify(PipelineEvent.Click(System.currentTimeMillis(), node)) as Observation.Click
+        return classifier.classify(PipelineEvent.Click(System.currentTimeMillis(), node))
     }
 
     private fun Observation.Click.intent(): String =

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/event/type/view/clicked/UnknownClickTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/event/type/view/clicked/UnknownClickTest.kt
@@ -31,7 +31,7 @@ class UnknownClickTest {
         UiNode(viewIdResourceName = viewId, text = text)
 
     private fun classifyClick(node: UiNode): Observation.Click =
-        classifier.classify(PipelineEvent.Click(System.currentTimeMillis(), node)) as Observation.Click
+        classifier.classify(PipelineEvent.Click(System.currentTimeMillis(), node))
 
     private fun Observation.Click.intent(): String =
         (parsed as ParsedFields.ClickFields).intent

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/notification/NotificationClassifierTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/notification/NotificationClassifierTest.kt
@@ -51,7 +51,7 @@ class NotificationClassifierTest {
     )
 
     private fun classifyNotification(raw: RawNotificationData): Observation.Notification =
-        classifier.classify(PipelineEvent.Notification(raw.postTime, raw)) as Observation.Notification
+        classifier.classify(PipelineEvent.Notification(raw.postTime, raw))
 
     /** Extract [ParsedFields.NotificationFields] from a classification result. */
     private fun Observation.Notification.notifFields(): ParsedFields.NotificationFields =

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/notification/UnknownNotificationClassifierTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/notification/UnknownNotificationClassifierTest.kt
@@ -40,7 +40,7 @@ class UnknownNotificationClassifierTest {
         )
 
     private fun classifyNotification(raw: RawNotificationData): Observation.Notification =
-        classifier.classify(PipelineEvent.Notification(raw.postTime, raw)) as Observation.Notification
+        classifier.classify(PipelineEvent.Notification(raw.postTime, raw))
 
     @Test
     fun `all-null notification is unknown`() {

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/TriageRulesTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/TriageRulesTest.kt
@@ -301,7 +301,7 @@ class TriageRulesTest {
         )
         assertEquals("pickup_shopping", result?.intent)
         assertEquals(5, (result?.fields?.get("itemsRemaining") as Number).toInt())
-        assertEquals(13, (result?.fields?.get("itemsShopped") as Number).toInt())
+        assertEquals(13, (result.fields["itemsShopped"] as Number).toInt())
     }
 
     @Test

--- a/app/src/test/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngineTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngineTest.kt
@@ -90,7 +90,7 @@ class SideEffectEngineTest {
     private val uiInteractionHandler: UiInteractionHandler = mock()
     /** Live-path dedupe (#436) consults this for every keyed effect — default "not fired". */
     private val effectsFiredDao: EffectsFiredDao = mock {
-        onBlocking { hasBeenFired(any()) } doReturn false
+        on { hasBeenFired(any()) } doReturn false
     }
     private val ttsEffectHandler: TtsEffectHandler = mock()
 
@@ -101,7 +101,7 @@ class SideEffectEngineTest {
 
     /** Default: every capability granted — individual tests stub denial. */
     private val capabilityGrants: RuleCapabilityGrants = mock {
-        onBlocking { isActionGranted(anyOrNull(), any()) } doReturn true
+        on { isActionGranted(anyOrNull(), any()) } doReturn true
     }
 
     private fun buildEngine(defaultDispatcher: CoroutineDispatcher) = SideEffectEngine(
@@ -207,7 +207,7 @@ class SideEffectEngineTest {
     @Test
     fun `an AUTOMATION fire without a granted capability is denied`() = runTest {
         val engine = buildEngine(StandardTestDispatcher(testScheduler))
-        wheneverBlocking { capabilityGrants.isActionGranted(anyOrNull(), any()) }
+        whenever { capabilityGrants.isActionGranted(anyOrNull(), any()) }
             .thenReturn(false)
 
         engine.process(acceptActionEffect(trigger = ActionTrigger.AUTOMATION))
@@ -232,7 +232,7 @@ class SideEffectEngineTest {
     @Test
     fun `a USER fire is its own consent — the grant store is not consulted`() = runTest {
         val engine = buildEngine(StandardTestDispatcher(testScheduler))
-        wheneverBlocking { capabilityGrants.isActionGranted(anyOrNull(), any()) }
+        whenever { capabilityGrants.isActionGranted(anyOrNull(), any()) }
             .thenReturn(false)
 
         engine.process(acceptActionEffect(trigger = ActionTrigger.USER))
@@ -414,7 +414,7 @@ class SideEffectEngineTest {
     fun `keyed effects dedupe on the live path - not just during recovery`() = runTest {
         val engine = buildEngine(StandardTestDispatcher(testScheduler))
         val effect = AppEffect.StartSession("sess-7", "DoorDash")
-        wheneverBlocking { effectsFiredDao.hasBeenFired(effect.effectKey!!) }
+        whenever { effectsFiredDao.hasBeenFired(effect.effectKey) }
             .thenReturn(true)
 
         engine.process(effect, recovering = false)

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/WizardViewModelTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/WizardViewModelTest.kt
@@ -67,8 +67,8 @@ class WizardViewModelTest {
         whenever(strategyRepository.protectStatsMode).thenReturn(flowOf(false))
         whenever(strategyRepository.scoringRules).thenReturn(flowOf(emptyList()))
         whenever(strategyRepository.automationConfig).thenReturn(flowOf(tunedAutomation))
-        wheneverBlocking { vehicleRepository.getYears() }.thenReturn(emptyList())
-        wheneverBlocking { gasPriceRepository.fetchGasPriceOnly(any()) }
+        whenever { vehicleRepository.getYears() }.thenReturn(emptyList())
+        whenever { gasPriceRepository.fetchGasPriceOnly(any()) }
             .thenReturn(Result.failure(RuntimeException("offline in test")))
     }
 

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/capability/RuleCapabilityRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/capability/RuleCapabilityRepository.kt
@@ -31,7 +31,7 @@ import javax.inject.Singleton
 @Singleton
 class RuleCapabilityRepository @Inject constructor(
     private val dataSource: RuleCapabilityDataSource,
-    @param:ApplicationScope scope: CoroutineScope,
+    @ApplicationScope scope: CoroutineScope,
 ) : RuleCapabilityGrants {
 
     /**

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/capture/DiskCaptureBus.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/capture/DiskCaptureBus.kt
@@ -30,7 +30,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 @Singleton
 class DiskCaptureBus @Inject constructor(
     @param:ApplicationContext private val context: Context,
-    @param:IoDispatcher ioDispatcher: CoroutineDispatcher,
+    @IoDispatcher ioDispatcher: CoroutineDispatcher,
 ) : CaptureBus {
 
     private val scope = CoroutineScope(ioDispatcher + SupervisorJob())

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/location/OdometerRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/location/OdometerRepository.kt
@@ -22,7 +22,7 @@ import kotlinx.coroutines.flow.first
 class OdometerRepository @Inject constructor(
     private val odometerLocalDataSource: OdometerLocalDataSource,
     private val locationDataSource: LocationDataSource,
-    @param:IoDispatcher ioDispatcher: CoroutineDispatcher,
+    @IoDispatcher ioDispatcher: CoroutineDispatcher,
 ) {
     private val scope = CoroutineScope(ioDispatcher + SupervisorJob())
     private var trackingJob: Job? = null

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/log/LogRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/log/LogRepository.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.channels.Channel
 @Singleton
 class LogRepository @Inject constructor(
     @param:ApplicationContext private val context: Context,
-    @param:IoDispatcher ioDispatcher: CoroutineDispatcher,
+    @IoDispatcher ioDispatcher: CoroutineDispatcher,
 ) {
     // Run file operations on IO thread to never block the main thread
     private val scope = CoroutineScope(ioDispatcher + SupervisorJob())

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/settings/DevSettingsRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/settings/DevSettingsRepository.kt
@@ -21,7 +21,7 @@ import javax.inject.Named
 class DevSettingsRepository @Inject constructor(
     private val dataSource: DevSettingsDataSource,
     @param:Named("isDebug") private val isDebug: Boolean,
-    @param:IoDispatcher ioDispatcher: CoroutineDispatcher,
+    @IoDispatcher ioDispatcher: CoroutineDispatcher,
 ) {
     private val scope = CoroutineScope(ioDispatcher + SupervisorJob())
 

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/settings/PlatformPreferencesRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/settings/PlatformPreferencesRepository.kt
@@ -19,7 +19,7 @@ import javax.inject.Singleton
 class PlatformPreferencesRepository @Inject constructor(
     private val dataSource: PlatformPreferencesDataSource,
     @param:ApplicationContext private val context: Context,
-    @param:ApplicationScope scope: CoroutineScope,
+    @ApplicationScope scope: CoroutineScope,
 ) : PlatformPreferences {
     private val packageManager: PackageManager = context.packageManager
 

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/strategy/StrategyRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/strategy/StrategyRepository.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 class StrategyRepository @Inject constructor(
     private val dataSource: StrategyDataSource,
     private val appPreferencesRepository: AppPreferencesRepository,
-    @param:IoDispatcher ioDispatcher: CoroutineDispatcher,
+    @IoDispatcher ioDispatcher: CoroutineDispatcher,
 ) {
     private val scope = CoroutineScope(ioDispatcher + SupervisorJob())
 

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/PipelineV2.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/PipelineV2.kt
@@ -17,7 +17,7 @@ class PipelineV2 @Inject constructor(
     accessibilityPipeline: AccessibilityPipeline,
     notificationPipeline: NotificationPipeline,
     stats: PipelineStats,
-    @param:ApplicationScope scope: CoroutineScope,
+    @ApplicationScope scope: CoroutineScope,
 ) {
     /**
      * HOT shared stream (#361). The upstream chain runs side effects — frame


### PR DESCRIPTION
## Summary

A clean compile across `:app` / `:core:*` / `:domain` emitted **22 warnings**; this clears them all (those modules now compile warning-free). No behavior change.

| Count | Warning | Fix |
|---|---|---|
| 8 | `Redundant annotation target 'param'` | dropped the redundant `@param:` on **plain** Hilt-qualified constructor params (`@param:ApplicationScope`/`@param:IoDispatcher` → `@ApplicationScope`/`@IoDispatcher`). The `@param:` on `val` properties (`ApplicationContext`, `Named`) is *not* redundant and was left alone. |
| 7 | deprecated `wheneverBlocking {}` / `onBlocking {}` | → `whenever {}` / `on {}` (Mockito-Kotlin's own `ReplaceWith`), in `SideEffectEngineTest` + `WizardViewModelTest` |
| 4 | `No cast needed` | removed redundant `as Observation.Notification` / `as Observation.Click` in the classifier tests |
| 1 | `ExperimentalCoroutinesApi` opt-in | moved `@OptIn` off `displayedSessionId` (not experimental) onto `messages`, where the `flatMapLatest` is (`BubbleViewModel`) |
| 1 | unnecessary `!!` | `SideEffectEngineTest` |
| 1 | unnecessary safe-call | `TriageRulesTest` |

Verified with a `--rerun-tasks` clean compile (0 warnings) + full `testDebugUnitTest` green; the touched test classes were force-re-run.