### PR TITLE
refactor(bubble): one PhasePresentation SSOT for statusBadge + PhaseChip (audit #12)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleScreen.kt
@@ -70,7 +70,9 @@ import cloud.trotter.dashbuddy.domain.state.FlowRegion
 import cloud.trotter.dashbuddy.domain.state.Mode
 import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.domain.state.PlatformRegion
+import cloud.trotter.dashbuddy.domain.state.presentation
 import cloud.trotter.dashbuddy.ui.bubble.cards.FlowCardItem
+import cloud.trotter.dashbuddy.ui.formatters.color
 import cloud.trotter.dashbuddy.ui.formatters.getIconResId
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateMapOf
@@ -367,31 +369,20 @@ private fun SessionMetricsActions(
 @Composable
 private fun statusBadge(region: PlatformRegion?, flow: Flow): Pair<String, Color> {
     val c = AppTheme.colors
-    val green = c.good
-    val amber = c.warn
-    val blue = c.stOffer
-    val grey = c.neutral
 
-    // Mode-driven badges
-    if (region?.mode == Mode.Paused) return "PAUSED" to amber
+    // Mode-driven badges — orthogonal to the flow phase (availability axis).
+    if (region?.mode == Mode.Paused) return "PAUSED" to c.warn
     if (region == null || region.mode == Mode.Offline) {
         return when (flow) {
-            Flow.SessionEnded -> "DONE" to grey
-            else -> "OFFLINE" to grey
+            Flow.SessionEnded -> "DONE" to c.neutral
+            else -> "OFFLINE" to c.neutral
         }
     }
 
-    // Flow-driven badges (online)
-    return when (flow) {
-        Flow.Idle -> "WAITING" to green
-        Flow.OfferPresented -> "OFFER" to blue
-        Flow.TaskPickupNavigation -> "PICKUP" to green
-        Flow.TaskPickupArrived -> "AT STORE" to green
-        Flow.TaskDropoffNavigation -> "DELIVERING" to green
-        Flow.TaskDropoffArrived -> "AT DOOR" to green
-        Flow.PostTask -> "DELIVERED" to green
-        Flow.SessionEnded -> "DONE" to grey
-    }
+    // Flow-driven badges (online) — long-form label + color from the phase SSOT
+    // (PhasePresentation in :domain; the chip in FlowCardItem shares the row).
+    val p = flow.presentation
+    return p.longLabel to p.longColor.color(c)
 }
 
 @Composable

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardItem.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardItem.kt
@@ -54,8 +54,12 @@ import cloud.trotter.dashbuddy.core.designsystem.component.AppGaugeRing
 import cloud.trotter.dashbuddy.core.designsystem.theme.AppColors
 import cloud.trotter.dashbuddy.domain.model.cards.FlowCardSnapshot
 import cloud.trotter.dashbuddy.domain.state.PickupActivity
+import cloud.trotter.dashbuddy.domain.state.flowPhase
+import cloud.trotter.dashbuddy.domain.state.presentation
 import cloud.trotter.dashbuddy.domain.model.event.AppEventType
+import cloud.trotter.dashbuddy.ui.formatters.color
 import cloud.trotter.dashbuddy.ui.formatters.displayLabel
+import cloud.trotter.dashbuddy.ui.formatters.phaseBg
 import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluator
 import cloud.trotter.dashbuddy.domain.state.customerDisplayName
 
@@ -158,16 +162,15 @@ private fun CardHeader(
 
 @Composable
 private fun PhaseChip(snapshot: FlowCardSnapshot, isActive: Boolean) {
-    // Semantic brand tokens per AppColors' contract (#358) — the chip now
-    // agrees with statusBadge instead of remapping phases onto M3 roles.
+    // Short-form label + color from the phase-presentation SSOT (#audit-12) —
+    // the same row statusBadge() reads, so the two can no longer drift. The chip
+    // uses the SHORT label/color; the status badge uses the long pair on the same
+    // entry. Background is the family's *Bg variant.
     val c = AppTheme.colors
-    val (label, color, bg) = when (snapshot) {
-        is FlowCardSnapshot.Awaiting -> Triple("AWAIT", c.neutral, c.neutralBg)
-        is FlowCardSnapshot.Offer -> Triple("OFFER", c.stOffer, c.stOfferBg)
-        is FlowCardSnapshot.Pickup -> Triple("PICKUP", c.stPickup, c.stPickupBg)
-        is FlowCardSnapshot.Delivery -> Triple("DROPOFF", c.stPickup, c.stPickupBg)
-        is FlowCardSnapshot.PostTask -> Triple("PAID", c.good, c.goodBg)
-    }
+    val p = snapshot.flowPhase().presentation
+    val label = p.shortLabel
+    val color = p.shortColor.color(c)
+    val bg = p.shortColor.phaseBg(c)
     Surface(
         shape = RoundedCornerShape(4.dp),
         color = if (isActive) bg else bg.copy(alpha = bg.alpha * 0.6f),

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/formatters/PhaseColors.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/formatters/PhaseColors.kt
@@ -1,0 +1,27 @@
+package cloud.trotter.dashbuddy.ui.formatters
+
+import androidx.compose.ui.graphics.Color
+import cloud.trotter.dashbuddy.core.designsystem.theme.AppColors
+import cloud.trotter.dashbuddy.domain.state.PhaseColor
+
+/**
+ * Resolves a domain [PhaseColor] token to its concrete brand [Color] (#audit-12).
+ *
+ * The phase-presentation SSOT lives in pure-Kotlin `:domain` and names color
+ * families as tokens; this is the single UI-side place that binds each token to
+ * an `AppColors` field. The background (`*Bg`) variant is [phaseBg].
+ */
+fun PhaseColor.color(c: AppColors): Color = when (this) {
+    PhaseColor.GOOD -> c.good
+    PhaseColor.NEUTRAL -> c.neutral
+    PhaseColor.OFFER -> c.stOffer
+    PhaseColor.PICKUP -> c.stPickup
+}
+
+/** The `*Bg` (tinted background) variant of a [PhaseColor] family. */
+fun PhaseColor.phaseBg(c: AppColors): Color = when (this) {
+    PhaseColor.GOOD -> c.goodBg
+    PhaseColor.NEUTRAL -> c.neutralBg
+    PhaseColor.OFFER -> c.stOfferBg
+    PhaseColor.PICKUP -> c.stPickupBg
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/PhasePresentation.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/PhasePresentation.kt
@@ -1,0 +1,108 @@
+package cloud.trotter.dashbuddy.domain.state
+
+import cloud.trotter.dashbuddy.domain.model.cards.FlowCardSnapshot
+
+/**
+ * Semantic brand color token for a flow-phase label (#audit-12).
+ *
+ * A plain Kotlin enum — NOT a Compose `Color` — so the presentation SSOT can
+ * live in pure-Kotlin `:domain` while the UI layer resolves each token to the
+ * matching `AppColors` family (`:core:designsystem` has no project deps, so the
+ * concrete colors cannot be referenced here). Each value names a brand family;
+ * the `*Bg` background variant of that family is derived by the resolver.
+ */
+enum class PhaseColor {
+    /** good — the positive/on-track family. */
+    GOOD,
+
+    /** neutral — the muted/idle family. */
+    NEUTRAL,
+
+    /** stOffer — the offer (blue) family. */
+    OFFER,
+
+    /** stPickup — the pickup/dropoff (purple) family. */
+    PICKUP,
+}
+
+/**
+ * The single source of truth for how a canonical [Flow] phase is labelled and
+ * colored in the bubble HUD (#audit-12). Previously two hand-maintained tables
+ * — `statusBadge()` (the TopAppBar status badge) and `PhaseChip()` (the card-
+ * stack chip) — drifted behind only a code comment ("the chip now agrees with
+ * statusBadge"). Both now derive from this one entry per phase.
+ *
+ * The long status badge and the short card chip legitimately differ — both in
+ * wording (e.g. "AT STORE"/"AT DOOR" vs "PICKUP"/"DROPOFF", "DELIVERED" vs
+ * "PAID") and in color (e.g. pickup is `good` on the badge but `stPickup` on
+ * the chip) — so both forms are encoded here as distinct fields; no distinction
+ * is lost.
+ *
+ * @param longLabel  the status-badge wording (TopAppBar).
+ * @param longColor  the status-badge color token.
+ * @param shortLabel the card-chip wording (card stack header).
+ * @param shortColor the card-chip color token (its `*Bg` is derived in the UI).
+ */
+data class PhasePresentation(
+    val longLabel: String,
+    val longColor: PhaseColor,
+    val shortLabel: String,
+    val shortColor: PhaseColor,
+)
+
+/**
+ * The phase → presentation table. Keyed on the canonical [Flow] phase so both
+ * the badge (keyed directly on [Flow]) and the chip (keyed on a card snapshot
+ * that resolves to a [Flow] via [FlowCardSnapshot.flowPhase]) read the same row.
+ *
+ * Values preserve the exact labels/colors that the two former tables produced.
+ */
+val Flow.presentation: PhasePresentation
+    get() = when (this) {
+        Flow.Idle -> PhasePresentation(
+            longLabel = "WAITING", longColor = PhaseColor.GOOD,
+            shortLabel = "AWAIT", shortColor = PhaseColor.NEUTRAL,
+        )
+        Flow.OfferPresented -> PhasePresentation(
+            longLabel = "OFFER", longColor = PhaseColor.OFFER,
+            shortLabel = "OFFER", shortColor = PhaseColor.OFFER,
+        )
+        Flow.TaskPickupNavigation -> PhasePresentation(
+            longLabel = "PICKUP", longColor = PhaseColor.GOOD,
+            shortLabel = "PICKUP", shortColor = PhaseColor.PICKUP,
+        )
+        Flow.TaskPickupArrived -> PhasePresentation(
+            longLabel = "AT STORE", longColor = PhaseColor.GOOD,
+            shortLabel = "PICKUP", shortColor = PhaseColor.PICKUP,
+        )
+        Flow.TaskDropoffNavigation -> PhasePresentation(
+            longLabel = "DELIVERING", longColor = PhaseColor.GOOD,
+            shortLabel = "DROPOFF", shortColor = PhaseColor.PICKUP,
+        )
+        Flow.TaskDropoffArrived -> PhasePresentation(
+            longLabel = "AT DOOR", longColor = PhaseColor.GOOD,
+            shortLabel = "DROPOFF", shortColor = PhaseColor.PICKUP,
+        )
+        Flow.PostTask -> PhasePresentation(
+            longLabel = "DELIVERED", longColor = PhaseColor.GOOD,
+            shortLabel = "PAID", shortColor = PhaseColor.GOOD,
+        )
+        Flow.SessionEnded -> PhasePresentation(
+            longLabel = "DONE", longColor = PhaseColor.NEUTRAL,
+            shortLabel = "DONE", shortColor = PhaseColor.NEUTRAL,
+        )
+    }
+
+/**
+ * The canonical [Flow] phase a card snapshot represents — the chip's key into
+ * [presentation]. Pickup/Delivery cards collapse the nav/arrived sub-states to
+ * the navigation phase because the chip wording is identical across both (only
+ * the status badge distinguishes "PICKUP"/"AT STORE", "DELIVERING"/"AT DOOR").
+ */
+fun FlowCardSnapshot.flowPhase(): Flow = when (this) {
+    is FlowCardSnapshot.Awaiting -> Flow.Idle
+    is FlowCardSnapshot.Offer -> Flow.OfferPresented
+    is FlowCardSnapshot.Pickup -> Flow.TaskPickupNavigation
+    is FlowCardSnapshot.Delivery -> Flow.TaskDropoffNavigation
+    is FlowCardSnapshot.PostTask -> Flow.PostTask
+}

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/state/PhasePresentationTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/state/PhasePresentationTest.kt
@@ -1,0 +1,65 @@
+package cloud.trotter.dashbuddy.domain.state
+
+import cloud.trotter.dashbuddy.domain.model.cards.FlowCardSnapshot
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pins the phase-presentation SSOT (#audit-12) to the exact labels and color
+ * tokens the two former hand-maintained tables — `statusBadge()` and
+ * `PhaseChip()` — produced. This consolidation must not change a single
+ * displayed string or color, so the table is asserted byte-for-byte; a future
+ * edit that drifts a label/color fails here instead of silently diverging.
+ */
+class PhasePresentationTest {
+
+    @Test
+    fun `long-form status-badge labels and colors match the legacy statusBadge table`() {
+        // The exact (label, color) pairs statusBadge() returned for each online flow phase.
+        val expected = mapOf(
+            Flow.Idle to ("WAITING" to PhaseColor.GOOD),
+            Flow.OfferPresented to ("OFFER" to PhaseColor.OFFER),
+            Flow.TaskPickupNavigation to ("PICKUP" to PhaseColor.GOOD),
+            Flow.TaskPickupArrived to ("AT STORE" to PhaseColor.GOOD),
+            Flow.TaskDropoffNavigation to ("DELIVERING" to PhaseColor.GOOD),
+            Flow.TaskDropoffArrived to ("AT DOOR" to PhaseColor.GOOD),
+            Flow.PostTask to ("DELIVERED" to PhaseColor.GOOD),
+            Flow.SessionEnded to ("DONE" to PhaseColor.NEUTRAL),
+        )
+        Flow.entries.forEach { flow ->
+            val p = flow.presentation
+            assertEquals("longLabel for $flow", expected.getValue(flow).first, p.longLabel)
+            assertEquals("longColor for $flow", expected.getValue(flow).second, p.longColor)
+        }
+    }
+
+    @Test
+    fun `short-form chip labels and colors match the legacy PhaseChip table`() {
+        // The exact (label, color) pairs PhaseChip() produced, resolved via flowPhase().
+        val cases = listOf(
+            FlowCardSnapshot.Awaiting(id = "a", phaseStartedAt = 0L) to ("AWAIT" to PhaseColor.NEUTRAL),
+            FlowCardSnapshot.Offer(phaseStartedAt = 0L, offerHash = "h") to ("OFFER" to PhaseColor.OFFER),
+            FlowCardSnapshot.Pickup(phaseStartedAt = 0L, taskId = "t", jobId = "j", storeName = "s")
+                to ("PICKUP" to PhaseColor.PICKUP),
+            FlowCardSnapshot.Delivery(phaseStartedAt = 0L, taskId = "t", jobId = "j")
+                to ("DROPOFF" to PhaseColor.PICKUP),
+            FlowCardSnapshot.PostTask(phaseStartedAt = 0L, jobId = "j")
+                to ("PAID" to PhaseColor.GOOD),
+        )
+        cases.forEach { (snap, expected) ->
+            val p = snap.flowPhase().presentation
+            assertEquals("shortLabel for ${snap::class.simpleName}", expected.first, p.shortLabel)
+            assertEquals("shortColor for ${snap::class.simpleName}", expected.second, p.shortColor)
+        }
+    }
+
+    @Test
+    fun `every Flow phase has a presentation`() {
+        // Exhaustive `when` guarantees this; the assertion documents the contract.
+        Flow.entries.forEach { flow ->
+            val p = flow.presentation
+            assertEquals("non-blank longLabel for $flow", false, p.longLabel.isBlank())
+            assertEquals("non-blank shortLabel for $flow", false, p.shortLabel.isBlank())
+        }
+    }
+}


### PR DESCRIPTION
## What

Collapse the two hand-maintained parallel phase tables in the bubble HUD into one **PhasePresentation SSOT**, with both call sites deriving from it.

- **`:domain` (pure Kotlin) — `state/PhasePresentation.kt`**: a `Flow.presentation` table keyed on the canonical `Flow` phase. Each entry carries **both** forms that legitimately differ:
  - the **long** status-badge form (`longLabel` + `longColor`)
  - the **short** card-chip form (`shortLabel` + `shortColor`)
  Colors are a plain `PhaseColor` token enum (`GOOD`/`NEUTRAL`/`OFFER`/`PICKUP`) so the SSOT stays Compose-free and can live in `:domain`. A `FlowCardSnapshot.flowPhase()` helper maps a card snapshot to its canonical `Flow` (the chip's key).
- **`:app` — `ui/formatters/PhaseColors.kt`**: the single UI-side resolver binding a `PhaseColor` token to its concrete `AppColors` color + `*Bg` background. This is the one place that crosses the token → Compose `Color` boundary (legal: `:app` sees both `:domain` and `:core:designsystem`).
- **`statusBadge()`** (`BubbleScreen.kt`) now returns `flow.presentation.longLabel`/`longColor`. The mode overrides (PAUSED / OFFLINE) stay — they're the orthogonal availability axis, not a flow phase.
- **`PhaseChip()`** (`FlowCardItem.kt`) now reads `shortLabel`/`shortColor` (+ derived `*Bg`).
- New `:domain` test `PhasePresentationTest` pins the full table **byte-for-byte** against the exact labels/colors the two former tables produced.

**No displayed label or color changes** — this is a pure consolidation. Distinctions preserved: `"AT STORE"`/`"AT DOOR"` (badge) vs `"PICKUP"`/`"DROPOFF"` (chip); `"DELIVERED"` (badge) vs `"PAID"` (chip); and the per-surface color split (pickup is `good` on the badge but `stPickup` on the chip).

## Why (audit finding)

> `statusBadge()` (BubbleScreen.kt:367-395) and `FlowCardItem.PhaseChip()` (159-183) are two hand-maintained parallel phase->label/color tables reconciled only by a code comment ("the chip now agrees with statusBadge"). Extract ONE PhasePresentation SSOT (in :domain or :core:designsystem) keyed on the canonical Flow phase, returning (shortLabel, longLabel, semantic AppColors token). Have BOTH call sites derive from it. Where the long status text and short chip text legitimately differ (e.g. "DELIVERING"/"AT DOOR" vs "DROPOFF", "DELIVERED" vs "PAID"), encode BOTH as fields on the single entry — do NOT lose those distinctions. PRESERVE the currently-displayed labels and colors exactly; this is a consolidation, not a visual change.

The finding also flagged the module-boundary constraint: `:core:designsystem` has no project deps, so it can't see the `Flow` type. The SSOT therefore lives in `:domain` keyed on a plain `PhaseColor` token enum, and the token→`AppColors` resolver lives in `:app` where both are visible — the documented dependency direction (`:app → :domain`, `:app → :core:designsystem`) is respected.

## Security/privacy posture

No change to the trust boundary. This touches only HUD label/color presentation derived from already-reduced `AppState`/`FlowCardSnapshot`; it parses no third-party UI, reads no PII, fires no effects, and reaches no network. Reducers/steppers are untouched and stay pure. The phase-presentation map is a pure function of the canonical `Flow`/snapshot (no wall clock); the bubble's ticking time-derived values are unaffected.

## Test

- `./gradlew testDebugUnitTest` — **BUILD SUCCESSFUL** (all modules; `:app` Compose call sites compile, full suite green).
- `./gradlew :domain:test --tests "*PhasePresentationTest*"` — **passing** (the new byte-for-byte table guard).

No recognition rules/parsers changed, so `AllMatchersSuite` was not required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)