### PR TITLE
refactor(format): route TipEffectHandler + FakeOfferCard through Formats SSOT (#502)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/TipEffectHandler.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/TipEffectHandler.kt
@@ -1,6 +1,7 @@
 package cloud.trotter.dashbuddy.state.effects
 
 import cloud.trotter.dashbuddy.domain.model.chat.ChatPersona
+import cloud.trotter.dashbuddy.domain.format.Formats
 import cloud.trotter.dashbuddy.core.state.AppEffect
 import cloud.trotter.dashbuddy.ui.bubble.BubbleManager
 import kotlinx.coroutines.CoroutineScope
@@ -18,9 +19,9 @@ class TipEffectHandler @Inject constructor(
     fun process(scope: CoroutineScope, effect: AppEffect.ProcessTipNotification) {
         scope.launch(Dispatchers.IO) {
             try {
-                Timber.i("Tip received: \$${effect.amount} from ${effect.storeName}")
+                Timber.i("Tip received: ${Formats.money(effect.amount)} from ${effect.storeName}")
                 bubbleManager.postMessage(
-                    text = "Nice! \$${effect.amount} tip from ${effect.storeName}",
+                    text = "Nice! ${Formats.money(effect.amount)} tip from ${effect.storeName}",
                     persona = ChatPersona.Dispatcher
                 )
             } catch (e: Exception) {

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/components/FakeOfferCard.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/components/FakeOfferCard.kt
@@ -25,7 +25,7 @@ import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
 import androidx.compose.ui.unit.dp
 import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
 import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
-import java.util.Locale
+import cloud.trotter.dashbuddy.domain.format.Formats
 import cloud.trotter.dashbuddy.ui.formatters.recommendationLabel
 
 @Composable
@@ -84,28 +84,28 @@ fun FakeOfferCard(
                 if (hasAnyCost) {
                     val netSuffix = if (evaluation.isUsingDefaults) " (est.)" else ""
                     Text(
-                        text = "$${fmt(evaluation.payAmount)} gross  →  $${fmt(evaluation.netPayAmount)} net$netSuffix",
+                        text = "${Formats.money(evaluation.payAmount)} gross  →  ${Formats.money(evaluation.netPayAmount)} net$netSuffix",
                         style = MaterialTheme.typography.bodyLarge,
                         fontWeight = FontWeight.SemiBold,
                         color = animatedContentColor
                     )
                     if (hasFuelCost) {
                         Text(
-                            text = "−$${fmt(evaluation.fuelCostEstimate)} fuel",
+                            text = "−${Formats.money(evaluation.fuelCostEstimate)} fuel",
                             style = MaterialTheme.typography.bodySmall,
                             color = animatedContentColor.copy(alpha = 0.65f)
                         )
                     }
                     if (hasNonFuelCost) {
                         Text(
-                            text = "−$${fmt(evaluation.nonFuelCostEstimate)} wear & fixed costs",
+                            text = "−${Formats.money(evaluation.nonFuelCostEstimate)} wear & fixed costs",
                             style = MaterialTheme.typography.bodySmall,
                             color = animatedContentColor.copy(alpha = 0.65f)
                         )
                     }
                 } else {
                     Text(
-                        text = "$${fmt(evaluation.payAmount)}",
+                        text = "${Formats.money(evaluation.payAmount)}",
                         style = MaterialTheme.typography.bodyLarge,
                         fontWeight = FontWeight.SemiBold,
                         color = animatedContentColor
@@ -123,12 +123,12 @@ fun FakeOfferCard(
                 ) {
                     MetricCell(
                         label = "\$/mi",
-                        value = "$${fmt(evaluation.dollarsPerMile)}",
+                        value = "${Formats.money(evaluation.dollarsPerMile)}",
                         color = animatedContentColor
                     )
                     MetricCell(
                         label = "\$/hr",
-                        value = "$${fmt(evaluation.dollarsPerHour)}",
+                        value = "${Formats.money(evaluation.dollarsPerHour)}",
                         color = animatedContentColor
                     )
                     MetricCell(
@@ -147,7 +147,7 @@ fun FakeOfferCard(
                 ) {
                     MetricCell(
                         label = "miles",
-                        value = fmt(evaluation.distanceMiles),
+                        value = Formats.decimal(evaluation.distanceMiles),
                         color = animatedContentColor
                     )
                     MetricCell(
@@ -190,5 +190,3 @@ private fun MetricCell(label: String, value: String, color: Color) {
         )
     }
 }
-
-private fun fmt(value: Double): String = String.format(Locale.getDefault(), "%.2f", value)


### PR DESCRIPTION
## What

Closes #502 — two money-formatting SSOT bypasses now route through the `:domain` `Formats` SSOT (#467, which owns the `$` + 2-dp + locale policy).

- **TipEffectHandler** — `"\$${effect.amount}"` (a raw `Double` → `$3.0`/`$3.456`) in the log line and the "Nice! … tip" bubble → `Formats.money(effect.amount)`.
- **FakeOfferCard** — a local `fmt()` (`String.format("%.2f")`) behind seven literal `"$…"` prefixes (gross/net/fuel/wear/pay, $/mi, $/hr) → `Formats.money`; the bare **miles** value → `Formats.decimal`. Local `fmt()` and the now-unused `java.util.Locale` import deleted.

Scanned `main` — no other raw-`$`+Double money bypass remains.

## Output

Offer card unchanged (still `$X.XX`); the tip bubble now shows a proper `$3.00` instead of `$3.0`.

## Security/privacy

No posture change — display formatting only.