### PR TITLE
feat(offer-card): icon badges + co-icon-text shop badge [cart N] + item-count fix (#461)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardItem.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardItem.kt
@@ -1,5 +1,6 @@
 package cloud.trotter.dashbuddy.ui.bubble.cards
 
+import androidx.annotation.DrawableRes
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -8,6 +9,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
@@ -27,6 +29,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import cloud.trotter.dashbuddy.R
 import cloud.trotter.dashbuddy.domain.format.Formats
 import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
 import cloud.trotter.dashbuddy.domain.format.formatCountdown
@@ -338,15 +342,7 @@ private fun OfferBody(snap: FlowCardSnapshot.Offer, isActive: Boolean) {
                     Text(secondary, style = AppTheme.num.smNum, color = c.text2, maxLines = 1)
                 }
             }
-            // Item count promoted to the hero tier (#461): Shop & Deliver and
-            // multi-item offers surface the count beside the $/hr hero (the
-            // footer caption was easy to miss), using the space on the right.
-            if (snap.itemCount > 1) {
-                Column(horizontalAlignment = Alignment.End) {
-                    Text("${snap.itemCount}", style = AppTheme.num.heroNum, color = c.text, maxLines = 1)
-                    Text("items", style = AppTheme.num.smNum, color = c.text2, maxLines = 1)
-                }
-            }
+            // (#461: the item count now rides the [cart N] shop badge below, not the hero tier.)
         }
 
         // Verdict banner — action word + reason + quality chip, tinted by the action.
@@ -386,7 +382,9 @@ private fun OfferBody(snap: FlowCardSnapshot.Offer, isActive: Boolean) {
             }
         }
 
-        // Badge pills.
+        // Badge row (#461): icon badges tinted by their brand color; the SHOP badge is co-icon-text
+        // [🛒 N] — the shopping-chat cart + the item count. Badges without a drawable fall back to a
+        // text pill so nothing is dropped.
         if (snap.badges.isNotEmpty()) {
             FlowRow(
                 horizontalArrangement = Arrangement.spacedBy(6.dp),
@@ -394,7 +392,16 @@ private fun OfferBody(snap: FlowCardSnapshot.Offer, isActive: Boolean) {
             ) {
                 snap.badges.forEach { b ->
                     val (label, col) = badgeMeta(b, c)
-                    AppChip(label, color = col, container = c.surface3)
+                    when {
+                        b == "SHOP" -> BadgeIcon(
+                            iconRes = R.drawable.ic_chat_shopping_cart,
+                            label = snap.itemCount.takeIf { it > 0 }?.toString(),
+                            color = col,
+                        )
+                        else -> badgeIcon(b)
+                            ?.let { BadgeIcon(iconRes = it, label = null, color = col) }
+                            ?: AppChip(label, color = col, container = c.surface3)
+                    }
                 }
             }
         }
@@ -419,6 +426,48 @@ private fun OfferCountdownText(expiresAt: Long, countdownSeconds: Int) {
         color = col,
         fontWeight = FontWeight.Bold,
     )
+}
+
+/**
+ * Badge enum name → `ic_badge_*` drawable (#461); null means "no icon, render the text pill". The
+ * SHOP badge is handled by the caller (the shopping-chat cart + the item count, [🛒 N]).
+ */
+@DrawableRes
+private fun badgeIcon(name: String): Int? = when (name) {
+    "HIGH_PAYING" -> R.drawable.ic_badge_dollar_plus
+    "PRIORITY_ACCESS" -> R.drawable.ic_badge_priority_access
+    "COLLECT_CASH" -> R.drawable.ic_badge_collect_cash
+    "RED_CARD" -> R.drawable.ic_badge_red_card
+    "LARGE_ORDER" -> R.drawable.ic_badge_large_order
+    "PIZZA_BAG" -> R.drawable.ic_badge_pizza_bag
+    "ALCOHOL", "INCLUDES_ALCOHOL" -> R.drawable.ic_badge_alcohol
+    "CHECK_RECIPIENT_ID", "AGE_RESTRICTED_18_PLUS", "AGE_RESTRICTED_21_PLUS",
+    "CONTAINS_RESTRICTED_ITEMS" -> R.drawable.ic_badge_id_check
+    else -> null
+}
+
+/**
+ * Icon badge in the [AppChip] pill family (#461): a brand-tinted icon, optionally with a trailing
+ * label — the SHOP badge rides its item count here ([🛒 N]). Mirrors AppChip's chip tokens.
+ */
+@Composable
+private fun BadgeIcon(
+    @DrawableRes iconRes: Int,
+    label: String?,
+    color: Color,
+    container: Color = AppTheme.colors.surface3,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        modifier = Modifier
+            .clip(CircleShape)
+            .background(container)
+            .padding(horizontal = 7.dp, vertical = 4.dp),
+    ) {
+        Icon(painterResource(iconRes), contentDescription = null, tint = color, modifier = Modifier.size(14.dp))
+        if (label != null) Text(label, style = AppTheme.num.chip, color = color)
+    }
 }
 
 /** Maps a badge enum name to a short label + brand color for the pill row. */

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/LiveCardBuilder.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/LiveCardBuilder.kt
@@ -1,6 +1,7 @@
 package cloud.trotter.dashbuddy.ui.bubble.cards
 
 import cloud.trotter.dashbuddy.domain.model.cards.FlowCardSnapshot
