### PR TITLE
fix(state): job-scope the DELIVERY_COMPLETED fallback — cross-job stale-task leak (#518)

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
@@ -18,6 +18,7 @@ import cloud.trotter.dashbuddy.domain.state.AppState
 import cloud.trotter.dashbuddy.domain.state.DestructiveKind
 import cloud.trotter.dashbuddy.domain.state.Flow
 import cloud.trotter.dashbuddy.domain.state.FlowRegion
+import cloud.trotter.dashbuddy.domain.state.Job
 import cloud.trotter.dashbuddy.domain.state.Mode
 import cloud.trotter.dashbuddy.domain.state.OfferIntent
 import cloud.trotter.dashbuddy.domain.state.ParsedFields
@@ -31,6 +32,7 @@ import cloud.trotter.dashbuddy.domain.state.Task
 import cloud.trotter.dashbuddy.domain.state.TaskPhase
 import cloud.trotter.dashbuddy.domain.state.TaskSubFlow
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import cloud.trotter.dashbuddy.domain.pipeline.ObservationPayload
@@ -444,6 +446,51 @@ class EffectMapTest {
         assertTrue("Should emit UpdateBubble with store name", effects.any {
             it is AppEffect.UpdateBubble && it.text.contains("Chipotle")
         })
+    }
+
+    @Test
+    fun `DELIVERY_COMPLETED does not re-fire a prior job's already-completed task on PostTask exit (#518)`() {
+        val (platform, base) = stateWithPlatform()
+        // A stale PRIOR-job dropoff that already completed (sits in recentTasks); the active job is NEW.
+        val stale = Task(
+            taskId = "task-prior-33", jobId = "job-prior", phase = TaskPhase.DROPOFF,
+            customerNameHash = "3c53c662", startedAt = 100L, completedAt = 200L,
+        )
+        val region = base.copy(
+            activeJob = Job("job-new", offerStoreHint = emptyList(), parentOfferHash = null, startedAt = 1000L),
+            activeTask = null,
+            recentTasks = listOf(stale),
+        )
+        val prev = AppState(regions = Regions(flow = FlowRegion(flow = Flow.PostTask), platforms = mapOf(platform to region)))
+        val next = AppState(regions = Regions(flow = FlowRegion(flow = Flow.TaskPickupArrived), platforms = mapOf(platform to region)))
+
+        val effects = effectMap.diff(prev, next, screenObs(flow = Flow.TaskPickupArrived))
+        assertFalse(
+            "a PostTask exit must not re-complete a prior job's stale task (cross-job leak)",
+            effects.logEventTypes().contains(AppEventType.DELIVERY_COMPLETED),
+        )
+    }
+
+    @Test
+    fun `DELIVERY_COMPLETED fires for the task just retired on this PostTask exit (#518 keeps normal)`() {
+        val (platform, base) = stateWithPlatform()
+        val job = Job("job-new", offerStoreHint = emptyList(), parentOfferHash = null, startedAt = 1000L)
+        val active = Task(
+            taskId = "task-36", jobId = "job-new", phase = TaskPhase.DROPOFF,
+            customerNameHash = "abc123", startedAt = 100L, completedAt = null,
+        )
+        // prev: PostTask, the delivered task is ACTIVE (NOT yet in recentTasks).
+        val prevRegion = base.copy(activeJob = job, activeTask = active, recentTasks = emptyList())
+        val prev = AppState(regions = Regions(flow = FlowRegion(flow = Flow.PostTask), platforms = mapOf(platform to prevRegion)))
+        // next: PostTask exit; the task is freshly retired into recentTasks (was NOT in prev.recentTasks).
+        val nextRegion = prevRegion.copy(activeTask = null, recentTasks = listOf(active.copy(completedAt = 2000L)))
+        val next = AppState(regions = Regions(flow = FlowRegion(flow = Flow.TaskDropoffArrived), platforms = mapOf(platform to nextRegion)))
+
+        val effects = effectMap.diff(prev, next, screenObs(flow = Flow.TaskDropoffArrived))
+        assertTrue(
+            "a genuinely just-retired task still completes",
+            effects.logEventTypes().contains(AppEventType.DELIVERY_COMPLETED),
+        )
     }
 
     @Test

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -294,9 +294,15 @@ class EffectMap @Inject constructor() {
                     // Prefer it (same-id guard: a stacked next-task frame mints
                     // a NEW activeTask on this same exit, which must not be the
                     // one we report); fall back to the last committed task.
-                    val completedTask = next.activeTask
-                        ?.takeIf { it.taskId == p.activeTask?.taskId }
-                        ?: next.recentTasks.lastOrNull()
+                    // #518: resolve the task being completed — the still-active delivered task, or
+                    // the one just retired into recentTasks on this exit, JOB-SCOPED so a PRIOR job's
+                    // stale task can never be the fallback (the cross-job leak, db seq 117/100 — a
+                    // prior job's already-completed dropoff re-firing under the new job). When there
+                    // is no active job to scope by, keep the prior unscoped behaviour (the payload's
+                    // jobId would be null regardless).
+                    val completedJobId = p.activeJob?.jobId
+                    val completedTask = next.activeTask?.takeIf { it.taskId == p.activeTask?.taskId }
+                        ?: next.recentTasks.lastOrNull { completedJobId == null || it.jobId == completedJobId }
                     if (completedTask != null) {
                         val retireSince = p.pendingDestructive
                             ?.takeIf { it.kind == DestructiveKind.TASK_RETIRE }?.since


### PR DESCRIPTION
Refs #518 (the cross-job leak half — the worst: a prior job's already-completed dropoff re-firing under the new job, db seq 117/100). `EffectMap` now job-scopes the completion fallback so a prior job's stale task can never be picked; lenient when there's no active job. Grounded in the 06-17 db. `EffectMapTest` regressions added; the #431 grace-completion path still works.

The **per-task idempotency** for *same-job* duplicate completions (seq 119/122) needs replay-stable completed-task tracking — kept open on #518 as the remaining part.

Security/privacy: state-layer event-emission guard; no new data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)