### PR TITLE
fix(recognition): delivery_summary_collapsed rejects live pickup screens (#517)

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/TriageRulesTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/TriageRulesTest.kt
@@ -366,6 +366,26 @@ class TriageRulesTest {
     }
 
     @Test
+    fun `a pickup screen with a 'this offer' recap is NOT a delivery summary (#517)`() {
+        // The Chili's 06-17 misrecognition: a live pickup screen whose stacked-offer recap row carries
+        // the literal "this offer" matched delivery_summary_collapsed -> post:task -> a spurious $0
+        // DELIVERY_COMPLETED. The reject on pickup chrome must now exclude it.
+        assertNotEquals(
+            "a pickup frame must not classify as a delivery summary",
+            "delivery_summary_collapsed",
+            screen(
+                tree(
+                    node(text = "this offer"),
+                    node(text = "\$19.10"),
+                    node(text = "Pickup from"),
+                    node(text = "Chili's Grill & Bar"),
+                    node(text = "Arrived at store"),
+                ),
+            ),
+        )
+    }
+
+    @Test
     fun `navigation_generic — ETA path keeps flow idle (so a declined offer returns to idle)`() {
         val t = tree(node(text = "5 min"), node(text = "Exit 23"), node(text = "1.2 mi"))
         assertEquals("navigation_generic", screen(t))

--- a/core/pipeline/src/main/assets/rules/doordash.json
+++ b/core/pipeline/src/main/assets/rules/doordash.json
@@ -654,6 +654,15 @@
       "reject": [
         {
           "allTextContains": "pause orders"
+        },
+        {
+          "allTextContains": "Pickup from"
+        },
+        {
+          "allTextContains": "Arrived at store"
+        },
+        {
+          "allTextContains": "Start pickup"
         }
       ],
       "parse": {


### PR DESCRIPTION
Fixes #517 — the trigger for the 06-17 ghost "$0.00 PAID". A live pickup screen with a stacked-offer `this offer` recap row was classifying as `delivery_summary_collapsed` (post:task, $0). Adds a reject on pickup chrome (`Pickup from` / `Arrived at store` / `Start pickup`) — all 28 real summary snapshots are clean of these (golden guard green). Grounded in the real Chili's capture. `TriageRulesTest` regression added.

Security/privacy: recognition tightening only; no new data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)