+import cloud.trotter.dashbuddy.domain.model.order.OrderType
 import cloud.trotter.dashbuddy.domain.state.AppState
 import cloud.trotter.dashbuddy.domain.state.Flow
 import cloud.trotter.dashbuddy.domain.state.Mode
@@ -53,8 +54,12 @@ object LiveCardBuilder {
                     dollarsPerMile = pending.evaluation?.dollarsPerMile,
                     dollarsPerHour = pending.evaluation?.dollarsPerHour,
                     qualityLevel = pending.evaluation?.qualityLevel,
+                    // #461: synthetic SHOP marker from the order type (parity with FlowCardMapper, so
+                    // the LIVE offer card surfaces the [cart N] shop badge while it's on screen).
                     badges = (offer.badges.map { it.name } +
-                        offer.orders.flatMap { it.badges }.map { it.name }).distinct(),
+                        offer.orders.flatMap { it.badges }.map { it.name } +
+                        if (offer.orders.any { it.orderType == OrderType.SHOP_FOR_ITEMS }) listOf("SHOP") else emptyList()
+                        ).distinct(),
                     expiresAt = offer.initialCountdownSeconds?.let { pending.presentedAt + it * 1000L },
                     countdownSeconds = offer.initialCountdownSeconds,
                     outcome = null,

