### PR TITLE
refactor(rules): extract ReDoS guard + consent-key enumeration out of RuleCompiler for auditability (audit #11)

### DIFF
--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/CapabilityEnumerator.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/CapabilityEnumerator.kt
@@ -1,0 +1,89 @@
+package cloud.trotter.dashbuddy.core.pipeline.rules
+
+import cloud.trotter.dashbuddy.domain.action.RuleAction
+import cloud.trotter.dashbuddy.domain.capability.RuleCapability
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+/**
+ * Derives the consent keys for a compiled ruleset (#422/#425). Extracted from
+ * [RuleCompiler] (audit #11) so the security-load-bearing key derivation has a
+ * findable, independently-testable home, depending only on [CompiledRule] /
+ * [Binding] and the [sha256OrNull] SSOT — not on the rest of the compiler.
+ *
+ * The unit of user consent is one [RuleCapability] per (rule, action) whose
+ * well-known target bind name the rule binds. The key content-pins consent to
+ * the binding DEFINITION, so a remote update that repoints a binding forces
+ * re-consent.
+ */
+internal object CapabilityEnumerator {
+
+    /**
+     * Enumerate the app-owned actions a compiled ruleset's bindings enable —
+     * one [RuleCapability] per (rule, action) whose well-known target bind name
+     * ([RuleAction.targetBindName]) the rule binds. Deduped by
+     * [RuleCapability.key] (the same binding compiled into several branches is
+     * one capability). [source] is recorded for provenance only — consent is
+     * uniform regardless of where the rule came from.
+     *
+     * The key hashes `(ruleId, action, the CANONICAL binding definition)` —
+     * pinned to the predicate that selects the node, so repointing the binding
+     * (even with the same bind name) forces re-consent. The execution gate
+     * (#417) looks grants up from this enumeration at fire time; nothing is
+     * threaded through the effect pipeline.
+     */
+    fun enumerate(
+        rules: List<CompiledRule<*>>,
+        source: String,
+    ): List<RuleCapability> {
+        val byKey = LinkedHashMap<String, RuleCapability>()
+        fun consider(ruleId: String, bindings: List<Binding>) {
+            for (binding in bindings) {
+                val action = RuleAction.byTargetBindName[binding.name] ?: continue
+                // Structurally-unambiguous key input (#422): a canonical JSON
+                // object, NOT delimiter-joined fields. Rule ids and bind names
+                // are arbitrary JSON strings (no charset constraint), so JSON
+                // string escaping is what makes the field boundaries exact —
+                // distinct tuples can never collide on the same input.
+                val keyInput = canonicalJson(
+                    buildJsonObject {
+                        put("rule", ruleId)
+                        put("action", action.wire)
+                        put("bind", binding.name)
+                        put("def", binding.defJson ?: JsonNull)
+                    },
+                )
+                val key = sha256OrNull(keyInput) ?: continue // fail closed: unkeyable → not consentable
+                byKey.getOrPut(key) {
+                    RuleCapability(
+                        ruleId = ruleId,
+                        action = action,
+                        targetBindName = binding.name,
+                        key = key,
+                        source = source,
+                    )
+                }
+            }
+        }
+        for (rule in rules) {
+            consider(rule.id, rule.bindings)
+            for (branch in rule.branches) consider(rule.id, branch.bindings)
+        }
+        return byKey.values.toList()
+    }
+
+    /** Stable serialization (recursively sorted object keys) so reordering a
+     *  binding's keys doesn't change its consent key (#422). */
+    private fun canonicalJson(element: JsonElement): String = when (element) {
+        is JsonObject -> element.entries
+            .sortedBy { it.key }
+            .joinToString(",", "{", "}") { "${it.key}:${canonicalJson(it.value)}" }
+        is JsonArray -> element.joinToString(",", "[", "]") { canonicalJson(it) }
+        is JsonPrimitive -> element.toString()
+    }
+}

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RegexSafety.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RegexSafety.kt
@@ -1,0 +1,140 @@
+package cloud.trotter.dashbuddy.core.pipeline.rules
+
+/**
+ * The ONE place rule regexes are turned into [Regex] (#418). Extracted from
+ * [RuleCompiler] (audit #11) so the ReDoS guard has a findable,
+ * independently-testable home — it is the load-time security boundary for the
+ * untrusted-rule path, not incidental compiler plumbing.
+ *
+ * Recognition runs regex on the per-event hot path, and Kotlin/Java [Regex] has
+ * no match timeout, so one pathological pattern hangs the classification thread.
+ * Every regex compiled from rule JSON MUST go through [compileRegex]; nothing in
+ * the rule engine constructs a [Regex] directly.
+ *
+ * The length cap stays owned by [RuleCompiler.MAX_REGEX_LENGTH] (the documented
+ * public constant other modules reference) — this object reads it, it does not
+ * re-declare it.
+ */
+internal object RegexSafety {
+
+    /**
+     * Compile a rule-supplied pattern into a case-insensitive [Regex], enforcing
+     * the length cap and the catastrophic-backtracking guard first. Throws
+     * [RuleCompileException] on an over-long, ReDoS-prone, or invalid pattern.
+     */
+    fun compileRegex(pattern: String): Regex {
+        if (pattern.length > RuleCompiler.MAX_REGEX_LENGTH)
+            throw RuleCompileException(
+                "Regex pattern length ${pattern.length} exceeds " +
+                    "MAX_REGEX_LENGTH=${RuleCompiler.MAX_REGEX_LENGTH}",
+            )
+        assertNoCatastrophicBacktracking(pattern)
+        return try {
+            Regex(pattern, RegexOption.IGNORE_CASE)
+        } catch (e: Exception) {
+            throw RuleCompileException("Invalid regex pattern: '$pattern'", e)
+        }
+    }
+
+    /**
+     * Reject regex prone to catastrophic backtracking at COMPILE time (#418).
+     * Java/Kotlin [Regex] has no match timeout, and recognition runs regex on
+     * the per-event hot path, so one pathological pattern hangs the
+     * classification thread. The dominant exploit class — and the careless-
+     * author footgun — is an UNBOUNDED quantifier applied to a group whose body
+     * already contains an unbounded quantifier: `(a+)+`, `(a*)*`, `(.*)+`,
+     * `(\d+){2,}`. This is a conservative structural check: it accepts linear
+     * patterns like `(\d+)`, `(ab)+`, `\d+\.\d+`, `(?:abc)+` and rejects the
+     * nested-unbounded family.
+     */
+    fun assertNoCatastrophicBacktracking(pattern: String) {
+        // Phase 1: neutralize escapes and char classes, so the structural walk
+        // sees only literal atoms, group parens, and quantifiers. Inside a char
+        // class `[...]` the chars `(`, `)`, `+`, `*` are literal, and an escaped
+        // atom (`\d`) is one logical atom — both would confuse the walk.
+        val cleaned = StringBuilder()
+        var i = 0
+        while (i < pattern.length) {
+            when (pattern[i]) {
+                '\\' -> { cleaned.append('a'); i += 2 } // escaped atom → neutral atom
+                '[' -> {
+                    i++
+                    while (i < pattern.length && pattern[i] != ']') {
+                        if (pattern[i] == '\\') i++
+                        i++
+                    }
+                    i++ // past ']'
+                    cleaned.append('a') // the class is one neutral atom
+                }
+                else -> { cleaned.append(pattern[i]); i++ }
+            }
+        }
+
+        // Phase 2: walk the cleaned pattern; per group, track whether its body
+        // (recursively) contains an unbounded quantifier.
+        val s = cleaned.toString()
+        val containsUnbounded = ArrayDeque<Boolean>()
+        containsUnbounded.addLast(false) // top level
+        var j = 0
+        while (j < s.length) {
+            when (s[j]) {
+                '(' -> { containsUnbounded.addLast(false); j++ }
+                ')' -> {
+                    val bodyUnbounded = containsUnbounded.removeLast()
+                    val qEnd = unboundedQuantifierEnd(s, j + 1)
+                    if (qEnd != -1) {
+                        if (bodyUnbounded) {
+                            throw RuleCompileException(
+                                "Regex '$pattern' nests unbounded quantifiers (ReDoS risk) — " +
+                                    "an unbounded quantifier wraps a group that already repeats unboundedly.",
+                            )
+                        }
+                        // This group is itself unbounded → its parent now is too.
+                        if (containsUnbounded.isNotEmpty()) {
+                            containsUnbounded[containsUnbounded.size - 1] = true
+                        }
+                        j = qEnd
+                    } else {
+                        if (bodyUnbounded && containsUnbounded.isNotEmpty()) {
+                            containsUnbounded[containsUnbounded.size - 1] = true
+                        }
+                        j++
+                    }
+                }
+                '*', '+' -> {
+                    containsUnbounded[containsUnbounded.size - 1] = true
+                    j++
+                    if (j < s.length && s[j] == '?') j++ // lazy
+                }
+                '{' -> {
+                    val qEnd = unboundedQuantifierEnd(s, j)
+                    if (qEnd != -1) {
+                        containsUnbounded[containsUnbounded.size - 1] = true
+                        j = qEnd
+                    } else {
+                        // bounded {n} / {n,m} — skip past it
+                        val close = s.indexOf('}', j)
+                        j = if (close == -1) j + 1 else close + 1
+                    }
+                }
+                else -> j++
+            }
+        }
+    }
+
+    /** End index after an UNBOUNDED quantifier at [pos] (`*`, `+`, `{n,}`), or -1. */
+    private fun unboundedQuantifierEnd(s: String, pos: Int): Int {
+        if (pos >= s.length) return -1
+        return when (s[pos]) {
+            '*', '+' -> if (pos + 1 < s.length && s[pos + 1] == '?') pos + 2 else pos + 1
+            '{' -> {
+                val close = s.indexOf('}', pos)
+                if (close == -1) return -1
+                val body = s.substring(pos + 1, close)
+                if (!body.matches(Regex("\\d+,"))) return -1 // {n,} only; {n} / {n,m} are bounded
+                if (close + 1 < s.length && s[close + 1] == '?') close + 2 else close + 1
+            }
+            else -> -1
+        }
+    }
+}

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompiler.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompiler.kt
@@ -8,9 +8,6 @@ import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.JsonNull
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.doubleOrNull
 import kotlinx.serialization.json.int
@@ -87,53 +84,8 @@ object RuleCompiler {
     fun enumerateCapabilities(
         rules: List<CompiledRule<*>>,
         source: String,
-    ): List<cloud.trotter.dashbuddy.domain.capability.RuleCapability> {
-        val byKey = LinkedHashMap<String, cloud.trotter.dashbuddy.domain.capability.RuleCapability>()
-        fun consider(ruleId: String, bindings: List<Binding>) {
-            for (binding in bindings) {
-                val action = cloud.trotter.dashbuddy.domain.action.RuleAction
-                    .byTargetBindName[binding.name] ?: continue
-                // Structurally-unambiguous key input (#422): a canonical JSON
-                // object, NOT delimiter-joined fields. Rule ids and bind names
-                // are arbitrary JSON strings (no charset constraint), so JSON
-                // string escaping is what makes the field boundaries exact —
-                // distinct tuples can never collide on the same input.
-                val keyInput = canonicalJson(
-                    buildJsonObject {
-                        put("rule", ruleId)
-                        put("action", action.wire)
-                        put("bind", binding.name)
-                        put("def", binding.defJson ?: JsonNull)
-                    },
-                )
-                val key = sha256OrNull(keyInput) ?: continue // fail closed: unkeyable → not consentable
-                byKey.getOrPut(key) {
-                    cloud.trotter.dashbuddy.domain.capability.RuleCapability(
-                        ruleId = ruleId,
-                        action = action,
-                        targetBindName = binding.name,
-                        key = key,
-                        source = source,
-                    )
-                }
-            }
-        }
-        for (rule in rules) {
-            consider(rule.id, rule.bindings)
-            for (branch in rule.branches) consider(rule.id, branch.bindings)
-        }
-        return byKey.values.toList()
-    }
-
-    /** Stable serialization (recursively sorted object keys) so reordering a
-     *  binding's keys doesn't change its consent key (#422). */
-    private fun canonicalJson(element: JsonElement): String = when (element) {
-        is JsonObject -> element.entries
-            .sortedBy { it.key }
-            .joinToString(",", "{", "}") { "${it.key}:${canonicalJson(it.value)}" }
-        is JsonArray -> element.joinToString(",", "[", "]") { canonicalJson(it) }
-        is JsonPrimitive -> element.toString()
-    }
+    ): List<cloud.trotter.dashbuddy.domain.capability.RuleCapability> =
+        CapabilityEnumerator.enumerate(rules, source)
 
     // ==========================================================================
     //  Unified rule compilation
@@ -1274,118 +1226,10 @@ object RuleCompiler {
         else -> json.toString()
     }
 
-    internal fun compileRegex(pattern: String): Regex {
-        if (pattern.length > MAX_REGEX_LENGTH)
-            throw RuleCompileException(
-                "Regex pattern length ${pattern.length} exceeds MAX_REGEX_LENGTH=$MAX_REGEX_LENGTH",
-            )
-        assertNoCatastrophicBacktracking(pattern)
-        return try {
-            Regex(pattern, RegexOption.IGNORE_CASE)
-        } catch (e: Exception) {
-            throw RuleCompileException("Invalid regex pattern: '$pattern'", e)
-        }
-    }
-
     /**
-     * Reject regex prone to catastrophic backtracking at COMPILE time (#418).
-     * Java/Kotlin [Regex] has no match timeout, and recognition runs regex on
-     * the per-event hot path, so one pathological pattern hangs the
-     * classification thread. The dominant exploit class — and the careless-
-     * author footgun — is an UNBOUNDED quantifier applied to a group whose body
-     * already contains an unbounded quantifier: `(a+)+`, `(a*)*`, `(.*)+`,
-     * `(\d+){2,}`. This is a conservative structural check: it accepts linear
-     * patterns like `(\d+)`, `(ab)+`, `\d+\.\d+`, `(?:abc)+` and rejects the
-     * nested-unbounded family.
+     * Compile a rule-supplied regex through the [RegexSafety] guard (length cap
+     * + ReDoS rejection, #418). Kept here as the compiler's call site / public
+     * entry point; the security logic lives in [RegexSafety] (audit #11).
      */
-    internal fun assertNoCatastrophicBacktracking(pattern: String) {
-        // Phase 1: neutralize escapes and char classes, so the structural walk
-        // sees only literal atoms, group parens, and quantifiers. Inside a char
-        // class `[...]` the chars `(`, `)`, `+`, `*` are literal, and an escaped
-        // atom (`\d`) is one logical atom — both would confuse the walk.
-        val cleaned = StringBuilder()
-        var i = 0
-        while (i < pattern.length) {
-            when (pattern[i]) {
-                '\\' -> { cleaned.append('a'); i += 2 } // escaped atom → neutral atom
-                '[' -> {
-                    i++
-                    while (i < pattern.length && pattern[i] != ']') {
-                        if (pattern[i] == '\\') i++
-                        i++
-                    }
-                    i++ // past ']'
-                    cleaned.append('a') // the class is one neutral atom
-                }
-                else -> { cleaned.append(pattern[i]); i++ }
-            }
-        }
-
-        // Phase 2: walk the cleaned pattern; per group, track whether its body
-        // (recursively) contains an unbounded quantifier.
-        val s = cleaned.toString()
-        val containsUnbounded = ArrayDeque<Boolean>()
-        containsUnbounded.addLast(false) // top level
-        var j = 0
-        while (j < s.length) {
-            when (s[j]) {
-                '(' -> { containsUnbounded.addLast(false); j++ }
-                ')' -> {
-                    val bodyUnbounded = containsUnbounded.removeLast()
-                    val qEnd = unboundedQuantifierEnd(s, j + 1)
-                    if (qEnd != -1) {
-                        if (bodyUnbounded) {
-                            throw RuleCompileException(
-                                "Regex '$pattern' nests unbounded quantifiers (ReDoS risk) — " +
-                                    "an unbounded quantifier wraps a group that already repeats unboundedly.",
-                            )
-                        }
-                        // This group is itself unbounded → its parent now is too.
-                        if (containsUnbounded.isNotEmpty()) {
-                            containsUnbounded[containsUnbounded.size - 1] = true
-                        }
-                        j = qEnd
-                    } else {
-                        if (bodyUnbounded && containsUnbounded.isNotEmpty()) {
-                            containsUnbounded[containsUnbounded.size - 1] = true
-                        }
-                        j++
-                    }
-                }
-                '*', '+' -> {
-                    containsUnbounded[containsUnbounded.size - 1] = true
-                    j++
-                    if (j < s.length && s[j] == '?') j++ // lazy
-                }
-                '{' -> {
-                    val qEnd = unboundedQuantifierEnd(s, j)
-                    if (qEnd != -1) {
-                        containsUnbounded[containsUnbounded.size - 1] = true
-                        j = qEnd
-                    } else {
-                        // bounded {n} / {n,m} — skip past it
-                        val close = s.indexOf('}', j)
-                        j = if (close == -1) j + 1 else close + 1
-                    }
-                }
-                else -> j++
-            }
-        }
-    }
-
-    /** End index after an UNBOUNDED quantifier at [pos] (`*`, `+`, `{n,}`), or -1. */
-    private fun unboundedQuantifierEnd(s: String, pos: Int): Int {
-        if (pos >= s.length) return -1
-        return when (s[pos]) {
-            '*', '+' -> if (pos + 1 < s.length && s[pos + 1] == '?') pos + 2 else pos + 1
-            '{' -> {
-                val close = s.indexOf('}', pos)
-                if (close == -1) return -1
-                val body = s.substring(pos + 1, close)
-                if (!body.matches(Regex("\\d+,"))) return -1 // {n,} only; {n} / {n,m} are bounded
-                if (close + 1 < s.length && s[close + 1] == '?') close + 2 else close + 1
-            }
-            else -> -1
-        }
-    }
+    internal fun compileRegex(pattern: String): Regex = RegexSafety.compileRegex(pattern)
 }

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/CapabilityEnumeratorTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/CapabilityEnumeratorTest.kt
@@ -1,0 +1,89 @@
+package cloud.trotter.dashbuddy.core.pipeline.rules
+
+import cloud.trotter.dashbuddy.domain.action.RuleAction
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Focused unit test for the extracted [CapabilityEnumerator] (audit #11). The
+ * end-to-end behaviour through the compiler is covered by
+ * `RuleCapabilityEnumerationTest` (via `RuleCompiler.enumerateCapabilities`);
+ * this hits the extracted object directly so the security-load-bearing
+ * consent-key derivation has its own home — the content-pinned key and the
+ * fail-closed dedup invariants are asserted in isolation.
+ */
+class CapabilityEnumeratorTest {
+
+    private fun compile(rulesJson: String): List<CompiledRule<UiNode>> =
+        RuleCompiler.compileRules(Json.parseToJsonElement(rulesJson).jsonArray, RuleContext.SCREEN)
+
+    private fun declineRule(bindPredicate: String = """{ "hasText": "Decline" }""") = """
+    [{
+      "id": "doordash.screen.offer_popup_test",
+      "priority": 10,
+      "require": { "exists": { "hasText": "Decline" } },
+      "bind": { "declineButton": { "find": $bindPredicate } }
+    }]
+    """.trimIndent()
+
+    @Test
+    fun `binding a well-known target yields one keyed capability attributed to its source`() {
+        val caps = CapabilityEnumerator.enumerate(compile(declineRule()), source = "asset:doordash.json")
+        assertEquals(1, caps.size)
+        val cap = caps.single()
+        assertEquals("doordash.screen.offer_popup_test", cap.ruleId)
+        assertEquals(RuleAction.DECLINE_OFFER, cap.action)
+        assertEquals("declineButton", cap.targetBindName)
+        assertEquals("asset:doordash.json", cap.source)
+        assertTrue("key must be a non-blank hash", cap.key.isNotBlank())
+    }
+
+    @Test
+    fun `the consent key is stable across compiles`() {
+        val a = CapabilityEnumerator.enumerate(compile(declineRule()), "asset:doordash.json").single()
+        val b = CapabilityEnumerator.enumerate(compile(declineRule()), "asset:doordash.json").single()
+        assertEquals(a.key, b.key)
+    }
+
+    @Test
+    fun `repointing the binding predicate changes the key - silent escalation is caught`() {
+        val decline = CapabilityEnumerator.enumerate(
+            compile(declineRule(bindPredicate = """{ "hasText": "Decline" }""")), "s",
+        ).single()
+        val accept = CapabilityEnumerator.enumerate(
+            compile(declineRule(bindPredicate = """{ "hasText": "Accept" }""")), "s",
+        ).single()
+        assertNotEquals(decline.key, accept.key)
+    }
+
+    @Test
+    fun `reordering binding keys does NOT change the consent key`() {
+        val one = CapabilityEnumerator.enumerate(
+            compile(declineRule(bindPredicate = """{ "hasText": "Decline", "hasIdSuffix": "btn" }""")), "s",
+        ).single()
+        val reordered = CapabilityEnumerator.enumerate(
+            compile(declineRule(bindPredicate = """{ "hasIdSuffix": "btn", "hasText": "Decline" }""")), "s",
+        ).single()
+        assertEquals(one.key, reordered.key)
+    }
+
+    @Test
+    fun `non-action bind names produce no capability`() {
+        val rules = compile(
+            """
+            [{
+              "id": "doordash.screen.summary_test",
+              "priority": 11,
+              "require": { "exists": { "hasText": "Decline" } },
+              "bind": { "payField": { "find": { "hasTextContaining": "$" } } }
+            }]
+            """.trimIndent(),
+        )
+        assertTrue(CapabilityEnumerator.enumerate(rules, "s").isEmpty())
+    }
+}

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RegexSafetyTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RegexSafetyTest.kt
@@ -1,0 +1,94 @@
+package cloud.trotter.dashbuddy.core.pipeline.rules
+
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+/**
+ * Focused unit test for the extracted [RegexSafety] guard (audit #11). The
+ * end-to-end ReDoS contract through the compiler is in `RegexReDoSTest` (via
+ * `RuleCompiler.compileRegex`); this hits the extracted object directly so the
+ * security unit has its own home and the catastrophic-backtracking detector is
+ * exercised in isolation — including a pattern that WOULD hang the matcher if it
+ * compiled.
+ */
+class RegexSafetyTest {
+
+    // =========================================================================
+    // assertNoCatastrophicBacktracking — direct
+    // =========================================================================
+
+    @Test
+    fun `nested unbounded quantifier is flagged before any Regex is built`() {
+        try {
+            RegexSafety.assertNoCatastrophicBacktracking("(a+)+")
+            fail("expected RuleCompileException for nested unbounded quantifier")
+        } catch (e: RuleCompileException) {
+            assertTrue(
+                "error should name the ReDoS risk: ${e.message}",
+                e.message!!.contains("ReDoS"),
+            )
+        }
+    }
+
+    @Test
+    fun `linear pattern passes the structural check`() {
+        // Must not throw — a group with an unbounded body that is not itself
+        // quantified is linear.
+        RegexSafety.assertNoCatastrophicBacktracking("(\\d+)\\.(\\d+)")
+    }
+
+    // =========================================================================
+    // compileRegex — the guard short-circuits the hang
+    // =========================================================================
+
+    @Test
+    fun `compileRegex rejects a catastrophic pattern fast instead of hanging at match time`() {
+        // `(a+)+$` is the classic ReDoS exploit: matched against a long run of
+        // 'a' followed by a non-'a', a real Regex backtracks exponentially and
+        // hangs the per-event classification thread (Kotlin Regex has no match
+        // timeout). The guard must reject it at COMPILE time, well under a
+        // second — the assertion below would never return if the engine instead
+        // tried to match the exploit string.
+        val start = System.nanoTime()
+        try {
+            RegexSafety.compileRegex("(a+)+\$")
+            fail("expected RuleCompileException (ReDoS) for (a+)+\$")
+        } catch (e: RuleCompileException) {
+            val elapsedMs = (System.nanoTime() - start) / 1_000_000
+            assertTrue("guard should reject quickly, took ${elapsedMs}ms", elapsedMs < 1_000)
+        }
+    }
+
+    @Test
+    fun `compileRegex returns a usable case-insensitive Regex for a safe pattern`() {
+        val regex = RegexSafety.compileRegex("\\\$\\d+\\.\\d{2}")
+        assertNotNull(regex)
+        assertTrue(regex.containsMatchIn("total \$12.34 due"))
+    }
+
+    @Test
+    fun `compileRegex enforces the length cap owned by RuleCompiler`() {
+        val tooLong = "a".repeat(RuleCompiler.MAX_REGEX_LENGTH + 1)
+        try {
+            RegexSafety.compileRegex(tooLong)
+            fail("expected RuleCompileException for over-long pattern")
+        } catch (e: RuleCompileException) {
+            assertTrue(
+                "error should name the length cap: ${e.message}",
+                e.message!!.contains("MAX_REGEX_LENGTH"),
+            )
+        }
+    }
+
+    @Test
+    fun `compileRegex rejects a syntactically invalid pattern`() {
+        try {
+            RegexSafety.compileRegex("[invalid(")
+            fail("expected RuleCompileException for invalid regex")
+        } catch (e: RuleCompileException) {
+            assertTrue(e.message!!.contains("Invalid regex"))
+        }
+    }
+}


### PR DESCRIPTION
## What

`RuleCompiler.kt` (was 1391 LOC) is cohesive and stays whole. This extracts **only** the two self-contained, security-load-bearing units into their own findable, independently-testable files, and points the compiler's call sites at them:

- **`RegexSafety`** (new) — the ReDoS guard: `compileRegex` + `assertNoCatastrophicBacktracking` + `unboundedQuantifierEnd` (#418). `RuleCompiler.compileRegex` now delegates one line to it.
- **`CapabilityEnumerator`** (new) — the consent-key derivation: `enumerateCapabilities` + `canonicalJson` (#422/#425), depending only on `CompiledRule`/`Binding` and the `sha256OrNull` SSOT. `RuleCompiler.enumerateCapabilities` now delegates.

The move is **behavior-preserving** — the extracted bodies are byte-for-byte identical, only relocated. The public `RuleCompiler` surface (`compileRegex`, `enumerateCapabilities`, `MAX_REGEX_LENGTH`) is unchanged, so existing callers (`TransformRegistry`, `JsonRuleInterpreter`) and existing tests (`RuleCompilerTest`, `RegexReDoSTest`, `RuleCapabilityEnumerationTest`) keep working untouched. Removed three now-orphaned imports from `RuleCompiler` (`JsonNull`, `buildJsonObject`, `kotlinx...put`). `RuleCompiler.kt` drops to ~1235 LOC.

A focused unit test was added for **each** extracted unit, hitting the new objects directly:
- `RegexSafetyTest` — exercises the catastrophic-backtracking detector in isolation, including a `(a+)+$` exploit pattern, and asserts the guard rejects it at compile time (sub-second, so the per-event matcher can never hang on it); also covers the length cap and invalid-pattern paths.
- `CapabilityEnumeratorTest` — asserts the content-pinned consent-key invariants (stable across compiles, changes when the binding predicate is repointed = silent-escalation guard, unaffected by key reordering, no capability for non-action bind names).

## Why (audit finding)

> RuleCompiler.kt (1391 LOC) is COHESIVE and must NOT be broadly split. Extract ONLY the two self-contained, security-load-bearing units so they have a findable, independently-testable home: (a) the ReDoS guard — compileRegex + assertNoCatastrophicBacktracking + unboundedQuantifierEnd (~lines 1277-1390) into a new ReDoSGuard (or RegexSafety) file; (b) the consent-key derivation — enumerateCapabilities + canonicalJson (~lines 87-136, depends only on CompiledRule + the existing Sha256 SSOT) into a CapabilityEnumerator file. Behavior-PRESERVING move; update RuleCompiler call sites to delegate. Add a focused unit test for EACH extracted unit (the ReDoS guard especially — exercise a catastrophic-backtracking pattern). Recognition behavior must not change: run RuleCompilerTest + AllMatchersSuite + the full unit suite.

## Security/privacy posture

This makes the two **load-time security boundaries for the untrusted-rule path** auditable, without weakening either.

- **Trusted:** nothing new — both extracted units are pure compile-time checks over rule JSON, no new inputs, no network, no I/O.
- **Gated / scrubbed (unchanged):**
  - The ReDoS guard (`RegexSafety`) still rejects nested-unbounded patterns *before* any `Regex` is constructed, so a pathological pattern from a (future, forkable #192) rule source can never reach the per-event hot path. The length cap remains the single owner `RuleCompiler.MAX_REGEX_LENGTH` (SSOT); `RegexSafety` reads it rather than re-declaring it. `RegexSafety.compileRegex` is the one path that turns a rule string into a `Regex` — no new `Regex(...)` construction was introduced.
  - The consent-key derivation (`CapabilityEnumerator`) still hashes `(ruleId, action, canonical binding definition)` via the fail-closed `sha256OrNull` SSOT (unkeyable → no capability, i.e. not consentable). The content-pinning that defeats silent escalation is preserved and is now covered by a focused test that directly asserts the key changes when a binding predicate is repointed.
- No change to the trust boundary, the dasher-blocked / customer-hashed split, or any effect/permission gate.

## Test

- `./gradlew testDebugUnitTest` (full suite, all modules) — **BUILD SUCCESSFUL**.
- `./gradlew :app:testDebugUnitTest --tests "*AllMatchersSuite*"` (recognition regressions) — **BUILD SUCCESSFUL** (recognition behavior unchanged).
- Targeted: `RuleCompilerTest`, `RegexReDoSTest`, `RuleCapabilityEnumerationTest` (existing, unchanged) + new `RegexSafetyTest`, `CapabilityEnumeratorTest` — all green.

Note for central reconciliation: `CLAUDE.md` describes `:core:pipeline` as containing "RuleCompiler, Ruleset, JsonRuleInterpreter, observation classifier" — still accurate; `RegexSafety` and `CapabilityEnumerator` are internal helpers within the same rules package and don't change that summary. No `CLAUDE.md` edit made (left to the orchestrator per protocol).