### PR TITLE
fix(effects): give per-task bubbles an idempotency key (#566)

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
@@ -5,6 +5,7 @@ import cloud.trotter.dashbuddy.domain.action.RuleAction
 import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
 import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
 import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
+import cloud.trotter.dashbuddy.domain.model.chat.ChatPersona
 import cloud.trotter.dashbuddy.domain.model.event.AppEventType
 import cloud.trotter.dashbuddy.domain.model.offer.ParsedOffer
 import cloud.trotter.dashbuddy.domain.model.order.OrderType
@@ -34,6 +35,9 @@ import cloud.trotter.dashbuddy.domain.state.TaskPhase
 import cloud.trotter.dashbuddy.domain.state.TaskSubFlow
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import cloud.trotter.dashbuddy.domain.pipeline.ObservationPayload
@@ -1454,5 +1458,65 @@ class EffectMapTest {
         assertTrue("Should emit StartOdometer", effects.any { it is AppEffect.StartOdometer })
         assertTrue("Should emit StartSession", effects.any { it is AppEffect.StartSession })
         assertTrue("Should emit DASH_START", effects.logEventTypes().contains(AppEventType.DASH_START))
+    }
+
+    // =====================================================================================
+    // #566 — per-task bubble idempotency key (double fly-away on a stacked/new pickup)
+    // =====================================================================================
+
+    @Test
+    fun `a new pickup bubble carries a per-task dedupe key (#566, wiring)`() {
+        // A new pickup (prevTask null → nextTask PICKUP) emits a KEYED UpdateBubble, so the engine's
+        // effects_fired gate can collapse the two-site double emission of "Pickup: <store>".
+        val (platform, base) = stateWithPlatform()
+        val pickup = Task(taskId = "task-1", jobId = "job-1", phase = TaskPhase.PICKUP, storeName = "H-E-B", startedAt = 100L)
+        val prev = AppState(regions = Regions(flow = FlowRegion(flow = Flow.OfferPresented), platforms = mapOf(platform to base)))
+        val nextRegion = base.copy(activeTask = pickup)
+        val next = AppState(regions = Regions(flow = FlowRegion(flow = Flow.TaskPickupNavigation), platforms = mapOf(platform to nextRegion)))
+
+        val bubble = effectMap.diff(
+            prev, next,
+            screenObs(
+                flow = Flow.TaskPickupNavigation,
+                parsed = ParsedFields.TaskFields(storeName = "H-E-B", phase = TaskPhase.PICKUP, subFlow = TaskSubFlow.NAVIGATION),
+            ),
+        ).effectsOfType<AppEffect.UpdateBubble>().firstOrNull { it.text.contains("Pickup") }
+
+        assertNotNull("a new pickup should emit a bubble", bubble)
+        assertNotNull("the pickup bubble must carry a dedupe key so the double fly-away dedups (#566)", bubble!!.effectKey)
+        assertTrue("the key is scoped to the task id", bubble.effectKey!!.contains("task-1"))
+    }
+
+    @Test
+    fun `the same task switching persona produces different bubble keys, so the activity change still fires (#566)`() {
+        // H-E-B leg: NAVIGATOR (heading to store) → SHOPPER (now shopping). Same task, same text, but
+        // distinct personas → distinct keys → the legitimate re-emit is NOT suppressed.
+        val nav = AppEffect.UpdateBubble("Pickup: H-E-B", ChatPersona.Navigator, dedupeScope = "task-1")
+        val shop = AppEffect.UpdateBubble("Pickup: H-E-B", ChatPersona.Shopper, dedupeScope = "task-1")
+        assertNotEquals("NAVIGATOR→SHOPPER on the same leg must still fire", nav.effectKey, shop.effectKey)
+    }
+
+    @Test
+    fun `the same store on a later distinct leg produces a different bubble key (#566)`() {
+        // Two separate H-E-B pickups in one dash (effects_fired persists ~48h) must each fire.
+        val first = AppEffect.UpdateBubble("Pickup: H-E-B", ChatPersona.Navigator, dedupeScope = "task-1")
+        val later = AppEffect.UpdateBubble("Pickup: H-E-B", ChatPersona.Navigator, dedupeScope = "task-9")
+        assertNotEquals("a later same-store leg must still fire", first.effectKey, later.effectKey)
+    }
+
+    @Test
+    fun `identical task, persona and text produce the same key, so the consecutive double dedups (#566)`() {
+        // The bug: two EffectMap sites emit the byte-identical bubble on consecutive frames of one leg.
+        val a = AppEffect.UpdateBubble("Pickup: Petsmart", ChatPersona.Navigator, dedupeScope = "task-1")
+        val b = AppEffect.UpdateBubble("Pickup: Petsmart", ChatPersona.Navigator, dedupeScope = "task-1")
+        assertEquals("the consecutive identical double must collapse to one", a.effectKey, b.effectKey)
+        assertNotNull(a.effectKey)
+    }
+
+    @Test
+    fun `a one-shot non-task bubble stays unkeyed so it can legitimately recur (#566)`() {
+        // Offer/session/resume/paused/earnings bubbles pass no dedupeScope → null key → never deduped.
+        assertNull("Offer Accepted must stay unkeyed", AppEffect.UpdateBubble("Offer Accepted", ChatPersona.Dispatcher).effectKey)
+        assertNull("a default bubble is unkeyed", AppEffect.UpdateBubble("Dash Paused!").effectKey)
     }
 }

