### PR TITLE
docs(field-log): 2026-06-13 ghost offer with empty parse — watch item + hypothesis

### DIFF
--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -63,6 +63,18 @@ immediately (no second pass needed) so it gets triaged.
 _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **broken** on the
 2026-06-09 dash — moved to that session's log entry below for triage.)_
 
+- **⚠️ WATCH — "ghost offer" with EMPTY parse logged as a card (2026-06-13 #1, NOT yet fixed).**
+  A phantom Offer card appeared in the stack (between Mello Mushroom and Pei Wei) with **no store, no
+  pay, no miles** — Score 24, `$-2/hr`, Net `-$0.36`, outcome **Timed out**. Hypothesis: a partial
+  `offer_popup` frame whose chrome (Decline + Accept/footer id) satisfied `require` before the content
+  (store `display_name` / pay `$`) rendered → empty parse, still scored + logged as `OFFER_TIMEOUT`.
+  The morning's dedupe/self-recognition fixes wouldn't catch it (distinct empty hash; real DD popup,
+  not our overlay). **What to watch:** any Offer card (live or in the last-dash stack) that shows a
+  **blank store and no pay/miles** — note when it appears (mid another offer? between offers?) and
+  **grab the `offer_popup` capture + `OFFER_TIMEOUT` event** so we can confirm the partial-render tree
+  and decide a validity/settle gate. (See 2026-06-13 log entry #1.)
+  - Sightings: 1 (2026-06-13, desk/screenshot). Gathering frequency before a fix.
+
 - **Offer card surfaces Shop & Deliver: item count in the hero row + a SHOP badge (#461 a/b).**
   The item count moved from a small footer caption up to the hero row (beside the score ring /
   $/hr), and a Shop & Deliver offer now shows a "Shop & Deliver" badge pill. On a shop offer:
@@ -641,6 +653,52 @@ _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **bro
   - **Status:** Triaged → tracked as #279 (summary attribution fixed in PR; the
     "summary after the idle screen" ordering was the root cause). Field-validate
     via the #279 checklist item above.
+
+---
+
+## 2026-06-13 — DoorDash session (desk review of post-#487 build)
+
+- **Platform tested:** DoorDash
+- **Branch under test:** `master` @ `aaa8d94` (post the 2026-06-13 morning batch: #464–#490 — incl.
+  #473 durable-last-dash, #470 double-dropoff, #466 money-formatter SSOT, #461 shop cards,
+  #462/#463 recognition + privacy batches). The bubble now shows the last dash again (#473).
+- **Field conditions:** desk review of a completed dash in the bubble's last-dash card stack, with a
+  developer screenshot. Recorded for triage — **hypothesis, not a concluded fix.**
+
+### Bugs
+
+#### 1. **Ghost offer** — a phantom Offer card with EMPTY parse (no store / no pay / no miles), scored and logged
+In the card stack, **between the Mello Mushroom and Pei Wei offers**, there is a ghost Offer card the
+dasher doesn't recognize. From the screenshot:
+
+- **Ghost card:** Score **24**, hero **`$-2/hr`**, **Net `-$0.36` · `-$0.36/mi`**, verdict
+  **DECLINE / BAD OFFER**, outcome chip **Timed out** — and **no store name, no pay amount, no real
+  distance** (the `-$0.36` / `-$0.36/mi` are cost-only artifacts of an empty parse).
+- **Pei Wei card (contrast, fully populated):** Score 66, `$18/hr`, Net `$8.26 · 8.4 mi · $0.98/mi`,
+  `2 items`, store `Pei Wei & Cold Stone Creamery`, Declined.
+
+- **Likely cause (hypothesis):** a **transient/partial `offer_popup` frame**. The rule's `require`
+  (`doordash.json` `doordash.screen.offer_popup`) is satisfied by the popup **chrome** — `"Decline"`
+  text + (`"Accept"`/`"Add to route"`) + the `accept_button`/`accept_decline_footer_container` id —
+  which renders **early**. But the **content** nodes the `parse` reads (`display_name` for the
+  store/orders, the `$` pay text) hadn't rendered yet, so the parse produced **empty `orders`, null
+  `payAmount`, and a near-zero/garbage distance**. The evaluator still scored the empty offer (Score
+  24, Net `-$0.36` = $0 pay minus ~1 mi of cost), and because the frame was then replaced/expired
+  without a real Accept/Decline, it was logged as **`OFFER_TIMEOUT`** → a ghost card. (This is the
+  empty-parse cousin of the 06-09 #4 phantom, but **not** self-recognition — that gate is intact;
+  this is a real DoorDash popup caught mid-render.)
+- **Would the morning's fixes catch it? Probably not.** `#427`/`#436` dedupe the **same** offer by
+  hash (a distinct empty parse has its own hash); the #4 self-recognition gate only drops **our**
+  overlay. **Nothing currently rejects a real-but-empty partial offer frame** — there is no
+  validity/settle gate before an `offer_popup` is presented, scored, and logged.
+- **To confirm (desk):** pull the `offer_popup/*.json` capture in the Mello→Pei Wei gap + the
+  `OFFER_TIMEOUT` `app_events` row. Expect a **partial tree** (footer/accept chrome present, but no
+  `display_name` / no pay `$` node) and an **empty `parsedOffer`**.
+- **Possible directions (desk call, NOT a concluded fix):** (a) a **validity gate** — don't
+  present/score/log an `offer_popup` whose parse has **empty `orders` AND null `payAmount`**;
+  (b) **settle/debounce** the offer frame before eval (the idea dropped in 06-09 #4 — but this empty
+  partial-render is exactly its use case); (c) require at least a store **or** a pay value before the
+  evaluator runs. Logged to the watch list so a live dash can confirm frequency before any fix.
 
 ---
 


### PR DESCRIPTION
Docs-only — `docs/field-testing/README.md`.

`[skip ci]`

## What
Desk review on `master` @ `aaa8d94` (post the 2026-06-13 morning batch). A **ghost Offer card** appeared in the bubble's last-dash stack, between the Mello Mushroom and Pei Wei offers:

- Score **24**, hero **`$-2/hr`**, Net **`-$0.36` · `-$0.36/mi`**, **DECLINE / BAD OFFER**, outcome **Timed out** — and **no store, no pay, no miles** (vs. the Pei Wei card which is fully populated). Developer screenshot confirms.

## Hypothesis (recorded, not fixed)
A **transient/partial `offer_popup` frame**: the popup chrome (`"Decline"` + `"Accept"`/`"Add to route"` + the `accept_button`/`accept_decline_footer_container` id) satisfies `require` and renders early, but the content nodes the `parse` reads (store `display_name`, pay `$`) hadn't rendered yet → **empty `orders`, null `payAmount`, near-zero distance**. The evaluator still scored it (24, Net ≈ $0 − ~1mi cost = −$0.36) and it was logged as **`OFFER_TIMEOUT`** → ghost card.

- **Not** self-recognition — that gate (#4) is intact on current master.
- The morning's **#427/#436** dedupe fixes wouldn't catch it (a distinct empty parse has its own hash); there is **no validity/settle gate** before an offer is presented/scored/logged.

## Desk confirm + possible directions (a desk call, not concluded)
- Pull the `offer_popup/*.json` in the Mello→Pei Wei gap + the `OFFER_TIMEOUT` `app_events` row → expect a partial tree (chrome present, no `display_name`/pay) and empty `parsedOffer`.
- Candidate fixes: (a) validity gate — don't present/score/log an offer with empty `orders` AND null `payAmount`; (b) settle/debounce the offer frame before eval; (c) require a store or pay before the evaluator runs.

Added a dated entry (#1) + a "Next field test — things to look for" watch item.

Security/privacy posture: docs-only; no code/recognition/capture/network/effects changes.

https://claude.ai/code/session_012QK9LZaC1Txcfp4LVcTQS1

---
_Generated by [Claude Code](https://claude.ai/code/session_012QK9LZaC1Txcfp4LVcTQS1)_