### PR TITLE
docs(field-testing): 2026-06-20 dash log — inflated $/hr, crash recovery (2/2), same-store stacks

### DIFF
--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -801,11 +801,12 @@ Accept and Decline registered on DoorDash — and moved to that session's entry 
 
 - **Platform tested:** DoorDash
 - **Branch under test:** `master` (build inferred — developer to correct if running a feature branch).
-- **Field conditions:** Live evening dash, separate from the earlier (~17:01) H-E-B dash. **Same-store
-  double stack — both orders at Panda Express.** In-field marker only; no screenshot. **Marker for desk
-  review, not a concluded observation.** No code changes from this session.
+- **Field conditions:** Live evening dash, separate from the earlier (~17:01) H-E-B dash. **Two
+  same-store double stacks:** one at Panda Express (first dropoff ~19:39), one at Perry's Pizzeria.
+  In-field markers only; no screenshots. **Markers for desk review, not concluded observations.** No
+  code changes from this session.
 
-### Verification TODOs — same-store stacked double (marker for desk review)
+### Verification TODOs — same-store stacked doubles (markers for desk review)
 
 1. **Same-store double stack at Panda Express — first dropoff completed ~19:39, set as a desk-review
    marker.** Both orders in the stack are from the **same store (Panda Express)** — one pickup location,
@@ -831,6 +832,18 @@ Accept and Decline registered on DoorDash — and moved to that session's entry 
        accumulator — see the v1 caveat in `FlowCardMapper.kt`.)
    - **Status:** Open — **marker only**, awaiting end-of-dash log upload for the desk cross-reference
      above. Acting as field-testing agent: recorded only, no code changes.
+
+2. **Second same-store double stack — Perry's Pizzeria — set as an additional desk-review marker.**
+   A second double stack later in the same evening dash, **both orders at Perry's Pizzeria**. Same shape
+   as item #1 (one store, two customer dropoffs), flagged live as another specimen to cross-reference.
+   Two same-store stacks in one dash gives the desk review **two independent samples** of the multi-drop
+   + same-store-pickup path to compare.
+   - **What to pull / check at desk:** identical checklist to item #1 — offer shape (one stacked offer
+     vs two `OFFER_RECEIVED`s), same-store pickup identity (two distinct orders, not merged/re-minted),
+     two distinct dropoffs (own customer hash + address, none dropped/duplicated/mis-ordered),
+     exactly one `DELIVERY_COMPLETED` per leg reconciling to earnings, and how the HUD rendered two
+     same-store orders.
+   - **Status:** Open — **marker only**, awaiting end-of-dash log upload. Recorded only, no code changes.
 
 ---
 

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -797,6 +797,65 @@ Accept and Decline registered on DoorDash — and moved to that session's entry 
 
 ---
 
