### PR TITLE
fix(recognition): reject blank/zero-pay offer popups — the ghost offer (#498)

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/TriageRulesTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/TriageRulesTest.kt
@@ -382,10 +382,12 @@ class TriageRulesTest {
     @Test
     fun `navigation_generic — does not steal an offer popup (offer_popup wins)`() {
         // A real offer popup carries the DoorDash accept_button structure (not just the button
-        // labels) — the require demands it so our own overlay can't masquerade as an offer (#4).
+        // labels) AND a pay amount — the require demands the structure so our own overlay can't
+        // masquerade as an offer (#4), and the validate demands a parsed payAmount so a blank,
+        // chrome-only frame isn't recognized as an offer (#498).
         assertEquals(
             "offer_popup",
-            screen(tree(node(text = "Decline"), node(text = "Accept"), node(id = "accept_button"), node(id = "maneuverView"))),
+            screen(tree(node(text = "Decline"), node(text = "Accept"), node(id = "accept_button"), node(text = "$8.50"), node(id = "maneuverView"))),
         )
     }
 

--- a/app/src/test/java/cloud/trotter/dashbuddy/replay/GhostOfferReplayTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/replay/GhostOfferReplayTest.kt
@@ -1,100 +1,56 @@
 package cloud.trotter.dashbuddy.replay
 
 import cloud.trotter.dashbuddy.domain.model.event.AppEventType
-import cloud.trotter.dashbuddy.domain.model.event.payload.OfferReceivedPayload
-import cloud.trotter.dashbuddy.domain.model.offer.ParsedOffer
-import cloud.trotter.dashbuddy.domain.pipeline.Observation
 import cloud.trotter.dashbuddy.domain.state.ParsedFields
 import cloud.trotter.dashbuddy.test.util.SessionReplay
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNotEquals
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
-import org.junit.Ignore
 import org.junit.Test
 
 /**
- * First [SessionReplay] regression: reproduces the field-observed "ghost offer" (#498) by
- * replaying two REAL captures from the 2026-06-14 dash through the production rules —
- *  1. `01_real_offer_heb_1630.json` — a genuine H-E-B Shop & Deliver offer.
- *  2. `02_ghost_offer_blank_1631.json` — a blank `offer_popup` frame (only Accept/Decline
- *     chrome, no store/pay/distance) captured 16:31:52, which the device logged as
- *     OFFER_RECEIVED + immediate OFFER_TIMEOUT (db `app_events` seq 152/153, session
- *     `session-doordash-1781470176806-43`).
+ * [SessionReplay] regression for the #498 "ghost offer": a blank `offer_popup` frame (only
+ * Accept/Decline chrome, no store/pay/distance) was recognized as a real offer and logged an
+ * `OFFER_RECEIVED` with `offerHash == sha256("null|null|null|")` (db seq 152) before an immediate
+ * `OFFER_TIMEOUT`. The fix: the `offer_popup` rule now `validate`s `payAmount != null`, so a frame
+ * with no scored fields is not recognized as an offer.
  *
- * The all-null parse produces `offerHash == sha256("null|null|null|")`, the same fingerprint
- * recorded in the db — so this test grounds #498 in reproducible data instead of narration.
+ * Replays two real 2026-06-14 captures: `01` = a genuine H-E-B Shop & Deliver offer, `02` = the
+ * blank ghost. They sort by capture time (01 @ 16:30:55, 02 @ 16:31:52), so `first()` is the real
+ * offer and `last()` is the ghost.
  */
 class GhostOfferReplayTest {
 
     private val session = "snapshots/sessions/ghost_offer_2026_06_14"
 
-    /** sha256("null|null|null|") — the deterministic fingerprint of an all-null offer parse. */
-    private val nullOfferHash = "906a43f85fed65ed12efc8878df2ccf467e4171b7c288720e0d13137997c0382"
-
-    private fun Observation.Screen.offer(): ParsedOffer =
-        (parsed as ParsedFields.OfferFields).parsedOffer
-
     @Test
-    fun `harness reproduces the ghost offer from real captures (characterization, #498)`() {
-        val obs = SessionReplay.replayRecognition(session)
-        obs.forEachIndexed { i, o ->
-            println("frame[$i] target=${o.target} ruleId=${o.ruleId} flow=${o.flow} parsed=${o.parsed::class.simpleName} ts=${o.timestamp}")
-        }
-        assertEquals("expected 2 frames (real H-E-B offer, then blank ghost)", 2, obs.size)
-        val real = obs[0]
-        val ghost = obs[1]
-
-        // Both the real and blank frames currently recognize as offer_popup.
+    fun `the real offer is still recognized with its scored fields (#498 does not over-reject)`() {
+        val real = SessionReplay.replayRecognition(session).first()
         assertEquals("offer_popup", real.target)
-        assertEquals("offer_popup", ghost.target)
-
-        // The REAL offer parses its scored fields.
-        val realOffer = real.offer()
-        assertEquals(18.25, realOffer.payAmount!!, 0.001)
-        assertEquals(11.3, realOffer.distanceMiles!!, 0.001)
-        assertNotEquals(nullOfferHash, realOffer.offerHash)
-
-        // The GHOST (blank chrome — no store/pay/distance) STILL recognizes as an offer and
-        // parses to an all-null offer whose hash is sha256("null|null|null|") — the exact hash
-        // the device logged. This is the #498 defect, reproduced from the real capture.
-        val ghostOffer = ghost.offer()
-        assertNull("ghost offer must have no pay", ghostOffer.payAmount)
-        assertNull("ghost offer must have no distance", ghostOffer.distanceMiles)
-        assertEquals(nullOfferHash, ghostOffer.offerHash)
+        val offer = (real.parsed as ParsedFields.OfferFields).parsedOffer
+        assertEquals(18.25, offer.payAmount!!, 0.001)
+        assertEquals(11.3, offer.distanceMiles!!, 0.001)
     }
 
-    @Ignore("RED until #498 — recognition must reject a blank offer_popup (require the scored fields).")
     @Test
-    fun `after #498 a blank offer_popup must not become an offer`() {
-        val obs = SessionReplay.replayRecognition(session)
-        val ghost = obs[1]
+    fun `the blank ghost offer is rejected at recognition (#498, Level A)`() {
+        val ghost = SessionReplay.replayRecognition(session).last()
+        println("ghost → target=${ghost.target} parsed=${ghost.parsed::class.simpleName}")
         assertFalse(
-            "blank offer frame should not parse to an all-null OfferFields once #498 lands",
-            ghost.parsed is ParsedFields.OfferFields && ghost.offer().offerHash == nullOfferHash,
+            "a blank offer_popup with no pay must not parse to an offer",
+            ghost.parsed is ParsedFields.OfferFields,
         )
+        assertFalse("…and must not be classified as offer_popup", ghost.target == "offer_popup")
     }
 
     @Test
-    fun `Level B - the blank offer drives a phantom OFFER_RECEIVED through the state machine (#498)`() {
-        // Isolate the blank ghost frame and reduce it from idle through the REAL state machine.
-        // The defect: a blank frame becomes a logged OFFER_RECEIVED — the exact event the device
-        // emitted (db seq 152). Level A proved the recognition; Level B proves the emitted EVENT.
+    fun `the blank ghost offer emits no OFFER_RECEIVED through the state machine (#498, Level B)`() {
         val ghostFrame = SessionReplay.loadSession(session).first { it.file.contains("ghost") }
         val steps = SessionReplay.reduce(listOf(ghostFrame))
         println(SessionReplay.trace(steps))
-
-        val received = steps.flatMap { it.events }.filter { it.type == AppEventType.OFFER_RECEIVED }
-        assertEquals("blank frame emits exactly one phantom OFFER_RECEIVED", 1, received.size)
-        assertEquals(nullOfferHash, (received.single().payload as OfferReceivedPayload).offerHash)
-    }
-
-    @Ignore("RED until #498 — a blank offer_popup must emit no OFFER_RECEIVED.")
-    @Test
-    fun `after #498 the blank offer emits no OFFER_RECEIVED (Level B)`() {
-        val ghostFrame = SessionReplay.loadSession(session).first { it.file.contains("ghost") }
-        val events = SessionReplay.reduce(listOf(ghostFrame)).flatMap { it.events }
-        assertTrue(events.none { it.type == AppEventType.OFFER_RECEIVED })
+        assertTrue(
+            "a blank offer must not emit a phantom OFFER_RECEIVED",
+            steps.flatMap { it.events }.none { it.type == AppEventType.OFFER_RECEIVED },
+        )
     }
 }

--- a/core/pipeline/src/main/assets/rules/doordash.json
+++ b/core/pipeline/src/main/assets/rules/doordash.json
@@ -502,6 +502,13 @@
           }
         }
       },
+      "validate": [
+        {
+          "assert": "fieldNotNull",
+          "field": "payAmount",
+          "onFail": "skip"
+        }
+      ],
       "effects": [
         {
           "screenshot": {

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -80,7 +80,13 @@ _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **bro
     a leak is known. (#504 was filed on a bad assumption about this and has been closed.)
   - Captured: 0/1 each (these are capture asks, not pass/fail validations).
 
-- **⚠️ WATCH — "ghost offer" with EMPTY parse logged as a card (2026-06-13 #1, NOT yet fixed).**
+- **✅ FIX SHIPPED — "ghost offer" with EMPTY parse logged as a card (#498). CONFIRM ON DASH.**
+  Fixed by gating the `offer_popup` rule on a parsed `payAmount` (a blank/chrome-only frame with no
+  pay is no longer recognized as an offer; proven by `GhostOfferReplayTest` replaying the real
+  16:31:52 ghost capture — now classifies UNKNOWN, emits no OFFER_RECEIVED). **Confirm on dash: 0/2 —**
+  no blank-store / `$-2/hr` Offer card should appear (mid-offer, between offers, or right after an
+  accept), while **real offers still recognize normally**. If a blank card still appears, capture the
+  `offer_popup` frame + the offer event. *(Below is the original watch context, kept for reference.)*
   A phantom Offer card appeared in the stack (between Mello Mushroom and Pei Wei) with **no store, no
   pay, no miles** — Score 24, `$-2/hr`, Net `-$0.36`, outcome **Timed out**. Hypothesis: a partial
   `offer_popup` frame whose chrome (Decline + Accept/footer id) satisfied `require` before the content


### PR DESCRIPTION
## What
Fixes the **"ghost offer"** (#498): a chrome-only `offer_popup` frame (Accept/Decline buttons, no
store/pay/distance) was recognized as a real offer and logged a phantom `OFFER_RECEIVED` whose
`offerHash == sha256("null|null|null|")` — recurring across sessions (db seq 152 on 06-14, seq 39 on
06-12), each immediately timing out at `$-2/hr`.

## Fix
Gate the `offer_popup` rule on a parsed `payAmount` via the existing 5-phase `validate` step:
```json
"validate": [ { "assert": "fieldNotNull", "field": "payAmount", "onFail": "skip" } ]
```
A frame that parses no pay is no longer recognized as an offer (the branch is skipped → the frame
falls to UNKNOWN). Per the developer's steer: **a better match at the matcher, not a downstream
settle gate.** `payAmount` is the essential scored component — without it nothing is computable, and
the ghost has it null.

## Validated by the replay harness (no field dash needed)
`GhostOfferReplayTest` replays two **real 06-14 captures** and now asserts the *fixed* behaviour:
- the real H-E-B offer still recognizes with pay 18.25 / dist 11.3;
- the blank ghost is **rejected** → classifies `UNKNOWN`/`None` (Level A) and emits **no
  `OFFER_RECEIVED`** through the real state machine (Level B).

Full recognition suite green: **571 tests, 0 failures** — all 15 `offer_popup` corpus snapshots still
classify, `ParseOutputGolden` unchanged. One synthetic fixture in `TriageRulesTest` gained a pay node
(a real offer popup carries pay).

## Security / privacy posture
Touches **recognition** only, and strictly *tightens* it (rejects offers with no pay). No new data is
captured, no parse output changes, and nothing is loosened. `Refs #498` — the dropoff-arrival side of
that issue (same "require the content you render" principle on the arrival rule) remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
