### PR TITLE
fix(datastore): use EconomyField.name instead of hardcoded string literals in the user-set write path (audit #5)

### DIFF
--- a/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/settings/AppPreferencesDataSource.kt
+++ b/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/settings/AppPreferencesDataSource.kt
@@ -1,6 +1,7 @@
 package cloud.trotter.dashbuddy.core.datastore.settings
 
 import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.MutablePreferences
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.doublePreferencesKey
@@ -10,6 +11,7 @@ import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import cloud.trotter.dashbuddy.core.datastore.di.AppPreferences
+import cloud.trotter.dashbuddy.domain.evaluation.EconomyField
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
@@ -129,6 +131,19 @@ class AppPreferencesDataSource @Inject constructor(
     // ============================================================================================
     // ENCAPSULATED WRITE ACTIONS
     // ============================================================================================
+
+    /**
+     * Adds [fields] to the persisted user-set marker set. Takes [EconomyField] values
+     * (not raw strings) so the marker names derive from the `:domain` enum — the SSOT
+     * the read path already resolves through [EconomyField.fromPersistedName] — and a
+     * field rename is caught by the compiler instead of silently writing a name no read
+     * can resolve. Must be called from inside a [DataStore.edit] block.
+     */
+    private fun MutablePreferences.markUserSet(vararg fields: EconomyField) {
+        this[Keys.USER_SET_ECONOMY_FIELDS] =
+            (this[Keys.USER_SET_ECONOMY_FIELDS] ?: emptySet()) + fields.map { it.name }
+    }
+
     suspend fun updateGasPrice(price: Float) {
         ds.edit { it[Keys.GAS_PRICE] = price }
     }
@@ -173,8 +188,7 @@ class AppPreferencesDataSource @Inject constructor(
         ds.edit {
             it[Keys.TIRE_SET_COST] = setCost
             it[Keys.TIRE_LIFETIME_MI] = lifetimeMi
-            it[Keys.USER_SET_ECONOMY_FIELDS] = (it[Keys.USER_SET_ECONOMY_FIELDS] ?: emptySet()) +
-                setOf("TIRE_COST", "TIRE_LIFETIME")
+            it.markUserSet(EconomyField.TIRE_COST, EconomyField.TIRE_LIFETIME)
         }
     }
 
@@ -182,8 +196,7 @@ class AppPreferencesDataSource @Inject constructor(
         ds.edit {
             it[Keys.OIL_COST] = cost
             it[Keys.OIL_INTERVAL_MI] = intervalMi
-            it[Keys.USER_SET_ECONOMY_FIELDS] = (it[Keys.USER_SET_ECONOMY_FIELDS] ?: emptySet()) +
-                setOf("OIL_COST", "OIL_INTERVAL")
+            it.markUserSet(EconomyField.OIL_COST, EconomyField.OIL_INTERVAL)
         }
     }
 
@@ -191,8 +204,7 @@ class AppPreferencesDataSource @Inject constructor(
         ds.edit {
             it[Keys.BRAKES_COST] = cost
             it[Keys.BRAKES_INTERVAL_MI] = intervalMi
-            it[Keys.USER_SET_ECONOMY_FIELDS] = (it[Keys.USER_SET_ECONOMY_FIELDS] ?: emptySet()) +
-                setOf("BRAKES_COST", "BRAKES_INTERVAL")
+            it.markUserSet(EconomyField.BRAKES_COST, EconomyField.BRAKES_INTERVAL)
         }
     }
 
@@ -200,8 +212,7 @@ class AppPreferencesDataSource @Inject constructor(
         ds.edit {
             it[Keys.FLUIDS_COST] = cost
             it[Keys.FLUIDS_INTERVAL_MI] = intervalMi
-            it[Keys.USER_SET_ECONOMY_FIELDS] = (it[Keys.USER_SET_ECONOMY_FIELDS] ?: emptySet()) +
-                setOf("FLUIDS_COST", "FLUIDS_INTERVAL")
+            it.markUserSet(EconomyField.FLUIDS_COST, EconomyField.FLUIDS_INTERVAL)
         }
     }
 
@@ -209,8 +220,7 @@ class AppPreferencesDataSource @Inject constructor(
         ds.edit {
             it[Keys.MISC_YEARLY] = yearly
             it[Keys.MISC_YEARLY_MI] = yearlyMi
-            it[Keys.USER_SET_ECONOMY_FIELDS] = (it[Keys.USER_SET_ECONOMY_FIELDS] ?: emptySet()) +
-                setOf("MISC_YEARLY", "MISC_YEARLY_MI")
+            it.markUserSet(EconomyField.MISC_YEARLY, EconomyField.MISC_YEARLY_MI)
         }
     }
 
@@ -219,32 +229,32 @@ class AppPreferencesDataSource @Inject constructor(
             it[Keys.INCLUDE_DEPRECIATION] = include
             it[Keys.PURCHASE_PRICE] = purchasePrice
             it[Keys.TOTAL_LIFETIME_MI] = totalLifetimeMi
-            it[Keys.USER_SET_ECONOMY_FIELDS] = (it[Keys.USER_SET_ECONOMY_FIELDS] ?: emptySet()) +
-                setOf("INCLUDE_DEPRECIATION", "PURCHASE_PRICE", "TOTAL_LIFETIME_MI")
+            it.markUserSet(
+                EconomyField.INCLUDE_DEPRECIATION,
+                EconomyField.PURCHASE_PRICE,
+                EconomyField.TOTAL_LIFETIME_MI,
+            )
         }
     }
 
     suspend fun updateInsuranceDelta(perMonth: Double) {
         ds.edit {
             it[Keys.INSURANCE_DELTA_PER_MONTH] = perMonth
-            it[Keys.USER_SET_ECONOMY_FIELDS] = (it[Keys.USER_SET_ECONOMY_FIELDS] ?: emptySet()) +
-                setOf("INSURANCE_DELTA")
+            it.markUserSet(EconomyField.INSURANCE_DELTA)
         }
     }
 
     suspend fun updateRegistrationDelta(perYear: Double) {
         ds.edit {
             it[Keys.REGISTRATION_DELTA_PER_YEAR] = perYear
-            it[Keys.USER_SET_ECONOMY_FIELDS] = (it[Keys.USER_SET_ECONOMY_FIELDS] ?: emptySet()) +
-                setOf("REGISTRATION_DELTA")
+            it.markUserSet(EconomyField.REGISTRATION_DELTA)
         }
     }
 
     suspend fun updateExpectedAnnualMi(miles: Double) {
         ds.edit {
             it[Keys.EXPECTED_ANNUAL_MI] = miles
-            it[Keys.USER_SET_ECONOMY_FIELDS] = (it[Keys.USER_SET_ECONOMY_FIELDS] ?: emptySet()) +
-                setOf("EXPECTED_ANNUAL_MI")
+            it.markUserSet(EconomyField.EXPECTED_ANNUAL_MI)
         }
     }
 
@@ -253,8 +263,11 @@ class AppPreferencesDataSource @Inject constructor(
             it[Keys.PHONE_PLAN_TOTAL] = total
             it[Keys.PHONE_PLAN_LINES] = lines
             it[Keys.PHONE_BUSINESS_PERCENT] = dashPercent
-            it[Keys.USER_SET_ECONOMY_FIELDS] = (it[Keys.USER_SET_ECONOMY_FIELDS] ?: emptySet()) +
-                setOf("PHONE_PLAN_TOTAL", "PHONE_PLAN_LINES", "PHONE_BUSINESS_PERCENT")
+            it.markUserSet(
+                EconomyField.PHONE_PLAN_TOTAL,
+                EconomyField.PHONE_PLAN_LINES,
+                EconomyField.PHONE_BUSINESS_PERCENT,
+            )
         }
     }
 
