### PR TITLE
fix(rules,state): kill the add-on phantom $0 completion (defense-in-depth) (#564)

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
@@ -495,6 +495,31 @@ class EffectMapTest {
     }
 
     @Test
+    fun `DELIVERY_COMPLETED does not fire when the retired task is a PICKUP that never reached dropoff (#564)`() {
+        val (platform, base) = stateWithPlatform()
+        val job = Job("job-new", offerStoreHint = emptyList(), parentOfferHash = null, startedAt = 1000L)
+        // 06-21 seq98: a mid-stack Burger King add-on offer grace-retires an in-flight PICKUP task
+        // (Smoky Mo's …32, never picked up), and a transient/misrecognized delivery-summary frame
+        // drives this PostTask exit. The retired task is a PICKUP — it never reached the dropoff —
+        // so it must NOT fabricate a $0, customer-less "completion" of a store never delivered.
+        val pickup = Task(
+            taskId = "task-32", jobId = "job-new", phase = TaskPhase.PICKUP,
+            storeName = "Smoky Mo's BBQ", startedAt = 100L, completedAt = null,
+        )
+        val prevRegion = base.copy(activeJob = job, activeTask = pickup, recentTasks = emptyList())
+        val prev = AppState(regions = Regions(flow = FlowRegion(flow = Flow.PostTask), platforms = mapOf(platform to prevRegion)))
+        // PostTask exit; the PICKUP task is freshly retired into recentTasks (the grace-retire commit).
+        val nextRegion = prevRegion.copy(activeTask = null, recentTasks = listOf(pickup.copy(completedAt = 2000L)))
+        val next = AppState(regions = Regions(flow = FlowRegion(flow = Flow.TaskPickupNavigation), platforms = mapOf(platform to nextRegion)))
+
+        val effects = effectMap.diff(prev, next, screenObs(flow = Flow.TaskPickupNavigation))
+        assertFalse(
+            "a retired PICKUP task that never reached dropoff must not complete (#564 add-on phantom)",
+            effects.logEventTypes().contains(AppEventType.DELIVERY_COMPLETED),
+        )
+    }
+
+    @Test
     fun `stacked pickup transition fires PICKUP_NAV_STARTED and ResumeOdometer for the new task`() {
         // Costa Pacifica pickup completed (moved to recentTasks) and a new
         // Chili's pickup task minted by the stepper. The diff-task gate must

--- a/app/src/test/java/cloud/trotter/dashbuddy/replay/AddonPhantomReplayTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/replay/AddonPhantomReplayTest.kt
@@ -1,0 +1,42 @@
+package cloud.trotter.dashbuddy.replay
+
+import cloud.trotter.dashbuddy.test.util.SessionReplay
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+/**
+ * [SessionReplay] regression for the #564 "add-on phantom" (06-21 dash, seq98).
+ *
+ * When a **Burger King add-on** offer was accepted mid-stack, its transient frame was misrecognized
+ * as `delivery_summary_collapsed`: the rule's `require` keyed on `"this offer"`, which the offer's
+ * "Your Silver status gave you priority for **this offer**." line satisfies, and the rejects covered
+ * only pickup markers. That false summary drove a PostTask-exit which fabricated a $0, customer-less
+ * `DELIVERY_COMPLETED` of the in-flight (grace-retired) Smoky Mo's PICKUP — corrupting the ledger.
+ *
+ * Defense-in-depth fix, two independent guards:
+ *  - **recognition** (this test): `delivery_summary_collapsed` now rejects the offer-only markers
+ *    `"High paying offer"` / `"Total will be higher"` / `"Additional"`, so an add-on offer frame can
+ *    no longer masquerade as a delivery summary (it falls through to UNKNOWN — harmless, never
+ *    forwarded to the state machine).
+ *  - **state** ([cloud.trotter.dashbuddy.core.state.EffectMapTest], #564): a PostTask exit only
+ *    completes a task that actually reached `TaskPhase.DROPOFF`, so a retired PICKUP can never
+ *    complete even if some other frame trips the exit.
+ *
+ * Fixture: the real redacted de5eb2 capture (the live app tagged it `delivery_summary_collapsed` —
+ * the bug). `assignment_id_text` is DoorDash's opaque offer id, not customer PII; the merchant name
+ * is not PII under the privacy model.
+ */
+class AddonPhantomReplayTest {
+
+    private val session = "snapshots/sessions/addon_phantom_2026_06_21"
+
+    @Test
+    fun `the Burger King add-on offer frame is not misrecognized as a delivery summary (#564, Level A)`() {
+        val obs = SessionReplay.replayRecognition(session).single()
+        println("add-on frame → target=${obs.target} parsed=${obs.parsed::class.simpleName}")
+        assertNotEquals(
+            "an add-on offer frame must not classify as a delivery summary (would fabricate a \$0 completion)",
+            "delivery_summary_collapsed", obs.target,
+        )
+    }
+}

--- a/app/src/test/resources/snapshots/sessions/addon_phantom_2026_06_21/01_addon_offer_de5eb2.json
+++ b/app/src/test/resources/snapshots/sessions/addon_phantom_2026_06_21/01_addon_offer_de5eb2.json
@@ -1,0 +1,769 @@
+{
+    "captureId": "b60ecf89-21fd-4ea9-9ea2-37204d6087c6",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1782080315532,
+    "platform": "doordash",
+    "ruleId": "doordash.screen.delivery_summary_collapsed",
+    "classificationName": "delivery_summary_collapsed",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 136,
+                            "right": 1080,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 136,
+                                    "right": 1080,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 136,
+                                            "right": 1080,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 136,
+                                                    "right": 1080,
+                                                    "bottom": 2347
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/accept_decline_fragment_container",
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/bottomSheetLayout",
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 136,
+                                                                    "right": 1080,
+                                                                    "bottom": 2347
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/accept_constraint_layout",
+                                                                        "class": "android.view.ViewGroup",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 136,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/map_container",
+                                                                                "class": "android.widget.FrameLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 136,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2347
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 136,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2347
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.view.TextureView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 136,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2347
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 136,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2347
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 5,
+                                                                                                    "top": 1404,
+                                                                                                    "right": 194,
+                                                                                                    "bottom": 1451
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isClickable": true,
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 200,
+                                                                                                    "top": 1404,
+                                                                                                    "right": 247,
+                                                                                                    "bottom": 1451
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/secondary_action_button_dash_plus",
+                                                                                "class": "android.widget.Button",
+                                                                                "isClickable": true,
+                                                                                "bounds": {
+                                                                                    "left": 816,
+                                                                                    "top": 172,
+                                                                                    "right": 1044,
+                                                                                    "bottom": 297
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "text": "Decline",
+                                                                                        "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "bounds": {
+                                                                                            "left": 852,
+                                                                                            "top": 202,
+                                                                                            "right": 1008,
+                                                                                            "bottom": 268
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "text": "8d155d86-b8d0-4f23-9354-6f7f3a21c493",
+                                                                                "id": "com.doordash.driverapp:id/assignment_id_text",
+                                                                                "class": "android.widget.TextView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 709,
+                                                                                    "top": 1410,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 1451
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/load_progress",
+                                                                        "class": "android.widget.RelativeLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 136,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "state": "in progress",
+                                                                                "id": "com.doordash.driverapp:id/progress_bar",
+                                                                                "class": "android.widget.ProgressBar",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 486,
+                                                                                    "top": 1188,
+                                                                                    "right": 593,
+                                                                                    "bottom": 1295
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/progress_message",
+                                                                                "class": "android.widget.TextView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 540,
+                                                                                    "top": 1295,
+                                                                                    "right": 540,
+                                                                                    "bottom": 1342
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/prism_sheet",
+                                                                        "class": "android.view.ViewGroup",
+                                                                        "isClickable": true,
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 1451,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/prism_sheet_collar_view",
+                                                                                "class": "android.widget.FrameLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 1451,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 1644
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/collar_background",
+                                                                                        "class": "android.widget.LinearLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 1451,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 1644
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/custom_view_container",
+                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 1451,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 1626
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/animated_collar_view_container",
+                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 1451,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 1626
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.doordash.driverapp:id/animated_collar_view_icon",
+                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 36,
+                                                                                                                    "top": 1503,
+                                                                                                                    "right": 107,
+                                                                                                                    "bottom": 1574
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "id": "com.doordash.driverapp:id/layout_textContainer",
+                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 125,
+                                                                                                                    "top": 1487,
+                                                                                                                    "right": 1044,
+                                                                                                                    "bottom": 1590
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "High paying offer!",
+                                                                                                                        "id": "com.doordash.driverapp:id/animated_collar_view_title",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 125,
+                                                                                                                            "top": 1487,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 1539
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "text": "Your Silver status gave you priority for this offer.",
+                                                                                                                        "id": "com.doordash.driverapp:id/animated_collar_view_body",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 125,
+                                                                                                                            "top": 1543,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 1590
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/handle_overlay",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 1617,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 1644
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/extra_space",
+                                                                                "class": "android.view.View",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 1644,
+                                                                                    "right": 0,
+                                                                                    "bottom": 1680
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/prism_sheet_content_parent_container",
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 1680,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2311
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/nested_scroll_view",
+                                                                                        "class": "android.widget.ScrollView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 1680,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2311
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/prism_content_container",
+                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 1680,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2151
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/bottomsheet_content_container",
+                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 1680,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2151
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.doordash.driverapp:id/accept_decline_recycler_view_container",
+                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 1680,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2151
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "id": "com.doordash.driverapp:id/items_recycler_view",
+                                                                                                                        "class": "androidx.recyclerview.widget.RecyclerView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 1680,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2151
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1680,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 1681
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1681,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 1765
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 1681,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 1765
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "+$7.15+  Total will be higher",
+                                                                                                                                                "id": "com.doordash.driverapp:id/text_field",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 1681,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 1765
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1765,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 1830
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 1765,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 1830
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Additional 1.4 mi",
+                                                                                                                                                "id": "com.doordash.driverapp:id/text_field",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 1765,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 1830
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1830,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 1886
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 1830,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 1886
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Deliver by 5:36 PM",
+                                                                                                                                                "id": "com.doordash.driverapp:id/text_field",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 1830,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 1886
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1886,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 1926
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 1922,
+                                                                                                                                            "right": 1044,
+                                                                                                                                            "bottom": 1926
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1926,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2070
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 1926,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2070
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/work_unit_icon_container",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 45,
+                                                                                                                                                    "top": 1953,
+                                                                                                                                                    "right": 99,
+                                                                                                                                                    "bottom": 2007
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.doordash.driverapp:id/work_unit_image",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 45,
+                                                                                                                                                            "top": 1953,
+                                                                                                                                                            "right": 99,
+                                                                                                                                                            "bottom": 2007
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "Pickup",
+                                                                                                                                                "id": "com.doordash.driverapp:id/work_unit_type",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 126,
+                                                                                                                                                    "top": 1959,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2001
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/bottom_vertical_line",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 71,
+                                                                                                                                                    "top": 2007,
+                                                                                                                                                    "right": 73,
+                                                                                                                                                    "bottom": 2070
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/display_name_container",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 126,
+                                                                                                                                                    "top": 2019,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 2070
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "text": "Burger King",
+                                                                                                                                                        "id": "com.doordash.driverapp:id/display_name",
+                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 126,
+                                                                                                                                                            "top": 2019,
+                                                                                                                                                            "right": 383,
+                                                                                                                                                            "bottom": 2070
+                                                                                                                                                        }
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.doordash.driverapp:id/display_name_secondary",
+                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 383,
+                                                                                                                                                            "top": 2019,
+                                                                                                                                                            "right": 383,
+                                                                                                                                                            "bottom": 2070
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 2070,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2151
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/prism_sheet_footer_divider",
+                                                                        "class": "android.view.View",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 2147,
+                                                                            "right": 1080,
+                                                                            "bottom": 2151
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/prism_sheet_footer_container",
+                                                                        "class": "android.widget.LinearLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 2151,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/core/pipeline/src/main/assets/rules/doordash.json
+++ b/core/pipeline/src/main/assets/rules/doordash.json
@@ -663,8 +663,18 @@
         },
         {
           "allTextContains": "Start pickup"
+        },
+        {
+          "allTextContains": "Total will be higher"
+        },
+        {
+          "allTextContains": "High paying offer"
+        },
+        {
+          "allTextContains": "Additional"
         }
       ],
+      "comment": "#564: reject the OFFER-only markers above ('Total will be higher'/'High paying offer'/'Additional') — an add-on offer popup carries 'this offer' (in 'priority for this offer') which satisfies require, but it is NOT a delivery summary. Without these rejects a transient offer/loading frame mid-stack masqueraded as a collapsed summary and fabricated a $0 completion (06-21 seq98, Burger King add-on).",
       "parse": {
         "as": "post_task",
         "fields": {

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -303,7 +303,13 @@ class EffectMap @Inject constructor() {
                     val completedJobId = p.activeJob?.jobId
                     val completedTask = next.activeTask?.takeIf { it.taskId == p.activeTask?.taskId }
                         ?: next.recentTasks.lastOrNull { completedJobId == null || it.jobId == completedJobId }
-                    if (completedTask != null) {
+                    // #564: a delivery completes a DROPOFF, never a PICKUP. A mid-stack add-on offer
+                    // can grace-retire an in-flight PICKUP task and a transient/misrecognized
+                    // delivery-summary frame then drives this PostTask-exit — fabricating a $0,
+                    // customer-less "completion" of a store that was never delivered (06-21 seq98:
+                    // Smoky Mo's pickup …32 completed at the moment the Burger King add-on was
+                    // accepted). Only a task that actually reached the dropoff phase may complete.
+                    if (completedTask != null && completedTask.phase == TaskPhase.DROPOFF) {
                         val retireSince = p.pendingDestructive
                             ?.takeIf { it.kind == DestructiveKind.TASK_RETIRE }?.since
                         val payload = deliveryCompletedPayload(

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -63,6 +63,18 @@ immediately (no second pass needed) so it gets triaged.
 _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **broken** on the
 2026-06-09 dash — moved to that session's log entry below for triage.)_
 
+- **🔧 FIX SHIPPED — add-on offer no longer fabricates a $0 "completion" (#564, PR #570). CONFIRM ON DASH.**
+  06-21 seq98: accepting a **mid-stack add-on** offer (a new order added while a pickup was in
+  flight) misrecognized the offer's transient frame as a delivery summary and logged a **fake $0,
+  customer-less completion** of the not-yet-picked-up store — corrupting earnings. Fixed two ways
+  (recognition rejects offer markers; the state machine only completes a task that reached the
+  **dropoff**). **Confirm on dash: 0/2 —** when you **accept an add-on/stacked offer while still at
+  or heading to a store** (esp. a "High paying offer!" add-on), watch that **no** bogus completion
+  pops (no "$0.00" delivery, no premature "delivered" for a store you haven't dropped), the earnings
+  total **doesn't jump then stay wrong**, and the original pickup keeps its identity (no duplicate
+  store task). If a phantom completion still appears, note the add-on's store + the store you were
+  working, and grab the capture sequence around the accept.
+
 - **🔧 MERGED — realistic $/hr + score on Shop & Deliver offers (#556). CONFIRM ON DASH.**
   The time model now estimates a shop by its item count at the dasher's shopping pace (seed 0.8
   items/min, learned from your own completed shops) instead of a flat 7-min overhead — so a grocery


### PR DESCRIPTION
Closes #564.

## The bug (06-21 dash, seq98)
Accepting a mid-stack **Burger King add-on** offer fabricated a **\$0, customer-less `DELIVERY_COMPLETED`** of the in-flight (never-picked-up) Smoky Mo's PICKUP — corrupting the ledger (phantom \$0 row + the real Smoky leg replaced). Two independent failures lined up, same shape as the 06-17 ghost: a live screen matched a completion rule and tripped a stepper path the prior guards didn't cover.

1. **Recognition** — the add-on offer's transient frame matched `delivery_summary_collapsed`. The rule's `require` keys on `"this offer"`, which the offer's *"Your Silver status gave you priority for this offer."* line satisfies, and the rejects covered only pickup markers.
2. **State** — that false summary drove a `PostTask` exit, and the completion path reported `recentTasks.lastOrNull{…}` **regardless of phase**, so the grace-retired PICKUP got "completed". (`#518`'s taskId-dedup can't stop a *first* spurious completion.)

## The fix — defense-in-depth (either guard alone stops it)
- **Recognition** (`doordash.json`): `delivery_summary_collapsed` now also rejects the offer-only markers `"High paying offer"` / `"Total will be higher"` / `"Additional"`. The add-on frame now falls through to **UNKNOWN** (captured to disk, never forwarded to the state machine).
- **State** (`EffectMap.kt`): the PostTask-exit completion only fires for a task that actually reached `TaskPhase.DROPOFF`. A retired PICKUP can never complete even if some other frame trips the exit.

## Tests
- **`AddonPhantomReplayTest`** (Level A): replays the **real redacted de5eb2 capture** (the live app tagged it `delivery_summary_collapsed` — the bug) and asserts it no longer classifies as a delivery summary (now → `UNKNOWN`).
- **`EffectMapTest`** (#564): a retired **PICKUP** task on PostTask exit emits no `DELIVERY_COMPLETED`; the existing #518 DROPOFF-completion cases still pass.
- `AllMatchersSuite` green — no real delivery summary regressed by the new rejects; parse-output golden unchanged.
- Full `testDebugUnitTest` green.

## Security / privacy
Fixture carries no customer PII — `assignment_id_text` is DoorDash's opaque offer id, and merchant names are not PII under the privacy model; redacted via `SnapshotRedactor`. No new INFO logging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)