### PR TITLE
refactor(cards): move task realized-rate economics out of the composable into snapshot/domain (audit #6)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardItem.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardItem.kt
@@ -53,6 +53,7 @@ import cloud.trotter.dashbuddy.core.designsystem.component.AppChip
 import cloud.trotter.dashbuddy.core.designsystem.component.AppGaugeRing
 import cloud.trotter.dashbuddy.core.designsystem.theme.AppColors
 import cloud.trotter.dashbuddy.domain.model.cards.FlowCardSnapshot
+import cloud.trotter.dashbuddy.domain.model.cards.TaskEconomics
 import cloud.trotter.dashbuddy.domain.state.PickupActivity
 import cloud.trotter.dashbuddy.domain.state.flowPhase
 import cloud.trotter.dashbuddy.domain.state.presentation
@@ -501,7 +502,7 @@ private fun PickupBody(snap: FlowCardSnapshot.Pickup, isActive: Boolean) {
         primary = snap.storeName,
         netPay = snap.netPay,
         estMinutes = snap.estMinutes,
-        distanceMiles = snap.distanceMiles,
+        perMile = snap.perMile,
         confirmedAt = snap.confirmedAt,
         itemsShopped = snap.itemsShopped,
         itemsRemaining = snap.itemsRemaining,
@@ -522,7 +523,7 @@ private fun DeliveryBody(snap: FlowCardSnapshot.Delivery, isActive: Boolean) {
         primary = customerDisplayName(snap.customerHash),
         netPay = snap.netPay,
         estMinutes = snap.estMinutes,
-        distanceMiles = snap.distanceMiles,
+        perMile = snap.perMile,
         confirmedAt = null,
         itemsShopped = null,
         itemsRemaining = null,
@@ -549,7 +550,7 @@ private fun TaskBody(
     primary: String,
     netPay: Double?,
     estMinutes: Double?,
-    distanceMiles: Double?,
+    perMile: Double?,
     confirmedAt: Long?,
     itemsShopped: Int?,
     itemsRemaining: Int?,
@@ -560,10 +561,10 @@ private fun TaskBody(
     val arrived = arrivedAt != null
     val verb = if (isDrop) "deliver" else "pickup"
     val overdue = deadlineMillis != null && now > deadlineMillis
-    val hourly = projectedHourly(netPay, estMinutes, deadlineMillis, now)
-    // Fixed $/mi efficiency off the job (#503 deliverable 2) — distance doesn't erode like time,
-    // so it's the steady companion to the realized $/hr; shown as the metric's sub line.
-    val perMile = if (netPay != null && distanceMiles != null && distanceMiles > 0.0) netPay / distanceMiles else null
+    // Live realized $/hr — ticks with `now` (erodes past the deadline), so it is recomputed here
+    // each tick from the snapshot's anchors via the TaskEconomics SSOT, never frozen at reduce
+    // time. The fixed $/mi companion ([perMile]) is precomputed on the snapshot.
+    val hourly = TaskEconomics.projectedHourly(netPay, estMinutes, deadlineMillis, now)
 
     Column(
         modifier = Modifier.fillMaxWidth(),
@@ -636,7 +637,7 @@ private fun TaskBody(
         Caption(caption)
 
         // ---- drop-it floor banner: overdue AND the rate has eroded below the floor ----
-        if (isActive && overdue && hourly != null && hourly < DROP_FLOOR_HOURLY) {
+        if (isActive && overdue && hourly != null && TaskEconomics.belowDropFloor(hourly)) {
             Surface(shape = MaterialTheme.shapes.small, color = c.badBg) {
                 Row(
                     modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp, vertical = 8.dp),
@@ -717,26 +718,15 @@ private fun TaskMetric(
     }
 }
 
-/** The drop-it floor (#460): once overdue and the realized rate falls below
- *  this, the card flags the wait as no longer worth it. */
-private const val DROP_FLOOR_HOURLY = 12.0
-
 /**
- * Live realized $/hr on a task (#460). Pay is fixed; the offer's time estimate
- * has slack up to the deadline — once past it, every extra minute erodes the
- * rate (the drop-it signal). Null when no accepted-offer economics are known.
+ * The $/hr tier → brand Color mapping for the task co-hero (#460). The tier
+ * *classification* (the cutoffs) lives in [TaskEconomics]; the UI keeps only
+ * the color lookup (audit #6).
  */
-private fun projectedHourly(netPay: Double?, estMinutes: Double?, deadlineMillis: Long?, now: Long): Double? {
-    if (netPay == null || estMinutes == null || estMinutes <= 0.0) return null
-    val pastMin = if (deadlineMillis != null) ((now - deadlineMillis) / 60_000.0).coerceAtLeast(0.0) else 0.0
-    return netPay / ((estMinutes + pastMin) / 60.0)
-}
-
-/** $/hr color tiers for the task co-hero (#460): ≥16 good, ≥10 amber, else red. */
-private fun hourlyColor(hourly: Double, c: AppColors): Color = when {
-    hourly >= 16.0 -> c.good
-    hourly >= 10.0 -> c.warn
-    else -> c.bad
+private fun hourlyColor(hourly: Double, c: AppColors): Color = when (TaskEconomics.hourlyTier(hourly)) {
+    TaskEconomics.HourlyTier.GOOD -> c.good
+    TaskEconomics.HourlyTier.WARN -> c.warn
+    TaskEconomics.HourlyTier.POOR -> c.bad
 }
 
 /**

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/cards/FlowCardSnapshot.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/cards/FlowCardSnapshot.kt
@@ -163,6 +163,13 @@ sealed class FlowCardSnapshot {
         val distanceMiles: Double? = null,
     ) : FlowCardSnapshot() {
         override val id: String get() = "pickup:$taskId"
+
+        /**
+         * Precomputed fixed $/mi efficiency (#503 deliverable 2) — distance
+         * doesn't erode like time, so unlike the live $/hr this is decided once,
+         * off the [TaskEconomics] SSOT, instead of in the composable (audit #6).
+         */
+        val perMile: Double? get() = TaskEconomics.perMile(netPay, distanceMiles)
     }
 
     /**
@@ -190,6 +197,13 @@ sealed class FlowCardSnapshot {
         val distanceMiles: Double? = null,
     ) : FlowCardSnapshot() {
         override val id: String get() = "delivery:$taskId"
+
+        /**
+         * Precomputed fixed $/mi efficiency (#503 deliverable 2) — distance
+         * doesn't erode like time, so unlike the live $/hr this is decided once,
+         * off the [TaskEconomics] SSOT, instead of in the composable (audit #6).
+         */
+        val perMile: Double? get() = TaskEconomics.perMile(netPay, distanceMiles)
     }
 
     /**

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/cards/TaskEconomics.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/cards/TaskEconomics.kt
@@ -1,0 +1,66 @@
+package cloud.trotter.dashbuddy.domain.model.cards
+
+/**
+ * The realized-rate economics for an in-flight task card (#460/#503), extracted
+ * from the bubble HUD composable so the FORMULAS and the dasher's economic
+ * thresholds live in one pure, unit-testable place (audit #6).
+ *
+ * Two rates back the task co-hero:
+ *  - [perMile] is fixed — quoted distance doesn't erode like time, so it's the
+ *    steady companion to the live $/hr and is precomputed onto the snapshot.
+ *  - [projectedHourly] erodes: pay is fixed, but every minute past the deadline
+ *    stretches the denominator (the drop-it signal). It depends on `now`, so it
+ *    is recomputed by the composable each tick from the snapshot's anchors —
+ *    never frozen at reduce time.
+ *
+ * The UI keeps only the tier → Color mapping; the tier *classification* and the
+ * drop-floor comparison are decided here.
+ */
+object TaskEconomics {
+
+    /**
+     * The drop-it floor (#460): once a task is overdue and its realized rate
+     * falls below this, the card flags the wait as no longer worth it.
+     */
+    const val DROP_FLOOR_HOURLY = 12.0
+
+    /** $/hr at or above this is a "good" task rate. */
+    const val GOOD_HOURLY = 16.0
+
+    /** $/hr at or above this (but below [GOOD_HOURLY]) is a "warn" task rate. */
+    const val WARN_HOURLY = 10.0
+
+    /** Coarse $/hr tier for the task co-hero (#460); the UI maps this to a brand Color. */
+    enum class HourlyTier { GOOD, WARN, POOR }
+
+    /**
+     * Fixed $/mi efficiency off the job (#503 deliverable 2). Distance doesn't
+     * erode, so this is precomputed onto the snapshot. Null when pay or distance
+     * is unknown / non-positive.
+     */
+    fun perMile(netPay: Double?, distanceMiles: Double?): Double? =
+        if (netPay != null && distanceMiles != null && distanceMiles > 0.0) netPay / distanceMiles else null
+
+    /**
+     * Live realized $/hr on a task (#460). Pay is fixed; the offer's time estimate
+     * has slack up to the deadline — once past it, every extra minute erodes the
+     * rate (the drop-it signal). Null when no accepted-offer economics are known.
+     *
+     * Depends on [now]; recompute it per tick rather than caching it on the snapshot.
+     */
+    fun projectedHourly(netPay: Double?, estMinutes: Double?, deadlineMillis: Long?, now: Long): Double? {
+        if (netPay == null || estMinutes == null || estMinutes <= 0.0) return null
+        val pastMin = if (deadlineMillis != null) ((now - deadlineMillis) / 60_000.0).coerceAtLeast(0.0) else 0.0
+        return netPay / ((estMinutes + pastMin) / 60.0)
+    }
+
+    /** True once the live realized rate has eroded below the drop-it floor. */
+    fun belowDropFloor(hourly: Double): Boolean = hourly < DROP_FLOOR_HOURLY
+
+    /** $/hr tier (#460): ≥16 good, ≥10 warn, else poor. */
+    fun hourlyTier(hourly: Double): HourlyTier = when {
+        hourly >= GOOD_HOURLY -> HourlyTier.GOOD
+        hourly >= WARN_HOURLY -> HourlyTier.WARN
+        else -> HourlyTier.POOR
+    }
+}

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/model/cards/TaskEconomicsTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/model/cards/TaskEconomicsTest.kt
@@ -1,0 +1,90 @@
+package cloud.trotter.dashbuddy.domain.model.cards
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Audit #6 — the task realized-rate FORMULAS + thresholds moved out of the bubble
+ * composable into this pure, unit-testable SSOT.
+ */
+class TaskEconomicsTest {
+
+    // ---- perMile (fixed; precomputed onto the snapshot) ----
+
+    @Test
+    fun `perMile divides net pay by distance`() {
+        assertEquals(2.5, TaskEconomics.perMile(netPay = 10.0, distanceMiles = 4.0)!!, 1e-9)
+    }
+
+    @Test
+    fun `perMile is null when an input is missing or distance is non-positive`() {
+        assertNull(TaskEconomics.perMile(netPay = null, distanceMiles = 4.0))
+        assertNull(TaskEconomics.perMile(netPay = 10.0, distanceMiles = null))
+        assertNull(TaskEconomics.perMile(netPay = 10.0, distanceMiles = 0.0))
+        assertNull(TaskEconomics.perMile(netPay = 10.0, distanceMiles = -1.0))
+    }
+
+    // ---- projectedHourly (live; erodes past the deadline) ----
+
+    @Test
+    fun `projectedHourly is pay over estimated hours before the deadline`() {
+        // $12 over 30 estimated minutes = $24/hr, regardless of `now` while not yet overdue.
+        val hourly = TaskEconomics.projectedHourly(
+            netPay = 12.0, estMinutes = 30.0, deadlineMillis = 10_000L, now = 5_000L,
+        )
+        assertEquals(24.0, hourly!!, 1e-9)
+    }
+
+    @Test
+    fun `projectedHourly holds steady up to the deadline then erodes past it`() {
+        val deadline = 600_000L // 10 min in
+        val atDeadline = TaskEconomics.projectedHourly(
+            netPay = 12.0, estMinutes = 30.0, deadlineMillis = deadline, now = deadline,
+        )!!
+        // 10 minutes past the deadline stretches 30 -> 40 estimated minutes: $12 / (40/60) = $18/hr.
+        val tenPast = TaskEconomics.projectedHourly(
+            netPay = 12.0, estMinutes = 30.0, deadlineMillis = deadline, now = deadline + 600_000L,
+        )!!
+        assertEquals(24.0, atDeadline, 1e-9)
+        assertEquals(18.0, tenPast, 1e-9)
+        assertTrue("rate must erode past the deadline", tenPast < atDeadline)
+    }
+
+    @Test
+    fun `projectedHourly with no deadline does not erode`() {
+        val hourly = TaskEconomics.projectedHourly(
+            netPay = 12.0, estMinutes = 30.0, deadlineMillis = null, now = 999_999_999L,
+        )
+        assertEquals(24.0, hourly!!, 1e-9)
+    }
+
+    @Test
+    fun `projectedHourly is null when economics are unknown`() {
+        assertNull(TaskEconomics.projectedHourly(null, 30.0, 0L, 0L))
+        assertNull(TaskEconomics.projectedHourly(12.0, null, 0L, 0L))
+        assertNull(TaskEconomics.projectedHourly(12.0, 0.0, 0L, 0L))
+        assertNull(TaskEconomics.projectedHourly(12.0, -5.0, 0L, 0L))
+    }
+
+    // ---- drop floor + tier thresholds ----
+
+    @Test
+    fun `belowDropFloor tracks the floor boundary`() {
+        assertTrue(TaskEconomics.belowDropFloor(TaskEconomics.DROP_FLOOR_HOURLY - 0.01))
+        assertFalse(TaskEconomics.belowDropFloor(TaskEconomics.DROP_FLOOR_HOURLY))
+        assertFalse(TaskEconomics.belowDropFloor(TaskEconomics.DROP_FLOOR_HOURLY + 5.0))
+    }
+
+    @Test
+    fun `hourlyTier maps the good warn poor cutoffs`() {
+        assertEquals(TaskEconomics.HourlyTier.GOOD, TaskEconomics.hourlyTier(TaskEconomics.GOOD_HOURLY))
+        assertEquals(TaskEconomics.HourlyTier.GOOD, TaskEconomics.hourlyTier(25.0))
+        assertEquals(TaskEconomics.HourlyTier.WARN, TaskEconomics.hourlyTier(TaskEconomics.WARN_HOURLY))
+        assertEquals(TaskEconomics.HourlyTier.WARN, TaskEconomics.hourlyTier(TaskEconomics.GOOD_HOURLY - 0.01))
+        assertEquals(TaskEconomics.HourlyTier.POOR, TaskEconomics.hourlyTier(TaskEconomics.WARN_HOURLY - 0.01))
+        assertEquals(TaskEconomics.HourlyTier.POOR, TaskEconomics.hourlyTier(0.0))
+    }
+}


### PR DESCRIPTION
## What

The bubble HUD `TaskBody` composable (`FlowCardItem.kt`) computed the task
realized-rate economics inline — `projectedHourly()`, `perMile = netPay/distanceMiles`,
the `DROP_FLOOR_HOURLY = 12.0` constant, and the `$/hr` tier cutoffs (16/10) baked
into `hourlyColor()`. The Offer path already does this right (precomputed
`dollarsPerHour`/`dollarsPerMile` on the snapshot via `LiveCardBuilder`), so the
task path was the lone divergence.

This PR extracts the FORMULAS + the dasher's economic thresholds into a pure,
unit-testable SSOT and leaves only the Color tier mapping in the UI:

- **New `TaskEconomics` (`:domain`, cards package):** `perMile`, `projectedHourly`,
  `belowDropFloor`, the `DROP_FLOOR_HOURLY` / `GOOD_HOURLY` / `WARN_HOURLY` constants,
  and a `HourlyTier` enum.
- **`FlowCardSnapshot.Pickup`/`Delivery`** now expose a precomputed `perMile`
  (a computed `get()` deriving from the existing `netPay`/`distanceMiles` anchors
  via `TaskEconomics` — no duplicate stored state). Distance doesn't erode, so the
  fixed `$/mi` rate is decided once, off the snapshot.
- **`FlowCardItem.TaskBody`** now reads `perMile` off the snapshot, routes the live
  `$/hr` through `TaskEconomics.projectedHourly`, the drop-floor banner through
  `TaskEconomics.belowDropFloor`, and `hourlyColor` maps `TaskEconomics.hourlyTier`
  → brand Color. The inline formulas + constants are deleted.
- **New `TaskEconomicsTest`** (8 cases): `perMile`, the holds-then-erodes `$/hr`,
  the drop-floor boundary, the tier cutoffs.

Integrates with the merged Wave-A refactors (#1 `LiveCardBuilder`/`FlowCardSnapshot`
`Offer.from` SSOT, #12 `FlowCardItem`) — branched off latest `master`.

## Why (audit finding)

Audit finding #6: business economics were computed inside the composable, duplicating
formulas and burying the dasher's economic thresholds in the UI layer. That violates
SSOT (the Offer path had already moved the same kind of math onto the snapshot) and
single-responsibility (a glance composable shouldn't own the drop-it floor or the
$/hr tier cutoffs). Moving them to a pure `:domain` helper makes them unit-testable
and gives them one owner.

**Reactive constraint honored:** the live `$/hr` ERODES with `now` (every minute past
the deadline stretches the denominator — the drop-it signal). Its anchors
(`netPay`/`estMinutes`/`deadlineMillis`) stay on the snapshot and the composable
recomputes the ticking value each `rememberNow()` tick via `TaskEconomics.projectedHourly`
— it is NOT frozen at reduce time. Only the genuinely fixed `$/mi` is precomputed onto
the snapshot.

## Security/privacy posture

No change. This is a pure UI→domain code move of on-device economic math — no
recognition, capture, network, or effect surface is touched. The math stays on-device;
nothing is logged, persisted, or uploaded; no PII is involved (the inputs are the
dasher's own accepted-offer pay/distance/time). `:domain` stays pure Kotlin (no
Android/Compose deps added).

## Test

- `./gradlew testDebugUnitTest` — BUILD SUCCESSFUL (all modules green).
- `./gradlew :domain:test --tests "*TaskEconomicsTest*"` — 8 tests, 0 failures
  (the `:domain` pure-Kotlin module's test task is `:domain:test`, not
  `testDebugUnitTest`).
- No recognition rules/parsers touched, so `AllMatchersSuite` is not implicated; the
  full suite passed regardless.

Note: this PR does not edit `CLAUDE.md`. No statement in it is made stale by this
change (the architecture/module descriptions don't enumerate the task-card economics).