### PR TITLE
feat(503): create the dropoff subtask from the offer, resolve later (slice 3)

### DIFF
--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
@@ -78,8 +78,14 @@ class PlatformRegionStepper @Inject constructor() {
      */
     private fun reconcileJobTasks(region: PlatformRegion): PlatformRegion {
         val job = region.activeJob ?: return region
-        val jobTasks = region.recentTasks.filter { it.jobId == job.jobId } +
+        val lineage = region.recentTasks.filter { it.jobId == job.jobId } +
             listOfNotNull(region.activeTask?.takeIf { it.jobId == job.jobId })
+        val lineageIds = lineage.mapTo(HashSet()) { it.taskId }
+        // #503 slice 3: preserve pre-created (offer-spawned, not-yet-activated) subtasks — those on
+        // the job but not yet in the active/completed lineage — then the lineage. Once an expected
+        // subtask is activated its taskId enters the lineage, so it isn't double-listed.
+        val pending = job.tasks.filter { it.taskId !in lineageIds && it.completedAt == null }
+        val jobTasks = pending + lineage
         return if (job.tasks == jobTasks) region else region.copy(activeJob = job.copy(tasks = jobTasks))
     }
 
@@ -494,15 +500,29 @@ class PlatformRegionStepper @Inject constructor() {
             val existing = region.activeJob
 
             if (existing == null) {
+                val jobId = mintId("job", region, obs)
                 return region.copy(
                     activeJob = Job(
-                        jobId = mintId("job", region, obs),
+                        jobId = jobId,
                         offerStoreHint = storeHints,
                         parentOfferHash = pending?.offerHash,
                         acceptedOffers = listOf(economics),
                         startedAt = obs.timestamp,
+                        // #503 slice 3: pre-create the offer's dropoff subtask (customer TBD). The
+                        // dropoff screen later RESOLVES the customer onto this subtask instead of
+                        // minting a fresh dropoff — the root fix for the premature "Customer" card
+                        // (a dropoff surfaced before its customer resolves).
+                        tasks = listOf(
+                            Task(
+                                taskId = mintId("task", region, obs, offset = 1),
+                                jobId = jobId,
+                                phase = TaskPhase.DROPOFF,
+                                customerNameHash = null,
+                                startedAt = obs.timestamp,
+                            ),
+                        ),
                     ),
-                    mintCounter = region.mintCounter + 1,
+                    mintCounter = region.mintCounter + 2,
                 )
             }
 
@@ -643,6 +663,47 @@ class PlatformRegionStepper @Inject constructor() {
                         ),
                         recentTasks = (region.recentTasks.filterNot { it.taskId == resumable.taskId } +
                             listOfNotNull(displaced)).takeLast(MAX_RECENT_TASKS),
+                        pendingDestructive = null,
+                    )
+                }
+
+                // #503 slice 3: resolve onto a pre-created (offer-spawned, customer-TBD) dropoff
+                // subtask of this job instead of minting a fresh dropoff — the dropoff screen
+                // RESOLVES the customer onto the subtask the offer created at accept. Fixes the
+                // premature "Customer" card / phantom drops (a dropoff that exists before its
+                // customer is known).
+                val expectedDropoff = if (taskPhase == TaskPhase.DROPOFF) {
+                    val displacedIds = region.recentTasks.mapTo(HashSet()) { it.taskId }
+                    region.activeJob?.tasks?.firstOrNull { pending ->
+                        pending.phase == TaskPhase.DROPOFF &&
+                            pending.customerNameHash == null &&
+                            pending.completedAt == null &&
+                            pending.taskId != currentTask?.taskId &&
+                            pending.taskId !in displacedIds
+                    }
+                } else null
+
+                if (expectedDropoff != null) {
+                    val retireSince = region.pendingDestructive
+                        ?.takeIf { it.kind == DestructiveKind.TASK_RETIRE }?.since
+                    val displaced = currentTask?.copy(completedAt = retireSince ?: obs.timestamp)
+                    val justArrived = taskSubFlow == TaskSubFlow.ARRIVED && expectedDropoff.arrivedAt == null
+                    return region.copy(
+                        activeTask = expectedDropoff.copy(
+                            subPhase = taskSubFlow,
+                            storeName = taskFields?.storeName ?: expectedDropoff.storeName,
+                            storeAddress = taskFields?.storeAddress ?: expectedDropoff.storeAddress,
+                            customerNameHash = taskFields?.customerNameHash,
+                            customerAddressHash = taskFields?.customerAddressHash,
+                            deadlineMillis = taskFields?.deadline?.time ?: expectedDropoff.deadlineMillis,
+                            activity = taskFields?.activity,
+                            itemsRemaining = taskFields?.itemsRemaining,
+                            itemsShopped = taskFields?.itemsShopped,
+                            redCardTotal = taskFields?.redCardTotal,
+                            startedAt = obs.timestamp,
+                            arrivedAt = if (justArrived) obs.timestamp else expectedDropoff.arrivedAt,
+                        ),
+                        recentTasks = (region.recentTasks + listOfNotNull(displaced)).takeLast(MAX_RECENT_TASKS),
                         pendingDestructive = null,
                     )
                 }

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/JobEconomicsTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/JobEconomicsTest.kt
@@ -85,6 +85,16 @@ class JobEconomicsTest {
         ),
     )
 
