### PR TITLE
docs: reconcile architecture docs with the implemented system (#440)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,8 +105,9 @@ The project uses modular Clean Architecture with a strict dependency graph:
 - **`:core:pipeline`** — Accessibility pipeline, notification pipeline, JSON rule engine
   (RuleCompiler, Ruleset, JsonRuleInterpreter), observation classifier. Reads third-party UI.
 - **`:core:state`** — Multi-region state machine (StateMachine, FlowRegionStepper,
-  PlatformRegionStepper, CrossPlatformRegionStepper), effect map, healing policy, crash recovery
-  (StateManagerV2). Defines `EffectExecutor` and `MetadataProvider` interfaces.
+  PlatformRegionStepper, CrossPlatformRegionStepper), effect map, `TransitionPolicy` (the
+  expected/unexpected classification + commit graces; replaced the old `HealingPolicy`), crash
+  recovery (StateManagerV2). Defines `EffectExecutor` and `MetadataProvider` interfaces.
 - **`:core:database`** — Room entities, DAOs, and database setup.
 - **`:core:data`** — Repository implementations, mappers, data sources. Bridges domain interfaces to
   concrete data layers.
@@ -138,9 +139,10 @@ solution is a multi-stage pipeline:
 `:domain`). Per-event-type sub-pipelines (`ContentChangedPipeline` — debounced,
 `StateChangedPipeline`, `WindowsChangedPipeline`, plus click handling in `AccessibilityPipeline`)
 and a parallel `NotificationPipeline` (`NotificationListener` → `NotificationFilter` →
-`NotificationMapper`) emit `PipelineEvent`s. `AccessibilityPipeline.output()` has three drop gates:
-**sensitive** screens, **noise**, and **UNKNOWN** (captured to disk for triage, never forwarded to
-the state machine). Snapshots are attributed to the window's *real* package (not the event's), so
+`NotificationMapper`) emit `PipelineEvent`s. `AccessibilityPipeline.output()` drops in stages:
+a fail-closed **rulesets-not-loaded** gate (#432), then **sensitive**/**noise** (the shared content
+gate, #399), then **disabled-platform** (defense-in-depth), then **UNKNOWN** (captured to disk for
+triage, never forwarded to the state machine). Snapshots are attributed to the window's *real* package (not the event's), so
 our own overlay is dropped (#4 / PR #334). Frame admission is `FrameGate` (identity dedup +
 content-hash rolling suppression of UNKNOWN frames, #360); envelope assembly is the shared
 `CaptureWriter` (#361); `PipelineV2.events` is a HOT `shareIn` stream — one upstream pass feeds

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/FrameGate.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/FrameGate.kt
@@ -13,8 +13,11 @@ import cloud.trotter.dashbuddy.domain.pipeline.UNKNOWN_TARGET
  * The two layers solve different problems:
  *  - **Identity dedup** (`lastIdentity`) suppresses the same RECOGNIZED screen
  *    re-observed back-to-back. It is deliberately NOT updated by UNKNOWN
- *    frames, so a known screen re-forwards after an UNKNOWN interlude even if
- *    its own identity didn't change.
+ *    frames, so an UNKNOWN interlude does not reset identity dedup: an
+ *    *unchanged* known screen STAYS suppressed across it (an UNKNOWN between two
+ *    identical sightings isn't a change), while a known screen with a *new*
+ *    identity still forwards. (A null-identity click clears `lastIdentity`, so
+ *    the same screen forwards again after it.)
  *  - **UNKNOWN suppression** ([UnknownSuppressor]): UNKNOWN identity is
  *    contentless (constant target + ParsedFields.None), so consecutive
  *    *distinct* unknown screens were indistinguishable and every noisy frame

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/AccessibilityPipeline.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/AccessibilityPipeline.kt
@@ -134,7 +134,8 @@ class AccessibilityPipeline @Inject constructor(
         // Dedup + Capture: write unique observations to disk, skip duplicates.
         // Known screens dedup by identity; UNKNOWN frames dedup by tree/node
         // content hash in a rolling seen-set (#360) — lastIdentity semantics
-        // (known-after-UNKNOWN re-forwarding) are preserved inside FrameGate.
+        // (an UNKNOWN interlude doesn't reset known-screen dedup) are preserved
+        // inside FrameGate.
         .mapNotNull { (obs, event) ->
             val contentHash = when (event) {
                 is PipelineEvent.Screen -> event.tree.stableHash

--- a/docs/adr/ADR-0001-matcher-rule-format.md
+++ b/docs/adr/ADR-0001-matcher-rule-format.md
@@ -10,6 +10,20 @@ envelope header with pipeline declarations.
 
 ---
 
+> **Implementation status (2026-06-13, #440).** The **rule format / engine** half of this ADR
+> is implemented and shipping; the **distribution** half is aspirational. Read the spec below
+> with this table in mind:
+>
+> | Area | Status |
+> |---|---|
+> | Compiled rule format, 5-phase evaluation, named bindings, reject entries, `on` modifier, parse sub-language, engine-owned transforms | **Implemented** — see `RuleCompiler` / `Ruleset` / `JsonRuleInterpreter`, `docs/rules.schema.json` |
+> | Platform envelope header (`platform_id` / `format_version` / `pipelines`) | **Implemented** (in the bundled `assets/rules/*.json`) |
+> | JSON5 authoring → canonical JSON tooling | **Future** — rules are hand-authored as JSON today; no JSON5 toolchain |
+> | Signing / integrity verification before compile | **Future** — hard prerequisite for any remote source (#416) |
+> | CDN / OTA delivery, dual-running, forkable sources | **Future** — the #192 matchers split; rules are bundled in-APK today (`assets/rules/`) |
+>
+> The DSL↔schema discrepancies are tracked separately in #241.
+
 ## Context
 
 Screen matchers, click classifiers, and notification classifiers are currently compiled into the

--- a/docs/adr/ADR-0005-pipeline-driven-multi-region-state-architecture.md
+++ b/docs/adr/ADR-0005-pipeline-driven-multi-region-state-architecture.md
@@ -9,6 +9,18 @@
 
 ---
 
+> **Amendment (2026-06-13, #440).** Two parts of the original design were not built as
+> written — the as-implemented system diverges as follows:
+> - **Lifecycle healing is `TransitionPolicy`, not `ModeConfidence` thresholds.** The
+>   confidence-threshold healing in §5.5/§5.8 was abandoned. Healing is now an
+>   expected/unexpected transition classification plus commit graces (`TransitionPolicy`),
+>   and in practice rides on the Offline→Online edge — there is no `ModeConfidence`
+>   accumulator. (The expected/unexpected `outcomes` machinery is itself currently dormant —
+>   no ruleset declares `outcomes` — see #439.)
+> - **A single set of steppers, not a per-platform stepper map.** `FlowRegionStepper` /
+>   `PlatformRegionStepper` / `CrossPlatformRegionStepper` are pure functions applied per
+>   region; the per-platform map of stepper instances described here was never built.
+
 ## Context
 
 DashBuddy's pipeline and state machine have grown organically. The accessibility

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/capture/EnvelopeBuilder.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/capture/EnvelopeBuilder.kt
@@ -14,8 +14,9 @@ import java.util.UUID
  * Builds a capture envelope from pipeline context and a raw payload,
  * serializes it to JSON. Stateless utility — all context is passed per call.
  *
- * Lives in `:core:data` because it depends on kotlinx.serialization for
- * JSON encoding — `:domain` is pure Kotlin.
+ * Lives in `:domain` alongside the capture contracts — kotlinx.serialization
+ * is available here (`:domain` has no *Android* dependencies, which is the
+ * actual constraint; it is not serialization-free).
  */
 object EnvelopeBuilder {
 

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/FlowRegion.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/FlowRegion.kt
@@ -25,8 +25,9 @@ data class FlowRegion(
 
 /**
  * An offer that has been presented and is awaiting accept/decline/timeout.
- * The offer stack automaton pushes when entering [Flow.OfferPresented] and
- * pops when leaving it.
+ * A single depth-1 slot (NOT a stack): set when entering [Flow.OfferPresented]
+ * and cleared when leaving it — one pending offer at a time (relevant to #251's
+ * concurrent-offer case, which this does not yet model).
  *
  * @param returnFlow The flow to return to on decline/timeout.
  * @param targets Named UI targets the offer rule bound on this screen


### PR DESCRIPTION
## Summary

Six places where the docs described a different system than the one built:

1. **FrameGate kdoc + `AccessibilityPipeline` comment** — both claimed an UNKNOWN interlude makes a known screen *"re-forward"*. The code (and `FrameGateTest.lastIdentity semantics survive an UNKNOWN interlude`) do the **opposite**: not updating `lastIdentity` on UNKNOWN means an *unchanged* known screen **stays suppressed** across the interlude. Corrected both.
2. **CLAUDE.md** — `:core:state` "healing policy" → **`TransitionPolicy`** (`HealingPolicy` is gone); "three drop gates" → the actual staged drops (rulesets-not-loaded #432, sensitive/noise #399, **disabled-platform**, UNKNOWN).
3. **ADR-0005** — amendment note: the `ModeConfidence` threshold-healing design (§5.5/§5.8) was abandoned for `TransitionPolicy`, and the per-platform stepper *map* was never built (a single set of pure steppers).
4. **ADR-0001** — implementation-status table: the rule-format/engine half is shipping; the distribution half (JSON5 authoring, signing #416, CDN/OTA #192, dual-running) is aspirational.
5. **`FlowRegion` kdoc** — "offer **stack** automaton" → a single **depth-1 slot** (relevant to #251).
6. **`EnvelopeBuilder` kdoc** — "Lives in `:core:data` … `:domain` is pure Kotlin" → it lives in **`:domain`** (the real constraint is *no Android deps*, not serialization). (`DispatchersModule`'s kdoc was already correct.)

Docs/comments only — no code change; build green.

Closes #440.