### PR TITLE
refactor(network): one NetworkClientFactory — make #348 api_key redaction the default (audit #7)

### DIFF
--- a/core/network/src/main/java/cloud/trotter/dashbuddy/core/network/di/GasPriceApiModule.kt
+++ b/core/network/src/main/java/cloud/trotter/dashbuddy/core/network/di/GasPriceApiModule.kt
@@ -1,19 +1,10 @@
 package cloud.trotter.dashbuddy.core.network.di
 
-import cloud.trotter.dashbuddy.core.network.BuildConfig
 import cloud.trotter.dashbuddy.core.network.fuel.price.eia.EiaApi
-import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import kotlinx.serialization.json.Json
-import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.OkHttpClient
-import okhttp3.logging.HttpLoggingInterceptor
-import retrofit2.Retrofit
-import timber.log.Timber
-import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 
 @Module
@@ -21,38 +12,14 @@ import javax.inject.Singleton
 object GasPriceApiModule {
 
     private const val BASE_URL = "https://api.eia.gov/"
+
     @Provides
     @Singleton
     fun provideEiaApi(): EiaApi {
-        val json = Json { ignoreUnknownKeys = true }
-        val contentType = "application/json".toMediaType()
-
-        val client = OkHttpClient.Builder()
-            .apply {
-                // Debug-only, Timber-piped, and the EIA key travels as a query param —
-                // redact it so the secret never reaches logcat or the persisted file log (#348).
-                if (BuildConfig.DEBUG) {
-                    val timberLogger = HttpLoggingInterceptor.Logger { message ->
-                        Timber.tag("EiaApi").v(message)
-                    }
-                    addInterceptor(
-                        HttpLoggingInterceptor(timberLogger).apply {
-                            level = HttpLoggingInterceptor.Level.BODY
-                            redactQueryParams("api_key")
-                        }
-                    )
-                }
-            }
-            .connectTimeout(30, TimeUnit.SECONDS)
-            .readTimeout(30, TimeUnit.SECONDS)
-            .writeTimeout(30, TimeUnit.SECONDS)
-            .build()
-
-        return Retrofit.Builder()
-            .baseUrl(BASE_URL)
-            .client(client)
-            .addConverterFactory(json.asConverterFactory(contentType))
-            .build()
+        // The EIA key travels as the `api_key` query param — redaction is the factory
+        // default, so it's stripped from logs without a per-module reminder (#348).
+        val client = NetworkClientFactory.okHttpClient(logTag = "EiaApi")
+        return NetworkClientFactory.retrofit(BASE_URL, client)
             .create(EiaApi::class.java)
     }
 }

