### PR TITLE
docs: 2026-06-19 field-dash analysis + logging Principle #7

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,6 +260,34 @@ Every new feature or refactor holds to these — they are forefront design input
      apply). Consent UI = #422 PR 3.
    When a change touches recognition, capture, network, or effects, state its security/privacy
    posture in the PR — what's trusted, what's gated, what's scrubbed.
+7. **Semantic, PII-safe logging.** Log levels carry *meaning*, not volume convenience, and the log is
+   two products: an on-device **DEBUG firehose** for us, and an **INFO+ slice a user can export as a
+   bug report** to send to the developer. Pairs with #6 (the export is a privacy surface). The 06-19
+   dash is the receipt: ~110k lines, one Timber tag (`App`), DEBUG 76% / INFO 22% / WARN 1.2% / ERROR
+   0, with per-frame `SCREEN:` spam at INFO and benign tree-mapper noise drowning the real WARN — and
+   raw merchant names already leaking into INFO+ lines (`Pickup: H-E-B`, a TTS line naming two stores).
+   The level taxonomy:
+   - **VERBOSE** — per-frame trace (`SCREEN:` lines, tree-mapper `👻 NULL CHILDREN`). Firehose only;
+     never shipped or exported.
+   - **DEBUG** — single reducer/effect steps (`PROCESSING: <Event>`, grace-resume, gate decisions,
+     capture writes). Firehose only.
+   - **INFO** — user-meaningful milestones (offer received/accepted/declined, delivery completed,
+     crash recovery, periodic `PipelineStats`). This is the **shareable** stream and **must be PII-safe
+     by construction**: economics, counters, state names, `sha256` hashes only — **no raw
+     store/customer/address text** (the dasher's own first + last-initial is fine). Raw third-party UI
+     text lives at DEBUG/VERBOSE only.
+   - **WARN** — a defended invariant fired (a suppressed phantom/ghost, a fail-closed gate denial, a
+     grace timer waking a commit, an unhandled event). Must not be drowned by benign noise — if it's
+     benign and frequent, it's VERBOSE.
+   - **ERROR** — lost data or a crashed subsystem (pipeline restart, snapshot/journal write or decode
+     failure, recovery failure). Always shipped/exported.
+
+   Every component logs under its own **stable tag** (`Timber.tag("Pipeline")`, `"StateMachine"`,
+   `"Effects"`…), never the catch-all `App`. The INFO-must-be-PII-safe rule is **fail-closed and
+   tested** (reuse `SensitiveTextMarkers`): a raw merchant/customer string in an INFO+ line is a
+   privacy defect of the same class as leaking it to disk — gate the shareable-export sink behind that
+   test, do not trust call-site discipline. When a change adds or moves a log site, state its level and
+   (for INFO+) confirm it carries no raw PII. (Implementation tracked in #551.)
 
 If a change genuinely can't satisfy one of these, say so explicitly in the PR description instead
 of silently violating it.

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -104,6 +104,8 @@ _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **bro
   with no real delivery. If a phantom/duplicate dropoff still shows, capture the dropoff frame sequence
   + the `app_state_snapshots` for that order. (Stacks are still #503 slice 3b — extra dropoffs on a
   multi-drop may still mis-handle, separate from this.)
+  - Confirmed: 1/2 (2026-06-19 desk analysis of the dash db — 0 null-customer/$0.00 dropoffs across
+    248 snapshots; all 9 completions carry a distinct customer hash + non-null pay).
 
 - **🔧 FIX IN FLIGHT — a delivery can't be logged/counted twice (#518, PRs #520 + #522). CONFIRM ON DASH.**
   Two halves of the spurious-`DELIVERY_COMPLETED` bug: PR #520 stopped a **prior job's** task
@@ -115,6 +117,9 @@ _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **bro
   real deliveries** (no doubling). Watch especially when the receipt screen is shown, dismissed, and
   re-shown. If a delivery double-counts, capture the `app_events` (`DELIVERY_COMPLETED` rows) +
   `app_state_snapshots` for that order.
+  - Confirmed: 1/2 (2026-06-19 desk analysis — exactly 1 `DELIVERY_COMPLETED` per job for all 9 jobs;
+    9 accepts pair 1:1 with 9 completions; earnings reconcile to the cent; the one stack's 2 drops →
+    1 combined receipt is expected, not a double-count).
 
 - **🔧 FIX IN FLIGHT — multi-drop stack: Job owns ordered dropoffs, routed by customer name (#503 slice 3b, PR #523). CONFIRM ON DASH.**
   The structural multi-drop fix: an offer pre-creates **one dropoff placeholder per order**, and each
@@ -791,6 +796,84 @@ Accept and Decline registered on DoorDash — and moved to that session's entry 
     via the #279 checklist item above.
 
 ---
+
+## 2026-06-19 — DoorDash session (desk analysis of captured dash data)
+
+- **Platform tested:** DoorDash
+- **Branch under test:** `master` at `fac5d0d7` (post-#544 SSOT campaign) — **before** the unmerged
+  #526 pickup-placeholder work (branch `refactor/526-pickup-placeholders-swap`).
+- **Field conditions:** 4 dashes, ~8h. Analysis is a **desk pass over the uploaded data**
+  (`~/dashbuddy/logs/2026/06/19/`: db `dashbuddy-v2.db` = 116 `app_events` + 248 `app_state_snapshots`;
+  ~110k log lines; 76 UNKNOWN window + 47 UNKNOWN click captures), grounded + adversarially verified.
+  **Hypotheses, not concluded fixes.** No code changes from this session.
+
+### Verification TODOs — 06-17 fixes held in the field (confirmation 1/2)
+
+The event stream is **structurally clean** — 18 `OFFER_RECEIVED` (9 ACCEPTED + 9 DECLINED), 9
+`DELIVERY_COMPLETED`, every offer carries non-null pay, every completion carries non-null pay + a
+distinct customer hash, exactly one completion per job, earnings reconcile to the cent ($152.07
+completed vs $145.90 accepted = two legit post-accept tip bumps), and **zero ERROR log lines** across
+8h. This is **confirmation 1/2** for each of the following (each still needs a 2nd clean dash):
+
+- **#498** (phantom / "the customer" / $0.00 completion): 0 dropoff tasks with a null `customerNameHash`
+  across all 248 snapshots; "the customer" placeholder never stuck; no $0.00 completion.
+- **#518** (cross-job leak / double-count): exactly 1 `DELIVERY_COMPLETED` per job for all 9 jobs; the
+  #522 idempotency key is firing.
+- **#517 / #498 ghost**: all 18 `OFFER_RECEIVED` have a non-null `parsedOffer.payAmount`.
+
+### Bugs / data-quality — the one multi-store stack (job `…210799-1`: Target SHOP + Maple Street PICKUP, $15.15)
+
+This was the **first real multi-store stack on the post-#503 build** and the only rich anomaly of the
+day. Two pickups (Target, Maple Street) and two distinct dropoff customers (`8e2dfa`, `e1266f`) formed
+correctly — the old heuristic minted both pickups fine and slice-3b kept the drops distinct. But:
+
+#### 1. A PICKUP task acquired a delivery customer hash — *(data-quality, hypothesis → #548)*
+The Maple Street **pickup** task carries `customerNameHash=8e2dfa`. It binds on the `pickup_arrival`
+frame (`app_events` seq 9; snapshot rowid 45→50). **Likely cause:** the `pickup_arrival` rule
+legitimately `sha256`'s the "Order for X" name (`doordash.json:1071`) and the stepper stamps it onto
+the active pickup (`PlatformRegionStepper:901`). Privacy is intact (hash at edge); semantically a
+pickup shouldn't own a delivery customer, and that hash then bleeds onto the first dropoff. Filed #548.
+
+#### 2. Both dropoffs labelled "Maple Street" — the Target order's drop lost its store — *(bug, hypothesis → folded into #526)*
+Final state (snapshot rowid 1005): both DROPOFFs show `store='Maple Street Biscuit Company'`, but the
+combined receipt (seq 18 `parsedPay`) proves one is the Target order (`Target (02426) $2.25` alongside
+`Maple Street - Alamo Ranch $6.50`), and `offerStoreHint=['Target']`. **Likely cause:** **no dropoff
+rule parses a `storeName` at all**, so `storeName = taskFields?.storeName ?: currentTask?.storeName`
+(`PlatformRegionStepper:876`) makes each drop inherit the prior pickup's store. There is no
+offer-order-index ↔ dropoff binding to recover Target on its drop. **This is exactly the mis-attribution
+class #526's swap primitive targets** — and it reshaped #526: the reliable mis-bind signal is *store
+divergence* (a dropoff's inherited store ≠ its order's `offerStoreHint`), **not** customer correlation
+(which already works), and #526's scope widens to dropoff store re-attribution.
+
+### Field UX context — stacked-drop completion is one combined receipt *(dev clarification, NOT a bug)*
+
+The stack fired 2 `DELIVERY_ARRIVED` + 2 `DELIVERY_CONFIRMED` but only **1** `DELIVERY_COMPLETED`
+($15.15 combined). **Dev confirmed in-field (2026-06-19): this is expected** — DoorDash shows **no
+PostTask receipt between stacked drops; one combined receipt at the end**. Completion fires on
+PostTask-exit (`EffectMap:286`), so one combined completion is correct. The end receipt's `parsedPay`
+breaks out per-order pay, which is the data source for **per-drop attribution = #528** (an enhancement,
+not a defect).
+
+### Open questions / recognition gaps (lower priority — state stayed clean via grace)
+
+1. **Dropoff-arrived "refined map pin" card → UNKNOWN** (~7 frames; ids `dropping_off_action_view` /
+   `complete_delivery_steps_button`). Carries raw name + full address + gate code → any rule MUST
+   `sha256` name/address and not store gate-code text. Filed #549.
+2. **Shopping sub-flow family → UNKNOWN** (~10 frames): barcode-scan-confirm, substitution / wrong-item
+   / shelf-photo / weight-mismatch, and a **"we adjusted your pay" toast** (a mid-shop pay change
+   currently invisible to the state machine). Filed #550.
+3. **The stack offer's UNKNOWN frames are transient partial renders** of the bottom-sheet (loading →
+   Accept-only → Decline-only) — **not** a missed offer; the stable frame parsed the 2-order stack
+   correctly. Frame-admission noise, not a recognition gap.
+
+### Meta / architecture — logging is not semantic (→ CLAUDE.md Principle #7, #551)
+
+~110k lines under one Timber tag (`App`), DEBUG 76% / INFO 22% / WARN 1.2% / ERROR 0; INFO is per-frame
+`SCREEN:` spam (`dropoff_navigation` ×7,406), WARN is drowned by benign `👻 NULL CHILDREN`. **Privacy
+finding:** raw merchant names already leak into INFO+ lines (`INFO/Chat: Pickup: H-E-B`; a TTS line
+naming two stores) — a user-shareable bug report from INFO+ would ship third-party identity in
+plaintext. Drove the new **Development Principle #7 (Semantic, PII-safe logging)** + implementation
+issue #551.
 
 ## 2026-06-17 — DoorDash session (live dash, in-field narration)
 


### PR DESCRIPTION
Docs-only. `[skip ci]`

## What
1. **`docs/field-testing/README.md`** — 2026-06-19 session entry (desk analysis of the uploaded dash data). The 06-17 fixes (#498/#518/#517) held in the field — confirmation **1/2** (clean 9-accept/9-completion stream, 0 ERROR, earnings reconcile to the cent). The one multi-store stack (Target SHOP + Maple Street PICKUP) surfaced store mis-attribution; stacked-drop single combined receipt confirmed **expected** by the dev. Bumped #498/#518 checklist items to Confirmed 1/2.
2. **`CLAUDE.md`** — new **Development Principle #7 (Semantic, PII-safe logging)**: 5-level taxonomy (VERBOSE/DEBUG/INFO/WARN/ERROR with concrete mappings), per-component tags (retire the catch-all `App`), two sinks (on-device DEBUG firehose vs a PII-safe INFO+ export a user can send as a bug report), and a fail-closed PII guard. Driven by the 06-19 log (one tag, ERROR 0, raw merchant names leaking into INFO+ lines — a direct privacy-pledge hit). Implementation tracked in #551.

## Linked work from this analysis
- #548 (pickup acquires a customer hash), #549 (dropoff "refined map pin" card → UNKNOWN), #550 (shopping sub-flow incl. pay-adjusted toast), #551 (logging implementation).
- #526 reshaped (store-divergence trigger + dropoff store re-attribution); #528 gets the per-drop attribution note.

## Posture
Docs only — no code, recognition, capture, network, or effect change. Principle #7 itself is a privacy-hardening guideline; its implementation (#551) carries the actual privacy surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)