### PR TITLE
refactor(chat): ChatPersona.fromWire SSOT — unify the two divergent persona parsers (audit #2)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
@@ -457,7 +457,9 @@ class SideEffectEngine @Inject constructor(
 
     private fun bubbleFromArgs(args: Map<String, String>) {
         val text = args["text"] ?: return
-        val persona = resolvePersona(args["persona"])
+        // Persona parsing is the SSOT ChatPersona.fromWire (#audit-2); the bubble
+        // verb's schema can't carry a Merchant/Customer name, so none is supplied.
+        val persona = ChatPersona.fromWire(args["persona"])
         bubbleManager.postMessage(text, persona)
     }
 
@@ -534,18 +536,6 @@ class SideEffectEngine @Inject constructor(
         }
         // Untracking happens via the job's self-removing completion handler.
         activeTimers[type]?.cancel()
-    }
-
-    private fun resolvePersona(wire: String?): ChatPersona = when (wire?.lowercase()) {
-        "dispatcher" -> ChatPersona.Dispatcher
-        "system" -> ChatPersona.System
-        "earnings" -> ChatPersona.Earnings
-        "inspector" -> ChatPersona.Inspector
-        "navigator" -> ChatPersona.Navigator
-        "shopper" -> ChatPersona.Shopper
-        "good_offer" -> ChatPersona.GoodOffer
-        "bad_offer" -> ChatPersona.BadOffer
-        else -> ChatPersona.Dispatcher
     }
 
     private fun isExternalEffect(effect: AppEffect): Boolean = when (effect) {

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/chat/mappers/ChatMessageMapper.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/chat/mappers/ChatMessageMapper.kt
@@ -3,26 +3,11 @@ package cloud.trotter.dashbuddy.core.database.chat.mappers
 import cloud.trotter.dashbuddy.core.database.chat.ChatMessageEntity
 import cloud.trotter.dashbuddy.domain.model.chat.ChatMessage
 import cloud.trotter.dashbuddy.domain.model.chat.ChatPersona
-import timber.log.Timber
 
 fun ChatMessageEntity.toDomain(): ChatMessage {
-    val persona = when (this.personaType) {
-        "DISPATCHER" -> ChatPersona.Dispatcher
-        "SYSTEM" -> ChatPersona.System
-        "DASHER" -> ChatPersona.Dasher
-        "MERCHANT" -> ChatPersona.Merchant(this.personaName)
-        "CUSTOMER" -> ChatPersona.Customer(this.personaName)
-        "GOOD_OFFER" -> ChatPersona.GoodOffer
-        "BAD_OFFER" -> ChatPersona.BadOffer
-        "INSPECTOR" -> ChatPersona.Inspector
-        "NAVIGATOR" -> ChatPersona.Navigator
-        "SHOPPER" -> ChatPersona.Shopper
-        "EARNINGS" -> ChatPersona.Earnings
-        else -> {
-            Timber.w("Unknown chat persona '%s' — coercing to Dispatcher", personaType)
-            ChatPersona.Dispatcher
-        }
-    }
+    // Persona parsing is the SSOT ChatPersona.fromWire (#audit-2); the name-bearing
+    // personas (Merchant/Customer) carry personaName.
+    val persona = ChatPersona.fromWire(this.personaType, name = this.personaName)
 
     return ChatMessage(
         id = this.id,

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/chat/ChatPersona.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/chat/ChatPersona.kt
@@ -1,5 +1,7 @@
 package cloud.trotter.dashbuddy.domain.model.chat
 
+import java.util.Locale
+
 sealed class ChatPersona {
     abstract val id: String
     abstract val displayName: String
@@ -57,5 +59,35 @@ sealed class ChatPersona {
     data object Earnings : ChatPersona() {
         override val id = "earnings"
         override val displayName = "Earnings"
+    }
+
+    companion object {
+        /**
+         * SSOT for parsing a wire/string persona token into a [ChatPersona] (#audit-2).
+         *
+         * Case-INSENSITIVE (`Locale.ROOT`), so it accepts both the rule-engine
+         * lowercase tokens (`"dispatcher"`, `"good_offer"`, …) and the persisted
+         * UPPERCASE persisted-entity tokens (`"DISPATCHER"`, `"GOOD_OFFER"`, …)
+         * — the union of the two former hand-maintained `when`-tables. Exhaustive
+         * over every persona constant; an unknown/null token falls back to
+         * [Dispatcher]. The name-bearing personas ([Dasher] aside) carry the
+         * supplied [name]; callers that have no name (e.g. the rule-engine bubble
+         * verb, whose schema can't produce a Merchant/Customer) pass the default.
+         */
+        fun fromWire(wire: String?, name: String = ""): ChatPersona =
+            when (wire?.uppercase(Locale.ROOT)) {
+                "DISPATCHER" -> Dispatcher
+                "SYSTEM" -> System
+                "DASHER" -> Dasher
+                "MERCHANT" -> Merchant(name)
+                "CUSTOMER" -> Customer(name)
+                "GOOD_OFFER" -> GoodOffer
+                "BAD_OFFER" -> BadOffer
+                "INSPECTOR" -> Inspector
+                "NAVIGATOR" -> Navigator
+                "SHOPPER" -> Shopper
+                "EARNINGS" -> Earnings
+                else -> Dispatcher
+            }
     }
 }


### PR DESCRIPTION
## What

Introduces `ChatPersona.fromWire(wire: String?, name: String = ""): ChatPersona` in `:domain` as the single owner of String→`ChatPersona` parsing, and delegates both former call sites to it:

- `SideEffectEngine.bubbleFromArgs` (was the private `resolvePersona` — lowercase keys, 8 personas)
- `ChatMessageMapper.toDomain` (was an inline `when` — UPPERCASE keys, 11 personas)

Both hand-maintained `when`-tables are deleted. `fromWire` is **case-insensitive** (`Locale.ROOT`), so it accepts both the rule-engine lowercase tokens (`"dispatcher"`, `"good_offer"`, …) and the persisted UPPERCASE entity tokens (`"DISPATCHER"`, `"GOOD_OFFER"`, …) — the **union** of the two tables' previously-accepted keys, exhaustive over **every** persona constant, with the same `Dispatcher` fallback. Name-bearing personas (`Merchant`/`Customer`) carry the supplied `name`; the bubble verb has no name to give (its schema can't produce a Merchant/Customer) and passes the default.

Grep confirms there is no other String→`ChatPersona` parse in the codebase. The other `ChatPersona` `when`s (OfferFormatters, ChatFormatters, EffectMap) map from enums/personas, not strings, and are out of scope.

## Why (audit finding)

> Two String->ChatPersona parsers diverge: SideEffectEngine.resolvePersona (~lines 539-549, lowercase keys, 8 personas) and ChatMessageMapper.toDomain (~lines 9-25, UPPERCASE keys, 11 personas incl. DASHER/MERCHANT/CUSTOMER), both defaulting to Dispatcher. Add ChatPersona.fromWire(wire: String?): ChatPersona in :domain — case-INSENSITIVE, exhaustive over ALL persona constants, Dispatcher fallback — and delegate BOTH call sites to it. Delete the two hand-maintained when-tables. Union both sites' currently-accepted keys so neither loses coverage. Confirm via grep there are no OTHER String->ChatPersona parses.

This is the SSOT principle from CLAUDE.md: every piece of logic has exactly one owner. Two divergent persona parsers (one lowercase, one uppercase, with different persona coverage) are a divergence bug waiting to fire — exactly the class of duplication the SSOT campaign targets.

### Behavior notes
- No behavior change for any token either site formerly accepted — each resolves to the same persona. The mapper additionally tolerates case variance now (strictly a superset; under alpha single-user assumptions this is safe and only more robust).
- The mapper previously logged a Timber warning on an unknown persona token. That diagnostic is dropped rather than re-implemented at the edge, because re-deriving "did we fall back?" from the result would false-positive on a legitimate `DISPATCHER` token. The fallback behavior itself is unchanged.

`fromWire` lives in `:domain` (pure Kotlin, no Android deps) and is consumed from `:core:database` and `:app`, both of which already depend on `:domain` — the module dependency graph is respected.

## Security/privacy posture

No change to the trust boundary. This is a pure refactor of in-memory enum/string parsing; it touches no recognition rules, no capture path, no network, no effect gating, and no PII handling. The name-bearing personas pass `personaName` through exactly as before (the customer-name hashing happens upstream of this mapper, unchanged).

## Test

`./gradlew testDebugUnitTest` — BUILD SUCCESSFUL (all modules: `:app`, `:core:database`, `:core:state`, `:core:pipeline`, `:domain`). No recognition rules/parsers were touched, so `AllMatchersSuite` is not separately implicated; it ran as part of the full suite regardless.

### CLAUDE.md staleness
None. No statement in CLAUDE.md references `resolvePersona` or the persona parse path.