### PR TITLE
fix(bubble): post offer Accept/Decline as a separate heads-up notification (#457)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/OfferActionReceiver.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/OfferActionReceiver.kt
@@ -3,8 +3,10 @@ package cloud.trotter.dashbuddy.state.effects
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import androidx.core.app.NotificationManagerCompat
 import cloud.trotter.dashbuddy.core.state.StateManagerV2
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.ui.bubble.BubbleManager
 import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.android.EntryPointAccessors
@@ -32,6 +34,9 @@ class OfferActionReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         val action = intent.getStringExtra(EXTRA_ACTION) ?: return
         Timber.i("OfferActionReceiver: %s", action)
+        // #457: dismiss the heads-up immediately — the dasher acted. (Offer resolution also fires
+        // CancelOfferNotification, but cancel now so the banner/shade entry doesn't linger.)
+        NotificationManagerCompat.from(context).cancel(BubbleManager.OFFER_NOTIFICATION_ID)
         val deps = EntryPointAccessors.fromApplication(context.applicationContext, Deps::class.java)
         deps.stateManager().dispatch(
             Observation.UiInput(timestamp = System.currentTimeMillis(), action = action),

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
@@ -343,8 +343,14 @@ class SideEffectEngine @Inject constructor(
             }
 
             is AppEffect.CancelOfferNotification -> {
-                // Untracking happens via the job's self-removing completion handler.
+                // Abort a still-pending (delayed) post — untracking is via the job's self-removing
+                // completion handler.
                 pendingOfferNotifications[effect.offerHash ?: "no-hash"]?.cancel()
+                // #457: the offer heads-up is now a SEPARATE notification (its own id), not the
+                // self-replacing bubble — so if it already posted, dismiss it explicitly when the
+                // offer resolves (accept/decline/timeout) so an Accept/Decline banner can't outlive
+                // the offer.
+                bubbleManager.cancelOfferNotification()
             }
 
             // --- TIMING LOGIC (Pure Coroutines) ---

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManager.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManager.kt
@@ -49,8 +49,17 @@ class BubbleManager @Inject constructor(
 ) {
 
     companion object {
-        /** The single bubble/chat notification id. */
+        /** The persistent bubble/chat (chathead) notification id. */
         const val BUBBLE_NOTIFICATION_ID = 1
+
+        /**
+         * The separate heads-up OFFER notification id (#457). A NORMAL (non-bubble) notification so
+         * the dasher can act from the heads-up banner WITHOUT pulling the shade: pulling the shade
+         * makes SystemUI foreground, which drops DoorDash's offer window from the accessibility
+         * live-window set, failing the fail-closed verified click (the #457 field symptom). A
+         * heads-up banner floats over DoorDash without displacing it, so the click lands.
+         */
+        const val OFFER_NOTIFICATION_ID = 2
 
         /** Bubble expanded-view height (dp). */
         const val BUBBLE_DESIRED_HEIGHT_DP = 600
@@ -58,11 +67,16 @@ class BubbleManager @Inject constructor(
         /** PendingIntent request codes for the offer notification actions (#367). */
         const val REQUEST_CODE_ACCEPT = 10
         const val REQUEST_CODE_DECLINE = 11
+        const val REQUEST_CODE_OFFER_CONTENT = 12
+
+        /** Backstop auto-dismiss for the offer heads-up if a resolution cancel is somehow missed. */
+        const val OFFER_HEADS_UP_TIMEOUT_MS = 90_000L
     }
     // 1. ADDED: CoroutineScope for the suspend database calls
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
     private val channelId = "bubble_channel"
+    private val offerChannelId = "offer_channel"
     private val shortcutId = "DashBuddy_Bubble_Shortcut"
 
     /**
@@ -139,6 +153,18 @@ class BubbleManager @Inject constructor(
             setAllowBubbles(true)
         }
         notificationManager.createNotificationChannel(channel)
+
+        // #457: a SEPARATE, non-bubble channel for the actionable offer heads-up. The bubble channel
+        // allows bubbles, so its notifications render as the chathead and suppress the heads-up banner
+        // — forcing a shade-pull that breaks the Accept/Decline verified click. This channel never
+        // bubbles, so an offer posts as a normal high-importance heads-up over DoorDash.
+        val offerChannel = NotificationChannel(
+            offerChannelId, "Offer Alerts", NotificationManager.IMPORTANCE_HIGH
+        ).apply {
+            description = "Heads-up offer alerts with Accept / Decline"
+            setAllowBubbles(false)
+        }
+        notificationManager.createNotificationChannel(offerChannel)
     }
 
     private fun pushDynamicShortcut() {
@@ -174,7 +200,6 @@ class BubbleManager @Inject constructor(
         text: CharSequence,
         persona: ChatPersona,
         expand: Boolean,
-        offerActionable: Boolean = false,
     ) {
 
         val senderPerson = Person.Builder()
@@ -224,26 +249,62 @@ class BubbleManager @Inject constructor(
             .setCategory(Notification.CATEGORY_MESSAGE)
             .setPriority(NotificationCompat.PRIORITY_MAX)
 
-        if (offerActionable) {
-            builder.addAction(offerAction("Decline", OfferIntent.DECLINE, REQUEST_CODE_DECLINE))
-            builder.addAction(offerAction("Accept", OfferIntent.ACCEPT, REQUEST_CODE_ACCEPT))
-        }
-
         notificationManager.notify(BUBBLE_NOTIFICATION_ID, builder.build())
     }
 
     /**
-     * Post the offer evaluation as a heads-up notification with Accept /
-     * Decline action buttons. Formatting (Spannable summary + persona)
-     * happens HERE at the UI edge (#436) — the side-effect engine hands over
-     * the domain evaluation and stays free of Android text types.
+     * Post the offer evaluation. The offer reaches the dasher on three surfaces (#457):
+     *  - the in-bubble offer **card** (state-driven `LiveCardBuilder`, shown when the bubble is open) —
+     *    not touched here;
+     *  - the **chat stream** entry (saved below, the in-bubble history);
+     *  - a **separate heads-up notification** with Accept/Decline ([showOfferHeadsUp]) — the
+     *    actionable surface that pops over DoorDash.
+     *
+     * The actions live on the heads-up, NOT the chathead bubble notification: a bubble notification is
+     * shown as the floating chathead and suppresses the heads-up, forcing a shade-pull that displaces
+     * DoorDash from the accessibility live-window set and fails the verified click (#457).
+     * Formatting happens HERE at the UI edge (#436) — the engine hands over the domain evaluation.
      */
     fun postOfferNotification(evaluation: OfferEvaluation) {
         val summary = evaluation.toNotificationSummary()
         val persona = evaluation.notificationPersona()
         Timber.tag("Chat").i("[${persona.displayName}]: $summary")
         scope.launch { chatRepository.saveMessage(activeSessionId.value, summary.toString(), persona) }
-        showNotification(summary, persona, expand = false, offerActionable = true)
+        showOfferHeadsUp(summary, persona)
+    }
+
+    /**
+     * #457: the actionable offer surface — a separate, **non-bubble** heads-up notification (own
+     * channel + id, no `BubbleMetadata`). A heads-up banner floats over DoorDash without displacing
+     * it, so tapping Accept/Decline fires while the offer window is still live and the verified click
+     * lands — unlike the old bubble notification, whose actions were only reachable via the shade
+     * (which made SystemUI foreground and emptied DoorDash's live-window set). Backstopped by a
+     * timeout; normally dismissed by [cancelOfferNotification] on resolution / when the dasher acts.
+     */
+    private fun showOfferHeadsUp(text: CharSequence, persona: ChatPersona) {
+        val openBubble = Intent(context, BubbleActivity::class.java).apply { action = Intent.ACTION_VIEW }
+        val contentIntent = PendingIntent.getActivity(
+            context, REQUEST_CODE_OFFER_CONTENT, openBubble,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE,
+        )
+        val builder = NotificationCompat.Builder(context, offerChannelId)
+            .setSmallIcon(R.drawable.bag_red_idle)
+            .setContentTitle(persona.displayName)
+            .setContentText(text)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(text))
+            .setContentIntent(contentIntent)
+            .setCategory(Notification.CATEGORY_RECOMMENDATION)
+            .setPriority(NotificationCompat.PRIORITY_MAX)
+            .setAutoCancel(true)
+            .setTimeoutAfter(OFFER_HEADS_UP_TIMEOUT_MS)
+            .addAction(offerAction("Decline", OfferIntent.DECLINE, REQUEST_CODE_DECLINE))
+            .addAction(offerAction("Accept", OfferIntent.ACCEPT, REQUEST_CODE_ACCEPT))
+        notificationManager.notify(OFFER_NOTIFICATION_ID, builder.build())
+    }
+
+    /** #457: dismiss the heads-up offer notification — on offer resolution or after the dasher acts. */
+    fun cancelOfferNotification() {
+        notificationManager.cancel(OFFER_NOTIFICATION_ID)
     }
 
     private fun offerAction(label: String, action: String, requestCode: Int): NotificationCompat.Action {

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
@@ -289,6 +289,24 @@ class EffectMapTest {
     }
 
     @Test
+    fun `an offer replaced by a new offer dismisses the old heads-up (#457)`() {
+        // Separate-id heads-up (#457): when a new offer replaces the old one, the OLD banner must be
+        // dismissed now — else it lingers until the new offer's async eval lands and a tap in that
+        // window would resolve against the NEW offer.
+        val prev = AppState(regions = Regions(
+            flow = FlowRegion(flow = Flow.OfferPresented, pendingOffer = testPendingOffer),
+        ))
+        val next = AppState(regions = Regions(
+            flow = FlowRegion(flow = Flow.OfferPresented, pendingOffer = testPendingOffer.copy(offerHash = "hash-456")),
+        ))
+
+        val effects = effectMap.diff(prev, next, screenObs(flow = Flow.OfferPresented))
+        val cancels = effects.filterIsInstance<AppEffect.CancelOfferNotification>()
+        assertEquals("the old offer's heads-up is dismissed on replace", 1, cancels.size)
+        assertEquals("hash-123", cancels[0].offerHash)
+    }
+
+    @Test
     fun `offer timeout emits OFFER_TIMEOUT log and UpdateBubble`() {
         val prev = AppState(regions = Regions(
             flow = FlowRegion(

--- a/app/src/test/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngineTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngineTest.kt
@@ -413,6 +413,22 @@ class SideEffectEngineTest {
     }
 
     @Test
+    fun `a resolved offer dismisses an already-posted heads-up (#457)`() = runTest {
+        // The offer heads-up is now a SEPARATE notification (own id), not the self-replacing bubble,
+        // so once it has posted, resolution must explicitly dismiss it.
+        val engine = buildEngine(StandardTestDispatcher(testScheduler))
+        engine.process(AppEffect.PostOfferNotification(testEvaluation(), offerHash = "hash-9"))
+        runCurrent()
+        advanceTimeBy(SideEffectEngine.OFFER_NOTIFICATION_DELAY_MS + 100)
+        runCurrent()
+        verify(bubbleManager, times(1)).postOfferNotification(any())
+
+        engine.process(AppEffect.CancelOfferNotification(offerHash = "hash-9"))
+        runCurrent()
+        verify(bubbleManager, times(1)).cancelOfferNotification()
+    }
+
+    @Test
     fun `keyed effects dedupe on the live path - not just during recovery`() = runTest {
         val engine = buildEngine(StandardTestDispatcher(testScheduler))
         val effect = AppEffect.StartSession("sess-7", "DoorDash")

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -151,6 +151,12 @@ class EffectMap @Inject constructor() {
             val outcome = resolveOfferOutcome(obs, prevOffer)
             add(logEffect(sessionId, outcome, obs.timestamp, offerPayload(prevOffer, outcome, obs.timestamp, "Replaced by new offer")))
 
+            // #457: dismiss the OLD offer's heads-up now. Its Accept/Decline is a separate, persistent
+            // notification (not the self-replacing bubble), so without this the prior banner lingers
+            // until the new offer's async eval lands — and a tap in that window would resolve against
+            // the NEW pending offer. The new offer's heads-up re-posts on eval-landing below.
+            add(AppEffect.CancelOfferNotification(prevOffer.offerHash))
+
             // Evaluate the new offer (notification + spoken read fire on eval-landing below).
             val offer = nextOffer.offerFields
             add(AppEffect.EvaluateOffer(offer.parsedOffer, nextOffer.offerHash))

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -63,6 +63,20 @@ immediately (no second pass needed) so it gets triaged.
 _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **broken** on the
 2026-06-09 dash — moved to that session's log entry below for triage.)_
 
+- **🔧 FIX SHIPPED — offer Accept/Decline as a separate heads-up notification (#457, PR #576). CONFIRM ON DASH — this one NEEDS the field.**
+  Root cause found: the offer was a **bubble** notification (shown as the chathead, heads-up suppressed),
+  so reaching the buttons meant pulling the **shade** — which makes SystemUI foreground and drops
+  DoorDash from the accessibility live-window set, so the verified click logged "No live windows" and
+  failed (the in-bubble buttons work because the overlay doesn't displace DoorDash). Fix: the offer now
+  posts a **separate, non-bubble heads-up notification** (new `offer_channel`, own id) that pops a banner
+  **over** DoorDash with Accept/Decline. **Confirm on dash: 0/2 —** when an offer arrives, a heads-up
+  banner with Accept/Decline should appear **over DoorDash** (no shade-pull needed); tapping **Accept**
+  or **Decline** there should actually accept/decline the DoorDash offer (watch the next screen + the log:
+  `OfferActionReceiver` then a successful click, **not** "No live windows"). The offer **card** inside the
+  bubble + the chat entry should still appear as before. The banner should dismiss after you act or when
+  the offer resolves. **This is a strong hypothesis but unproven without the device** — if the buttons
+  still do nothing, grab the log around the tap (the `UiInteractionHandler` line says why).
+
 - **🔧 FIX SHIPPED — dropoff customer reads "\<store\>'s customer", not a 6-char hash (#568, PR #575). CONFIRM ON DASH.**
   The dropoff bubble/card used to show the raw 6-char hash prefix (e.g. "Heading to 45ceda") or "the
   customer". Now it's store-flavored — "Heading to H-E-B's customer" / the card reads "Maple Street's


### PR DESCRIPTION
Closes #457.

## Root cause (06-12 field log)
The notification buttons **did** dispatch (`OfferActionReceiver` fired ×4), but the verified click failed:
```
OfferActionReceiver: accept_offer
Performing accept_offer on doordash
UiInteractionHandler: attempting verified click (… offer_popup)
WARN  No live windows for package com.doordash.driverapp — cannot click
WARN  accept_offer did not fire — target failed resolution/verification (fail closed)
```
The offer was a **Bubble** notification (single id 1 + `BubbleMetadata`). Android renders a bubble-eligible notification as the floating chathead and **suppresses the heads-up**, so reaching the buttons required pulling the **shade** — which makes SystemUI foreground and **removes DoorDash's offer window from the accessibility live-window set**, so the fail-closed verified click (#425) aborts. The in-bubble buttons work because tapping the chathead opens DashBuddy as an **overlay** that doesn't displace DoorDash.

## Fix
Post the offer as a **separate, non-bubble heads-up notification**: new `offer_channel` (`IMPORTANCE_HIGH`, `setAllowBubbles(false)`), own id (`OFFER_NOTIFICATION_ID = 2`), **no** `BubbleMetadata`, with the Accept/Decline actions. A heads-up banner floats **over** DoorDash without displacing it → tapping an action fires while the offer window is still live → the click lands (same as the overlay path). The chathead bubble keeps being the persistent HUD and no longer carries the offer actions.

The offer still reaches the dasher on the other two surfaces, unchanged: the state-driven in-bubble offer **card** (`LiveCardBuilder`) and the **chat-stream** entry.

## Lifecycle
The post/cancel lifecycle already existed (`PostOfferNotification` + `CancelOfferNotification` + the #436 settle-delay). Changes: `CancelOfferNotification` now also **dismisses the posted heads-up** (it's a separate id, not the self-replacing bubble); `OfferActionReceiver` dismisses it immediately on tap; a 90s `setTimeoutAfter` backstops a missed cancel.

This is also the **prerequisite for the #110 Stage-3 auto-click** (which fires programmatically while DoorDash is foreground and sidesteps the live-window issue entirely).

## Tests & validation
`SideEffectEngineTest` — `CancelOfferNotification` dismisses an already-posted heads-up; the existing post / cancel-pending tests still pass. Full `testDebugUnitTest` green. `BubbleManager` notification building is Android-edge (not JVM-unit-testable), so **the end-to-end "click lands" behavior NEEDS field validation** — strong hypothesis (the log proves the shade-pull is the killer; the overlay path proves a non-displacing surface works), but accessibility window-visibility is device-specific. Field-test checklist item added (`Confirmed: 0/2`).

## Security / privacy
No change to what's actuated (the same app-owned `ACCEPT_OFFER`/`DECLINE_OFFER` RuleActions, #425 verified click) or logged. Merchant names aren't PII; no customer text on the notification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)