--- a/app/src/test/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngineTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngineTest.kt
@@ -34,6 +34,8 @@ import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
@@ -422,6 +424,41 @@ class SideEffectEngineTest {
 
         verify(bubbleManager, never()).startSession(any(), any())
         verifyBlocking(effectsFiredDao, never()) { markFired(any()) }
+    }
+
+    @Test
+    fun `two identical keyed pickup bubbles post the fly-away exactly once (#566 end-to-end)`() = runTest {
+        // The double fly-away: two EffectMap sites emit the byte-identical per-task bubble on
+        // consecutive frames. With a dedupeScope (taskId) the bubble now carries an effectKey, so the
+        // engine's effects_fired gate collapses the second. Stateful: not-fired on the first call,
+        // fired on the second (as markFired would have recorded between them).
+        val engine = buildEngine(StandardTestDispatcher(testScheduler))
+        val bubble = AppEffect.UpdateBubble("Pickup: Petsmart", dedupeScope = "task-1")
+        assertNotNull("the per-task bubble must be keyed for this to work", bubble.effectKey)
+        whenever { effectsFiredDao.hasBeenFired(bubble.effectKey!!) }.thenReturn(false, true)
+
+        engine.process(bubble, recovering = false)
+        runCurrent()
+        engine.process(bubble, recovering = false)
+        runCurrent()
+
+        verify(bubbleManager, times(1)).postMessage(eq("Pickup: Petsmart"), any(), any())
+        verifyBlocking(effectsFiredDao, times(1)) { markFired(any()) }
+    }
+
+    @Test
+    fun `an unkeyed one-shot bubble posts every time (#566 does not over-dedup)`() = runTest {
+        // Offer/session/etc. bubbles have no dedupeScope → null key → the gate never suppresses them.
+        val engine = buildEngine(StandardTestDispatcher(testScheduler))
+        val bubble = AppEffect.UpdateBubble("Offer Accepted")
+        assertNull("a one-shot bubble must stay unkeyed", bubble.effectKey)
+
+        engine.process(bubble, recovering = false)
+        runCurrent()
+        engine.process(bubble, recovering = false)
+        runCurrent()
+
+        verify(bubbleManager, times(2)).postMessage(eq("Offer Accepted"), any(), any())
     }
 
     @Test

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/AppEffect.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/AppEffect.kt
@@ -44,11 +44,29 @@ sealed class AppEffect {
     }
 
     // 2. Update UI (The Bubble)