--- a/core/network/src/main/java/cloud/trotter/dashbuddy/core/network/di/NetworkClientFactory.kt
+++ b/core/network/src/main/java/cloud/trotter/dashbuddy/core/network/di/NetworkClientFactory.kt
@@ -1,0 +1,99 @@
+package cloud.trotter.dashbuddy.core.network.di
+
+import cloud.trotter.dashbuddy.core.network.BuildConfig
+import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import timber.log.Timber
+import java.util.concurrent.TimeUnit
+
+/**
+ * Single source of truth for Retrofit/OkHttp client assembly across [core:network].
+ *
+ * Before this existed, every API module hand-rolled its own [OkHttpClient] +
+ * [Retrofit.Builder], and the two copies had already diverged on the #348 security
+ * hardening (one redacted the `api_key` query param and set timeouts, the other did
+ * neither). Centralizing the assembly here makes the secure path the *default* path:
+ * any provider that calls [okHttpClient] gets debug-gated, Timber-piped BODY logging
+ * **with secret redaction and standard timeouts baked in** — there is no longer a
+ * per-module step to remember.
+ *
+ * Providers pass only what differs (base URL, logging tag, and — if the upstream
+ * carries secrets in additional query params — extra param names to redact).
+ */
+object NetworkClientFactory {
+
+    private const val DEFAULT_TIMEOUT_SECONDS = 30L
+
+    /**
+     * Query parameters redacted from HTTP logs by default (#348). The EIA gas-price API
+     * carries its secret as an `api_key` query param, so it must never reach logcat or
+     * the persisted file log. Redaction is the default so a new caller cannot forget it.
+     */
+    private val DEFAULT_REDACTED_QUERY_PARAMS = listOf("api_key")
+
+    /**
+     * Lenient JSON for government APIs whose schemas we do not control: ignore unknown
+     * keys, tolerate loose typing, coerce nulls into defaults. Shared so both gov-API
+     * providers parse identically.
+     */
+    val govApiJson: Json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        coerceInputValues = true
+    }
+
+    /**
+     * A [OkHttpClient] with the #348 hardening baked in as the default:
+     *  - **Debug-only** Timber-piped BODY [HttpLoggingInterceptor] (release gets no HTTP
+     *    logging at all), with [redactedQueryParams] stripped so secrets never reach logs.
+     *  - Standard connect/read/write timeouts.
+     *
+     * @param logTag Timber tag for the HTTP log lines (debug builds only).
+     * @param redactedQueryParams query-param names to redact from logs; defaults to the
+     *   shared secret list (`api_key`). Pass a superset if the upstream carries more secrets.
+     */
+    fun okHttpClient(
+        logTag: String,
+        redactedQueryParams: List<String> = DEFAULT_REDACTED_QUERY_PARAMS,
+    ): OkHttpClient = OkHttpClient.Builder()
+        .apply {
+            // Debug builds only — release gets no HTTP logging at all (#348).
+            if (BuildConfig.DEBUG) {
+                val timberLogger = HttpLoggingInterceptor.Logger { message ->
+                    Timber.tag(logTag).v(message)
+                }
+                addInterceptor(
+                    HttpLoggingInterceptor(timberLogger).apply {
+                        level = HttpLoggingInterceptor.Level.BODY
+                        redactedQueryParams.forEach { redactQueryParams(it) }
+                    }
+                )
+            }
+        }
+        .connectTimeout(DEFAULT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        .readTimeout(DEFAULT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        .writeTimeout(DEFAULT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        .build()
+
+    /**
+     * Builds a [Retrofit] for [baseUrl] over [client], decoding JSON via [json]
+     * (defaults to [govApiJson]). The kotlinx-serialization converter is wired here so
+     * no provider repeats the media-type/converter boilerplate.
+     */
+    fun retrofit(
+        baseUrl: String,
+        client: OkHttpClient,
+        json: Json = govApiJson,
+    ): Retrofit {
+        val contentType = "application/json".toMediaType()
+        return Retrofit.Builder()
+            .baseUrl(baseUrl)
+            .client(client)
+            .addConverterFactory(json.asConverterFactory(contentType))
+            .build()
+    }
+}

--- a/core/network/src/main/java/cloud/trotter/dashbuddy/core/network/di/VehicleNetworkModule.kt
+++ b/core/network/src/main/java/cloud/trotter/dashbuddy/core/network/di/VehicleNetworkModule.kt
@@ -1,18 +1,10 @@
 package cloud.trotter.dashbuddy.core.network.di
 
-import cloud.trotter.dashbuddy.core.network.BuildConfig
 import cloud.trotter.dashbuddy.core.network.vehicle.efficiency.epa.EpaApi
-import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import kotlinx.serialization.json.Json
-import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.OkHttpClient
-import okhttp3.logging.HttpLoggingInterceptor
-import retrofit2.Retrofit
-import timber.log.Timber
 import javax.inject.Singleton
 
 /**
@@ -28,36 +20,11 @@ object VehicleNetworkModule {
     @Provides
     @Singleton
     fun provideFuelEconomyApi(): EpaApi {
-        // Custom OkHttp logger that pipes directly into Timber at the VERBOSE level.
-        // This prevents OkHttp from cluttering the standard INFO logcat.
-        val customTimberLogger = HttpLoggingInterceptor.Logger { message ->
-            Timber.tag("FuelEconomyAPI").v(message)
-        }
-
-        val loggingInterceptor = HttpLoggingInterceptor(customTimberLogger).apply {
-            // Logs headers and body. If this becomes too noisy, drop it to BASIC
-            level = HttpLoggingInterceptor.Level.BODY
-        }
-
-        val client = OkHttpClient.Builder()
-            // Debug builds only — release gets no HTTP logging at all (#348).
-            .apply { if (BuildConfig.DEBUG) addInterceptor(loggingInterceptor) }
-            .build()
-
-        // Configure JSON parsing to be highly forgiving since we don't control the government's API schemas
-        val networkJson = Json {
-            ignoreUnknownKeys = true
-            isLenient = true
-            coerceInputValues = true
-        }
-
-        val contentType = "application/json".toMediaType()
-
-        return Retrofit.Builder()
-            .baseUrl(BASE_URL)
-            .client(client)
-            .addConverterFactory(networkJson.asConverterFactory(contentType))
-            .build()
+        // Same hardened client + lenient gov-API Json as the gas-price module, via the
+        // shared factory — including the #348 secret-redaction + timeouts it previously
+        // lacked.
+        val client = NetworkClientFactory.okHttpClient(logTag = "FuelEconomyAPI")
+        return NetworkClientFactory.retrofit(BASE_URL, client)
             .create(EpaApi::class.java)
     }
 }


### PR DESCRIPTION
## What

Extract a single `NetworkClientFactory` (`core/network/di`) as the SSOT for Retrofit/OkHttp client assembly, and route both API providers through it.

The only two Retrofit/OkHttp providers — `GasPriceApiModule` and `VehicleNetworkModule` — hand-duplicated the client assembly. The factory provides:

- `okHttpClient(logTag, redactedQueryParams = ["api_key"])` — a debug-gated, Timber-piped `HttpLoggingInterceptor(BODY)` `OkHttpClient` with **#348 secret redaction and standard 30s connect/read/write timeouts baked in as the default**.
- `govApiJson` — one shared lenient government-API `Json` (`ignoreUnknownKeys` + `isLenient` + `coerceInputValues`).
- `retrofit(baseUrl, client, json = govApiJson)` — wires the kotlinx-serialization converter once.

Both providers now pass only what differs (base URL + log tag). No external callers reference these modules; the provided `EiaApi` / `EpaApi` Hilt bindings are unchanged, so both APIs stay functional.

Behavior note: the EIA module previously used a non-lenient `Json { ignoreUnknownKeys = true }`; it now shares `govApiJson`. Lenient parsing is strictly more forgiving (a superset of the old config), and the EIA DTOs have no defaults/nullables that `coerceInputValues` would alter on a previously-successful parse, so no decode that succeeded before can fail now.

## Why (audit finding)

> The only two Retrofit/OkHttp providers — GasPriceApiModule and VehicleNetworkModule (core/network/di) — hand-duplicate the client assembly AND have DIVERGED on the #348 security hardening: GasPriceApiModule sets 30s timeouts + redactQueryParams("api_key") + lenient gov-API Json; VehicleNetworkModule lacks the redaction/timeouts. Extract one NetworkClientFactory (in core/network/di) providing: a debug-gated Timber HttpLoggingInterceptor(BODY) OkHttpClient with #348 secret redaction + standard timeouts baked in AS THE DEFAULT, a shared lenient gov-API Json, and a retrofit(baseUrl, client, json) helper. Both providers pass only what differs. SECURITY POSTURE: api_key/secret redaction is now the default path, not a per-module thing to remember — call this out in the PR. Keep both APIs functional.

## Security/privacy posture

This change tightens the trust boundary. **`api_key`/secret query-param redaction is now the default path**, not a per-module step to remember: any provider that calls `NetworkClientFactory.okHttpClient(...)` gets debug-gated BODY logging with secrets stripped, so a new caller cannot silently reintroduce the #348 leak. The `VehicleNetworkModule` (fueleconomy.gov), which previously had **no** redaction and **no** timeouts, now gets both. HTTP logging remains debug-only in both paths (release builds add no logging interceptor at all). No secrets are logged; no new network surface or PII handling is introduced.

## Test

`./gradlew testDebugUnitTest` — **BUILD SUCCESSFUL** (all modules green). This is a pure network-DI refactor touching no recognition rules/parsers, so `AllMatchersSuite` is not implicated; the full suite passed regardless.
