### PR TITLE
docs(field-testing): #556 merged status

### DIFF
--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -63,7 +63,7 @@ immediately (no second pass needed) so it gets triaged.
 _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **broken** on the
 2026-06-09 dash — moved to that session's log entry below for triage.)_
 
-- **🔧 NEW (branch `feature/556-shop-time-model`) — realistic $/hr + score on Shop & Deliver offers (#556). CONFIRM ON DASH.**
+- **🔧 MERGED — realistic $/hr + score on Shop & Deliver offers (#556). CONFIRM ON DASH.**
   The time model now estimates a shop by its item count at the dasher's shopping pace (seed 0.8
   items/min, learned from your own completed shops) instead of a flat 7-min overhead — so a grocery
   run no longer reads a wildly inflated `$/hr` / "AWESOME" score. **This is a verdict-mover** (it


### PR DESCRIPTION
Docs-only. `[skip ci]` — flips the #556 shop-time-model checklist item from 'branch' to MERGED now that #559 landed, so the field-testing agent reads accurate status.