+## 2026-06-20 — DoorDash session (live dash, in-field narration)
+
+- **Platform tested:** DoorDash
+- **Branch under test:** `master` (build inferred — developer to correct if running a feature branch).
+- **Field conditions:** Live Saturday dash. Single ACV (alcohol) Shop-&-Deliver offer from **H-E-B**
+  (grocery). Observation narrated from the bubble HUD while the offer/pickup card was on screen; one
+  screenshot captured. **Hypotheses, not concluded fixes.** No code changes from this session.
+
+### Bugs
+
+1. **`$/hr` on the offer/active card is wildly inflated for shop-&-wait offers (~$116/hr on a ~1-hour
+   $30 grocery run).** Screenshot: H-E-B offer, gross **$30.03**, card hero reads **`$116/hr`**, sub-line
+   **`Net $28.89 · 3.2 mi · $9.03/mi`**, score **86 ("AWESOME OFFER")**. The pickup card on the same
+   screen shows **`36:08` to go / pickup by 16:53** — i.e. the *pickup deadline alone* is ~36 min, and
+   the dasher estimates the whole job at **almost an hour**. So the real rate is ~**$30/hr**, not $116.
+   - **The number is internally consistent — the *time model* is the bug (not an arithmetic slip).**
+     The hourly is `netPay / estTimeHours` where
+     `estTimeMinutes = (dist × avgMinutesPerMile) + basePickupMinutes`
+     (`OfferEvaluator.evaluate`, `domain/.../evaluation/OfferEvaluator.kt:24-29`). With the defaults
+     `avgMinutesPerMile = 2.5`, `basePickupMinutes = 7.0`
+     (`UserEconomy.kt:105-106`): `3.2 × 2.5 + 7 = 15.0 min = 0.25 h` → `28.89 / 0.25 = $115.56/hr` →
+     rounds to the `$116/hr` on screen. The estimate is **15 minutes for a job DoorDash itself says is
+     36+ minutes to pickup.**
+   - **Likely root cause (hypothesis): the time estimate is a pure distance heuristic with no
+     shop/wait component and no use of the platform's own timing signals.** `basePickupMinutes` is a
+     single flat 7-min overhead for *both* pickup and dropoff — fine for a hand-it-to-me restaurant
+     bag, badly wrong for a **Shop & Deliver / grocery / alcohol** order where in-store shopping +
+     checkout + ID-check is the dominant time sink and is **independent of drive distance**. A 25-item
+     H-E-B shop and a 1-item McDonald's bag get the *same* 7-min overhead. The model also ignores the
+     real signals already on the offer/pickup screen — the **pickup-by deadline** and (for shops) the
+     **item count** — which we parse and already carry on the cards (`itemsRemaining`/`itemsShopped`,
+     `deadlineMillis` in `FlowCardMapper`).
+   - **This very likely also inflates the offer *score*, confirming the dasher's worry that "the
+     offer logic is off too."** The same `estTimeMinutes` → `activeHourly` feeds the **`ACTIVE_HOURLY`
+     scoring metric** (`OfferEvaluator.kt:140` → `calculateMetricScore` → `:197`,
+     `(hourly / target).coerceIn(0,1)`). A 4–5× inflated hourly will peg that metric at its max for
+     almost any shop offer, dragging the composite score up — plausibly a big part of why a ~$30/hr-real
+     grocery run scored **86 / "AWESOME"**. So this is one model error surfacing in two places (the HUD
+     number *and* the accept/decline verdict), exactly because `dollarsPerHour` is the SSOT for both.
+   - **Open questions to resolve at the desk / next capture:**
+     - Is `offer.distanceMiles` (3.2 mi) the full pickup→dropoff route or just one leg? If it's only
+       the delivery leg, the drive-time term is *also* under-counting (separate from the missing shop
+       time).
+     - Do we already parse a **pickup-by / dropoff-by deadline** off the offer screen (vs only the
+       pickup card)? If a deadline is available at *offer* time, the estimate could anchor on it
+       instead of the distance heuristic. (`deadlineMillis` exists on the pickup card payload — need to
+       check whether it's populated pre-accept.)
+     - Should Shop & Deliver get a distinct time model — e.g. a per-item shop-time term
+       (`itemCount × minutesPerItem`) plus a checkout/ID-check constant — gated on the
+       shop/alcohol recognition we already have? Would need a `minutesPerItem` constant in
+       `UserEconomy` and the parsed item count threaded into `evaluate`.
+     - Would the cleanest near-term anchor be "trust DoorDash's own time": if the offer exposes an
+       estimated active time or a delivery-by window, prefer it and fall back to the heuristic only
+       when absent?
+   - **Status:** Open. Needs desk confirmation of (a) what distance/deadline/item fields are present on
+     the offer at evaluation time, and (b) a decision on the Shop-&-Deliver time model before any change.
+
+---
+
 ## 2026-06-19 — DoorDash session (desk analysis of captured dash data)
 
 - **Platform tested:** DoorDash

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -803,7 +803,9 @@ Accept and Decline registered on DoorDash — and moved to that session's entry 
 - **Branch under test:** `master` (build inferred — developer to correct if running a feature branch).
 - **Field conditions:** Live Saturday dash. Single ACV (alcohol) Shop-&-Deliver offer from **H-E-B**
   (grocery). Observation narrated from the bubble HUD while the offer/pickup card was on screen; one
-  screenshot captured. **Hypotheses, not concluded fixes.** No code changes from this session.
+  screenshot captured. Mid-dash, a **real phone power-off at the H-E-B checkout lane (~17:01)** gave a
+  live **crash-recovery** test (item #2). **Hypotheses, not concluded fixes.** No code changes from
+  this session.
 
 ### Bugs
 
@@ -865,6 +867,32 @@ Accept and Decline registered on DoorDash — and moved to that session's entry 
      this session: recorded only, no code changes. When implemented this needs field re-validation that a
      grocery/ACV shop now reads a realistic `$/hr` and a non-inflated score — add a "Next field test"
      checklist item at that point.
+
+### Verification TODOs — crash recovery held in the field (confirmation 1/2)
+
+2. **Crash recovery survived a real mid-checkout power-off and resumed the dash on the correct phase.**
+   ~17:01, at the **H-E-B checkout lane**, the dasher **dropped the phone and it powered off** mid
+   **checkout/pickup flow** (same H-E-B ACV shop as item #1). On restart, the dasher relaunched
+   DoorDash/DashBuddy and the **bubble HUD came back up, recognized it was still on a pickup, and the
+   prior (pre-crash) dash resumed** — no new dash, no lost session. This is exactly the `StateManagerV2`
+   crash-recovery path (replay observations over the last snapshot) working against a **true cold
+   power-loss** (not a process kill) — the strongest version of the test.
+   - **Why this is a good characterization case:** the crash landed **inside the checkout/pickup
+     confirm window**, which is the phase the dropoff/grace machinery is most sensitive to (the
+     06-17/06-19 phantom-dropoff and double-complete investigations all clustered around
+     pickup-confirm → dropoff transitions). Recovering *onto a pickup* mid-checkout — rather than
+     skipping to dropoff or re-minting the task — is the behavior we want to confirm held.
+   - **Needs end-of-dash cross-reference (why this is 1/2, not done):** the bubble *looked* correct
+     in-field, but the ground truth is the captured data. At desk, check the uploaded
+     `app_state_snapshots` / `app_events` for this dash around 17:01 for: (a) the recovery restored the
+     **same** job/task identity (no re-mint, no new sessionId for the resumed dash); (b) **exactly one**
+     pickup task for the H-E-B shop across the crash boundary (the checkout interruption didn't split or
+     double it); (c) the eventual `DELIVERY_COMPLETED` for this order fires **once** and reconciles into
+     session earnings (this delivery was the second-to-last of the dash). Confirm against the db before
+     marking validated.
+   - **Status:** Open — **1/2 field confirmations** (in-field bubble recovery looked correct, 2026-06-20).
+     Needs the end-of-dash db cross-reference above for the second confirmation. Acting as field-testing
+     agent: recorded only, no code changes.
 
 ---
 

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -836,23 +836,35 @@ Accept and Decline registered on DoorDash — and moved to that session's entry 
      almost any shop offer, dragging the composite score up — plausibly a big part of why a ~$30/hr-real
      grocery run scored **86 / "AWESOME"**. So this is one model error surfacing in two places (the HUD
      number *and* the accept/decline verdict), exactly because `dollarsPerHour` is the SSOT for both.
-   - **Open questions to resolve at the desk / next capture:**
-     - Is `offer.distanceMiles` (3.2 mi) the full pickup→dropoff route or just one leg? If it's only
-       the delivery leg, the drive-time term is *also* under-counting (separate from the missing shop
-       time).
-     - Do we already parse a **pickup-by / dropoff-by deadline** off the offer screen (vs only the
-       pickup card)? If a deadline is available at *offer* time, the estimate could anchor on it
-       instead of the distance heuristic. (`deadlineMillis` exists on the pickup card payload — need to
-       check whether it's populated pre-accept.)
-     - Should Shop & Deliver get a distinct time model — e.g. a per-item shop-time term
-       (`itemCount × minutesPerItem`) plus a checkout/ID-check constant — gated on the
-       shop/alcohol recognition we already have? Would need a `minutesPerItem` constant in
-       `UserEconomy` and the parsed item count threaded into `evaluate`.
-     - Would the cleanest near-term anchor be "trust DoorDash's own time": if the offer exposes an
-       estimated active time or a delivery-by window, prefer it and fall back to the heuristic only
-       when absent?
-   - **Status:** Open. Needs desk confirmation of (a) what distance/deadline/item fields are present on
-     the offer at evaluation time, and (b) a decision on the Shop-&-Deliver time model before any change.
+   - **Desk findings + developer-confirmed direction (06-20):**
+     - **Distance is whole-offer.** Developer confirms `offer.distanceMiles` is (should be) the full
+       offer route, not a single leg — so the drive-time term isn't the under-count; the missing
+       **shop/wait time** is.
+     - **We already parse the platform's own deadline — the evaluator just throws it away.**
+       `ParsedOffer` carries `dueByTimeMillis` / `dueByTimeText` (the "Deliver by" time) and it's
+       **populated on real DoorDash offers** (corpus e.g. `dueByTimeMillis=1780333740000`,
+       `dueByTimeText=5:09 PM` in `approved-parse-output.json`). `ParsedOffer` also has
+       `timeToCompleteMinutes`, but that's **only parsed for Uber** (`uber.json:160`) and is **null on
+       every DoorDash offer** (DoorDash doesn't surface a "time to complete"). Yet `OfferEvaluator`
+       reads only `payAmount` / `distanceMiles` / `itemCount` (`OfferEvaluator.kt:12-14`) — it never
+       touches `dueByTimeMillis`. **Direction:** the estimate should parse/anchor on the offer's own
+       deadline (derive a delivery window from `dueByTimeMillis − now` on DoorDash;
+       `timeToCompleteMinutes` directly on Uber) and fall back to our heuristic only when the platform
+       gives us nothing.
+     - **Shops get their own time model, item-rate based — not a flat constant.** Developer: a Shop &
+       Deliver estimate must be distinct from restaurant/retail *pickup* and must be driven by the
+       **dasher's own pick rate (items/minute)**, not a magic number. We already parse the shop
+       `itemCount` (corpus: CVS=4, Dollar General=9, Michaels=11…), so the shop term is roughly
+       `itemCount ÷ itemsPerMinute` (+ a checkout/ID-check overhead), gated on the
+       SHOP_FOR_ITEMS / alcohol recognition we already have. Until we can *measure* a given dasher's
+       items/min, seed a **sensible default** rate and let it be refined once we have real shop-duration
+       data per dasher (an estimated, eventually-learned metric — a new `UserEconomy` field, default
+       now, personalized later).
+   - **Status:** Open — direction agreed (parse offer deadline as the primary/anchor signal + a separate
+     item-rate shop model with a seeded default), implementation deferred. Acting as field-testing agent
+     this session: recorded only, no code changes. When implemented this needs field re-validation that a
+     grocery/ACV shop now reads a realistic `$/hr` and a non-inflated score — add a "Next field test"
+     checklist item at that point.
 
 ---
 

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -868,7 +868,7 @@ Accept and Decline registered on DoorDash — and moved to that session's entry 
      grocery/ACV shop now reads a realistic `$/hr` and a non-inflated score — add a "Next field test"
      checklist item at that point.
 
-### Verification TODOs — crash recovery held in the field (confirmation 1/2)
+### Verification TODOs — crash recovery held in the field (confirmation 2/2)
 
 2. **Crash recovery survived a real mid-checkout power-off and resumed the dash on the correct phase.**
    ~17:01, at the **H-E-B checkout lane**, the dasher **dropped the phone and it powered off** mid
@@ -882,17 +882,21 @@ Accept and Decline registered on DoorDash — and moved to that session's entry 
      06-17/06-19 phantom-dropoff and double-complete investigations all clustered around
      pickup-confirm → dropoff transitions). Recovering *onto a pickup* mid-checkout — rather than
      skipping to dropoff or re-minting the task — is the behavior we want to confirm held.
-   - **Needs end-of-dash cross-reference (why this is 1/2, not done):** the bubble *looked* correct
-     in-field, but the ground truth is the captured data. At desk, check the uploaded
-     `app_state_snapshots` / `app_events` for this dash around 17:01 for: (a) the recovery restored the
-     **same** job/task identity (no re-mint, no new sessionId for the resumed dash); (b) **exactly one**
-     pickup task for the H-E-B shop across the crash boundary (the checkout interruption didn't split or
-     double it); (c) the eventual `DELIVERY_COMPLETED` for this order fires **once** and reconciles into
-     session earnings (this delivery was the second-to-last of the dash). Confirm against the db before
-     marking validated.
-   - **Status:** Open — **1/2 field confirmations** (in-field bubble recovery looked correct, 2026-06-20).
-     Needs the end-of-dash db cross-reference above for the second confirmation. Acting as field-testing
-     agent: recorded only, no code changes.
+   - **Second confirmation — held through end of dash (2026-06-20).** After recovery the resumed dash
+     stayed intact: the prior dash's history was **all still present**, the dasher **finished the
+     delivery and ended the dash normally**, and everything persisted as expected (no lost session, no
+     duplicate dash). Two independent in-field confirmations: the recovery itself (resumed onto the
+     pickup) and the clean end-of-dash teardown.
+   - **Still want the db cross-reference at desk (not blocking the 2/2 — confirmatory).** Logs will be
+     reviewed anyway; when they are, verify in `app_state_snapshots` / `app_events` around 17:01: (a) the
+     recovery restored the **same** job/task identity (no re-mint, no new sessionId for the resumed
+     dash); (b) **exactly one** pickup task for the H-E-B shop across the crash boundary (the checkout
+     interruption didn't split or double it); (c) the eventual `DELIVERY_COMPLETED` for this order fires
+     **once** and reconciles into session earnings (this delivery was the second-to-last of the dash).
+   - **Status:** **Validated — 2/2 field confirmations** (recovery onto pickup + clean end-of-dash with
+     full history intact, both 2026-06-20). Desk db cross-reference above remains as a confirmatory check
+     during the routine log review, not a blocker. Acting as field-testing agent: recorded only, no code
+     changes.
 
 ---
 

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -797,6 +797,43 @@ Accept and Decline registered on DoorDash — and moved to that session's entry 
 
 ---
 
+## 2026-06-20 — DoorDash session (evening dash, same-store double stack)
+
+- **Platform tested:** DoorDash
+- **Branch under test:** `master` (build inferred — developer to correct if running a feature branch).
+- **Field conditions:** Live evening dash, separate from the earlier (~17:01) H-E-B dash. **Same-store
+  double stack — both orders at Panda Express.** In-field marker only; no screenshot. **Marker for desk
+  review, not a concluded observation.** No code changes from this session.
+
+### Verification TODOs — same-store stacked double (marker for desk review)
+
+1. **Same-store double stack at Panda Express — first dropoff completed ~19:39, set as a desk-review
+   marker.** Both orders in the stack are from the **same store (Panda Express)** — one pickup location,
+   two distinct customer dropoffs. Dasher dropped the **first** of the two at ~19:39 and flagged it live
+   so we can pull the captured data later. Stacked + multi-drop handling is a **known frontier** (#503
+   slice 3b multi-drop not shipped; the same-store add-on re-mint guard is #499/#503), so this is a
+   real-world specimen of exactly that case.
+   - **What to pull / check at desk (from this dash's `app_events` + `app_state_snapshots`):**
+     - **Offer shape:** did this arrive as **one stacked offer** (two orders in one `ParsedOffer`) or
+       two separate `OFFER_RECEIVED`s? Note the offer-accept sequence around the stack.
+     - **Same-store pickup identity:** with both pickups at Panda Express, did the task lifecycle keep
+       **two distinct orders** but (correctly) **one pickup activity**, or did the same-store re-match
+       (#499 pickup re-match by store) **collapse/merge** them or **re-mint**? Want: two orders, not one,
+       and not three.
+     - **Two distinct dropoffs:** each dropoff should resolve to its **own customer hash** and its **own
+       address** — the multi-drop path (slice 3b) is unshipped, so watch for a **dropped, duplicated, or
+       mis-ordered** second dropoff after the first completed at ~19:39.
+     - **Completion + earnings:** **exactly one** `DELIVERY_COMPLETED` per dropoff (two total), each with
+       a distinct customer hash and non-null pay, and **session earnings reconcile** to the sum (no
+       double-count, no missing leg).
+     - **Bubble/flow cards:** how did the HUD render two same-store orders — two cards, one merged card?
+       (FlowCardMapper v1 assumes a single delivery in flight; a stack overwrites the accepted-economics
+       accumulator — see the v1 caveat in `FlowCardMapper.kt`.)
+   - **Status:** Open — **marker only**, awaiting end-of-dash log upload for the desk cross-reference
+     above. Acting as field-testing agent: recorded only, no code changes.
+
+---
+
 ## 2026-06-20 — DoorDash session (live dash, in-field narration)
 
 - **Platform tested:** DoorDash


### PR DESCRIPTION
Field-testing log updates from the 2026-06-20 dashes. Docs-only — no code changes. `[skip ci]`

Acting as the field-testing agent (record, not fix) per the field-testing discipline in `CLAUDE.md`. All items are hypotheses / desk-review markers framed for the developer to triage; no recognition, evaluation, or state-machine code was touched.

## What's logged

**Daytime H-E-B dash entry:**
- **Inflated `$/hr` on shop-&-wait offers (Open).** `$116/hr` shown on a ~1-hour $30 H-E-B ACV grocery run. The number is internally consistent — the *time model* is the bug: `estTimeMinutes = dist × avgMinutesPerMile + basePickupMinutes` (`OfferEvaluator.kt:24`) estimates 15 min for a job DoorDash itself says is 36+ min to pickup, because there's no shop/wait component and the offer's own deadline is ignored. Same `estTimeMinutes` feeds the `ACTIVE_HOURLY` scoring metric, so the score (86 / "AWESOME") is likely inflated too. Developer-confirmed direction recorded: anchor on the offer's parsed `dueByTimeMillis` (already populated on DoorDash offers, currently unused by the evaluator) + a separate item-rate shop model (`itemCount ÷ itemsPerMinute`) with a seeded default until a per-dasher items/min metric can be learned. Implementation deferred.
- **Crash recovery — Validated 2/2.** Real cold power-off at the H-E-B checkout lane (~17:01) mid pickup/checkout flow → restart → bubble recovered the dash and resumed on the correct pickup phase; held clean through end of dash (full history intact, normal teardown). Confirmatory db cross-reference noted for the routine log review.

**Evening dash entry:**
- **Two same-store double stacks (markers for desk review):** Panda Express (first dropoff ~19:39) and Perry's Pizzeria. Each is a live specimen of the unshipped multi-drop frontier (#503 slice 3b) + same-store re-match guard (#499/#503), with the exact `app_events` / `app_state_snapshots` cross-checks to run once the logs are uploaded.

## Posture
Docs-only; no trust/gate/scrub surface touched. Recognition, evaluation, and state-machine behavior are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WbjBeWRVgsTqtDGisJyjrH

---
_Generated by [Claude Code](https://claude.ai/code/session_01WbjBeWRVgsTqtDGisJyjrH)_