+    //
+    // #566: per-task bubbles (a pickup/dropoff heads-up) carry a [dedupeScope] = the task id, so the
+    // engine's effects_fired idempotency gate (which only acts on a non-null effectKey) collapses the
+    // double fly-away that fired when two EffectMap sites emitted the same "Pickup: <store>" on
+    // consecutive frames of one leg. The key is scoped to task + persona + content so it does NOT
+    // suppress a legitimate re-emit: the same task switching persona (NAVIGATOR→SHOPPER) or a later,
+    // distinct leg at the same store both produce a different key and still fire. One-shot bubbles
+    // (offer/session/resume/paused/earnings) leave [dedupeScope] null → effectKey null → never deduped
+    // (they may legitimately recur within the effects_fired window). persona.id for a Customer is the
+    // 6-char hash prefix (privacy-safe); merchant names aren't PII; text.hashCode() avoids storing the
+    // literal in the table. NOTE: this reuses the recovery-scoped effects_fired table for a cosmetic UI
+    // dedup rather than the in-state lastAnnouncedPostTaskTaskId anchor — a deliberate, lighter trade
+    // for a LOW cosmetic bug (UpdateBubble is an external effect, suppressed at the recovery gate
+    // before markFired, so recovery replays are unaffected).
     data class UpdateBubble(
         val text: String,
         val persona: ChatPersona = ChatPersona.Dispatcher,
-        val expand: Boolean = false
-    ) : AppEffect()
+        val expand: Boolean = false,
+        val dedupeScope: String? = null,
+    ) : AppEffect() {
+        override val effectKey: String? get() =
+            dedupeScope?.let { "bubble:$it:${persona.id}:${text.hashCode()}" }
+    }
 
     /**
      * Capture an evidence screenshot. [category] is the user-consent bucket

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -585,7 +585,7 @@ class EffectMap @Inject constructor() {
                         storeName,
                         nextTask.customerNameHash,
                     )
-                    add(AppEffect.UpdateBubble("Pickup: $storeName", persona))
+                    add(AppEffect.UpdateBubble("Pickup: $storeName", persona, dedupeScope = nextTask.taskId))
                 }
             }
 
@@ -639,7 +639,7 @@ class EffectMap @Inject constructor() {
                 }
 
                 val customer = customerDisplayName(customerHash)
-                add(AppEffect.UpdateBubble("Heading to $customer", ChatPersona.Customer(customer)))
+                add(AppEffect.UpdateBubble("Heading to $customer", ChatPersona.Customer(customer), dedupeScope = nextTask.taskId))
             }
 
             // Arrival detection — task subflow changed to ARRIVED
@@ -694,7 +694,7 @@ class EffectMap @Inject constructor() {
                         storeName,
                         nextTask.customerNameHash,
                     )
-                    add(AppEffect.UpdateBubble("Pickup: $storeName", persona))
+                    add(AppEffect.UpdateBubble("Pickup: $storeName", persona, dedupeScope = nextTask.taskId))
                 }
 
                 // Store name resolution — re-emit the pickup payload with the

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -63,6 +63,15 @@ immediately (no second pass needed) so it gets triaged.
 _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **broken** on the
 2026-06-09 dash — moved to that session's log entry below for triage.)_
 
+- **🔧 FIX SHIPPED — no more double fly-away bubble on a new/stacked pickup (#566, PR #573). CONFIRM ON DASH.**
+  When a pickup started (or a stacked pickup handed off), the "Pickup: <store>" heads-up bubble flew
+  out **twice** in quick succession (the second often icon-less). Fixed with a per-task dedupe key.
+  **Confirm on dash: 0/2 —** on each new pickup (especially the second store of a stack), the
+  "Pickup: <store>" notification should fly out **once**, not twice. A genuine change should still
+  show: e.g. heading-to-store → start-shopping may update the bubble (that's expected, different
+  state), and a later separate trip to the same store should still announce. If you still see an
+  immediate identical double, note the store + whether it was the first or a stacked pickup.
+
 - **🔧 FIX SHIPPED — a pickup no longer borrows a customer identity (#548, PR #572). CONFIRM ON DASH.**
   On a **multi-store stack**, a restaurant pickup screen could bleed the *other* drop's customer onto
   the pickup task (latent — no visible bubble effect, but a data-model defect). The pickup screen no


### PR DESCRIPTION
Closes #566.

## Bug
A new/stacked pickup fired the heads-up **fly-away twice**: two `EffectMap` sites emit the byte-identical `"Pickup: <store>"` on consecutive frames of one leg (Site A new-task mint + Site B same-task store/activity change), and `UpdateBubble` declared **no `effectKey`**, so the engine's `effects_fired` dedup (gated on `key != null`) never acted. 06-21 db: three consecutive same-text/same-persona NAVIGATOR doubles (Petsmart 29ms, McDonald's 24ms, Burger King 16ms) — systematic. **UI-only** (exactly one `PICKUP_NAV_STARTED` in `app_events`; the keyed `LogEvent` deduped, the keyless bubble did not).

## Fix
Per-task bubbles carry `dedupeScope = taskId`; `UpdateBubble.effectKey = "bubble:<taskId>:<persona.id>:<text.hashCode()>"`. Scoping to **task + persona + content** avoids over-suppression (verified against the data):
- same leg switching persona **NAVIGATOR→SHOPPER** → distinct `persona.id` → different key → still fires;
- a later **distinct same-store leg** → distinct `taskId` → different key → still fires;
- the **consecutive identical double** → same key → collapses to one.

One-shot bubbles (offer/session/resume/paused/earnings) pass no scope → null key → never deduped (they may legitimately recur within the window).

## Design note (raised by the adversarial pre-review)
This reuses the recovery-scoped `effects_fired` table for a **cosmetic UI dedup** rather than the in-state `lastAnnouncedPostTaskTaskId` anchor — a deliberate, lighter trade for a LOW cosmetic bug. `UpdateBubble` is an **external** effect (suppressed at the recovery gate *before* `markFired`), so crash-recovery replays are unaffected. The heavier SSOT-anchor alternative was considered and rejected for proportionality.

## Tests (`EffectMapTest`)
new-pickup emits a **keyed** bubble (wiring); NAVIGATOR→SHOPPER same task → **different** keys; later same-store leg → **different** key; identical task/persona/text → **same** key (the double collapses); a one-shot bubble stays **unkeyed**. Full `testDebugUnitTest` green.

## Security / privacy
`persona.id` for a Customer is the 6-char hash prefix; merchant names aren't PII; `text.hashCode()` avoids storing the literal in `effects_fired`. No new INFO logging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)