### PR TITLE
refactor(offer-card): single FlowCardSnapshot.Offer factory — kill LiveCardBuilder/FlowCardMapper duplication (audit #1)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardMapper.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardMapper.kt
@@ -1,6 +1,5 @@
 package cloud.trotter.dashbuddy.ui.bubble.cards
 
-import cloud.trotter.dashbuddy.domain.model.order.OrderType
 import cloud.trotter.dashbuddy.domain.model.event.AppEvent
 import cloud.trotter.dashbuddy.domain.model.cards.FlowCardSnapshot
 import cloud.trotter.dashbuddy.domain.model.event.AppEventType
@@ -90,33 +89,13 @@ object FlowCardMapper {
                         completed.add(it.copy(phaseEndedAt = payload.presentedAt))
                         openAwaiting = null
                     }
-                    val storeNames = payload.parsedOffer.orders
-                        .map { it.storeName }
-                        .distinct()
                     completed.add(
-                        FlowCardSnapshot.Offer(
+                        FlowCardSnapshot.Offer.from(
+                            parsedOffer = payload.parsedOffer,
+                            evaluation = payload.evaluation,
+                            offerHash = payload.offerHash,
                             phaseStartedAt = payload.presentedAt,
                             phaseEndedAt = payload.decidedAt,
-                            offerHash = payload.offerHash,
-                            payAmount = payload.parsedOffer.payAmount,
-                            distanceMiles = payload.parsedOffer.distanceMiles,
-                            itemCount = payload.parsedOffer.itemCount,
-                            storeNames = storeNames,
-                            evaluationScore = payload.evaluation?.score,
-                            evaluationAction = payload.evaluation?.action?.name,
-                            netPayAmount = payload.evaluation?.netPayAmount,
-                            dollarsPerMile = payload.evaluation?.dollarsPerMile,
-                            dollarsPerHour = payload.evaluation?.dollarsPerHour,
-                            qualityLevel = payload.evaluation?.qualityLevel,
-                            badges = (payload.parsedOffer.badges.map { it.name } +
-                                payload.parsedOffer.orders.flatMap { it.badges }.map { it.name } +
-                                // Synthetic SHOP badge (#461) so a Shop & Deliver offer is
-                                // typed at a glance — orderType is known at offer time.
-                                if (payload.parsedOffer.orders.any { it.orderType == OrderType.SHOP_FOR_ITEMS }) {
-                                    listOf("SHOP")
-                                } else {
-                                    emptyList()
-                                }).distinct(),
                             outcome = payload.outcome,
                         )
                     )

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/LiveCardBuilder.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/LiveCardBuilder.kt
@@ -1,7 +1,6 @@
 package cloud.trotter.dashbuddy.ui.bubble.cards
 
 import cloud.trotter.dashbuddy.domain.model.cards.FlowCardSnapshot
-import cloud.trotter.dashbuddy.domain.model.order.OrderType
 import cloud.trotter.dashbuddy.domain.state.AppState
 import cloud.trotter.dashbuddy.domain.state.Flow
 import cloud.trotter.dashbuddy.domain.state.Mode
@@ -41,25 +40,12 @@ object LiveCardBuilder {
             Flow.OfferPresented -> {
                 val pending = state.regions.flow.pendingOffer ?: return null
                 val offer = pending.offerFields.parsedOffer
-                FlowCardSnapshot.Offer(
-                    phaseStartedAt = pending.presentedAt,
+                FlowCardSnapshot.Offer.from(
+                    parsedOffer = offer,
+                    evaluation = pending.evaluation,
                     offerHash = pending.offerHash,
-                    payAmount = offer.payAmount,
-                    distanceMiles = offer.distanceMiles,
-                    itemCount = offer.itemCount,
-                    storeNames = offer.orders.map { it.storeName }.distinct(),
-                    evaluationScore = pending.evaluation?.score,
-                    evaluationAction = pending.evaluation?.action?.name,
-                    netPayAmount = pending.evaluation?.netPayAmount,
-                    dollarsPerMile = pending.evaluation?.dollarsPerMile,
-                    dollarsPerHour = pending.evaluation?.dollarsPerHour,
-                    qualityLevel = pending.evaluation?.qualityLevel,
-                    // #461: synthetic SHOP marker from the order type (parity with FlowCardMapper, so
-                    // the LIVE offer card surfaces the [cart N] shop badge while it's on screen).
-                    badges = (offer.badges.map { it.name } +
-                        offer.orders.flatMap { it.badges }.map { it.name } +
-                        if (offer.orders.any { it.orderType == OrderType.SHOP_FOR_ITEMS }) listOf("SHOP") else emptyList()
-                        ).distinct(),
+                    phaseStartedAt = pending.presentedAt,
+                    // Live card derives the countdown anchors so the expiry bar can tick.
                     expiresAt = offer.initialCountdownSeconds?.let { pending.presentedAt + it * 1000L },
                     countdownSeconds = offer.initialCountdownSeconds,
                     outcome = null,

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/cards/FlowCardSnapshot.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/cards/FlowCardSnapshot.kt
@@ -1,7 +1,10 @@
 package cloud.trotter.dashbuddy.domain.model.cards
 
+import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
 import cloud.trotter.dashbuddy.domain.evaluation.OfferQuality
 import cloud.trotter.dashbuddy.domain.model.event.AppEventType
+import cloud.trotter.dashbuddy.domain.model.offer.ParsedOffer
+import cloud.trotter.dashbuddy.domain.model.order.OrderType
 import cloud.trotter.dashbuddy.domain.model.pay.ParsedPay
 
 /**
@@ -72,6 +75,63 @@ sealed class FlowCardSnapshot {
         val outcome: AppEventType? = null,
     ) : FlowCardSnapshot() {
         override val id: String get() = "offer:$offerHash"
+
+        companion object {
+            /**
+             * Single owner (SSOT) for assembling an [Offer] card from a
+             * [ParsedOffer] + its [OfferEvaluation]. Both the live builder
+             * (from `AppState`) and the event-log fold call this so the
+             * badge list, store-name derivation, and the parsed/evaluation
+             * field copy can never drift apart again (the #461 SHOP-parity
+             * bug was exactly that divergence). Call-site-specific framing
+             * — `phaseStartedAt`/`phaseEndedAt`, `offerHash`, the live
+             * countdown anchors, and the decided `outcome` — stays a
+             * parameter; only the shared assembly lives here.
+             */
+            fun from(
+                parsedOffer: ParsedOffer,
+                evaluation: OfferEvaluation?,
+                offerHash: String,
+                phaseStartedAt: Long,
+                phaseEndedAt: Long? = null,
+                expiresAt: Long? = null,
+                countdownSeconds: Int? = null,
+                outcome: AppEventType? = null,
+            ): Offer = Offer(
+                phaseStartedAt = phaseStartedAt,
+                phaseEndedAt = phaseEndedAt,
+                offerHash = offerHash,
+                payAmount = parsedOffer.payAmount,
+                distanceMiles = parsedOffer.distanceMiles,
+                itemCount = parsedOffer.itemCount,
+                storeNames = parsedOffer.orders.map { it.storeName }.distinct(),
+                evaluationScore = evaluation?.score,
+                evaluationAction = evaluation?.action?.name,
+                netPayAmount = evaluation?.netPayAmount,
+                dollarsPerMile = evaluation?.dollarsPerMile,
+                dollarsPerHour = evaluation?.dollarsPerHour,
+                qualityLevel = evaluation?.qualityLevel,
+                badges = badgesOf(parsedOffer),
+                expiresAt = expiresAt,
+                countdownSeconds = countdownSeconds,
+                outcome = outcome,
+            )
+
+            /**
+             * The offer + order badge enum names for the pill row, plus a
+             * synthetic `"SHOP"` marker when any order is a Shop & Deliver
+             * (#461) — `orderType` is known at offer time, so the card can be
+             * typed at a glance.
+             */
+            private fun badgesOf(parsedOffer: ParsedOffer): List<String> =
+                (parsedOffer.badges.map { it.name } +
+                    parsedOffer.orders.flatMap { it.badges }.map { it.name } +
+                    if (parsedOffer.orders.any { it.orderType == OrderType.SHOP_FOR_ITEMS }) {
+                        listOf("SHOP")
+                    } else {
+                        emptyList()
+                    }).distinct()
+        }
     }
 
     /**


### PR DESCRIPTION
## What

`LiveCardBuilder.build()` (live card from `AppState`) and `FlowCardMapper.fold()` (completed cards from the `AppEvent` log) each assembled a `FlowCardSnapshot.Offer` with **byte-identical** logic — the badges list and the parsed/evaluation field copy. This extracts one owner.

- New SSOT factory `FlowCardSnapshot.Offer.from(...)` in `:domain` (pure Kotlin) centralizes:
  - the **badges list** — offer badge names + order badge names + a synthetic `"SHOP"` when any order is `OrderType.SHOP_FOR_ITEMS`, then `.distinct()` (extracted to a private `badgesOf`)
  - the **field copy** from `ParsedOffer`/`OfferEvaluation` — `payAmount`/`distanceMiles`/`itemCount`/`storeNames` + `evaluationScore`/`evaluationAction`/`netPayAmount`/`dollarsPerMile`/`dollarsPerHour`/`qualityLevel`
- Call-site-specific framing stays a parameter: `phaseStartedAt`/`phaseEndedAt`, `offerHash`, `outcome`, and the live countdown anchors (`expiresAt`/`countdownSeconds`, which only the live builder derives so the expiry bar keeps ticking).
- Both call sites now delegate; the parallel assembly is removed. Two now-unused `OrderType` imports dropped.

## Why (audit finding)

> LiveCardBuilder.kt (~lines 54-62) and FlowCardMapper.kt (~lines 111-119) build FlowCardSnapshot.Offer with byte-identical logic — the badges list (parsedOffer.badges.map{it.name} + orders.flatMap{it.badges}.map{it.name} + a synthetic "SHOP" if any order is OrderType.SHOP_FOR_ITEMS, then .distinct()) AND the field copy (payAmount/distanceMiles/itemCount/evaluation*/dollarsPerMile/dollarsPerHour/qualityLevel/expiresAt). This already shipped one divergence bug (the #461 SHOP-parity fix). Extract ONE owner — a single factory FlowCardSnapshot.Offer.from(...) (or a pure helper in :domain) that BOTH call sites delegate to — removing the parallel assembly entirely. Behavior must stay byte-identical (the FlowCardMapperTest golden must still pass).

SSOT (CLAUDE.md principle 5): the two-copy assembly was a divergence bug waiting to fire — and it already did, in the #461 SHOP-parity patch that had to touch both. Now one definition; everything derives.

## Security/privacy posture

No change to the trust boundary. This is pure view-state assembly of an already-recognized offer; the factory copies the same fields the two call sites already copied. `storeNames` comes from the already-parsed offer; no new PII is read, stored, or logged, and customer hashing is untouched (offer screens don't carry customer PII). The factory lives in `:domain` (pure Kotlin, no Android/Compose/Hilt) and respects the `:app → :domain` and `:core:* → :domain` dependency graph. The live builder still derives the countdown anchor (not a frozen string), so the expiry bar keeps ticking per the Reactive UI rules.

## Test

- `./gradlew testDebugUnitTest` → BUILD SUCCESSFUL (full suite, all modules). `FlowCardMapperTest` — including the `#461` SHOP-badge golden (`a Shop & Deliver offer gets a synthetic SHOP badge` / `a plain pickup offer does NOT get a SHOP badge`) — passes unchanged, confirming byte-identical behavior.
- No recognition rules/parsers touched, so `AllMatchersSuite` was not separately required; it runs within the full suite regardless.