### PR TITLE
fix(dashboard): consume OdometerRepository.sessionMilesFlow — drop duplicated meters->miles factor (audit #8)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardViewModel.kt
@@ -43,12 +43,10 @@ class DashboardViewModel @Inject constructor(
         .map { state -> getStatusText(state) }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), "Offline")
 
-    // 3. Session Miles
-    val sessionMiles: StateFlow<String> = odometerRepository.sessionMeters
-        .map { meters ->
-            val miles = meters * 0.000621371
-            "${Formats.decimal(miles)} mi"
-        }
+    // 3. Session Miles — derive from the repository's miles flow (SSOT for the
+    // meters->miles factor); this VM only formats for display.
+    val sessionMiles: StateFlow<String> = odometerRepository.sessionMilesFlow
+        .map { miles -> "${Formats.decimal(miles)} mi" }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), "0.0 mi")
 
     // 4. First Run Check


### PR DESCRIPTION
## What

`DashboardViewModel.sessionMiles` now derives from `OdometerRepository.sessionMilesFlow` instead of collecting the raw `sessionMeters` flow and re-applying the literal `0.000621371`. The VM only formats for display (`Formats.decimal(miles)` + `" mi"`); the meters→miles conversion lives solely in `OdometerRepository`.

Net diff: `app/.../dashboard/DashboardViewModel.kt`, −6/+4. The literal `0.000621371` and the raw `sessionMeters` reference are now both absent from the `:app` module (verified by grep).

## Why (audit finding)

> OdometerRepository defines metersToMiles=0.000621371 and exposes sessionMilesFlow = sessionMeters.map{it*metersToMiles}. DashboardViewModel (~lines 47-51) IGNORES sessionMilesFlow, collects raw sessionMeters, and re-applies the same literal 0.000621371. Have DashboardViewModel consume odometerRepository.sessionMilesFlow directly and delete the local conversion + magic number. If a bare factor is genuinely needed elsewhere, promote a single named METERS_PER_MILE constant referenced from both; otherwise just reuse the flow. Behavior identical.

This is an SSOT divergence (CLAUDE.md Development Principle #5): the meters→miles factor had two copies. `OdometerRepository` already centralizes it internally — its private `metersToMiles` is referenced by `sessionMilesFlow`, `getCurrentSessionMiles()`, and `getCurrentMiles()`. So no new promoted constant was needed; the repository's miles flow is the single owner and the VM now consumes it.

## Security/privacy posture

No change to the trust boundary. This is a pure UI-layer refactor of how session-distance is derived for the dashboard text — no recognition, capture, network, or effects touched; no PII; same on-device GPS-derived odometer value, same factor, same formatting.

## Test

`./gradlew testDebugUnitTest` — BUILD SUCCESSFUL, all modules green. The change touches no recognition rules/parsers, so the full suite (which includes the matcher regressions) is sufficient; behavior is identical (same factor, same `Formats.decimal` formatting).