### PR TITLE
refactor(state): pre-create pickup placeholders + swap guard (#526, partial)

### DIFF
--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
@@ -20,6 +20,7 @@ import cloud.trotter.dashbuddy.domain.state.TaskSubFlow
 import cloud.trotter.dashbuddy.domain.state.TransitionKind
 import javax.inject.Inject
 import javax.inject.Singleton
+import java.util.Locale
 import cloud.trotter.dashbuddy.domain.state.UNKNOWN_STORE
 
 /**
@@ -84,6 +85,37 @@ class PlatformRegionStepper @Inject constructor() {
             startedAt = obs.timestamp,
         )
     }
+
+    /**
+     * #526: pre-create one PICKUP placeholder per **distinct store** an accepted offer covers,
+     * the symmetric counterpart to [preCreatedDropoffs]. Two orders at the *same* store are ONE
+     * combined pickup on DoorDash (the #499 fold-in), so [distinctStoreHints] must already be
+     * de-duplicated — a 2-order same-store offer owns ONE pickup placeholder but two dropoffs.
+     * Each placeholder carries its order's [Task.expectedStoreHint]; the authoritative
+     * [Task.storeName] is filled when a pickup screen resolves onto it. ids are minted at
+     * [startOffset]..[startOffset]+size-1; the caller advances the counter in the same copy().
+     */
+    private fun preCreatedPickups(
+        region: PlatformRegion,
+        obs: Observation,
+        jobId: String,
+        distinctStoreHints: List<String>,
+        startOffset: Long,
+    ): List<Task> = distinctStoreHints.mapIndexed { i, hint ->
+        Task(
+            taskId = mintId("task", region, obs, offset = startOffset + i),
+            jobId = jobId,
+            phase = TaskPhase.PICKUP,
+            expectedStoreHint = hint,
+            storeName = null,
+            startedAt = obs.timestamp,
+        )
+    }
+
+    /** De-duplicate raw offer store hints case-insensitively, preserving first-seen order. */
+    private fun distinctStoreHints(storeHints: List<String>): List<String> =
+        storeHints.map { it.trim() }.filter { it.isNotEmpty() }
+            .distinctBy { it.lowercase(Locale.ROOT) }
 
     fun step(
         prev: PlatformRegion,
@@ -523,14 +555,17 @@ class PlatformRegionStepper @Inject constructor() {
             val storeHints = parsedOffer?.orders?.map { it.storeName } ?: emptyList()
             val existing = region.activeJob
 
-            // #503 slice 3b: pre-create one dropoff placeholder PER ORDER the offer covers, so a
-            // stack's Job owns ordered dropoffs (not a single drop). Fallback to 1 when the offer
-            // wasn't parsed — the pre-3b behaviour for a single delivery.
+            // #503 slice 3b: one DROPOFF placeholder PER ORDER (each order is its own customer).
+            // #526: one PICKUP placeholder per DISTINCT store (same-store orders are one combined
+            // pickup, #499). Dropoffs fall back to 1 when the offer wasn't parsed (single delivery).
             val dropoffCount = parsedOffer?.orders?.size?.takeIf { it > 0 } ?: 1
+            val offerPickupHints = distinctStoreHints(storeHints)
 
             if (existing == null) {
                 val jobId = mintId("job", region, obs)
-                // job at offset 0; the N dropoff placeholders at offsets 1..N.
+                // job at offset 0; N dropoff placeholders at 1..N; P pickup placeholders at N+1..N+P.
+                val dropoffs = preCreatedDropoffs(region, obs, jobId, dropoffCount, startOffset = 1)
+                val pickups = preCreatedPickups(region, obs, jobId, offerPickupHints, startOffset = (1 + dropoffCount).toLong())
                 return region.copy(
                     activeJob = Job(
                         jobId = jobId,
@@ -538,9 +573,9 @@ class PlatformRegionStepper @Inject constructor() {
                         parentOfferHash = pending?.offerHash,
                         acceptedOffers = listOf(economics),
                         startedAt = obs.timestamp,
-                        tasks = preCreatedDropoffs(region, obs, jobId, dropoffCount, startOffset = 1),
+                        tasks = dropoffs + pickups,
                     ),
-                    mintCounter = region.mintCounter + dropoffCount + 1,
+                    mintCounter = region.mintCounter + 1 + dropoffCount + pickups.size,
                 )
             }
 
@@ -548,16 +583,23 @@ class PlatformRegionStepper @Inject constructor() {
             val alreadyCounted = economics.offerHash != null &&
                 existing.acceptedOffers.any { it.offerHash == economics.offerHash }
             if (alreadyCounted) return region
-            // #503 slice 3b: the add-on offer brings its own dropoff(s) — append a placeholder per
-            // order so a stacked add-on's drops are owned by the job too (offsets 0..N-1, no job mint
-            // this step).
+            // #503 slice 3b: the add-on's own dropoff(s) append (offsets 0..D-1). #526: the add-on's
+            // pickup placeholders append too — but only for stores the job does NOT already own (a
+            // same-store add-on folds into the existing pickup, #499), at offsets D..D+P-1.
+            val existingPickupHints = existing.tasks
+                .filter { it.phase == TaskPhase.PICKUP }
+                .mapNotNull { it.expectedStoreHint?.lowercase(Locale.ROOT) }
+                .toSet()
+            val addOnPickupHints = offerPickupHints.filter { it.lowercase(Locale.ROOT) !in existingPickupHints }
+            val addOnDropoffs = preCreatedDropoffs(region, obs, existing.jobId, dropoffCount, startOffset = 0)
+            val addOnPickups = preCreatedPickups(region, obs, existing.jobId, addOnPickupHints, startOffset = dropoffCount.toLong())
             return region.copy(
                 activeJob = existing.copy(
                     acceptedOffers = existing.acceptedOffers + economics,
                     offerStoreHint = existing.offerStoreHint + storeHints,
-                    tasks = existing.tasks + preCreatedDropoffs(region, obs, existing.jobId, dropoffCount, startOffset = 0),
+                    tasks = existing.tasks + addOnDropoffs + addOnPickups,
                 ),
-                mintCounter = region.mintCounter + dropoffCount,
+                mintCounter = region.mintCounter + dropoffCount + addOnPickups.size,
             )
         }
 
@@ -698,6 +740,56 @@ class PlatformRegionStepper @Inject constructor() {
                         ),
                         recentTasks = (region.recentTasks.filterNot { it.taskId == resumable.taskId } +
                             listOfNotNull(displaced)).takeLast(MAX_RECENT_TASKS),
+                        pendingDestructive = null,
+                    )
+                }
+
+                // #526: resolve a pickup screen onto a pre-created (offer-spawned) PICKUP
+                // placeholder of this job instead of minting — the symmetric counterpart to the
+                // dropoff resolution below. Store hints are unreliable, so prefer the OPEN
+                // placeholder whose hint EXACTLY (case-insensitively) matches the screen's parsed
+                // store; otherwise fall back to the next open placeholder in order. "Open" =
+                // storeName not yet resolved, not completed, not the current/displaced task.
+                // Entry into this branch is still gated by the stacked-pickup heuristic (above),
+                // so this changes which taskId a recognized pickup gets (a stable, offer-owned id),
+                // not WHEN a pickup is recognized — the conservative #526 step. A wrong hint match
+                // can be repaired without re-minting via [Job.withSwappedAccumulation] (the swap
+                // guard); the automatic trigger for it awaits a reliable mis-bind signal (see PR).
+                val expectedPickup = if (taskPhase == TaskPhase.PICKUP) {
+                    val displacedIds = region.recentTasks.mapTo(HashSet()) { it.taskId }
+                    val openPickups = region.activeJob?.tasks.orEmpty().filter { p ->
+                        p.phase == TaskPhase.PICKUP &&
+                            p.storeName == null &&
+                            p.completedAt == null &&
+                            p.taskId != currentTask?.taskId &&
+                            p.taskId !in displacedIds
+                    }
+                    val screenStore = taskFields?.storeName?.trim()?.takeIf { it.isNotEmpty() }
+                    val hintMatch = screenStore?.let { s ->
+                        openPickups.firstOrNull { it.expectedStoreHint?.equals(s, ignoreCase = true) == true }
+                    }
+                    hintMatch ?: openPickups.firstOrNull()
+                } else null
+
+                if (expectedPickup != null) {
+                    val retireSince = region.pendingDestructive
+                        ?.takeIf { it.kind == DestructiveKind.TASK_RETIRE }?.since
+                    val displaced = currentTask?.copy(completedAt = retireSince ?: obs.timestamp)
+                    val justArrived = taskSubFlow == TaskSubFlow.ARRIVED && expectedPickup.arrivedAt == null
+                    return region.copy(
+                        activeTask = expectedPickup.copy(
+                            subPhase = taskSubFlow,
+                            storeName = taskFields?.storeName ?: expectedPickup.storeName,
+                            storeAddress = taskFields?.storeAddress ?: expectedPickup.storeAddress,
+                            deadlineMillis = taskFields?.deadline?.time ?: expectedPickup.deadlineMillis,
+                            activity = taskFields?.activity,
+                            itemsRemaining = taskFields?.itemsRemaining,
+                            itemsShopped = taskFields?.itemsShopped,
+                            redCardTotal = taskFields?.redCardTotal,
+                            startedAt = obs.timestamp,
+                            arrivedAt = if (justArrived) obs.timestamp else expectedPickup.arrivedAt,
+                        ),
+                        recentTasks = (region.recentTasks + listOfNotNull(displaced)).takeLast(MAX_RECENT_TASKS),
                         pendingDestructive = null,
                     )
                 }

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/PickupPlaceholderTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/PickupPlaceholderTest.kt
@@ -1,0 +1,228 @@
+package cloud.trotter.dashbuddy.core.state
+
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
+import cloud.trotter.dashbuddy.domain.model.offer.ParsedOffer
+import cloud.trotter.dashbuddy.domain.model.order.OrderType
+import cloud.trotter.dashbuddy.domain.model.order.ParsedOrder
+import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.state.Flow
+import cloud.trotter.dashbuddy.domain.state.FlowRegion
+import cloud.trotter.dashbuddy.domain.state.Job
+import cloud.trotter.dashbuddy.domain.state.Mode
+import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import cloud.trotter.dashbuddy.domain.state.PendingOffer
+import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.domain.state.PlatformRegion
+import cloud.trotter.dashbuddy.domain.state.Session
+import cloud.trotter.dashbuddy.domain.state.Task
+import cloud.trotter.dashbuddy.domain.state.TaskPhase
+import cloud.trotter.dashbuddy.domain.state.TaskSubFlow
+import cloud.trotter.dashbuddy.domain.state.swapTaskAccumulation
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #526 — pre-created PICKUP placeholders (the symmetric counterpart of the dropoff placeholders)
+ * and the **swap guard**.
+ *
+ * An accepted offer pre-creates one pickup placeholder per *distinct* store it covers (same-store
+ * orders are one combined pickup, #499); a pickup screen resolves onto its placeholder by an exact
+ * store-hint match, falling back to the next open slot. Because store hints are unreliable, a slot
+ * can be mis-bound — the swap guard re-attributes accumulated data to the right order slot without
+ * re-minting.
+ */
+class PickupPlaceholderTest {
+
+    private val stepper = PlatformRegionStepper()
+    private val flowStepper = FlowRegionStepper()
+    private val policy = TransitionPolicy()
+
+    // ---- helpers ----
+
+    private fun region(
+        activeJob: Job? = null,
+        activeTask: Task? = null,
+        recentTasks: List<Task> = emptyList(),
+    ) = PlatformRegion(
+        platform = Platform.DoorDash,
+        mode = Mode.Online,
+        session = Session("sess-1", startedAt = 100L),
+        activeJob = activeJob,
+        activeTask = activeTask,
+        recentTasks = recentTasks,
+    )
+
+    private fun order(i: Int, store: String) = ParsedOrder(
+        orderIndex = i, orderType = OrderType.PICKUP, storeName = store,
+        itemCount = 1, isItemCountEstimated = false, badges = emptySet(),
+    )
+
+    private fun offerFlow(hash: String, stores: List<String>) = FlowRegion(
+        flow = Flow.OfferPresented,
+        pendingOffer = PendingOffer(
+            offerHash = hash,
+            offerFields = ParsedFields.OfferFields(
+                parsedOffer = ParsedOffer(
+                    offerHash = hash,
+                    payAmount = 10.0,
+                    distanceMiles = 5.0,
+                    orders = stores.mapIndexed { i, s -> order(i, s) },
+                ),
+            ),
+            presentedAt = 500L,
+            returnFlow = Flow.Idle,
+        ),
+    )
+
+    private fun pickupObs(timestamp: Long, store: String, subFlow: TaskSubFlow = TaskSubFlow.NAVIGATION) =
+        Observation.Screen(
+            timestamp = timestamp, captureId = null, ruleId = "doordash.screen.pickup",
+            metadata = ReplayMetadata.EMPTY,
+            flow = if (subFlow == TaskSubFlow.ARRIVED) Flow.TaskPickupArrived else Flow.TaskPickupNavigation,
+            modeHint = Mode.Online,
+            parsed = ParsedFields.TaskFields(phase = TaskPhase.PICKUP, subFlow = subFlow, storeName = store),
+        )
+
+    private fun step(prev: PlatformRegion, prevFlow: FlowRegion, obs: Observation): PlatformRegion {
+        val nextFlow = if (obs is Observation.FlowObservation) flowStepper.step(prevFlow, obs) else prevFlow
+        return stepper.step(prev, prevFlow, nextFlow, obs, policy)
+    }
+
+    private fun pickups(r: PlatformRegion) = r.activeJob!!.tasks.filter { it.phase == TaskPhase.PICKUP }
+    private fun pickupHints(r: PlatformRegion) =
+        pickups(r).mapNotNull { it.expectedStoreHint }.toSet()
+
+    // =====================================================================
+    // SWAP PRIMITIVE (the capability the guard is built on)
+    // =====================================================================
+
+    @Test
+    fun `swapTaskAccumulation exchanges screen data but preserves slot identity`() {
+        val a = Task(
+            taskId = "t-A", jobId = "job-1", phase = TaskPhase.PICKUP,
+            expectedStoreHint = "Sprouts", storeName = "CVS Pharmacy",
+            arrivedAt = 900L, itemsShopped = 3, startedAt = 100L,
+        )
+        val b = Task(
+            taskId = "t-B", jobId = "job-1", phase = TaskPhase.PICKUP,
+            expectedStoreHint = "CVS", storeName = "Sprouts Market",
+            arrivedAt = null, itemsShopped = 10, startedAt = 200L,
+        )
+
+        val (na, nb) = swapTaskAccumulation(a, b)
+
+        // Slot identity is preserved on each side.
+        assertEquals("t-A", na.taskId); assertEquals("Sprouts", na.expectedStoreHint); assertEquals(100L, na.startedAt)
+        assertEquals("t-B", nb.taskId); assertEquals("CVS", nb.expectedStoreHint); assertEquals(200L, nb.startedAt)
+        // Accumulated screen data is exchanged.
+        assertEquals("Sprouts Market", na.storeName); assertEquals(10, na.itemsShopped); assertNull(na.arrivedAt)
+        assertEquals("CVS Pharmacy", nb.storeName); assertEquals(3, nb.itemsShopped); assertEquals(900L, nb.arrivedAt)
+    }
+
+    @Test
+    fun `withSwappedAccumulation re-attributes mis-bound data to the correct order slot`() {
+        // The Sprouts slot accidentally holds the CVS pickup's data, and vice versa.
+        val sproutsSlot = Task(taskId = "t-A", jobId = "job-1", phase = TaskPhase.PICKUP, expectedStoreHint = "Sprouts", storeName = "CVS", startedAt = 100L)
+        val cvsSlot = Task(taskId = "t-B", jobId = "job-1", phase = TaskPhase.PICKUP, expectedStoreHint = "CVS", storeName = "Sprouts", startedAt = 100L)
+        val job = Job(jobId = "job-1", offerStoreHint = listOf("Sprouts", "CVS"), parentOfferHash = null, startedAt = 100L, tasks = listOf(sproutsSlot, cvsSlot))
+
+        val fixed = job.withSwappedAccumulation("t-A", "t-B")
+
+        assertEquals("Sprouts slot now holds Sprouts data", "Sprouts", fixed.tasks.single { it.taskId == "t-A" }.storeName)
+        assertEquals("CVS slot now holds CVS data", "CVS", fixed.tasks.single { it.taskId == "t-B" }.storeName)
+    }
+
+    @Test
+    fun `withSwappedAccumulation is a no-op for identical or missing ids`() {
+        val t = Task(taskId = "t-A", jobId = "job-1", phase = TaskPhase.PICKUP, startedAt = 100L)
+        val job = Job(jobId = "job-1", offerStoreHint = emptyList(), parentOfferHash = null, startedAt = 100L, tasks = listOf(t))
+        assertSame(job, job.withSwappedAccumulation("t-A", "t-A"))
+        assertSame(job, job.withSwappedAccumulation("t-A", "missing"))
+    }
+
+    // =====================================================================
+    // PLACEHOLDER CREATION
+    // =====================================================================
+
+    @Test
+    fun `single-store offer owns one pickup placeholder carrying the store hint`() {
+        val r = step(region(), offerFlow("o1", listOf("H-E-B")), pickupObs(1_000L, "H-E-B"))
+        assertEquals(1, pickups(r).size)
+        assertEquals(setOf("H-E-B"), pickupHints(r))
+    }
+
+    @Test
+    fun `two-distinct-store offer owns two pickup placeholders`() {
+        val r = step(region(), offerFlow("o1", listOf("Sprouts", "CVS")), pickupObs(1_000L, "Sprouts"))
+        assertEquals("two distinct stores → two pickup placeholders", 2, pickups(r).size)
+        assertEquals(setOf("Sprouts", "CVS"), pickupHints(r))
+        // The accept's Sprouts screen resolved onto the Sprouts slot; the CVS slot stays open.
+        assertEquals("Sprouts", r.activeTask?.storeName)
+        val open = pickups(r).filter { it.storeName == null }
+        assertEquals(1, open.size)
+        assertEquals("CVS", open.single().expectedStoreHint)
+    }
+
+    @Test
+    fun `same-store two-order offer owns ONE combined pickup but TWO dropoffs (#499 fold)`() {
+        val r = step(region(), offerFlow("o1", listOf("H-E-B", "H-E-B")), pickupObs(1_000L, "H-E-B"))
+        val job = r.activeJob!!
+        assertEquals("two same-store orders share one combined pickup", 1, job.tasks.count { it.phase == TaskPhase.PICKUP })
+        assertEquals("but each order is still its own dropoff", 2, job.tasks.count { it.phase == TaskPhase.DROPOFF })
+    }
+
+    @Test
+    fun `an offer with no parsed orders creates no pickup placeholder (single-delivery fallback)`() {
+        val r = step(region(), offerFlow("o1", emptyList()), pickupObs(1_000L, "H-E-B"))
+        // No store hints → no pickup placeholder; the pickup is minted fresh (pre-#526 behaviour).
+        assertNull("the active pickup is a fresh mint, not a placeholder", r.activeTask?.expectedStoreHint)
+        assertEquals("no offer-spawned pickup placeholder exists", 0, pickups(r).count { it.expectedStoreHint != null })
+    }
+
+    @Test
+    fun `add-on at a new store appends a pickup placeholder, a same-store add-on does not`() {
+        val r1 = step(region(), offerFlow("o1", listOf("H-E-B")), pickupObs(1_000L, "H-E-B"))
+        val r2 = step(r1, offerFlow("o2", listOf("Wendy's")), pickupObs(2_000L, "Wendy's"))
+        assertEquals("a new-store add-on brings its own pickup placeholder", setOf("H-E-B", "Wendy's"), pickupHints(r2))
+
+        val r3 = step(r2, offerFlow("o3", listOf("H-E-B")), pickupObs(3_000L, "H-E-B"))
+        assertEquals("a same-store add-on folds in — no duplicate placeholder", setOf("H-E-B", "Wendy's"), pickupHints(r3))
+        assertEquals(2, pickups(r3).count())
+    }
+
+    // =====================================================================
+    // RESOLUTION
+    // =====================================================================
+
+    @Test
+    fun `a stacked pickup resolves onto its hint-matching placeholder with the pre-created id (#526)`() {
+        // Offer covers two stores; visit Sprouts first, then CVS.
+        val r1 = step(region(), offerFlow("o1", listOf("Sprouts", "CVS")), pickupObs(1_000L, "Sprouts"))
+        val cvsSlotId = pickups(r1).single { it.storeName == null }.taskId
+        assertNotNull(cvsSlotId)
+
+        // Arrive at Sprouts (so the next pickup nav is a stacked transition).
+        val r2 = step(r1, FlowRegion(flow = Flow.TaskPickupNavigation), pickupObs(2_000L, "Sprouts", TaskSubFlow.ARRIVED))
+        // Navigate to CVS — resolves onto the pre-created CVS slot, not a fresh mint.
+        val r3 = step(r2, FlowRegion(flow = Flow.TaskPickupArrived), pickupObs(3_000L, "CVS"))
+
+        assertEquals("the CVS pickup keeps the offer-owned slot id", cvsSlotId, r3.activeTask?.taskId)
+        assertEquals("CVS", r3.activeTask?.storeName)
+        assertEquals("CVS", r3.activeTask?.expectedStoreHint)
+        assertTrue("the Sprouts pickup completed into recentTasks", r3.recentTasks.any { it.storeName == "Sprouts" && it.completedAt != null })
+    }
+
+    @Test
+    fun `a pickup whose store matches no hint falls onto the next open slot (the mis-bind the swap guard repairs)`() {
+        // The parsed store ("Mystery Mart") matches neither hint, so next-open binds it to the
+        // FIRST slot — which may be the wrong order. This is exactly the case the swap guard exists
+        // to repair once a reliable mis-bind signal is available.
+        val r = step(region(), offerFlow("o1", listOf("Sprouts", "CVS")), pickupObs(1_000L, "Mystery Mart"))
+        assertEquals("Mystery Mart", r.activeTask?.storeName)
+        assertEquals("bound by next-open to the first slot", "Sprouts", r.activeTask?.expectedStoreHint)
+    }
+}

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -63,6 +63,16 @@ immediately (no second pass needed) so it gets triaged.
 _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **broken** on the
 2026-06-09 dash — moved to that session's log entry below for triage.)_
 
+- **⏸️ NOT YET IN BUILD — pickup placeholders + swap guard (#526, branch `refactor/526-pickup-placeholders-swap`, unmerged). VALIDATE AFTER MERGE.**
+  Pickups now get pre-created from the offer like dropoffs do — one pickup task per **distinct store**
+  (two orders at the *same* store stay ONE combined pickup; two *different* stores → two pickups), each
+  resolving onto its offer-owned slot by store hint. **Confirm on a multi-store STACKED dash (after this
+  lands): 0/2 —** a 2-store stack should show **two** pickup tasks each keeping a **stable id** across
+  nav/arrival flicker; a same-store add-on should still **fold into one** pickup (combined item count, no
+  2nd pickup task). Watch for a pickup task bound to the **wrong order** (store-hint mismatch) — note the
+  offer's store names vs the parsed pickup store, since that's the case the swap guard is meant to repair
+  (the auto-trigger is deferred, so a mis-bind may currently persist). Needs a real multi-pickup stack.
+
 - **🔧 FIX SHIPPED — offer card icon badges + co-icon-text shop badge [cart N] (#461, PR #531). CONFIRM ON DASH.**
   The offer card's badges are now **icons** (red card, alcohol, large order, priority, etc., tinted by
   brand color), and the **Shop & Deliver** badge is the shopping-chat **cart icon + the item count**

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/Job.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/Job.kt
@@ -79,4 +79,58 @@ data class Job(
 
     /** Every offer hash that contributed to this job (the add-on chain). */
     val parentOfferHashes: List<String> get() = acceptedOffers.mapNotNull { it.offerHash }
+
+    /**
+     * Swap the **accumulated screen state** between two of this job's tasks, identified by id,
+     * while preserving each task's **slot identity** (`taskId`, `jobId`, `phase`,
+     * [Task.expectedStoreHint], `startedAt`). The order-slot stays put; the observations that
+     * were attributed to it move.
+     *
+     * This is the #526 swap guard: a pickup screen can be bound to the wrong pre-created order
+     * because the offer's store hints don't reliably match the parsed pickup store, so the data
+     * accumulated for one order may actually belong to its sibling. Swapping re-attributes it
+     * without re-minting (ids stay stable for effects/db). No-op if either id is absent or they
+     * are the same task. See [swapTaskAccumulation].
+     */
+    fun withSwappedAccumulation(taskIdA: String, taskIdB: String): Job {
+        if (taskIdA == taskIdB) return this
+        val a = tasks.firstOrNull { it.taskId == taskIdA } ?: return this
+        val b = tasks.firstOrNull { it.taskId == taskIdB } ?: return this
+        val (newA, newB) = swapTaskAccumulation(a, b)
+        return copy(tasks = tasks.map {
+            when (it.taskId) {
+                taskIdA -> newA
+                taskIdB -> newB
+                else -> it
+            }
+        })
+    }
+}
+
+/**
+ * Exchange the accumulated, screen-derived observations of two tasks while keeping each task's
+ * durable slot identity (`taskId`, `jobId`, `phase`, [Task.expectedStoreHint], `startedAt`).
+ * Pure; the basis of the #526 swap guard (see [Job.withSwappedAccumulation]). Returns the pair
+ * in the same order it was given: `first` keeps a's identity with b's data, `second` keeps b's
+ * identity with a's data.
+ */
+fun swapTaskAccumulation(a: Task, b: Task): Pair<Task, Task> {
+    fun Task.withAccumulationOf(other: Task) = copy(
+        subPhase = other.subPhase,
+        storeName = other.storeName,
+        storeAddress = other.storeAddress,
+        customerNameHash = other.customerNameHash,
+        customerAddressHash = other.customerAddressHash,
+        deadlineMillis = other.deadlineMillis,
+        activity = other.activity,
+        itemsRemaining = other.itemsRemaining,
+        itemsShopped = other.itemsShopped,
+        redCardTotal = other.redCardTotal,
+        arrivedAt = other.arrivedAt,
+        odometerAtEntry = other.odometerAtEntry,
+        odometerAtArrival = other.odometerAtArrival,
+        completedAt = other.completedAt,
+        recovered = other.recovered,
+    )
+    return a.withAccumulationOf(b) to b.withAccumulationOf(a)
 }

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/Task.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/Task.kt
@@ -12,6 +12,15 @@ data class Task(
     val jobId: String,
     val phase: TaskPhase,
     val subPhase: TaskSubFlow? = null,
+    /**
+     * The offer's store-name **hint** for this order's pickup, stamped when the task is
+     * pre-created from an accepted offer (#526). The hint is *not* authoritative — store
+     * names on the offer card and on the pickup screen routinely differ — so [storeName]
+     * (parsed from the pickup screen) remains the source of truth. The hint exists only to
+     * route a pickup screen to the right pre-created order slot and to detect/repair a
+     * mis-bound slot (the swap guard). Null for non-placeholder tasks and dropoff placeholders.
+     */
+    val expectedStoreHint: String? = null,
     val storeName: String? = null,
     val storeAddress: String? = null,
     val customerNameHash: String? = null,


### PR DESCRIPTION
**Partial #526 — opened for review, do NOT merge yet.** Built while the dev field-tested the current `master` build; this changes the delicate task-routing path and wants dev review + real multi-pickup field data before landing.

## What this does
Wires the **symmetric counterpart of the dropoff placeholders** (#503 slice 3b) for pickups, plus the **swap guard** the dev asked for.

### Pickup placeholders
- An accepted offer pre-creates **one PICKUP placeholder per distinct store** it covers. Two orders at the *same* store are ONE combined pickup on DoorDash (#499 fold-in), so hints are de-duplicated case-insensitively — a 2-order same-store offer owns **one** pickup placeholder but **two** dropoffs.
- `Task.expectedStoreHint` carries the offer's per-order hint; the parsed `storeName` stays authoritative.
- Ids minted **after** the dropoffs (`job=0, dropoffs=1..D, pickups=D+1..D+P`), so existing dropoff ids and the slice-3/3b tests are unchanged; only `mintCounter` ends higher (no accept-path test asserts it). The add-on path dedups its pickup hints against the job's existing ones.
- New `expectedPickup` resolution (symmetric to `expectedDropoff`): exact case-insensitive **hint match → next-open slot → existing mint**.

### Conservative by design (per the grounded #526 review)
- **Entry into the new-task branch is still gated by `isStackedPickupTransition`** — kept as the fallback. This changes *which* taskId a recognized pickup gets (a stable, offer-owned id), **not WHEN** a pickup is recognized. Deleting the heuristic was found unsafe, so it stays.

### Swap guard (the requested capability)
- `swapTaskAccumulation` (pure, `:domain`) + `Job.withSwappedAccumulation(idA, idB)` exchange the **accumulated screen data** between two sibling slots while preserving **slot identity** (`taskId`/`jobId`/`phase`/`expectedStoreHint`/`startedAt`). A wrong binding is corrected **without re-minting** — ids stay stable for effects/db.

## ⚠️ Decisions for review / deferred
1. **The automatic swap trigger is NOT wired** — only the capability. An exact store-name cross-match never fires on real noisy names (`"CVS"` vs `"CVS Pharmacy"` — exactly the unreliable-matching concern), and swapping lifecycle state (`completedAt`) between an active and a completed task would corrupt it. The trigger needs a **reliable mis-bind signal**: dropoff-customer correlation (ties to #159/#528) or a manual correction control. **Which do you want?**
2. **The heuristic is not retired**, only superseded when placeholders exist; a same-phase add-on at a *different* store still updates-in-place (the heuristic needs arrival to fire).
3. **Over-created pickup placeholders** (hint over-counts distinct stores) leak open (matches the audit's gap #4) — no reconciliation yet.
4. **Same-store consolidation** is keyed on case-insensitive exact hint equality — fuzzy variants of one store name would still over-create. Acceptable until field data says otherwise.

## Tests
New `PickupPlaceholderTest` (10): swap primitive + `withSwappedAccumulation`, creation (single / two-store / **same-store dedup** / no-orders fallback / add-on new-vs-same store), resolution (hint-match keeps the pre-created id; next-open mis-bind documented). **Full unit suite green** across all modules (state, replay, serialization, effects, recognition goldens).

## Security/privacy posture
State-layer only — no recognition, capture, network, or effect surface touched. The swap moves already-hashed `customerNameHash`/`customerAddressHash` between sibling slots of the same job; no raw PII is involved and the hashing model is unchanged.

## Field validation
Added a (pending-merge) item to `docs/field-testing/README.md` — validate on a real multi-store stacked dash after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)