### PR TITLE
feat(503): resume a prior subtask instead of re-minting (slice 2, fixes #499)

### DIFF
--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
@@ -600,6 +600,53 @@ class PlatformRegionStepper @Inject constructor() {
                 isStackedPickupTransition ||
                 isStackedDropoffTransition
             ) {
+                // #503 slice 2: returning to a prior subtask of this job (A→B→A, or back to a
+                // store after an offer interlude that retired the task) RESUMES its identity
+                // instead of re-minting — unless the platform signalled a genuinely-new stacked
+                // task (different store/customer, already arrived). Re-match by phase + store
+                // (pickup) / customer address (dropoff); this is the same-store add-on "fold in,
+                // don't re-mint" (#499). The single activeTask slot loses identity on every phase
+                // switch; the Job's task lineage in recentTasks lets us restore it.
+                val resumable = if (!isStackedPickupTransition && !isStackedDropoffTransition) {
+                    region.recentTasks.lastOrNull { prior ->
+                        prior.jobId == jobId && prior.phase == taskPhase &&
+                            when (taskPhase) {
+                                TaskPhase.PICKUP ->
+                                    prior.storeName != null && prior.storeName == taskFields?.storeName
+                                TaskPhase.DROPOFF ->
+                                    prior.customerAddressHash != null &&
+                                        prior.customerAddressHash == taskFields?.customerAddressHash
+                                else -> false
+                            }
+                    }
+                } else null
+
+                if (resumable != null) {
+                    val retireSince = region.pendingDestructive
+                        ?.takeIf { it.kind == DestructiveKind.TASK_RETIRE }?.since
+                    val displaced = currentTask?.copy(completedAt = retireSince ?: obs.timestamp)
+                    val justArrived = taskSubFlow == TaskSubFlow.ARRIVED && resumable.arrivedAt == null
+                    return region.copy(
+                        activeTask = resumable.copy(
+                            subPhase = taskSubFlow,
+                            completedAt = null,
+                            storeName = taskFields?.storeName ?: resumable.storeName,
+                            storeAddress = taskFields?.storeAddress ?: resumable.storeAddress,
+                            customerNameHash = taskFields?.customerNameHash ?: resumable.customerNameHash,
+                            customerAddressHash = taskFields?.customerAddressHash ?: resumable.customerAddressHash,
+                            deadlineMillis = taskFields?.deadline?.time ?: resumable.deadlineMillis,
+                            activity = taskFields?.activity ?: resumable.activity,
+                            itemsRemaining = taskFields?.itemsRemaining ?: resumable.itemsRemaining,
+                            itemsShopped = taskFields?.itemsShopped ?: resumable.itemsShopped,
+                            redCardTotal = taskFields?.redCardTotal ?: resumable.redCardTotal,
+                            arrivedAt = if (justArrived) obs.timestamp else resumable.arrivedAt,
+                        ),
+                        recentTasks = (region.recentTasks.filterNot { it.taskId == resumable.taskId } +
+                            listOfNotNull(displaced)).takeLast(MAX_RECENT_TASKS),
+                        pendingDestructive = null,
+                    )
+                }
+
                 // New task (different phase, no active task, or stacked-pickup transition).
                 // The displaced task commits inline; if a TASK_RETIRE grace was
                 // pending (receipt or idle already signalled its end, #431 pt 2)

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/TaskLifecycleGuardTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/TaskLifecycleGuardTest.kt
@@ -127,6 +127,39 @@ class TaskLifecycleGuardTest {
     }
 
     @Test
+    fun `returning to a prior task after switching away resumes its taskId (#499 A-B-A, slice 2)`() {
+        // PICKUP(H-E-B) -> DROPOFF(addr-1) -> back to PICKUP(H-E-B): the pickup must keep its identity,
+        // not re-mint. The single-slot model completes-and-re-mints on each phase switch (#499); with
+        // Job.tasks as the container, returning re-matches the existing subtask by store + phase.
+        val r0 = region(activeTask = null)
+        val (r1, f1) = step(
+            r0, FlowRegion(flow = Flow.Idle),
+            taskObs(Flow.TaskPickupNavigation, TaskPhase.PICKUP, TaskSubFlow.NAVIGATION, storeName = "H-E-B", timestamp = 1_000L),
+        )
+        val pickupId = r1.activeTask?.taskId
+        assertNotNull("pickup minted", pickupId)
+
+        val (r2, f2) = step(
+            r1, f1,
+            taskObs(Flow.TaskDropoffNavigation, TaskPhase.DROPOFF, TaskSubFlow.NAVIGATION, customerAddressHash = "addr-1", timestamp = 2_000L),
+        )
+        assertNotEquals("switching to the dropoff is a different task", pickupId, r2.activeTask?.taskId)
+        val dropoffId = r2.activeTask?.taskId
+
+        val (r3, _) = step(
+            r2, f2,
+            taskObs(Flow.TaskPickupNavigation, TaskPhase.PICKUP, TaskSubFlow.NAVIGATION, storeName = "H-E-B", timestamp = 3_000L),
+        )
+        assertEquals("returning to the H-E-B pickup must resume its taskId, not re-mint", pickupId, r3.activeTask?.taskId)
+        assertEquals("the job still has exactly the two subtasks (no phantom third)", 2, r3.activeJob?.tasks?.size)
+        assertEquals(
+            "Job.tasks holds the original pickup + dropoff, no duplicate",
+            setOf(pickupId, dropoffId),
+            r3.activeJob?.tasks?.map { it.taskId }?.toSet(),
+        )
+    }
+
+    @Test
     fun `Job tasks mirrors the job's task lineage (#503 slice 1)`() {
         // A pickup then a dropoff in the same job → Job.tasks accumulates both in lineage order,
         // even though the model still tracks only one activeTask + recentTasks (additive shadow).


### PR DESCRIPTION
## Slice 2 / #503 — resume a prior subtask instead of re-minting (fixes #499)
Step 2 — the **first behaviour change** of the incremental job-container re-model.

**The bug (#499):** the single `activeTask` slot loses a task's identity on every phase switch.
`PlatformRegionStepper:576-614` completes-and-re-mints on `currentTask.phase != taskPhase`, so
PICKUP→DROPOFF→back-to-PICKUP gives the pickup a brand-new `taskId` (and the same-store shopping
add-on re-mints instead of folding in).

**The fix:** before minting, `updateTaskLifecycle` re-matches a prior subtask of this job from the
task lineage — by **phase + `storeName`** (pickup) / **phase + `customerAddressHash`** (dropoff) — and
**resumes its identity** (restores its `taskId` + accumulated state, un-retires it), displacing the
current task. The genuinely-new **stacked transitions** (arrived at a *different* store/customer) are
explicitly excluded, so stacked orders still mint distinct `taskId`s.

This realises the #503 intent for #499: *"fold in, don't re-mint"* — returning to a store re-matches
its existing subtask rather than spawning a phantom.

**Validation (TDD):** new `TaskLifecycleGuardTest` case — `PICKUP(H-E-B) → DROPOFF → back to
PICKUP(H-E-B)` was **red** (re-minted `task-…3000-2`), now **green** (resumes `task-…1000-0`, job
still has exactly its two subtasks). Every locked guard / economics / state-machine test stays green
— the stacked-distinct cases are the regression gate and they pass.

**Security/privacy:** none affected — pure state-layer task-identity logic; no new data, no
recognition/capture change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
