### PR TITLE
feat(cards): live $/mi reads off the Job — the #503 economics deliverable

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardItem.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardItem.kt
@@ -449,6 +449,7 @@ private fun PickupBody(snap: FlowCardSnapshot.Pickup, isActive: Boolean) {
         primary = snap.storeName,
         netPay = snap.netPay,
         estMinutes = snap.estMinutes,
+        distanceMiles = snap.distanceMiles,
         confirmedAt = snap.confirmedAt,
         itemsShopped = snap.itemsShopped,
         itemsRemaining = snap.itemsRemaining,
@@ -469,6 +470,7 @@ private fun DeliveryBody(snap: FlowCardSnapshot.Delivery, isActive: Boolean) {
         primary = customerDisplayName(snap.customerHash),
         netPay = snap.netPay,
         estMinutes = snap.estMinutes,
+        distanceMiles = snap.distanceMiles,
         confirmedAt = null,
         itemsShopped = null,
         itemsRemaining = null,
@@ -495,6 +497,7 @@ private fun TaskBody(
     primary: String,
     netPay: Double?,
     estMinutes: Double?,
+    distanceMiles: Double?,
     confirmedAt: Long?,
     itemsShopped: Int?,
     itemsRemaining: Int?,
@@ -506,6 +509,9 @@ private fun TaskBody(
     val verb = if (isDrop) "deliver" else "pickup"
     val overdue = deadlineMillis != null && now > deadlineMillis
     val hourly = projectedHourly(netPay, estMinutes, deadlineMillis, now)
+    // Fixed $/mi efficiency off the job (#503 deliverable 2) — distance doesn't erode like time,
+    // so it's the steady companion to the realized $/hr; shown as the metric's sub line.
+    val perMile = if (netPay != null && distanceMiles != null && distanceMiles > 0.0) netPay / distanceMiles else null
 
     Column(
         modifier = Modifier.fillMaxWidth(),
@@ -556,7 +562,9 @@ private fun TaskBody(
                 live = isActive && hourly != null,
                 label = "Running at",
                 value = if (hourly != null) "${Formats.money0(hourly)}/hr${if (overdue) " ↓" else ""}" else "—",
-                sub = if (hourly == null) null else if (overdue) "dropping" else "on track",
+                // Sub line prefers the fixed $/mi efficiency; falls back to the erosion status.
+                sub = perMile?.let { "${Formats.money(it)}/mi" }
+                    ?: if (hourly == null) null else if (overdue) "dropping" else "on track",
                 color = hourly?.let { hourlyColor(it, c) } ?: c.text3,
             )
         }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardMapper.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardMapper.kt
@@ -40,6 +40,7 @@ object FlowCardMapper {
         // stacked add-on overwrites (the live card uses the accurate Job.blended).
         var acceptedNetPay: Double? = null
         var acceptedEstMin: Double? = null
+        var acceptedDistanceMiles: Double? = null
 
         for (event in events) {
             when (event.type) {
@@ -52,6 +53,7 @@ object FlowCardMapper {
                     lastDeliveryArrivedAt = null
                     acceptedNetPay = null
                     acceptedEstMin = null
+                    acceptedDistanceMiles = null
 
                     val payload = event.payload as? SessionStartPayload
                     openAwaiting = FlowCardSnapshot.Awaiting(
@@ -123,6 +125,7 @@ object FlowCardMapper {
                     if (payload.outcome == AppEventType.OFFER_ACCEPTED) {
                         acceptedNetPay = payload.evaluation?.netPayAmount
                         acceptedEstMin = payload.evaluation?.estimatedTimeMinutes
+                        acceptedDistanceMiles = payload.evaluation?.distanceMiles ?: payload.parsedOffer.distanceMiles
                     }
                     // Re-open Awaiting if the dasher returned to the
                     // waiting-for-offer state (declined / timeout). Accept
@@ -160,6 +163,7 @@ object FlowCardMapper {
                             jobId = payload.jobId,
                             netPay = acceptedNetPay,
                             estMinutes = acceptedEstMin,
+                            distanceMiles = acceptedDistanceMiles,
                             storeName = payload.storeName.ifBlank { UNKNOWN_STORE },
                             deadlineMillis = payload.deadlineMillis,
                             itemsRemaining = payload.itemsRemaining,
@@ -185,6 +189,7 @@ object FlowCardMapper {
                             jobId = payload.jobId,
                             netPay = acceptedNetPay,
                             estMinutes = acceptedEstMin,
+                            distanceMiles = acceptedDistanceMiles,
                             storeName = payload.storeName.ifBlank { UNKNOWN_STORE },
                             arrivedAt = payload.arrivedAt ?: event.occurredAt,
                             deadlineMillis = payload.deadlineMillis,
@@ -211,6 +216,7 @@ object FlowCardMapper {
                             jobId = payload.jobId,
                             netPay = acceptedNetPay,
                             estMinutes = acceptedEstMin,
+                            distanceMiles = acceptedDistanceMiles,
                             storeName = payload.storeName.ifBlank { UNKNOWN_STORE },
                             arrivedAt = payload.arrivedAt,
                             confirmedAt = payload.confirmedAt ?: event.occurredAt,
@@ -235,6 +241,7 @@ object FlowCardMapper {
                             jobId = payload.jobId,
                             netPay = acceptedNetPay,
                             estMinutes = acceptedEstMin,
+                            distanceMiles = acceptedDistanceMiles,
                             storeName = payload.storeName,
                             customerHash = payload.customerHash,
                             deadlineMillis = payload.deadlineMillis,
@@ -258,6 +265,7 @@ object FlowCardMapper {
                             jobId = payload.jobId,
                             netPay = acceptedNetPay,
                             estMinutes = acceptedEstMin,
+                            distanceMiles = acceptedDistanceMiles,
                             storeName = payload.storeName,
                             customerHash = payload.customerHash,
                             arrivedAt = payload.arrivedAt ?: event.occurredAt,
@@ -285,6 +293,7 @@ object FlowCardMapper {
                             jobId = payload.jobId,
                             netPay = acceptedNetPay,
                             estMinutes = acceptedEstMin,
+                            distanceMiles = acceptedDistanceMiles,
                             storeName = payload.storeName,
                             customerHash = payload.customerHash,
                             arrivedAt = payload.arrivedAt,

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/LiveCardBuilder.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/LiveCardBuilder.kt
@@ -76,6 +76,7 @@ object LiveCardBuilder {
                     activity = task.activity,
                     netPay = region.activeJob?.blendedNetPay,
                     estMinutes = region.activeJob?.blendedEstMinutes,
+                    distanceMiles = region.activeJob?.blendedDistanceMiles,
                 )
             }
 
@@ -92,6 +93,7 @@ object LiveCardBuilder {
                     deadlineMillis = task.deadlineMillis,
                     netPay = region.activeJob?.blendedNetPay,
                     estMinutes = region.activeJob?.blendedEstMinutes,
+                    distanceMiles = region.activeJob?.blendedDistanceMiles,
                 )
             }
 

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/JobEconomicsTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/JobEconomicsTest.kt
@@ -213,9 +213,11 @@ class JobEconomicsTest {
         val empty = Job(jobId = "j0", offerStoreHint = emptyList(), parentOfferHash = "o0", startedAt = 0L)
         assertNull(empty.blendedNetPay)
         assertNull(empty.blendedEstMinutes)
+        assertNull("no distance → null, never a misleading per-mile (#503 live per-mile)", empty.blendedDistanceMiles)
 
         val seeded = jobWith("o1", net = 6.5, est = 18.0, dist = 4.2, pay = 7.5)
         assertEquals(6.5, seeded.blendedNetPay!!, 0.001)
         assertEquals(18.0, seeded.blendedEstMinutes!!, 0.001)
+        assertEquals("blended distance sums the accepted offers (#503 live per-mile)", 4.2, seeded.blendedDistanceMiles!!, 0.001)
     }
 }

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/cards/FlowCardSnapshot.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/cards/FlowCardSnapshot.kt
@@ -98,6 +98,9 @@ sealed class FlowCardSnapshot {
         /** The job's blended estimated minutes — the $/hr denominator (erodes past
          *  the deadline, the drop-it signal). */
         val estMinutes: Double? = null,
+        /** The job's blended quoted distance — the denominator for the fixed "$/mi"
+         *  efficiency shown beside the live $/hr (#503 deliverable 2). Null → "—". */
+        val distanceMiles: Double? = null,
     ) : FlowCardSnapshot() {
         override val id: String get() = "pickup:$taskId"
     }
@@ -122,6 +125,9 @@ sealed class FlowCardSnapshot {
         val netPay: Double? = null,
         /** Blended estimated minutes — the $/hr denominator (erodes past deadline). */
         val estMinutes: Double? = null,
+        /** Blended quoted distance — the denominator for the fixed "$/mi" efficiency
+         *  shown beside the live $/hr (#503 deliverable 2). Null → "—". */
+        val distanceMiles: Double? = null,
     ) : FlowCardSnapshot() {
         override val id: String get() = "delivery:$taskId"
     }

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/Job.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/Job.kt
@@ -69,6 +69,14 @@ data class Job(
     /** Total quoted distance in miles across all offers. */
     val totalDistanceMiles: Double get() = acceptedOffers.sumOf { it.distanceMiles ?: 0.0 }
 
+    /**
+     * Distance denominator for the live "$/mi" task-card metric — null when no accepted offer has
+     * carried a distance yet (or it sums to 0), so the card shows "—" rather than a misleading
+     * $X/0mi. Mirrors [blendedEstMinutes] (#460 nullability discipline).
+     */
+    val blendedDistanceMiles: Double?
+        get() = acceptedOffers.mapNotNull { it.distanceMiles }.takeIf { it.isNotEmpty() }?.sum()?.takeIf { it > 0.0 }
+
     /** Every offer hash that contributed to this job (the add-on chain). */
     val parentOfferHashes: List<String> get() = acceptedOffers.mapNotNull { it.offerHash }
 }


### PR DESCRIPTION
## What

The last in-scope gap for #503's economics deliverable. #503 deliverable 2: the live **"$/hr AND $/mi"** rates read off the Job. `$/hr` was wired (`Job.blendedNetPay`/`blendedEstMinutes` → the #460 co-hero), but `$/mi` was **not** — `Job.totalDistanceMiles` had **zero** production readers.

## Change

- `Job.blendedDistanceMiles` — sum of accepted offers' distance, **null** when none or 0 (so the card shows "—", never a misleading `$X/0mi`), mirroring `blendedEstMinutes`'s nullability discipline.
- `distanceMiles` threaded onto `FlowCardSnapshot.Pickup`/`Delivery`; wired live in `LiveCardBuilder` (off `region.activeJob`) and historical in `FlowCardMapper` (off the accepted offer's evaluation).
- The fixed `$/mi` shows as the **sub line** of the live "Running at $/hr" co-hero — distance doesn't erode like time, so it's the steady companion to the realized hourly.

## Test

`JobEconomicsTest`: `blendedDistanceMiles` sums the accepted offers and is null with none.

## Closes out #503

This was the one genuinely-in-scope wire-up identified by a grounded design review of the #503 closeout. The Job-as-container model (slices 0/1/2/3/3b) is functionally complete; with $/mi now reading off the Job, deliverable 2 is fully met. Remaining items (heuristic-removal refactor, job-lifetime gap-restart, per-mile measurement fidelity) are being filed as separate follow-ups. See the #503 closing comment.

## Security/privacy

No posture change — offer-quoted numbers already on the Job; no new parse/store/network.