### PR TITLE
cleanup(domain): delete dead Kotlin text-matching recognition machinery on badge/order enums (audit #10)

### DIFF
--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/offer/OfferBadge.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/offer/OfferBadge.kt
@@ -2,137 +2,52 @@ package cloud.trotter.dashbuddy.domain.model.offer
 
 /**
  * Represents various textual badges or indicators that can appear on a DoorDash offer screen.
- * Each badge has a matching strategy: exact text, contains text, or a regex pattern.
+ *
+ * Recognition is data, not code (CLAUDE.md): the JSON rule engine emits these badges as parse
+ * output, so the enum is a stable set of serialized/UI keys (persisted by name via
+ * `DataTypeConverters`). Each constant carries only a human-readable [displayName]; the old
+ * Kotlin text-matching machinery (`findAllBadgesInScreen`/`findBadgesInText` and the
+ * `exactMatchText`/`containsText`/`regexPattern` columns) was superseded by the rules and removed.
  */
 enum class OfferBadge(
     val displayName: String,
-    val exactMatchText: String? = null, // For exact (ignore case) string matching
-    val containsText: String? = null,   // For contains (ignore case) string matching
-    val regexPattern: Regex? = null,    // For regex pattern matching
 ) {
     /** Indicates the offer is marked as high paying by DoorDash. */
-    HIGH_PAYING(
-        displayName = "High Paying",
-        regexPattern = Regex("""High-paying (shopping )?offer!""", RegexOption.IGNORE_CASE),
-    ),
+    HIGH_PAYING(displayName = "High Paying"),
 
     /** Indicates priority access due to Dasher status (Platinum, Gold, Silver) or Pro Shopper ratings. */
-    PRIORITY_ACCESS(
-        displayName = "Priority Access",
-        regexPattern = Regex(
-            """your\s+(Platinum|Gold|Silver)\s+status|Pro Shopper ratings gave you priority""",
-            RegexOption.IGNORE_CASE
-        ),
-    ),
+    PRIORITY_ACCESS(displayName = "Priority Access"),
 
     /** Indicates all orders in a stacked offer are from a single store. */
-    ALL_ORDERS_SAME_STORE(
-        displayName = "All Orders Same Store",
-        exactMatchText = "All orders are from the same store"
-    ),
+    ALL_ORDERS_SAME_STORE(displayName = "All Orders Same Store"),
 
     /** Indicates both orders in a stacked offer are for the same customer. */
-    BOTH_ORDERS_SAME_CUSTOMER(
-        displayName = "Both Orders Same Customer",
-        exactMatchText = "Both orders go to the same customer"
-    ),
+    BOTH_ORDERS_SAME_CUSTOMER(displayName = "Both Orders Same Customer"),
 
     /** Indicates customer can add items to a shopping order before checkout. */
-    ITEMS_CAN_BE_ADDED(
-        displayName = "Items Can Be Added",
-        exactMatchText = "Items can be added before checkout"
-    ),
+    ITEMS_CAN_BE_ADDED(displayName = "Items Can Be Added"),
 
     /** Indicates a Sharpie is recommended, often for Shop & Deliver orders. */
-    SHARPIE_RECOMMENDED(
-        displayName = "Sharpie Recommended",
-        exactMatchText = "Black marker or Sharpie recommended"
-    ),
+    SHARPIE_RECOMMENDED(displayName = "Sharpie Recommended"),
 
     /** Indicates the order contains age-restricted or other restricted items. */
-    CONTAINS_RESTRICTED_ITEMS(
-        displayName = "Contains Restricted Items",
-        exactMatchText = "Contains restricted items"
-    ),
+    CONTAINS_RESTRICTED_ITEMS(displayName = "Contains Restricted Items"),
 
     /** Indicates the order requires the Dasher to be 18+. */
-    AGE_RESTRICTED_18_PLUS(
-        displayName = "Age Restricted 18+",
-        exactMatchText = "Must be 18+ to accept order",
-    ),
+    AGE_RESTRICTED_18_PLUS(displayName = "Age Restricted 18+"),
 
     /** Indicates the order requires the Dasher to be 21+ (often for alcohol). */
-    AGE_RESTRICTED_21_PLUS(
-        displayName = "Age Restricted 21+",
-        exactMatchText = "Must be 21+ to accept order",
-    ),
+    AGE_RESTRICTED_21_PLUS(displayName = "Age Restricted 21+"),
 
     /** Indicates the Dasher must check the recipient's ID. */
-    CHECK_RECIPIENT_ID(
-        displayName = "Check Recipient ID",
-        exactMatchText = "Check recipient's ID",
-    ),
+    CHECK_RECIPIENT_ID(displayName = "Check Recipient ID"),
 
     /** Indicates the order includes alcohol (often part of 'Contains restricted items'). */
-    INCLUDES_ALCOHOL(
-        displayName = "Includes Alcohol",
-        containsText = "including alcohol",
-    ),
+    INCLUDES_ALCOHOL(displayName = "Includes Alcohol"),
 
     /** Indicates a cash on delivery (COD) order. */
-    COLLECT_CASH(
-        displayName = "Collect Cash",
-        exactMatchText = "Collect cash from customer",
-    ),
+    COLLECT_CASH(displayName = "Collect Cash"),
 
     /** Indicates the order might involve processing returns (often for alcohol or retail). */
-    MAY_NEED_RETURNS(
-        displayName = "May Need Returns",
-        exactMatchText = "May need returns"
-    );
-
-    companion object {
-        /**
-         * Finds all OfferBadges present in a given line of text.
-         * A single line of text could potentially match multiple badges.
-         *
-         * @param text The line of text to scan for badges.
-         * @return A list of all OfferBadge enums that match the text.
-         */
-        private fun findBadgesInText(text: String): List<OfferBadge> {
-            val foundBadges = mutableListOf<OfferBadge>()
-            for (badge in entries) {
-                if (badge.exactMatchText != null && badge.exactMatchText.equals(
-                        text,
-                        ignoreCase = true
-                    )
-                ) {
-                    foundBadges.add(badge)
-                } else if (badge.containsText != null && text.contains(
-                        badge.containsText,
-                        ignoreCase = true
-                    )
-                ) {
-                    foundBadges.add(badge)
-                } else if (badge.regexPattern != null && badge.regexPattern.containsMatchIn(text)) {
-                    foundBadges.add(badge)
-                }
-            }
-            return foundBadges.distinct()
-        }
-
-        /**
-         * Finds all OfferBadges present in a list of screen texts.
-         *
-         * @param screenTexts The list of strings representing the screen content.
-         * @return A set of all unique OfferBadge enums found across all screen texts.
-         */
-        fun findAllBadgesInScreen(screenTexts: List<String>): Set<OfferBadge> {
-            val allFoundBadges = mutableSetOf<OfferBadge>()
-            screenTexts.forEach { textLine ->
-                allFoundBadges.addAll(findBadgesInText(textLine))
-            }
-            return allFoundBadges
-        }
-    }
+    MAY_NEED_RETURNS(displayName = "May Need Returns"),
 }

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/order/OrderBadge.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/order/OrderBadge.kt
@@ -3,59 +3,23 @@ package cloud.trotter.dashbuddy.domain.model.order
 /**
  * Represents various textual badges that apply to a specific order/leg within an offer,
  * such as equipment requirements or specific handling notes for that part of the delivery.
+ *
+ * Recognition is data, not code (CLAUDE.md): the JSON rule engine mints these badges as parse
+ * output (e.g. `ParsedFieldsFactory` maps `isRedCard`/`isLargeOrder`/`hasAlcohol` to constants),
+ * so the enum is a stable set of serialized keys (persisted by name via `DataTypeConverters`). The
+ * old Kotlin text-matching machinery (`findAllBadgesInOrderBlock`/`findBadgesInText` and the
+ * `badgeText` column) was superseded by the rules and removed.
  */
-enum class OrderBadge(
-    val badgeText: String,          // The exact text to match on the screen (case-insensitive)
-) {
+enum class OrderBadge {
     /** Indicates that a Red Card is required for this specific order (e.g., for payment at the store). */
-    RED_CARD(
-        badgeText = "Red Card required",
-    ),
+    RED_CARD,
 
     /** Indicates this specific order is a large catering order, often requiring more space or different handling. */
-    LARGE_ORDER(
-        badgeText = "Large Order - Catering",
-    ),
+    LARGE_ORDER,
 
     /** Indicates a pizza bag is required for this specific order. */
-    PIZZA_BAG(
-        badgeText = "Pizza bag required",
-    ),
+    PIZZA_BAG,
 
     /** Indicates this specific order contains alcohol and may require ID check at pickup or dropoff for this leg. */
-    ALCOHOL(
-        badgeText = "Alcohol",
-    );
-
-    companion object {
-        /**
-         * Finds all OrderBadges present in a given line of text.
-         *
-         * @param text The line of text to scan for order-specific badges.
-         * @return A list of all OrderBadge enums that match the text.
-         */
-        private fun findBadgesInText(text: String): List<OrderBadge> {
-            val foundBadges = mutableListOf<OrderBadge>()
-            for (badge in entries) {
-                if (badge.badgeText.equals(text, ignoreCase = true)) {
-                    foundBadges.add(badge)
-                }
-            }
-            return foundBadges
-        }
-
-        /**
-         * Finds all OrderBadges present in a list of texts representing a single order's details.
-         *
-         * @param orderBlockTexts The list of strings for a specific order block.
-         * @return A set of all unique OrderBadge enums found in that block.
-         */
-        fun findAllBadgesInOrderBlock(orderBlockTexts: List<String>): Set<OrderBadge> {
-            val allFoundBadges = mutableSetOf<OrderBadge>()
-            orderBlockTexts.forEach { textLine ->
-                allFoundBadges.addAll(findBadgesInText(textLine))
-            }
-            return allFoundBadges
-        }
-    }
+    ALCOHOL,
 }

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/order/OrderType.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/order/OrderType.kt
@@ -4,6 +4,11 @@ package cloud.trotter.dashbuddy.domain.model.order
  * Represents the various types of orders that can be offered by DoorDash.
  * Each type has a display name that matches the text on the offer screen
  * and a flag indicating if it's a shopping-type order.
+ *
+ * Recognition is data, not code (CLAUDE.md): the JSON rule engine emits the order type as parse
+ * output, which `ParsedFieldsFactory` maps to a constant via the intrinsic [valueOf]. The old
+ * Kotlin text-matching helpers (`fromTypeName`/`orderTypeCount`/`allTypeNames`) were superseded by
+ * the rules and removed.
  */
 enum class OrderType(
     val typeName: String,
@@ -39,33 +44,4 @@ enum class OrderType(
         isShoppingOrder = false
     );
     // Add more types here if new, distinct strings appear on offer screens in the future.
-
-    companion object {
-        private val allTypeNames: List<String> by lazy { entries.map { it.typeName } }
-
-        /**
-         * Finds an OrderType by its typeName, ignoring case.
-         *
-         * @param text The typeName string to match.
-         * @return The matching OrderType, or null if not found.
-         */
-        fun fromTypeName(text: String): OrderType? {
-            return entries.find { it.typeName.equals(text, ignoreCase = true) }
-        }
-
-        /**
-         * Counts how many strings in the given list exactly match any of the OrderType typeNames.
-         * The match is case-insensitive.
-         *
-         * @param screenTexts The list of strings to check.
-         * @return The total count of matching order type strings.
-         */
-        fun orderTypeCount(screenTexts: List<String>): Int {
-            return screenTexts.count { textToCompare ->
-                allTypeNames.any { knownTypeName ->
-                    knownTypeName.equals(textToCompare, ignoreCase = true)
-                }
-            }
-        }
-    }
 }

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/model/offer/OfferBadgeTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/model/offer/OfferBadgeTest.kt
@@ -1,197 +1,32 @@
 package cloud.trotter.dashbuddy.domain.model.offer
 
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
+/**
+ * Recognition is data, not code (CLAUDE.md): the screen text-matching machinery
+ * (`findAllBadgesInScreen` + the `exactMatchText`/`containsText`/`regexPattern` columns) was
+ * superseded by the JSON rule engine and deleted, so its tests are gone too. What remains is the
+ * enum's role as a stable set of serialized/UI keys with a human-readable [OfferBadge.displayName].
+ */
 class OfferBadgeTest {
 
-    // -------------------------------------------------------------------------
-    // Exact match badges
-    // -------------------------------------------------------------------------
-
     @Test
-    fun `exact match - ALL_ORDERS_SAME_STORE detected`() {
-        val badges = OfferBadge.findAllBadgesInScreen(listOf("All orders are from the same store"))
-        assertTrue(OfferBadge.ALL_ORDERS_SAME_STORE in badges)
+    fun `every badge exposes a non-blank displayName`() {
+        OfferBadge.entries.forEach { badge ->
+            assertTrue(
+                "displayName for $badge should be non-blank",
+                badge.displayName.isNotBlank()
+            )
+        }
     }
 
     @Test
-    fun `exact match - case insensitive`() {
-        val badges = OfferBadge.findAllBadgesInScreen(listOf("ALL ORDERS ARE FROM THE SAME STORE"))
-        assertTrue(OfferBadge.ALL_ORDERS_SAME_STORE in badges)
-    }
-
-    @Test
-    fun `exact match - BOTH_ORDERS_SAME_CUSTOMER detected`() {
-        val badges = OfferBadge.findAllBadgesInScreen(listOf("Both orders go to the same customer"))
-        assertTrue(OfferBadge.BOTH_ORDERS_SAME_CUSTOMER in badges)
-    }
-
-    @Test
-    fun `exact match - SHARPIE_RECOMMENDED detected`() {
-        val badges = OfferBadge.findAllBadgesInScreen(listOf("Black marker or Sharpie recommended"))
-        assertTrue(OfferBadge.SHARPIE_RECOMMENDED in badges)
-    }
-
-    @Test
-    fun `exact match - AGE_RESTRICTED_18_PLUS detected`() {
-        val badges = OfferBadge.findAllBadgesInScreen(listOf("Must be 18+ to accept order"))
-        assertTrue(OfferBadge.AGE_RESTRICTED_18_PLUS in badges)
-    }
-
-    @Test
-    fun `exact match - AGE_RESTRICTED_21_PLUS detected`() {
-        val badges = OfferBadge.findAllBadgesInScreen(listOf("Must be 21+ to accept order"))
-        assertTrue(OfferBadge.AGE_RESTRICTED_21_PLUS in badges)
-    }
-
-    @Test
-    fun `exact match - CHECK_RECIPIENT_ID detected`() {
-        val badges = OfferBadge.findAllBadgesInScreen(listOf("Check recipient's ID"))
-        assertTrue(OfferBadge.CHECK_RECIPIENT_ID in badges)
-    }
-
-    @Test
-    fun `exact match - COLLECT_CASH detected`() {
-        val badges = OfferBadge.findAllBadgesInScreen(listOf("Collect cash from customer"))
-        assertTrue(OfferBadge.COLLECT_CASH in badges)
-    }
-
-    @Test
-    fun `exact match - MAY_NEED_RETURNS detected`() {
-        val badges = OfferBadge.findAllBadgesInScreen(listOf("May need returns"))
-        assertTrue(OfferBadge.MAY_NEED_RETURNS in badges)
-    }
-
-    @Test
-    fun `exact match - CONTAINS_RESTRICTED_ITEMS detected`() {
-        val badges = OfferBadge.findAllBadgesInScreen(listOf("Contains restricted items"))
-        assertTrue(OfferBadge.CONTAINS_RESTRICTED_ITEMS in badges)
-    }
-
-    @Test
-    fun `exact match - ITEMS_CAN_BE_ADDED detected`() {
-        val badges = OfferBadge.findAllBadgesInScreen(listOf("Items can be added before checkout"))
-        assertTrue(OfferBadge.ITEMS_CAN_BE_ADDED in badges)
-    }
-
-    // -------------------------------------------------------------------------
-    // Contains match badges
-    // -------------------------------------------------------------------------
-
-    @Test
-    fun `contains match - INCLUDES_ALCOHOL detected`() {
-        val badges = OfferBadge.findAllBadgesInScreen(listOf("This order, including alcohol, will be delivered"))
-        assertTrue(OfferBadge.INCLUDES_ALCOHOL in badges)
-    }
-
-    @Test
-    fun `contains match - INCLUDES_ALCOHOL case insensitive`() {
-        val badges = OfferBadge.findAllBadgesInScreen(listOf("Including Alcohol in this order"))
-        assertTrue(OfferBadge.INCLUDES_ALCOHOL in badges)
-    }
-
-    // -------------------------------------------------------------------------
-    // Regex match badges
-    // -------------------------------------------------------------------------
-
-    @Test
-    fun `regex match - HIGH_PAYING detected`() {
-        val badges = OfferBadge.findAllBadgesInScreen(listOf("High-paying offer!"))
-        assertTrue(OfferBadge.HIGH_PAYING in badges)
-    }
-
-    @Test
-    fun `regex match - HIGH_PAYING shopping variant detected`() {
-        val badges = OfferBadge.findAllBadgesInScreen(listOf("High-paying shopping offer!"))
-        assertTrue(OfferBadge.HIGH_PAYING in badges)
-    }
-
-    @Test
-    fun `regex match - PRIORITY_ACCESS Platinum detected`() {
-        val badges = OfferBadge.findAllBadgesInScreen(listOf("Your Platinum status gave you priority access"))
-        assertTrue(OfferBadge.PRIORITY_ACCESS in badges)
-    }
-
-    @Test
-    fun `regex match - PRIORITY_ACCESS Gold detected`() {
-        val badges = OfferBadge.findAllBadgesInScreen(listOf("your Gold status gives you this"))
-        assertTrue(OfferBadge.PRIORITY_ACCESS in badges)
-    }
-
-    @Test
-    fun `regex match - PRIORITY_ACCESS Silver detected`() {
-        val badges = OfferBadge.findAllBadgesInScreen(listOf("your Silver status gives you priority"))
-        assertTrue(OfferBadge.PRIORITY_ACCESS in badges)
-    }
-
-    // -------------------------------------------------------------------------
-    // Multiple badges in a single screen
-    // -------------------------------------------------------------------------
-
-    @Test
-    fun `multiple badges detected across screen texts`() {
-        val screenTexts = listOf(
-            "High-paying offer!",
-            "Must be 21+ to accept order",
-            "Collect cash from customer",
-        )
-        val badges = OfferBadge.findAllBadgesInScreen(screenTexts)
-        assertTrue(OfferBadge.HIGH_PAYING in badges)
-        assertTrue(OfferBadge.AGE_RESTRICTED_21_PLUS in badges)
-        assertTrue(OfferBadge.COLLECT_CASH in badges)
-        assertEquals(3, badges.size)
-    }
-
-    @Test
-    fun `contains badge detected within a longer line`() {
-        // INCLUDES_ALCOHOL uses containsText, so it matches as a substring in a longer line
-        val badges = OfferBadge.findAllBadgesInScreen(listOf("This order, including alcohol, will be delivered"))
-        assertTrue(OfferBadge.INCLUDES_ALCOHOL in badges)
-    }
-
-    @Test
-    fun `exact badge does not match when line has extra content`() {
-        // CONTAINS_RESTRICTED_ITEMS uses exactMatchText — it will NOT match a longer line
-        val badges = OfferBadge.findAllBadgesInScreen(listOf("Contains restricted items, including alcohol"))
-        assertFalse(OfferBadge.CONTAINS_RESTRICTED_ITEMS in badges)
-        // But INCLUDES_ALCOHOL (containsText) does match
-        assertTrue(OfferBadge.INCLUDES_ALCOHOL in badges)
-    }
-
-    // -------------------------------------------------------------------------
-    // No match
-    // -------------------------------------------------------------------------
-
-    @Test
-    fun `no badges on empty screen texts`() {
-        val badges = OfferBadge.findAllBadgesInScreen(emptyList())
-        assertTrue(badges.isEmpty())
-    }
-
-    @Test
-    fun `no badges on irrelevant texts`() {
-        val badges = OfferBadge.findAllBadgesInScreen(listOf("Pickup", "3.2 mi", "\$7.50 Guaranteed"))
-        assertTrue(badges.isEmpty())
-    }
-
-    @Test
-    fun `partial text does not match exact badge`() {
-        // "same store" alone should NOT match "All orders are from the same store"
-        val badges = OfferBadge.findAllBadgesInScreen(listOf("same store"))
-        assertFalse(OfferBadge.ALL_ORDERS_SAME_STORE in badges)
-    }
-
-    // -------------------------------------------------------------------------
-    // Deduplication
-    // -------------------------------------------------------------------------
-
-    @Test
-    fun `same badge text appearing twice returns only one badge instance`() {
-        val screenTexts = listOf("High-paying offer!", "High-paying offer!")
-        val badges = OfferBadge.findAllBadgesInScreen(screenTexts)
-        assertEquals(1, badges.count { it == OfferBadge.HIGH_PAYING })
+    fun `valueOf round-trips the serialized name for every badge`() {
+        // DataTypeConverters persists/restores badges by enum name — guard that contract.
+        OfferBadge.entries.forEach { badge ->
+            assertEquals(badge, OfferBadge.valueOf(badge.name))
+        }
     }
 }

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/model/order/OrderBadgeTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/model/order/OrderBadgeTest.kt
@@ -1,72 +1,21 @@
 package cloud.trotter.dashbuddy.domain.model.order
 
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
 import org.junit.Test
 
+/**
+ * Recognition is data, not code (CLAUDE.md): the order-block text-matching machinery
+ * (`findAllBadgesInOrderBlock` + the `badgeText` column) was superseded by the JSON rule engine
+ * and deleted, so its tests are gone too. `ParsedFieldsFactory` now mints these constants from
+ * parsed booleans; what remains is the enum's role as a stable set of serialized keys.
+ */
 class OrderBadgeTest {
 
     @Test
-    fun `RED_CARD detected by exact text`() {
-        val badges = OrderBadge.findAllBadgesInOrderBlock(listOf("Red Card required"))
-        assertTrue(OrderBadge.RED_CARD in badges)
-    }
-
-    @Test
-    fun `RED_CARD match is case insensitive`() {
-        val badges = OrderBadge.findAllBadgesInOrderBlock(listOf("red card required"))
-        assertTrue(OrderBadge.RED_CARD in badges)
-    }
-
-    @Test
-    fun `LARGE_ORDER detected`() {
-        val badges = OrderBadge.findAllBadgesInOrderBlock(listOf("Large Order - Catering"))
-        assertTrue(OrderBadge.LARGE_ORDER in badges)
-    }
-
-    @Test
-    fun `PIZZA_BAG detected`() {
-        val badges = OrderBadge.findAllBadgesInOrderBlock(listOf("Pizza bag required"))
-        assertTrue(OrderBadge.PIZZA_BAG in badges)
-    }
-
-    @Test
-    fun `ALCOHOL detected`() {
-        val badges = OrderBadge.findAllBadgesInOrderBlock(listOf("Alcohol"))
-        assertTrue(OrderBadge.ALCOHOL in badges)
-    }
-
-    @Test
-    fun `multiple badges detected across order block`() {
-        val orderTexts = listOf("Red Card required", "Pizza bag required")
-        val badges = OrderBadge.findAllBadgesInOrderBlock(orderTexts)
-        assertTrue(OrderBadge.RED_CARD in badges)
-        assertTrue(OrderBadge.PIZZA_BAG in badges)
-        assertEquals(2, badges.size)
-    }
-
-    @Test
-    fun `no badges on empty list`() {
-        assertTrue(OrderBadge.findAllBadgesInOrderBlock(emptyList()).isEmpty())
-    }
-
-    @Test
-    fun `no badges on irrelevant text`() {
-        val badges = OrderBadge.findAllBadgesInOrderBlock(listOf("Pickup", "Shop for items", "3 items"))
-        assertTrue(badges.isEmpty())
-    }
-
-    @Test
-    fun `partial text does not match - exact match only`() {
-        // OrderBadge uses exact matching — "Red Card" alone should NOT match "Red Card required"
-        val badges = OrderBadge.findAllBadgesInOrderBlock(listOf("Red Card"))
-        assertFalse(OrderBadge.RED_CARD in badges)
-    }
-
-    @Test
-    fun `duplicate text returns single badge instance`() {
-        val badges = OrderBadge.findAllBadgesInOrderBlock(listOf("Red Card required", "Red Card required"))
-        assertEquals(1, badges.count { it == OrderBadge.RED_CARD })
+    fun `valueOf round-trips the serialized name for every badge`() {
+        // DataTypeConverters persists/restores badges by enum name — guard that contract.
+        OrderBadge.entries.forEach { badge ->
+            assertEquals(badge, OrderBadge.valueOf(badge.name))
+        }
     }
 }

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/model/order/OrderTypeTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/model/order/OrderTypeTest.kt
@@ -1,68 +1,16 @@
 package cloud.trotter.dashbuddy.domain.model.order
 
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
 import org.junit.Test
 
+/**
+ * Recognition is data, not code (CLAUDE.md): the text-matching helpers
+ * (`fromTypeName`/`orderTypeCount`/`allTypeNames`) were superseded by the JSON rule engine and
+ * deleted, so their tests are gone too. `ParsedFieldsFactory` now resolves the order type from
+ * parse output via the intrinsic [OrderType.valueOf]. What remains is the [OrderType.isShoppingOrder]
+ * flag and the [OrderType.typeName] label.
+ */
 class OrderTypeTest {
-
-    // -------------------------------------------------------------------------
-    // fromTypeName
-    // -------------------------------------------------------------------------
-
-    @Test
-    fun `fromTypeName - exact match returns correct type`() {
-        assertEquals(OrderType.PICKUP, OrderType.fromTypeName("Pickup"))
-        assertEquals(OrderType.RESTAURANT_PICKUP, OrderType.fromTypeName("Restaurant Pickup"))
-        assertEquals(OrderType.SHOP_FOR_ITEMS, OrderType.fromTypeName("Shop for items"))
-        assertEquals(OrderType.RETAIL_PICKUP, OrderType.fromTypeName("Retail pickup"))
-    }
-
-    @Test
-    fun `fromTypeName - match is case insensitive`() {
-        assertEquals(OrderType.PICKUP, OrderType.fromTypeName("pickup"))
-        assertEquals(OrderType.PICKUP, OrderType.fromTypeName("PICKUP"))
-        assertEquals(OrderType.SHOP_FOR_ITEMS, OrderType.fromTypeName("SHOP FOR ITEMS"))
-    }
-
-    @Test
-    fun `fromTypeName - unknown text returns null`() {
-        assertNull(OrderType.fromTypeName("Unknown"))
-        assertNull(OrderType.fromTypeName(""))
-        assertNull(OrderType.fromTypeName("Deliver"))
-    }
-
-    // -------------------------------------------------------------------------
-    // orderTypeCount
-    // -------------------------------------------------------------------------
-
-    @Test
-    fun `orderTypeCount - counts matching type names in list`() {
-        val texts = listOf("Pickup", "Shop for items", "3.2 mi", "\$7.50")
-        assertEquals(2, OrderType.orderTypeCount(texts))
-    }
-
-    @Test
-    fun `orderTypeCount - empty list returns 0`() {
-        assertEquals(0, OrderType.orderTypeCount(emptyList()))
-    }
-
-    @Test
-    fun `orderTypeCount - no matches returns 0`() {
-        assertEquals(0, OrderType.orderTypeCount(listOf("Accept", "Decline", "3.2 mi")))
-    }
-
-    @Test
-    fun `orderTypeCount - multiple of same type counts each occurrence`() {
-        val texts = listOf("Pickup", "Pickup", "Pickup")
-        assertEquals(3, OrderType.orderTypeCount(texts))
-    }
-
-    @Test
-    fun `orderTypeCount - matching is case insensitive`() {
-        val texts = listOf("pickup", "SHOP FOR ITEMS")
-        assertEquals(2, OrderType.orderTypeCount(texts))
-    }
 
     // -------------------------------------------------------------------------
     // isShoppingOrder flag
@@ -86,5 +34,23 @@ class OrderTypeTest {
     @Test
     fun `isShoppingOrder - RETAIL_PICKUP is not a shopping order`() {
         assert(!OrderType.RETAIL_PICKUP.isShoppingOrder)
+    }
+
+    // -------------------------------------------------------------------------
+    // Serialized-key contract (ParsedFieldsFactory resolves via valueOf)
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `valueOf round-trips the serialized name for every type`() {
+        OrderType.entries.forEach { type ->
+            assertEquals(type, OrderType.valueOf(type.name))
+        }
+    }
+
+    @Test
+    fun `every type exposes a non-blank typeName`() {
+        OrderType.entries.forEach { type ->
+            assert(type.typeName.isNotBlank()) { "typeName for $type should be non-blank" }
+        }
     }
 }


### PR DESCRIPTION
## What

Recognition is **data, not code** (CLAUDE.md): the JSON rule engine + `ObservationClassifier` supersede every Kotlin matcher class. This deletes the dead text-matching machinery still hanging off three `:domain` enums — none of it had any production caller (only its own unit tests). Before deleting each symbol I grepped the whole repo (main + test) and confirmed zero production references.

Removed:
- `OfferBadge` — `findAllBadgesInScreen` / `findBadgesInText` companion and the `exactMatchText` / `containsText` / `regexPattern` columns that fed only them.
- `OrderBadge` — `findAllBadgesInOrderBlock` / `findBadgesInText` companion and the `badgeText` column that fed only it.
- `OrderType` — `fromTypeName` / `orderTypeCount` / `allTypeNames` companion.

Kept (still used in production):
- All enum **values** — serialized by `name` and restored via `valueOf` in `core:database` `DataTypeConverters`; `OrderBadge` constants minted by `ParsedFieldsFactory` (`RED_CARD`/`LARGE_ORDER`/`ALCOHOL`); `OrderType` resolved by `OrderType.valueOf(...)` in `ParsedFieldsFactory`, and `OrderType.SHOP_FOR_ITEMS` used by `FlowCardMapper`/`LiveCardBuilder`.
- `OfferBadge.displayName`, `OrderType.typeName`, `OrderType.isShoppingOrder` (per the finding; `isShoppingOrder` is still covered by its tests).

Obsolete test cases that exercised the deleted machinery are removed; the surviving members keep focused coverage (`displayName` non-blank, `isShoppingOrder` flag, `typeName` non-blank, and a `valueOf(name)` round-trip guarding the DB serialized-key contract).

Net: 6 files, +92 / −487.

## Why (audit finding)

> Per CLAUDE.md recognition is "data, not code — no Kotlin matcher classes". These have NO production callers (only their own unit tests), superseded by JSON rules: `OfferBadge.findAllBadgesInScreen/findBadgesInText` + `exactMatchText/containsText/regexPattern` columns; `OrderBadge.findAllBadgesInOrderBlock/findBadgesInText` + `badgeText` column; `OrderType.fromTypeName/orderTypeCount/allTypeNames`. DELETE the dead text-matching machinery and its now-obsolete test cases. KEEP the enum constants and still-used members: `displayName`, `OrderType.typeName/isShoppingOrder`, `OrderType.valueOf` as used by `ParsedFieldsFactory`, and the badge enum values used as serialized/UI-badge keys. Before deleting EACH symbol, grep the whole repo (main source) to confirm zero production callers. Run AllMatchersSuite + the full unit suite — both must stay green.

## Security/privacy posture

No change to the trust boundary. This deletes unused, never-invoked Kotlin matchers; all live recognition continues to run through the JSON rule engine, where the sensitive-screen block and customer-hash gates already live. No recognition coverage is added or downgraded, no PII handling changes, nothing is newly parsed/stored/logged. The serialized-key contract (badges/types persisted by enum `name`) is unchanged and is now guarded by an explicit `valueOf` round-trip test.

## Test

- `./gradlew testDebugUnitTest` (full suite, all modules) — **BUILD SUCCESSFUL**.
- `./gradlew :app:testDebugUnitTest --tests "*AllMatchersSuite*"` (recognition/ruleset regressions) — **BUILD SUCCESSFUL** (the enums feed `ParsedFieldsFactory`, so ran it explicitly).
- The three rewritten domain test classes execute via `:domain:test`: `OfferBadgeTest` (2), `OrderBadgeTest` (1), `OrderTypeTest` (6) — 9 tests, 0 failures, 0 skipped.

Note for central doc reconciliation: this change reinforces (does not contradict) CLAUDE.md's "no Kotlin matcher classes" statement — no CLAUDE.md edit needed.