### PR TITLE
fix(503): unresolved dropoff recipient shows a generic label, not "Customer" (slice 0)

### DIFF
--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/DisplayNames.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/DisplayNames.kt
@@ -9,8 +9,14 @@ package cloud.trotter.dashbuddy.domain.state
 /** Store-name sentinel for a task whose store hasn't resolved yet. */
 const val UNKNOWN_STORE = "Unknown"
 
-/** Customer display fallback when no name hash is available. */
-const val CUSTOMER_FALLBACK = "Customer"
+/**
+ * Display label for a recipient whose name hash hasn't resolved yet. Deliberately a
+ * lowercase generic phrase, not the proper-noun "Customer" — a dropoff card/message that
+ * surfaces this must read as "recipient not yet known", never masquerade as a specific
+ * person's name (#503 / the premature "Delivery for Customer" card). A real recipient
+ * shows the 6-char privacy-hash prefix instead.
+ */
+const val CUSTOMER_FALLBACK = "the customer"
 
 /** The ONE derivation of a short customer display name from the privacy hash. */
 fun customerDisplayName(customerHash: String?): String =

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/state/DisplayNamesTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/state/DisplayNamesTest.kt
@@ -1,0 +1,29 @@
+package cloud.trotter.dashbuddy.domain.state
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+/**
+ * Locks the customer display SSOT (#503 / the premature "Delivery for Customer" card). A recipient
+ * whose name hash hasn't resolved must render as a clearly-generic label, never the proper-noun
+ * "Customer" that reads like a specific person's name; a resolved recipient shows the 6-char
+ * privacy-hash prefix.
+ */
+class DisplayNamesTest {
+
+    @Test
+    fun `a resolved recipient shows the 6-char privacy-hash prefix`() {
+        assertEquals("680f4a", customerDisplayName("680f4a1b2c3d4e5f"))
+    }
+
+    @Test
+    fun `an unresolved recipient shows a generic label, not the proper-noun Customer`() {
+        assertEquals("the customer", customerDisplayName(null))
+        assertNotEquals(
+            "an unresolved recipient must not read as a specific name",
+            "Customer",
+            customerDisplayName(null),
+        )
+    }
+}


### PR DESCRIPTION
## Slice 0 / #503 — the half-formed "Customer" dropoff card
First stage of the #503 job-container re-model (built incrementally, each stage harness/test-validated).

**What:** a dropoff card / "Heading to …" message whose customer hash hasn't resolved rendered the
proper-noun `CUSTOMER_FALLBACK = "Customer"` — which reads like a specific person's name (the
"Delivery for Customer" premature card). This traced to `customerDisplayName(null)` returning that
literal (`DisplayNames.kt:13`), surfaced unsuppressed at `EffectMap:605/916` and `FlowCardItem:222/469`.

**Fix:** the unresolved-recipient fallback is now a clearly-generic `"the customer"` — it reads as
"recipient not yet known" and never masquerades as a real name. A resolved recipient still shows the
6-char privacy-hash prefix. Single SSOT change; all four surfaces route through `customerDisplayName`.

**Why now / why small:** it's a permanent display guard that's correct regardless of the deeper fix.
The *root* (a dropoff task surfaced before its customer resolves) is addressed in later slices —
`Job.tasks` populated additively, then dropoff subtasks created from the offer (#503 G5).

**Validation:** `DisplayNamesTest` locks the SSOT (unresolved → generic, never "Customer"; resolved →
prefix). Full app + state + domain suite green. No production behavior changes beyond the label.

**Security/privacy:** none affected — display-label only; the privacy hash and its derivation are
unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
