### PR TITLE
feat(state): quick-decline — auto-confirm the 2nd decline button when opted in (#577)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
@@ -5,6 +5,7 @@ import cloud.trotter.dashbuddy.core.data.strategy.StrategyRepository
 import cloud.trotter.dashbuddy.core.database.effects.EffectsFiredDao
 import cloud.trotter.dashbuddy.core.database.effects.EffectsFiredEntity
 import cloud.trotter.dashbuddy.domain.action.ActionTrigger
+import cloud.trotter.dashbuddy.domain.action.RuleAction
 import cloud.trotter.dashbuddy.domain.capability.RuleCapabilityGrants
 import cloud.trotter.dashbuddy.domain.config.EvidenceCategory
 import cloud.trotter.dashbuddy.domain.model.chat.ChatPersona
@@ -236,6 +237,16 @@ class SideEffectEngine @Inject constructor(
                         "Denied %s — no granted capability for rule '%s' (fail closed)",
                         effect.action.wire, effect.sourceRuleId,
                     )
+                    return
+                }
+                // #577 quick-decline: the auto-confirm of DoorDash's 2nd ("are you sure?") decline
+                // button fires ONLY when the dasher enabled quick-declines. The setting is the consent;
+                // gating here (not in the pure reducer) keeps EffectMap config-free. Off → no-op, the
+                // dasher confirms manually.
+                if (effect.action == RuleAction.CONFIRM_DECLINE &&
+                    !strategyRepository.automationConfig.first().quickDeclinesEnabled
+                ) {
+                    Timber.i("Skipped %s — quick declines off (dasher confirms manually)", effect.action.wire)
                     return
                 }
                 stampThrottle(throttleKey, now)

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/SettingsViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/SettingsViewModel.kt
@@ -3,6 +3,7 @@ package cloud.trotter.dashbuddy.ui.main.settings
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import cloud.trotter.dashbuddy.core.data.strategy.StrategyRepository
+import cloud.trotter.dashbuddy.domain.config.OfferAutomationConfig
 import cloud.trotter.dashbuddy.domain.evaluation.EvaluationConfig
 import cloud.trotter.dashbuddy.domain.evaluation.ScoringRule
 import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
@@ -29,10 +30,19 @@ class SettingsViewModel @Inject constructor(
         .filterNotNull()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), EvaluationConfig())
 
+    // #577: the offer-automation flags (only quick-declines is live today).
+    val automationConfig: StateFlow<OfferAutomationConfig> = strategyRepository.automationConfig
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), OfferAutomationConfig())
+
     // --- ACTIONS ---
 
     fun toggleProtectStats(enabled: Boolean) = viewModelScope.launch {
         strategyRepository.setProtectStatsMode(enabled)
+    }
+
+    /** #577 quick-declines / single-click declines — auto-confirm DoorDash's 2nd decline button. */
+    fun toggleQuickDeclines(enabled: Boolean) = viewModelScope.launch {
+        strategyRepository.setQuickDeclines(enabled)
     }
 
     fun toggleAllowShopping(allowed: Boolean) = viewModelScope.launch {

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/StrategySettingsScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/StrategySettingsScreen.kt
@@ -51,6 +51,7 @@ fun StrategySettingsScreen(
     viewModel: SettingsViewModel = hiltViewModel()
 ) {
     val config by viewModel.evaluationConfig.collectAsStateWithLifecycle()
+    val automation by viewModel.automationConfig.collectAsStateWithLifecycle() // #577
 
     // Local Sim State
     var simPay by remember { mutableFloatStateOf(6.50f) }
@@ -170,6 +171,12 @@ fun StrategySettingsScreen(
                     subtitle = "If off, Red Card orders are auto-declined",
                     checked = config.allowShopping,
                     onCheckedChange = { viewModel.toggleAllowShopping(it) }
+                )
+                SwitchRow(
+                    label = "⚡ Single-click declines",
+                    subtitle = "Auto-confirm DoorDash's 'are you sure?' so a decline is one tap",
+                    checked = automation.quickDeclinesEnabled,
+                    onCheckedChange = { viewModel.toggleQuickDeclines(it) }
                 )
                 HorizontalDivider(Modifier.padding(vertical = 16.dp))
             }

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
@@ -1085,6 +1085,70 @@ class EffectMapTest {
         )
     }
 
