### PR TITLE
fix(state): make DELIVERY_COMPLETED idempotent per task (#518)

### DIFF
--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/AppEffect.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/AppEffect.kt
@@ -27,10 +27,20 @@ sealed class AppEffect {
      * Log a domain [AppEvent] (the core of event sourcing). Entity assembly —
      * payload encoding + device metadata — happens at the executor edge (#354/#119);
      * the state layer emits pure domain data. `occurredAt` is observation-derived,
-     * so this key is identical between live execution and recovery replay (#300).
+     * so the default key is identical between live execution and recovery replay (#300).
+     *
+     * [effectKeyOverride] lets a caller scope idempotency to a logical identity instead of
+     * the observation timestamp — a once-per-thing event whose triggering screen can recur.
+     * #518: DELIVERY_COMPLETED keys on the completed task so a re-entered PostTask receipt
+     * (PostTask→nav→PostTask→nav) can't fire — and double-count — the same delivery twice
+     * (06-17 db: real $23.62 and $11.20 deliveries each logged twice on a receipt flap). The
+     * override must itself be replay-stable (taskId is minted deterministically).
      */
-    data class LogEvent(val event: AppEvent) : AppEffect() {
-        override val effectKey: String get() = "log:${event.type}:${event.occurredAt}"
+    data class LogEvent(
+        val event: AppEvent,
+        val effectKeyOverride: String? = null,
+    ) : AppEffect() {
+        override val effectKey: String get() = effectKeyOverride ?: "log:${event.type}:${event.occurredAt}"
     }
 
     // 2. Update UI (The Bubble)

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -313,7 +313,15 @@ class EffectMap @Inject constructor() {
                             postTaskFields = p.lastPostTaskFields,
                             sessionEarnings = next.session?.runningEarnings ?: p.session?.runningEarnings,
                         )
-                        add(logEffect(sessionId, AppEventType.DELIVERY_COMPLETED, obs.timestamp, payload))
+                        // #518: scope idempotency to the completed task, not obs.timestamp, so a
+                        // re-entered PostTask receipt can't re-fire (and double-count) the same
+                        // delivery. taskId is replay-stable; the cross-job leak is handled above.
+                        add(
+                            logEffect(
+                                sessionId, AppEventType.DELIVERY_COMPLETED, obs.timestamp, payload,
+                                effectKeyOverride = "log:${AppEventType.DELIVERY_COMPLETED}:${completedTask.taskId}",
+                            )
+                        )
                     }
                 }
             }
@@ -933,13 +941,15 @@ class EffectMap @Inject constructor() {
         type: AppEventType,
         occurredAt: Long,
         payload: AppEventPayload?,
+        effectKeyOverride: String? = null,
     ): AppEffect = AppEffect.LogEvent(
         AppEvent(
             type = type,
             occurredAt = occurredAt,
             sessionId = sessionId,
             payload = payload,
-        )
+        ),
+        effectKeyOverride = effectKeyOverride,
     )
 
     // =========================================================================

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapPayloadTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapPayloadTest.kt
@@ -472,6 +472,9 @@ class EffectMapPayloadTest {
         assertEquals(7.50, payload.parsedPay!!.total, 0.001)
         assertEquals(47.50, payload.sessionEarningsAtCompletion!!, 0.001)
         assertEquals(3000L, payload.completedAt)
+        // #518: idempotency scoped to the completed task (not obs.timestamp) so a re-entered
+        // PostTask receipt can't re-fire the same delivery via effects_fired.
+        assertEquals("log:DELIVERY_COMPLETED:T6", logs[0].effectKey)
     }
 
     // =========================================================================

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -95,6 +95,17 @@ _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **bro
   + the `app_state_snapshots` for that order. (Stacks are still #503 slice 3b — extra dropoffs on a
   multi-drop may still mis-handle, separate from this.)
 
+- **🔧 FIX IN FLIGHT — a delivery can't be logged/counted twice (#518, PRs #520 + #522). CONFIRM ON DASH.**
+  Two halves of the spurious-`DELIVERY_COMPLETED` bug: PR #520 stopped a **prior job's** task
+  re-completing under a new job (cross-job leak); PR #522 makes `DELIVERY_COMPLETED` **idempotent per
+  task** so a re-shown receipt (`PostTask → nav → PostTask → nav`) can't fire the **same** delivery
+  twice. 06-17 evidence: two **real** deliveries ($23.62, $11.20) were each logged twice → doubled
+  earnings. **Confirm on dash: 0/2 —** each completed delivery should produce **exactly one** "Saved:
+  $X" bubble and **one** completed card, and the **session-earnings total must match the sum of the
+  real deliveries** (no doubling). Watch especially when the receipt screen is shown, dismissed, and
+  re-shown. If a delivery double-counts, capture the `app_events` (`DELIVERY_COMPLETED` rows) +
+  `app_state_snapshots` for that order.
+
 - **📸 CAPTURE NEEDED — GoPuff (Drive) screens, to finalize the #501 rules.** The 06-14 deep-dive
   enumerated the GoPuff flow (all inside the DoorDash app — there is no separate GoPuff app) from real
   captures, but three things would help finalize the rules. **On the next GoPuff dash, drop these into


### PR DESCRIPTION
## What

The remaining **same-job** half of #518 (the cross-job half landed in PR #520). A re-entered PostTask receipt — `PostTask → nav → PostTask → nav` — fired `DELIVERY_COMPLETED` **twice for the same task**, because the `LogEvent` idempotency key was `log:<type>:<occurredAt>` and the two exits carry different observation timestamps, so `effects_fired` never deduped them.

## Grounded in the 2026-06-17 db

Three duplicate same-task completions in one session:
- **task-…-10** — `$23.62`, a **real** delivery, logged twice (seq 28/30);
- **task-…-20** — `$11.20`, a **real** delivery, logged twice (seq 65/67);
- **task-…-36** — `$0.00`, on a receipt flap (seq 119/122).

The first two **double-count real earnings**, not just $0 ghosts — so this corrupts the dasher's totals.

## Fix

Add an optional `effectKeyOverride` to `AppEffect.LogEvent`, and key `DELIVERY_COMPLETED` on the completed task: `log:DELIVERY_COMPLETED:<taskId>`. `taskId` is minted deterministically from `(platform, obs.timestamp, mintCounter)`, so the key stays **replay-stable** (#300) and recovery still dedups correctly. The second fire for the same delivery is now skipped by `effects_fired.hasBeenFired`. The cross-job leak remains handled by the job-scoped `completedTask` resolution from PR #520.

## Test

`EffectMapPayloadTest` asserts the emitted effect's key is `log:DELIVERY_COMPLETED:T6` (task-scoped, not timestamp-scoped).

## Security/privacy

No posture change — no new parse, store, or network; the key is an internal idempotency string.

Closes the #518 thread (cross-job PR #520 + same-job here). Continues the 06-17 ghost-paid investigation (#517 PR #519 recognition, #498 PR #521 dropoff phantom/over-mint).