@@ -262,8 +275,7 @@ class AppPreferencesDataSource @Inject constructor(
         ds.edit {
             it[Keys.AVG_MIN_PER_MILE] = avgMinPerMile
             it[Keys.BASE_PICKUP_MIN] = basePickupMin
-            it[Keys.USER_SET_ECONOMY_FIELDS] = (it[Keys.USER_SET_ECONOMY_FIELDS] ?: emptySet()) +
-                setOf("AVG_MIN_PER_MILE", "BASE_PICKUP_MIN")
+            it.markUserSet(EconomyField.AVG_MIN_PER_MILE, EconomyField.BASE_PICKUP_MIN)
         }
     }
 


### PR DESCRIPTION
## What

`AppPreferencesDataSource`'s `USER_SET_ECONOMY_FIELDS` write path hardcoded `EconomyField` names as **raw string literals** across 11 methods (e.g. `setOf("TIRE_COST", "TIRE_LIFETIME")`, `setOf("INSURANCE_DELTA")`, `setOf("AVG_MIN_PER_MILE", "BASE_PICKUP_MIN")`). `EconomyField` (`:domain`) is the owner of these names, and the **read** path already routes through `EconomyField.fromPersistedName` — but the write path kept a hand-maintained second copy.

This PR makes the marker write take `EconomyField` *values* (the cleaner option the finding suggested) so renames are compiler-caught:

