### PR TITLE
feat(state): multi-drop ownership — Job owns ordered dropoffs, routed by customer name (#503 slice 3b)

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/state/StateMachineTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/state/StateMachineTest.kt
@@ -142,10 +142,14 @@ class StateMachineTest {
         storeName: String = "Chipotle",
         phase: TaskPhase = TaskPhase.PICKUP,
         subFlow: TaskSubFlow = TaskSubFlow.NAVIGATION,
+        customerNameHash: String? = null,
+        customerAddressHash: String? = null,
     ) = ParsedFields.TaskFields(
         storeName = storeName,
         phase = phase,
         subFlow = subFlow,
+        customerNameHash = customerNameHash,
+        customerAddressHash = customerAddressHash,
     )
 
     // =========================================================================
@@ -860,6 +864,82 @@ class StateMachineTest {
             2,
             job.tasks.count { it.phase == TaskPhase.DROPOFF },
         )
+    }
+
+    @Test
+    fun `a stacked offer routes each dropoff screen to its own customer subtask (#503 slice 3b)`() {
+        var state = AppState()
+        state = machine.step(state, screenObs(
+            flow = Flow.OfferPresented,
+            parsed = multiOrderOfferFields(listOf("Chili's Grill & Bar", "Jim's Restaurant")),
+        )).newState
+        state = machine.step(state, screenObs(flow = Flow.TaskPickupNavigation, parsed = taskFields())).newState
+        // Drop A (arrive), then drop B — the arrival + distinct customer makes B a stacked-dropoff
+        // transition, so each resolves onto its own placeholder instead of B overwriting A.
+        state = machine.step(state, screenObs(
+            flow = Flow.TaskDropoffNavigation,
+            parsed = taskFields(phase = TaskPhase.DROPOFF, customerNameHash = "cust-A", customerAddressHash = "addr-A"),
+        )).newState
+        state = machine.step(state, screenObs(
+            flow = Flow.TaskDropoffArrived,
+            parsed = taskFields(phase = TaskPhase.DROPOFF, subFlow = TaskSubFlow.ARRIVED, customerNameHash = "cust-A", customerAddressHash = "addr-A"),
+        )).newState
+        state = machine.step(state, screenObs(
+            flow = Flow.TaskDropoffNavigation,
+            parsed = taskFields(phase = TaskPhase.DROPOFF, customerNameHash = "cust-B", customerAddressHash = "addr-B"),
+        )).newState
+
+        val dd = state.regions.platforms[Platform.DoorDash]!!
+        val resolvedDropoffs = (dd.activeJob!!.tasks + dd.recentTasks + listOfNotNull(dd.activeTask))
+            .filter { it.phase == TaskPhase.DROPOFF && it.customerNameHash != null }
+            .distinctBy { it.taskId }
+        assertEquals("two distinct customers → two resolved dropoffs", 2, resolvedDropoffs.size)
+        assertEquals(setOf("cust-A", "cust-B"), resolvedDropoffs.map { it.customerNameHash }.toSet())
+    }
+
+    @Test
+    fun `returning to an earlier stacked drop resumes it, not a duplicate (#503 slice 3b-2)`() {
+        var state = AppState()
+        state = machine.step(state, screenObs(
+            flow = Flow.OfferPresented,
+            parsed = multiOrderOfferFields(listOf("Chili's Grill & Bar", "Jim's Restaurant")),
+        )).newState
+        state = machine.step(state, screenObs(flow = Flow.TaskPickupNavigation, parsed = taskFields())).newState
+        // A (arrive) → B (arrive) → back to A. Each move is a stacked-dropoff transition.
+        state = machine.step(state, screenObs(
+            flow = Flow.TaskDropoffNavigation,
+            parsed = taskFields(phase = TaskPhase.DROPOFF, customerNameHash = "cust-A", customerAddressHash = "addr-A"),
+        )).newState
+        state = machine.step(state, screenObs(
+            flow = Flow.TaskDropoffArrived,
+            parsed = taskFields(phase = TaskPhase.DROPOFF, subFlow = TaskSubFlow.ARRIVED, customerNameHash = "cust-A", customerAddressHash = "addr-A"),
+        )).newState
+        state = machine.step(state, screenObs(
+            flow = Flow.TaskDropoffNavigation,
+            parsed = taskFields(phase = TaskPhase.DROPOFF, customerNameHash = "cust-B", customerAddressHash = "addr-B"),
+        )).newState
+        state = machine.step(state, screenObs(
+            flow = Flow.TaskDropoffArrived,
+            parsed = taskFields(phase = TaskPhase.DROPOFF, subFlow = TaskSubFlow.ARRIVED, customerNameHash = "cust-B", customerAddressHash = "addr-B"),
+        )).newState
+        // Return to A — with a DRIFTED address (addr-A2) to prove the resume keys on the stable
+        // NAME hash, not the address. Must RESUME A's subtask, not mint a third dropoff.
+        state = machine.step(state, screenObs(
+            flow = Flow.TaskDropoffNavigation,
+            parsed = taskFields(phase = TaskPhase.DROPOFF, customerNameHash = "cust-A", customerAddressHash = "addr-A2"),
+        )).newState
+
+        val dd = state.regions.platforms[Platform.DoorDash]!!
+        val dropsForA = (dd.activeJob!!.tasks + dd.recentTasks + listOfNotNull(dd.activeTask))
+            .filter { it.phase == TaskPhase.DROPOFF && it.customerNameHash == "cust-A" }
+            .distinctBy { it.taskId }
+        assertEquals("returning to A resumes its subtask, no duplicate", 1, dropsForA.size)
+        assertEquals("A is active again", "cust-A", dd.activeTask?.customerNameHash)
+        // And exactly two distinct customer dropoffs overall (A and B), never a third.
+        val allResolved = (dd.activeJob!!.tasks + dd.recentTasks + listOfNotNull(dd.activeTask))
+            .filter { it.phase == TaskPhase.DROPOFF && it.customerNameHash != null }
+            .distinctBy { it.taskId }
+        assertEquals("only two customer dropoffs ever exist", 2, allResolved.size)
     }
 
     @Test

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/state/StateMachineTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/state/StateMachineTest.kt
@@ -116,6 +116,28 @@ class StateMachineTest {
             ),
         )
 
