### PR TITLE
feat(state): shadow store-chain projector + order attribution (#159 / #526 Step 3)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/DashBuddyApplication.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/DashBuddyApplication.kt
@@ -52,6 +52,9 @@ class DashBuddyApplication : Application(), Configuration.Provider {
     @Inject
     lateinit var jsonRuleInterpreter: JsonRuleInterpreter
 
+    @Inject
+    lateinit var shadowStoreChainLogger: cloud.trotter.dashbuddy.state.shadow.ShadowStoreChainLogger
+
     // Global Context Accessor (Still useful for Utils, but avoid if possible)
     companion object {
         lateinit var instance: DashBuddyApplication
@@ -112,6 +115,13 @@ class DashBuddyApplication : Application(), Configuration.Provider {
         // 3. Initialize State
         stateManagerV2.initialize()
         Timber.i("StateManagerV2 initialized.")
+
+        // 3b. Shadow store-chain projection (#159 / #526 Step 3): debug-only, log-only — observe
+        // completed jobs and log the offer→pickup→dropoff→payout chain so we can verify store
+        // resolution against real dashes and build corpus before a persisting projector exists.
+        if (BuildConfig.DEBUG) {
+            shadowStoreChainLogger.start(applicationScope)
+        }
 
         // 4. Schedule Background Tasks
         scheduleBackgroundWorkers()

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/shadow/ShadowStoreChainLogger.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/shadow/ShadowStoreChainLogger.kt
@@ -1,0 +1,70 @@
+package cloud.trotter.dashbuddy.state.shadow
+
+import cloud.trotter.dashbuddy.core.state.StateManagerV2
+import cloud.trotter.dashbuddy.domain.model.pay.ParsedPay
+import cloud.trotter.dashbuddy.domain.state.Job
+import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.domain.state.StoreChainProjector
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * #159 / #526 Step 3 — **shadow** projection of the store-entity chain (offer → pickup → dropoff →
+ * payout) for each completed job. It only **logs** the projection (it never writes an authoritative
+ * read model), so we can read the logs, verify the resolution against real dashes, and build corpus
+ * before a future post-session projector is trusted to persist per-store statistics.
+ *
+ * Runs off the hot path: a passive collector on [StateManagerV2.state] that captures the active job
+ * (with its resolved task stores) and the PostTask payout while a job is live, and emits one chain
+ * line when the job clears. Debug-build only (a diagnostic, like captures). PII-safe by construction
+ * — store names are merchant names, customers are logged as `sha256` prefixes only (no raw PII).
+ */
+@Singleton
+class ShadowStoreChainLogger @Inject constructor(
+    private val stateManager: StateManagerV2,
+) {
+    private data class Pending(val job: Job, val payout: ParsedPay?)
+
+    fun start(scope: CoroutineScope) {
+        scope.launch {
+            val pending = HashMap<Platform, Pending>()
+            stateManager.state.collect { state ->
+                for ((platform, region) in state.regions.platforms) {
+                    val job = region.activeJob
+                    if (job != null) {
+                        val prior = pending[platform]
+                        // A back-to-back job switch (no idle between) — flush the prior job first.
+                        if (prior != null && prior.job.jobId != job.jobId) logChain(prior.job, prior.payout)
+                        // Keep the payout once PostTask surfaces it, even if a later frame clears it.
+                        val payout = region.lastPostTaskFields?.parsedPay
+                            ?: prior?.takeIf { it.job.jobId == job.jobId }?.payout
+                        pending[platform] = Pending(job, payout)
+                    } else {
+                        pending.remove(platform)?.let { logChain(it.job, it.payout) }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun logChain(job: Job, payout: ParsedPay?) {
+        val chain = StoreChainProjector.project(job, payout)
+        if (chain.links.isEmpty()) return
+        val body = chain.links.joinToString("; ") { l ->
+            buildString {
+                append("[").append(l.canonicalStore).append("]")
+                append(" offer=").append(l.offerName ?: "—")
+                append(" dropoff=").append(l.dropoffName ?: "—")
+                append(" payout=").append(l.payoutName ?: "—")
+                append(" key=").append(l.runningKey ?: "—")
+                l.realizedTip?.let { append(" tip=").append(it) }
+                append(" custs=").append(l.customerHashes.map { it.take(6) })
+            }
+        }
+        Timber.tag("ShadowProjector").i("job %s store-chain (%d): %s", chain.jobId, chain.links.size, body)
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/test/util/SnapshotRedactor.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/test/util/SnapshotRedactor.kt
@@ -53,10 +53,28 @@ object SnapshotRedactor {
         """\b\d{1,6}\s+([A-Za-z0-9.'\-]+\s+){0,4}""" +
             """(Rd|Road|St|Street|Ave|Avenue|Blvd|Boulevard|Dr|Drive|Ln|Lane|Way|Ct|Court|""" +
             """Hwy|Highway|Pkwy|Parkway|Pl|Place|Cir|Circle|Trl|Trail|Loop|Ter|Terrace|Pike|""" +
+            """Path|Walk|Pass|Run|Row|Bend|Bnd|Cove|Cv|Crossing|Xing|Square|Sq|Plaza|Plz|""" +
+            """Point|Pt|Alley|Aly|Trace|Trce|Manor|Mnr|Grove|Grv|Ridge|Rdg|Creek|Crk|Hill|Hills|""" +
             """I-\d+|FM\s*\d+|US-?\d+)\b""",
         RegexOption.IGNORE_CASE,
     )
+    /** "City, ST 78254" (incl. ZIP+4) — the city/state/zip line of a dropoff address, often id-less. */
+    private val CITY_STATE_ZIP = Regex("""\b[A-Z][A-Za-z.'-]+(?:\s+[A-Z][A-Za-z.'-]+){0,3},\s*[A-Z]{2}\s+\d{5}(?:-\d{4})?\b""")
+    /**
+     * A full single-line address "7610 Fletchers, San Antonio, TX 78254" — house number + a
+     * (possibly suffix-less) street, then city, ST zip. Masked whole so an unsuffixed street can't
+     * survive ahead of the city/state/zip. Anchored to the ZIP so it can't run away.
+     */
+    private val FULL_ADDRESS = Regex("""\b\d{1,6}\s+[^,]+,\s*[A-Z][A-Za-z .'-]+,\s*[A-Z]{2}\s+\d{5}(?:-\d{4})?\b""")
+    /**
+     * A bare street line with no recognized suffix, e.g. "7610 Flecthers" — `<housenum> <Word(s)>`
+     * with the whole string being just that. Anchored to the full value so it can't eat "29 items"
+     * or "$15.15 Guaranteed"; requires a capitalized street word, not a unit/count.
+     */
+    private val BARE_STREET = Regex("""^\d{2,6}\s+[A-Z][A-Za-z.'-]+(?:\s+[A-Z][A-Za-z0-9.'-]+){0,3}$""")
     private val APT = Regex("""(?i)\b(apt|suite|ste|unit|bldg|building|gate code|gate)\b[:#\s]*[A-Za-z0-9\-]+""")
+    /** A quoted free-text customer note, e.g. "Corner House, please leave at door." — customer-entered, mask whole. */
+    private val QUOTED_NOTE = Regex(""""[^"]{6,}"""")
 
     /** Masked payout/debit card on cashout screens, e.g. "Visa ••••6222" or "Debit card ....1234". */
     private val CARD = Regex(
@@ -120,12 +138,18 @@ object SnapshotRedactor {
         for (p in NAME_PREFIXES) {
             if (text.startsWith(p, ignoreCase = true) && text.length > p.length) return text.substring(0, p.length) + MASK
         }
+        // A whole-value bare street line ("7610 Flecthers") with no recognized suffix — mask outright
+        // before the token-level passes, so a residual unsuffixed street can't leak.
+        if (BARE_STREET.matches(text.trim())) return "[address]"
         var t = text
         t = EMAIL.replace(t, "[email]")
         t = PHONE.replace(t, "[phone]")
         t = CARD.replace(t, "[card]")
+        t = QUOTED_NOTE.replace(t, "\"[note]\"")
         t = APT.replace(t) { it.value.substringBefore(it.groupValues[1]) + it.groupValues[1] + " " + MASK }
+        t = FULL_ADDRESS.replace(t, "[address]")
         t = STREET.replace(t, "[address]")
+        t = CITY_STATE_ZIP.replace(t, "[address]")
         return t
     }
 }

--- a/app/src/test/resources/snapshots/approved-parse-output.json
+++ b/app/src/test/resources/snapshots/approved-parse-output.json
@@ -1556,6 +1556,69 @@
             "subFlow": "NAVIGATION"
         }
     },
+    "dropoff_pre_arrival/2026-06-19__doordash__dropoff_pre_arrival_maple_stack__1af5ba.json": {
+        "ruleId": "doordash.screen.dropoff_pre_arrival",
+        "intent": "dropoff_pre_arrival",
+        "shape": "task",
+        "fields": {
+            "arrivalConfirmed": false,
+            "customerAddressHash": null,
+            "customerNameHash": "017ad73325fcf108a972edac618f9edfc957c5b1de10f8b371b0a8bfa4f59e2d",
+            "deadline": {
+                "text": "11:04 AM",
+                "time": 1780311840000
+            },
+            "itemsRemaining": null,
+            "itemsShopped": null,
+            "phase": "DROPOFF",
+            "redCardTotal": null,
+            "storeAddress": null,
+            "storeName": "Maple Street Biscuit - Alamo Ranch",
+            "subFlow": "NAVIGATION"
+        }
+    },
+    "dropoff_pre_arrival/2026-06-19__doordash__dropoff_pre_arrival_target_stack__0a2d69.json": {
+        "ruleId": "doordash.screen.dropoff_pre_arrival",
+        "intent": "dropoff_pre_arrival",
+        "shape": "task",
+        "fields": {
+            "arrivalConfirmed": false,
+            "customerAddressHash": null,
+            "customerNameHash": "017ad73325fcf108a972edac618f9edfc957c5b1de10f8b371b0a8bfa4f59e2d",
+            "deadline": {
+                "text": "11:20 AM",
+                "time": 1780312800000
+            },
+            "itemsRemaining": null,
+            "itemsShopped": null,
+            "phase": "DROPOFF",
+            "redCardTotal": null,
+            "storeAddress": null,
+            "storeName": "Target (02426)",
+            "subFlow": "NAVIGATION"
+        }
+    },
+    "dropoff_pre_arrival/2026-06-19__doordash__dropoff_pre_arrival_walgreens__6f91ba.json": {
+        "ruleId": "doordash.screen.dropoff_pre_arrival",
+        "intent": "dropoff_pre_arrival",
+        "shape": "task",
+        "fields": {
+            "arrivalConfirmed": false,
+            "customerAddressHash": null,
+            "customerNameHash": "017ad73325fcf108a972edac618f9edfc957c5b1de10f8b371b0a8bfa4f59e2d",
+            "deadline": {
+                "text": "2:32 PM",
+                "time": 1780324320000
+            },
+            "itemsRemaining": null,
+            "itemsShopped": null,
+            "phase": "DROPOFF",
+            "redCardTotal": null,
+            "storeAddress": null,
+            "storeName": "Walgreens (3571)",
+            "subFlow": "NAVIGATION"
+        }
+    },
     "dropoff_pre_arrival/20260128_180652_578_DROPOFF_DETAILS_PRE_ARRIVAL.json": {
         "ruleId": "doordash.screen.dropoff_pre_arrival",
         "intent": "dropoff_pre_arrival",
@@ -1594,7 +1657,7 @@
             "phase": "DROPOFF",
             "redCardTotal": null,
             "storeAddress": null,
-            "storeName": null,
+            "storeName": "True Texas Bbq (799)",
             "subFlow": "NAVIGATION"
         }
     },
@@ -1615,7 +1678,7 @@
             "phase": "DROPOFF",
             "redCardTotal": null,
             "storeAddress": null,
-            "storeName": null,
+            "storeName": "True Texas Bbq (799)",
             "subFlow": "NAVIGATION"
         }
     },

--- a/app/src/test/resources/snapshots/dropoff_pre_arrival/2026-06-19__doordash__dropoff_pre_arrival_maple_stack__1af5ba.json
+++ b/app/src/test/resources/snapshots/dropoff_pre_arrival/2026-06-19__doordash__dropoff_pre_arrival_maple_stack__1af5ba.json
@@ -1,0 +1,778 @@
+{
+    "captureId": "7df01aa2-ffe8-41b4-a6af-c0ac51513994",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1781885096423,
+    "platform": "doordash",
+    "ruleId": "doordash.screen.dropoff_pre_arrival",
+    "classificationName": "dropoff_pre_arrival",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 136,
+                            "right": 1080,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 136,
+                                    "right": 1080,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 136,
+                                            "right": 1080,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/container",
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 136,
+                                                    "right": 1080,
+                                                    "bottom": 2347
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/toolbar_container",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 136
+                                                        }
+                                                    },
+                                                    {
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/fragment",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 136,
+                                                                    "right": 1080,
+                                                                    "bottom": 2347
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.view.ViewGroup",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 136,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/drop_off_workflow_host_fragment",
+                                                                                "class": "android.widget.FrameLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 136,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2347
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/drop_off_workflow_host_fragment",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 136,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2347
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "androidx.compose.ui.platform.ComposeView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 136,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2347
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 136,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2347
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 136,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2347
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 243,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2032
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 243,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 535
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "text": "Deliver to [redacted]",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 288,
+                                                                                                                                            "right": 573,
+                                                                                                                                            "bottom": 354
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "text": "by 11:04 AM",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 363,
+                                                                                                                                            "right": 256,
+                                                                                                                                            "bottom": 410
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 419,
+                                                                                                                                            "right": 204,
+                                                                                                                                            "bottom": 526
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 28,
+                                                                                                                                                    "top": 420,
+                                                                                                                                                    "right": 134,
+                                                                                                                                                    "bottom": 526
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "Call",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 108,
+                                                                                                                                                    "top": 451,
+                                                                                                                                                    "right": 175,
+                                                                                                                                                    "bottom": 494
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 437,
+                                                                                                                                                    "right": 204,
+                                                                                                                                                    "bottom": 508
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 222,
+                                                                                                                                            "top": 419,
+                                                                                                                                            "right": 472,
+                                                                                                                                            "bottom": 526
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 214,
+                                                                                                                                                    "top": 420,
+                                                                                                                                                    "right": 320,
+                                                                                                                                                    "bottom": 526
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "Message",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 294,
+                                                                                                                                                    "top": 451,
+                                                                                                                                                    "right": 443,
+                                                                                                                                                    "bottom": 494
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 222,
+                                                                                                                                                    "top": 437,
+                                                                                                                                                    "right": 472,
+                                                                                                                                                    "bottom": 508
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 571,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 1145
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 179,
+                                                                                                                                            "top": 603,
+                                                                                                                                            "right": 1008,
+                                                                                                                                            "bottom": 710
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "[address]",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 179,
+                                                                                                                                                    "top": 607,
+                                                                                                                                                    "right": 479,
+                                                                                                                                                    "bottom": 659
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "[address]",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 179,
+                                                                                                                                                    "top": 659,
+                                                                                                                                                    "right": 873,
+                                                                                                                                                    "bottom": 706
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 179,
+                                                                                                                                                    "top": 607,
+                                                                                                                                                    "right": 1008,
+                                                                                                                                                    "bottom": 706
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 742,
+                                                                                                                                            "right": 1044,
+                                                                                                                                            "bottom": 1145
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 690,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 744
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isClickable": true,
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 744,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 1145
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 1181,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 1497
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 179,
+                                                                                                                                            "top": 1209,
+                                                                                                                                            "right": 910,
+                                                                                                                                            "bottom": 1315
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Leave it at the door",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 179,
+                                                                                                                                                    "top": 1236,
+                                                                                                                                                    "right": 574,
+                                                                                                                                                    "bottom": 1288
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 179,
+                                                                                                                                                    "top": 1236,
+                                                                                                                                                    "right": 919,
+                                                                                                                                                    "bottom": 1288
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 910,
+                                                                                                                                            "top": 1208,
+                                                                                                                                            "right": 1017,
+                                                                                                                                            "bottom": 1315
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 910,
+                                                                                                                                                    "top": 1208,
+                                                                                                                                                    "right": 1017,
+                                                                                                                                                    "bottom": 1315
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 1290,
+                                                                                                                                            "right": 1044,
+                                                                                                                                            "bottom": 1396
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "text": "\"[note]\"",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 178,
+                                                                                                                                            "top": 1397,
+                                                                                                                                            "right": 991,
+                                                                                                                                            "bottom": 1444
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 1533,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 1676
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 1533,
+                                                                                                                                            "right": 1044,
+                                                                                                                                            "bottom": 1676
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 54,
+                                                                                                                                                    "top": 1551,
+                                                                                                                                                    "right": 161,
+                                                                                                                                                    "bottom": 1658
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "Maple Street Biscuit - Alamo Ranch",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 179,
+                                                                                                                                                    "top": 1579,
+                                                                                                                                                    "right": 904,
+                                                                                                                                                    "bottom": 1631
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 1980,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2086
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 2034,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2347
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 2070,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 2177
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.Button",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 2070,
+                                                                                                                                            "right": 1044,
+                                                                                                                                            "bottom": 2177
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Continue",
+                                                                                                                                                "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 445,
+                                                                                                                                                    "top": 2091,
+                                                                                                                                                    "right": 635,
+                                                                                                                                                    "bottom": 2157
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 2204,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 2311
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.Button",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 2204,
+                                                                                                                                            "right": 1044,
+                                                                                                                                            "bottom": 2311
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Directions",
+                                                                                                                                                "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 435,
+                                                                                                                                                    "top": 2225,
+                                                                                                                                                    "right": 646,
+                                                                                                                                                    "bottom": 2291
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 136,
+                                                                                                                            "right": 107,
+                                                                                                                            "bottom": 243
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "desc": "Settings",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 27,
+                                                                                                                                    "top": 163,
+                                                                                                                                    "right": 80,
+                                                                                                                                    "bottom": 216
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 9,
+                                                                                                                                    "top": 145,
+                                                                                                                                    "right": 98,
+                                                                                                                                    "bottom": 234
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 107,
+                                                                                                                            "top": 137,
+                                                                                                                            "right": 866,
+                                                                                                                            "bottom": 243
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 866,
+                                                                                                                            "top": 136,
+                                                                                                                            "right": 973,
+                                                                                                                            "bottom": 243
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "desc": "Safety",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 893,
+                                                                                                                                    "top": 163,
+                                                                                                                                    "right": 946,
+                                                                                                                                    "bottom": 216
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 875,
+                                                                                                                                    "top": 145,
+                                                                                                                                    "right": 964,
+                                                                                                                                    "bottom": 234
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 973,
+                                                                                                                            "top": 136,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 243
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "desc": "Help",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 1000,
+                                                                                                                                    "top": 163,
+                                                                                                                                    "right": 1053,
+                                                                                                                                    "bottom": 216
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 982,
+                                                                                                                                    "top": 145,
+                                                                                                                                    "right": 1071,
+                                                                                                                                    "bottom": 234
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/dropoff_pre_arrival/2026-06-19__doordash__dropoff_pre_arrival_target_stack__0a2d69.json
+++ b/app/src/test/resources/snapshots/dropoff_pre_arrival/2026-06-19__doordash__dropoff_pre_arrival_target_stack__0a2d69.json
@@ -1,0 +1,788 @@
+{
+    "captureId": "3219343c-7422-41c3-a482-b77af02f663b",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1781885117593,
+    "platform": "doordash",
+    "ruleId": "doordash.screen.dropoff_pre_arrival",
+    "classificationName": "dropoff_pre_arrival",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 136,
+                            "right": 1080,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 136,
+                                    "right": 1080,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 136,
+                                            "right": 1080,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/container",
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 136,
+                                                    "right": 1080,
+                                                    "bottom": 2347
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/toolbar_container",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 136
+                                                        }
+                                                    },
+                                                    {
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/fragment",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 136,
+                                                                    "right": 1080,
+                                                                    "bottom": 2347
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.view.ViewGroup",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 136,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/drop_off_workflow_host_fragment",
+                                                                                "class": "android.widget.FrameLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 136,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2347
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/drop_off_workflow_host_fragment",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 136,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2347
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "androidx.compose.ui.platform.ComposeView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 136,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2347
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 136,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2347
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 136,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2347
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 243,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2166
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 243,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 535
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "text": "Deliver to [redacted]",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 288,
+                                                                                                                                            "right": 493,
+                                                                                                                                            "bottom": 354
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "text": "by 11:20 AM",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 363,
+                                                                                                                                            "right": 254,
+                                                                                                                                            "bottom": 410
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 419,
+                                                                                                                                            "right": 204,
+                                                                                                                                            "bottom": 526
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 28,
+                                                                                                                                                    "top": 420,
+                                                                                                                                                    "right": 134,
+                                                                                                                                                    "bottom": 526
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "Call",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 108,
+                                                                                                                                                    "top": 451,
+                                                                                                                                                    "right": 175,
+                                                                                                                                                    "bottom": 494
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 437,
+                                                                                                                                                    "right": 204,
+                                                                                                                                                    "bottom": 508
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 222,
+                                                                                                                                            "top": 419,
+                                                                                                                                            "right": 472,
+                                                                                                                                            "bottom": 526
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 214,
+                                                                                                                                                    "top": 420,
+                                                                                                                                                    "right": 320,
+                                                                                                                                                    "bottom": 526
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "Message",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 294,
+                                                                                                                                                    "top": 451,
+                                                                                                                                                    "right": 443,
+                                                                                                                                                    "bottom": 494
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 222,
+                                                                                                                                                    "top": 437,
+                                                                                                                                                    "right": 472,
+                                                                                                                                                    "bottom": 508
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 571,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 1145
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 179,
+                                                                                                                                            "top": 603,
+                                                                                                                                            "right": 1008,
+                                                                                                                                            "bottom": 710
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "[address]",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 179,
+                                                                                                                                                    "top": 607,
+                                                                                                                                                    "right": 521,
+                                                                                                                                                    "bottom": 659
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "[address]",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 179,
+                                                                                                                                                    "top": 659,
+                                                                                                                                                    "right": 591,
+                                                                                                                                                    "bottom": 706
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 179,
+                                                                                                                                                    "top": 607,
+                                                                                                                                                    "right": 1008,
+                                                                                                                                                    "bottom": 706
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 742,
+                                                                                                                                            "right": 1044,
+                                                                                                                                            "bottom": 1145
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 690,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 744
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isClickable": true,
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 744,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 1145
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 1181,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 1342
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 179,
+                                                                                                                                            "top": 1209,
+                                                                                                                                            "right": 910,
+                                                                                                                                            "bottom": 1315
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Leave it at the door",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 179,
+                                                                                                                                                    "top": 1236,
+                                                                                                                                                    "right": 574,
+                                                                                                                                                    "bottom": 1288
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 179,
+                                                                                                                                                    "top": 1236,
+                                                                                                                                                    "right": 919,
+                                                                                                                                                    "bottom": 1288
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 910,
+                                                                                                                                            "top": 1208,
+                                                                                                                                            "right": 1017,
+                                                                                                                                            "bottom": 1315
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 910,
+                                                                                                                                                    "top": 1208,
+                                                                                                                                                    "right": 1017,
+                                                                                                                                                    "bottom": 1315
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 1378,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 1699
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 1378,
+                                                                                                                                            "right": 1044,
+                                                                                                                                            "bottom": 1699
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Target (02426)",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 179,
+                                                                                                                                                    "top": 1424,
+                                                                                                                                                    "right": 487,
+                                                                                                                                                    "bottom": 1476
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 72,
+                                                                                                                                                    "top": 1521,
+                                                                                                                                                    "right": 1008,
+                                                                                                                                                    "bottom": 1628
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "class": "android.view.View",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 179,
+                                                                                                                                                            "top": 1521,
+                                                                                                                                                            "right": 286,
+                                                                                                                                                            "bottom": 1628
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "desc": "Chobani Zero Sugar Sweet Cream Coffee Creamer (24 oz)",
+                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 179,
+                                                                                                                                                                    "top": 1521,
+                                                                                                                                                                    "right": 286,
+                                                                                                                                                                    "bottom": 1628
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "class": "android.view.View",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 295,
+                                                                                                                                                            "top": 1521,
+                                                                                                                                                            "right": 402,
+                                                                                                                                                            "bottom": 1628
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "desc": "Horizon Organic Half & Half Carton (1 qt)",
+                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 295,
+                                                                                                                                                                    "top": 1521,
+                                                                                                                                                                    "right": 402,
+                                                                                                                                                                    "bottom": 1628
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 72,
+                                                                                                                                                    "top": 1521,
+                                                                                                                                                    "right": 179,
+                                                                                                                                                    "bottom": 1699
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 901,
+                                                                                                                                                    "top": 1521,
+                                                                                                                                                    "right": 1008,
+                                                                                                                                                    "bottom": 1699
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 2114,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2220
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 2168,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2347
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 2204,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 2311
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.Button",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 2204,
+                                                                                                                                            "right": 1044,
+                                                                                                                                            "bottom": 2311
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Directions",
+                                                                                                                                                "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 435,
+                                                                                                                                                    "top": 2225,
+                                                                                                                                                    "right": 646,
+                                                                                                                                                    "bottom": 2291
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 136,
+                                                                                                                            "right": 107,
+                                                                                                                            "bottom": 243
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "desc": "Settings",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 27,
+                                                                                                                                    "top": 163,
+                                                                                                                                    "right": 80,
+                                                                                                                                    "bottom": 216
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 9,
+                                                                                                                                    "top": 145,
+                                                                                                                                    "right": 98,
+                                                                                                                                    "bottom": 234
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 107,
+                                                                                                                            "top": 137,
+                                                                                                                            "right": 866,
+                                                                                                                            "bottom": 243
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 866,
+                                                                                                                            "top": 136,
+                                                                                                                            "right": 973,
+                                                                                                                            "bottom": 243
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "desc": "Safety",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 893,
+                                                                                                                                    "top": 163,
+                                                                                                                                    "right": 946,
+                                                                                                                                    "bottom": 216
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 875,
+                                                                                                                                    "top": 145,
+                                                                                                                                    "right": 964,
+                                                                                                                                    "bottom": 234
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 973,
+                                                                                                                            "top": 136,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 243
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "desc": "Help",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 1000,
+                                                                                                                                    "top": 163,
+                                                                                                                                    "right": 1053,
+                                                                                                                                    "bottom": 216
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 982,
+                                                                                                                                    "top": 145,
+                                                                                                                                    "right": 1071,
+                                                                                                                                    "bottom": 234
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/dropoff_pre_arrival/2026-06-19__doordash__dropoff_pre_arrival_walgreens__6f91ba.json
+++ b/app/src/test/resources/snapshots/dropoff_pre_arrival/2026-06-19__doordash__dropoff_pre_arrival_walgreens__6f91ba.json
@@ -1,0 +1,690 @@
+{
+    "captureId": "28d89a46-291f-4d22-9606-fdafc88f200e",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1781897273244,
+    "platform": "doordash",
+    "ruleId": "doordash.screen.dropoff_pre_arrival",
+    "classificationName": "dropoff_pre_arrival",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": -210,
+            "top": 0,
+            "right": 869,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": -210,
+                    "top": 0,
+                    "right": 869,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 136,
+                            "right": 1080,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": -210,
+                                    "top": 136,
+                                    "right": 869,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": -210,
+                                            "top": 136,
+                                            "right": 869,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/container",
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": -210,
+                                                    "top": 136,
+                                                    "right": 869,
+                                                    "bottom": 2347
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/toolbar_container",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": -210,
+                                                            "top": 136,
+                                                            "right": 869,
+                                                            "bottom": 136
+                                                        }
+                                                    },
+                                                    {
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": -210,
+                                                            "top": 136,
+                                                            "right": 869,
+                                                            "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/fragment",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": -210,
+                                                                    "top": 136,
+                                                                    "right": 869,
+                                                                    "bottom": 2347
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.view.ViewGroup",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": -210,
+                                                                            "top": 136,
+                                                                            "right": 869,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/drop_off_workflow_host_fragment",
+                                                                                "class": "android.widget.FrameLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": -210,
+                                                                                    "top": 136,
+                                                                                    "right": 869,
+                                                                                    "bottom": 2347
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/drop_off_workflow_host_fragment",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": -210,
+                                                                                            "top": 136,
+                                                                                            "right": 869,
+                                                                                            "bottom": 2347
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "androidx.compose.ui.platform.ComposeView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": -210,
+                                                                                                    "top": 136,
+                                                                                                    "right": 869,
+                                                                                                    "bottom": 2347
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": -210,
+                                                                                                            "top": 136,
+                                                                                                            "right": 869,
+                                                                                                            "bottom": 2347
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": -210,
+                                                                                                                    "top": 136,
+                                                                                                                    "right": 869,
+                                                                                                                    "bottom": 2347
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": -210,
+                                                                                                                            "top": 243,
+                                                                                                                            "right": 869,
+                                                                                                                            "bottom": 2032
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": -174,
+                                                                                                                                    "top": 243,
+                                                                                                                                    "right": 833,
+                                                                                                                                    "bottom": 464
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "text": "Deliver to [redacted]",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": -174,
+                                                                                                                                            "top": 288,
+                                                                                                                                            "right": 314,
+                                                                                                                                            "bottom": 354
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "text": "by 2:32 PM",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": -174,
+                                                                                                                                            "top": 363,
+                                                                                                                                            "right": 29,
+                                                                                                                                            "bottom": 410
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": -174,
+                                                                                                                                    "top": 500,
+                                                                                                                                    "right": 833,
+                                                                                                                                    "bottom": 1074
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": -31,
+                                                                                                                                            "top": 532,
+                                                                                                                                            "right": 797,
+                                                                                                                                            "bottom": 639
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "[address]",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": -31,
+                                                                                                                                                    "top": 536,
+                                                                                                                                                    "right": 402,
+                                                                                                                                                    "bottom": 588
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "[address]",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": -31,
+                                                                                                                                                    "top": 588,
+                                                                                                                                                    "right": 372,
+                                                                                                                                                    "bottom": 635
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": -31,
+                                                                                                                                                    "top": 536,
+                                                                                                                                                    "right": 797,
+                                                                                                                                                    "bottom": 635
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": -174,
+                                                                                                                                            "top": 671,
+                                                                                                                                            "right": 833,
+                                                                                                                                            "bottom": 1074
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": -174,
+                                                                                                                                                    "top": 619,
+                                                                                                                                                    "right": 833,
+                                                                                                                                                    "bottom": 673
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isClickable": true,
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": -174,
+                                                                                                                                                    "top": 673,
+                                                                                                                                                    "right": 833,
+                                                                                                                                                    "bottom": 1074
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": -174,
+                                                                                                                                    "top": 1110,
+                                                                                                                                    "right": 833,
+                                                                                                                                    "bottom": 1426
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": -31,
+                                                                                                                                            "top": 1138,
+                                                                                                                                            "right": 699,
+                                                                                                                                            "bottom": 1244
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Leave it at the door",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": -31,
+                                                                                                                                                    "top": 1165,
+                                                                                                                                                    "right": 363,
+                                                                                                                                                    "bottom": 1217
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": -31,
+                                                                                                                                                    "top": 1165,
+                                                                                                                                                    "right": 708,
+                                                                                                                                                    "bottom": 1217
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 699,
+                                                                                                                                            "top": 1137,
+                                                                                                                                            "right": 806,
+                                                                                                                                            "bottom": 1244
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 699,
+                                                                                                                                                    "top": 1137,
+                                                                                                                                                    "right": 806,
+                                                                                                                                                    "bottom": 1244
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": -174,
+                                                                                                                                            "top": 1219,
+                                                                                                                                            "right": 833,
+                                                                                                                                            "bottom": 1325
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "text": "\"[note]\"",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": -32,
+                                                                                                                                            "top": 1326,
+                                                                                                                                            "right": 780,
+                                                                                                                                            "bottom": 1373
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": -174,
+                                                                                                                                    "top": 1462,
+                                                                                                                                    "right": 833,
+                                                                                                                                    "bottom": 1605
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": -174,
+                                                                                                                                            "top": 1462,
+                                                                                                                                            "right": 833,
+                                                                                                                                            "bottom": 1605
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": -156,
+                                                                                                                                                    "top": 1481,
+                                                                                                                                                    "right": -49,
+                                                                                                                                                    "bottom": 1587
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "Walgreens (3571)",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": -31,
+                                                                                                                                                    "top": 1508,
+                                                                                                                                                    "right": 324,
+                                                                                                                                                    "bottom": 1560
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": -210,
+                                                                                                                            "top": 1980,
+                                                                                                                            "right": 869,
+                                                                                                                            "bottom": 2086
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": -210,
+                                                                                                                            "top": 2034,
+                                                                                                                            "right": 869,
+                                                                                                                            "bottom": 2347
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 8,
+                                                                                                                                    "top": 2070,
+                                                                                                                                    "right": 1016,
+                                                                                                                                    "bottom": 2177
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.Button",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 8,
+                                                                                                                                            "top": 2070,
+                                                                                                                                            "right": 1016,
+                                                                                                                                            "bottom": 2177
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Continue",
+                                                                                                                                                "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 417,
+                                                                                                                                                    "top": 2091,
+                                                                                                                                                    "right": 607,
+                                                                                                                                                    "bottom": 2157
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 2204,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 2311
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.Button",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 8,
+                                                                                                                                            "top": 2204,
+                                                                                                                                            "right": 1016,
+                                                                                                                                            "bottom": 2311
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Directions",
+                                                                                                                                                "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 407,
+                                                                                                                                                    "top": 2225,
+                                                                                                                                                    "right": 618,
+                                                                                                                                                    "bottom": 2291
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": -27,
+                                                                                                                            "top": 136,
+                                                                                                                            "right": 79,
+                                                                                                                            "bottom": 243
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "desc": "Settings",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 163,
+                                                                                                                                    "right": 52,
+                                                                                                                                    "bottom": 216
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": -18,
+                                                                                                                                    "top": 145,
+                                                                                                                                    "right": 70,
+                                                                                                                                    "bottom": 234
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 79,
+                                                                                                                            "top": 137,
+                                                                                                                            "right": 838,
+                                                                                                                            "bottom": 243
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 838,
+                                                                                                                            "top": 136,
+                                                                                                                            "right": 945,
+                                                                                                                            "bottom": 243
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "desc": "Safety",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 865,
+                                                                                                                                    "top": 163,
+                                                                                                                                    "right": 918,
+                                                                                                                                    "bottom": 216
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 847,
+                                                                                                                                    "top": 145,
+                                                                                                                                    "right": 936,
+                                                                                                                                    "bottom": 234
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 945,
+                                                                                                                            "top": 136,
+                                                                                                                            "right": 1052,
+                                                                                                                            "bottom": 243
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "desc": "Help",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 972,
+                                                                                                                                    "top": 163,
+                                                                                                                                    "right": 1025,
+                                                                                                                                    "bottom": 216
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 982,
+                                                                                                                                    "top": 145,
+                                                                                                                                    "right": 1071,
+                                                                                                                                    "bottom": 234
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/core/pipeline/src/main/assets/rules/doordash.json
+++ b/core/pipeline/src/main/assets/rules/doordash.json
@@ -1448,6 +1448,39 @@
             "separator": ", ",
             "transform": "sha256"
           },
+          "storeName": {
+            "comment": "#526: the dropoff card's merchant label — the same store as the pickup, but in DoorDash's running-key form ('Target (02426)', 'Maple Street Biscuit - Alamo Ranch'), which does NOT string-match the offer/pickup name. The node has no id, so it's anchored by text shape: '<name> (<storeNum>)' (reliable for chains) first, then a strict all-Title-Case '<Name> - <Area>' (so a lowercase delivery instruction can't false-match). Not PII (a merchant name); feeds per-task store self-labelling + the post-session store-entity projector (#159). Null when the card variant doesn't show it.",
+            "coalesce": [
+              {
+                "find": {
+                  "all": [
+                    {
+                      "hasTextMatchesRegex": "^.{1,60} \\(\\d{2,6}\\)$"
+                    },
+                    {
+                      "hasNoId": true
+                    }
+                  ]
+                },
+                "read": "text",
+                "transform": "trim"
+              },
+              {
+                "find": {
+                  "all": [
+                    {
+                      "hasTextMatchesRegex": "^[A-Z][\\w .'&-]{1,48} - [A-Z][\\w .'&-]{1,48}$"
+                    },
+                    {
+                      "hasNoId": true
+                    }
+                  ]
+                },
+                "read": "text",
+                "transform": "trim"
+              }
+            ]
+          },
           "deadlineText": {
             "find": {
               "hasTextMatchesRegex": "\\bby\\s+\\d{1,2}:\\d{2}"

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
@@ -781,8 +781,17 @@ class PlatformRegionStepper @Inject constructor() {
                         jobId = jobId,
                         phase = taskPhase,
                         subPhase = taskSubFlow,
-                        storeName = taskFields?.storeName ?: currentTask?.storeName,
-                        storeAddress = taskFields?.storeAddress ?: currentTask?.storeAddress,
+                        // #526: a newly-minted task takes its store from its OWN frame; only inherit
+                        // the displaced task's store on a SAME-phase mint (e.g. a stacked-pickup
+                        // parser flicker). A cross-phase mint (pickup→dropoff) must NOT inherit — the
+                        // dropoff screen carries its own store (`Target (02426)`), and inheriting the
+                        // pickup's store mislabelled a multi-store stack's drop (06-19 Target+Maple).
+                        // A dropoff with no store frame yet stays null and fills in on its own later
+                        // dropoff_pre_arrival frame via the same-phase update path below.
+                        storeName = taskFields?.storeName
+                            ?: currentTask?.storeName?.takeIf { currentTask.phase == taskPhase },
+                        storeAddress = taskFields?.storeAddress
+                            ?: currentTask?.storeAddress?.takeIf { currentTask.phase == taskPhase },
                         customerNameHash = taskFields?.customerNameHash,
                         customerAddressHash = taskFields?.customerAddressHash,
                         deadlineMillis = taskFields?.deadline?.time,

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
@@ -18,6 +18,7 @@ import cloud.trotter.dashbuddy.domain.state.Task
 import cloud.trotter.dashbuddy.domain.state.TaskPhase
 import cloud.trotter.dashbuddy.domain.state.TaskSubFlow
 import cloud.trotter.dashbuddy.domain.state.TransitionKind
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
 import cloud.trotter.dashbuddy.domain.state.UNKNOWN_STORE
@@ -91,7 +92,59 @@ class PlatformRegionStepper @Inject constructor() {
         nextFlow: FlowRegion,
         obs: Observation,
         policy: TransitionPolicy,
-    ): PlatformRegion = reconcileJobTasks(stepCore(prev, prevFlow, nextFlow, obs, policy))
+    ): PlatformRegion = reconcileDropoffStore(reconcileJobTasks(stepCore(prev, prevFlow, nextFlow, obs, policy)))
+
+    /**
+     * #526: a dropoff's store is resolved from the job's PICKUP lineage, not from the dropoff card's
+     * own text format (which varies per merchant — `Target (02426)` / `Maple Street Biscuit - Alamo
+     * Ranch` — and can't be reliably parsed, see the rule comment). A dropoff always follows its
+     * pickup, and the job already holds the pickups with their authoritative, screen-parsed store
+     * names, so:
+     *  - **one distinct pickup store** (the common single delivery, and same-store stacks) → every
+     *    dropoff is that store. No dropoff parse needed; zero format risk.
+     *  - **multiple pickup stores** (a multi-store stack) → match the dropoff's parsed store *candidate*
+     *    (the rule's best-effort `storeName`) to the pickup with the most shared leading name tokens.
+     *    The match also VALIDATES: a garbage candidate matches no pickup → resolves to null, never a
+     *    wrong store (a wrong store would silently mis-attribute the order/economics).
+     *  - **no pickup seen yet** → keep the candidate as-is.
+     * The resolved value is the matched pickup's canonical (offer-aligned) store name, so pickup and
+     * dropoff carry a consistent label. The dropoff card's running-key form still lives on the
+     * payout for the post-session store-entity projector (#159).
+     */
+    private fun reconcileDropoffStore(region: PlatformRegion): PlatformRegion {
+        val active = region.activeTask ?: return region
+        if (active.phase != TaskPhase.DROPOFF) return region
+        val pickupStores = region.recentTasks
+            .filter { it.jobId == active.jobId && it.phase == TaskPhase.PICKUP && it.storeName != null }
+            .map { it.storeName!! }
+            .distinctBy { it.lowercase(Locale.ROOT) }
+        val resolved = when {
+            pickupStores.size == 1 -> pickupStores.single()
+            pickupStores.isEmpty() -> active.storeName
+            else -> {
+                val cand = active.storeName ?: return region
+                val candTokens = storeTokens(cand)
+                pickupStores
+                    .map { it to sharedLeadingTokens(storeTokens(it), candTokens) }
+                    .filter { it.second >= 1 }
+                    .maxByOrNull { it.second }
+                    ?.first
+            }
+        }
+        return if (resolved == active.storeName) region else region.copy(activeTask = active.copy(storeName = resolved))
+    }
+
+    /** Lowercase alphanumeric tokens of a store name; drops the store-number / punctuation noise that
+     *  differs between the offer/pickup form and the dropoff/payout running-key form. */
+    private fun storeTokens(name: String): List<String> =
+        name.lowercase(Locale.ROOT).split(Regex("[^a-z0-9]+")).filter { it.isNotEmpty() }
+
+    /** Count of matching tokens from the start of both lists — how much of the store name they share. */
+    private fun sharedLeadingTokens(a: List<String>, b: List<String>): Int {
+        var i = 0
+        while (i < a.size && i < b.size && a[i] == b[i]) i++
+        return i
+    }
 
     /**
      * Step 1 of the #503 job-container re-model (additive): mirror the active job's task lineage

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
@@ -14,6 +14,7 @@ import cloud.trotter.dashbuddy.domain.state.PendingDestructive
 import cloud.trotter.dashbuddy.domain.state.PlatformRegion
 import cloud.trotter.dashbuddy.domain.state.Session
 import cloud.trotter.dashbuddy.domain.state.SessionType
+import cloud.trotter.dashbuddy.domain.state.StoreNameMatch
 import cloud.trotter.dashbuddy.domain.state.Task
 import cloud.trotter.dashbuddy.domain.state.TaskPhase
 import cloud.trotter.dashbuddy.domain.state.TaskSubFlow
@@ -123,27 +124,12 @@ class PlatformRegionStepper @Inject constructor() {
             pickupStores.isEmpty() -> active.storeName
             else -> {
                 val cand = active.storeName ?: return region
-                val candTokens = storeTokens(cand)
-                pickupStores
-                    .map { it to sharedLeadingTokens(storeTokens(it), candTokens) }
-                    .filter { it.second >= 1 }
-                    .maxByOrNull { it.second }
-                    ?.first
+                // Match the dropoff's candidate to the pickup with the most shared brand tokens
+                // (the SSOT comparison in [StoreNameMatch]); no match → null, never a wrong store.
+                StoreNameMatch.bestMatch(pickupStores, cand)
             }
         }
         return if (resolved == active.storeName) region else region.copy(activeTask = active.copy(storeName = resolved))
-    }
-
-    /** Lowercase alphanumeric tokens of a store name; drops the store-number / punctuation noise that
-     *  differs between the offer/pickup form and the dropoff/payout running-key form. */
-    private fun storeTokens(name: String): List<String> =
-        name.lowercase(Locale.ROOT).split(Regex("[^a-z0-9]+")).filter { it.isNotEmpty() }
-
-    /** Count of matching tokens from the start of both lists — how much of the store name they share. */
-    private fun sharedLeadingTokens(a: List<String>, b: List<String>): Int {
-        var i = 0
-        while (i < a.size && i < b.size && a[i] == b[i]) i++
-        return i
     }
 
     /**

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/DropoffStoreLabelTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/DropoffStoreLabelTest.kt
@@ -18,12 +18,15 @@ import org.junit.Assert.assertNull
 import org.junit.Test
 
 /**
- * #526 — a dropoff labels its store from its OWN frame (the dropoff card carries it as
- * `Target (02426)` / `Maple Street Biscuit - Alamo Ranch`), and must NOT inherit the prior
- * pickup's store across the phase change. The 06-19 Target+Maple stack mislabelled the Target
- * order's drop "Maple Street" precisely because the cross-phase mint inherited the active pickup's
- * store. Single deliveries (where pickup and dropoff are the same store) are unaffected — the drop
- * just gets the store from its own frame instead of by inheritance.
+ * #526 — a dropoff's store is resolved from the job's PICKUP lineage, not from the dropoff card's
+ * own (per-merchant-variable, often unparseable) text. A dropoff always follows its pickup, and the
+ * job already holds the pickups with their authoritative store names:
+ *  - single pickup store → every dropoff is that store (no dropoff parse; the common 8/9 case);
+ *  - multiple pickup stores → match the dropoff's parsed candidate to a pickup by shared leading
+ *    name tokens, which also validates (garbage candidate → no match → null, never a wrong store).
+ *
+ * This is the proper fix for the 06-19 Target+Maple stack mislabel (the Target drop had inherited
+ * the active Maple pickup's store).
  */
 class DropoffStoreLabelTest {
 
@@ -31,26 +34,27 @@ class DropoffStoreLabelTest {
     private val flowStepper = FlowRegionStepper()
     private val policy = TransitionPolicy()
 
-    private fun region(activeTask: Task?) = PlatformRegion(
+    private fun completedPickup(id: String, store: String) = Task(
+        taskId = id, jobId = "job-1", phase = TaskPhase.PICKUP,
+        storeName = store, arrivedAt = 300L, startedAt = 200L, completedAt = 400L,
+    )
+
+    private fun region(pickups: List<Task>, activeTask: Task? = null) = PlatformRegion(
         platform = Platform.DoorDash,
         mode = Mode.Online,
         session = Session("sess-1", startedAt = 100L),
-        activeJob = Job("job-1", offerStoreHint = emptyList(), parentOfferHash = null, startedAt = 200L),
+        activeJob = Job("job-1", offerStoreHint = emptyList(), parentOfferHash = null, startedAt = 150L),
         activeTask = activeTask,
+        recentTasks = pickups,
     )
 
-    private fun pickup(store: String) = Task(
-        taskId = "pick-1", jobId = "job-1", phase = TaskPhase.PICKUP,
-        storeName = store, arrivedAt = 800L, startedAt = 300L,
-    )
-
-    private fun dropoffObs(timestamp: Long, store: String? = null, customer: String? = "cust-1") =
+    private fun dropoffObs(timestamp: Long, store: String? = null, customer: String) =
         Observation.Screen(
             timestamp = timestamp, captureId = null, ruleId = "doordash.screen.dropoff_pre_arrival",
             metadata = ReplayMetadata.EMPTY, flow = Flow.TaskDropoffNavigation, modeHint = Mode.Online,
             parsed = ParsedFields.TaskFields(
                 phase = TaskPhase.DROPOFF, subFlow = TaskSubFlow.NAVIGATION,
-                storeName = store, customerNameHash = customer, customerAddressHash = "addr-1",
+                storeName = store, customerNameHash = customer, customerAddressHash = "addr-$customer",
             ),
         )
 
@@ -60,38 +64,59 @@ class DropoffStoreLabelTest {
     }
 
     @Test
-    fun `a dropoff takes the store parsed from its own frame`() {
+    fun `single-store job — the dropoff takes the pickup store with no dropoff parse`() {
         val (r, _) = step(
-            region(pickup("Maple Street Biscuit Company")),
-            FlowRegion(flow = Flow.TaskPickupArrived),
+            region(pickups = listOf(completedPickup("pick-1", "H-E-B"))),
+            FlowRegion(flow = Flow.Idle),
+            dropoffObs(1_000L, store = null, customer = "cust-1"),
+        )
+        assertEquals(TaskPhase.DROPOFF, r.activeTask?.phase)
+        assertEquals("a single-pickup job's dropoff is that pickup's store", "H-E-B", r.activeTask?.storeName)
+    }
+
+    @Test
+    fun `single-store job — a dropoff card's running-key form resolves to the canonical pickup store`() {
+        val (r, _) = step(
+            region(pickups = listOf(completedPickup("pick-1", "H-E-B"))),
+            FlowRegion(flow = Flow.Idle),
+            dropoffObs(1_000L, store = "H-E-B plus! #1055", customer = "cust-1"),
+        )
+        assertEquals("the dropoff is canonicalised to the pickup's store name", "H-E-B", r.activeTask?.storeName)
+    }
+
+    @Test
+    fun `multi-store stack — each dropoff matches its own pickup, not the last active one`() {
+        val pickups = listOf(
+            completedPickup("pick-target", "Target"),
+            completedPickup("pick-maple", "Maple Street Biscuit Company"),
+        )
+        val (rTarget, _) = step(
+            region(pickups), FlowRegion(flow = Flow.Idle),
             dropoffObs(1_000L, store = "Target (02426)", customer = "cust-target"),
         )
-        assertEquals(TaskPhase.DROPOFF, r.activeTask?.phase)
-        assertEquals("the drop is labelled by its own store, not the active pickup's", "Target (02426)", r.activeTask?.storeName)
+        assertEquals("the Target drop resolves to Target (not the last pickup, Maple)", "Target", rTarget.activeTask?.storeName)
+
+        val (rMaple, _) = step(
+            region(pickups), FlowRegion(flow = Flow.Idle),
+            dropoffObs(2_000L, store = "Maple Street Biscuit - Alamo Ranch", customer = "cust-maple"),
+        )
+        assertEquals(
+            "the Maple drop resolves to Maple via shared leading tokens (cores differ: '- Alamo Ranch' vs 'Company')",
+            "Maple Street Biscuit Company", rMaple.activeTask?.storeName,
+        )
     }
 
     @Test
-    fun `a dropoff with no store frame does NOT inherit the pickup store (decontamination, #526)`() {
-        // This is the 06-19 mislabel: pickup is Maple, the drop frame carries no store → it must
-        // NOT become "Maple Street Biscuit Company"; it stays null until its own store frame arrives.
+    fun `multi-store stack — a garbage candidate matches no pickup and resolves to null (never a wrong store)`() {
+        val pickups = listOf(
+            completedPickup("pick-target", "Target"),
+            completedPickup("pick-maple", "Maple Street Biscuit Company"),
+        )
         val (r, _) = step(
-            region(pickup("Maple Street Biscuit Company")),
-            FlowRegion(flow = Flow.TaskPickupArrived),
-            dropoffObs(1_000L, store = null, customer = "cust-target"),
+            region(pickups), FlowRegion(flow = Flow.Idle),
+            // A store-absent dropoff frame can yield junk (e.g. an item name); it must NOT be assigned.
+            dropoffObs(1_000L, store = "Horizon Organic Half & Half", customer = "cust-x"),
         )
-        assertEquals(TaskPhase.DROPOFF, r.activeTask?.phase)
-        assertNull("a cross-phase mint must not inherit the pickup's store", r.activeTask?.storeName)
-    }
-
-    @Test
-    fun `the dropoff store sticks once parsed, across later store-less frames`() {
-        val (r1, f1) = step(
-            region(pickup("Target")),
-            FlowRegion(flow = Flow.TaskPickupArrived),
-            dropoffObs(1_000L, store = "Target (02426)", customer = "cust-1"),
-        )
-        // A later same-phase dropoff frame without the store node keeps the resolved store.
-        val (r2, _) = step(r1, f1, dropoffObs(2_000L, store = null, customer = "cust-1"))
-        assertEquals("Target (02426)", r2.activeTask?.storeName)
+        assertNull("an unmatched candidate is rejected, not mis-assigned", r.activeTask?.storeName)
     }
 }

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/DropoffStoreLabelTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/DropoffStoreLabelTest.kt
@@ -1,0 +1,97 @@
+package cloud.trotter.dashbuddy.core.state
+
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
+import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.state.Flow
+import cloud.trotter.dashbuddy.domain.state.FlowRegion
+import cloud.trotter.dashbuddy.domain.state.Job
+import cloud.trotter.dashbuddy.domain.state.Mode
+import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.domain.state.PlatformRegion
+import cloud.trotter.dashbuddy.domain.state.Session
+import cloud.trotter.dashbuddy.domain.state.Task
+import cloud.trotter.dashbuddy.domain.state.TaskPhase
+import cloud.trotter.dashbuddy.domain.state.TaskSubFlow
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * #526 — a dropoff labels its store from its OWN frame (the dropoff card carries it as
+ * `Target (02426)` / `Maple Street Biscuit - Alamo Ranch`), and must NOT inherit the prior
+ * pickup's store across the phase change. The 06-19 Target+Maple stack mislabelled the Target
+ * order's drop "Maple Street" precisely because the cross-phase mint inherited the active pickup's
+ * store. Single deliveries (where pickup and dropoff are the same store) are unaffected — the drop
+ * just gets the store from its own frame instead of by inheritance.
+ */
+class DropoffStoreLabelTest {
+
+    private val stepper = PlatformRegionStepper()
+    private val flowStepper = FlowRegionStepper()
+    private val policy = TransitionPolicy()
+
+    private fun region(activeTask: Task?) = PlatformRegion(
+        platform = Platform.DoorDash,
+        mode = Mode.Online,
+        session = Session("sess-1", startedAt = 100L),
+        activeJob = Job("job-1", offerStoreHint = emptyList(), parentOfferHash = null, startedAt = 200L),
+        activeTask = activeTask,
+    )
+
+    private fun pickup(store: String) = Task(
+        taskId = "pick-1", jobId = "job-1", phase = TaskPhase.PICKUP,
+        storeName = store, arrivedAt = 800L, startedAt = 300L,
+    )
+
+    private fun dropoffObs(timestamp: Long, store: String? = null, customer: String? = "cust-1") =
+        Observation.Screen(
+            timestamp = timestamp, captureId = null, ruleId = "doordash.screen.dropoff_pre_arrival",
+            metadata = ReplayMetadata.EMPTY, flow = Flow.TaskDropoffNavigation, modeHint = Mode.Online,
+            parsed = ParsedFields.TaskFields(
+                phase = TaskPhase.DROPOFF, subFlow = TaskSubFlow.NAVIGATION,
+                storeName = store, customerNameHash = customer, customerAddressHash = "addr-1",
+            ),
+        )
+
+    private fun step(prev: PlatformRegion, prevFlow: FlowRegion, obs: Observation): Pair<PlatformRegion, FlowRegion> {
+        val nextFlow = if (obs is Observation.FlowObservation) flowStepper.step(prevFlow, obs) else prevFlow
+        return stepper.step(prev, prevFlow, nextFlow, obs, policy) to nextFlow
+    }
+
+    @Test
+    fun `a dropoff takes the store parsed from its own frame`() {
+        val (r, _) = step(
+            region(pickup("Maple Street Biscuit Company")),
+            FlowRegion(flow = Flow.TaskPickupArrived),
+            dropoffObs(1_000L, store = "Target (02426)", customer = "cust-target"),
+        )
+        assertEquals(TaskPhase.DROPOFF, r.activeTask?.phase)
+        assertEquals("the drop is labelled by its own store, not the active pickup's", "Target (02426)", r.activeTask?.storeName)
+    }
+
+    @Test
+    fun `a dropoff with no store frame does NOT inherit the pickup store (decontamination, #526)`() {
+        // This is the 06-19 mislabel: pickup is Maple, the drop frame carries no store → it must
+        // NOT become "Maple Street Biscuit Company"; it stays null until its own store frame arrives.
+        val (r, _) = step(
+            region(pickup("Maple Street Biscuit Company")),
+            FlowRegion(flow = Flow.TaskPickupArrived),
+            dropoffObs(1_000L, store = null, customer = "cust-target"),
+        )
+        assertEquals(TaskPhase.DROPOFF, r.activeTask?.phase)
+        assertNull("a cross-phase mint must not inherit the pickup's store", r.activeTask?.storeName)
+    }
+
+    @Test
+    fun `the dropoff store sticks once parsed, across later store-less frames`() {
+        val (r1, f1) = step(
+            region(pickup("Target")),
+            FlowRegion(flow = Flow.TaskPickupArrived),
+            dropoffObs(1_000L, store = "Target (02426)", customer = "cust-1"),
+        )
+        // A later same-phase dropoff frame without the store node keeps the resolved store.
+        val (r2, _) = step(r1, f1, dropoffObs(2_000L, store = null, customer = "cust-1"))
+        assertEquals("Target (02426)", r2.activeTask?.storeName)
+    }
+}

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -63,6 +63,24 @@ immediately (no second pass needed) so it gets triaged.
 _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **broken** on the
 2026-06-09 dash — moved to that session's log entry below for triage.)_
 
+- **🔧 NEW (branch `feature/159-shadow-store-projector`) — dropoff store recognition + pickup-matched resolution (#526/#553). CONFIRM ON DASH.**
+  A dropoff now shows the **correct store**, resolved from the job's pickups (single delivery → the
+  pickup's store; multi-store stack → matched per drop), not inherited from the last active pickup.
+  **Confirm on dash: 0/2 —** on a normal single delivery the dropoff card should show the **right
+  store** (the one you picked up from). On a **multi-store stack** (the real test), each drop should
+  show its **own** store — e.g. a Target+Maple stack shows the Target drop as Target and the Maple
+  drop as Maple, **not both the same**. If a drop shows the wrong store (especially the *other*
+  stop's), capture the dropoff frame sequence + note the stack's stores.
+
+- **🔬 NEW (debug build) — shadow store-chain projector logs (#159/#554). READ THE LOG AFTER A DASH.**
+  Debug-only, log-only: after each completed job the log emits a `ShadowProjector` line —
+  `job <id> store-chain (N): [Store] offer=… dropoff=… payout=… key=… tip=… custs=[…]` — linking the
+  store across offer→pickup→dropoff→payout. **Confirm: 0/2 —** after a dash, grep the app log for
+  `ShadowProjector` and check each job's chain looks right: the four forms line up to the same store,
+  the `key` is the store number/area, the `tip` matches the receipt, and a **stack shows one line per
+  store**. It must **never** affect on-dash behavior (it's shadow). Note any chain that mis-links or
+  any missing/duplicate line. This is the corpus for the eventual persisting #159 projector.
+
 - **🔧 FIX SHIPPED — offer card icon badges + co-icon-text shop badge [cart N] (#461, PR #531). CONFIRM ON DASH.**
   The offer card's badges are now **icons** (red card, alcohol, large order, priority, etc., tinted by
   brand color), and the **Shop & Deliver** badge is the shopping-chat **cart icon + the item count**

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/StoreChainProjection.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/StoreChainProjection.kt
@@ -1,0 +1,92 @@
+package cloud.trotter.dashbuddy.domain.state
+
+import cloud.trotter.dashbuddy.domain.model.pay.ParsedPay
+
+/**
+ * One store entity's appearance across the surfaces of a job — the offer order, its pickup, its
+ * dropoff(s), and the payout line — correlated by brand tokens ([StoreNameMatch]). This is the
+ * runtime, in-memory shape of the #159 store entity: the **chain** that links DoorDash's different
+ * representations of the same physical store, so a later post-session projector can resolve and
+ * accumulate per-store statistics. All customer data stays hashed (privacy: store names are not PII).
+ */
+data class StoreChainLink(
+    /** The authoritative store name from the pickup screen (the anchor / canonical brand form). */
+    val canonicalStore: String,
+    /** The offer-card form of this store (`Target`), if the offer named it. */
+    val offerName: String?,
+    /** The dropoff-card form, if any dropoff resolved to this store. */
+    val dropoffName: String?,
+    /** The payout-line form — the running-key representation (`Target (02426)`), the #159 doordash_key carrier. */
+    val payoutName: String?,
+    /** The running key teased out of [payoutName]: the store number (`02426`) or area (`Alamo Ranch`). */
+    val runningKey: String?,
+    /** Hashed customers delivered to this store on this job (dedup-safe; never raw PII). */
+    val customerHashes: List<String>,
+    /** Realized tip attributed to this store from the payout, when present. */
+    val realizedTip: Double?,
+)
+
+/** The full store chain for one job — every order/store linked across offer → pickup → dropoff → payout. */
+data class JobStoreChain(
+    val jobId: String,
+    val links: List<StoreChainLink>,
+)
+
+/**
+ * Projects a completed (or in-flight) [Job] + its payout into the per-store [JobStoreChain] (#159 /
+ * #526 Step 3 — order attribution). Pure and side-effect-free: it is *shadow* projection input —
+ * the caller logs it for verification / corpus and does NOT mutate authoritative state during a dash.
+ *
+ * Anchors on the job's **pickups** (the authoritative store names) and attaches each other surface
+ * form to the pickup whose brand tokens it best matches, so the offer/dropoff/payout running-key
+ * forms (which don't string-match) line up with the right order. A surface form that matches no
+ * pickup is dropped rather than mis-attributed.
+ */
+object StoreChainProjector {
+
+    fun project(job: Job, payout: ParsedPay?): JobStoreChain {
+        // The pickups are the anchors — one store-entity link per distinct pickup store.
+        val pickupStores = job.tasks
+            .filter { it.phase == TaskPhase.PICKUP && !it.storeName.isNullOrBlank() }
+            .map { it.storeName!! }
+            .distinct()
+
+        val offerHints = job.offerStoreHint.filter { it.isNotBlank() }
+        val dropoffStores = job.tasks
+            .filter { it.phase == TaskPhase.DROPOFF && !it.storeName.isNullOrBlank() }
+            .map { it.storeName!! }
+        val payoutItems = payout?.customerTips.orEmpty().filter { it.type.isNotBlank() }
+
+        val links = pickupStores.map { canonical ->
+            val offerName = StoreNameMatch.bestMatch(offerHints, canonical)
+            val dropoffName = StoreNameMatch.bestMatch(dropoffStores, canonical)
+            val payoutItem = payoutItems
+                .map { it to StoreNameMatch.sharedLeadingTokens(it.type, canonical) }
+                .filter { it.second >= 1 }
+                .maxByOrNull { it.second }
+                ?.first
+            val customerHashes = job.tasks
+                .filter { it.phase == TaskPhase.DROPOFF && it.storeName == canonical && it.customerNameHash != null }
+                .mapNotNull { it.customerNameHash }
+                .distinct()
+            StoreChainLink(
+                canonicalStore = canonical,
+                offerName = offerName,
+                dropoffName = dropoffName,
+                payoutName = payoutItem?.type,
+                runningKey = payoutItem?.type?.let { extractRunningKey(it) },
+                customerHashes = customerHashes,
+                realizedTip = payoutItem?.amount,
+            )
+        }
+        return JobStoreChain(jobId = job.jobId, links = links)
+    }
+
+    /** Tease the DoorDash running key out of a payout store form: the `(02426)` number or the ` - Area` suffix. */
+    private fun extractRunningKey(payoutName: String): String? {
+        Regex("""\((\d{2,6})\)\s*$""").find(payoutName)?.let { return it.groupValues[1] }
+        val dash = payoutName.indexOf(" - ")
+        if (dash >= 0) return payoutName.substring(dash + 3).trim().ifEmpty { null }
+        return null
+    }
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/StoreNameMatch.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/StoreNameMatch.kt
@@ -1,0 +1,46 @@
+package cloud.trotter.dashbuddy.domain.state
+
+import java.util.Locale
+
+/**
+ * Store-name correlation across surfaces (#526 / #159). The same physical store renders
+ * differently per DoorDash screen — the offer/pickup show the brand name (`Target`,
+ * `Maple Street Biscuit Company`), while the dropoff card and payout show a running-key form
+ * (`Target (02426)`, `Maple Street Biscuit - Alamo Ranch`). String equality fails; these surfaces
+ * are correlated by their **shared leading name tokens** (the brand core they have in common).
+ *
+ * The single source of truth for that comparison — used by [PlatformRegionStepper] to resolve a
+ * dropoff's store from the job's pickups, and by the store-chain projection to link offer ↔ pickup
+ * ↔ dropoff ↔ payout. Locale-safe (`Locale.ROOT`).
+ */
+object StoreNameMatch {
+
+    /** Lowercase alphanumeric tokens; drops store-number / punctuation noise that differs per surface. */
+    fun tokens(name: String): List<String> =
+        name.lowercase(Locale.ROOT).split(Regex("[^a-z0-9]+")).filter { it.isNotEmpty() }
+
+    /** Count of equal tokens from the start of both lists — how much of the brand name they share. */
+    fun sharedLeadingTokens(a: List<String>, b: List<String>): Int {
+        var i = 0
+        while (i < a.size && i < b.size && a[i] == b[i]) i++
+        return i
+    }
+
+    /** Shared leading tokens between two raw store-name strings. */
+    fun sharedLeadingTokens(a: String, b: String): Int = sharedLeadingTokens(tokens(a), tokens(b))
+
+    /**
+     * The candidate that shares the most leading tokens with [target] (≥1), or null if none do.
+     * Used to pick which known store (e.g. a job's pickup) a surface form belongs to. Ties resolve
+     * to the first candidate in iteration order.
+     */
+    fun bestMatch(candidates: List<String>, target: String): String? {
+        if (candidates.isEmpty()) return null
+        val t = tokens(target)
+        return candidates
+            .map { it to sharedLeadingTokens(tokens(it), t) }
+            .filter { it.second >= 1 }
+            .maxByOrNull { it.second }
+            ?.first
+    }
+}

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/state/StoreChainProjectorTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/state/StoreChainProjectorTest.kt
@@ -1,0 +1,118 @@
+package cloud.trotter.dashbuddy.domain.state
+
+import cloud.trotter.dashbuddy.domain.model.pay.ParsedPay
+import cloud.trotter.dashbuddy.domain.model.pay.ParsedPayItem
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * #159 / #526 Step 3 — the store-chain projection links offer ↔ pickup ↔ dropoff ↔ payout for each
+ * store of a job, correlating the differing surface forms by brand tokens. Modelled on the real
+ * 2026-06-19 Target + Maple Street stack.
+ */
+class StoreChainProjectorTest {
+
+    private fun pickup(id: String, store: String) = Task(
+        taskId = id, jobId = "job-1", phase = TaskPhase.PICKUP, storeName = store, startedAt = 100L, completedAt = 200L,
+    )
+
+    private fun dropoff(id: String, store: String, cust: String) = Task(
+        taskId = id, jobId = "job-1", phase = TaskPhase.DROPOFF, storeName = store,
+        customerNameHash = cust, startedAt = 300L, completedAt = 400L,
+    )
+
+    private fun job(tasks: List<Task>, offerHints: List<String>) = Job(
+        jobId = "job-1", offerStoreHint = offerHints, parentOfferHash = null, startedAt = 50L, tasks = tasks,
+    )
+
+    @Test
+    fun `multi-store stack links each store across all four surfaces`() {
+        val j = job(
+            tasks = listOf(
+                pickup("p-target", "Target"),
+                pickup("p-maple", "Maple Street Biscuit Company"),
+                dropoff("d-target", "Target", "cust-A"),
+                dropoff("d-maple", "Maple Street Biscuit Company", "cust-B"),
+            ),
+            offerHints = listOf("Target", "Maple Street Biscuit Company"),
+        )
+        val payout = ParsedPay(
+            appPayComponents = listOf(ParsedPayItem("Base Pay", 6.40)),
+            customerTips = listOf(
+                ParsedPayItem("Maple Street Biscuit - Alamo Ranch", 6.50),
+                ParsedPayItem("Target (02426)", 2.25),
+            ),
+        )
+
+        val chain = StoreChainProjector.project(j, payout)
+        assertEquals("job-1", chain.jobId)
+        assertEquals(2, chain.links.size)
+
+        val target = chain.links.single { it.canonicalStore == "Target" }
+        assertEquals("Target", target.offerName)
+        assertEquals("Target", target.dropoffName)
+        assertEquals("the payout running-key form links by brand token", "Target (02426)", target.payoutName)
+        assertEquals("02426", target.runningKey)
+        assertEquals(listOf("cust-A"), target.customerHashes)
+        assertEquals(2.25, target.realizedTip!!, 0.001)
+
+        val maple = chain.links.single { it.canonicalStore == "Maple Street Biscuit Company" }
+        assertEquals("Maple Street Biscuit Company", maple.offerName)
+        assertEquals(
+            "the dash-suffix payout form links to the brand despite the core mismatch",
+            "Maple Street Biscuit - Alamo Ranch", maple.payoutName,
+        )
+        assertEquals("Alamo Ranch", maple.runningKey)
+        assertEquals(listOf("cust-B"), maple.customerHashes)
+        assertEquals(6.50, maple.realizedTip!!, 0.001)
+    }
+
+    @Test
+    fun `single-store job links the one store and its payout`() {
+        val j = job(
+            tasks = listOf(pickup("p1", "H-E-B"), dropoff("d1", "H-E-B", "cust-1")),
+            offerHints = listOf("H-E-B"),
+        )
+        val payout = ParsedPay(
+            appPayComponents = listOf(ParsedPayItem("Base Pay", 7.0)),
+            customerTips = listOf(ParsedPayItem("H-E-B (799)", 5.5)),
+        )
+        val chain = StoreChainProjector.project(j, payout)
+        assertEquals(1, chain.links.size)
+        val link = chain.links.single()
+        assertEquals("H-E-B", link.canonicalStore)
+        assertEquals("799", link.runningKey)
+        assertEquals(5.5, link.realizedTip!!, 0.001)
+        assertEquals(listOf("cust-1"), link.customerHashes)
+    }
+
+    @Test
+    fun `a payout line matching no pickup is not attributed`() {
+        val j = job(
+            tasks = listOf(pickup("p1", "Target"), dropoff("d1", "Target", "cust-1")),
+            offerHints = listOf("Target"),
+        )
+        // A stray payout line for a store with no pickup in this job → dropped, not mis-attributed.
+        val payout = ParsedPay(
+            appPayComponents = emptyList(),
+            customerTips = listOf(ParsedPayItem("Whataburger (123)", 3.0)),
+        )
+        val chain = StoreChainProjector.project(j, payout)
+        assertEquals(1, chain.links.size)
+        assertNull("Target gets no payout line (Whataburger doesn't match)", chain.links.single().payoutName)
+    }
+
+    @Test
+    fun `null payout still yields the pickup-anchored links`() {
+        val j = job(
+            tasks = listOf(pickup("p1", "Chipotle"), dropoff("d1", "Chipotle", "cust-1")),
+            offerHints = listOf("Chipotle"),
+        )
+        val chain = StoreChainProjector.project(j, payout = null)
+        assertEquals(1, chain.links.size)
+        assertNull(chain.links.single().payoutName)
+        assertNull(chain.links.single().realizedTip)
+        assertEquals("Chipotle", chain.links.single().canonicalStore)
+    }
+}


### PR DESCRIPTION
Stacked on #553 (dropoff-store resolution). Builds the full **store-entity chain** for a job and projects it in **shadow** (logged, never persisted) so we can verify store resolution on real dashes and build corpus before a persisting post-session projector (#159) exists.

## The chain (Step 3 — order attribution)
For each store of a job, `StoreChainProjector` links its four surface forms, correlated by shared brand tokens (string equality fails — `Target` ≠ `Target (02426)`, `Maple Street Biscuit Company` ≠ `Maple Street Biscuit - Alamo Ranch`):
- **offer** name (`Job.offerStoreHint`)
- **pickup** name (authoritative anchor)
- **dropoff** name (resolved by #553)
- **payout** running-key form + realized tip (`ParsedPay.customerTips[].type`/amount) → the #159 `doordash_key` (`02426`, `Alamo Ranch`)
- hashed customers delivered there

A surface form that matches no pickup is dropped, never mis-attributed.

## Shadow, not authoritative
- `StoreChainProjector` — pure domain function. `JobStoreChain` / `StoreChainLink` data.
- `ShadowStoreChainLogger` — **debug-only, log-only** observer on `StateManagerV2.state`; emits one chain line per completed job, off the hot path, never mutating state. This is the "run it live and log it" step (per the dev steer) — a persisting post-session projector comes later under #159.
- **SSOT:** extracted the store token-match (was private in `PlatformRegionStepper`) into `domain/StoreNameMatch`, now shared by the stepper's dropoff resolution and the projector.

## Security/privacy posture
State-layer + a debug-only diagnostic log. PII-safe by construction: store names are merchant names (not customer PII, already parsed from the offer); customers are logged as `sha256` prefixes only; no raw name/address. No network/effect surface. The shadow logger writes no authoritative state.

## Tests
`StoreChainProjectorTest` (multi-store stack links all four surfaces; single-store; unmatched payout dropped; null payout) — modelled on the real 2026-06-19 Target+Maple stack. Full unit suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)