- Added a private `MutablePreferences.markUserSet(vararg fields: EconomyField)` helper that derives the persisted names from `it.name`. `:core:datastore` already depends on `:domain`, so no new module dependency.
- Replaced all 11 literal `setOf("…")` marker writes with `markUserSet(EconomyField.X, …)`.
- This also collapses the 11 duplicated `(it[USER_SET_ECONOMY_FIELDS] ?: emptySet()) + …` read-modify-write expressions into the one helper.

**No behavior change.** Every literal mapped exactly to its enum name (verified field-by-field), so the persisted set is byte-identical to before.

## Why (audit finding)

> AppPreferencesDataSource USER_SET_ECONOMY_FIELDS write path hardcodes EconomyField names as raw string literals across ~11 methods (e.g. setOf("TIRE_COST","TIRE_LIFETIME"), "INSURANCE_DELTA", setOf("AVG_MIN_PER_MILE","BASE_PICKUP_MIN")). EconomyField (:domain) is the owner; the READ path already routes through fromPersistedName. Replace the write-path literals with EconomyField.X.name (the module already depends on :domain) — or, cleaner, make the marker API take EconomyField values so renames are compiler-caught. ALSO audit the noted drift: the enum lists VEHICLE_CLASS/VEHICLE_MPG/GAS_PRICE as user-settable but updateVehicleClass/updateGasPrice/updateEconomySettings write them WITHOUT marking user-set — if marking them is clearly correct and safe, do it; if uncertain, document it in the PR rather than guessing.

This is the SSOT principle (CLAUDE.md #5): the names now have exactly one owner (`EconomyField`), and the write path derives from it instead of maintaining a parallel hand-typed copy that a rename could silently desync from the read path.

### On the noted drift (VEHICLE_CLASS / VEHICLE_MPG / GAS_PRICE) — deliberately NOT changed

The enum lists `VEHICLE_CLASS`, `VEHICLE_MPG`, `GAS_PRICE` as user-settable, yet `updateVehicleClass` / `updateGasPrice` / `updateEconomySettings` write the values without marking them user-set. Per the finding's guidance ("if uncertain, document it rather than guessing"), I traced the callers and concluded marking them is **NOT clearly safe**, so this PR leaves the marking behavior unchanged:

- **`GAS_PRICE`** — `updateGasPrice` is called by `FuelPriceRepository.fetchAndSaveCurrentGasPrice` on an **automatic EIA-API price refresh** (`core/data/.../fuel/FuelPriceRepository.kt:27`). Marking `GAS_PRICE` user-set there would falsely pin an *auto-fetched* price as user-customized, breaking both the "(default)" badge and the class-default-tracking semantics. Clearly wrong.
- **`VEHICLE_MPG`** — only written via `updateEconomySettings`, a **bundled** write (year/make/model/trim/mpg/isGasAuto/price). The wizard's E-Bike branch calls it with a hardcoded `999f` MPG and `0.0f` price (`WizardViewModel.saveAndFinish`, not user-chosen values), and the bundle also carries the auto-fetched gas price — so marking from inside this method would entangle MPG/GAS_PRICE incorrectly.
- **`VEHICLE_CLASS`** — `updateVehicleClass` *is* always a genuine user choice, so marking it would be semantically correct. But the in-memory wizard already tracks `EconomyField.VEHICLE_CLASS` (`WizardViewModel.updateVehicleClass`, line 175), and the persist path (`AppPreferencesRepository.persistUserSetEconomy`) has **no branch** that writes VEHICLE_CLASS/VEHICLE_MPG/GAS_PRICE markers at all — it only persists the cost/time groups. So wiring VEHICLE_CLASS through correctly is a larger change (new persist branch + deciding the auto-vs-user split for the other two) that exceeds this finding's tight scope and risks the GAS_PRICE/MPG footguns above. Recommend a separate issue if the "(default)" badge for these three is wanted.

## Security/privacy posture

No change to the trust boundary. This touches only how the *names* of already-persisted, on-device, non-PII economy markers are spelled in the write path (an enum reference vs a string literal). No recognition, capture, network, or effects code is involved; nothing new is persisted, logged, or uploaded.

## Test

`./gradlew testDebugUnitTest` — **BUILD SUCCESSFUL** (full multi-module suite, all green). No recognition rules/parsers touched, so `AllMatchersSuite` was not separately required (it also runs as part of the full suite and passed). Behavior is unchanged: each literal maps to its identical enum name, so the persisted `USER_SET_ECONOMY_FIELDS` set is byte-identical.