### PR TITLE
fix(rules): a PICKUP screen must not parse a customer identity (#548)

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/recognition/matchers/PickupNoCustomerIdentityTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/recognition/matchers/PickupNoCustomerIdentityTest.kt
@@ -1,0 +1,54 @@
+package cloud.trotter.dashbuddy.core.pipeline.recognition.matchers
+
+import cloud.trotter.dashbuddy.test.util.TestRulesetFactory
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * #548 structural invariant: a PICKUP-phase recognition rule must NEVER parse a customer identity.
+ *
+ * A pickup belongs to a STORE, not a customer; only DROPOFF rules hash the customer (the
+ * customers-are-hashed pledge applies on the drop side). The 06-20 Peng's stack bug was a
+ * multi-node `pickup_arrival` screen whose `customerNameHash` parse bled the *other* drop's
+ * customer hash onto the PICKUP task — a customer identity a pickup has no business owning.
+ *
+ * The fix removed that parse; this test is the regression guard against any future rule edit
+ * silently re-adding a customer field to a PICKUP parse. It reads the production rule JSON (the
+ * SSOT producer) directly, so it covers every rule and branch — not only the screens with corpus.
+ */
+class PickupNoCustomerIdentityTest {
+
+    private val customerFields = listOf("customerNameHash", "customerAddressHash")
+
+    @Test
+    fun `no PICKUP-phase rule parses a customer identity (#548)`() {
+        val offenders = mutableListOf<String>()
+        File(TestRulesetFactory.rulesDir).listFiles { f -> f.extension == "json" }?.sortedBy { it.name }
+            ?.forEach { file ->
+                val root = Json.parseToJsonElement(file.readText()).jsonObject
+                root["screens"]?.jsonArray?.forEach { collectOffenders(it.jsonObject, file.name, offenders) }
+            }
+        assertTrue(
+            "A PICKUP-phase rule parsed a customer identity — pickups belong to a store, not a " +
+                "customer (#548). Offenders:\n" + offenders.joinToString("\n"),
+            offenders.isEmpty(),
+        )
+    }
+
+    private fun collectOffenders(rule: JsonObject, fileName: String, offenders: MutableList<String>) {
+        val fields = rule["parse"]?.jsonObject?.get("fields")?.jsonObject
+        if (fields?.get("phase")?.jsonPrimitive?.contentOrNull == "PICKUP") {
+            val id = rule["id"]?.jsonPrimitive?.contentOrNull ?: "(no id)"
+            customerFields.filter { fields.containsKey(it) }
+                .forEach { offenders += "$fileName :: $id parses '$it' on a PICKUP-phase parse" }
+        }
+        rule["branches"]?.jsonArray?.forEach { collectOffenders(it.jsonObject, fileName, offenders) }
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/recognition/matchers/PickupNoCustomerIdentityTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/recognition/matchers/PickupNoCustomerIdentityTest.kt
@@ -33,7 +33,11 @@ class PickupNoCustomerIdentityTest {
         File(TestRulesetFactory.rulesDir).listFiles { f -> f.extension == "json" }?.sortedBy { it.name }
             ?.forEach { file ->
                 val root = Json.parseToJsonElement(file.readText()).jsonObject
-                root["screens"]?.jsonArray?.forEach { collectOffenders(it.jsonObject, file.name, offenders) }
+                // Scan every rule section that can carry a parse block (screens today; notifications/
+                // clicks defensively) so a PICKUP customer parse can't slip in via any surface.
+                for (section in listOf("screens", "notifications", "clicks")) {
+                    root[section]?.jsonArray?.forEach { collectOffenders(it.jsonObject, file.name, offenders) }
+                }
             }
         assertTrue(
             "A PICKUP-phase rule parsed a customer identity — pickups belong to a store, not a " +

--- a/app/src/test/resources/snapshots/approved-parse-output.json
+++ b/app/src/test/resources/snapshots/approved-parse-output.json
@@ -2646,7 +2646,7 @@
         "fields": {
             "arrivalConfirmed": true,
             "customerAddressHash": null,
-            "customerNameHash": "017ad73325fcf108a972edac618f9edfc957c5b1de10f8b371b0a8bfa4f59e2d",
+            "customerNameHash": null,
             "deadline": {
                 "text": "19:12",
                 "time": 1780341120000
@@ -2667,7 +2667,7 @@
         "fields": {
             "arrivalConfirmed": true,
             "customerAddressHash": null,
-            "customerNameHash": "017ad73325fcf108a972edac618f9edfc957c5b1de10f8b371b0a8bfa4f59e2d",
+            "customerNameHash": null,
             "deadline": {
                 "text": "19:12",
                 "time": 1780341120000
@@ -2688,7 +2688,7 @@
         "fields": {
             "arrivalConfirmed": true,
             "customerAddressHash": null,
-            "customerNameHash": "017ad73325fcf108a972edac618f9edfc957c5b1de10f8b371b0a8bfa4f59e2d",
+            "customerNameHash": null,
             "deadline": {
                 "text": "19:12",
                 "time": 1780341120000
@@ -2709,7 +2709,7 @@
         "fields": {
             "arrivalConfirmed": true,
             "customerAddressHash": null,
-            "customerNameHash": "017ad73325fcf108a972edac618f9edfc957c5b1de10f8b371b0a8bfa4f59e2d",
+            "customerNameHash": null,
             "deadline": {
                 "text": "19:12",
                 "time": 1780341120000
@@ -2730,7 +2730,7 @@
         "fields": {
             "arrivalConfirmed": true,
             "customerAddressHash": null,
-            "customerNameHash": "017ad73325fcf108a972edac618f9edfc957c5b1de10f8b371b0a8bfa4f59e2d",
+            "customerNameHash": null,
             "deadline": {
                 "text": "19:43",
                 "time": 1780342980000
@@ -2751,7 +2751,7 @@
         "fields": {
             "arrivalConfirmed": true,
             "customerAddressHash": null,
-            "customerNameHash": "017ad73325fcf108a972edac618f9edfc957c5b1de10f8b371b0a8bfa4f59e2d",
+            "customerNameHash": null,
             "deadline": {
                 "text": "19:43",
                 "time": 1780342980000
@@ -2772,7 +2772,7 @@
         "fields": {
             "arrivalConfirmed": true,
             "customerAddressHash": null,
-            "customerNameHash": "017ad73325fcf108a972edac618f9edfc957c5b1de10f8b371b0a8bfa4f59e2d",
+            "customerNameHash": null,
             "deadline": {
                 "text": "19:43",
                 "time": 1780342980000
@@ -2793,7 +2793,7 @@
         "fields": {
             "arrivalConfirmed": true,
             "customerAddressHash": null,
-            "customerNameHash": "017ad73325fcf108a972edac618f9edfc957c5b1de10f8b371b0a8bfa4f59e2d",
+            "customerNameHash": null,
             "deadline": {
                 "text": "19:50",
                 "time": 1780343400000
@@ -2814,7 +2814,7 @@
         "fields": {
             "arrivalConfirmed": true,
             "customerAddressHash": null,
-            "customerNameHash": "017ad73325fcf108a972edac618f9edfc957c5b1de10f8b371b0a8bfa4f59e2d",
+            "customerNameHash": null,
             "deadline": {
                 "text": "19:50",
                 "time": 1780343400000
@@ -2835,7 +2835,7 @@
         "fields": {
             "arrivalConfirmed": true,
             "customerAddressHash": null,
-            "customerNameHash": "017ad73325fcf108a972edac618f9edfc957c5b1de10f8b371b0a8bfa4f59e2d",
+            "customerNameHash": null,
             "deadline": {
                 "text": "19:50",
                 "time": 1780343400000
@@ -2856,7 +2856,7 @@
         "fields": {
             "arrivalConfirmed": true,
             "customerAddressHash": null,
-            "customerNameHash": "017ad73325fcf108a972edac618f9edfc957c5b1de10f8b371b0a8bfa4f59e2d",
+            "customerNameHash": null,
             "deadline": {
                 "text": "19:50",
                 "time": 1780343400000
@@ -2877,7 +2877,7 @@
         "fields": {
             "arrivalConfirmed": true,
             "customerAddressHash": null,
-            "customerNameHash": "017ad73325fcf108a972edac618f9edfc957c5b1de10f8b371b0a8bfa4f59e2d",
+            "customerNameHash": null,
             "deadline": {
                 "text": "19:50",
                 "time": 1780343400000
@@ -2898,7 +2898,7 @@
         "fields": {
             "arrivalConfirmed": true,
             "customerAddressHash": null,
-            "customerNameHash": "017ad73325fcf108a972edac618f9edfc957c5b1de10f8b371b0a8bfa4f59e2d",
+            "customerNameHash": null,
             "deadline": {
                 "text": "19:50",
                 "time": 1780343400000
@@ -2919,7 +2919,7 @@
         "fields": {
             "arrivalConfirmed": true,
             "customerAddressHash": null,
-            "customerNameHash": "017ad73325fcf108a972edac618f9edfc957c5b1de10f8b371b0a8bfa4f59e2d",
+            "customerNameHash": null,
             "deadline": {
                 "text": "19:50",
                 "time": 1780343400000
@@ -2940,7 +2940,7 @@
         "fields": {
             "arrivalConfirmed": true,
             "customerAddressHash": null,
-            "customerNameHash": "017ad73325fcf108a972edac618f9edfc957c5b1de10f8b371b0a8bfa4f59e2d",
+            "customerNameHash": null,
             "deadline": {
                 "text": "19:50",
                 "time": 1780343400000

--- a/core/pipeline/src/main/assets/rules/doordash.json
+++ b/core/pipeline/src/main/assets/rules/doordash.json
@@ -1076,13 +1076,6 @@
         "fields": {
           "phase": "PICKUP",
           "subFlow": "ARRIVED",
-          "customerNameHash": {
-            "find": {
-              "hasIdSuffix": "customer_name"
-            },
-            "read": "text",
-            "transform": "sha256"
-          },
           "storeName": {
             "from": "contactView",
             "find": {

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -63,6 +63,14 @@ immediately (no second pass needed) so it gets triaged.
 _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **broken** on the
 2026-06-09 dash — moved to that session's log entry below for triage.)_
 
+- **🔧 FIX SHIPPED — a pickup no longer borrows a customer identity (#548, PR #572). CONFIRM ON DASH.**
+  On a **multi-store stack**, a restaurant pickup screen could bleed the *other* drop's customer onto
+  the pickup task (latent — no visible bubble effect, but a data-model defect). The pickup screen no
+  longer parses a customer at all. **Confirm on dash: 0/2 —** on a stacked/multi-store order, the
+  **pickup** bubble should read the **store/merchant** (never a 6-character customer fragment), and no
+  customer should bleed onto the first dropoff. Hard to see directly; mainly verified in the db/log —
+  but flag anything where a pickup card shows a customer-looking label.
+
 - **🔧 FIX SHIPPED — dropoff customer fills in the card instead of re-minting it (#565, PR #571). CONFIRM ON DASH.**
   06-21 Walgreens: at the dropoff the bubble showed **"the customer"** for a bit, then when you
   started navigating the card **re-minted** (a fresh card appeared) instead of just filling in the


### PR DESCRIPTION
Closes #548.

## Bug
`doordash.screen.pickup_arrival` parsed `customerNameHash` into a **PICKUP**-phase task — the only one of four `customerNameHash`-parsing rules whose phase is PICKUP (the other three are DROPOFF). On a multi-store stack, the restaurant arrival screen's multi-node layout let that parse bleed the **other drop's** customer hash onto the PICKUP task (06-20 Peng's stack: the Peng's pickup carried the sibling drop's customer hash, verified across snapshots 160/200/250/300). A pickup belongs to a **store**, not a customer.

Latent today (no bubble/log leak — `pickup_arrival` never emits `activity=CONFIRMED`, so the persona stays Merchant; `PickupPayload` carries no customer hash), but it violates the data-model invariant and is a customer-PII processing site that shouldn't exist.

## Fix
Remove the `customerNameHash` parse block from `pickup_arrival` — kill it at the single producer (SSOT) rather than guarding three generic stepper consumers. The stepper stays phase-agnostic; the three DROPOFF customer parses are untouched, so customer dedup/correlation on the drop side is unaffected. **Privacy-positive:** one fewer place the customer's name ("Order for &lt;name&gt;") is hashed/stored.

## Tests
- **`PickupNoCustomerIdentityTest`** (NEW — the real regression guard): a structural invariant over the production rule JSON asserting **no** PICKUP-phase rule declares `customerNameHash`/`customerAddressHash`. Walks every rule + branch (not just corpus'd screens), so a future edit can't silently re-add the field. (Per the adversarial review, promoted from "optional" to the headline guard — the issue *is* about an invariant.)
- `approved-parse-output.json` regenerated: 15 `pickup_arrival` entries flip `customerNameHash` → `null`; **no other parse field changed** (reviewed diff).
- `AllMatchersSuite` + full `testDebugUnitTest` green — `pickup_arrival` still recognizes store/deadline/itemCount/redCard/arrival.

## Security / privacy
Net **reduction** in customer-PII processing (removes a hash site). No new INFO logging. Merchant names aren't PII.

🤖 Generated with [Claude Code](https://claude.com/claude-code)