### PR TITLE
refactor(platform): move display-name/short-name/verb onto the Platform enum SSOT (audit #9)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManager.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManager.kt
@@ -20,6 +20,7 @@ import cloud.trotter.dashbuddy.state.effects.OfferActionReceiver
 import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
 import cloud.trotter.dashbuddy.domain.model.chat.ChatPersona
 import cloud.trotter.dashbuddy.domain.state.OfferIntent
+import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.domain.state.activeSessionId
 import cloud.trotter.dashbuddy.ui.formatters.getIconResId // <-- Your new UI Formatter!
 import cloud.trotter.dashbuddy.ui.formatters.notificationPersona
@@ -95,11 +96,22 @@ class BubbleManager @Inject constructor(
         postMessage("Done $verb!", ChatPersona.Dispatcher)
     }
 
-    private fun sessionVerb(platformName: String?): String = when {
-        platformName.equals("uber", ignoreCase = true) -> "Ubering"
-        platformName.equals("doordash", ignoreCase = true) -> "Dashing"
-        platformName != null -> "driving for $platformName"
-        else -> "driving"
+    /**
+     * The dispatcher chat verb for a session. Resolves the serialized
+     * platform id (the enum constant name [EffectMap] carries, e.g.
+     * `"DoorDash"`) to a [Platform] and reads its [Platform.sessionVerb]
+     * SSOT (audit #9) — no more wire-name string matching leaking into the
+     * UI layer. Platforms without a specific verb fall back to
+     * "driving for <displayName>"; an unresolved or null id to "driving".
+     */
+    private fun sessionVerb(platformName: String?): String {
+        val platform = Platform.fromName(platformName)
+        return when {
+            platform?.sessionVerb != null -> platform.sessionVerb!!
+            platform != null -> "driving for ${platform.displayName}"
+            platformName != null -> "driving for $platformName"
+            else -> "driving"
+        }
     }
 
     fun postMessage(

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleScreen.kt
@@ -282,10 +282,11 @@ private fun StatusBadgeTitle(region: PlatformRegion?, flow: FlowRegion, platform
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(6.dp)
     ) {
-        // Platform label — only shown when a platform is active
+        // Platform label — only shown when a platform is active.
+        // Short name is the SSOT on the Platform enum (audit #9).
         platform?.let {
             Text(
-                text = platformShortName(it),
+                text = it.shortName,
                 style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
                 fontWeight = FontWeight.Medium,
@@ -617,14 +618,6 @@ private fun ModeRow(
 }
 
 
-
-private fun platformShortName(platform: Platform): String = when (platform) {
-    Platform.DoorDash -> "DD"
-    Platform.Uber -> "Uber"
-    Platform.Instacart -> "IC"
-    Platform.WalmartSpark -> "Spark"
-    Platform.Unknown -> ""
-}
 
 fun getPreviewText(html: String): String {
     if (html.isBlank()) return ""

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/PlatformSettingsViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/PlatformSettingsViewModel.kt
@@ -38,7 +38,7 @@ class PlatformSettingsViewModel @Inject constructor(
             monitorablePlatforms.map { platform ->
                 PlatformUiState(
                     platform = platform,
-                    displayName = platform.displayName(),
+                    displayName = platform.displayName,
                     packageName = platform.packageName!!,
                     isEnabled = platform in enabled,
                     isInstalled = isInstalled(platform),
@@ -58,13 +58,5 @@ class PlatformSettingsViewModel @Inject constructor(
         true
     } catch (_: PackageManager.NameNotFoundException) {
         false
-    }
-
-    private fun Platform.displayName(): String = when (this) {
-        Platform.DoorDash -> "DoorDash"
-        Platform.Uber -> "Uber Driver"
-        Platform.Instacart -> "Instacart Shopper"
-        Platform.WalmartSpark -> "Walmart Spark"
-        Platform.Unknown -> "Unknown"
     }
 }

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/Platform.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/Platform.kt
@@ -1,5 +1,7 @@
 package cloud.trotter.dashbuddy.domain.state
 
+import java.util.Locale
+
 /**
  * Identifies a gig platform. Derived from the platform prefix of a rule's
  * `id` field (e.g., `"doordash.screen.offer"` → [DoorDash]).
@@ -7,17 +9,30 @@ package cloud.trotter.dashbuddy.domain.state
  * New platforms are added here and in the corresponding ruleset. The
  * state machine creates a [PlatformRegion] per platform automatically
  * on first observation.
+ *
+ * Display metadata lives here as the SSOT (audit #9): [displayName] (settings
+ * label), [shortName] (bubble HUD badge), and [sessionVerb] (the dispatcher
+ * chat gerund — "Dashing"/"Ubering"; `null` falls back to a generic verb at
+ * the UI edge). No UI/Android types — this is pure copy + a phrase, derived
+ * everywhere it's shown.
  */
-enum class Platform(val wire: String, val packageName: String?) {
-    DoorDash("doordash", "com.doordash.driverapp"),
-    Uber("uber", "com.ubercab.driver"),
-    Instacart("instacart", "com.instacart.shopper"),
-    WalmartSpark("walmart_spark", "com.walmart.spark"),
-    Unknown("_unknown", null),
+enum class Platform(
+    val wire: String,
+    val packageName: String?,
+    val displayName: String,
+    val shortName: String,
+    val sessionVerb: String?,
+) {
+    DoorDash("doordash", "com.doordash.driverapp", "DoorDash", "DD", "Dashing"),
+    Uber("uber", "com.ubercab.driver", "Uber Driver", "Uber", "Ubering"),
+    Instacart("instacart", "com.instacart.shopper", "Instacart Shopper", "IC", null),
+    WalmartSpark("walmart_spark", "com.walmart.spark", "Walmart Spark", "Spark", null),
+    Unknown("_unknown", null, "Unknown", "", null),
     ;
 
     companion object {
         private val byWire = entries.associateBy { it.wire }
+        private val byName = entries.associateBy { it.name.lowercase(Locale.ROOT) }
 
         /** Resolve the platform prefix from a rule id, or [Unknown]. */
         fun fromRuleId(ruleId: String?): Platform {
@@ -26,6 +41,18 @@ enum class Platform(val wire: String, val packageName: String?) {
         }
 
         fun fromWire(wire: String): Platform? = byWire[wire]
+
+        /**
+         * Resolve a platform from a serialized identifier — either an enum
+         * constant name (e.g. `"DoorDash"`, the form [EffectMap] carries via
+         * `platform.name`) or a wire prefix (`"doordash"`). Case-insensitive,
+         * [Locale.ROOT]. Returns `null` when nothing matches so callers can
+         * choose their own fallback.
+         */
+        fun fromName(name: String?): Platform? {
+            val key = name?.lowercase(Locale.ROOT) ?: return null
+            return byName[key] ?: byWire[key]
+        }
 
         private val byPackage = entries
             .filter { it.packageName != null }


### PR DESCRIPTION
## What

Audit finding #9: platform display metadata was hand-maintained in three independent `when`-tables. This PR makes the `Platform` enum (`:domain`) the single source of truth and points all three call sites at it.

- **`Platform` enum** (`domain/.../state/Platform.kt`) — adds three constructor properties: `displayName` (settings label), `shortName` (bubble HUD badge), `sessionVerb` (nullable dispatcher-chat gerund), plus a `fromName(String?)` resolver that accepts either an enum constant name (the form `EffectMap` carries via `platform.name`) or a wire prefix, case-insensitive (`Locale.ROOT`). Pure copy — no Android/UI types enter `:domain`.
- **`PlatformSettingsViewModel`** — reads `platform.displayName`; the local `Platform.displayName()` when-table is deleted.
- **`BubbleScreen.StatusBadgeTitle`** — renders `platform.shortName` directly; the file-level `platformShortName()` when-table is deleted.
- **`BubbleManager.sessionVerb`** — resolves the serialized platform id via `Platform.fromName` and reads `Platform.sessionVerb`, replacing the `equals("doordash"/"uber", ignoreCase = true)` string matching that leaked wire-name constants into the UI layer. Verbless platforms fall back to `"driving for <displayName>"`, an unresolved/null id to `"driving"`.

DoorDash → "Dashing" and Uber → "Ubering" produce byte-identical chat copy to before (the incoming `platformName` is `platform.name`, e.g. `"DoorDash"`, which `fromName` resolves correctly). Wave A #12's `PhasePresentation`-derived `statusBadge`/`PhaseChip` are left fully intact.

## Why (audit finding)

> Platform display metadata is hand-maintained in 3+ when-tables: `PlatformSettingsViewModel` (->"DoorDash"/"Uber Driver"...), `BubbleScreen.platformShortName` (->"DD"/"Uber"/"IC"/"Spark"), `BubbleManager.sessionVerb` (string-matches platform NAMES to verbs).

Three hand-maintained copies of the same per-platform copy are a divergence bug waiting to fire (SSOT principle, CLAUDE.md §5). Adding a platform previously meant touching three files in three modules; now it's one enum row. The `sessionVerb` rewrite also stops wire-name string constants (`"doordash"`/`"uber"`) from leaking into the app/UI layer — recognition matches on the enum, not on re-typed strings.

## Security/privacy posture

No security surface touched. This is a pure display-copy/labeling refactor: no recognition rules, no parsers, no capture, no network, no effect gates, no PII. The strings moved are static platform brand labels and a chat verb — nothing dasher- or customer-derived. `:domain` stays pure Kotlin (the only added import is `java.util.Locale` for the existing locale-safe-machine-ops policy). Module boundaries and the documented dependency graph are unchanged.

## Test

`./gradlew testDebugUnitTest` — BUILD SUCCESSFUL (all modules). No recognition rules/parsers were touched, so the `AllMatchersSuite` golden guard was not required; the existing `EffectMapTest`/`SideEffectEngineTest` cases that exercise `StartSession`/`EndSession` with `"DoorDash"`/`"Uber"` platform names still pass, confirming the verb resolution is behavior-preserving.

Note: this change removes the `BubbleScreen.platformShortName` and `PlatformSettingsViewModel.displayName()` symbols referenced in audit finding #9 — if any doc text names them, it is now stale (no CLAUDE.md edits made here per the fixer protocol; flagging for central doc reconciliation).