### PR TITLE
fix(capture): #597 — clicks never dedup at the bus; UNKNOWN cap re-arms per burst

### DIFF
--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CaptureWriter.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CaptureWriter.kt
@@ -94,6 +94,19 @@ class CaptureWriter @Inject constructor(
         event: PipelineEvent.Click,
         screenTarget: String?,
     ): Observation.Click {
+        // Same fail-closed backstop as captureScreen (#432), added with #597:
+        // an UNKNOWN click envelope carries the raw tapped node, and a tap on
+        // an unruled sensitive surface must not persist its text. (Rule-matched
+        // clicks are app-vocabulary buttons — Accept/Decline/confirm — whose
+        // labels carry no PII.)
+        if (obs.target == UNKNOWN_TARGET) {
+            val marker = SensitiveTextMarkers.findMarker(event.node)
+            if (marker != null) {
+                stats.onScrubbedUnknownCapture()
+                Timber.w("Capture scrubbed: UNKNOWN click hit sensitive marker '%s'", marker)
+                return obs
+            }
+        }
         val platform = Platform.fromPackage(event.packageName).wire
         val capture = EnvelopeBuilder.build(
             pipelineId = AccessibilityPipeline.CLICK_PIPELINE_ID,
@@ -111,11 +124,14 @@ class CaptureWriter @Inject constructor(
             classification = obs.target,
             platform = platform,
             envelopeJson = capture.envelopeJson,
-            // #597: clicks are NEVER deduped at the bus. The bus's seen-set lives as
-            // long as the a11y process (days), and a repeat tap on the same button
-            // hashes identically — dedup here decayed click forensics to zero within
-            // a week. Clicks are human-bounded (one envelope per physical tap), so
-            // every one persists; the envelope keeps its contentHash for replay.
+            // #597: rule-matched clicks are NEVER deduped at the bus. The bus's
+            // seen-set lives as long as the a11y process (days), and a repeat tap
+            // on the same button hashes identically — dedup here decayed click
+            // forensics to zero within a week. Rule-matched clicks are
+            // human-bounded (one envelope per physical tap), so every one
+            // persists; the envelope keeps its contentHash for replay. (UNKNOWN
+            // clicks are separately bounded by FrameGate's UnknownSuppressor
+            // before this method is reached.)
             contentHash = null,
         )
         Timber.d(

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CaptureWriter.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CaptureWriter.kt
@@ -111,7 +111,12 @@ class CaptureWriter @Inject constructor(
             classification = obs.target,
             platform = platform,
             envelopeJson = capture.envelopeJson,
-            contentHash = capture.contentHash,
+            // #597: clicks are NEVER deduped at the bus. The bus's seen-set lives as
+            // long as the a11y process (days), and a repeat tap on the same button
+            // hashes identically — dedup here decayed click forensics to zero within
+            // a week. Clicks are human-bounded (one envelope per physical tap), so
+            // every one persists; the envelope keeps its contentHash for replay.
+            contentHash = null,
         )
         Timber.d(
             "Captured click: target=%s  ruleId=%s  captured=%s",

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/FrameGate.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/FrameGate.kt
@@ -50,18 +50,27 @@ internal class FrameGate(
             return true
         }
         if (contentHash == null) return true
-        return unknownSuppressor.shouldCapture(contentHash)
+        return unknownSuppressor.shouldCapture(contentHash, obs.timestamp)
     }
 }
 
 /**
- * Rolling LRU seen-set + per-process cap for UNKNOWN captures (#360).
+ * Rolling LRU seen-set + burst-window cap for UNKNOWN captures (#360/#597).
  * Re-seeing a recent hash refreshes its recency, so an animation alternating
  * between two frames suppresses both after the first sighting of each.
+ *
+ * The cap defends against a *flood* (a pathological screen producing endless
+ * distinct hashes) — it is NOT a lifetime budget. The a11y process lives for
+ * days, so a per-process cap quietly became "blind for the rest of the week"
+ * (#597: hit 25 min into a dash, suppressed triage ~4 h incl. a whole support
+ * flow). A flood by definition has no quiet gaps, so a [quietGapMs] stretch
+ * with no UNKNOWN frames means the flood is over and the cap re-arms. Driven
+ * by `obs.timestamp` (event time), never a wall clock.
  */
 internal class UnknownSuppressor(
     private val capacity: Int = 32,
-    private val processCap: Int = 200,
+    private val burstCap: Int = 200,
+    private val quietGapMs: Long = 30 * 60 * 1000L,
 ) {
     private val seen = object : LinkedHashMap<Int, Unit>(capacity, 0.75f, true) {
         override fun removeEldestEntry(eldest: MutableMap.MutableEntry<Int, Unit>): Boolean =
@@ -69,20 +78,30 @@ internal class UnknownSuppressor(
     }
     private var captured = 0
     private var capLogged = false
+    private var lastAttemptMs = 0L
 
     @Synchronized
-    fun shouldCapture(contentHash: Int): Boolean {
+    fun shouldCapture(contentHash: Int, nowMs: Long = 0L): Boolean {
+        if (lastAttemptMs != 0L && nowMs - lastAttemptMs > quietGapMs && captured > 0) {
+            Timber.d(
+                "UNKNOWN capture cap re-armed after %d min quiet (%d captured last burst)",
+                (nowMs - lastAttemptMs) / 60_000, captured,
+            )
+            captured = 0
+            capLogged = false
+        }
+        lastAttemptMs = nowMs
         if (seen.containsKey(contentHash)) {
             seen[contentHash] = Unit // refresh recency
             return false
         }
-        if (captured >= processCap) {
-            // No silent truncation: say so, once.
+        if (captured >= burstCap) {
+            // No silent truncation: say so, once per burst.
             if (!capLogged) {
                 capLogged = true
                 Timber.w(
-                    "UNKNOWN capture cap (%d) reached — suppressing further unknown captures this process",
-                    processCap,
+                    "UNKNOWN capture cap (%d) reached — suppressing until a %d-min quiet gap",
+                    burstCap, quietGapMs / 60_000,
                 )
             }
             return false

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/FrameGate.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/FrameGate.kt
@@ -81,7 +81,7 @@ internal class UnknownSuppressor(
     private var lastAttemptMs = 0L
 
     @Synchronized
-    fun shouldCapture(contentHash: Int, nowMs: Long = 0L): Boolean {
+    fun shouldCapture(contentHash: Int, nowMs: Long): Boolean {
         if (lastAttemptMs != 0L && nowMs - lastAttemptMs > quietGapMs && captured > 0) {
             Timber.d(
                 "UNKNOWN capture cap re-armed after %d min quiet (%d captured last burst)",
@@ -90,7 +90,11 @@ internal class UnknownSuppressor(
             captured = 0
             capLogged = false
         }
-        lastAttemptMs = nowMs
+        // Never regress the anchor: notification postTime is not monotonic
+        // (reposts/group summaries), and an out-of-order frame that pulled
+        // lastAttemptMs backwards would fake a quiet gap mid-flood (adversarial
+        // F1 on #597).
+        lastAttemptMs = maxOf(lastAttemptMs, nowMs)
         if (seen.containsKey(contentHash)) {
             seen[contentHash] = Unit // refresh recency
             return false

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureScrubTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureScrubTest.kt
@@ -12,6 +12,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
@@ -76,5 +77,46 @@ class CaptureScrubTest {
 
         verify(captureBus, times(1)).offer(any(), any(), any(), any(), any(), any())
         assertTrue(stats.scrubbedUnknownCaptureCount == 0L)
+    }
+
+    // #597: clicks now always persist (no bus dedup) — so the click path needs
+    // the same fail-closed backstop: an UNKNOWN click on an unruled sensitive
+    // surface must never persist the tapped node's text.
+
+    private fun unknownClickObs() = Observation.Click(
+        timestamp = 1_000L,
+        captureId = null,
+        ruleId = null,
+        metadata = ReplayMetadata.EMPTY,
+        flow = null,
+        modeHint = null,
+        parsed = ParsedFields.None,
+        target = UNKNOWN_TARGET,
+    )
+
+    @Test
+    fun `UNKNOWN click with sensitive text is never offered to the capture bus`() {
+        val toxic = UiNode(text = "Available balance: \$152.10", isClickable = true)
+        writer.captureClick(
+            unknownClickObs(),
+            PipelineEvent.Click(timestamp = 1_000L, node = toxic, packageName = "com.doordash.driverapp"),
+            screenTarget = null,
+        )
+
+        verify(captureBus, never()).offer(any(), any(), anyOrNull(), any(), any(), anyOrNull())
+        assertEquals(1L, stats.scrubbedUnknownCaptureCount)
+    }
+
+    @Test
+    fun `benign UNKNOWN click still captures for triage`() {
+        val benign = UiNode(text = "Some new button", isClickable = true)
+        writer.captureClick(
+            unknownClickObs(),
+            PipelineEvent.Click(timestamp = 1_000L, node = benign, packageName = "com.doordash.driverapp"),
+            screenTarget = null,
+        )
+
+        verify(captureBus, times(1)).offer(any(), any(), anyOrNull(), any(), any(), anyOrNull())
+        assertEquals(0L, stats.scrubbedUnknownCaptureCount)
     }
 }

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/ClickCaptureNoDedupTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/ClickCaptureNoDedupTest.kt
@@ -1,0 +1,67 @@
+package cloud.trotter.dashbuddy.core.pipeline
+
+import cloud.trotter.dashbuddy.domain.capture.CaptureBus
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+/**
+ * #597 — click captures are NEVER deduped at the bus. The bus's content-hash
+ * seen-set lives as long as the a11y process (days on a phone that never
+ * reboots), and a repeat tap on the same button hashes identically — so
+ * dedup decayed click forensics to zero within a week (37→17→1→2→0 captures/
+ * day on the 06-25→30 field week), costing the click envelopes for both
+ * headline incidents. Clicks are human-bounded: every physical tap persists.
+ */
+class ClickCaptureNoDedupTest {
+
+    private val captureBus: CaptureBus = mock()
+    private val writer = CaptureWriter(captureBus, PipelineStats())
+
+    private fun clickObs(t: Long) = Observation.Click(
+        timestamp = t,
+        captureId = null,
+        ruleId = "doordash.click.decline_offer",
+        metadata = ReplayMetadata.EMPTY,
+        flow = null,
+        modeHint = null,
+        parsed = ParsedFields.None,
+        target = "decline_offer",
+    )
+
+    private fun clickEvent(t: Long) = PipelineEvent.Click(
+        timestamp = t,
+        node = UiNode(text = "Decline", isClickable = true),
+        packageName = "com.doordash.driverapp",
+    )
+
+    @Test
+    fun `click offers carry a null dedup hash so the bus never suppresses them`() {
+        whenever(captureBus.offer(any(), any(), anyOrNull(), any(), any(), anyOrNull()))
+            .thenReturn("cap-1")
+
+        // The same button tapped twice — identical node content, identical screen.
+        writer.captureClick(clickObs(1_000L), clickEvent(1_000L), screenTarget = "offer_popup")
+        writer.captureClick(clickObs(2_000L), clickEvent(2_000L), screenTarget = "offer_popup")
+
+        val hashCaptor = argumentCaptor<Int?>()
+        verify(captureBus, times(2)).offer(
+            any(), eq("accessibility.click"), anyOrNull(), any(), any(), hashCaptor.capture(),
+        )
+        // Both taps reached the bus, and neither carried a dedupable hash.
+        assertEquals(2, hashCaptor.allValues.size)
+        hashCaptor.allValues.forEach { assertNull(it) }
+    }
+}

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/FrameGateTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/FrameGateTest.kt
@@ -83,7 +83,7 @@ class FrameGateTest {
 
     @Test
     fun `rolling capacity evicts oldest - an evicted hash can capture again`() {
-        val suppressor = UnknownSuppressor(capacity = 2, processCap = 1_000)
+        val suppressor = UnknownSuppressor(capacity = 2, burstCap = 1_000)
         assertTrue(suppressor.shouldCapture(1))
         assertTrue(suppressor.shouldCapture(2))
         assertTrue(suppressor.shouldCapture(3)) // evicts 1
@@ -93,7 +93,7 @@ class FrameGateTest {
 
     @Test
     fun `re-seeing a hash refreshes its recency`() {
-        val suppressor = UnknownSuppressor(capacity = 2, processCap = 1_000)
+        val suppressor = UnknownSuppressor(capacity = 2, burstCap = 1_000)
         assertTrue(suppressor.shouldCapture(1))
         assertTrue(suppressor.shouldCapture(2))
         assertFalse(suppressor.shouldCapture(1)) // touch 1 → 2 is now eldest
@@ -103,8 +103,8 @@ class FrameGateTest {
     }
 
     @Test
-    fun `process cap stops captures but suppression of seen hashes continues`() {
-        val suppressor = UnknownSuppressor(capacity = 8, processCap = 2)
+    fun `burst cap stops captures but suppression of seen hashes continues`() {
+        val suppressor = UnknownSuppressor(capacity = 8, burstCap = 2)
         assertTrue(suppressor.shouldCapture(1))
         assertTrue(suppressor.shouldCapture(2))
         assertFalse(suppressor.shouldCapture(3)) // cap reached
@@ -112,5 +112,47 @@ class FrameGateTest {
         var capped = 0
         for (h in 10..20) if (!suppressor.shouldCapture(h)) capped++
         assertEquals(11, capped)
+    }
+
+    // #597: the cap is per burst-window, re-armed by a quiet gap — the a11y
+    // process lives for days, so a lifetime cap meant days of triage blindness.
+
+    @Test
+    fun `cap re-arms after a quiet gap - a later dash gets a fresh budget`() {
+        val gapMs = 30 * 60 * 1000L
+        val suppressor = UnknownSuppressor(capacity = 8, burstCap = 2, quietGapMs = gapMs)
+        assertTrue(suppressor.shouldCapture(1, nowMs = 1_000L))
+        assertTrue(suppressor.shouldCapture(2, nowMs = 2_000L))
+        assertFalse(suppressor.shouldCapture(3, nowMs = 3_000L)) // cap reached mid-burst
+        // 31 minutes of silence — flood over; new distinct unknowns capture again.
+        val later = 3_000L + gapMs + 60_000L
+        assertTrue(suppressor.shouldCapture(4, nowMs = later))
+        assertTrue(suppressor.shouldCapture(5, nowMs = later + 1_000L))
+        assertFalse(suppressor.shouldCapture(6, nowMs = later + 2_000L)) // fresh cap holds
+    }
+
+    @Test
+    fun `no re-arm during a continuous flood`() {
+        val gapMs = 30 * 60 * 1000L
+        val suppressor = UnknownSuppressor(capacity = 8, burstCap = 2, quietGapMs = gapMs)
+        assertTrue(suppressor.shouldCapture(1, nowMs = 0L))
+        assertTrue(suppressor.shouldCapture(2, nowMs = 1_000L))
+        // A flood ticking every minute for hours: gap never exceeds quietGapMs.
+        var t = 2_000L
+        for (h in 100..400) {
+            assertFalse(suppressor.shouldCapture(h, nowMs = t))
+            t += 60_000L
+        }
+    }
+
+    @Test
+    fun `re-arm resets the cap, not the seen-set - known hashes stay suppressed`() {
+        val gapMs = 30 * 60 * 1000L
+        val suppressor = UnknownSuppressor(capacity = 8, burstCap = 2, quietGapMs = gapMs)
+        assertTrue(suppressor.shouldCapture(1, nowMs = 1_000L))
+        assertTrue(suppressor.shouldCapture(2, nowMs = 2_000L))
+        val later = 2_000L + gapMs + 60_000L
+        assertFalse(suppressor.shouldCapture(1, nowMs = later)) // seen — still deduped
+        assertTrue(suppressor.shouldCapture(3, nowMs = later + 1_000L)) // new hash captures
     }
 }

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/FrameGateTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/FrameGateTest.kt
@@ -84,33 +84,34 @@ class FrameGateTest {
     @Test
     fun `rolling capacity evicts oldest - an evicted hash can capture again`() {
         val suppressor = UnknownSuppressor(capacity = 2, burstCap = 1_000)
-        assertTrue(suppressor.shouldCapture(1))
-        assertTrue(suppressor.shouldCapture(2))
-        assertTrue(suppressor.shouldCapture(3)) // evicts 1
-        assertTrue(suppressor.shouldCapture(1)) // 1 was evicted → captures again
-        assertFalse(suppressor.shouldCapture(3)) // still resident
+        assertTrue(suppressor.shouldCapture(1, nowMs = 1_000L))
+        assertTrue(suppressor.shouldCapture(2, nowMs = 2_000L))
+        assertTrue(suppressor.shouldCapture(3, nowMs = 3_000L)) // evicts 1
+        assertTrue(suppressor.shouldCapture(1, nowMs = 4_000L)) // 1 was evicted → captures again
+        assertFalse(suppressor.shouldCapture(3, nowMs = 5_000L)) // still resident
     }
 
     @Test
     fun `re-seeing a hash refreshes its recency`() {
         val suppressor = UnknownSuppressor(capacity = 2, burstCap = 1_000)
-        assertTrue(suppressor.shouldCapture(1))
-        assertTrue(suppressor.shouldCapture(2))
-        assertFalse(suppressor.shouldCapture(1)) // touch 1 → 2 is now eldest
-        assertTrue(suppressor.shouldCapture(3))  // evicts 2, not 1
-        assertFalse(suppressor.shouldCapture(1))
-        assertTrue(suppressor.shouldCapture(2))  // 2 was evicted
+        assertTrue(suppressor.shouldCapture(1, nowMs = 1_000L))
+        assertTrue(suppressor.shouldCapture(2, nowMs = 2_000L))
+        assertFalse(suppressor.shouldCapture(1, nowMs = 3_000L)) // touch 1 → 2 is now eldest
+        assertTrue(suppressor.shouldCapture(3, nowMs = 4_000L))  // evicts 2, not 1
+        assertFalse(suppressor.shouldCapture(1, nowMs = 5_000L))
+        assertTrue(suppressor.shouldCapture(2, nowMs = 6_000L))  // 2 was evicted
     }
 
     @Test
     fun `burst cap stops captures but suppression of seen hashes continues`() {
         val suppressor = UnknownSuppressor(capacity = 8, burstCap = 2)
-        assertTrue(suppressor.shouldCapture(1))
-        assertTrue(suppressor.shouldCapture(2))
-        assertFalse(suppressor.shouldCapture(3)) // cap reached
-        assertFalse(suppressor.shouldCapture(1)) // seen — still suppressed
+        assertTrue(suppressor.shouldCapture(1, nowMs = 1_000L))
+        assertTrue(suppressor.shouldCapture(2, nowMs = 2_000L))
+        assertFalse(suppressor.shouldCapture(3, nowMs = 3_000L)) // cap reached
+        assertFalse(suppressor.shouldCapture(1, nowMs = 4_000L)) // seen — still suppressed
         var capped = 0
-        for (h in 10..20) if (!suppressor.shouldCapture(h)) capped++
+        var t = 5_000L
+        for (h in 10..20) { if (!suppressor.shouldCapture(h, nowMs = t)) capped++; t += 1_000L }
         assertEquals(11, capped)
     }
 
@@ -143,6 +144,22 @@ class FrameGateTest {
             assertFalse(suppressor.shouldCapture(h, nowMs = t))
             t += 60_000L
         }
+    }
+
+    @Test
+    fun `an out-of-order timestamp cannot fake a quiet gap mid-flood`() {
+        // Notification postTime is not monotonic (reposts/group summaries). A
+        // backwards frame must not regress the anchor and re-arm the cap
+        // (adversarial F1 on #597).
+        val gapMs = 30 * 60 * 1000L
+        val suppressor = UnknownSuppressor(capacity = 8, burstCap = 2, quietGapMs = gapMs)
+        assertTrue(suppressor.shouldCapture(1, nowMs = 1_000L))
+        assertTrue(suppressor.shouldCapture(2, nowMs = 2_000L))
+        assertFalse(suppressor.shouldCapture(3, nowMs = 3_000L)) // capped
+        // A frame stamped 45 min in the PAST arrives out of order…
+        assertFalse(suppressor.shouldCapture(4, nowMs = 3_000L - 45 * 60 * 1000L))
+        // …the next in-order frame must still be capped (no fake quiet gap).
+        assertFalse(suppressor.shouldCapture(5, nowMs = 4_000L))
     }
 
     @Test

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -73,6 +73,18 @@ card's **mechanical** half, #577 (re-confirmed, 24/24, ~0.55 s — with a new po
 that entry's Bug #1), the #457 path, and #554 ShadowProjector (2/2). The #462/#460 dropoff item
 was found **broken-in-part** (raw PII in capture envelopes) and moved to that entry's Bug #7.)_
 
+- **🔧 FIX SHIPPED — click captures record every tap + UNKNOWN cap re-arms after quiet (#597). READ THE PULL AFTER A DASH.**
+  The week-long a11y process turned two per-process guards into forever-guards: click captures
+  deduped to zero by day 3 (repeat taps hash identically), and the UNKNOWN cap (200) went blind
+  for the rest of the week once hit. Now: clicks are **never** deduped (every physical tap
+  persists an envelope), and the cap is **per burst**, re-arming after a 30-min gap with no
+  UNKNOWN frames. **Confirm on next pull: 0/2 —** `captures/doordash/accessibility.click/`
+  should contain envelopes for that day's accepts/declines/confirms (`captured=true` on the
+  `Captured click:` log lines), even for buttons tapped on prior days; if an UNKNOWN-flood day
+  happens, later dashes should still capture UNKNOWNs (`UNKNOWN capture cap re-armed` DEBUG
+  line). Broken = `captured=false` on a first-of-day click, or a capped day staying blind on
+  the next dash.
+
 - **👁 VISUAL-ONLY — rich offer notification looks right: gauge ring, countdown, badges (#578/#583). CONFIRM BY EYE.**
   The mechanical halves are validated (buttons fire from the floating heads-up; the card posts
   with live PendingIntents; zero RemoteViews errors across a full week) — what desk data cannot

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -73,17 +73,21 @@ card's **mechanical** half, #577 (re-confirmed, 24/24, ~0.55 s — with a new po
 that entry's Bug #1), the #457 path, and #554 ShadowProjector (2/2). The #462/#460 dropoff item
 was found **broken-in-part** (raw PII in capture envelopes) and moved to that entry's Bug #7.)_
 
-- **🔧 FIX SHIPPED — click captures record every tap + UNKNOWN cap re-arms after quiet (#597). READ THE PULL AFTER A DASH.**
+- **🔧 FIX SHIPPED — click captures record every rule-matched tap + UNKNOWN cap re-arms after quiet (#597). READ THE PULL AFTER A DASH.**
   The week-long a11y process turned two per-process guards into forever-guards: click captures
   deduped to zero by day 3 (repeat taps hash identically), and the UNKNOWN cap (200) went blind
-  for the rest of the week once hit. Now: clicks are **never** deduped (every physical tap
-  persists an envelope), and the cap is **per burst**, re-arming after a 30-min gap with no
-  UNKNOWN frames. **Confirm on next pull: 0/2 —** `captures/doordash/accessibility.click/`
-  should contain envelopes for that day's accepts/declines/confirms (`captured=true` on the
-  `Captured click:` log lines), even for buttons tapped on prior days; if an UNKNOWN-flood day
-  happens, later dashes should still capture UNKNOWNs (`UNKNOWN capture cap re-armed` DEBUG
-  line). Broken = `captured=false` on a first-of-day click, or a capped day staying blind on
-  the next dash.
+  for the rest of the week once hit. Now: **rule-matched** clicks (accept/decline/confirm…) are
+  never deduped — every physical tap persists an envelope (UNKNOWN clicks stay bounded by the
+  shared UNKNOWN budget, and now pass the sensitive-marker backstop) — and the UNKNOWN cap is
+  **per burst**, re-arming after a 30-min gap with no UNKNOWN frames on that pipeline.
+  **Confirm on next pull: 0/2 —** `captures/doordash/accessibility.click/` should contain
+  envelopes for that day's accepts/declines/confirms (`captured=true` on the `Captured click:`
+  log lines), even for buttons tapped on prior days; if an UNKNOWN-flood day happens, later
+  dashes should still capture UNKNOWNs. Broken = `captured=false` on a rule-matched click, or a
+  capped day staying blind on the next dash. **Calibration:** opening DoorDash casually between
+  dashes resets the quiet gap (correct behavior, not a failure), and the `UNKNOWN capture cap
+  re-armed` DEBUG line fires after any burst, capped or not — it alone doesn't mean the cap was
+  hit.
 
 - **👁 VISUAL-ONLY — rich offer notification looks right: gauge ring, countdown, badges (#578/#583). CONFIRM BY EYE.**
   The mechanical halves are validated (buttons fire from the floating heads-up; the card posts


### PR DESCRIPTION
Closes #597. The a11y process lives for days, so two per-process forensic guards became forever-guards (06-25→30 receipts: click captures 37→17→1→2→0/day; UNKNOWN cap hit 25 min into 06-28 → ~4 h blind).

## Changes
- **`CaptureWriter.captureClick`** offers with `contentHash = null` — the bus only dedups non-null hashes, so every physical tap persists an envelope. Clicks are human-bounded; `FrameGate` already never deduped clicks (#366), the bus was the only suppressor. The envelope keeps its `contentHash` for replay.
- **`UnknownSuppressor`**: `processCap` → `burstCap` — the 200 cap now re-arms after a 30-min gap with **no UNKNOWN frames** (a flood by definition has no quiet gaps, so runaway protection holds). Driven by `obs.timestamp` (event time), never a wall clock. The rolling LRU seen-set (animation dedup) is untouched by re-arm.

## Tests
`FrameGateTest`: re-arm after quiet gap / no re-arm during a continuous flood / re-arm resets the budget not the seen-set. New `ClickCaptureNoDedupTest`: two identical taps both reach the bus with a null dedup hash. `:core:pipeline` + `:app` suites green.

## Security/privacy posture
No new data collected — both paths already captured this content; this restores intended debug-build availability. Captures remain debug-only (`NoOpCaptureBus` in release, #346); UNKNOWN captures still pass the `SensitiveTextMarkers` fail-closed backstop (#432) before reaching the bus. (Raw-PII-in-envelopes is tracked separately as #598 and is not widened by this change: clicks capture the tapped node, same content class as before.)

### Design-goal review
1 (UDF): suppressor stays pure event-time-driven (`obs.timestamp`, no wall clock). 3 (SRP): changes confined to the two guard classes + one call site. 5 (SSOT): dedup policy per capture class lives in one place each (bus hash for screens/notifications; FrameGate for frames). 6 (privacy): posture stated above — no new content classes captured, backstops unchanged. 7 (logging): cap WARN now says "until a 30-min quiet gap" (still once per burst); re-arm logs at DEBUG. 8: no platform literals introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)