### PR TITLE
fix(state): clean up phantom + over-minted dropoff tasks (#498)

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepperTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepperTest.kt
@@ -66,6 +66,8 @@ class PlatformRegionStepperTest {
         storeName: String?,
         phase: TaskPhase,
         subFlow: TaskSubFlow,
+        customerNameHash: String? = null,
+        customerAddressHash: String? = null,
         timestamp: Long = 1_000L,
     ): Observation.Screen = Observation.Screen(
         timestamp = timestamp,
@@ -78,6 +80,8 @@ class PlatformRegionStepperTest {
             storeName = storeName,
             phase = phase,
             subFlow = subFlow,
+            customerNameHash = customerNameHash,
+            customerAddressHash = customerAddressHash,
         ),
     )
 
@@ -251,6 +255,10 @@ class PlatformRegionStepperTest {
                 storeName = null,
                 phase = TaskPhase.DROPOFF,
                 subFlow = TaskSubFlow.NAVIGATION,
+                // A real dropoff_navigation always carries a customer hash; an identity-less
+                // dropoff frame is suppressed by the #498 phantom guard (see TaskLifecycleGuardTest).
+                customerNameHash = "cust-name-1",
+                customerAddressHash = "cust-addr-1",
             ),
             policy = policy,
         )

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
@@ -613,7 +613,14 @@ class PlatformRegionStepper @Inject constructor() {
                 currentTask.arrivedAt != null &&
                 taskSubFlow == TaskSubFlow.NAVIGATION &&
                 taskFields?.customerAddressHash != null &&
-                taskFields.customerAddressHash != currentTask.customerAddressHash
+                taskFields.customerAddressHash != currentTask.customerAddressHash &&
+                // #498 task-path: only a genuinely DIFFERENT customer starts a new stacked dropoff —
+                // gate on the stable customer NAME hash, not just the address. An unstable dropoff
+                // address parse split one physical drop into two tasks on 06-17 (task-39/-40 carried
+                // the same name hash f5b3497a but different address hashes). A present, changed name
+                // is required; a null/unchanged name is the same customer, so update, don't re-mint.
+                taskFields.customerNameHash != null &&
+                taskFields.customerNameHash != currentTask.customerNameHash
 
             if (currentTask == null ||
                 currentTask.phase != taskPhase ||

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
@@ -715,6 +715,26 @@ class PlatformRegionStepper @Inject constructor() {
                     )
                 }
 
+                // #498 phantom-dropoff guard: a transition INTO a dropoff that carries no
+                // customer identity at all (no name hash AND no address hash) is a transient
+                // confirmation/geofence/arriving screen — dropoff_completed_confirm,
+                // dropoff_geofence_warning, nav_arriving — whose flow is task:dropoff:* but
+                // which parses no customer. It is NOT a distinct delivery. Minting a fresh
+                // dropoff here produced the "the customer" phantom: an identity-less dropoff
+                // that immediately completed (06-17 captures: task-9 on a single H-E-B order,
+                // task-13, and task-38 on the Jim's stack — the only cn==null && ca==null
+                // dropoffs in the whole session; every real dropoff carried a customer hash).
+                // Keep the current task; the customer-bearing dropoff_navigation/pre_arrival
+                // frame that follows transitions properly (it just resolves identity first).
+                // Resume and resolve-onto-placeholder above are unaffected — both reuse an
+                // existing task; this only suppresses the fall-through NEW mint.
+                if (taskPhase == TaskPhase.DROPOFF &&
+                    taskFields?.customerNameHash == null &&
+                    taskFields?.customerAddressHash == null
+                ) {
+                    return region
+                }
+
                 // New task (different phase, no active task, or stacked-pickup transition).
                 // The displaced task commits inline; if a TASK_RETIRE grace was
                 // pending (receipt or idle already signalled its end, #431 pt 2)

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/TaskLifecycleGuardTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/TaskLifecycleGuardTest.kt
@@ -349,6 +349,42 @@ class TaskLifecycleGuardTest {
     }
 
     @Test
+    fun `an identity-less dropoff frame does NOT mint a phantom dropoff (#498)`() {
+        // 06-17: a transient dropoff confirm/arriving screen (flow task:dropoff:* but no customer
+        // parse — dropoff_completed_confirm / dropoff_geofence_warning / nav_arriving) minted an
+        // identity-less "the customer" dropoff that immediately completed (task-9 single H-E-B,
+        // task-38 Jim's stack). The pickup must stay active until a customer-bearing dropoff frame.
+        val r0 = region(pickupTask("pick-A", "H-E-B", arrivedAt = 800L))
+        val (r1, _) = step(
+            r0, FlowRegion(flow = Flow.TaskPickupArrived),
+            taskObs(Flow.TaskDropoffArrived, TaskPhase.DROPOFF, TaskSubFlow.ARRIVED, timestamp = 1_000L),
+        )
+
+        assertEquals("identity-less dropoff frame must NOT mint a task", "pick-A", r1.activeTask?.taskId)
+        assertEquals("the pickup stays active", TaskPhase.PICKUP, r1.activeTask?.phase)
+        assertTrue("no phantom retired the pickup", r1.recentTasks.none { it.completedAt != null })
+    }
+
+    @Test
+    fun `a customer-bearing dropoff after an identity-less one mints with identity (#498)`() {
+        // The guard only DELAYS the mint until identity is known: once the real
+        // dropoff_navigation arrives with a customer, the transition happens normally.
+        val r0 = region(pickupTask("pick-A", "H-E-B", arrivedAt = 800L))
+        val (r1, f1) = step(
+            r0, FlowRegion(flow = Flow.TaskPickupArrived),
+            taskObs(Flow.TaskDropoffArrived, TaskPhase.DROPOFF, TaskSubFlow.ARRIVED, timestamp = 1_000L),
+        )
+        val (r2, _) = step(
+            r1, f1,
+            taskObs(Flow.TaskDropoffNavigation, TaskPhase.DROPOFF, TaskSubFlow.NAVIGATION, customerNameHash = "name-1", customerAddressHash = "cust-1", timestamp = 1_100L),
+        )
+
+        assertNotEquals("a customer-bearing dropoff mints a new task", "pick-A", r2.activeTask?.taskId)
+        assertEquals(TaskPhase.DROPOFF, r2.activeTask?.phase)
+        assertEquals("name-1", r2.activeTask?.customerNameHash)
+    }
+
+    @Test
     fun `same-customer dropoff nav flicker keeps the same task`() {
         val r0 = region(dropoffTask("task-A", customerAddressHash = "cust-1", arrivedAt = 800L))
         val (r1, _) = step(

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/TaskLifecycleGuardTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/TaskLifecycleGuardTest.kt
@@ -55,9 +55,15 @@ class TaskLifecycleGuardTest {
         storeName = storeName, startedAt = 300L, arrivedAt = arrivedAt,
     )
 
-    private fun dropoffTask(taskId: String, customerAddressHash: String, arrivedAt: Long? = null) = Task(
+    private fun dropoffTask(
+        taskId: String,
+        customerAddressHash: String,
+        arrivedAt: Long? = null,
+        customerNameHash: String? = null,
+    ) = Task(
         taskId = taskId, jobId = "job-1", phase = TaskPhase.DROPOFF,
-        customerAddressHash = customerAddressHash, startedAt = 300L, arrivedAt = arrivedAt,
+        customerAddressHash = customerAddressHash, customerNameHash = customerNameHash,
+        startedAt = 300L, arrivedAt = arrivedAt,
     )
 
     private fun taskObs(
@@ -67,6 +73,7 @@ class TaskLifecycleGuardTest {
         storeName: String? = null,
         storeAddress: String? = null,
         customerAddressHash: String? = null,
+        customerNameHash: String? = null,
         itemsShopped: Int? = null,
         itemsRemaining: Int? = null,
         timestamp: Long,
@@ -76,7 +83,7 @@ class TaskLifecycleGuardTest {
         parsed = ParsedFields.TaskFields(
             phase = phase, subFlow = subFlow,
             storeName = storeName, storeAddress = storeAddress,
-            customerAddressHash = customerAddressHash,
+            customerAddressHash = customerAddressHash, customerNameHash = customerNameHash,
             itemsShopped = itemsShopped, itemsRemaining = itemsRemaining,
         ),
     )
@@ -301,16 +308,44 @@ class TaskLifecycleGuardTest {
 
     @Test
     fun `stacked dropoff mints a new task on customer change`() {
-        val r0 = region(dropoffTask("task-A", customerAddressHash = "cust-1", arrivedAt = 800L))
+        val r0 = region(dropoffTask("task-A", customerAddressHash = "cust-1", customerNameHash = "name-1", arrivedAt = 800L))
         val (r1, _) = step(
             r0, FlowRegion(flow = Flow.TaskDropoffArrived),
-            taskObs(Flow.TaskDropoffNavigation, TaskPhase.DROPOFF, TaskSubFlow.NAVIGATION, customerAddressHash = "cust-2", timestamp = 1_000L),
+            taskObs(Flow.TaskDropoffNavigation, TaskPhase.DROPOFF, TaskSubFlow.NAVIGATION, customerAddressHash = "cust-2", customerNameHash = "name-2", timestamp = 1_000L),
         )
 
         assertNotEquals("a different customer mints a new dropoff task", "task-A", r1.activeTask?.taskId)
         assertEquals(TaskPhase.DROPOFF, r1.activeTask?.phase)
         assertEquals("cust-2", r1.activeTask?.customerAddressHash)
         assertTrue(r1.recentTasks.any { it.taskId == "task-A" && it.completedAt != null })
+    }
+
+    @Test
+    fun `same customer with a drifting dropoff address does NOT split into a second task (#498)`() {
+        // 06-17 over-mint: one physical Jim's drop minted task-39 and task-40 — same customer NAME
+        // hash (f5b3497a) but a different (unstable) address parse. The stacked-dropoff transition
+        // is now gated on the stable NAME hash, so a drifting address alone must not re-mint.
+        val r0 = region(dropoffTask("task-A", customerAddressHash = "cust-1", customerNameHash = "name-1", arrivedAt = 800L))
+        val (r1, _) = step(
+            r0, FlowRegion(flow = Flow.TaskDropoffArrived),
+            taskObs(Flow.TaskDropoffNavigation, TaskPhase.DROPOFF, TaskSubFlow.NAVIGATION, customerAddressHash = "cust-2", customerNameHash = "name-1", timestamp = 1_000L),
+        )
+
+        assertEquals("same customer name must NOT mint a second task on a drifting address", "task-A", r1.activeTask?.taskId)
+        assertTrue("no prior dropoff should be retired", r1.recentTasks.none { it.taskId == "task-A" && it.completedAt != null })
+    }
+
+    @Test
+    fun `a dropoff frame with no customer name does NOT mint a second task (#498)`() {
+        // A null/blank customer-name parse (the phantom-task source) must never start a new
+        // stacked dropoff — it's the same customer until a present, different name says otherwise.
+        val r0 = region(dropoffTask("task-A", customerAddressHash = "cust-1", customerNameHash = "name-1", arrivedAt = 800L))
+        val (r1, _) = step(
+            r0, FlowRegion(flow = Flow.TaskDropoffArrived),
+            taskObs(Flow.TaskDropoffNavigation, TaskPhase.DROPOFF, TaskSubFlow.NAVIGATION, customerAddressHash = "cust-2", customerNameHash = null, timestamp = 1_000L),
+        )
+
+        assertEquals("a nameless dropoff frame must NOT mint a second task", "task-A", r1.activeTask?.taskId)
     }
 
     @Test

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -82,6 +82,19 @@ _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **bro
   (Single-order this build; **multi-drop is slice 3b, not yet shipped** — a stacked/GoPuff multi-drop
   may still mis-handle the extra dropoffs.)
 
+- **🔧 FIX IN FLIGHT — phantom + over-minted dropoff tasks cleaned up (#498, PR #521). CONFIRM ON DASH.**
+  Two state-layer guards from the 06-17 capture investigation: (a) a dropoff frame that parses **no
+  customer at all** (a transient confirm/arriving screen) no longer mints a fresh **identity-less**
+  dropoff — the "the customer" card that immediately completes (06-17 task-9 on a **single H-E-B**
+  order); (b) a **drifting dropoff address** with the **same customer name** no longer splits one drop
+  into two tasks (06-17 task-39/-40). **Confirm on dash: 0/2 —** on a **single** order, the dropoff
+  card should resolve to the **real 6-char hash** with **no** brief "the customer" card flashing/
+  completing alongside it, and exactly **one** dropoff card per real stop (no duplicate). The phantom
+  also silently fired spurious `DELIVERY_COMPLETED`s — watch for any **$0.00 PAID** card that mints
+  with no real delivery. If a phantom/duplicate dropoff still shows, capture the dropoff frame sequence
+  + the `app_state_snapshots` for that order. (Stacks are still #503 slice 3b — extra dropoffs on a
+  multi-drop may still mis-handle, separate from this.)
+
 - **📸 CAPTURE NEEDED — GoPuff (Drive) screens, to finalize the #501 rules.** The 06-14 deep-dive
   enumerated the GoPuff flow (all inside the DoorDash app — there is no separate GoPuff app) from real
   captures, but three things would help finalize the rules. **On the next GoPuff dash, drop these into
@@ -739,13 +752,32 @@ Accept and Decline registered on DoorDash — and moved to that session's entry 
 
 ### Bugs
 
-#### 1. Stacked (double) H-E-B order — dropoff card never resolves to the customer hash; stays on "the customer"
-On a **double / stacked** order (the dasher first read it as a single dropoff, then corrected: there
-**was a second minted task** — it's a genuine double), believed to be **H-E-B**, a drop-off card
-showed the **placeholder "to the customer"** and **never resolved to a real customer hash**. The
-dasher's read: the chrome/frame was **recognized but carried no customer data** — the customer field
-was **probably null/empty** in the hash (i.e. recognized frame, empty customer parse), so the card
-sat on the placeholder instead of the short 6-char hash code.
+#### 1. Single H-E-B order — dropoff card never resolves to the customer hash; stays on "the customer"
+> **CORRECTION (2026-06-18, dev):** this was **NOT a stack** — *H-E-B offers are only ever single*
+> (right now). The original in-field read of a "double" was wrong; the "second minted task" it
+> referred to was the **phantom dropoff** the desk follow-up below identifies, not a real second drop.
+> The stacked/multi-drop framing in the rest of this item is superseded by that follow-up.
+
+On a (single) **H-E-B** order, a drop-off card showed the **placeholder "to the customer"** and
+**never resolved to a real customer hash**. The dasher's read: the chrome/frame was **recognized but
+carried no customer data** — the customer field was **null/empty** in the hash (recognized frame,
+empty customer parse), so the card sat on the placeholder instead of the short 6-char hash code.
+
+- **Desk follow-up (2026-06-18, grounded in the 06-17 capture db `app_state_snapshots`):** confirmed
+  the mechanism, and it is **not** multi-drop. Dropoff phase is entered from the *flow* (a
+  `task:dropoff:*` screen), so a transient confirmation/arriving screen that parses **no customer**
+  (`dropoff_completed_confirm`, `dropoff_geofence_warning`, `nav_arriving`) yields `taskPhase=DROPOFF`
+  with a null customer, and the stepper's fall-through mint created a fresh **identity-less dropoff**
+  (`customerNameHash==null && customerAddressHash==null`) that immediately completed — rendering as
+  "the customer". Evidence: the *only* such null/null DROPOFF tasks in the whole ~2-day session were
+  **task-9** (this single H-E-B order), **task-13**, and **task-38** (which belongs to a genuine Jim's
+  stack — a separate case); every real, resolved dropoff carried a customer hash. A second, distinct
+  defect on the Jim's **stack** also split one physical drop into two tasks (task-39/-40 — same name
+  hash, drifting address hash). **Fix in flight — PR #521** (`#498`): (a) gate the stacked-dropoff
+  mint on the stable customer-**name** hash; (b) suppress the fall-through dropoff mint when the frame
+  carries no customer identity at all (resume / resolve-onto-placeholder paths untouched). Needs field
+  re-validation that a single H-E-B dropoff now shows the real 6-char hash. The multi-drop *stack*
+  ownership itself remains #503 slice 3b.
 
 - **Field UX note — the placeholder copy CHANGED (and this part looks correct):** the placeholder is
   now all-lowercase **"to the customer"**, not the old name-like capital **"Customer."** That matches


### PR DESCRIPTION
Two grounded fixes for the reopened **#498** dropoff-ghosting, both verified against the 2026-06-17 capture session's state snapshots. Continues #517 (PR #519, recognition) and #518 (PR #520, cross-job `DELIVERY_COMPLETED` leak).

## 1. Over-mint — one drop split into two (commit 1)

A single physical Jim's dropoff minted **two** tasks (task-39/-40) — same customer **name** hash `f5b3497a`, different (unstable) dropoff **address** hashes. `isStackedDropoffTransition` keyed the second-dropoff mint solely on `customerAddressHash` change, so a drifting address parse split one drop in two.

**Fix:** gate the stacked-dropoff transition on the **stable customer-name hash** — a new stacked dropoff mints only when a *present* name hash **differs** from the active task's. Null/unchanged name → same customer → update, don't re-mint.

## 2. Phantom — the "the customer" identity-less dropoff (commit 2)

A transition INTO a dropoff whose frame carries **no customer identity at all** (no name hash AND no address hash) was minting a fresh dropoff task. Those are transient confirmation/geofence/arriving screens (`dropoff_completed_confirm`, `dropoff_geofence_warning`, `nav_arriving`) — flow is `task:dropoff:*` (so `taskPhase` derives from the flow) but they parse no customer, so the fall-through mint created an identity-less dropoff that immediately completed and rendered as **"the customer"**.

**Grounding:** the *only* `cn==null && ca==null` DROPOFF tasks in the whole ~2-day session were **task-9** (single H-E-B order — the developer's report), **task-13**, and **task-38** (the Jim's stack). Every real resolved dropoff carried a customer hash → gating on "has any identity" isolates phantoms with **zero false positives**.

**Fix:** in the dropoff mint branch — *after* resume and resolve-onto-placeholder, both of which reuse an existing task and are untouched — bail before the fall-through NEW mint when `taskPhase==DROPOFF && customerNameHash==null && customerAddressHash==null`. The current task stays active; the customer-bearing `dropoff_navigation` frame that follows transitions normally. The guard only **delays** the mint until identity is known.

## Tests

`TaskLifecycleGuardTest` (+4, 21 total):
- same name + drifting address → one task, retires nothing;
- nameless dropoff frame → no second task;
- identity-less dropoff frame → pickup stays active, nothing retired;
- customer-bearing dropoff after an identity-less one → mints with identity.

`PlatformRegionStepperTest`: `screenObs` gained customer params; the PICKUP→DROPOFF regression guard now models a real (customer-bearing) dropoff.

## Security/privacy

No posture change. Customer hashes are the existing edge `sha256` (Pledge: customers hashed, not blocked). Nothing new is parsed, stored, or unblocked; the block side is untouched.

## Remaining from the 06-17 thread
- `#518` same-job idempotency (duplicate completions of the *same* task);
- multi-drop stack ownership (#503 3b) — the phantom guard + name key clean up the stack's worst symptoms, but the durable structural fix is the Job-owns-ordered-dropoffs model.