### PR TITLE
fix(rules): recognize the dropoff-arrived 'Leave it at the door' card (#549)

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/test/util/SnapshotRedactor.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/test/util/SnapshotRedactor.kt
@@ -36,6 +36,10 @@ object SnapshotRedactor {
         "chat_input_text_field", "bottom_sheet_address_line_1", "bottom_sheet_address_line_2",
         "tvTitle", "tvLastMessage",
         "bottom_sheet_instructions", "step_description", "instructions_list", "instruction_text",
+        // #549: the dropoff-arrival card's free instruction text carries the customer's gate code +
+        // note ("Leave at my door: Gate code 883423# …") — never parsed by any rule; masked here so
+        // the committed corpus fixture can't leak it.
+        "dasher_instruction_content_collapsed",
         // GoPuff (DoorDash Drive) batch screens (#501): the per-order customer name on the
         // bin-scan/pickup-steps screens.
         "order_cx_name",

--- a/app/src/test/resources/snapshots/approved-parse-output.json
+++ b/app/src/test/resources/snapshots/approved-parse-output.json
@@ -1520,7 +1520,7 @@
         "shape": "task",
         "fields": {
             "arrivalConfirmed": false,
-            "customerAddressHash": null,
+            "customerAddressHash": "7837e58dbff05ad014939819476f3029f3d6b6dc2def2b03f502decbef888e43",
             "customerNameHash": "75adb7969770f4910879f8d929335ac1f2b5c66adc3574bccaa4cdab310f690d",
             "deadline": {
                 "text": "20:04",
@@ -1541,7 +1541,7 @@
         "shape": "task",
         "fields": {
             "arrivalConfirmed": false,
-            "customerAddressHash": null,
+            "customerAddressHash": "7837e58dbff05ad014939819476f3029f3d6b6dc2def2b03f502decbef888e43",
             "customerNameHash": "75adb7969770f4910879f8d929335ac1f2b5c66adc3574bccaa4cdab310f690d",
             "deadline": {
                 "text": "20:04",
@@ -1945,6 +1945,27 @@
             "deadline": {
                 "text": "8:16 PM",
                 "time": 1780344960000
+            },
+            "itemsRemaining": null,
+            "itemsShopped": null,
+            "phase": "DROPOFF",
+            "redCardTotal": null,
+            "storeAddress": null,
+            "storeName": null,
+            "subFlow": "NAVIGATION"
+        }
+    },
+    "dropoff_pre_arrival/20260621_151916_dropoff_refined_pin_leave_at_door.json": {
+        "ruleId": "doordash.screen.dropoff_pre_arrival",
+        "intent": "dropoff_pre_arrival",
+        "shape": "task",
+        "fields": {
+            "arrivalConfirmed": false,
+            "customerAddressHash": "7342b159859c4de641357a7c8243c1090043221af131d43681d8443b3e0a7100",
+            "customerNameHash": "017ad73325fcf108a972edac618f9edfc957c5b1de10f8b371b0a8bfa4f59e2d",
+            "deadline": {
+                "text": "15:27",
+                "time": 1780327620000
             },
             "itemsRemaining": null,
             "itemsShopped": null,

--- a/app/src/test/resources/snapshots/dropoff_pre_arrival/20260621_151916_dropoff_refined_pin_leave_at_door.json
+++ b/app/src/test/resources/snapshots/dropoff_pre_arrival/20260621_151916_dropoff_refined_pin_leave_at_door.json
@@ -1,0 +1,950 @@
+{
+    "captureId": "bad1f13c-3ec7-4366-8227-2c2b51f31e65",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1782073156382,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 136,
+                            "right": 1080,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 136,
+                                    "right": 1080,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 136,
+                                            "right": 1080,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/container",
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 136,
+                                                    "right": 1080,
+                                                    "bottom": 2347
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/toolbar_container",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 278
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/toolbar",
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 136,
+                                                                    "right": 1080,
+                                                                    "bottom": 278
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "desc": "Current dash",
+                                                                        "class": "android.widget.ImageButton",
+                                                                        "isClickable": true,
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 144,
+                                                                            "right": 125,
+                                                                            "bottom": 269
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "text": "Deliver by 15:27",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 133,
+                                                                            "top": 182,
+                                                                            "right": 424,
+                                                                            "bottom": 232
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "class": "androidx.appcompat.widget.LinearLayoutCompat",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 866,
+                                                                            "top": 144,
+                                                                            "right": 1080,
+                                                                            "bottom": 269
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "desc": "Safety",
+                                                                                "id": "com.doordash.driverapp:id/action_dasher_safety",
+                                                                                "class": "android.widget.Button",
+                                                                                "isClickable": true,
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 866,
+                                                                                    "top": 153,
+                                                                                    "right": 973,
+                                                                                    "bottom": 260
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "desc": "Help",
+                                                                                "id": "com.doordash.driverapp:id/action_self_help",
+                                                                                "class": "android.widget.Button",
+                                                                                "isClickable": true,
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 973,
+                                                                                    "top": 153,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 260
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 278,
+                                                            "right": 1080,
+                                                            "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/fragment",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 278,
+                                                                    "right": 1080,
+                                                                    "bottom": 2347
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/drop_off_container",
+                                                                        "class": "android.view.ViewGroup",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 278,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/main_view_container",
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 278,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2347
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/map_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 278,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2347
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 278,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2347
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.TextureView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 278,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2347
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 278,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2347
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "class": "android.widget.ImageView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 1496,
+                                                                                                            "right": 189,
+                                                                                                            "bottom": 1543
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "class": "android.widget.ImageView",
+                                                                                                        "isClickable": true,
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 195,
+                                                                                                            "top": 1496,
+                                                                                                            "right": 242,
+                                                                                                            "bottom": 1543
+                                                                                                        }
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/dash_total_pay",
+                                                                                        "class": "android.widget.LinearLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 844,
+                                                                                            "top": 296,
+                                                                                            "right": 1062,
+                                                                                            "bottom": 430
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "$0.00",
+                                                                                                "id": "com.doordash.driverapp:id/running_total_pay",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 880,
+                                                                                                    "top": 314,
+                                                                                                    "right": 1026,
+                                                                                                    "bottom": 366
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "this dash",
+                                                                                                "id": "com.doordash.driverapp:id/text_pay",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 880,
+                                                                                                    "top": 370,
+                                                                                                    "right": 1026,
+                                                                                                    "bottom": 412
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/drop_off_bottom_sheet_container",
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 1568,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2347
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/bottom_sheet_handle",
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 482,
+                                                                                            "top": 1586,
+                                                                                            "right": 562,
+                                                                                            "bottom": 1595
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/drop_off_recycler_view",
+                                                                                        "class": "androidx.recyclerview.widget.RecyclerView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 1613,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2347
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 1613,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 1764
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "text": "Delivery for",
+                                                                                                        "id": "com.doordash.driverapp:id/user_name_label",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 36,
+                                                                                                            "top": 1649,
+                                                                                                            "right": 246,
+                                                                                                            "bottom": 1696
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "text": "[redacted]",
+                                                                                                        "id": "com.doordash.driverapp:id/user_name",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 36,
+                                                                                                            "top": 1696,
+                                                                                                            "right": 767,
+                                                                                                            "bottom": 1762
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/call_button",
+                                                                                                        "class": "android.widget.ImageButton",
+                                                                                                        "isClickable": true,
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 803,
+                                                                                                            "top": 1661,
+                                                                                                            "right": 892,
+                                                                                                            "bottom": 1750
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/text_button",
+                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                        "isClickable": true,
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 928,
+                                                                                                            "top": 1648,
+                                                                                                            "right": 1044,
+                                                                                                            "bottom": 1764
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.doordash.driverapp:id/chat_button_internal",
+                                                                                                                "class": "android.widget.ImageButton",
+                                                                                                                "isClickable": true,
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 943,
+                                                                                                                    "top": 1663,
+                                                                                                                    "right": 1030,
+                                                                                                                    "bottom": 1750
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 1764,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2091
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/address_divider",
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 1800,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 1802
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/address_spacing",
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 1802,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 1838
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/ic_address",
+                                                                                                        "class": "android.widget.ImageView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 36,
+                                                                                                            "top": 1838,
+                                                                                                            "right": 89,
+                                                                                                            "bottom": 1891
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "text": "[redacted]",
+                                                                                                        "id": "com.doordash.driverapp:id/address_line_1",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 125,
+                                                                                                            "top": 1838,
+                                                                                                            "right": 937,
+                                                                                                            "bottom": 1880
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "text": "[redacted]",
+                                                                                                        "id": "com.doordash.driverapp:id/address_line_2",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 125,
+                                                                                                            "top": 1880,
+                                                                                                            "right": 955,
+                                                                                                            "bottom": 1927
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/expand_button",
+                                                                                                        "class": "android.widget.ImageView",
+                                                                                                        "isClickable": true,
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 973,
+                                                                                                            "top": 1838,
+                                                                                                            "right": 1062,
+                                                                                                            "bottom": 1891
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "text": "[redacted]",
+                                                                                                        "id": "com.doordash.driverapp:id/address_subpremise_line",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 125,
+                                                                                                            "top": 1927,
+                                                                                                            "right": 1044,
+                                                                                                            "bottom": 1974
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/directions_button",
+                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                        "isClickable": true,
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 125,
+                                                                                                            "top": 2010,
+                                                                                                            "right": 490,
+                                                                                                            "bottom": 2091
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.doordash.driverapp:id/action_icon",
+                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 179,
+                                                                                                                    "top": 2028,
+                                                                                                                    "right": 224,
+                                                                                                                    "bottom": 2073
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "Directions",
+                                                                                                                "id": "com.doordash.driverapp:id/action_text",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 242,
+                                                                                                                    "top": 2010,
+                                                                                                                    "right": 436,
+                                                                                                                    "bottom": 2091
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "androidx.recyclerview.widget.RecyclerView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 2091,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2215
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 124,
+                                                                                                            "top": 2126,
+                                                                                                            "right": 267,
+                                                                                                            "bottom": 2215
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.doordash.driverapp:id/thumbnail",
+                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                "isClickable": true,
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 124,
+                                                                                                                    "top": 2126,
+                                                                                                                    "right": 231,
+                                                                                                                    "bottom": 2215
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "androidx.recyclerview.widget.RecyclerView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 2215,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2303
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 124,
+                                                                                                            "top": 2250,
+                                                                                                            "right": 195,
+                                                                                                            "bottom": 2303
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.doordash.driverapp:id/icon",
+                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 124,
+                                                                                                                    "top": 2250,
+                                                                                                                    "right": 177,
+                                                                                                                    "bottom": 2303
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 195,
+                                                                                                            "top": 2250,
+                                                                                                            "right": 266,
+                                                                                                            "bottom": 2303
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.doordash.driverapp:id/icon",
+                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 195,
+                                                                                                                    "top": 2250,
+                                                                                                                    "right": 248,
+                                                                                                                    "bottom": 2303
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 2303,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2347
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "text": "More information available",
+                                                                                                        "id": "com.doordash.driverapp:id/additional_info_text",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 125,
+                                                                                                            "top": 2303,
+                                                                                                            "right": 955,
+                                                                                                            "bottom": 2347
+                                                                                                        }
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 2350,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2347
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/divider",
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 2386,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2347
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/dasher_instructions_tags",
+                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 125,
+                                                                                                            "top": 2415,
+                                                                                                            "right": 125,
+                                                                                                            "bottom": 2347
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/ic_instructions",
+                                                                                                        "class": "android.widget.ImageView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 36,
+                                                                                                            "top": 2428,
+                                                                                                            "right": 89,
+                                                                                                            "bottom": 2347
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "text": "Leave it at the door",
+                                                                                                        "id": "com.doordash.driverapp:id/instructions_title",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 125,
+                                                                                                            "top": 2433,
+                                                                                                            "right": 937,
+                                                                                                            "bottom": 2347
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/expand_button",
+                                                                                                        "class": "android.widget.ImageView",
+                                                                                                        "isClickable": true,
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 973,
+                                                                                                            "top": 2428,
+                                                                                                            "right": 1062,
+                                                                                                            "bottom": 2347
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "text": "[redacted]",
+                                                                                                        "id": "com.doordash.driverapp:id/dasher_instruction_content_collapsed",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 125,
+                                                                                                            "top": 2494,
+                                                                                                            "right": 938,
+                                                                                                            "bottom": 2347
+                                                                                                        }
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 2596,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2347
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/divider",
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 2632,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2347
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/order_contents_header_icon",
+                                                                                                        "class": "android.widget.ImageView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 36,
+                                                                                                            "top": 2670,
+                                                                                                            "right": 89,
+                                                                                                            "bottom": 2347
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "text": "Popeyes Louisiana Kitchen (1 item)",
+                                                                                                        "id": "com.doordash.driverapp:id/order_contents_header_title",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 125,
+                                                                                                            "top": 2670,
+                                                                                                            "right": 937,
+                                                                                                            "bottom": 2347
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/order_contents_expand_button",
+                                                                                                        "class": "android.widget.ImageView",
+                                                                                                        "isClickable": true,
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 973,
+                                                                                                            "top": 2670,
+                                                                                                            "right": 1062,
+                                                                                                            "bottom": 2347
+                                                                                                        }
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isClickable": true,
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 2730,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2347
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "text": "1 ×",
+                                                                                                        "id": "com.doordash.driverapp:id/order_item_count",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 36,
+                                                                                                            "top": 2766,
+                                                                                                            "right": 89,
+                                                                                                            "bottom": 2347
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "text": "Cajun Fries",
+                                                                                                        "id": "com.doordash.driverapp:id/order_item_name",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 125,
+                                                                                                            "top": 2766,
+                                                                                                            "right": 1044,
+                                                                                                            "bottom": 2347
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "text": "Side Size: Large",
+                                                                                                        "id": "com.doordash.driverapp:id/order_item_instructions",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 125,
+                                                                                                            "top": 2813,
+                                                                                                            "right": 1044,
+                                                                                                            "bottom": 2347
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/flowTags",
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 125,
+                                                                                                            "top": 2869,
+                                                                                                            "right": 1044,
+                                                                                                            "bottom": 2347
+                                                                                                        }
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/dropping_off_action_view",
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 2151,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2347
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/button_background",
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 2151,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2347
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "desc": "Complete delivery steps",
+                                                                                        "id": "com.doordash.driverapp:id/complete_delivery_steps_button",
+                                                                                        "class": "android.widget.Button",
+                                                                                        "isClickable": true,
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 36,
+                                                                                            "top": 2204,
+                                                                                            "right": 1044,
+                                                                                            "bottom": 2311
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "Complete delivery steps",
+                                                                                                "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 292,
+                                                                                                    "top": 2225,
+                                                                                                    "right": 789,
+                                                                                                    "bottom": 2291
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/core/pipeline/src/main/assets/rules/doordash.json
+++ b/core/pipeline/src/main/assets/rules/doordash.json
@@ -1320,7 +1320,7 @@
         "flow": "task:dropoff:navigation",
         "modeHint": "online"
       },
-      "comment": "Two dropoff layouts (#462/#460): the en-route nav card ('Deliver to <name>' + Directions/Call/Message) and the arrival detail card ('Delivery for' label with the name in a sibling node + 'Hand it to recipient'). The arrival card was dropping to UNKNOWN — its first text is 'Delivery for'/'Deliver by', neither of which startsWith 'Deliver to'. 'Hand it to recipient' is the dropoff-specific discriminator (the pickup card also carries 'Delivery for', so keying on that alone would steal it). The alcohol variant of the arrival card additionally carries the priority-0 sensitive id/signature banner (#463), so it is blocked before reaching here.",
+      "comment": "Dropoff layouts (#462/#460/#549): (1) the en-route nav card ('Deliver to <name>' + Directions/Call/Message); (2) the arrival detail card with 'Delivery for' + 'Hand it to recipient'; (3) #549: the arrival detail card whose instruction is NOT 'Hand it to recipient' (e.g. 'Leave it at the door'), anchored on 'Delivery for' + the complete_delivery_steps_button id (the third require branch) — it was dropping to UNKNOWN. The arrival card's first text is 'Delivery for'/'Deliver by', neither of which startsWith 'Deliver to'. 'Hand it to recipient' / complete_delivery_steps_button are the dropoff-specific discriminators (the pickup card also carries 'Delivery for', so keying on that alone would steal it). The arrival card's address nodes carry ids (address_line_1/_2), so customerAddressHash uses a coalesce (id-less shape first, by-id second). The alcohol variant additionally carries the priority-0 sensitive id/signature banner (#463), blocked before reaching here. Recognize-only (flow stays task:dropoff:navigation); the gate-code/instruction node is never parsed.",
       "require": {
         "any": [
           {
@@ -1364,6 +1364,20 @@
               {
                 "exists": {
                   "hasText": "Hand it to recipient"
+                }
+              }
+            ]
+          },
+          {
+            "all": [
+              {
+                "exists": {
+                  "hasTextContaining": "Delivery for"
+                }
+              },
+              {
+                "exists": {
+                  "hasIdSuffix": "complete_delivery_steps_button"
                 }
               }
             ]
@@ -1414,42 +1428,65 @@
             ]
           },
           "customerAddressHash": {
-            "join": [
+            "comment": "#549: two address layouts. The en-route nav card's address is id-LESS (matched by the digit-leading shape, first branch). The arrival detail card's address carries ids (address_line_1/_2), so the id-less branch returns null and the second by-id branch reads it. coalesce picks the first non-null and applies NO top-level transform, so EACH branch hashes its own result — the address is never stored in the clear.",
+            "coalesce": [
               {
-                "find": {
-                  "all": [
-                    {
-                      "hasTextMatchesRegex": "^\\d{1,5}\\s+\\S"
+                "join": [
+                  {
+                    "find": {
+                      "all": [
+                        {
+                          "hasTextMatchesRegex": "^\\d{1,5}\\s+\\S"
+                        },
+                        {
+                          "hasNoId": true
+                        }
+                      ]
                     },
-                    {
-                      "hasNoId": true
-                    }
-                  ]
-                },
-                "read": "text"
+                    "read": "text"
+                  },
+                  {
+                    "find": {
+                      "all": [
+                        {
+                          "hasTextMatchesRegex": "^\\d{1,5}\\s+\\S"
+                        },
+                        {
+                          "hasNoId": true
+                        }
+                      ]
+                    },
+                    "navigate": "sibling(1)",
+                    "rejectIf": {
+                      "not": {
+                        "hasTextMatchesRegex": "\\d{5}$"
+                      }
+                    },
+                    "read": "text"
+                  }
+                ],
+                "separator": ", ",
+                "transform": "sha256"
               },
               {
-                "find": {
-                  "all": [
-                    {
-                      "hasTextMatchesRegex": "^\\d{1,5}\\s+\\S"
+                "join": [
+                  {
+                    "find": {
+                      "hasIdSuffix": "address_line_1"
                     },
-                    {
-                      "hasNoId": true
-                    }
-                  ]
-                },
-                "navigate": "sibling(1)",
-                "rejectIf": {
-                  "not": {
-                    "hasTextMatchesRegex": "\\d{5}$"
+                    "read": "text"
+                  },
+                  {
+                    "find": {
+                      "hasIdSuffix": "address_line_2"
+                    },
+                    "read": "text"
                   }
-                },
-                "read": "text"
+                ],
+                "separator": ", ",
+                "transform": "sha256"
               }
-            ],
-            "separator": ", ",
-            "transform": "sha256"
+            ]
           },
           "storeName": {
             "comment": "#526: the dropoff card's merchant label — the same store as the pickup, but in DoorDash's running-key form ('Target (02426)', 'Maple Street Biscuit - Alamo Ranch'), which does NOT string-match the offer/pickup name. The node has no id, so it's anchored by text shape: '<name> (<storeNum>)' (reliable for chains) first, then a strict all-Title-Case '<Name> - <Area>' (so a lowercase delivery instruction can't false-match). Not PII (a merchant name); feeds per-task store self-labelling + the post-session store-entity projector (#159). Null when the card variant doesn't show it.",

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompiler.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompiler.kt
@@ -671,6 +671,17 @@ object RuleCompiler {
     }
 
     private fun compileCoalesce(obj: JsonObject): (UiNode, Bindings) -> Any? {
+        // #549 hardening: coalesce returns the first non-null branch verbatim — it does NOT apply a
+        // top-level transform. Silently dropping one would be a privacy footgun: a PII coalesce whose
+        // sha256 sat at the top level (instead of inside each branch) would emit the RAW value. Reject
+        // it at compile time so the transform must live in each branch (where it actually runs).
+        if ("transform" in obj) {
+            throw RuleCompileException(
+                "coalesce does not apply a top-level 'transform' — put the transform inside each " +
+                    "branch (a top-level transform would be silently dropped, which for a PII field " +
+                    "would leak the raw value)",
+            )
+        }
         val exprs = obj["coalesce"]!!.jsonArray.map { compileParseExpression(it) }
 
         return { tree, bindings ->

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompilerTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompilerTest.kt
@@ -499,6 +499,32 @@ class RuleCompilerTest {
         RuleCompiler.compileTreePred(Json.parseToJsonElement(json))
     }
 
+    @Test(expected = RuleCompileException::class)
+    fun `coalesce with a top-level transform throws - it would be silently dropped (#549)`() {
+        // A coalesce returns the chosen branch verbatim; a top-level transform is NOT applied. For a
+        // PII field (sha256 at the top instead of in each branch) that would leak the raw value, so
+        // the compiler must reject it — the transform has to live inside each branch.
+        val rule = """
+            [{
+              "id": "test.coalesce.toptransform",
+              "priority": 9999,
+              "state": { "flow": "task:dropoff:navigation" },
+              "require": { "exists": { "hasText": "x" } },
+              "parse": {
+                "as": "task",
+                "fields": {
+                  "phase": "DROPOFF",
+                  "customerAddressHash": {
+                    "coalesce": [ { "find": { "hasIdSuffix": "address_line_1" }, "read": "text" } ],
+                    "transform": "sha256"
+                  }
+                }
+              }
+            }]
+        """.trimIndent()
+        RuleCompiler.compileRules<UiNode>(parseJson(rule).jsonArray, RuleContext.SCREEN)
+    }
+
     // =========================================================================
     // compileEffectEntry — verb validation
     // =========================================================================

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -63,6 +63,16 @@ immediately (no second pass needed) so it gets triaged.
 _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **broken** on the
 2026-06-09 dash — moved to that session's log entry below for triage.)_
 
+- **🔬 FIX SHIPPED (recognize-only) — dropoff-arrived 'Leave it at the door' card now recognized (#549, PR #574). READ THE LOG / WATCH UNKNOWNs.**
+  A dropoff-arrival card whose instruction is *not* "Hand it to recipient" (e.g. "Leave it at the
+  door", a refined map pin, "Complete delivery steps") was falling to **UNKNOWN** — the state machine
+  got no clean dropoff signal and leaned on the grace window. Now recognized (customer name + address
+  **hashed**; the gate-code/instruction text is never stored). **Confirm: 0/2 —** after a dash with a
+  "leave at door" / gate-code delivery, grep the captures/log: that arrival screen should recognize as
+  a dropoff (not pile into UNKNOWN), and INFO/db must show **no** raw address/gate-code (hashes only).
+  This is recognize-only — it does **not** yet flip an "arrived" state (deferred, needs a fresh
+  capture to decide), so don't expect a behavior change, just cleaner recognition.
+
 - **🔧 FIX SHIPPED — no more double fly-away bubble on a new/stacked pickup (#566, PR #573). CONFIRM ON DASH.**
   When a pickup started (or a stacked pickup handed off), the "Pickup: <store>" heads-up bubble flew
   out **twice** in quick succession (the second often icon-less). Fixed with a per-task dedupe key.


### PR DESCRIPTION
Closes #549.

## Bug
A dropoff-arrival detail card whose instruction is **not** "Hand it to recipient" — e.g. **"Leave it at the door"** (a refined map pin + "Complete delivery steps", ids `dropping_off_action_view` / `complete_delivery_steps_button`) — fell to **UNKNOWN**. `dropoff_pre_arrival`'s first two require branches need `"Deliver to"`/`"Heading to"` or `"Hand it to recipient"`, which this variant lacks. The state machine got no clean dropoff signal and leaned on the grace window.

## Fix (recognize-only)
Flow stays `task:dropoff:navigation` — the arrived-state decision is **deferred** (a real state-machine fork that wants a fresh capture, per the issue + adversarial review).

- **Third require branch** anchored on `'Delivery for'` + `complete_delivery_steps_button` — both present on the arrival card, **absent** on the empty map-only frames (verified: 12-44-49 has only `dropping_off_action_view`), so blank frames are not recognized as a delivery screen. *(The over-broad `dropping_off_action_view` anchor the first draft proposed was rejected in adversarial review for exactly this reason.)*
- **`customerAddressHash` → coalesce:** existing id-less digit-shape join **first** (existing frames unchanged), a **by-id** join (`address_line_1` + `address_line_2`) **second** — this card's address nodes carry ids, so the id-less find returns null. `coalesce` applies no top-level transform, so **each branch hashes its own result** — the address is never stored in the clear. Side benefit: completes address capture on two existing dropoff frames (711/alcohol) that also have id'd addresses (`None → hash`; both are sample fixtures → same redacted hash). The existing name parse (`'Delivery for' → sibling`) already works, so **no** redundant name branch.

## Privacy (load-bearing)
Customer name + address `sha256`'d. The `dasher_instruction_content_collapsed` node (gate code `883423#` + free note) is **never read** by any rule. Added that id to `SnapshotRedactor.PII_ID_SUFFIXES` so the committed corpus fixture masks it — verified the new fixture has **no** name/gate-code/address plaintext (all `[redacted]`).

## Tests
- New redacted corpus frame — the **real** 06-21 Leslie L/Popeyes "Leave it at the door" card — auto-sorts to `dropoff_pre_arrival/` via `InboxProcessorTest` (PII gate passed).
- `approved-parse-output.json` regenerated: new entry has name+address hashed, no gate code/instruction; the two 711/alcohol entries gain a hashed address (`None → hash`); **no other entry changed**.
- `AllMatchersSuite` + full `testDebugUnitTest` green; the 5 existing "Hand it to recipient" frames still classify `dropoff_pre_arrival` (additive branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)