### PR TITLE
feat(offer-engine): Shop & Deliver time model + learned items/min (#556 Phase A)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
@@ -280,6 +280,17 @@ class SideEffectEngine @Inject constructor(
             is AppEffect.PauseOdometer -> odometerEffectHandler.pause()
             is AppEffect.ResumeOdometer -> odometerEffectHandler.resume()
 
+            is AppEffect.RecordShopRate -> {
+                // #556: learn the dasher's shopping pace. PII-safe (store name is a merchant name).
+                val minutes = effect.shopDurationMs / 60_000.0
+                strategyRepository.recordShopRate(effect.itemsShopped, minutes)
+                Timber.tag("ShopRate").i(
+                    "recorded %d items / %.1f min = %.2f/min (store=%s)",
+                    effect.itemsShopped, minutes,
+                    if (minutes > 0) effect.itemsShopped / minutes else 0.0, effect.storeName ?: "?",
+                )
+            }
+
             is AppEffect.ProcessTipNotification -> tipEffectHandler.process(engineScope, effect)
 
             // --- LOOPBACKS (Produces Events) ---
@@ -547,6 +558,7 @@ class SideEffectEngine @Inject constructor(
         is AppEffect.StopOdometer,
         is AppEffect.PauseOdometer,
         is AppEffect.ResumeOdometer,
+        is AppEffect.RecordShopRate,
         is AppEffect.StartSession,
         is AppEffect.EndSession,
         is AppEffect.ProcessTipNotification,

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
@@ -28,6 +28,7 @@ import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.domain.state.PlatformRegion
 import cloud.trotter.dashbuddy.domain.state.Regions
 import cloud.trotter.dashbuddy.domain.state.Session
+import cloud.trotter.dashbuddy.domain.state.PickupActivity
 import cloud.trotter.dashbuddy.domain.state.Task
 import cloud.trotter.dashbuddy.domain.state.TaskPhase
 import cloud.trotter.dashbuddy.domain.state.TaskSubFlow
@@ -662,6 +663,42 @@ class EffectMapTest {
             "Should NOT emit DELIVERY_CONFIRMED on a pickup-leaving transition",
             !effects.logEventTypes().contains(AppEventType.DELIVERY_CONFIRMED),
         )
+        assertTrue(
+            "a non-shop pickup feeds no shop-rate sample (#556)",
+            effects.none { it is AppEffect.RecordShopRate },
+        )
+    }
+
+    @Test
+    fun `a completed SHOP pickup emits RecordShopRate with measured items and duration (#556)`() {
+        val (platform, _) = stateWithPlatform()
+        val session = Session("sess-1", startedAt = 100L)
+        val arrivedAt = 100_000L
+        val confirmAt = arrivedAt + 30 * 60_000L  // 30 min in-store → 24 items = 0.8/min
+        val shopPickup = Task(
+            taskId = "task-1", jobId = "job-1", phase = TaskPhase.PICKUP, storeName = "H-E-B",
+            activity = PickupActivity.SHOPPING, itemsShopped = 24, arrivedAt = arrivedAt, startedAt = 900L,
+        )
+        val prev = AppState(regions = Regions(
+            flow = FlowRegion(flow = Flow.TaskPickupArrived),
+            platforms = mapOf(platform to PlatformRegion(platform, mode = Mode.Online, session = session, activeTask = shopPickup)),
+        ))
+        val dropoff = Task(taskId = "task-2", jobId = "job-1", phase = TaskPhase.DROPOFF, startedAt = confirmAt)
+        val next = AppState(regions = Regions(
+            flow = FlowRegion(flow = Flow.TaskDropoffNavigation),
+            platforms = mapOf(platform to PlatformRegion(platform, mode = Mode.Online, session = session, activeTask = dropoff)),
+        ))
+
+        val effects = effectMap.diff(prev, next, screenObs(
+            flow = Flow.TaskDropoffNavigation, timestamp = confirmAt,
+            parsed = ParsedFields.TaskFields(phase = TaskPhase.DROPOFF, subFlow = TaskSubFlow.NAVIGATION),
+        ))
+
+        val rec = effects.filterIsInstance<AppEffect.RecordShopRate>().single()
+        assertEquals(24, rec.itemsShopped)
+        assertEquals(30 * 60_000L, rec.shopDurationMs)
+        assertEquals("task-1", rec.taskId)
+        assertEquals("the sample is idempotent per pickup task", "shop_rate:task-1", rec.effectKey)
     }
 
     @Test

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/strategy/StrategyRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/strategy/StrategyRepository.kt
@@ -171,15 +171,24 @@ class StrategyRepository @Inject constructor(
         protectStatsMode,
         allowShopping,
         appPreferencesRepository.userEconomy,
-    ) { rules, protect, shop, economy ->
+        dataSource.learnedShopRate,
+    ) { rules, protect, shop, economy, shopRate ->
         EvaluationConfig(
             protectStatsMode = protect,
             rules = rules,
             allowShopping = shop,
-            userEconomy = economy,
+            // #556: fold the learned shopping pace into the economy here (it lives in the strategy
+            // store, not the user-economy store, so it's never reseeded by a vehicle-class change).
+            userEconomy = economy.copy(
+                learnedShopItemsPerMinute = shopRate.itemsPerMin,
+                shopRateSampleCount = shopRate.sampleCount,
+            ),
         )
     }.stateIn(scope, SharingStarted.Eagerly, null)
 
+
+    /** #556: fold a completed shop's measured pace into the learned overall items/min (atomic). */
+    suspend fun recordShopRate(items: Int, minutes: Double) = dataSource.recordShopRate(items, minutes)
 
     suspend fun clearPreferences() {
         Timber.w("Clearing Strategy Preferences")

--- a/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/strategy/StrategyDataSource.kt
+++ b/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/strategy/StrategyDataSource.kt
@@ -5,9 +5,12 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.doublePreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import cloud.trotter.dashbuddy.core.datastore.di.StrategyPreferences
 import cloud.trotter.dashbuddy.core.datastore.strategy.dto.ScoringRuleDto
+import cloud.trotter.dashbuddy.domain.evaluation.LearnedShopRate
+import cloud.trotter.dashbuddy.domain.evaluation.ShopRate
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.serialization.InternalSerializationApi
@@ -41,6 +44,12 @@ class StrategyDataSource @Inject constructor(
         val RULE_LIST_JSON = stringPreferencesKey("rule_list_config_v1")
         val PROTECT_STATS_MODE = booleanPreferencesKey("protect_stats_mode")
         val ALLOW_SHOPPING = booleanPreferencesKey("allow_shopping")
+
+        // #556: learned overall shopping pace (running mean items/min + sample count). Not a
+        // user-set economy field — a measured value, kept here so a vehicle-class reseed never
+        // touches it; folded into the evaluator's UserEconomy by StrategyRepository.
+        val LEARNED_SHOP_RATE = doublePreferencesKey("learned_shop_items_per_min")
+        val SHOP_RATE_SAMPLES = intPreferencesKey("shop_rate_sample_count")
     }
 
     val evidenceMaster: Flow<Boolean> = ds.data.map { it[Keys.EVIDENCE_MASTER] ?: EvidenceConfig.DEFAULT_MASTER }
@@ -75,6 +84,26 @@ class StrategyDataSource @Inject constructor(
 
     val protectStatsMode: Flow<Boolean> = ds.data.map { it[Keys.PROTECT_STATS_MODE] ?: false }
     val allowShopping: Flow<Boolean> = ds.data.map { it[Keys.ALLOW_SHOPPING] ?: true }
+
+    /** #556: the learned overall shopping pace + how many shops back it (null pace until first sample). */
+    val learnedShopRate: Flow<LearnedShopRate> = ds.data.map {
+        LearnedShopRate(it[Keys.LEARNED_SHOP_RATE], it[Keys.SHOP_RATE_SAMPLES] ?: 0)
+    }
+
+    /**
+     * #556: fold one measured shop ([items] over [minutes] in-store) into the running mean, atomically
+     * (read-modify-write inside one edit, so back-to-back stacked shops can't race). Out-of-band
+     * samples (below the [ShopRate] floors) are no-ops.
+     */
+    suspend fun recordShopRate(items: Int, minutes: Double) {
+        ds.edit { p ->
+            val (avg, n) = ShopRate.fold(p[Keys.LEARNED_SHOP_RATE], p[Keys.SHOP_RATE_SAMPLES] ?: 0, items, minutes)
+            if (avg != null) {
+                p[Keys.LEARNED_SHOP_RATE] = avg
+                p[Keys.SHOP_RATE_SAMPLES] = n
+            }
+        }
+    }
 
     suspend fun setEvidenceMaster(enabled: Boolean) {
         ds.edit { prefs ->

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/AppEffect.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/AppEffect.kt
@@ -90,6 +90,21 @@ sealed class AppEffect {
     data object StopOdometer : AppEffect()
     data object PauseOdometer : AppEffect()   // pause GPS while stationary; session total preserved
     data object ResumeOdometer : AppEffect()  // resume GPS after stationary pause
+
+    /**
+     * #556: a Shop & Deliver pickup just completed — fold its measured pace ([itemsShopped] over
+     * [shopDurationMs] in-store) into the learned overall items/min. Idempotent per task so a
+     * re-observed confirm can't double-count (mirrors the #518 DELIVERY_COMPLETED keying).
+     */
+    data class RecordShopRate(
+        val itemsShopped: Int,
+        val shopDurationMs: Long,
+        val storeName: String?,
+        val jobId: String,
+        val taskId: String,
+    ) : AppEffect() {
+        override val effectKey: String get() = "shop_rate:$taskId"
+    }
     /**
      * Evaluate the pending offer. [offerHash] rides the async round-trip so the result
      * can be correlated back — a replaced offer must never inherit the previous offer's

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -616,6 +616,22 @@ class EffectMap @Inject constructor() {
                 add(logEffect(sessionId, AppEventType.DELIVERY_NAV_STARTED, obs.timestamp, deliveryStart))
                 add(AppEffect.ResumeOdometer)
 
+                // #556: a completed SHOP pickup feeds the learned items/min. In-store time is
+                // measured arrived→confirmed (the 0.8/min seed basis); the handler floors out noise.
+                val shopItems = prevTask.itemsShopped ?: 0
+                val shopArrivedAt = prevTask.arrivedAt
+                if (prevTask.activity == PickupActivity.SHOPPING && shopItems > 0 && shopArrivedAt != null) {
+                    add(
+                        AppEffect.RecordShopRate(
+                            itemsShopped = shopItems,
+                            shopDurationMs = obs.timestamp - shopArrivedAt,
+                            storeName = prevTask.storeName,
+                            jobId = prevTask.jobId,
+                            taskId = prevTask.taskId,
+                        ),
+                    )
+                }
+
                 val customer = customerDisplayName(customerHash)
                 add(AppEffect.UpdateBubble("Heading to $customer", ChatPersona.Customer(customer)))
             }

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -63,6 +63,17 @@ immediately (no second pass needed) so it gets triaged.
 _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **broken** on the
 2026-06-09 dash — moved to that session's log entry below for triage.)_
 
+- **🔧 NEW (branch `feature/556-shop-time-model`) — realistic $/hr + score on Shop & Deliver offers (#556). CONFIRM ON DASH.**
+  The time model now estimates a shop by its item count at the dasher's shopping pace (seed 0.8
+  items/min, learned from your own completed shops) instead of a flat 7-min overhead — so a grocery
+  run no longer reads a wildly inflated `$/hr` / "AWESOME" score. **This is a verdict-mover** (it
+  changes accept/decline rankings, not just the readout). **Confirm on dash: 0/2 —** on a Shop &
+  Deliver / grocery / ACV offer (e.g. H-E-B, Sprouts) the card `$/hr` should look **realistic**
+  (~$25–40/hr range, not $100+), the score should be sane, and a normal restaurant **pickup** offer
+  should read the **same as before** (only shops changed). After a few shop dashes, the learned pace
+  kicks in — grep the log for `ShopRate` to see it recording (`N items / M min = X/min`). If a shop
+  still reads inflated, note the offer's item count + quoted miles + the `$/hr` shown.
+
 - **🔧 MERGED — dropoff store recognition + pickup-matched resolution (#526/#553). CONFIRM ON DASH.**
   A dropoff shows the store **resolved from the job's pickups** (single → the pickup's store;
   multi-store stack → matched per drop), not inherited from the last active pickup.

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/OfferEvaluator.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/OfferEvaluator.kt
@@ -20,8 +20,21 @@ class OfferEvaluator() {
         val operatingCost = fuelCost + nonFuelCost
         val netPay = grossPay - operatingCost
 
-        // Time estimate using user-configured constants
-        val estTimeMinutes = (dist * economy.avgMinutesPerMile) + economy.basePickupMinutes
+        // Time estimate = whole-route drive + handling (#556). Handling for a Shop & Deliver order
+        // is its item count at the dasher's effective shopping pace (items/min — already absorbs
+        // in-store + checkout + ID-check + wait), floored at the base overhead so a tiny/unparsed
+        // shop can't under-count; a non-shop leg keeps the flat base. The old flat base for ALL
+        // offers estimated a 25-item grocery run at ~15 min → the ~$116/hr bug.
+        val driveMinutes = dist * economy.avgMinutesPerMile
+        val isShop = offer.orders.any { it.orderType.isShoppingOrder }
+        val handlingMinutes = if (isShop) {
+            val nonShopLegs = offer.orders.count { !it.orderType.isShoppingOrder }
+            maxOf(items / economy.effectiveShopItemsPerMinute, economy.basePickupMinutes) +
+                nonShopLegs * economy.basePickupMinutes
+        } else {
+            economy.basePickupMinutes
+        }
+        val estTimeMinutes = driveMinutes + handlingMinutes
         val estTimeHours = estTimeMinutes / 60.0
 
         // Metrics operate on net pay

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/ShopRate.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/ShopRate.kt
@@ -1,0 +1,37 @@
+package cloud.trotter.dashbuddy.domain.evaluation
+
+/** The persisted learned shopping pace: the running mean items/min and the shops behind it (#556). */
+data class LearnedShopRate(val itemsPerMin: Double?, val sampleCount: Int)
+
+/**
+ * Folds measured shops into the dasher's learned overall shopping pace (#556). Pure and
+ * order-independent (a running incremental mean), so the same function backs the live
+ * per-shop update and, later, the post-session #159 store/chain projector.
+ *
+ * The rate is **effective** items/min — measured arrive→leave, so it already absorbs in-store
+ * time + checkout + ID-check + wait (the same basis as [UserEconomy.DEFAULT_SHOP_ITEMS_PER_MIN]).
+ */
+object ShopRate {
+
+    /** Min items in a measured shop before it counts — a 1–2 item "shop" is noise, not a pace sample. */
+    const val MIN_ITEMS = 3
+
+    /** Min in-store minutes before a sample counts — guards a sub-minute mis-timed sample. */
+    const val MIN_MINUTES = 2.0
+
+    /** A new measured shop is in-band (worth folding) only above the noise floors. */
+    fun isValidSample(items: Int, minutes: Double): Boolean = items >= MIN_ITEMS && minutes >= MIN_MINUTES
+
+    /**
+     * Fold one measured shop ([items] over [minutes] in-store) into the running mean items/min and
+     * sample count. Out-of-band samples are ignored (returns the prior pair unchanged). The mean is
+     * incremental — `avg + (rate - avg) / n` — so it's stable and independent of fold order.
+     */
+    fun fold(prevAvg: Double?, prevN: Int, items: Int, minutes: Double): Pair<Double?, Int> {
+        if (!isValidSample(items, minutes)) return prevAvg to prevN
+        val rate = items / minutes
+        val n = (prevN.coerceAtLeast(0)) + 1
+        val avg = if (prevAvg == null || prevN <= 0) rate else prevAvg + (rate - prevAvg) / n
+        return avg to n
+    }
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/UserEconomy.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/UserEconomy.kt
@@ -31,6 +31,18 @@ data class UserEconomy(
     /** Base overhead per offer (pickup + dropoff) in minutes — default 7.0. */
     val basePickupMinutes: Double = DEFAULT_BASE_PICKUP_MINUTES,
 
+    /**
+     * Learned overall **shopping pace** (items/minute, *effective* — measured arrive→leave, so it
+     * already absorbs in-store time + checkout + ID-check + wait). Null until enough shops are
+     * measured; the Shop & Deliver time estimate falls back to [DEFAULT_SHOP_ITEMS_PER_MIN].
+     * Populated by the repository from a separately-persisted learned store — **NOT** user-set (a
+     * vehicle-class reseed must never touch it), hence deliberately not an [EconomyField] / not in
+     * [userSetFields]. #556. (Per-store / chain pace is the deferred #159 tier.)
+     */
+    val learnedShopItemsPerMinute: Double? = null,
+    /** Number of measured shops behind [learnedShopItemsPerMinute]; gates trusting it (#556). */
+    val shopRateSampleCount: Int = 0,
+
     // Maintenance (paired: cost + interval/lifetime). Defaults are zero so a
     // hand-constructed UserEconomy is cost-free for tests. Production paths
     // populate these from the VehicleClass preset via the repository.
@@ -93,6 +105,15 @@ data class UserEconomy(
 
     val operatingCostPerMile: Double get() = fuelCostPerMile + nonFuelCostPerMile
 
+    /**
+     * Items/minute for the Shop & Deliver time estimate (#556): the learned overall pace once
+     * [MIN_SHOP_SAMPLES] shops have been measured, else the data-derived seed. Always > 0.
+     */
+    val effectiveShopItemsPerMinute: Double
+        get() = learnedShopItemsPerMinute
+            ?.takeIf { shopRateSampleCount >= MIN_SHOP_SAMPLES && it > 0.0 }
+            ?: DEFAULT_SHOP_ITEMS_PER_MIN
+
     fun isUserSet(field: EconomyField): Boolean = field in userSetFields
 
     /** True when at least one [EconomyField] is still at its class/default value. */
@@ -104,6 +125,16 @@ data class UserEconomy(
 
         const val DEFAULT_MINUTES_PER_MILE = 2.5
         const val DEFAULT_BASE_PICKUP_MINUTES = 7.0
+
+        /**
+         * Effective shopping pace (items/min, incl. checkout/ID/wait), the cold-start seed for the
+         * Shop & Deliver time estimate. Derived from 48 real shops across the 2026-06 capture corpus
+         * (median 0.79, IQR 0.66–0.92). The old flat 7-min handling estimated a 25-item shop at
+         * ~15 min → the ~$116/hr bug (#556); 0.8/min puts it at ~31 min in-store. */
+        const val DEFAULT_SHOP_ITEMS_PER_MIN = 0.8
+
+        /** Measured shops required before the learned pace overrides [DEFAULT_SHOP_ITEMS_PER_MIN]. */
+        const val MIN_SHOP_SAMPLES = 5
         const val DEFAULT_ANNUAL_MI = 10_000.0
         const val DEFAULT_PHONE_PLAN_TOTAL = 80.0
         const val DEFAULT_PHONE_PLAN_LINES = 1

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/evaluation/ShopTimeModelTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/evaluation/ShopTimeModelTest.kt
@@ -1,0 +1,73 @@
+package cloud.trotter.dashbuddy.domain.evaluation
+
+import cloud.trotter.dashbuddy.domain.model.offer.ParsedOffer
+import cloud.trotter.dashbuddy.domain.model.order.OrderType
+import cloud.trotter.dashbuddy.domain.model.order.ParsedOrder
+import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleClass
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #556 — the Shop & Deliver time model. The old flat 7-min handling estimated a 25-item grocery run
+ * at ~15 min → a ~$116/hr reading and an inflated score. Handling for a shop is now its item count
+ * at the effective shopping pace (items/min, default 0.8 from the 2026-06 corpus), so a real
+ * grocery run reads a realistic time and rate. Non-shop pickups are unchanged.
+ */
+class ShopTimeModelTest {
+
+    private val evaluator = OfferEvaluator()
+    // E_BIKE → zero operating cost, so netPay == grossPay and we can assert the rate exactly.
+    private val economy = UserEconomy(vehicleClass = VehicleClass.E_BIKE)
+    private val config = EvaluationConfig(rules = emptyList(), userEconomy = economy)
+
+    private fun offer(pay: Double, dist: Double, itemCount: Int, type: OrderType) = ParsedOffer(
+        offerHash = "h", payAmount = pay, distanceMiles = dist, itemCount = itemCount,
+        orders = listOf(ParsedOrder(0, type, "Store", itemCount, false, emptySet())),
+    )
+
+    @Test
+    fun `a 25-item shop is estimated at items-over-pace plus drive, not the flat base`() {
+        // The real H-E-B specimen: $30.03, 3.2 mi, 25 items. drive 3.2*2.5=8; shop 25/0.8=31.25.
+        val r = evaluator.evaluate(offer(30.03, 3.2, 25, OrderType.SHOP_FOR_ITEMS), config)
+        assertEquals(39.25, r.estimatedTimeMinutes, 0.01)
+        // The bug read ~$116/hr (30.03 / ((8+7)/60)); now it's a realistic ~$46/hr.
+        assertEquals(30.03 / (39.25 / 60.0), r.dollarsPerHour, 0.1)
+        assertTrue("shop \$/hr is no longer inflated", r.dollarsPerHour < 60.0)
+    }
+
+    @Test
+    fun `a non-shop pickup keeps the flat base handling (unchanged)`() {
+        // PICKUP: drive 3*2.5=7.5 + base 7 = 14.5 — exactly the old model.
+        val r = evaluator.evaluate(offer(7.0, 3.0, 1, OrderType.PICKUP), config)
+        assertEquals(14.5, r.estimatedTimeMinutes, 0.01)
+    }
+
+    @Test
+    fun `a tiny or unparsed shop is floored at the base handling, never under-counted`() {
+        // 1 item / 0.8 = 1.25 min would be absurd; floor at base (7) + drive.
+        val r = evaluator.evaluate(offer(8.0, 2.0, 1, OrderType.SHOP_FOR_ITEMS), config)
+        assertEquals(2.0 * 2.5 + 7.0, r.estimatedTimeMinutes, 0.01)
+    }
+
+    @Test
+    fun `the learned pace overrides the seed once enough shops are measured`() {
+        val warm = economy.copy(learnedShopItemsPerMinute = 1.0, shopRateSampleCount = UserEconomy.MIN_SHOP_SAMPLES)
+        assertEquals(1.0, warm.effectiveShopItemsPerMinute, 0.0)
+        val cold = economy.copy(learnedShopItemsPerMinute = 1.0, shopRateSampleCount = 2) // below floor
+        assertEquals(UserEconomy.DEFAULT_SHOP_ITEMS_PER_MIN, cold.effectiveShopItemsPerMinute, 0.0)
+        assertEquals(UserEconomy.DEFAULT_SHOP_ITEMS_PER_MIN, economy.effectiveShopItemsPerMinute, 0.0)
+    }
+
+    @Test
+    fun `ShopRate fold is an order-independent running mean that ignores noise`() {
+        var avg: Double? = null; var n = 0
+        // two real shops: 0.8/min and 1.0/min → mean 0.9 over n=2
+        ShopRate.fold(avg, n, 24, 30.0).let { avg = it.first; n = it.second } // 0.8
+        ShopRate.fold(avg, n, 20, 20.0).let { avg = it.first; n = it.second } // 1.0
+        assertEquals(2, n); assertEquals(0.9, avg!!, 1e-9)
+        // a sub-floor 2-item / 0.5-min blip is ignored (no poisoning)
+        val (avg2, n2) = ShopRate.fold(avg, n, 2, 0.5)
+        assertEquals(2, n2); assertEquals(0.9, avg2!!, 1e-9)
+    }
+}


### PR DESCRIPTION
Fixes the inflated `$/hr` (and score) on shop-&-wait offers. Planning + a cross-database measurement preceded this — see #556 for the full analysis.

## The bug
The time model was a flat 7-min handling for **all** offers (`OfferEvaluator`: `estTimeMinutes = dist*avgMinutesPerMile + basePickupMinutes`), so a 25-item grocery run was estimated at ~15 min → **~$116/hr** and an "AWESOME" score. Since the same `estTimeMinutes` feeds both `$/hr` (display) and the `ACTIVE_HOURLY` **score**, it's a verdict-mover.

## What the data said (23 DBs, 106 deliveries, 48 shops)
- `heuristic ÷ actual`: pickups **0.9×** (fine), **shops 0.5×** (the bug).
- Effective shop pace (arrive→leave, absorbs checkout/ID/wait): **median 0.79 items/min** → seed **0.8** (the planner's guessed 1.4 would have re-created the bug — hence "derive from real data first").
- The DoorDash deadline is **well-calibrated, not padded** (window ÷ actual **median 1.0×**) → informs the deferred blend.

## This PR (Phase A + shop item-rate model)
- **`OfferEvaluator`:** time = whole-route drive + handling; **shop** handling = `items / effectiveShopItemsPerMinute`, floored at the base (tiny/unparsed shop) and +base per non-shop leg (mixed stack). Non-shop pickups unchanged. H-E-B specimen → ~39 min / ~$46/hr.
- **`UserEconomy`:** `DEFAULT_SHOP_ITEMS_PER_MIN = 0.8` seed + learned `learnedShopItemsPerMinute`/`shopRateSampleCount` (a **measured** value, deliberately **not** a user-set `EconomyField` so a vehicle-class reseed never touches it) + `effectiveShopItemsPerMinute` (learned once ≥5 shops, else seed).
- **Learning loop:** `AppEffect.RecordShopRate` emitted at the `PICKUP_CONFIRMED` edge for a shop pickup → `StrategyDataSource.recordShopRate` folds it atomically (`ShopRate` pure running mean, noise-floored) → `StrategyRepository` folds the learned pace into the evaluator's economy. Idempotent per task (`shop_rate:<taskId>`), recovery-suppressed.

## Deferred (next)
- **Offer-deadline blend** — a *guarded average* (cap the misparse/rollover tail), since the data shows the deadline is well-calibrated. Lands after field-validating the shop-time fix (per the dev's sequencing).
- **Per-store / chain pace** — rides on #159 persistence (offer-time can only use chain-level).

## Security/privacy posture
Domain / state / datastore only. The new `ShopRate` log line is PII-safe (store names are merchant names; no customer data). No network/effect surface.

## Tests
`ShopTimeModelTest` (5), `EffectMapTest` +2 (shop emits `RecordShopRate`, non-shop doesn't), `ShopRate` fold. Full unit suite green.

## Field validation
Added a checklist item — a grocery/ACV shop should read a realistic `$/hr` + sane score; pickups unchanged; `ShopRate` log lines accumulate the learned pace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)