+    private fun dropoffObs(timestamp: Long, customerNameHash: String?, customerAddressHash: String? = null) =
+        Observation.Screen(
+            timestamp = timestamp, captureId = null, ruleId = "doordash.screen.dropoff_nav",
+            metadata = ReplayMetadata.EMPTY, flow = Flow.TaskDropoffNavigation, modeHint = Mode.Online,
+            parsed = ParsedFields.TaskFields(
+                phase = TaskPhase.DROPOFF, subFlow = TaskSubFlow.NAVIGATION,
+                customerNameHash = customerNameHash, customerAddressHash = customerAddressHash,
+            ),
+        )
+
     private fun jobWith(offerHash: String, net: Double, est: Double, dist: Double, pay: Double) = Job(
         jobId = "job-1",
         offerStoreHint = listOf("H-E-B"),
@@ -104,6 +114,48 @@ class JobEconomicsTest {
     }
 
     // ---- tests ----
+
+    @Test
+    fun `accept pre-creates the offer's dropoff subtask, customer TBD (#503 slice 3)`() {
+        val r1 = step(
+            onlineRegion(activeJob = null),
+            offerFlow("offer-1", net = 6.0, est = 18.0, dist = 4.0, pay = 8.5),
+            acceptObs(1_000L, "H-E-B"),
+        )
+        val job = r1.activeJob
+        assertNotNull("accept starts a job", job)
+        val dropoffs = job!!.tasks.filter { it.phase == TaskPhase.DROPOFF }
+        assertEquals("accept pre-creates exactly one dropoff subtask", 1, dropoffs.size)
+        assertNull("its customer is TBD until the dropoff screen resolves it", dropoffs.single().customerNameHash)
+        assertEquals("the active task is the pickup, not the pre-created dropoff", TaskPhase.PICKUP, r1.activeTask?.phase)
+    }
+
+    @Test
+    fun `the dropoff screen resolves the customer onto the pre-created subtask, no fresh mint (#503 slice 3)`() {
+        val r1 = step(
+            onlineRegion(activeJob = null),
+            offerFlow("offer-1", net = 6.0, est = 18.0, dist = 4.0, pay = 8.5),
+            acceptObs(1_000L, "H-E-B"),
+        )
+        val expectedDropoffId = r1.activeJob!!.tasks.single { it.phase == TaskPhase.DROPOFF }.taskId
+
+        // The dropoff screen (a real customer) RESOLVES onto the pre-created subtask — same taskId,
+        // customer filled in — instead of minting a fresh dropoff.
+        val r2 = step(r1, FlowRegion(flow = Flow.TaskPickupNavigation), dropoffObs(2_000L, customerNameHash = "cust-1"))
+
+        assertEquals("resolves onto the pre-created subtask (same taskId)", expectedDropoffId, r2.activeTask?.taskId)
+        assertEquals("the customer is now resolved", "cust-1", r2.activeTask?.customerNameHash)
+        assertEquals(
+            "no phantom: the job still has exactly the pickup + the (now-resolved) dropoff",
+            2,
+            r2.activeJob?.tasks?.size,
+        )
+        assertEquals(
+            "exactly one DROPOFF subtask (the resolved one), no duplicate",
+            1,
+            r2.activeJob?.tasks?.count { it.phase == TaskPhase.DROPOFF },
+        )
+    }
 
     @Test
     fun `first accept seeds job economics from the offer`() {


### PR DESCRIPTION
## Slice 3 / #503 — create the dropoff subtask *from the offer*, resolve later
Step 3 — the **model inversion** (the riskiest slice). Until now tasks were minted lazily from the
*screen*, so a dropoff could exist before its customer was known → the premature "Delivery for
Customer" card and the phantom-drop family.

**Three changes (`PlatformRegionStepper`):**
1. `updateJobLifecycle` (accept): pre-create the offer's **dropoff subtask** on the `Job` with
   **customer TBD** (`customerNameHash = null`).
2. `updateTaskLifecycle` (dropoff mint branch): when a dropoff screen arrives, **resolve the customer
   onto the pre-created subtask** (keep its `taskId`) instead of minting a fresh dropoff.
3. `reconcileJobTasks`: preserve pre-created (not-yet-activated) subtasks alongside the
   active/completed lineage, so the expected dropoff survives until the screen resolves it.

Net: the dropoff is a **known, identity-stable subtask from the offer**; the screen fills in the
customer — no phantom dropoff minted before its customer is known.

**Scope (this slice):** single-offer (one expected dropoff per new job). Multi-drop / add-on expected
dropoffs are a follow-up, and **real GoPuff multi-drop replay validation waits on #501** (those screens
are still UNKNOWN). Validated here with synthetic TDD.

**Validation:** new `JobEconomicsTest` cases — *accept pre-creates a customer-TBD dropoff*; *the
dropoff screen resolves onto it (same `taskId`, customer filled, no fresh mint, exactly one DROPOFF
subtask)*. Full locked suite green (JobEconomics 6 / TaskLifecycle 17 / StateMachine 34, 0 failures) —
the economics + stacked-distinct + guard tests are the regression gate.

**Security/privacy:** none affected — state-layer task identity only; the customer name is still
`sha256`-hashed by recognition before it reaches the subtask (TBD = null until then).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
