### PR TITLE
refactor(ui): route 6 money/decimal sites through Formats SSOT (audit #3)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/StrategySettingsScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/StrategySettingsScreen.kt
@@ -39,11 +39,11 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import cloud.trotter.dashbuddy.domain.format.Formats
 import cloud.trotter.dashbuddy.ui.main.settings.components.DraggableRuleRow
 import cloud.trotter.dashbuddy.ui.main.settings.components.FakeOfferCard
 import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.rememberReorderableLazyListState
-import java.util.Locale
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -117,7 +117,7 @@ fun StrategySettingsScreen(
                 ) {
                     Column(Modifier.weight(1f)) {
                         Text(
-                            "Pay: $${String.format(Locale.getDefault(), "%.2f", simPay)}",
+                            "Pay: ${Formats.money(simPay.toDouble())}",
                             style = MaterialTheme.typography.labelSmall
                         )
                         Slider(
@@ -129,7 +129,7 @@ fun StrategySettingsScreen(
                     Spacer(Modifier.width(16.dp))
                     Column(Modifier.weight(1f)) {
                         Text(
-                            "Dist: ${String.format(Locale.getDefault(), "%.1f", simDist)} mi",
+                            "Dist: ${Formats.decimal(simDist.toDouble())} mi",
                             style = MaterialTheme.typography.labelSmall
                         )
                         Slider(

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/WizardScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/WizardScreen.kt
@@ -46,7 +46,6 @@ import cloud.trotter.dashbuddy.ui.main.setup.wizard.components.WizardBottomBar
 import cloud.trotter.dashbuddy.ui.main.setup.wizard.components.WizardTopBar
 import cloud.trotter.dashbuddy.ui.main.setup.wizard.model.WizardStep
 import kotlinx.coroutines.launch
-import java.util.Locale
 import cloud.trotter.dashbuddy.domain.format.Formats
 
 @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
@@ -221,7 +220,7 @@ fun WizardScreen(
                     WizardStep.MAX_DISTANCE -> {
                         MetricSliderCard(
                             step = currentStep, value = state.maxDistance, valueRange = 1f..25f,
-                            valueFormatter = { String.format(Locale.getDefault(), "%.1f mi", it) },
+                            valueFormatter = { "${Formats.decimal(it.toDouble())} mi" },
                             onValueChange = viewModel::updateMaxDistance,
                             footerText = if (isCherryPicker) "We will auto-decline offers exceeding this distance." else "We will flag offers exceeding this distance in red."
                         )

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/cards/GasPriceCard.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/cards/GasPriceCard.kt
@@ -25,10 +25,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import cloud.trotter.dashbuddy.domain.format.Formats
 import cloud.trotter.dashbuddy.domain.model.vehicle.FuelType
 import cloud.trotter.dashbuddy.ui.main.setup.wizard.components.WizardCardHeader
 import cloud.trotter.dashbuddy.ui.main.setup.wizard.model.WizardStep
-import java.util.Locale
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
@@ -114,7 +114,7 @@ fun GasPriceCard(
                 CircularProgressIndicator(modifier = Modifier.size(48.dp))
             } else {
                 Text(
-                    text = String.format(Locale.getDefault(), "$%.2f", price),
+                    text = Formats.money(price.toDouble()),
                     style = MaterialTheme.typography.displayMedium,
                     fontWeight = FontWeight.Black,
                     color = MaterialTheme.colorScheme.primary
@@ -127,7 +127,7 @@ fun GasPriceCard(
             }
         } else {
             Text(
-                text = String.format(Locale.getDefault(), "$%.2f", price),
+                text = Formats.money(price.toDouble()),
                 style = MaterialTheme.typography.displayMedium,
                 fontWeight = FontWeight.Black,
                 color = MaterialTheme.colorScheme.primary

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/cards/VehicleCard.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/cards/VehicleCard.kt
@@ -30,11 +30,11 @@ import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import cloud.trotter.dashbuddy.domain.format.Formats
 import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleClass
 import cloud.trotter.dashbuddy.ui.main.setup.wizard.components.VehicleDropdown
 import cloud.trotter.dashbuddy.ui.main.setup.wizard.components.WizardCardHeader
 import cloud.trotter.dashbuddy.ui.main.setup.wizard.model.WizardStep
-import java.util.Locale
 import cloud.trotter.dashbuddy.ui.main.setup.wizard.VEHICLE_NOT_LISTED
 import android.net.Uri
 
@@ -179,7 +179,7 @@ fun VehicleCard(
                 Spacer(modifier = Modifier.height(24.dp))
 
                 Text(
-                    text = String.format(Locale.getDefault(), "%.1f MPG", mpg),
+                    text = "${Formats.decimal(mpg.toDouble())} MPG",
                     style = MaterialTheme.typography.displaySmall,
                     fontWeight = FontWeight.Black,
                     color = MaterialTheme.colorScheme.primary


### PR DESCRIPTION
## What

Routes six UI sites that still formatted numbers with raw `String.format(Locale.getDefault(), ...)` through the `format.Formats` SSOT in `:domain`:

- `GasPriceCard.kt` (2 sites): `"$%.2f"` -> `Formats.money(price.toDouble())`
- `StrategySettingsScreen.kt`: sim pay `"$%.2f"` -> `Formats.money(simPay.toDouble())`; sim dist `"%.1f"` + `" mi"` -> `Formats.decimal(simDist.toDouble())` + `" mi"`
- `VehicleCard.kt`: `"%.1f MPG"` -> `Formats.decimal(mpg.toDouble())` + `" MPG"`
- `WizardScreen.kt`: `"%.1f mi"` -> `Formats.decimal(it.toDouble())` + `" mi"`

Removed the now-unused `java.util.Locale` imports from all four files; added the `Formats` import where missing.

`Formats.money` is `"$%.2f"` and `Formats.decimal(_, 1)` is `"%.1f"` (both pin `Locale.getDefault()`), so en-US output is byte-identical. Every call site value is a `Float`; `.toDouble()` is exact for 2/1-decimal rounding, so the rendered string does not change. **No new formatter copy is introduced — this removes duplication, pointing each site at the one owner.**

`CurrencyInput.editableAmount` is deliberately left untouched — it is the documented #467 input round-trip *machine* string (`Locale.US`, pinned at its own call site), not a display string.

## Why (audit finding)

> Finding #3: Six UI sites bypass the `format.Formats` SSOT with raw `String.format` (the #358/#456 bug class): `GasPriceCard.kt:117` and `:130` (`"$%.2f"`), `StrategySettingsScreen.kt:120` (sim pay `"$%.2f"`) and `:132` (`"%.1f"` + `" mi"`), `VehicleCard.kt:182` (`"%.1f MPG"`), `WizardScreen.kt:224` (`"%.1f mi"`). Replace money sites with `Formats.money(...)` and decimal sites with `Formats.decimal(...)` + the unit suffix. First confirm `Formats.money/decimal/money0` exist in `:domain` (`format.Formats`) and produce the intended strings. Do NOT touch `CurrencyInput.editableAmount` (documented #467 input round-trip machine string). Visual output must be unchanged for en-US.

Confirmed `Formats.money(Double)` -> `String.format(locale, "$%.2f", amount)` and `Formats.decimal(Double, digits=1)` -> `String.format(locale, "%.${digits}f", value)` exist in `domain/.../format/Formats.kt` and produce the intended strings.

## Security/privacy posture

No change to the trust boundary. This is a display-formatting refactor only — no recognition, capture, network, or effect path is touched; no new data is read, stored, logged, or uploaded.

## Test

`./gradlew testDebugUnitTest` — BUILD SUCCESSFUL (227 tasks, all modules compile and pass). The change does not touch recognition rules/parsers, so `AllMatchersSuite` is not implicated (and `:core:pipeline:testDebugUnitTest` passed as part of the full run regardless).