+    /** An offer covering N orders (a stack) — one [ParsedOrder] per store. */
+    private fun multiOrderOfferFields(
+        stores: List<String>,
+        hash: String = "hash-multi",
+    ) = ParsedFields.OfferFields(
+        parsedOffer = ParsedOffer(
+            offerHash = hash,
+            payAmount = 12.0,
+            distanceMiles = 5.0,
+            orders = stores.mapIndexed { i, s ->
+                ParsedOrder(
+                    orderIndex = i,
+                    orderType = OrderType.PICKUP,
+                    storeName = s,
+                    itemCount = 1,
+                    isItemCountEstimated = false,
+                    badges = emptySet(),
+                )
+            },
+        ),
+    )
+
     private fun taskFields(
         storeName: String = "Chipotle",
         phase: TaskPhase = TaskPhase.PICKUP,
@@ -791,6 +813,53 @@ class StateMachineTest {
         assertNotNull(dd.activeJob)
         assertNotNull(dd.activeTask)
         assertEquals(TaskPhase.PICKUP, dd.activeTask!!.phase)
+    }
+
+    @Test
+    fun `single-order offer pre-creates one dropoff placeholder (#503 slice 3)`() {
+        var state = AppState()
+        state = machine.step(state, screenObs(flow = Flow.OfferPresented, parsed = offerFields())).newState
+        state = machine.step(state, screenObs(flow = Flow.TaskPickupNavigation, parsed = taskFields())).newState
+
+        val job = state.regions.platforms[Platform.DoorDash]!!.activeJob!!
+        val dropoffs = job.tasks.filter { it.phase == TaskPhase.DROPOFF }
+        assertEquals("a single delivery owns one dropoff placeholder", 1, dropoffs.size)
+        assertTrue("customer is TBD until the dropoff screen", dropoffs.all { it.customerNameHash == null })
+    }
+
+    @Test
+    fun `two-order offer pre-creates two dropoff placeholders (#503 slice 3b)`() {
+        var state = AppState()
+        state = machine.step(state, screenObs(
+            flow = Flow.OfferPresented,
+            parsed = multiOrderOfferFields(listOf("Chili's Grill & Bar", "Jim's Restaurant")),
+        )).newState
+        state = machine.step(state, screenObs(flow = Flow.TaskPickupNavigation, parsed = taskFields())).newState
+
+        val job = state.regions.platforms[Platform.DoorDash]!!.activeJob!!
+        val dropoffs = job.tasks.filter { it.phase == TaskPhase.DROPOFF }
+        assertEquals("a 2-order stack owns 2 ordered dropoffs", 2, dropoffs.size)
+        assertTrue("all start as customer-TBD placeholders", dropoffs.all { it.customerNameHash == null })
+        assertEquals("distinct task ids", 2, dropoffs.map { it.taskId }.toSet().size)
+    }
+
+    @Test
+    fun `add-on offer appends a dropoff placeholder onto the active job (#503 slice 3b)`() {
+        var state = AppState()
+        // First offer (1 order) → job with 1 dropoff placeholder.
+        state = machine.step(state, screenObs(flow = Flow.OfferPresented, parsed = offerFields("Chipotle", "hash-A"))).newState
+        state = machine.step(state, screenObs(flow = Flow.TaskPickupNavigation, parsed = taskFields())).newState
+        // Add-on offer (different hash) accepted mid-pickup → append its own dropoff placeholder.
+        state = machine.step(state, screenObs(flow = Flow.OfferPresented, parsed = offerFields("Wendy's", "hash-B"))).newState
+        state = machine.step(state, screenObs(flow = Flow.TaskPickupNavigation, parsed = taskFields(storeName = "Wendy's"))).newState
+
+        val job = state.regions.platforms[Platform.DoorDash]!!.activeJob!!
+        assertEquals("both offers fold into the one job", 2, job.acceptedOffers.size)
+        assertEquals(
+            "the add-on appended its own dropoff placeholder",
+            2,
+            job.tasks.count { it.phase == TaskPhase.DROPOFF },
+        )
     }
 
     @Test

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
@@ -61,6 +61,30 @@ class PlatformRegionStepper @Inject constructor() {
         offset: Long = 0,
     ): String = "$kind-${region.platform.wire}-${obs.timestamp}-${region.mintCounter + offset}"
 
+    /**
+     * #503 slice 3b: pre-create one customer-TBD dropoff placeholder per order an accepted offer
+     * covers, so a Job owns ordered dropoffs for a stack (not just a single drop). Each dropoff
+     * screen later RESOLVES its customer onto the next open placeholder by name (slice 3 + 3b-2).
+     * The count comes from the offer's parsed order list (fallback 1 when the offer wasn't parsed);
+     * ids are minted at [startOffset]..[startOffset]+count-1 off the region's mint counter, which the
+     * caller advances past in the same copy().
+     */
+    private fun preCreatedDropoffs(
+        region: PlatformRegion,
+        obs: Observation,
+        jobId: String,
+        count: Int,
+        startOffset: Long,
+    ): List<Task> = (0 until count).map { i ->
+        Task(
+            taskId = mintId("task", region, obs, offset = startOffset + i),
+            jobId = jobId,
+            phase = TaskPhase.DROPOFF,
+            customerNameHash = null,
+            startedAt = obs.timestamp,
+        )
+    }
+
     fun step(
         prev: PlatformRegion,
         prevFlow: FlowRegion,
@@ -499,8 +523,14 @@ class PlatformRegionStepper @Inject constructor() {
             val storeHints = parsedOffer?.orders?.map { it.storeName } ?: emptyList()
             val existing = region.activeJob
 
+            // #503 slice 3b: pre-create one dropoff placeholder PER ORDER the offer covers, so a
+            // stack's Job owns ordered dropoffs (not a single drop). Fallback to 1 when the offer
+            // wasn't parsed — the pre-3b behaviour for a single delivery.
+            val dropoffCount = parsedOffer?.orders?.size?.takeIf { it > 0 } ?: 1
+
             if (existing == null) {
                 val jobId = mintId("job", region, obs)
+                // job at offset 0; the N dropoff placeholders at offsets 1..N.
                 return region.copy(
                     activeJob = Job(
                         jobId = jobId,
@@ -508,21 +538,9 @@ class PlatformRegionStepper @Inject constructor() {
                         parentOfferHash = pending?.offerHash,
                         acceptedOffers = listOf(economics),
                         startedAt = obs.timestamp,
-                        // #503 slice 3: pre-create the offer's dropoff subtask (customer TBD). The
-                        // dropoff screen later RESOLVES the customer onto this subtask instead of
-                        // minting a fresh dropoff — the root fix for the premature "Customer" card
-                        // (a dropoff surfaced before its customer resolves).
-                        tasks = listOf(
-                            Task(
-                                taskId = mintId("task", region, obs, offset = 1),
-                                jobId = jobId,
-                                phase = TaskPhase.DROPOFF,
-                                customerNameHash = null,
-                                startedAt = obs.timestamp,
-                            ),
-                        ),
+                        tasks = preCreatedDropoffs(region, obs, jobId, dropoffCount, startOffset = 1),
                     ),
-                    mintCounter = region.mintCounter + 2,
+                    mintCounter = region.mintCounter + dropoffCount + 1,
                 )
             }
 
@@ -530,11 +548,16 @@ class PlatformRegionStepper @Inject constructor() {
             val alreadyCounted = economics.offerHash != null &&
                 existing.acceptedOffers.any { it.offerHash == economics.offerHash }
             if (alreadyCounted) return region
+            // #503 slice 3b: the add-on offer brings its own dropoff(s) — append a placeholder per
+            // order so a stacked add-on's drops are owned by the job too (offsets 0..N-1, no job mint
+            // this step).
             return region.copy(
                 activeJob = existing.copy(
                     acceptedOffers = existing.acceptedOffers + economics,
                     offerStoreHint = existing.offerStoreHint + storeHints,
+                    tasks = existing.tasks + preCreatedDropoffs(region, obs, existing.jobId, dropoffCount, startOffset = 0),
                 ),
+                mintCounter = region.mintCounter + dropoffCount,
             )
         }
 

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
@@ -650,26 +650,31 @@ class PlatformRegionStepper @Inject constructor() {
                 isStackedPickupTransition ||
                 isStackedDropoffTransition
             ) {
-                // #503 slice 2: returning to a prior subtask of this job (A→B→A, or back to a
-                // store after an offer interlude that retired the task) RESUMES its identity
-                // instead of re-minting — unless the platform signalled a genuinely-new stacked
-                // task (different store/customer, already arrived). Re-match by phase + store
-                // (pickup) / customer address (dropoff); this is the same-store add-on "fold in,
-                // don't re-mint" (#499). The single activeTask slot loses identity on every phase
-                // switch; the Job's task lineage in recentTasks lets us restore it.
-                val resumable = if (!isStackedPickupTransition && !isStackedDropoffTransition) {
-                    region.recentTasks.lastOrNull { prior ->
-                        prior.jobId == jobId && prior.phase == taskPhase &&
-                            when (taskPhase) {
-                                TaskPhase.PICKUP ->
-                                    prior.storeName != null && prior.storeName == taskFields?.storeName
-                                TaskPhase.DROPOFF ->
-                                    prior.customerAddressHash != null &&
-                                        prior.customerAddressHash == taskFields?.customerAddressHash
-                                else -> false
-                            }
-                    }
-                } else null
+                // #503 slice 2/3b-2: returning to a prior subtask of this job (A→B→A, or back to a
+                // store after an offer interlude that retired the task) RESUMES its identity instead
+                // of re-minting. The single activeTask slot loses identity on every phase switch; the
+                // Job's task lineage in recentTasks lets us restore it.
+                //
+                // Dropoff is re-matched on the STABLE customer-NAME hash, NOT the address (#498:
+                // dropoff addresses drift between frames, so an address key split one physical drop
+                // into two). This runs even under a stacked-dropoff transition, so returning to an
+                // earlier stacked drop routes to it instead of minting a duplicate. Pickup re-matches
+                // by store, but only when the platform did NOT signal a genuinely-new stacked pickup
+                // (two distinct orders at the same store must stay distinct — the same-store add-on
+                // "fold in, don't re-mint" of #499 is the !isStackedPickupTransition case).
+                val resumable = when {
+                    taskPhase == TaskPhase.DROPOFF && taskFields?.customerNameHash != null ->
+                        region.recentTasks.lastOrNull {
+                            it.jobId == jobId && it.phase == TaskPhase.DROPOFF &&
+                                it.customerNameHash == taskFields.customerNameHash
+                        }
+                    taskPhase == TaskPhase.PICKUP && !isStackedPickupTransition ->
+                        region.recentTasks.lastOrNull {
+                            it.jobId == jobId && it.phase == TaskPhase.PICKUP &&
+                                it.storeName != null && it.storeName == taskFields?.storeName
+                        }
+                    else -> null
+                }
 
                 if (resumable != null) {
                     val retireSince = region.pendingDestructive

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -106,6 +106,17 @@ _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **bro
   re-shown. If a delivery double-counts, capture the `app_events` (`DELIVERY_COMPLETED` rows) +
   `app_state_snapshots` for that order.
 
+- **🔧 FIX IN FLIGHT — multi-drop stack: Job owns ordered dropoffs, routed by customer name (#503 slice 3b, PR #523). CONFIRM ON DASH.**
+  The structural multi-drop fix: an offer pre-creates **one dropoff placeholder per order**, and each
+  dropoff screen routes to its own customer subtask by the **stable name hash** (addresses drift).
+  **Confirm on a STACKED / multi-drop dash: 0/2 —** a 2-order stack should show **exactly two** dropoff
+  cards, each resolving to the **right customer** (6-char hash), and the counts/earnings should match
+  **two** deliveries (not 4, the 06-17 Jim's-stack symptom; not 1). Returning to an earlier drop (or
+  the app re-showing it) should **resume** that drop, not spawn a duplicate. This is the real test of
+  the 06-17 dropoff thread end-to-end — needs an actual stacked order (or a GoPuff multi-drop, though
+  GoPuff recognition is still #501). If a drop duplicates, mis-resolves, or a phantom appears, capture
+  the dropoff frame sequence + `app_state_snapshots` for the stack.
+
 - **📸 CAPTURE NEEDED — GoPuff (Drive) screens, to finalize the #501 rules.** The 06-14 deep-dive
   enumerated the GoPuff flow (all inside the DoorDash app — there is no separate GoPuff app) from real
   captures, but three things would help finalize the rules. **On the next GoPuff dash, drop these into


### PR DESCRIPTION
## What

The structural multi-drop fix (#503 slice 3b): a **Job owns ordered dropoffs** and each dropoff screen **routes to its own customer subtask** by the stable customer-name hash. Two commits.

### 3b-1 — pre-create one dropoff placeholder per offer order
Slice 3 pre-created exactly **one** dropoff subtask at offer-accept, and an add-on offer pre-created **none** — so a stacked offer's Job didn't own its dropoffs and the extras minted ad hoc (the 06-17 Jim's stack over-minted). Now pre-create one customer-TBD placeholder **per `parsedOffer.orders`** (fallback 1), on both the new-job and add-on accept branches; the existing resolve-onto-placeholder step then resolves each forward dropoff onto the next open placeholder.

### 3b-2 — route dropoffs by stable customer-name hash
The dropoff resume keyed on `customerAddressHash`, which **drifts** between frames (the #498 over-mint root), and was gated out under a stacked-dropoff transition — so returning to an earlier stacked drop minted a duplicate. Re-key the dropoff resume on the **customer-name** hash and let it run even under a stacked transition, so a dropoff frame routes to the existing subtask for that customer instead of re-minting. Pickup resume is unchanged (store match, still distinct per stacked pickup).

## Why this completes the 06-17 story

Re-tracing the Jim's stack (job-35) through the merged guards (#519/#520/#521/#522) **plus** this slice: the `nav_arriving` no-customer frame is dropped (phantom guard), the address-drift no longer splits a drop (name-key guard), and now **2 ordered placeholders** receive the 2 customers → **2 dropoffs for 2 customers**, not 4. Returning to an earlier drop resumes it by name.

## Tests (StateMachineTest, full machine)

- single-order offer → 1 dropoff placeholder (unchanged);
- two-order offer → 2 distinct customer-TBD placeholders; add-on offer → appends its own;
- a 2-order stack routes each dropoff to its own customer subtask (2 distinct);
- returning to the first drop with a **drifted address** resumes it by name — no third task, only ever 2 customer dropoffs.

## Security/privacy

No posture change — placeholders carry no customer data (customer resolves at the dropoff screen, hashed at the edge as before); routing keys on the existing customer-name `sha256`.

## Remaining

3b-3 (per-dropoff **economics** attribution) is a softer, display-oriented refinement — the offer often gives no per-order pay, and the per-delivery receipt already carries each drop's `totalPay`. Tracked under #503. Needs field validation on a real stacked/GoPuff multi-drop (checklist item to follow).