### PR TITLE
feat(bubble): offer notification score gauge ring + brand-styled buttons (#583)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManager.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManager.kt
@@ -340,13 +340,16 @@ class BubbleManager @Inject constructor(
         val action = offer.evaluationAction?.let { runCatching { OfferAction.valueOf(it) }.getOrNull() }
         val verdictArgb = offerVerdictArgb(action)
 
-        rv.setTextViewText(
-            R.id.notif_offer_verdict,
-            if (expanded) offer.qualityLevel?.displayLabel()?.let { "${offerVerdictLabel(action)} · $it" }
-                ?: offerVerdictLabel(action)
-            else offerVerdictLabel(action),
-        )
-        rv.setInt(R.id.notif_offer_verdict, "setBackgroundColor", verdictArgb)
+        // Verdict banner is expanded-only by design; the collapsed heads-up conveys the verdict
+        // through the gauge ring color (the compact layout has no verdict view).
+        if (expanded) {
+            rv.setTextViewText(
+                R.id.notif_offer_verdict,
+                offer.qualityLevel?.displayLabel()?.let { "${offerVerdictLabel(action)} · $it" }
+                    ?: offerVerdictLabel(action),
+            )
+            rv.setInt(R.id.notif_offer_verdict, "setBackgroundColor", verdictArgb)
+        }
         rv.setTextViewText(R.id.notif_offer_rate, "${money0(offer.dollarsPerHour)}/hr")
         if (!expanded) {
             rv.setTextViewText(
@@ -370,13 +373,13 @@ class BubbleManager @Inject constructor(
 
         // Score gauge ring — drawn to a bitmap (RemoteViews can't draw an arc). Sized to the slot
         // (larger on the expanded card); hidden when the offer didn't score.
-        val score = offer.evaluationScore?.toInt()
-        if (score != null) {
+        val scoreValue = offer.evaluationScore
+        if (scoreValue != null) {
             val gaugeDp = if (expanded) 56 else 40
             val gaugePx = (gaugeDp * context.resources.displayMetrics.density).toInt()
             rv.setImageViewBitmap(
                 R.id.notif_offer_gauge,
-                scoreGaugeBitmap(score, offerScoreArgb(offer.evaluationScore ?: 0.0), gaugePx),
+                scoreGaugeBitmap(scoreValue.toInt(), offerScoreArgb(scoreValue), gaugePx),
             )
             rv.setViewVisibility(R.id.notif_offer_gauge, View.VISIBLE)
         } else {

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManager.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManager.kt
@@ -27,6 +27,7 @@ import cloud.trotter.dashbuddy.ui.formatters.notificationPersona
 import cloud.trotter.dashbuddy.ui.formatters.toNotificationSummary
 import cloud.trotter.dashbuddy.ui.formatters.displayLabel
 import cloud.trotter.dashbuddy.ui.formatters.offerBadgeIcon
+import cloud.trotter.dashbuddy.ui.formatters.offerScoreArgb
 import cloud.trotter.dashbuddy.ui.formatters.offerVerdictArgb
 import cloud.trotter.dashbuddy.ui.formatters.offerVerdictLabel
 import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
@@ -311,15 +312,19 @@ class BubbleManager @Inject constructor(
             .setCustomContentView(buildOfferCardView(offer, R.layout.notif_offer_compact, expanded = false))
             .setCustomHeadsUpContentView(buildOfferCardView(offer, R.layout.notif_offer_compact, expanded = false))
             .setCustomBigContentView(buildOfferCardView(offer, R.layout.notif_offer_expanded, expanded = true))
-            .addAction(offerAction("Decline", OfferIntent.DECLINE, REQUEST_CODE_DECLINE))
-            .addAction(offerAction("Accept", OfferIntent.ACCEPT, REQUEST_CODE_ACCEPT))
+        // #583: Accept/Decline are now brand-styled TextViews INSIDE the custom card
+        // (wired via setOnClickPendingIntent in buildOfferCardView), not the system action row —
+        // the two can't coexist without doubling the buttons. Field-gated: if a dash shows the
+        // in-card buttons don't fire from the floating heads-up, revert to addAction(offerAction(…)).
         notificationManager.notify(OFFER_NOTIFICATION_ID, builder.build())
     }
 
     /**
-     * #578: populate a `notif_offer_*` [RemoteViews] from the offer card snapshot. Colors/countdown/
-     * badges are set at runtime (RemoteViews can't use theme attrs — badges would render black
-     * otherwise). Score ring → ProgressBar + number; countdown → a self-ticking [Chronometer].
+     * #578/#583: populate a `notif_offer_*` [RemoteViews] from the offer card snapshot. Colors/
+     * countdown/badges/gauge are set at runtime (RemoteViews can't use theme attrs — badges would
+     * render black otherwise). Score → a Canvas-drawn ring [scoreGaugeBitmap] pushed via
+     * `setImageViewBitmap` (RemoteViews can't draw an arc); countdown → a self-ticking
+     * [Chronometer]; Accept/Decline → brand-styled `TextView`s wired with `setOnClickPendingIntent`.
      */
     // Null-safe money/distance for the notification card — "—" when a metric didn't parse.
     private fun money(d: Double?) = d?.let { Formats.money(it) } ?: "—"
@@ -363,10 +368,32 @@ class BubbleManager @Inject constructor(
             rv.setViewVisibility(R.id.notif_offer_countdown, View.GONE)
         }
 
+        // Score gauge ring — drawn to a bitmap (RemoteViews can't draw an arc). Sized to the slot
+        // (larger on the expanded card); hidden when the offer didn't score.
+        val score = offer.evaluationScore?.toInt()
+        if (score != null) {
+            val gaugeDp = if (expanded) 56 else 40
+            val gaugePx = (gaugeDp * context.resources.displayMetrics.density).toInt()
+            rv.setImageViewBitmap(
+                R.id.notif_offer_gauge,
+                scoreGaugeBitmap(score, offerScoreArgb(offer.evaluationScore ?: 0.0), gaugePx),
+            )
+            rv.setViewVisibility(R.id.notif_offer_gauge, View.VISIBLE)
+        } else {
+            rv.setViewVisibility(R.id.notif_offer_gauge, View.GONE)
+        }
+
+        // Brand-styled Accept/Decline (both layouts) — fire the same broadcast as the old action row.
+        rv.setOnClickPendingIntent(
+            R.id.notif_btn_decline,
+            offerActionPendingIntent(OfferIntent.DECLINE, REQUEST_CODE_DECLINE),
+        )
+        rv.setOnClickPendingIntent(
+            R.id.notif_btn_accept,
+            offerActionPendingIntent(OfferIntent.ACCEPT, REQUEST_CODE_ACCEPT),
+        )
+
         if (expanded) {
-            val score = offer.evaluationScore?.toInt()
-            rv.setTextViewText(R.id.notif_offer_score, score?.let { "Score $it" } ?: "")
-            rv.setProgressBar(R.id.notif_offer_score_bar, 100, score ?: 0, false)
             rv.setTextViewText(
                 R.id.notif_offer_metrics,
                 "Net ${money(offer.netPayAmount)} · Gross ${money(offer.payAmount)} · " +
@@ -401,15 +428,15 @@ class BubbleManager @Inject constructor(
         notificationManager.cancel(OFFER_NOTIFICATION_ID)
     }
 
-    private fun offerAction(label: String, action: String, requestCode: Int): NotificationCompat.Action {
+    /** #583: the Accept/Decline broadcast, wired onto the in-card buttons via setOnClickPendingIntent. */
+    private fun offerActionPendingIntent(action: String, requestCode: Int): PendingIntent {
         val intent = Intent(context, OfferActionReceiver::class.java).apply {
             this.action = OfferActionReceiver.ACTION
             putExtra(OfferActionReceiver.EXTRA_ACTION, action)
         }
-        val pi = PendingIntent.getBroadcast(
+        return PendingIntent.getBroadcast(
             context, requestCode, intent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
         )
-        return NotificationCompat.Action.Builder(0, label, pi).build()
     }
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/OfferGaugeBitmap.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/OfferGaugeBitmap.kt
@@ -1,0 +1,54 @@
+package cloud.trotter.dashbuddy.ui.bubble
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.RectF
+import android.graphics.Typeface
+import androidx.compose.ui.graphics.toArgb
+import cloud.trotter.dashbuddy.core.designsystem.theme.darkAppColors
+
+/**
+ * #583: the offer **score gauge ring**, drawn with a plain [Canvas] into a [Bitmap] for the rich
+ * notification. RemoteViews can't draw a ring (no Canvas/custom View), and the in-app Compose
+ * [cloud.trotter.dashbuddy.core.designsystem.component.AppGaugeRing] can't be rendered off-screen
+ * from the notification-post path (it has no window/lifecycle owner there). So this is a faithful
+ * Canvas re-draw of the same ring: a track circle + a `-90°` score sweep arc in the score-band color
+ * + the centered score. Colors come from the fixed dark palette ([darkAppColors]); the band color
+ * is the SSOT [cloud.trotter.dashbuddy.ui.formatters.offerScoreArgb]. Drawn on a filled card-colored
+ * disc so it reads the same regardless of the (system-controlled) notification background.
+ */
+fun scoreGaugeBitmap(score: Int, ringArgb: Int, sizePx: Int): Bitmap {
+    val colors = darkAppColors()
+    val bmp = Bitmap.createBitmap(sizePx, sizePx, Bitmap.Config.ARGB_8888)
+    val canvas = Canvas(bmp)
+    val cx = sizePx / 2f
+    val stroke = sizePx * 0.12f
+    val pad = stroke / 2f + sizePx * 0.04f
+    val rect = RectF(pad, pad, sizePx - pad, sizePx - pad)
+
+    // Self-contained disc so the ring/number read on any notification theme.
+    Paint(Paint.ANTI_ALIAS_FLAG).apply { color = colors.surface2.toArgb() }
+        .also { canvas.drawCircle(cx, cx, cx, it) }
+
+    val ring = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.STROKE
+        strokeWidth = stroke
+        strokeCap = Paint.Cap.ROUND
+    }
+    canvas.drawArc(rect, -90f, 360f, false, ring.apply { color = colors.surface3.toArgb() })
+    canvas.drawArc(
+        rect, -90f, 360f * (score.coerceIn(0, 100) / 100f), false,
+        ring.apply { color = ringArgb },
+    )
+
+    val text = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = colors.text.toArgb()
+        textAlign = Paint.Align.CENTER
+        textSize = sizePx * 0.34f
+        typeface = Typeface.DEFAULT_BOLD
+    }
+    val baseline = cx - (text.descent() + text.ascent()) / 2f
+    canvas.drawText(score.toString(), cx, baseline, text)
+    return bmp
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/formatters/OfferFormatters.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/formatters/OfferFormatters.kt
@@ -11,6 +11,7 @@ import cloud.trotter.dashbuddy.R
 import cloud.trotter.dashbuddy.core.designsystem.theme.darkAppColors
 import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
 import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
+import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluator
 import cloud.trotter.dashbuddy.domain.format.Formats
 import cloud.trotter.dashbuddy.domain.evaluation.OfferQuality
 import cloud.trotter.dashbuddy.domain.model.chat.ChatPersona
@@ -33,6 +34,19 @@ fun offerVerdictArgb(action: OfferAction?): Int = darkAppColors().let { c ->
         OfferAction.ACCEPT -> c.good
         OfferAction.DECLINE -> c.bad
         OfferAction.MANUAL_REVIEW -> c.warn
+        else -> c.warn
+    }
+}.toArgb()
+
+/**
+ * Score-band color as an ARGB int for the notification gauge ring (#583) — mirrors the bubble offer
+ * card's ring color (`OfferBody`): the evaluator's real decision boundaries (#400). good ≥ ACCEPT,
+ * bad ≤ DECLINE, warn in between.
+ */
+fun offerScoreArgb(score: Double): Int = darkAppColors().let { c ->
+    when {
+        score >= OfferEvaluator.ACCEPT_THRESHOLD -> c.good
+        score <= OfferEvaluator.DECLINE_THRESHOLD -> c.bad
         else -> c.warn
     }
 }.toArgb()

--- a/app/src/main/res/drawable/notif_btn_accept.xml
+++ b/app/src/main/res/drawable/notif_btn_accept.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- #583: brand-styled Accept button background for the offer notification. Literal colors —
+     theme attrs don't resolve in the notification's remote process. -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="#3DDC84" />
+    <corners android:radius="10dp" />
+</shape>

--- a/app/src/main/res/drawable/notif_btn_decline.xml
+++ b/app/src/main/res/drawable/notif_btn_decline.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- #583: Decline button background — muted surface so Accept is the emphasized action. Literal
+     colors (theme attrs don't resolve in the notification process). -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="#243240" />
+    <corners android:radius="10dp" />
+    <stroke android:width="1dp" android:color="#3A4A5A" />
+</shape>

--- a/app/src/main/res/layout/notif_offer_compact.xml
+++ b/app/src/main/res/layout/notif_offer_compact.xml
@@ -1,55 +1,89 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- #578: the glanceable offer card that floats over DoorDash (heads-up + collapsed). Only
-     RemoteViews-legal widgets (TextView/LinearLayout/Chronometer). Colors/countdown set at runtime;
-     text uses the notification text appearances so it stays readable on any notification theme. -->
+<!-- #583: the glanceable offer card over DoorDash (heads-up ~88dp) — score gauge (bitmap) + $/hr +
+     live countdown, with brand-styled Accept/Decline as clickable TextViews (setOnClickPendingIntent).
+     RemoteViews-legal widgets only. -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="horizontal"
-    android:gravity="center_vertical"
+    android:orientation="vertical"
     android:paddingTop="2dp"
     android:paddingBottom="2dp">
 
-    <TextView
-        android:id="@+id/notif_offer_verdict"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:paddingStart="8dp"
-        android:paddingEnd="8dp"
-        android:paddingTop="3dp"
-        android:paddingBottom="3dp"
-        android:textColor="#FFFFFFFF"
-        android:textStyle="bold"
-        android:textSize="12sp" />
-
     <LinearLayout
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:layout_marginStart="8dp"
-        android:orientation="vertical">
+        android:orientation="horizontal"
+        android:gravity="center_vertical">
 
-        <TextView
-            android:id="@+id/notif_offer_rate"
+        <ImageView
+            android:id="@+id/notif_offer_gauge"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:layout_marginEnd="8dp" />
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/notif_offer_rate"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textAppearance="@style/TextAppearance.Compat.Notification.Title"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/notif_offer_sub"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:ellipsize="end"
+                android:maxLines="1"
+                android:textAppearance="@style/TextAppearance.Compat.Notification.Line2" />
+        </LinearLayout>
+
+        <Chronometer
+            android:id="@+id/notif_offer_countdown"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
             android:textAppearance="@style/TextAppearance.Compat.Notification.Title"
             android:textStyle="bold" />
-
-        <TextView
-            android:id="@+id/notif_offer_sub"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:ellipsize="end"
-            android:maxLines="1"
-            android:textAppearance="@style/TextAppearance.Compat.Notification.Line2" />
     </LinearLayout>
 
-    <Chronometer
-        android:id="@+id/notif_offer_countdown"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:textAppearance="@style/TextAppearance.Compat.Notification.Title"
-        android:textStyle="bold" />
+        android:orientation="horizontal"
+        android:layout_marginTop="6dp">
+
+        <TextView
+            android:id="@+id/notif_btn_decline"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:background="@drawable/notif_btn_decline"
+            android:gravity="center"
+            android:paddingTop="9dp"
+            android:paddingBottom="9dp"
+            android:text="Decline"
+            android:textColor="#E6EDF3"
+            android:textSize="14sp" />
+
+        <TextView
+            android:id="@+id/notif_btn_accept"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_marginStart="8dp"
+            android:background="@drawable/notif_btn_accept"
+            android:gravity="center"
+            android:paddingTop="9dp"
+            android:paddingBottom="9dp"
+            android:text="Accept"
+            android:textColor="#0B0F14"
+            android:textSize="14sp"
+            android:textStyle="bold" />
+    </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/notif_offer_expanded.xml
+++ b/app/src/main/res/layout/notif_offer_expanded.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- #578: the full offer card shown when the notification is expanded (shade). RemoteViews-legal
-     widgets only. Score ring → ProgressBar + number (no Canvas in RemoteViews); badges → a fixed
-     row of ImageView slots populated/tinted at runtime. -->
+<!-- #583: full offer card (expanded ~252dp) — verdict banner + score gauge (bitmap) + $/hr + live
+     countdown + metrics + badges + store + brand-styled Accept/Decline. RemoteViews-legal only. -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -27,6 +26,12 @@
         android:gravity="center_vertical"
         android:layout_marginTop="6dp">
 
+        <ImageView
+            android:id="@+id/notif_offer_gauge"
+            android:layout_width="56dp"
+            android:layout_height="56dp"
+            android:layout_marginEnd="10dp" />
+
         <TextView
             android:id="@+id/notif_offer_rate"
             android:layout_width="0dp"
@@ -43,21 +48,6 @@
             android:textAppearance="@style/TextAppearance.Compat.Notification.Title"
             android:textStyle="bold" />
     </LinearLayout>
-
-    <TextView
-        android:id="@+id/notif_offer_score"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="2dp"
-        android:textAppearance="@style/TextAppearance.Compat.Notification.Info" />
-
-    <ProgressBar
-        android:id="@+id/notif_offer_score_bar"
-        style="@android:style/Widget.ProgressBar.Horizontal"
-        android:layout_width="match_parent"
-        android:layout_height="6dp"
-        android:layout_marginTop="2dp"
-        android:max="100" />
 
     <TextView
         android:id="@+id/notif_offer_metrics"
@@ -88,4 +78,39 @@
         android:ellipsize="end"
         android:maxLines="1"
         android:textAppearance="@style/TextAppearance.Compat.Notification.Info" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_marginTop="8dp">
+
+        <TextView
+            android:id="@+id/notif_btn_decline"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:background="@drawable/notif_btn_decline"
+            android:gravity="center"
+            android:paddingTop="10dp"
+            android:paddingBottom="10dp"
+            android:text="Decline"
+            android:textColor="#E6EDF3"
+            android:textSize="15sp" />
+
+        <TextView
+            android:id="@+id/notif_btn_accept"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_marginStart="8dp"
+            android:background="@drawable/notif_btn_accept"
+            android:gravity="center"
+            android:paddingTop="10dp"
+            android:paddingBottom="10dp"
+            android:text="Accept"
+            android:textColor="#0B0F14"
+            android:textSize="15sp"
+            android:textStyle="bold" />
+    </LinearLayout>
 </LinearLayout>

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/bubble/OfferGaugeBitmapTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/bubble/OfferGaugeBitmapTest.kt
@@ -1,0 +1,34 @@
+package cloud.trotter.dashbuddy.ui.bubble
+
+import android.graphics.Color
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * #583: guards the Canvas-drawn score gauge that backs the rich offer notification. The bitmap is
+ * pushed into a RemoteViews `ImageView` via `setImageViewBitmap`, so it must (a) come out at the
+ * requested pixel size, and (b) never throw on out-of-range scores (the score is clamped 0..100).
+ * (Pixel fidelity of the drawn arc is Android-platform behavior; Robolectric's Canvas doesn't
+ * reliably rasterize, so this guards the contract that matters: a correctly-sized, crash-free bitmap.)
+ */
+@RunWith(RobolectricTestRunner::class)
+class OfferGaugeBitmapTest {
+
+    @Test
+    fun `bitmap is produced at the requested size`() {
+        val bmp = scoreGaugeBitmap(score = 72, ringArgb = Color.GREEN, sizePx = 120)
+        assertEquals(120, bmp.width)
+        assertEquals(120, bmp.height)
+    }
+
+    @Test
+    fun `out-of-range scores do not throw and still render`() {
+        // Below 0 and above 100 are clamped internally; the call must not crash.
+        for (score in listOf(-50, 0, 50, 100, 250)) {
+            val bmp = scoreGaugeBitmap(score = score, ringArgb = Color.RED, sizePx = 80)
+            assertEquals(80, bmp.width)
+        }
+    }
+}

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -67,7 +67,7 @@ _(#577 quick-decline auto-confirm and #457 notification Accept/Decline buttons w
 on the 2026-06-24 dash — moved to that session's log entry below. #577 carries a follow-up:
 the auto-confirm works but feels slow.)_
 
-- **🔬 FIX SHIPPED — rich notification: score gauge ring + brand-styled buttons (#583, PR #585). CONFIRM ON DASH.**
+- **🔬 FIX SHIPPED — rich notification: score gauge ring + brand-styled buttons (#583, PR #584). CONFIRM ON DASH.**
   Follow-up to #578: the offer heads-up's score is now a **circular gauge ring** (a Canvas-drawn
   bitmap — band-colored sweep + centered number, matching the bubble HUD's `AppGaugeRing`) on **both**
   the collapsed heads-up and the expanded card, and **Accept/Decline are now brand-styled buttons

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -67,17 +67,31 @@ _(#577 quick-decline auto-confirm and #457 notification Accept/Decline buttons w
 on the 2026-06-24 dash — moved to that session's log entry below. #577 carries a follow-up:
 the auto-confirm works but feels slow.)_
 
+- **🔬 FIX SHIPPED — rich notification: score gauge ring + brand-styled buttons (#583, PR #585). CONFIRM ON DASH.**
+  Follow-up to #578: the offer heads-up's score is now a **circular gauge ring** (a Canvas-drawn
+  bitmap — band-colored sweep + centered number, matching the bubble HUD's `AppGaugeRing`) on **both**
+  the collapsed heads-up and the expanded card, and **Accept/Decline are now brand-styled buttons
+  drawn inside the card** (green Accept / muted Decline) wired via `setOnClickPendingIntent` — the
+  system action row is gone (the two can't coexist without doubling the buttons). **Confirm on dash:
+  0/2 —** when an offer arrives, the heads-up over DoorDash should show a **filled circular score
+  ring** (not a flat bar) plus the green/muted in-card buttons; **tapping those in-card buttons must
+  actually Accept/Decline** the DoorDash offer (watch the log: `OfferActionReceiver` → successful
+  click, not "No live windows"). **Watch for (the field gate):** the **in-card buttons not firing
+  from the floating heads-up** (if they only work after a shade-pull, the custom-button approach is
+  wrong for the heads-up → revert to the system action row); the **gauge rendering blank/garbled**
+  (bitmap inflation failure); the gauge **missing** when an offer scored. Screenshot collapsed +
+  expanded if anything's off.
+
 - **🔬 FIX SHIPPED — rich offer heads-up notification (mini offer card) (#578, PR #581). CONFIRM ON DASH.**
-  The offer heads-up is now a **mini offer card** (custom RemoteViews via DecoratedCustomViewStyle):
+  The offer heads-up is a **mini offer card** (custom RemoteViews via DecoratedCustomViewStyle):
   a colored **verdict banner** (ACCEPT/DECLINE/REVIEW), the **$/hr** hero, net/$mi/distance, and a
-  **live countdown** that ticks; the expanded (shade-pull) view adds the **score bar + number**,
-  full metrics, **badges** (red card/alcohol/large-order/etc.), and the store. Accept/Decline still
-  fire (the #457 path is untouched). **Confirm on dash: 0/2 —** when an offer arrives, the heads-up
-  over DoorDash should show the verdict + $/hr + a ticking countdown (not just a text line), and
-  expanding it shows the full card with badges; Accept/Decline must still work. **Watch for:** badges
-  rendering **black** (tint bug) instead of colored; the notification **not appearing at all** (a
-  RemoteViews failure → would mean it fell back / regressed #457 — grab the log); the countdown not
-  ticking. If anything looks off, screenshot the notification (collapsed + expanded).
+  **live countdown** that ticks; the expanded (shade-pull) view adds the **score** (now a gauge ring,
+  see #583), full metrics, **badges** (red card/alcohol/large-order/etc.), and the store. **Confirm on
+  dash: 0/2 —** when an offer arrives, the heads-up over DoorDash should show the verdict + $/hr + a
+  ticking countdown (not just a text line), and expanding it shows the full card with badges. **Watch
+  for:** badges rendering **black** (tint bug) instead of colored; the notification **not appearing at
+  all** (a RemoteViews failure → would mean it fell back / regressed #457 — grab the log); the
+  countdown not ticking. If anything looks off, screenshot the notification (collapsed + expanded).
 
 - **🔧 FIX SHIPPED — quick-decline / single-click declines (#577, PR #580). OPT IN + CONFIRM ON DASH.**
   DoorDash's decline is two-step (Decline → "are you sure?" → Decline again). With **Settings →


### PR DESCRIPTION
Follow-up to #578 (PR #581). Makes the rich offer heads-up read like the in-app bubble offer card rather than a stripped-down notification.

## What changed

**Score gauge ring.** RemoteViews can't draw an arc (no `Canvas`/custom `View`), so `OfferGaugeBitmap.scoreGaugeBitmap()` draws the same ring the bubble HUD's `AppGaugeRing` shows — a band-colored sweep over a track on a card-colored disc, centered score — to a `Bitmap`, pushed via `setImageViewBitmap`. Rendered on **both** the collapsed heads-up and the expanded card (replaces the flat `ProgressBar` + "Score N" text). The off-screen-Compose render route isn't usable from the notification-post path (no window/lifecycle owner there). The band color is the SSOT `offerScoreArgb` (`OfferEvaluator` ACCEPT/DECLINE thresholds) so the notification can't drift from the bubble.

**Brand-styled in-card Accept/Decline.** Buttons are now `TextView`s with literal-color background drawables (green Accept / muted Decline — theme attrs don't resolve in the SystemUI process), wired via `setOnClickPendingIntent` to the same `OfferActionReceiver` broadcast. The system action row is dropped (the two can't coexist without doubling the buttons).

- `offerAction` → `offerActionPendingIntent` (returns the `PendingIntent` the buttons consume).
- New `OfferGaugeBitmapTest` (size + clamp/no-throw guards).
- Field-test checklist: new #583 item + amended #578 item.

## Field gate
This is the one thing the unit tests can't prove: whether the in-card buttons fire from the **floating heads-up** (over DoorDash) and not only after a shade-pull. If a dash shows they don't, the fix is a one-line revert to `addAction(offerAction(…))` — the path is preserved in a comment in `showOfferHeadsUp`. Tracked in the field-test checklist (Confirmed: 0/2).

## Security / privacy
No new data. Renders only already-computed offer economics + score; no PII (merchant names aren't PII; no customer text). The notification trust posture is unchanged from #578/#457.

## Test
- `./gradlew :app:testDebugUnitTest` — green (incl. new `OfferGaugeBitmapTest`).
- `./gradlew :app:compileDebugKotlin` — green (AAPT links the new drawables/ids).

🤖 Generated with [Claude Code](https://claude.com/claude-code)