### PR TITLE
cleanup: cull dead in-memory vocabulary (#439, partial)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
@@ -271,9 +271,6 @@ class SideEffectEngine @Inject constructor(
                 if (!dispatchRuleEffect(effect.effect)) return
             }
 
-            is AppEffect.PlayNotificationSound -> { /* Implementation */
-            }
-
             is AppEffect.SpeakOffer -> ttsEffectHandler.speakOffer(effect.evaluation)
 
             is AppEffect.StartSession -> bubbleManager.startSession(effect.sessionId, effect.platformName)
@@ -347,10 +344,6 @@ class SideEffectEngine @Inject constructor(
             is AppEffect.CancelTimeout -> {
                 // Untracking happens via the job's self-removing completion handler.
                 activeTimers[effect.type]?.cancel()
-            }
-
-            is AppEffect.SequentialEffect -> {
-                effect.effects.forEach { child -> execute(child, recovering, correlationVersion) }
             }
         }
 
@@ -557,7 +550,6 @@ class SideEffectEngine @Inject constructor(
 
     private fun isExternalEffect(effect: AppEffect): Boolean = when (effect) {
         is AppEffect.UpdateBubble,
-        is AppEffect.PlayNotificationSound,
         is AppEffect.CaptureScreenshot,
         is AppEffect.PerformRuleAction,
         is AppEffect.RequestEffect,

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/input/AccessibilityListener.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/input/AccessibilityListener.kt
@@ -57,14 +57,12 @@ class AccessibilityListener : AccessibilityService() {
 
     override fun onDestroy() {
         super.onDestroy()
-        _instance = null
         Timber.d("Accessibility service destroyed")
     }
 
     override fun onServiceConnected() {
         super.onServiceConnected()
 
-        _instance = this
         Timber.d("Accessibility service connected")
 
         // In debug builds, widen to ALL event types and ALL packages so we can
@@ -83,12 +81,6 @@ class AccessibilityListener : AccessibilityService() {
     }
 
     companion object {
-        @Volatile
-        private var _instance: AccessibilityListener? = null
-
-        val instance: AccessibilityListener?
-            get() = _instance
-
         /** Event types that have pipeline handlers — everything else is "unhandled". */
         private val HANDLED_TYPES = setOf(
             AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED,

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/AppEffect.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/AppEffect.kt
@@ -40,9 +40,6 @@ sealed class AppEffect {
         val expand: Boolean = false
     ) : AppEffect()
 
-    // 3. System Commands (e.g. "Keep Screen On", "Play Sound")
-    data object PlayNotificationSound : AppEffect()
-
     /**
      * Capture an evidence screenshot. [category] is the user-consent bucket
      * the engine's evidence gate (#426) checks against `EvidenceConfig` —
@@ -138,10 +135,6 @@ sealed class AppEffect {
         override val effectKey: String
             get() = "effect:${effect.ruleId}:${effect.dedupeKey ?: effect.verb.wire}"
     }
-
-    data class SequentialEffect(
-        val effects: List<AppEffect>
-    ) : AppEffect()
 
     data class StartSession(val sessionId: String, val platformName: String) : AppEffect() {
         override val effectKey: String get() = "start_session:$sessionId"

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/state/TimeoutEvent.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/state/TimeoutEvent.kt
@@ -7,7 +7,8 @@ import cloud.trotter.dashbuddy.domain.pipeline.ObservationPayload
 data class TimeoutEvent(
     /** Explicit (#366): the engine stamps the fire time at the edge. */
     override val timestamp: Long,
-    val type: TimeoutType = TimeoutType.SESSION_PAUSED_SAFETY,
+    /** Required (#439): no default, so a missing type can't masquerade as a pause expiry. */
+    val type: TimeoutType,
     /** Platform region the timer belongs to — threads through to Observation.Timeout (#342). */
     val platform: Platform? = null,
     val payload: ObservationPayload? = null,

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/Observation.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/Observation.kt
@@ -154,10 +154,7 @@ sealed interface Observation : cloud.trotter.dashbuddy.domain.model.state.StateE
  */
 enum class TimeoutType {
     SESSION_PAUSED_SAFETY,
-    RETRY_CLICK,
     SETTLE_UI,
-    DECLINE_POPUP_WAIT,
-    SCREENSHOT_WAIT,
 
     /**
      * Wakes the state machine when a [PendingDestructive] grace deadline


### PR DESCRIPTION
## Summary

The clearly-dead, **non-persisted** slice of the #439 cull — each verified to have zero emit/schedule/read sites:

- **`TimeoutType.RETRY_CLICK` / `DECLINE_POPUP_WAIT` / `SCREENSHOT_WAIT`** — enum-only, never scheduled (so never written to the persisted observation log either). Kept `SESSION_PAUSED_SAFETY` / `SETTLE_UI` / `GRACE_COMMIT`.
- **`TimeoutEvent.type`** — dropped the `= SESSION_PAUSED_SAFETY` default so a missing type can't masquerade as a pause expiry; now required (the one production caller already passes it).
- **`AppEffect.PlayNotificationSound`** (empty handler, zero emitters) + **`AppEffect.SequentialEffect`** (zero emitters) — removed the types + their `SideEffectEngine` branches.
- **`AccessibilityListener.instance`** companion (+ its `_instance` writes) — tracked the service singleton that nothing ever read.

No behavior change. Full `testDebugUnitTest` green.

## Deferred (need a decision or persisted-schema care)

Documented on #439 — **issue stays open**:
- **`TransitionPolicy` Expected/Unexpected `outcomes` machinery** — dormant (no ruleset declares `outcomes`) but woven through the compiler/classifier/stepper, so "delete the dormant safety-net vs wire it" is an architectural call, not a quick cull.
- **`Job.tasks` / `Session.runningMiles` / `CrossPlatformRegion` totals** — fields of the `@Serializable` `AppState` **recovery snapshot** (`SnapshotStore`); removing them is a snapshot-schema change, and the totals are reserved for the #314 projection layer.
- **`TreeSnapshot.contentChangeTypes`/`Source`** (still logged/accumulated), **`PendingOffer.returnFlow`** (in log payloads), the **`StateManagerV2` `!=` guard** (redundant with StateFlow's own dedup).