### PR TITLE
feat(503): mirror the job's task lineage onto Job.tasks (slice 1, additive)

### DIFF
--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
@@ -67,6 +67,28 @@ class PlatformRegionStepper @Inject constructor() {
         nextFlow: FlowRegion,
         obs: Observation,
         policy: TransitionPolicy,
+    ): PlatformRegion = reconcileJobTasks(stepCore(prev, prevFlow, nextFlow, obs, policy))
+
+    /**
+     * Step 1 of the #503 job-container re-model (additive): mirror the active job's task lineage
+     * onto [Job.tasks] after every core step — the completed tasks still in [PlatformRegion.recentTasks]
+     * plus the active task. Pure derivation from existing region state; nothing reads [Job.tasks] yet,
+     * so this changes no behavior. Later slices make the list authoritative (resume from it; create
+     * dropoff subtasks onto it from the offer).
+     */
+    private fun reconcileJobTasks(region: PlatformRegion): PlatformRegion {
+        val job = region.activeJob ?: return region
+        val jobTasks = region.recentTasks.filter { it.jobId == job.jobId } +
+            listOfNotNull(region.activeTask?.takeIf { it.jobId == job.jobId })
+        return if (job.tasks == jobTasks) region else region.copy(activeJob = job.copy(tasks = jobTasks))
+    }
+
+    private fun stepCore(
+        prev: PlatformRegion,
+        prevFlow: FlowRegion,
+        nextFlow: FlowRegion,
+        obs: Observation,
+        policy: TransitionPolicy,
     ): PlatformRegion {
         var current = prev
 

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/TaskLifecycleGuardTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/TaskLifecycleGuardTest.kt
@@ -127,6 +127,35 @@ class TaskLifecycleGuardTest {
     }
 
     @Test
+    fun `Job tasks mirrors the job's task lineage (#503 slice 1)`() {
+        // A pickup then a dropoff in the same job → Job.tasks accumulates both in lineage order,
+        // even though the model still tracks only one activeTask + recentTasks (additive shadow).
+        val r0 = region(activeTask = null)
+        val (r1, f1) = step(
+            r0, FlowRegion(flow = Flow.Idle),
+            taskObs(Flow.TaskPickupNavigation, TaskPhase.PICKUP, TaskSubFlow.NAVIGATION, storeName = "H-E-B", timestamp = 1_000L),
+        )
+        assertEquals("the active pickup is mirrored into Job.tasks", 1, r1.activeJob?.tasks?.size)
+        assertEquals(r1.activeTask?.taskId, r1.activeJob?.tasks?.single()?.taskId)
+        assertEquals(TaskPhase.PICKUP, r1.activeJob?.tasks?.single()?.phase)
+
+        val (r2, _) = step(
+            r1, f1,
+            taskObs(Flow.TaskDropoffNavigation, TaskPhase.DROPOFF, TaskSubFlow.NAVIGATION, customerAddressHash = "addr-1", timestamp = 2_000L),
+        )
+        assertEquals(
+            "Job.tasks now mirrors both legs in order",
+            listOf(TaskPhase.PICKUP, TaskPhase.DROPOFF),
+            r2.activeJob?.tasks?.map { it.phase },
+        )
+        assertEquals("the active dropoff is the last entry", r2.activeTask?.taskId, r2.activeJob?.tasks?.last()?.taskId)
+        assertTrue(
+            "every mirrored task belongs to the active job",
+            r2.activeJob?.tasks?.all { it.jobId == r2.activeJob?.jobId } == true,
+        )
+    }
+
+    @Test
     fun `sustained idle past the grace window retires the task`() {
         val r0 = region(pickupTask("task-A", "H-E-B", arrivedAt = 800L))
         val (r1, f1) = step(r0, FlowRegion(flow = Flow.TaskPickupArrived), idleObs(timestamp = 1_000L))


### PR DESCRIPTION
## Slice 1 / #503 — mirror the job's task lineage onto `Job.tasks` (additive)
Step 1 of the incremental job-container re-model. `Job.tasks` was declared (`Job.kt:45`) but never
written; tasks lived only on `PlatformRegion.activeTask`/`recentTasks`, linked to the job by a
`jobId` string. The single `activeTask` slot is the structural root of the #499 re-mint and the
premature dropoff card.

**What:** a single `reconcileJobTasks()` (wrapping `step()`) keeps `Job.tasks` as a consistent mirror
of the active job's lineage — the completed tasks still in `recentTasks` plus the active task, in
order. Pure derivation from existing region state.

**Behavior change: none.** Nothing reads `Job.tasks` yet — this is the safe additive foundation. The
later slices make it authoritative: **resume** from the list (fixes the #499 A→B→A re-mint, replacing
the single-slot heuristics), then **create dropoff subtasks onto it from the offer** (the root of the
"Customer" card / GoPuff phantom drops).

**Validation:** new `TaskLifecycleGuardTest` case — a pickup→dropoff lineage populates `Job.tasks` in
order, every entry belonging to the active job. All locked guard / economics / state-machine tests
green (the `step()` wrapper is behavior-neutral).

**Security/privacy:** none affected — pure state-shape derivation; no new data, no recognition/capture
change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
