### PR TITLE
test(replay): SessionReplay harness — reproduce field bugs as red/green tests (epic #505)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -335,6 +335,19 @@ Tests are data-driven using captured UI hierarchy JSON files under
    ratchets corpus coverage (new intents should ship with corpus) and lints dedupeKey
    `{field}` templates against fields the rule actually parses.
 
+### Session replay (capture sequence → recognition → state machine)
+
+The snapshot tests above are **per-frame** (does this screen recognize/parse right, in isolation).
+To reproduce a **field bug that's emergent across a session** — a ghost offer, a re-mint, doubled
+dropoffs — `SessionReplay` (`app/src/test/.../test/util/SessionReplay.kt`) replays a *chronological
+sequence* of real device `CaptureEnvelope`s: `replayRecognition` (Level A → `List<Observation>` via
+the production rules) and `reduce` (Level B → folds through the real `StateMachine`, returning a
+per-frame trace of `{observation, stateAfter, events}` where events match the db `app_events` shape).
+The captured session's db `app_events` is a **characterization** oracle (it *encodes* the bug), so
+Level-B assertions are hand-authored correct-behaviour invariants, **never `replay == db`**.
+`GhostOfferReplayTest` is the worked example (red/green for #498). Tracked + roadmapped (on-device
+review tool, verdict export) under epic #505.
+
 ## Key Technologies
 
 - **DI:** Hilt 2.59.2 with KSP

--- a/app/src/test/java/cloud/trotter/dashbuddy/replay/GhostOfferReplayTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/replay/GhostOfferReplayTest.kt
@@ -1,0 +1,100 @@
+package cloud.trotter.dashbuddy.replay
+
+import cloud.trotter.dashbuddy.domain.model.event.AppEventType
+import cloud.trotter.dashbuddy.domain.model.event.payload.OfferReceivedPayload
+import cloud.trotter.dashbuddy.domain.model.offer.ParsedOffer
+import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import cloud.trotter.dashbuddy.test.util.SessionReplay
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Ignore
+import org.junit.Test
+
+/**
+ * First [SessionReplay] regression: reproduces the field-observed "ghost offer" (#498) by
+ * replaying two REAL captures from the 2026-06-14 dash through the production rules —
+ *  1. `01_real_offer_heb_1630.json` — a genuine H-E-B Shop & Deliver offer.
+ *  2. `02_ghost_offer_blank_1631.json` — a blank `offer_popup` frame (only Accept/Decline
+ *     chrome, no store/pay/distance) captured 16:31:52, which the device logged as
+ *     OFFER_RECEIVED + immediate OFFER_TIMEOUT (db `app_events` seq 152/153, session
+ *     `session-doordash-1781470176806-43`).
+ *
+ * The all-null parse produces `offerHash == sha256("null|null|null|")`, the same fingerprint
+ * recorded in the db — so this test grounds #498 in reproducible data instead of narration.
+ */
+class GhostOfferReplayTest {
+
+    private val session = "snapshots/sessions/ghost_offer_2026_06_14"
+
+    /** sha256("null|null|null|") — the deterministic fingerprint of an all-null offer parse. */
+    private val nullOfferHash = "906a43f85fed65ed12efc8878df2ccf467e4171b7c288720e0d13137997c0382"
+
+    private fun Observation.Screen.offer(): ParsedOffer =
+        (parsed as ParsedFields.OfferFields).parsedOffer
+
+    @Test
+    fun `harness reproduces the ghost offer from real captures (characterization, #498)`() {
+        val obs = SessionReplay.replayRecognition(session)
+        obs.forEachIndexed { i, o ->
+            println("frame[$i] target=${o.target} ruleId=${o.ruleId} flow=${o.flow} parsed=${o.parsed::class.simpleName} ts=${o.timestamp}")
+        }
+        assertEquals("expected 2 frames (real H-E-B offer, then blank ghost)", 2, obs.size)
+        val real = obs[0]
+        val ghost = obs[1]
+
+        // Both the real and blank frames currently recognize as offer_popup.
+        assertEquals("offer_popup", real.target)
+        assertEquals("offer_popup", ghost.target)
+
+        // The REAL offer parses its scored fields.
+        val realOffer = real.offer()
+        assertEquals(18.25, realOffer.payAmount!!, 0.001)
+        assertEquals(11.3, realOffer.distanceMiles!!, 0.001)
+        assertNotEquals(nullOfferHash, realOffer.offerHash)
+
+        // The GHOST (blank chrome — no store/pay/distance) STILL recognizes as an offer and
+        // parses to an all-null offer whose hash is sha256("null|null|null|") — the exact hash
+        // the device logged. This is the #498 defect, reproduced from the real capture.
+        val ghostOffer = ghost.offer()
+        assertNull("ghost offer must have no pay", ghostOffer.payAmount)
+        assertNull("ghost offer must have no distance", ghostOffer.distanceMiles)
+        assertEquals(nullOfferHash, ghostOffer.offerHash)
+    }
+
+    @Ignore("RED until #498 — recognition must reject a blank offer_popup (require the scored fields).")
+    @Test
+    fun `after #498 a blank offer_popup must not become an offer`() {
+        val obs = SessionReplay.replayRecognition(session)
+        val ghost = obs[1]
+        assertFalse(
+            "blank offer frame should not parse to an all-null OfferFields once #498 lands",
+            ghost.parsed is ParsedFields.OfferFields && ghost.offer().offerHash == nullOfferHash,
+        )
+    }
+
+    @Test
+    fun `Level B - the blank offer drives a phantom OFFER_RECEIVED through the state machine (#498)`() {
+        // Isolate the blank ghost frame and reduce it from idle through the REAL state machine.
+        // The defect: a blank frame becomes a logged OFFER_RECEIVED — the exact event the device
+        // emitted (db seq 152). Level A proved the recognition; Level B proves the emitted EVENT.
+        val ghostFrame = SessionReplay.loadSession(session).first { it.file.contains("ghost") }
+        val steps = SessionReplay.reduce(listOf(ghostFrame))
+        println(SessionReplay.trace(steps))
+
+        val received = steps.flatMap { it.events }.filter { it.type == AppEventType.OFFER_RECEIVED }
+        assertEquals("blank frame emits exactly one phantom OFFER_RECEIVED", 1, received.size)
+        assertEquals(nullOfferHash, (received.single().payload as OfferReceivedPayload).offerHash)
+    }
+
+    @Ignore("RED until #498 — a blank offer_popup must emit no OFFER_RECEIVED.")
+    @Test
+    fun `after #498 the blank offer emits no OFFER_RECEIVED (Level B)`() {
+        val ghostFrame = SessionReplay.loadSession(session).first { it.file.contains("ghost") }
+        val events = SessionReplay.reduce(listOf(ghostFrame)).flatMap { it.events }
+        assertTrue(events.none { it.type == AppEventType.OFFER_RECEIVED })
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/test/util/SessionReplay.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/test/util/SessionReplay.kt
@@ -1,0 +1,173 @@
+package cloud.trotter.dashbuddy.test.util
+
+import cloud.trotter.dashbuddy.core.pipeline.ObservationClassifier
+import cloud.trotter.dashbuddy.core.pipeline.PipelineEvent
+import cloud.trotter.dashbuddy.core.pipeline.accessibility.TreeSnapshot
+import cloud.trotter.dashbuddy.core.pipeline.rules.JsonRuleInterpreter
+import cloud.trotter.dashbuddy.core.state.AppEffect
+import cloud.trotter.dashbuddy.core.state.CrossPlatformRegionStepper
+import cloud.trotter.dashbuddy.core.state.EffectMap
+import cloud.trotter.dashbuddy.core.state.FlowRegionStepper
+import cloud.trotter.dashbuddy.core.state.PlatformRegionStepper
+import cloud.trotter.dashbuddy.core.state.StateMachine
+import cloud.trotter.dashbuddy.core.state.TransitionPolicy
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadataProvider
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import cloud.trotter.dashbuddy.domain.model.event.AppEvent
+import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.state.AppState
+import cloud.trotter.dashbuddy.domain.state.Platform
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import java.io.File
+
+/**
+ * Session-replay harness — drives a *sequence* of real on-device captures through the
+ * production recognition layer so a field-observed defect can be reproduced and asserted
+ * as a red/green test, with no field dash required to validate a fix.
+ *
+ * This is **Level A** (recognition only): a real `CaptureEnvelope` sequence becomes a
+ * `List<Observation>` via the *production* rule JSON ([TestRulesetFactory]). It uses no
+ * steppers and no timers, so it is fully deterministic. It catches recognition-side
+ * defects — e.g. a blank `offer_popup` frame being classified as a real offer (#498), or a
+ * screen that should recognize but falls to UNKNOWN (#501).
+ *
+ * Level B (folding the Observation sequence through the real `StateMachine` to assert the
+ * emitted event timeline against the db oracle) builds on top of this and is added
+ * separately — it needs timer/grace synthesis and is documented in the harness design.
+ *
+ * Input lives under `app/src/test/resources/snapshots/sessions/<name>/`; each file is a
+ * device `CaptureEnvelope` (top-level `payload` = the `UiNode` tree, plus `timestamp` /
+ * `platform` / `captureId`).
+ */
+object SessionReplay {
+
+    private val json = Json { ignoreUnknownKeys = true; explicitNulls = false }
+
+    /** One replay input: a real capture with the envelope metadata [TestResourceLoader] discards. */
+    data class ReplayFrame(
+        val file: String,
+        val node: UiNode,
+        val capturedAtMs: Long,
+        val wire: String,
+        val captureId: String?,
+    )
+
+    /**
+     * Loads every `*.json` `CaptureEnvelope` under `src/test/resources/<pathFromResources>`,
+     * recovering the envelope's capture `timestamp` / `platform` / `captureId`, and sorts the
+     * frames into capture-time order. The `UiNode` tree itself is decoded by the existing
+     * [TestResourceLoader.loadNode] (same `payload` path the rest of the corpus uses).
+     */
+    fun loadSession(pathFromResources: String): List<ReplayFrame> {
+        val dir = File("src/test/resources/$pathFromResources")
+        require(dir.isDirectory) { "Not a session directory: ${dir.absolutePath}" }
+        return dir.listFiles { _, name -> name.endsWith(".json") }
+            ?.map { file ->
+                val root = json.parseToJsonElement(file.readText()).jsonObject
+                ReplayFrame(
+                    file = file.name,
+                    node = TestResourceLoader.loadNode(file),
+                    capturedAtMs = root["timestamp"]?.jsonPrimitive?.longOrNull ?: 0L,
+                    wire = root["platform"]?.jsonPrimitive?.contentOrNull ?: Platform.Unknown.wire,
+                    captureId = root["captureId"]?.jsonPrimitive?.contentOrNull,
+                )
+            }
+            ?.sortedBy { it.capturedAtMs }
+            ?: emptyList()
+    }
+
+    /**
+     * Level A — classify each frame through the production screen ruleset, returning the
+     * `Observation.Screen` sequence in capture order.
+     *
+     * Clock correction: [ObservationClassifier] stamps a Screen observation with
+     * `System.currentTimeMillis()` (its `eventNow`), **not** the capture time, so each
+     * returned observation is re-stamped with the frame's real `capturedAtMs` — the steppers
+     * are `obs.timestamp`-driven, so the replayed time must be the captured time.
+     */
+    fun replayRecognition(frames: List<ReplayFrame>): List<Observation.Screen> {
+        val classifier = screenClassifier()
+        return frames.map { frame ->
+            val pkg = Platform.entries.firstOrNull { it.wire == frame.wire }?.packageName
+            val event = PipelineEvent.Screen(
+                timestamp = frame.capturedAtMs,
+                tree = frame.node,
+                snapshot = TreeSnapshot(frame.node, TreeSnapshot.Source.WINDOWS_CHANGED, packageName = pkg),
+                packageName = pkg,
+            )
+            classifier.classify(event).copy(timestamp = frame.capturedAtMs)
+        }
+    }
+
+    /** Convenience: load + replay recognition in one call. */
+    fun replayRecognition(pathFromResources: String): List<Observation.Screen> =
+        replayRecognition(loadSession(pathFromResources))
+
+    /** One replayed step: the frame, what it recognized as, the state after, and the events it emitted. */
+    data class ReplayStep(
+        val frame: ReplayFrame,
+        val observation: Observation.Screen,
+        val stateAfter: AppState,
+        val events: List<AppEvent>,
+    )
+
+    /**
+     * Level B — fold the recognized observations through the REAL [StateMachine] and return a
+     * per-frame step trace: each frame's observation, the `AppState` after it, and the `AppEvent`s
+     * it emitted (the same events that land in the db `app_events` log). This is the shared spine of
+     * the automated tests, the JVM trace, and the on-device review screen.
+     *
+     * Screen-only caveat: offer accept/decline are driven by CLICK observations (EffectMap), which
+     * the on-disk corpus rarely contains — so a screen-only replay resolves offers to `OFFER_TIMEOUT`.
+     * Driving a full accept→pickup→dropoff chain needs synthetic click + timer observations (a later
+     * phase of the harness).
+     */
+    fun reduce(frames: List<ReplayFrame>): List<ReplayStep> {
+        val machine = StateMachine(
+            flowStepper = FlowRegionStepper(),
+            platformStepper = PlatformRegionStepper(),
+            crossPlatformStepper = CrossPlatformRegionStepper(),
+            transitionPolicy = TransitionPolicy(),
+            effectMap = EffectMap(),
+        )
+        val observations = replayRecognition(frames)
+        var state = AppState()
+        return frames.zip(observations).map { (frame, obs) ->
+            val transition = machine.step(state, obs)
+            state = transition.newState
+            ReplayStep(
+                frame = frame,
+                observation = obs,
+                stateAfter = state,
+                events = transition.effects.filterIsInstance<AppEffect.LogEvent>().map { it.event },
+            )
+        }
+    }
+
+    /** Convenience: load + reduce in one call. */
+    fun reduce(pathFromResources: String): List<ReplayStep> = reduce(loadSession(pathFromResources))
+
+    /** A readable per-step trace (JVM): `frame → recognized screen → emitted events`. */
+    fun trace(steps: List<ReplayStep>): String = buildString {
+        steps.forEachIndexed { i, s ->
+            val events = s.events.joinToString { it.type.name }.ifEmpty { "—" }
+            appendLine("[%2d] %-40s %-22s → %s".format(i, s.frame.file.take(40), s.observation.target ?: "UNKNOWN", events))
+        }
+    }
+
+    /**
+     * A classifier wired to the **production** screen rules with no Android Context — the same
+     * mock wiring [ClickClassifierTest] uses for the click path.
+     */
+    private fun screenClassifier(): ObservationClassifier = ObservationClassifier(
+        mock<JsonRuleInterpreter> { on { screenRuleset } doReturn TestRulesetFactory.screenRuleset },
+        mock<ReplayMetadataProvider> { on { current() } doReturn ReplayMetadata.EMPTY },
+    )
+}

--- a/app/src/test/resources/snapshots/sessions/ghost_offer_2026_06_14/01_real_offer_heb_1630.json
+++ b/app/src/test/resources/snapshots/sessions/ghost_offer_2026_06_14/01_real_offer_heb_1630.json
@@ -1,0 +1,974 @@
+{
+    "captureId": "b7db348e-7ae4-41a8-8fc4-1b6c95e8b556",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1781472655738,
+    "platform": "doordash",
+    "ruleId": "doordash.screen.offer_popup",
+    "classificationName": "offer_popup",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 136,
+                            "right": 1080,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 136,
+                                    "right": 1080,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 136,
+                                            "right": 1080,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 136,
+                                                    "right": 1080,
+                                                    "bottom": 2347
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/accept_decline_fragment_container",
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/bottomSheetLayout",
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 136,
+                                                                    "right": 1080,
+                                                                    "bottom": 2347
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/accept_constraint_layout",
+                                                                        "class": "android.view.ViewGroup",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 136,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/map_container",
+                                                                                "class": "android.widget.FrameLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 136,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2347
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 136,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2347
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.view.TextureView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 136,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2347
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 136,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2347
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 5,
+                                                                                                    "top": 1282,
+                                                                                                    "right": 194,
+                                                                                                    "bottom": 1329
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isClickable": true,
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 200,
+                                                                                                    "top": 1282,
+                                                                                                    "right": 247,
+                                                                                                    "bottom": 1329
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/secondary_action_button_dash_plus",
+                                                                                "class": "android.widget.Button",
+                                                                                "isClickable": true,
+                                                                                "bounds": {
+                                                                                    "left": 816,
+                                                                                    "top": 172,
+                                                                                    "right": 1044,
+                                                                                    "bottom": 297
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "text": "Decline",
+                                                                                        "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "bounds": {
+                                                                                            "left": 852,
+                                                                                            "top": 202,
+                                                                                            "right": 1008,
+                                                                                            "bottom": 268
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "text": "170d57fa-f3d8-409d-bd63-4cd39b06acde",
+                                                                                "id": "com.doordash.driverapp:id/assignment_id_text",
+                                                                                "class": "android.widget.TextView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 702,
+                                                                                    "top": 1288,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 1329
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/load_progress",
+                                                                        "class": "android.widget.RelativeLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 136,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "state": "in progress",
+                                                                                "id": "com.doordash.driverapp:id/progress_bar",
+                                                                                "class": "android.widget.ProgressBar",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 486,
+                                                                                    "top": 1188,
+                                                                                    "right": 593,
+                                                                                    "bottom": 1295
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/progress_message",
+                                                                                "class": "android.widget.TextView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 540,
+                                                                                    "top": 1295,
+                                                                                    "right": 540,
+                                                                                    "bottom": 1342
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/prism_sheet",
+                                                                        "class": "android.view.ViewGroup",
+                                                                        "isClickable": true,
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 1329,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/prism_sheet_collar_view",
+                                                                                "class": "android.widget.FrameLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 1329,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 1526
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/collar_background",
+                                                                                        "class": "android.widget.LinearLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 1329,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 1526
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/custom_view_container",
+                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 1329,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 1508
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/animated_collar_view_container",
+                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 1329,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 1508
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.doordash.driverapp:id/animated_collar_view_icon",
+                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 36,
+                                                                                                                    "top": 1365,
+                                                                                                                    "right": 143,
+                                                                                                                    "bottom": 1472
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "id": "com.doordash.driverapp:id/layout_textContainer",
+                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 161,
+                                                                                                                    "top": 1367,
+                                                                                                                    "right": 1044,
+                                                                                                                    "bottom": 1470
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "You're getting paid more as a Pro",
+                                                                                                                        "id": "com.doordash.driverapp:id/animated_collar_view_title",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 161,
+                                                                                                                            "top": 1367,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 1419
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "text": "High paying offer",
+                                                                                                                        "id": "com.doordash.driverapp:id/animated_collar_view_body",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 161,
+                                                                                                                            "top": 1423,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 1470
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/handle_overlay",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 1499,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 1526
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/extra_space",
+                                                                                "class": "android.view.View",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 1526,
+                                                                                    "right": 0,
+                                                                                    "bottom": 1562
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/prism_sheet_content_parent_container",
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 1562,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2311
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/nested_scroll_view",
+                                                                                        "class": "android.widget.ScrollView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 1562,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2311
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/prism_content_container",
+                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 1562,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2151
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/bottomsheet_content_container",
+                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 1562,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2151
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.doordash.driverapp:id/accept_decline_recycler_view_container",
+                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 1562,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2151
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "id": "com.doordash.driverapp:id/items_recycler_view",
+                                                                                                                        "class": "androidx.recyclerview.widget.RecyclerView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 1562,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2151
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1562,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 1563
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1563,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 1647
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 1563,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 1647
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "$18.25  Guaranteed (incl. tips)",
+                                                                                                                                                "id": "com.doordash.driverapp:id/text_field",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 1563,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 1647
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1647,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 1712
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 1647,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 1712
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "11.3 mi",
+                                                                                                                                                "id": "com.doordash.driverapp:id/text_field",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 1647,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 1712
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1712,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 1768
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 1712,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 1768
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Deliver by 5:35 PM",
+                                                                                                                                                "id": "com.doordash.driverapp:id/text_field",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 1712,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 1768
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1768,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 1808
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 1804,
+                                                                                                                                            "right": 1044,
+                                                                                                                                            "bottom": 1808
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1808,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 1952
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 1808,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 1952
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/work_unit_icon_container",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 45,
+                                                                                                                                                    "top": 1835,
+                                                                                                                                                    "right": 99,
+                                                                                                                                                    "bottom": 1889
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.doordash.driverapp:id/work_unit_image",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 45,
+                                                                                                                                                            "top": 1835,
+                                                                                                                                                            "right": 99,
+                                                                                                                                                            "bottom": 1889
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "Shop for items",
+                                                                                                                                                "id": "com.doordash.driverapp:id/work_unit_type",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 126,
+                                                                                                                                                    "top": 1841,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 1883
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/bottom_vertical_line",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 71,
+                                                                                                                                                    "top": 1889,
+                                                                                                                                                    "right": 73,
+                                                                                                                                                    "bottom": 1952
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/display_name_container",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isClickable": true,
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 126,
+                                                                                                                                                    "top": 1901,
+                                                                                                                                                    "right": 972,
+                                                                                                                                                    "bottom": 1952
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "text": "H-E-B",
+                                                                                                                                                        "id": "com.doordash.driverapp:id/display_name",
+                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 126,
+                                                                                                                                                            "top": 1901,
+                                                                                                                                                            "right": 264,
+                                                                                                                                                            "bottom": 1952
+                                                                                                                                                        }
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "text": "(32 units)",
+                                                                                                                                                        "id": "com.doordash.driverapp:id/display_name_secondary",
+                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 264,
+                                                                                                                                                            "top": 1901,
+                                                                                                                                                            "right": 435,
+                                                                                                                                                            "bottom": 1952
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/chevron",
+                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                "isClickable": true,
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1008,
+                                                                                                                                                    "top": 1912,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 1952
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1952,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2033
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 1952,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2033
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/top_vertical_line",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 71,
+                                                                                                                                                    "top": 1952,
+                                                                                                                                                    "right": 73,
+                                                                                                                                                    "bottom": 1979
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/work_unit_image",
+                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 45,
+                                                                                                                                                    "top": 1979,
+                                                                                                                                                    "right": 99,
+                                                                                                                                                    "bottom": 2033
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "Customer dropoff",
+                                                                                                                                                "id": "com.doordash.driverapp:id/display_name",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 126,
+                                                                                                                                                    "top": 1985,
+                                                                                                                                                    "right": 424,
+                                                                                                                                                    "bottom": 2027
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/display_name_secondary",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 433,
+                                                                                                                                                    "top": 1985,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2027
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 2033,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2073
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 2069,
+                                                                                                                                            "right": 1044,
+                                                                                                                                            "bottom": 2073
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 2073,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2151
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 2073,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2151
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/callout_image",
+                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 45,
+                                                                                                                                                    "top": 2091,
+                                                                                                                                                    "right": 99,
+                                                                                                                                                    "bottom": 2145
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "Items can be added before checkout",
+                                                                                                                                                "id": "com.doordash.driverapp:id/callout_text",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 117,
+                                                                                                                                                    "top": 2091,
+                                                                                                                                                    "right": 1035,
+                                                                                                                                                    "bottom": 2151
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/prism_sheet_footer_divider",
+                                                                        "class": "android.view.View",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 2147,
+                                                                            "right": 1080,
+                                                                            "bottom": 2151
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/prism_sheet_footer_container",
+                                                                        "class": "android.widget.LinearLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 2151,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/accept_decline_footer_container",
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 2151,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2347
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/accept_button",
+                                                                                        "class": "android.widget.Button",
+                                                                                        "isClickable": true,
+                                                                                        "bounds": {
+                                                                                            "left": 36,
+                                                                                            "top": 2187,
+                                                                                            "right": 1044,
+                                                                                            "bottom": 2311
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "Accept",
+                                                                                                "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "bounds": {
+                                                                                                    "left": 467,
+                                                                                                    "top": 2216,
+                                                                                                    "right": 613,
+                                                                                                    "bottom": 2282
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/textSwitcher_prism_button_end_text",
+                                                                                                "class": "android.widget.TextSwitcher",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 965,
+                                                                                                    "top": 2219,
+                                                                                                    "right": 1008,
+                                                                                                    "bottom": 2279
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "text": "8",
+                                                                                                        "id": "com.doordash.driverapp:id/textView_prism_button_end_text_1",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "bounds": {
+                                                                                                            "left": 983,
+                                                                                                            "top": 2219,
+                                                                                                            "right": 1008,
+                                                                                                            "bottom": 2279
+                                                                                                        }
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/sessions/ghost_offer_2026_06_14/02_ghost_offer_blank_1631.json
+++ b/app/src/test/resources/snapshots/sessions/ghost_offer_2026_06_14/02_ghost_offer_blank_1631.json
@@ -1,0 +1,549 @@
+{
+    "captureId": "fc21bd09-bfc7-40b7-ac1d-3cf7e84d9290",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1781472712465,
+    "platform": "doordash",
+    "ruleId": "doordash.screen.offer_popup",
+    "classificationName": "offer_popup",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 159,
+            "top": 0,
+            "right": 1239,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 159,
+                    "top": 0,
+                    "right": 1239,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 159,
+                            "top": 136,
+                            "right": 1239,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 159,
+                                    "top": 136,
+                                    "right": 1239,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 159,
+                                            "top": 136,
+                                            "right": 1239,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 159,
+                                                    "top": 136,
+                                                    "right": 1239,
+                                                    "bottom": 2347
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/accept_decline_fragment_container",
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 159,
+                                                            "top": 136,
+                                                            "right": 1239,
+                                                            "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/bottomSheetLayout",
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 159,
+                                                                    "top": 136,
+                                                                    "right": 1239,
+                                                                    "bottom": 2347
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/accept_constraint_layout",
+                                                                        "class": "android.view.ViewGroup",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 159,
+                                                                            "top": 136,
+                                                                            "right": 1239,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/secondary_action_button_dash_plus",
+                                                                                "class": "android.widget.Button",
+                                                                                "isClickable": true,
+                                                                                "bounds": {
+                                                                                    "left": 159,
+                                                                                    "top": 136,
+                                                                                    "right": 159,
+                                                                                    "bottom": 136
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "text": "Decline",
+                                                                                        "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "bounds": {
+                                                                                            "left": 159,
+                                                                                            "top": 136,
+                                                                                            "right": 159,
+                                                                                            "bottom": 136
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/map_container",
+                                                                                "class": "android.widget.FrameLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 159,
+                                                                                    "top": 136,
+                                                                                    "right": 1239,
+                                                                                    "bottom": 2347
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 159,
+                                                                                            "top": 136,
+                                                                                            "right": 1239,
+                                                                                            "bottom": 2347
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.view.TextureView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 159,
+                                                                                                    "top": 136,
+                                                                                                    "right": 1239,
+                                                                                                    "bottom": 2347
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 159,
+                                                                                                    "top": 136,
+                                                                                                    "right": 1239,
+                                                                                                    "bottom": 2347
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 164,
+                                                                                                    "top": 2021,
+                                                                                                    "right": 353,
+                                                                                                    "bottom": 2068
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isClickable": true,
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 359,
+                                                                                                    "top": 2021,
+                                                                                                    "right": 406,
+                                                                                                    "bottom": 2068
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "text": "a75dad78-3079-473c-b9b7-19e142a4864f",
+                                                                                "id": "com.doordash.driverapp:id/assignment_id_text",
+                                                                                "class": "android.widget.TextView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 870,
+                                                                                    "top": 2027,
+                                                                                    "right": 1239,
+                                                                                    "bottom": 2068
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/load_progress",
+                                                                        "class": "android.widget.RelativeLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 159,
+                                                                            "top": 136,
+                                                                            "right": 1239,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "state": "in progress",
+                                                                                "id": "com.doordash.driverapp:id/progress_bar",
+                                                                                "class": "android.widget.ProgressBar",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 645,
+                                                                                    "top": 1188,
+                                                                                    "right": 752,
+                                                                                    "bottom": 1295
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/progress_message",
+                                                                                "class": "android.widget.TextView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 699,
+                                                                                    "top": 1295,
+                                                                                    "right": 699,
+                                                                                    "bottom": 1342
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/prism_sheet",
+                                                                        "class": "android.view.ViewGroup",
+                                                                        "isClickable": true,
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 159,
+                                                                            "top": 2068,
+                                                                            "right": 1239,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/prism_sheet_collar_view",
+                                                                                "class": "android.widget.FrameLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 159,
+                                                                                    "top": 2068,
+                                                                                    "right": 1239,
+                                                                                    "bottom": 2068
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/handle_overlay",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 159,
+                                                                                            "top": 2068,
+                                                                                            "right": 159,
+                                                                                            "bottom": 2068
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/collar_background",
+                                                                                        "class": "android.widget.LinearLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 159,
+                                                                                            "top": 2068,
+                                                                                            "right": 159,
+                                                                                            "bottom": 2068
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/custom_view_container",
+                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 159,
+                                                                                                    "top": 2068,
+                                                                                                    "right": 159,
+                                                                                                    "bottom": 2068
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/animated_collar_view_container",
+                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 159,
+                                                                                                            "top": 2068,
+                                                                                                            "right": 159,
+                                                                                                            "bottom": 2068
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.doordash.driverapp:id/layout_textContainer",
+                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 159,
+                                                                                                                    "top": 2068,
+                                                                                                                    "right": 159,
+                                                                                                                    "bottom": 2068
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "High paying offer",
+                                                                                                                        "id": "com.doordash.driverapp:id/animated_collar_view_body",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 159,
+                                                                                                                            "top": 2068,
+                                                                                                                            "right": 159,
+                                                                                                                            "bottom": 2068
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "text": "You're getting paid more as a Pro",
+                                                                                                                        "id": "com.doordash.driverapp:id/animated_collar_view_title",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 159,
+                                                                                                                            "top": 2068,
+                                                                                                                            "right": 159,
+                                                                                                                            "bottom": 2068
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "id": "com.doordash.driverapp:id/animated_collar_view_icon",
+                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 159,
+                                                                                                                    "top": 2068,
+                                                                                                                    "right": 159,
+                                                                                                                    "bottom": 2068
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/extra_space",
+                                                                                "class": "android.view.View",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 159,
+                                                                                    "top": 2068,
+                                                                                    "right": 159,
+                                                                                    "bottom": 2104
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/prism_sheet_content_parent_container",
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 159,
+                                                                                    "top": 2104,
+                                                                                    "right": 1239,
+                                                                                    "bottom": 2311
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/nested_scroll_view",
+                                                                                        "class": "android.widget.ScrollView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 159,
+                                                                                            "top": 2104,
+                                                                                            "right": 1239,
+                                                                                            "bottom": 2311
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/prism_content_container",
+                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 159,
+                                                                                                    "top": 2104,
+                                                                                                    "right": 1239,
+                                                                                                    "bottom": 2104
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/bottomsheet_content_container",
+                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 159,
+                                                                                                            "top": 2104,
+                                                                                                            "right": 1239,
+                                                                                                            "bottom": 2104
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.doordash.driverapp:id/accept_decline_recycler_view_container",
+                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 159,
+                                                                                                                    "top": 2104,
+                                                                                                                    "right": 1239,
+                                                                                                                    "bottom": 2104
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "id": "com.doordash.driverapp:id/items_recycler_view",
+                                                                                                                        "class": "androidx.recyclerview.widget.RecyclerView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 159,
+                                                                                                                            "top": 2104,
+                                                                                                                            "right": 1239,
+                                                                                                                            "bottom": 2104
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/prism_sheet_footer_divider",
+                                                                        "class": "android.view.View",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 159,
+                                                                            "top": 2100,
+                                                                            "right": 1239,
+                                                                            "bottom": 2104
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/prism_sheet_footer_container",
+                                                                        "class": "android.widget.LinearLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 159,
+                                                                            "top": 2104,
+                                                                            "right": 1239,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/accept_decline_footer_container",
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 159,
+                                                                                    "top": 2104,
+                                                                                    "right": 1239,
+                                                                                    "bottom": 2347
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/accept_button",
+                                                                                        "class": "android.widget.Button",
+                                                                                        "isClickable": true,
+                                                                                        "bounds": {
+                                                                                            "left": 195,
+                                                                                            "top": 2204,
+                                                                                            "right": 1203,
+                                                                                            "bottom": 2311
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "Accept",
+                                                                                                "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "bounds": {
+                                                                                                    "left": 195,
+                                                                                                    "top": 2204,
+                                                                                                    "right": 195,
+                                                                                                    "bottom": 2204
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -63,6 +63,23 @@ immediately (no second pass needed) so it gets triaged.
 _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **broken** on the
 2026-06-09 dash — moved to that session's log entry below for triage.)_
 
+- **📸 CAPTURE NEEDED — GoPuff (Drive) screens, to finalize the #501 rules.** The 06-14 deep-dive
+  enumerated the GoPuff flow (all inside the DoorDash app — there is no separate GoPuff app) from real
+  captures, but three things would help finalize the rules. **On the next GoPuff dash, drop these into
+  `snapshots/INBOX/`:**
+  1. **The GoPuff bin/scan-steps screen** ("Pickup steps" / "Scan barcodes on N items" / "Pick up
+     order in Bin #N") — confirm it always follows an explicit "Arrived at store" tap (so #501 mints
+     `PICKUP_ARRIVED` from the right screen, not twice).
+  2. **A GoPuff offer card** — does it ever show an **Accept** button, or is acceptance always the
+     `accept_constraint_layout` control? (affects whether the Accept RuleAction can be aimed).
+  3. **A 3+ order GoPuff batch's bin screen** — does every order carry a customer name
+     (`order_cx_name`)? The per-drop dedupe depends on a stable per-order hash.
+  - **(Low-priority curiosity, NOT a known issue):** we saw a click labeled "Open digital Red Card"
+    but never captured what it opens. If it's easy, capture that screen once just to *see* what's on
+    it — there is **no evidence it exposes anything sensitive**; this is only to confirm, not because
+    a leak is known. (#504 was filed on a bad assumption about this and has been closed.)
+  - Captured: 0/1 each (these are capture asks, not pass/fail validations).
+
 - **⚠️ WATCH — "ghost offer" with EMPTY parse logged as a card (2026-06-13 #1, NOT yet fixed).**
   A phantom Offer card appeared in the stack (between Mello Mushroom and Pei Wei) with **no store, no
   pay, no miles** — Score 24, `$-2/hr`, Net `-$0.36`, outcome **Timed out**. Hypothesis: a partial
@@ -90,6 +107,11 @@ _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **bro
     re-satisfies `require` with no content → a phantom "new offer." Grab the `offer_popup` +
     offer/accept events near 00:33 UTC to see whether the ghost frame is a leftover of the
     just-accepted offer or a genuinely new partial popup.
+  - **Triaged 2026-06-15 → [#498](https://github.com/sjtrotter/DashBuddy/issues/498)** (recognition
+    rejects incomplete frames — the `offer_popup` rule must `require` the scored fields and an empty
+    parse must not become an offer; the all-zeros economics is `sha256("null|null|null|")`). The
+    post-accept ghost-offer trigger also feeds **#503** (Job container — the accept→job transition
+    shouldn't re-observe a chrome-only offer frame).
 
 - **Offer card surfaces Shop & Deliver: item count in the hero row + a SHOP badge (#461 a/b).**
   The item count moved from a small footer caption up to the hero row (beside the score ring /
@@ -726,6 +748,10 @@ cover yet.
 - **Captures needed:** the dasher will supply the Go-Puff arrival + QR-scan + post-scan screens
   (drop into `snapshots/INBOX/`, run `InboxProcessorTest` for the X-Ray) so the new rules can be
   written against real trees.
+- **Triaged 2026-06-15 → [#501](https://github.com/sjtrotter/DashBuddy/issues/501)** (recognize the
+  Go Puff / DoorDash-Drive flow; deep-dive over the 06-14 captures/db/log was run — db aggregate
+  `session-doordash-1781450940064-21` confirms NO clean `PICKUP_ARRIVED` on the warehouse pickup).
+  Recognize-only, not a sensitive surface.
 
 #### 2. Go Puff stacked order — **2-dropoff order logged FOUR drop-offs (doubled)**
 The Go Puff order was a **stacked order with two orders / two drop-offs** (not three — the earlier
@@ -749,8 +775,11 @@ than stacked-handling in general.
   spawning a phantom?). Compare against the later non-Go-Puff stacked order on the same dash (which
   the dasher says is behaving) to isolate whether the Go Puff path is the differentiator. Desk
   call — not a concluded fix.
-
-#### 3. **Same-store shopping add-on RE-MINTED the task** (Sprouts + PetSmart stack) — case study
+- **Triaged 2026-06-15 → [#501](https://github.com/sjtrotter/DashBuddy/issues/501) +
+  [#503](https://github.com/sjtrotter/DashBuddy/issues/503).** db confirms this is the unrecognized
+  Go Puff warehouse pickup + a **multi-drop batch** (one offer → 4 drop subtasks with phantom same-ms
+  `DELIVERY_NAV/ARRIVED`, seq 82–84). Recognizing the warehouse-pickup phase (#501) plus the Job
+  container owning the drop subtasks (#503) is what removes the doubling — not a generic settle gate.
 Strong case study for "what goes right vs. wrong" on stacked-shop + add-on. The order was a double
 stack: **Sprouts + PetSmart/Petco**. Sequence the dasher narrated:
 1. The app wanted **PetSmart first**, but the dasher would pass **Sprouts** on the way, so they used
@@ -792,6 +821,12 @@ should **bump the combined shop counts on the same task**, **add time to the pic
   `offer_popup` + accept event, then the frame sequence (navigation? → combined shop interface?),
   and watch whether `activeTask.taskId` changes (re-mint) or counts bump on the same task. Capture
   the multi-pickup shop tree for a possible new rule. Desk call — not a concluded fix.
+- **Triaged 2026-06-15 → [#499](https://github.com/sjtrotter/DashBuddy/issues/499) (blocked-by
+  [#503](https://github.com/sjtrotter/DashBuddy/issues/503)).** Direction: don't tune the 10s
+  `TASK_RETIRE` grace — re-model the **Job as the offer-accumulating container** so an add-on offer
+  accumulates into the active job and the returning shop screen **re-matches the existing subtask via
+  the offer's store hint** (the same-store correlation the dasher does by eye). Re-mint then can't
+  happen by construction.
 
 ---
 


### PR DESCRIPTION
## What
A **session-replay test harness** (`SessionReplay`) that drives a chronological sequence of real
on-device captures through the **production recognition rules** (Level A) and the **real
`StateMachine`** (Level B), so a field-observed bug can be reproduced and asserted as a **red/green
test — no field dash needed to validate a fix.**

## Why
Today a state-machine fix can only be confirmed by driving a real dash. This turns "I think this
fixes it" into "this test replays the real captures and asserts the bug is gone." First use:
grounding #498 (the ghost offer) in reproducible data.

## What's here
- `SessionReplay.loadSession / replayRecognition / reduce / trace` (test util). `reduce` returns a
  per-frame trace `{frame, observation, stateAfter, events}` where `events` matches the db
  `app_events` shape (the shared spine for tests, a JVM trace, and a future on-device review screen).
- `GhostOfferReplayTest` — replays two **real 2026-06-14 captures** (a genuine H-E-B offer + the
  blank "ghost" frame) and reproduces #498 at **both layers**:
  - Level A: the blank frame still recognizes as `offer_popup` and parses to an all-null offer with
    `offerHash == sha256("null|null|null|")` — the exact hash the device logged (db seq 152).
  - Level B: reducing that frame through the real machine emits a phantom `OFFER_RECEIVED`.
  - Two `@Ignore`'d targets flip **green** when #498 lands ("a blank offer must not become an offer /
    emit OFFER_RECEIVED").
- A short CLAUDE.md note + epic #505 with the roadmap (timer/click synthesis → GoPuff repro;
  on-device review tool with verdict export).

## Security / privacy posture
Touches **capture** (commits two real captures as test fixtures). Verified the fixtures contain **no
customer PII** — only store name + pay/distance (which the privacy model permits; customer
name/address are what get hashed/blocked, and neither appears here). Test-sourceset only; **no
production-code changes**, no network, and `reduce` only *collects* `LogEvent`s — it never executes
effects (no TTS/clicks/screenshots fire).

Tracked under epic #505.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
