### PR TITLE
refactor(rules): split validate-assertion vocabulary into ValidateRegistry (audit #13)

### DIFF
--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompiler.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompiler.kt
@@ -697,7 +697,7 @@ object RuleCompiler {
 
     private fun compileValidateEntry(obj: JsonObject): (Map<String, Any?>) -> ValidateOutcome {
         val assertName = obj["assert"]!!.jsonPrimitive.content
-        TransformRegistry.validateAssertionName(assertName)
+        ValidateRegistry.validateAssertionName(assertName)
         val onFail = obj["onFail"]?.jsonPrimitive?.content ?: "skip"
         // A typo'd onFail used to coerce silently to "skip" (#362).
         if (onFail !in setOf("skip", "dropParsed")) {
@@ -705,7 +705,7 @@ object RuleCompiler {
         }
 
         return { parsed ->
-            val outcome = TransformRegistry.validate(assertName, obj, parsed)
+            val outcome = ValidateRegistry.validate(assertName, obj, parsed)
             when (outcome) {
                 is ValidateOutcome.Pass -> ValidateOutcome.Pass
                 else -> if (onFail == "dropParsed") ValidateOutcome.DropParsed else ValidateOutcome.Skip

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/TransformRegistry.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/TransformRegistry.kt
@@ -4,8 +4,6 @@ import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.double
-import kotlinx.serialization.json.doubleOrNull
 import kotlinx.serialization.json.int
 import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonArray
@@ -18,11 +16,15 @@ import java.time.format.DateTimeFormatter
 import java.util.Locale
 
 /**
- * Closed, engine-owned vocabulary of value transforms and validate assertions.
+ * Closed, engine-owned vocabulary of value transforms.
  *
- * All verbs are compile-time validated: unknown names throw [RuleCompileException]
- * during rule loading, never at match time. Implementations are pure functions
- * over string values — no Android, no UiNode, no IO.
+ * All transform names are compile-time validated: unknown names throw
+ * [RuleCompileException] during rule loading, never at match time. Implementations
+ * are pure functions over string values — no Android, no UiNode, no IO.
+ *
+ * The sibling validate-assertion vocabulary (assertions over the parsed field
+ * map) lives in [ValidateRegistry] — the two share no state and dispatch
+ * independently (audit #13).
  *
  * Matches ADR-0001 v2 specification.
  */
@@ -221,27 +223,6 @@ object TransformRegistry {
     }
 
     // ========================================================================
-    //  Validate assertions
-    // ========================================================================
-
-    // ONE owner for the assertion vocabulary (#404): the dispatch map drives
-    // both validate() and the compile-time name check — adding an assertion
-    // is exactly one entry here plus its implementation.
-    private val knownAssertions: Map<String, (JsonObject, Map<String, Any?>) -> ValidateOutcome> = mapOf(
-        "sumApproxEquals" to ::validateSumApproxEquals,
-        "fieldsLe" to ::validateFieldsLe,
-        "fieldsGe" to ::validateFieldsGe,
-        "fieldNotNull" to ::validateFieldNotNull,
-        "fieldEquals" to ::validateFieldEquals,
-    )
-
-    fun validate(name: String, args: JsonObject, parsed: Map<String, Any?>): ValidateOutcome {
-        val assertion = knownAssertions[name]
-            ?: throw RuleCompileException("Unknown validate assertion: '$name'")
-        return assertion(args, parsed)
-    }
-
-    // ========================================================================
     //  Compile-time validation
     // ========================================================================
 
@@ -323,10 +304,6 @@ object TransformRegistry {
                 obj["then"]?.let { validateTransformSpec(it) }
             }
         }
-    }
-
-    fun validateAssertionName(name: String) {
-        if (name !in knownAssertions) throw RuleCompileException("Unknown validate assertion: '$name'")
     }
 
     // ========================================================================
@@ -458,105 +435,4 @@ object TransformRegistry {
         }
         return text.trim()
     }
-
-    // ========================================================================
-    //  Validate assertion implementations
-    // ========================================================================
-
-    /**
-     * Assert that the sum of named fields approximately equals a target field.
-     * ```json
-     * { "assert": "sumApproxEquals", "fields": ["appPay","customerTips"],
-     *   "target": "totalPay", "tolerance": 0.02 }
-     * ```
-     */
-    private fun validateSumApproxEquals(args: JsonObject, parsed: Map<String, Any?>): ValidateOutcome {
-        val fields = args["fields"]!!.jsonArray.map { it.jsonPrimitive.content }
-        val target = args["target"]!!.jsonPrimitive.content
-        val tolerance = args["tolerance"]?.jsonPrimitive?.doubleOrNull ?: 0.02
-
-        val sum = fields.sumOf { (parsed[it] as? Number)?.toDouble() ?: return ValidateOutcome.Pass }
-        val targetVal = (parsed[target] as? Number)?.toDouble() ?: return ValidateOutcome.Pass
-
-        return if (kotlin.math.abs(sum - targetVal) <= tolerance) ValidateOutcome.Pass
-        else ValidateOutcome.Skip
-    }
-
-    /**
-     * Assert that field A <= field B.
-     * ```json
-     * { "assert": "fieldsLe", "field": "totalEarnings", "le": "weeklyEarnings", "tolerance": 0.02 }
-     * ```
-     */
-    private fun validateFieldsLe(args: JsonObject, parsed: Map<String, Any?>): ValidateOutcome {
-        val fieldName = args["field"]!!.jsonPrimitive.content
-        val leName = args["le"]!!.jsonPrimitive.content
-        val tolerance = args["tolerance"]?.jsonPrimitive?.doubleOrNull ?: 0.0
-
-        val fieldVal = (parsed[fieldName] as? Number)?.toDouble() ?: return ValidateOutcome.Pass
-        val leVal = (parsed[leName] as? Number)?.toDouble() ?: return ValidateOutcome.Pass
-
-        return if (fieldVal <= leVal + tolerance) ValidateOutcome.Pass
-        else ValidateOutcome.DropParsed
-    }
-
-    /**
-     * Assert that field A >= field B.
-     */
-    private fun validateFieldsGe(args: JsonObject, parsed: Map<String, Any?>): ValidateOutcome {
-        val fieldName = args["field"]!!.jsonPrimitive.content
-        val geName = args["ge"]!!.jsonPrimitive.content
-        val tolerance = args["tolerance"]?.jsonPrimitive?.doubleOrNull ?: 0.0
-
-        val fieldVal = (parsed[fieldName] as? Number)?.toDouble() ?: return ValidateOutcome.Pass
-        val geVal = (parsed[geName] as? Number)?.toDouble() ?: return ValidateOutcome.Pass
-
-        return if (fieldVal >= geVal - tolerance) ValidateOutcome.Pass
-        else ValidateOutcome.DropParsed
-    }
-
-    /**
-     * Assert that a field is non-null.
-     */
-    private fun validateFieldNotNull(args: JsonObject, parsed: Map<String, Any?>): ValidateOutcome {
-        val fieldName = args["field"]!!.jsonPrimitive.content
-        return if (parsed[fieldName] != null) ValidateOutcome.Pass
-        else ValidateOutcome.Skip
-    }
-
-    /**
-     * Assert that a field equals a specific value.
-     */
-    private fun validateFieldEquals(args: JsonObject, parsed: Map<String, Any?>): ValidateOutcome {
-        val fieldName = args["field"]!!.jsonPrimitive.content
-        val expected = args["value"]
-
-        val actual = parsed[fieldName]
-        val matches = when {
-            expected is JsonPrimitive && expected.isString ->
-                actual?.toString() == expected.content
-            expected is JsonPrimitive && expected.doubleOrNull != null ->
-                (actual as? Number)?.toDouble() == expected.double
-            expected is JsonPrimitive && expected.content == "true" ->
-                actual == true
-            expected is JsonPrimitive && expected.content == "false" ->
-                actual == false
-            else -> actual?.toString() == expected?.toString()
-        }
-
-        return if (matches) ValidateOutcome.Pass else ValidateOutcome.Skip
-    }
-}
-
-/**
- * Outcome of a validate assertion.
- *
- * - [Pass] — assertion holds, continue with parsed fields.
- * - [Skip] — assertion fails, fall through to next branch.
- * - [DropParsed] — assertion fails, keep the match but reset parsed to None.
- */
-sealed class ValidateOutcome {
-    data object Pass : ValidateOutcome()
-    data object Skip : ValidateOutcome()
-    data object DropParsed : ValidateOutcome()
 }

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/ValidateRegistry.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/ValidateRegistry.kt
@@ -1,0 +1,152 @@
+package cloud.trotter.dashbuddy.core.pipeline.rules
+
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.double
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Closed, engine-owned vocabulary of validate assertions.
+ *
+ * Split out of [TransformRegistry] (audit #13): value transforms and
+ * validate-assertions are two independently-dispatched vocabularies that share
+ * no state, so each owns its own object. Assertions reason over the *parsed
+ * field map* and return a [ValidateOutcome]; value transforms reason over a
+ * single string value.
+ *
+ * All assertion names are compile-time validated: unknown names throw
+ * [RuleCompileException] during rule loading, never at match time. Implementations
+ * are pure functions over the parsed map — no Android, no UiNode, no IO.
+ *
+ * Matches ADR-0001 v2 specification.
+ */
+object ValidateRegistry {
+
+    // ONE owner for the assertion vocabulary (#404): the dispatch map drives
+    // both validate() and the compile-time name check — adding an assertion
+    // is exactly one entry here plus its implementation.
+    private val knownAssertions: Map<String, (JsonObject, Map<String, Any?>) -> ValidateOutcome> = mapOf(
+        "sumApproxEquals" to ::validateSumApproxEquals,
+        "fieldsLe" to ::validateFieldsLe,
+        "fieldsGe" to ::validateFieldsGe,
+        "fieldNotNull" to ::validateFieldNotNull,
+        "fieldEquals" to ::validateFieldEquals,
+    )
+
+    fun validate(name: String, args: JsonObject, parsed: Map<String, Any?>): ValidateOutcome {
+        val assertion = knownAssertions[name]
+            ?: throw RuleCompileException("Unknown validate assertion: '$name'")
+        return assertion(args, parsed)
+    }
+
+    /**
+     * Validate at compile time that a validate-assertion name is known.
+     * Call during rule loading to fail fast on typos.
+     */
+    fun validateAssertionName(name: String) {
+        if (name !in knownAssertions) throw RuleCompileException("Unknown validate assertion: '$name'")
+    }
+
+    // ========================================================================
+    //  Validate assertion implementations
+    // ========================================================================
+
+    /**
+     * Assert that the sum of named fields approximately equals a target field.
+     * ```json
+     * { "assert": "sumApproxEquals", "fields": ["appPay","customerTips"],
+     *   "target": "totalPay", "tolerance": 0.02 }
+     * ```
+     */
+    private fun validateSumApproxEquals(args: JsonObject, parsed: Map<String, Any?>): ValidateOutcome {
+        val fields = args["fields"]!!.jsonArray.map { it.jsonPrimitive.content }
+        val target = args["target"]!!.jsonPrimitive.content
+        val tolerance = args["tolerance"]?.jsonPrimitive?.doubleOrNull ?: 0.02
+
+        val sum = fields.sumOf { (parsed[it] as? Number)?.toDouble() ?: return ValidateOutcome.Pass }
+        val targetVal = (parsed[target] as? Number)?.toDouble() ?: return ValidateOutcome.Pass
+
+        return if (kotlin.math.abs(sum - targetVal) <= tolerance) ValidateOutcome.Pass
+        else ValidateOutcome.Skip
+    }
+
+    /**
+     * Assert that field A <= field B.
+     * ```json
+     * { "assert": "fieldsLe", "field": "totalEarnings", "le": "weeklyEarnings", "tolerance": 0.02 }
+     * ```
+     */
+    private fun validateFieldsLe(args: JsonObject, parsed: Map<String, Any?>): ValidateOutcome {
+        val fieldName = args["field"]!!.jsonPrimitive.content
+        val leName = args["le"]!!.jsonPrimitive.content
+        val tolerance = args["tolerance"]?.jsonPrimitive?.doubleOrNull ?: 0.0
+
+        val fieldVal = (parsed[fieldName] as? Number)?.toDouble() ?: return ValidateOutcome.Pass
+        val leVal = (parsed[leName] as? Number)?.toDouble() ?: return ValidateOutcome.Pass
+
+        return if (fieldVal <= leVal + tolerance) ValidateOutcome.Pass
+        else ValidateOutcome.DropParsed
+    }
+
+    /**
+     * Assert that field A >= field B.
+     */
+    private fun validateFieldsGe(args: JsonObject, parsed: Map<String, Any?>): ValidateOutcome {
+        val fieldName = args["field"]!!.jsonPrimitive.content
+        val geName = args["ge"]!!.jsonPrimitive.content
+        val tolerance = args["tolerance"]?.jsonPrimitive?.doubleOrNull ?: 0.0
+
+        val fieldVal = (parsed[fieldName] as? Number)?.toDouble() ?: return ValidateOutcome.Pass
+        val geVal = (parsed[geName] as? Number)?.toDouble() ?: return ValidateOutcome.Pass
+
+        return if (fieldVal >= geVal - tolerance) ValidateOutcome.Pass
+        else ValidateOutcome.DropParsed
+    }
+
+    /**
+     * Assert that a field is non-null.
+     */
+    private fun validateFieldNotNull(args: JsonObject, parsed: Map<String, Any?>): ValidateOutcome {
+        val fieldName = args["field"]!!.jsonPrimitive.content
+        return if (parsed[fieldName] != null) ValidateOutcome.Pass
+        else ValidateOutcome.Skip
+    }
+
+    /**
+     * Assert that a field equals a specific value.
+     */
+    private fun validateFieldEquals(args: JsonObject, parsed: Map<String, Any?>): ValidateOutcome {
+        val fieldName = args["field"]!!.jsonPrimitive.content
+        val expected = args["value"]
+
+        val actual = parsed[fieldName]
+        val matches = when {
+            expected is JsonPrimitive && expected.isString ->
+                actual?.toString() == expected.content
+            expected is JsonPrimitive && expected.doubleOrNull != null ->
+                (actual as? Number)?.toDouble() == expected.double
+            expected is JsonPrimitive && expected.content == "true" ->
+                actual == true
+            expected is JsonPrimitive && expected.content == "false" ->
+                actual == false
+            else -> actual?.toString() == expected?.toString()
+        }
+
+        return if (matches) ValidateOutcome.Pass else ValidateOutcome.Skip
+    }
+}
+
+/**
+ * Outcome of a validate assertion.
+ *
+ * - [Pass] — assertion holds, continue with parsed fields.
+ * - [Skip] — assertion fails, fall through to next branch.
+ * - [DropParsed] — assertion fails, keep the match but reset parsed to None.
+ */
+sealed class ValidateOutcome {
+    data object Pass : ValidateOutcome()
+    data object Skip : ValidateOutcome()
+    data object DropParsed : ValidateOutcome()
+}

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/ValidateRegistryTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/ValidateRegistryTest.kt
@@ -1,0 +1,173 @@
+package cloud.trotter.dashbuddy.core.pipeline.rules
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+/**
+ * Direct unit coverage for [ValidateRegistry] — the validate-assertion vocabulary
+ * split out of [TransformRegistry] (audit #13).
+ *
+ * Prior to the split these assertions were only exercised indirectly (through the
+ * RuleCompiler + Ruleset match path). These tests pin each assertion's outcome
+ * mapping (Pass / Skip / DropParsed) and the fail-fast on an unknown name.
+ */
+class ValidateRegistryTest {
+
+    private fun args(json: String) = Json.parseToJsonElement(json).jsonObject
+
+    // ── Dispatch / name validation ──────────────────────────────────────────
+
+    @Test
+    fun `validateAssertionName accepts every known assertion`() {
+        listOf("sumApproxEquals", "fieldsLe", "fieldsGe", "fieldNotNull", "fieldEquals")
+            .forEach { ValidateRegistry.validateAssertionName(it) }
+    }
+
+    @Test
+    fun `validateAssertionName rejects an unknown assertion`() {
+        val ex = assertThrows(RuleCompileException::class.java) {
+            ValidateRegistry.validateAssertionName("notAnAssertion")
+        }
+        assertEquals(true, ex.message?.contains("notAnAssertion"))
+    }
+
+    @Test
+    fun `validate throws on an unknown assertion name`() {
+        assertThrows(RuleCompileException::class.java) {
+            ValidateRegistry.validate("notAnAssertion", args("""{}"""), emptyMap())
+        }
+    }
+
+    // ── sumApproxEquals ─────────────────────────────────────────────────────
+
+    @Test
+    fun `sumApproxEquals passes within tolerance`() {
+        val out = ValidateRegistry.validate(
+            "sumApproxEquals",
+            args("""{ "fields": ["a","b"], "target": "t", "tolerance": 0.02 }"""),
+            mapOf("a" to 4.0, "b" to 6.0, "t" to 10.01),
+        )
+        assertEquals(ValidateOutcome.Pass, out)
+    }
+
+    @Test
+    fun `sumApproxEquals skips outside tolerance`() {
+        val out = ValidateRegistry.validate(
+            "sumApproxEquals",
+            args("""{ "fields": ["a","b"], "target": "t", "tolerance": 0.02 }"""),
+            mapOf("a" to 4.0, "b" to 6.0, "t" to 11.0),
+        )
+        assertEquals(ValidateOutcome.Skip, out)
+    }
+
+    @Test
+    fun `sumApproxEquals passes (no-op) when a field is missing`() {
+        // Missing inputs can't be checked, so the assertion is a no-op (Pass).
+        val out = ValidateRegistry.validate(
+            "sumApproxEquals",
+            args("""{ "fields": ["a","b"], "target": "t" }"""),
+            mapOf("a" to 4.0, "t" to 10.0),
+        )
+        assertEquals(ValidateOutcome.Pass, out)
+    }
+
+    // ── fieldsLe / fieldsGe ─────────────────────────────────────────────────
+
+    @Test
+    fun `fieldsLe passes when within bound and drops parsed when violated`() {
+        val pass = ValidateRegistry.validate(
+            "fieldsLe",
+            args("""{ "field": "a", "le": "b" }"""),
+            mapOf("a" to 5.0, "b" to 10.0),
+        )
+        assertEquals(ValidateOutcome.Pass, pass)
+
+        val drop = ValidateRegistry.validate(
+            "fieldsLe",
+            args("""{ "field": "a", "le": "b" }"""),
+            mapOf("a" to 15.0, "b" to 10.0),
+        )
+        assertEquals(ValidateOutcome.DropParsed, drop)
+    }
+
+    @Test
+    fun `fieldsGe passes when within bound and drops parsed when violated`() {
+        val pass = ValidateRegistry.validate(
+            "fieldsGe",
+            args("""{ "field": "a", "ge": "b" }"""),
+            mapOf("a" to 12.0, "b" to 10.0),
+        )
+        assertEquals(ValidateOutcome.Pass, pass)
+
+        val drop = ValidateRegistry.validate(
+            "fieldsGe",
+            args("""{ "field": "a", "ge": "b" }"""),
+            mapOf("a" to 5.0, "b" to 10.0),
+        )
+        assertEquals(ValidateOutcome.DropParsed, drop)
+    }
+
+    // ── fieldNotNull ────────────────────────────────────────────────────────
+
+    @Test
+    fun `fieldNotNull passes when present, skips when absent`() {
+        val present = ValidateRegistry.validate(
+            "fieldNotNull",
+            args("""{ "field": "f" }"""),
+            mapOf("f" to "value"),
+        )
+        assertEquals(ValidateOutcome.Pass, present)
+
+        val absent = ValidateRegistry.validate(
+            "fieldNotNull",
+            args("""{ "field": "f" }"""),
+            mapOf("f" to null),
+        )
+        assertEquals(ValidateOutcome.Skip, absent)
+    }
+
+    // ── fieldEquals ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `fieldEquals matches a string value`() {
+        val out = ValidateRegistry.validate(
+            "fieldEquals",
+            args("""{ "field": "f", "value": "accept" }"""),
+            mapOf("f" to "accept"),
+        )
+        assertEquals(ValidateOutcome.Pass, out)
+    }
+
+    @Test
+    fun `fieldEquals matches a numeric value`() {
+        val out = ValidateRegistry.validate(
+            "fieldEquals",
+            args("""{ "field": "n", "value": 3 }"""),
+            mapOf("n" to 3),
+        )
+        assertEquals(ValidateOutcome.Pass, out)
+    }
+
+    @Test
+    fun `fieldEquals matches a boolean value`() {
+        val out = ValidateRegistry.validate(
+            "fieldEquals",
+            args("""{ "field": "b", "value": true }"""),
+            mapOf("b" to true),
+        )
+        assertEquals(ValidateOutcome.Pass, out)
+    }
+
+    @Test
+    fun `fieldEquals skips on mismatch`() {
+        val out = ValidateRegistry.validate(
+            "fieldEquals",
+            args("""{ "field": "f", "value": "accept" }"""),
+            mapOf("f" to "decline"),
+        )
+        assertEquals(ValidateOutcome.Skip, out)
+    }
+}


### PR DESCRIPTION
## What

`TransformRegistry` (562 LOC) held **two independently-dispatched vocabularies that share no state**:

- **value transforms** — `apply` / `chain` / `applyAny`, the `known*Transforms` sets, `validateTransform*`, the parser impls, and the `TransformClock` / `withClock` scope; reason over a single string value.
- **validate-assertions** — `knownAssertions`, `validate` / `validateAssertionName`, the five `validateXxx` impls, and the top-level `ValidateOutcome` sealed class; reason over the *parsed field map* and return a `ValidateOutcome`.

This PR moves the VALIDATE half into its own `object ValidateRegistry` (same package, `core/pipeline/.../rules/`) and relocates the `ValidateOutcome` sealed class alongside it. `TransformClock` / `withClock` stay with the TRANSFORM half (they anchor time transforms to the observation instant, #343). `RuleCompiler`'s two validate call sites (`compileValidateEntry`) now route through `ValidateRegistry`.

Pure mechanical move — **no behavior change**: identical dispatch map, identical exception messages, identical `Pass` / `Skip` / `DropParsed` outcomes. Because everything lives in one package, no other call site (`Ruleset`, `CompiledRules`, `ObservationClassifier`) needed an import change — `ObservationClassifier` only uses `TransformRegistry.withClock`, which is untouched.

Also dropped the now-unused `double` / `doubleOrNull` imports from `TransformRegistry`, and added `ValidateRegistryTest` so the assertion path has **direct** unit coverage (previously only exercised indirectly via the RuleCompiler + Ruleset match path): the unknown-name fail-fast plus each assertion's Pass/Skip/DropParsed mapping.

Integrated on top of latest `master` (Wave A #11's ReDoS-guard / CapabilityEnumerator extraction already merged — the `RuleCompiler.compileRegex` call used by the `regex` transform is unaffected).

## Why (audit finding)

Audit finding #13: `TransformRegistry` mixed two unrelated dispatch vocabularies in one 562-LOC file. Single-responsibility / clean-code: each vocabulary should own its own small, focused unit. SSOT is preserved — the assertion dispatch map remains the one owner of the validate vocabulary, it just moved file. No third copy introduced.

## Security/privacy posture

No change to the trust boundary. This is a structural move within the on-device rule engine:
- **Trusted/untrusted unchanged**: the validate assertions still operate only on the already-parsed field map; they read no third-party UI directly and perform no IO/network/Android calls (pure functions over `Map<String, Any?>`).
- **Compile-time fail-fast preserved**: an unknown assertion name still throws `RuleCompileException` at rule-load time (now via `ValidateRegistry.validateAssertionName`), never at match time — fail-closed on bad rule data.
- **Sensitive-screen blocking, PII hashing, capability gates** are all in other layers and are untouched. No secrets logged. The `sha256` transform stays in `TransformRegistry`.

## Test

- `./gradlew testDebugUnitTest` — **BUILD SUCCESSFUL** (full suite, all modules).
- `./gradlew :app:testDebugUnitTest --tests "*AllMatchersSuite*"` — **BUILD SUCCESSFUL** (recognition regressions: golden guard + parse-output golden + ruleset + classifier).
- New `ValidateRegistryTest` (12 cases) covering the unknown-name throw and every assertion's outcome; `RuleCompilerTest` / `TransformHardeningTest` / `TransformRegistryTest` re-run green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)