--- a/app/src/test/resources/snapshots/approved-parse-output.json
+++ b/app/src/test/resources/snapshots/approved-parse-output.json
@@ -2367,7 +2367,7 @@
         "intent": "offer_popup",
         "shape": "offer",
         "fields": {
-            "parsedOffer": "ParsedOffer(offerHash=8c66a5d1d7b1abb0eb2a6cc15c22d118a18910237d942d4132ebefc38ee36ecf, itemCount=1, payAmount=9.78, payTextRaw=null, distanceMiles=9.6, distanceTextRaw=null, dueByTimeText=6:00 PM, dueByTimeMillis=1780336800000, timeToCompleteMinutes=null, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=PICKUP, storeName=Peter Piper Pizza, itemCount=1, isItemCountEstimated=true, badges=[])], rawExtractedTexts=null)"
+            "parsedOffer": "ParsedOffer(offerHash=8c66a5d1d7b1abb0eb2a6cc15c22d118a18910237d942d4132ebefc38ee36ecf, itemCount=0, payAmount=9.78, payTextRaw=null, distanceMiles=9.6, distanceTextRaw=null, dueByTimeText=6:00 PM, dueByTimeMillis=1780336800000, timeToCompleteMinutes=null, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=PICKUP, storeName=Peter Piper Pizza, itemCount=1, isItemCountEstimated=true, badges=[])], rawExtractedTexts=null)"
         }
     },
     "offer_popup/20260128_181353_816_OFFER_POPUP.json": {
@@ -2375,7 +2375,7 @@
         "intent": "offer_popup",
         "shape": "offer",
         "fields": {
-            "parsedOffer": "ParsedOffer(offerHash=557b56c07af05fd45d36f3468acaa7fdc7f7f1d5cc922d8062779b86bebc323b, itemCount=1, payAmount=7.6, payTextRaw=null, distanceMiles=2.9, distanceTextRaw=null, dueByTimeText=6:32 PM, dueByTimeMillis=1780338720000, timeToCompleteMinutes=null, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=PICKUP, storeName=True Texas BBQ, itemCount=1, isItemCountEstimated=true, badges=[])], rawExtractedTexts=null)"
+            "parsedOffer": "ParsedOffer(offerHash=557b56c07af05fd45d36f3468acaa7fdc7f7f1d5cc922d8062779b86bebc323b, itemCount=0, payAmount=7.6, payTextRaw=null, distanceMiles=2.9, distanceTextRaw=null, dueByTimeText=6:32 PM, dueByTimeMillis=1780338720000, timeToCompleteMinutes=null, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=PICKUP, storeName=True Texas BBQ, itemCount=1, isItemCountEstimated=true, badges=[])], rawExtractedTexts=null)"
         }
     },
     "offer_popup/20260128_182525_934_OFFER_POPUP.json": {
@@ -2399,7 +2399,7 @@
         "intent": "offer_popup",
         "shape": "offer",
         "fields": {
-            "parsedOffer": "ParsedOffer(offerHash=6dfe7dbc4fa70c5bc217f9dbfc76e9203359119daaf871683f66b45f6a17cba1, itemCount=2, payAmount=6.85, payTextRaw=null, distanceMiles=6.4, distanceTextRaw=null, dueByTimeText=7:06 PM, dueByTimeMillis=1780340760000, timeToCompleteMinutes=null, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=SHOP_FOR_ITEMS, storeName=CVS, itemCount=1, isItemCountEstimated=false, badges=[RED_CARD]), ParsedOrder(orderIndex=1, orderType=PICKUP, storeName=Bill Miller BBQ, itemCount=1, isItemCountEstimated=true, badges=[])], rawExtractedTexts=null)"
+            "parsedOffer": "ParsedOffer(offerHash=6dfe7dbc4fa70c5bc217f9dbfc76e9203359119daaf871683f66b45f6a17cba1, itemCount=1, payAmount=6.85, payTextRaw=null, distanceMiles=6.4, distanceTextRaw=null, dueByTimeText=7:06 PM, dueByTimeMillis=1780340760000, timeToCompleteMinutes=null, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=SHOP_FOR_ITEMS, storeName=CVS, itemCount=1, isItemCountEstimated=false, badges=[RED_CARD]), ParsedOrder(orderIndex=1, orderType=PICKUP, storeName=Bill Miller BBQ, itemCount=1, isItemCountEstimated=true, badges=[])], rawExtractedTexts=null)"
         }
     },
     "offer_popup/20260128_182655_860_OFFER_POPUP.json": {
@@ -2407,7 +2407,7 @@
         "intent": "offer_popup",
         "shape": "offer",
         "fields": {
-            "parsedOffer": "ParsedOffer(offerHash=0dda70d10932eba701ef1d2df425fe01b33876a325ebcbfc3e3ed3e4e59e2b3b, itemCount=1, payAmount=5.95, payTextRaw=null, distanceMiles=4.4, distanceTextRaw=null, dueByTimeText=6:46 PM, dueByTimeMillis=1780339560000, timeToCompleteMinutes=null, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=PICKUP, storeName=Taco Bell, itemCount=1, isItemCountEstimated=true, badges=[])], rawExtractedTexts=null)"
+            "parsedOffer": "ParsedOffer(offerHash=0dda70d10932eba701ef1d2df425fe01b33876a325ebcbfc3e3ed3e4e59e2b3b, itemCount=0, payAmount=5.95, payTextRaw=null, distanceMiles=4.4, distanceTextRaw=null, dueByTimeText=6:46 PM, dueByTimeMillis=1780339560000, timeToCompleteMinutes=null, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=PICKUP, storeName=Taco Bell, itemCount=1, isItemCountEstimated=true, badges=[])], rawExtractedTexts=null)"
         }
     },
     "offer_popup/20260128_185925_772_OFFER_POPUP.json": {
@@ -2415,7 +2415,7 @@
         "intent": "offer_popup",
         "shape": "offer",
         "fields": {
-            "parsedOffer": "ParsedOffer(offerHash=bb47312390e65ec432e318298828ec0a671c00ab3aa620a6c8fcb985781ef300, itemCount=1, payAmount=5.45, payTextRaw=null, distanceMiles=2.8, distanceTextRaw=null, dueByTimeText=7:23 PM, dueByTimeMillis=1780341780000, timeToCompleteMinutes=null, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=PICKUP, storeName=Raising Cane's, itemCount=1, isItemCountEstimated=true, badges=[RED_CARD])], rawExtractedTexts=null)"
+            "parsedOffer": "ParsedOffer(offerHash=bb47312390e65ec432e318298828ec0a671c00ab3aa620a6c8fcb985781ef300, itemCount=0, payAmount=5.45, payTextRaw=null, distanceMiles=2.8, distanceTextRaw=null, dueByTimeText=7:23 PM, dueByTimeMillis=1780341780000, timeToCompleteMinutes=null, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=PICKUP, storeName=Raising Cane's, itemCount=1, isItemCountEstimated=true, badges=[RED_CARD])], rawExtractedTexts=null)"
         }
     },
     "offer_popup/20260128_193825_010_OFFER_POPUP.json": {
@@ -2423,7 +2423,7 @@
         "intent": "offer_popup",
         "shape": "offer",
         "fields": {
-            "parsedOffer": "ParsedOffer(offerHash=a7b89a7758c44f9fa0b6316623df9fd1019b7e03135096abe0a019b9dcb68bac, itemCount=2, payAmount=12.15, payTextRaw=null, distanceMiles=10.7, distanceTextRaw=null, dueByTimeText=8:09 PM, dueByTimeMillis=1780344540000, timeToCompleteMinutes=null, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=PICKUP, storeName=Tarka Indian Kitchen, itemCount=1, isItemCountEstimated=true, badges=[]), ParsedOrder(orderIndex=1, orderType=PICKUP, storeName=Torchy's Tacos, itemCount=1, isItemCountEstimated=true, badges=[])], rawExtractedTexts=null)"
+            "parsedOffer": "ParsedOffer(offerHash=a7b89a7758c44f9fa0b6316623df9fd1019b7e03135096abe0a019b9dcb68bac, itemCount=0, payAmount=12.15, payTextRaw=null, distanceMiles=10.7, distanceTextRaw=null, dueByTimeText=8:09 PM, dueByTimeMillis=1780344540000, timeToCompleteMinutes=null, badges=[], initialCountdownSeconds=null, orders=[ParsedOrder(orderIndex=0, orderType=PICKUP, storeName=Tarka Indian Kitchen, itemCount=1, isItemCountEstimated=true, badges=[]), ParsedOrder(orderIndex=1, orderType=PICKUP, storeName=Torchy's Tacos, itemCount=1, isItemCountEstimated=true, badges=[])], rawExtractedTexts=null)"
         }
     },
     "offer_popup/20260128_202519_909_OFFER_POPUP.json": {

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/ParsedFieldsFactory.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/ParsedFieldsFactory.kt
@@ -275,7 +275,14 @@ object ParsedFieldsFactory {
             activity = f.str("activity"),
             parsedOffer = ParsedOffer(
                 offerHash = offerHash,
-                itemCount = orders.sumOf { it.itemCount }.coerceAtLeast(1),
+                // #461: the offer's item count is the SHOP item count — sum only the shop orders'
+                // CONFIRMED counts. A pickup order has no items but defaults to itemCount=1
+                // (isItemCountEstimated), so the old `sumOf{itemCount}.coerceAtLeast(1)` added a
+                // phantom +1 per pickup (Sprouts 25 + 1 pickup read 26; a pure-pickup stack read its
+                // order count). 0 here means "no shop items" → the [cart N] badge shows no number.
+                itemCount = orders
+                    .filter { it.orderType == OrderType.SHOP_FOR_ITEMS && !it.isItemCountEstimated }
+                    .sumOf { it.itemCount },
                 payAmount = payAmount,
                 distanceMiles = distance,
                 dueByTimeText = deliveryTimeText,

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -63,6 +63,16 @@ immediately (no second pass needed) so it gets triaged.
 _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **broken** on the
 2026-06-09 dash — moved to that session's log entry below for triage.)_
 
+- **🔧 FIX SHIPPED — offer card icon badges + co-icon-text shop badge [cart N] (#461, PR #531). CONFIRM ON DASH.**
+  The offer card's badges are now **icons** (red card, alcohol, large order, priority, etc., tinted by
+  brand color), and the **Shop & Deliver** badge is the shopping-chat **cart icon + the item count**
+  (`[🛒 N]`) — the count moved off the $/hr hero onto the badge. **Confirm on dash: 0/2 —** on a
+  **shop** offer (e.g. Sprouts/CVS) the card shows the cart badge with the **true item count** (a
+  25-item shop reads **25**, not 26), it shows **while the offer is live** (not just after), and a
+  pure-pickup (or pickup stack) shows **no** cart/count. Other badges should render as their icons. If
+  a count is off by the number of pickups in a stack, or the shop badge doesn't show live, note the
+  offer's order mix.
+
 - **✅ FIX SHIPPED — same-store add-on no longer re-mints the task (#499 / #503 slice 2). CONFIRM ON DASH.**
   The task lifecycle now **resumes a prior subtask** instead of re-minting on a phase switch / after an
   offer interlude (re-match by store for pickups, customer address for dropoffs). **Confirm on dash:


### PR DESCRIPTION
## What

The offer card's badges were text pills and the item count sat in the `$/hr` co-hero tier. Per the design (and your steer to reuse the shopping-chat cart), they're now **icon badges**, with the item count riding the **shop badge**.

- **Icon badges** — `BadgeIcon` (a brand-tinted icon in the `AppChip` pill family), mapped `badgeIcon(name) → ic_badge_*` (dollar_plus, priority_access, collect_cash, red_card, large_order, pizza_bag, alcohol, id_check). Badges with no drawable fall back to the text pill — nothing dropped.
- **Shop badge = co-icon-text `[🛒 N]`** — the shopping-chat cart (`ic_chat_shopping_cart`) + the item count. The hero-tier count block is removed (the count rides the badge now).
- **Parity fix** — `LiveCardBuilder` now injects the synthetic `SHOP` marker (`orderType == SHOP_FOR_ITEMS`) like `FlowCardMapper` already did, so the **live** offer card shows the shop badge while the offer is on screen (it only appeared on the frozen card before).
- **Item-count bug fixed** — the offer count is the **shop** item count: `orders.filter { SHOP_FOR_ITEMS && !isItemCountEstimated }.sumOf { itemCount }`, dropping the `coerceAtLeast(1)` floor. A pickup defaults to `itemCount=1`, so the old `sumOf{itemCount}` added a phantom **+1 per pickup** (a CVS-shop + BBQ-pickup stack read `2`, now reads the CVS shop count; pure-pickup offers read `0`). `itemCount` only feeds `OfferEvaluation.itemCount` as a **display passthrough** — score/time/economics don't use it — so it's display-safe.

## Golden review (the regression gate)

Parse-output golden regenerated: **6 offers change** — pure-pickup `1→0`, pickup stack `2→0`, and the CVS shop+pickup stack `2→1` (the true shop count). All numbers, **no PII**. `AllMatchersSuite` green.

## Out of scope (follow-up)

#461 part (c) — the **finished (PostTask) card showing order type** — needs threading `orderType` onto `FlowCardSnapshot.PostTask` + the `DELIVERY_COMPLETED` payload in `:domain`. Not done here; #461 can stay open for it.

## Security/privacy

No posture change — display + a count; no new parse/store/network.

Field validation queued: shop badge shows `[🛒 N]` with the **true** shop item count (e.g. a 25-item Sprouts reads 25, not 26) on both the live and frozen card; pure-pickup stacks show no count.