+    // =========================================================================
+    // #577 — quick-decline: deferred CONFIRM_DECLINE on the confirm screen
+    // =========================================================================
+
+    private fun confirmDeclineObs() = screenObs(
+        flow = Flow.OfferPresented,
+        ruleId = "doordash.screen.offer_popup_confirm_decline",
+    ).copy(targets = mapOf("confirmDeclineButton" to testNodeRef("com.doordash.driverapp:id/textView_prism_button_title")))
+
+    private fun offerPresentedState() = AppState(
+        regions = Regions(flow = FlowRegion(flow = Flow.OfferPresented, pendingOffer = testPendingOffer)),
+    )
+
+    @Test
+    fun `confirm-decline screen with bound target during an offer schedules a deferred CONFIRM_DECLINE (#577)`() {
+        // prev already OfferPresented so no offer-presentation noise; the confirm dialog is mid-offer.
+        val effects = effectMap.diff(offerPresentedState(), offerPresentedState(), confirmDeclineObs())
+        val scheduled = effects.filterIsInstance<AppEffect.ScheduleTimeout>()
+            .filter { it.type == cloud.trotter.dashbuddy.domain.pipeline.TimeoutType.SETTLE_UI }
+        assertEquals(1, scheduled.size)
+        val deferred = scheduled[0].payload as ObservationPayload.DeferredAction
+        assertEquals(RuleAction.CONFIRM_DECLINE.wire, deferred.action)
+        // No direct tap — the engine's quick-declines setting gate decides at fire time.
+        assertTrue(effects.filterIsInstance<AppEffect.PerformRuleAction>().isEmpty())
+    }
+
+    @Test
+    fun `confirm-decline screen WITHOUT a bound target schedules nothing - fail closed (#577)`() {
+        val obs = screenObs(flow = Flow.OfferPresented, ruleId = "doordash.screen.offer_popup_confirm_decline")
+        val effects = effectMap.diff(offerPresentedState(), offerPresentedState(), obs)
+        assertTrue(
+            effects.filterIsInstance<AppEffect.ScheduleTimeout>()
+                .none { it.payload is ObservationPayload.DeferredAction },
+        )
+    }
+
+    @Test
+    fun `confirm-decline screen with NO pending offer schedules nothing (#577)`() {
+        val effects = effectMap.diff(AppState(), AppState(), confirmDeclineObs())
+        assertTrue(
+            effects.filterIsInstance<AppEffect.ScheduleTimeout>()
+                .none { it.payload is ObservationPayload.DeferredAction },
+        )
+    }
+
+    @Test
+    fun `SETTLE_UI routes a deferred CONFIRM_DECLINE to an AUTOMATION PerformRuleAction (#577)`() {
+        val timeoutObs = Observation.Timeout(
+            timestamp = 1000L,
+            type = cloud.trotter.dashbuddy.domain.pipeline.TimeoutType.SETTLE_UI,
+            payload = ObservationPayload.DeferredAction(
+                action = RuleAction.CONFIRM_DECLINE.wire,
+                platform = Platform.DoorDash.wire,
+                ruleId = "doordash.screen.offer_popup_confirm_decline",
+                target = testNodeRef("com.doordash.driverapp:id/textView_prism_button_title"),
+            ),
+        )
+        val actions = effectMap.diff(AppState(), AppState(), timeoutObs)
+            .filterIsInstance<AppEffect.PerformRuleAction>()
+        assertEquals(1, actions.size)
+        assertEquals(RuleAction.CONFIRM_DECLINE, actions[0].action)
+        assertEquals(ActionTrigger.AUTOMATION, actions[0].trigger)
+    }
+
     @Test
     fun `SETTLE_UI timeout emits the deferred action as immediate PerformRuleAction`() {
         val payload = ObservationPayload.DeferredAction(

--- a/app/src/test/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngineTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngineTest.kt
@@ -11,6 +11,7 @@ import cloud.trotter.dashbuddy.domain.action.RuleAction
 import cloud.trotter.dashbuddy.domain.capability.RuleCapabilityGrants
 import cloud.trotter.dashbuddy.domain.config.EvidenceCategory
 import cloud.trotter.dashbuddy.domain.config.EvidenceConfig
+import cloud.trotter.dashbuddy.domain.config.OfferAutomationConfig
 import cloud.trotter.dashbuddy.domain.evaluation.EvaluationConfig
 import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
 import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluator
@@ -27,6 +28,7 @@ import cloud.trotter.dashbuddy.ui.bubble.BubbleManager
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -200,6 +202,42 @@ class SideEffectEngineTest {
         // Second fire inside RULE_ACTION_THROTTLE_MS is swallowed — an
         // app-owned bound on automated taps (#425).
         verify(uiInteractionHandler, times(1)).performVerifiedClick(any(), any(), any(), any())
+    }
+
+    // =========================================================================
+    // #577 — quick-decline: the setting is the consent (engine-edge gate)
+    // =========================================================================
+
+    private fun confirmDeclineEffect() = AppEffect.PerformRuleAction(
+        action = RuleAction.CONFIRM_DECLINE,
+        platform = Platform.DoorDash,
+        targetRef = NodeRef(
+            viewIdSuffix = "com.doordash.driverapp:id/textView_prism_button_title",
+            text = null, classNameHint = "android.widget.TextView",
+            boundsInScreen = BoundingBox(0, 100, 200, 150), pathFingerprint = "fp",
+        ),
+        sourceRuleId = "doordash.screen.offer_popup_confirm_decline",
+        trigger = ActionTrigger.AUTOMATION,
+    )
+
+    @Test
+    fun `CONFIRM_DECLINE fires when quick declines is ON (#577)`() = runTest {
+        val engine = buildEngine(StandardTestDispatcher(testScheduler))
+        whenever { strategyRepository.automationConfig }
+            .thenReturn(flowOf(OfferAutomationConfig(quickDeclinesEnabled = true)))
+        engine.process(confirmDeclineEffect())
+        runCurrent()
+        verify(uiInteractionHandler, times(1)).performVerifiedClick(any(), any(), any(), any())
+    }
+
+    @Test
+    fun `CONFIRM_DECLINE is denied when quick declines is OFF (#577)`() = runTest {
+        val engine = buildEngine(StandardTestDispatcher(testScheduler))
+        whenever { strategyRepository.automationConfig }
+            .thenReturn(flowOf(OfferAutomationConfig(quickDeclinesEnabled = false)))
+        engine.process(confirmDeclineEffect())
+        runCurrent()
+        verify(uiInteractionHandler, never()).performVerifiedClick(any(), any(), any(), any())
     }
 
     // =========================================================================

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/strategy/StrategyRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/strategy/StrategyRepository.kt
@@ -63,7 +63,8 @@ class StrategyRepository @Inject constructor(
         combine(
             dataSource.autoDecline, dataSource.autoDeclineMaxPay, dataSource.autoDeclineMinRatio,
         ) { enabled, maxPay, minRatio -> DeclineHalf(enabled, maxPay, minRatio) },
-    ) { master, accept, decline ->
+        dataSource.quickDeclines,
+    ) { master, accept, decline, quickDeclines ->
         OfferAutomationConfig(
             masterAutoPilotEnabled = master,
             autoAcceptEnabled = accept.enabled,
@@ -72,6 +73,7 @@ class StrategyRepository @Inject constructor(
             autoDeclineEnabled = decline.enabled,
             autoDeclineMaxPay = decline.maxPay,
             autoDeclineMinRatio = decline.minRatio,
+            quickDeclinesEnabled = quickDeclines,
         )
     }
 
@@ -120,6 +122,7 @@ class StrategyRepository @Inject constructor(
     suspend fun setProtectStatsMode(enabled: Boolean) = dataSource.setProtectStatsMode(enabled)
     suspend fun setAllowShopping(allowed: Boolean) = dataSource.setAllowShopping(allowed)
     suspend fun setMasterAutomation(enabled: Boolean) = dataSource.setMasterAutomation(enabled)
+    suspend fun setQuickDeclines(enabled: Boolean) = dataSource.setQuickDeclines(enabled) // #577
 
     // Maps Domain Models to DTOs before saving
     @OptIn(InternalSerializationApi::class)

--- a/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/strategy/StrategyDataSource.kt
+++ b/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/strategy/StrategyDataSource.kt
@@ -41,6 +41,8 @@ class StrategyDataSource @Inject constructor(
         val AUTO_DECLINE_MAX_PAY = doublePreferencesKey("auto_decline_max_pay")
         val AUTO_DECLINE_MIN_RATIO = doublePreferencesKey("auto_decline_min_ratio")
 
+        val QUICK_DECLINES = booleanPreferencesKey("quick_declines_enabled") // #577
+
         val RULE_LIST_JSON = stringPreferencesKey("rule_list_config_v1")
         val PROTECT_STATS_MODE = booleanPreferencesKey("protect_stats_mode")
         val ALLOW_SHOPPING = booleanPreferencesKey("allow_shopping")
@@ -66,6 +68,7 @@ class StrategyDataSource @Inject constructor(
     val autoDecline: Flow<Boolean> = ds.data.map { it[Keys.AUTO_DECLINE] ?: OfferAutomationConfig.DEFAULT_AUTO_DECLINE }
     val autoDeclineMaxPay: Flow<Double> = ds.data.map { it[Keys.AUTO_DECLINE_MAX_PAY] ?: OfferAutomationConfig.DEFAULT_DECLINE_MAX_PAY }
     val autoDeclineMinRatio: Flow<Double> = ds.data.map { it[Keys.AUTO_DECLINE_MIN_RATIO] ?: OfferAutomationConfig.DEFAULT_DECLINE_MIN_RATIO }
+    val quickDeclines: Flow<Boolean> = ds.data.map { it[Keys.QUICK_DECLINES] ?: OfferAutomationConfig.DEFAULT_QUICK_DECLINES } // #577
 
     @OptIn(InternalSerializationApi::class)
     val scoringRules: Flow<List<ScoringRuleDto>> = ds.data.map { prefs ->
@@ -138,6 +141,10 @@ class StrategyDataSource @Inject constructor(
 
     suspend fun setMasterAutomation(enabled: Boolean) {
         ds.edit { it[Keys.AUTO_MASTER] = enabled }
+    }
+
+    suspend fun setQuickDeclines(enabled: Boolean) { // #577
+        ds.edit { it[Keys.QUICK_DECLINES] = enabled }
     }
 
     suspend fun updateAutomation(

--- a/core/pipeline/src/main/assets/rules/doordash.json
+++ b/core/pipeline/src/main/assets/rules/doordash.json
@@ -304,9 +304,21 @@
     {
       "id": "doordash.screen.offer_popup_confirm_decline",
       "priority": 19,
+      "comment": "#577 quick-decline: bind the confirm dialog's 'Decline offer' button. Its label is on a child text node (textView_prism_button_title, not itself clickable) — bind the labelled node + 'decline' text so we never grab a sibling Cancel/Go-back; clickNodeStrict walks up to the clickable ancestor. The app-owned CONFIRM_DECLINE tap fires (AUTOMATION) only when the dasher enabled quick-declines.",
       "state": {
         "flow": "offer:presented",
         "modeHint": "online"
+      },
+      "bind": {
+        "confirmDeclineButton": {
+          "find": {
+            "all": [
+              { "hasIdSuffix": "textView_prism_button_title" },
+              { "hasTextContaining": "decline" }
+            ]
+          },
+          "optional": true
+        }
       },
       "require": {
         "exists": {

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -75,6 +75,7 @@ class EffectMap @Inject constructor() {
     fun diff(prev: AppState, next: AppState, obs: Observation): List<AppEffect> = buildList {
         addAll(diffRuleEffects(obs))
         addAll(diffExpandAction(obs))
+        addAll(diffConfirmDeclineAction(obs, next))
         addAll(diffSettleUiTimeout(obs))
         // Offer-resolution events fire in the FlowRegion handler. They need to
         // be scoped to the active platform's session so AppEventDao queries
@@ -865,6 +866,37 @@ class EffectMap @Inject constructor() {
             ParsedFieldsGate.FieldEquals("isExpanded", false), flowObs.parsed,
         )
         if (!collapsed) return emptyList()
+        return listOf(
+            AppEffect.ScheduleTimeout(
+                durationMs = EXPAND_SETTLE_MS,
+                type = TimeoutType.SETTLE_UI,
+                platform = flowObs.platform.takeIf { it != Platform.Unknown },
+                payload = ObservationPayload.DeferredAction(
+                    action = action.wire,
+                    platform = flowObs.platform.wire,
+                    ruleId = flowObs.ruleId,
+                    target = target,
+                ),
+            ),
+        )
+    }
+
+    /**
+     * #577 quick-decline: when DoorDash's confirm-decline dialog appears during an active offer and
+     * the rule bound a confirm button, schedule the app-owned [RuleAction.CONFIRM_DECLINE] tap behind
+     * the same SETTLE_UI delay as [diffExpandAction] — the dialog animates in and ~half the captured
+     * confirm frames are transitional, so the settle wait lets the button render. PURE: the dasher's
+     * *consent* is the `quickDeclinesEnabled` setting, enforced at the engine edge ([SideEffectEngine]
+     * denies the AUTOMATION fire when off) — here we only emit the deferred intent when the screen +
+     * offer context match. The fire is label-verified ("decline") + package-scoped; a missing/garbage
+     * target fails closed (the dasher confirms manually). The bind exists only on the
+     * confirm-decline rule, so `targets[...]` is the screen gate; `pendingOffer` confirms a live offer.
+     */
+    private fun diffConfirmDeclineAction(obs: Observation, next: AppState): List<AppEffect> {
+        val flowObs = obs as? Observation.Screen ?: return emptyList()
+        val action = RuleAction.CONFIRM_DECLINE
+        val target = flowObs.targets[action.targetBindName] ?: return emptyList()
+        if (next.regions.flow.pendingOffer == null) return emptyList()
         return listOf(
             AppEffect.ScheduleTimeout(
                 durationMs = EXPAND_SETTLE_MS,

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -63,6 +63,17 @@ immediately (no second pass needed) so it gets triaged.
 _(The #110 Stage 2a auto-expand + Stage 2b Accept/Decline items were found **broken** on the
 2026-06-09 dash — moved to that session's log entry below for triage.)_
 
+- **🔧 FIX SHIPPED — quick-decline / single-click declines (#577, PR #pending). OPT IN + CONFIRM ON DASH.**
+  DoorDash's decline is two-step (Decline → "are you sure?" → Decline again). With **Settings →
+  Strategy → "⚡ Single-click declines"** ON, the app auto-confirms that second button so a decline is
+  one action (closes the 06-21 #6 bug where a decline mis-resolved as TIMEOUT). **Confirm on dash:
+  0/2 —** turn the setting ON, then decline an offer (via the heads-up Decline, or by tapping Decline
+  in DoorDash directly): the "are you sure?" dialog should **auto-dismiss with the offer declined**,
+  no second tap needed; the decline should log `DELIVERY/OFFER_DECLINED`, **not** `OFFER_TIMEOUT`.
+  With the setting OFF, the confirm should still wait for your manual tap (default = off). Watch the
+  log for `Performing confirm_decline` (fired) vs `Skipped confirm_decline — quick declines off`. If
+  it taps the wrong button or fires when off, grab the confirm-screen capture.
+
 - **🔧 FIX SHIPPED — offer Accept/Decline as a separate heads-up notification (#457, PR #576). CONFIRM ON DASH — this one NEEDS the field.**
   Root cause found: the offer was a **bubble** notification (shown as the chathead, heads-up suppressed),
   so reaching the buttons meant pulling the **shade** — which makes SystemUI foreground and drops

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/action/RuleAction.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/action/RuleAction.kt
@@ -38,11 +38,24 @@ enum class RuleAction(
 
     /**
      * Tap the offer screen's initial Decline button. The platform's confirm
-     * dialog (if any) is left to the user — auto-confirm is #110 Stage 2c.
+     * dialog is finished by [CONFIRM_DECLINE] when the dasher opted into
+     * quick-declines (#577); otherwise the dasher confirms it manually.
      */
     DECLINE_OFFER(
         wire = "decline_offer",
         targetBindName = "declineButton",
+        verification = TargetExpectation(labelPattern = Regex("(?i)\\bdecline\\b")),
+    ),
+
+    /**
+     * Tap the SECOND ("are you sure?") decline button on DoorDash's
+     * confirm-decline dialog — the quick-decline auto-confirm (#577). Fired via
+     * AUTOMATION only when the dasher enabled quick-declines; gated at the
+     * engine edge. Label-verified ("decline") + package-scoped like every tap.
+     */
+    CONFIRM_DECLINE(
+        wire = "confirm_decline",
+        targetBindName = "confirmDeclineButton",
         verification = TargetExpectation(labelPattern = Regex("(?i)\\bdecline\\b")),
     ),
 

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/config/OfferAutomationConfig.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/config/OfferAutomationConfig.kt
@@ -16,6 +16,15 @@ data class OfferAutomationConfig(
     val autoDeclineEnabled: Boolean = DEFAULT_AUTO_DECLINE,
     val autoDeclineMaxPay: Double = DEFAULT_DECLINE_MAX_PAY,
     val autoDeclineMinRatio: Double = DEFAULT_DECLINE_MIN_RATIO,
+
+    /**
+     * #577 "quick declines" / single-click declines: when ON, the second
+     * ("are you sure?") decline button is auto-confirmed so a decline is one
+     * tap/voice command. This is "finish the decline I started," NOT the
+     * economics-driven auto-decline above ("decide for me") — independent of
+     * [masterAutoPilotEnabled]; the setting itself is the dasher's consent.
+     */
+    val quickDeclinesEnabled: Boolean = DEFAULT_QUICK_DECLINES,
 ) {
     companion object {
         // ONE owner for every default (#401): the DataStore fallbacks
@@ -27,5 +36,6 @@ data class OfferAutomationConfig(
         const val DEFAULT_AUTO_DECLINE = false
         const val DEFAULT_DECLINE_MAX_PAY = 3.50
         const val DEFAULT_DECLINE_MIN_RATIO = 0.50
+        const val DEFAULT_QUICK_DECLINES = false
     }
 }


### PR DESCRIPTION
Closes #577. (The former #110 "Stage 2c"; closes the 06-21 field bug #6 where a decline mis-resolved as `OFFER_TIMEOUT`.)

## What
DoorDash's decline is two-step: initial Decline → an "are you sure?" `offer_popup_confirm_decline` screen with a second button that **nothing clicked**. With the dasher's **Settings → Strategy → "⚡ Single-click declines"** toggle ON, the app auto-confirms that second button so a decline is one action.

## How — reuses the `EXPAND_EARNINGS` recognize→deferred-AUTOMATION precedent
- **`RuleAction.CONFIRM_DECLINE`** (`targetBindName=confirmDeclineButton`, label-verified `"decline"`). Auto-granted via the asset ruleset's capability enumeration.
- **`offer_popup_confirm_decline`** gains a `confirmDeclineButton` bind on the "Decline offer" text node (`textView_prism_button_title` + `"decline"` text — the node isn't itself clickable, so `clickNodeStrict` walks up; binding label+text avoids grabbing a sibling Cancel/Go-back).
- **`EffectMap.diffConfirmDeclineAction` (PURE):** when the confirm screen is recognized (the bind is present) during an active offer (`pendingOffer` set — the screen keeps `flow=offer:presented`), schedule the deferred `CONFIRM_DECLINE` behind `SETTLE_UI` (the dialog animates in; ~half the captured confirm frames are transitional, so the settle wait lets the button render). The generic `SETTLE_UI` catch routes it to `PerformRuleAction(AUTOMATION)` unchanged.
- **The setting is the consent:** `OfferAutomationConfig.quickDeclinesEnabled` (default **OFF**) persisted in the strategy DataStore; `SideEffectEngine` denies the AUTOMATION fire at the engine edge when off (keeps `EffectMap` config-free). First real consumer of the previously-dead `OfferAutomationConfig` store.

## Safety
Opt-in, default OFF. Four independent anchors must align: confirm-screen rule + label-verified click + DoorDash package scope + active-offer context. `RULE_ACTION_THROTTLE` + `SETTLE_UI` dedup prevent double-fire. Fail-closed everywhere (no bound target / not in an offer / setting off → no-op, dasher confirms manually). This is "finish the decline I started" — deliberately distinct from #110's economics-driven "decide for me."

## Tests
`EffectMapTest`: deferred `CONFIRM_DECLINE` on the confirm screen during an offer; fail-closed without a bound target / without a pending offer; `SETTLE_UI` routes `CONFIRM_DECLINE` → `AUTOMATION`. `SideEffectEngineTest`: fires when quick-declines ON, **denied** when OFF. `AllMatchersSuite` + capability enumeration green; full `testDebugUnitTest` green.

## Security / privacy
No new sensitive screen; the confirm-decline screen is an app-control surface (nothing parsed/stored). Same `#425` verified-click + `#417` capability gates. No new INFO PII. Field validation needed (checklist item, `Confirmed: 0/2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)