### PR TITLE
fix(privacy): #599 — Crimson balance notification is pledge-BLOCKED, not captured

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/notification/NotificationClassifierTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/notification/NotificationClassifierTest.kt
@@ -40,11 +40,13 @@ class NotificationClassifierTest {
         text: String? = null,
         bigText: String? = null,
         tickerText: String? = null,
+        channelId: String? = null,
     ) = RawNotificationData(
         title = title,
         text = text,
         tickerText = tickerText,
         bigText = bigText,
+        channelId = channelId,
         packageName = "com.doordash.driverapp",
         postTime = System.currentTimeMillis(),
         isClearable = true,
@@ -56,6 +58,30 @@ class NotificationClassifierTest {
     /** Extract [ParsedFields.NotificationFields] from a classification result. */
     private fun Observation.Notification.notifFields(): ParsedFields.NotificationFields =
         parsed as ParsedFields.NotificationFields
+
+    // =========================================================================
+    // Sensitive block — #599
+    // =========================================================================
+
+    @Test
+    fun `crimson balance notification parses SENSITIVE — pledge-blocked, never captured or forwarded`() {
+        // Synthetic text (fabricated amount) shaped like the real Savings Jar
+        // notification. The parse MUST be SensitiveFields: that is what the
+        // shared content gate (#399) keys on to drop the observation before
+        // capture and before the state machine.
+        val result = classifyNotification(
+            raw(
+                channelId = "dasher-notification-messages",
+                title = "You're building momentum!",
+                text = "Your DoorDash Crimson Savings Jar balance is now \$12.34",
+            )
+        )
+        assertEquals("sensitive.crimson_balance", result.target)
+        assertTrue(
+            "banking notification must parse as SensitiveFields, got ${result.parsed::class.simpleName}",
+            result.parsed is ParsedFields.SensitiveFields,
+        )
+    }
 
     // =========================================================================
     // AdditionalTip

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/notification/NotificationPipelineSensitiveOrderingTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/notification/NotificationPipelineSensitiveOrderingTest.kt
@@ -1,0 +1,125 @@
+package cloud.trotter.dashbuddy.core.pipeline.notification
+
+import android.app.Notification
+import android.os.Process
+import android.service.notification.StatusBarNotification
+import cloud.trotter.dashbuddy.core.pipeline.CaptureWriter
+import cloud.trotter.dashbuddy.core.pipeline.ObservationClassifier
+import cloud.trotter.dashbuddy.core.pipeline.PipelineStats
+import cloud.trotter.dashbuddy.core.pipeline.rules.JsonRuleInterpreter
+import cloud.trotter.dashbuddy.core.pipeline.notification.input.NotificationSource
+import cloud.trotter.dashbuddy.domain.capture.CaptureBus
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadataProvider
+import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.settings.PlatformPreferences
+import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.test.util.TestRulesetFactory
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+/**
+ * #599 adversarial F2 — pins the PIPELINE ORDERING the sensitive block rests
+ * on: a sensitive-classified notification must die at the shared content gate
+ * BEFORE [CaptureWriter] and before being forwarded. The classification and
+ * gate behaviors are unit-tested elsewhere; this test exists so a refactor
+ * that reorders `NotificationPipeline.output()` (capture above the gate)
+ * cannot go green. Runs the REAL pipeline against the PRODUCTION rulesets.
+ */
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class NotificationPipelineSensitiveOrderingTest {
+
+    private val captureBus: CaptureBus = mock()
+    private val platformPrefs: PlatformPreferences = mock {
+        on { enabledPlatforms } doReturn MutableStateFlow(setOf<Platform>(Platform.DoorDash))
+        on { enabledPackages } doReturn MutableStateFlow(setOf("com.doordash.driverapp"))
+    }
+    private val classifier = ObservationClassifier(
+        mock<JsonRuleInterpreter> {
+            on { notificationRuleset } doReturn TestRulesetFactory.notificationRuleset
+            on { isLoaded } doReturn true
+        },
+        mock<ReplayMetadataProvider> { on { current() } doReturn ReplayMetadata.EMPTY },
+    )
+    private val source = NotificationSource()
+    private val pipeline = NotificationPipeline(
+        source = source,
+        filter = NotificationFilter(platformPrefs),
+        classifier = classifier,
+        captureWriter = CaptureWriter(captureBus, PipelineStats()),
+        platformPreferences = platformPrefs,
+        stats = PipelineStats(),
+    )
+
+    private fun sbn(channelId: String, title: String, text: String): StatusBarNotification {
+        val n = Notification.Builder(RuntimeEnvironment.getApplication(), channelId)
+            .setContentTitle(title)
+            .setContentText(text)
+            .setSmallIcon(android.R.drawable.ic_dialog_info)
+            .build()
+        @Suppress("DEPRECATION")
+        return StatusBarNotification(
+            "com.doordash.driverapp", "com.doordash.driverapp",
+            1, null, 0, 0, 0, n, Process.myUserHandle(), System.currentTimeMillis(),
+        )
+    }
+
+    @Test
+    fun `sensitive balance notification never reaches the capture bus or the output flow`() = runTest {
+        whenever(captureBus.offer(any(), any(), anyOrNull(), any(), any(), anyOrNull()))
+            .thenReturn("cap-1")
+        val forwarded = mutableListOf<Observation.Notification>()
+        val job = backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) { pipeline.output().collect { forwarded += it } }
+        advanceUntilIdle()
+
+        // The pledge-blocked banking notification (synthetic text/amount).
+        source.emit(
+            sbn(
+                channelId = "dasher-notification-messages",
+                title = "You're building momentum!",
+                text = "Your DoorDash Crimson Savings Jar balance is now \$12.34",
+            )
+        )
+        advanceUntilIdle()
+
+        verify(captureBus, never()).offer(any(), any(), anyOrNull(), any(), any(), anyOrNull())
+        assertTrue("sensitive notification must not be forwarded", forwarded.isEmpty())
+
+        // CONTROL — the harness actually flows: a benign new-order notification
+        // is captured AND forwarded (proves the empty assertions above are not
+        // an artifact of a dead pipeline).
+        source.emit(
+            sbn(
+                channelId = "dasher-notification-channel-new-order-v2",
+                title = "New Delivery!",
+                text = "New order: go to Chipotle",
+            )
+        )
+        advanceUntilIdle()
+
+        verify(captureBus, times(1)).offer(any(), any(), anyOrNull(), any(), any(), anyOrNull())
+        assertEquals(1, forwarded.size)
+        assertEquals("new_order", forwarded.single().target)
+        job.cancel()
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/TriageRulesTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/TriageRulesTest.kt
@@ -103,8 +103,11 @@ class TriageRulesTest {
             "earnings_deposit",
             notif(raw(channelId = "dasher-notification-messages", title = "Dasher", text = "your dasher earnings for \$40 have been deposited to your DoorDash Crimson account.")),
         )
+        // #599: the balance notification is pledge-blocked — it must classify as the
+        // SENSITIVE intent (whose parse drops it at the shared content gate), never
+        // the old recognize+capture intent.
         assertEquals(
-            "crimson_balance",
+            "sensitive.crimson_balance",
             notif(raw(channelId = "dasher-notification-messages", title = "You're building momentum", text = "your DoorDash Crimson savings jar balance is now \$100")),
         )
     }

--- a/core/pipeline/src/main/assets/rules/doordash.json
+++ b/core/pipeline/src/main/assets/rules/doordash.json
@@ -3379,20 +3379,15 @@
       ]
     },
     {
-      "comment": "#599: the dasher's Crimson/DasherDirect BALANCE is pledge-blocked (banking — never parsed or stored). Sensitive parse -> the shared content gate (#399) drops it before capture and the state machine; priority 0 so nothing can outrank the block. Predicates deliberately stay narrow (savings jar / building momentum): earnings_deposit notifications also say 'DoorDash Crimson account' and their fate is a separate dev call (#599).",
+      "comment": "#599: the dasher's Crimson/DasherDirect BALANCE is pledge-blocked (banking — never parsed or stored). Sensitive parse -> the shared content gate (#399) drops it before capture and the state machine; priority 0 so nothing can outrank the block. Deliberately NO channel predicate (adversarial F1): DoorDash routes Crimson notifications over multiple channels (appboy incl.), and a channel-scoped block would let a rerouted balance push classify as a channel-only catch-all (marketing_promo) and capture raw — a block rule gains nothing from a channel key. TEXT predicates stay narrow (savings jar / building momentum): earnings_deposit notifications also say 'DoorDash Crimson account' and their fate is a separate dev call (#599).",
       "id": "doordash.notification.crimson_balance",
       "priority": 0,
       "overrideable": false,
       "intent": "sensitive.crimson_balance",
       "require": {
-        "all": [
-          { "channelIdEquals": "dasher-notification-messages" },
-          {
-            "any": [
-              { "anyFieldContains": "savings jar" },
-              { "anyFieldContains": "building momentum" }
-            ]
-          }
+        "any": [
+          { "anyFieldContains": "savings jar" },
+          { "anyFieldContains": "building momentum" }
         ]
       },
       "parse": { "as": "sensitive" }

--- a/core/pipeline/src/main/assets/rules/doordash.json
+++ b/core/pipeline/src/main/assets/rules/doordash.json
@@ -3379,9 +3379,11 @@
       ]
     },
     {
+      "comment": "#599: the dasher's Crimson/DasherDirect BALANCE is pledge-blocked (banking — never parsed or stored). Sensitive parse -> the shared content gate (#399) drops it before capture and the state machine; priority 0 so nothing can outrank the block. Predicates deliberately stay narrow (savings jar / building momentum): earnings_deposit notifications also say 'DoorDash Crimson account' and their fate is a separate dev call (#599).",
       "id": "doordash.notification.crimson_balance",
-      "priority": 27,
-      "intent": "crimson_balance",
+      "priority": 0,
+      "overrideable": false,
+      "intent": "sensitive.crimson_balance",
       "require": {
         "all": [
           { "channelIdEquals": "dasher-notification-messages" },
@@ -3393,9 +3395,7 @@
           }
         ]
       },
-      "effects": [
-        { "log": { "type": "NOTIFICATION_RECEIVED", "payload": "CRIMSON_BALANCE" } }
-      ]
+      "parse": { "as": "sensitive" }
     },
     {
       "id": "doordash.notification.transfer_complete",

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/SensitiveTextMarkers.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/SensitiveTextMarkers.kt
@@ -37,6 +37,7 @@ object SensitiveTextMarkers {
         "Emergency contact details",
         // doordash.screen.sensitive.catchall
         "Crimson",
+        "DasherDirect",
         "Biometric",
         "Available Balance",
         "Tax Form",

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -89,6 +89,17 @@ was found **broken-in-part** (raw PII in capture envelopes) and moved to that en
   re-armed` DEBUG line fires after any burst, capped or not — it alone doesn't mean the cap was
   hit.
 
+- **🔒 FIX SHIPPED — Crimson Savings Jar balance notification is now pledge-BLOCKED (#599). READ THE PULL AFTER A DASH.**
+  The dasher's Crimson/DasherDirect balance notification was being recognized and captured raw
+  (9 files found on the 06-25→30 pull — deleted from the device). The rule is now sensitive
+  (priority 0, `parse: sensitive`) — the shared content gate drops it before capture and the
+  state machine. **Confirm on next pull: 0/2 —** after a dash where the Savings Jar notification
+  arrived: `captures/doordash/notification/` must contain **no** `crimson_balance` (or
+  `sensitive.*`) folder/files, and the log shows `Sensitive gate: dropped sensitive.crimson_balance`
+  at DEBUG. Broken = any capture file containing "Savings Jar balance". (Note: `earnings_deposit`
+  and `transfer_complete` notifications still capture — their sensitive-vs-keep fate is an open
+  dev call on #599's siblings.)
+
 - **👁 VISUAL-ONLY — rich offer notification looks right: gauge ring, countdown, badges (#578/#583). CONFIRM BY EYE.**
   The mechanical halves are validated (buttons fire from the floating heads-up; the card posts
   with live PendingIntents; zero RemoteViews errors across a full week) — what desk data cannot


### PR DESCRIPTION
Closes #599. The dasher's Crimson/DasherDirect **balance** notification was a recognize+capture rule — the notification-pipeline hole in the dasher-banking block (9 raw balance captures on the 06-25→30 pull; **deleted from the device** as part of this fix).

## Change
`doordash.notification.crimson_balance` → sensitive: priority **0**, `overrideable: false`, intent `sensitive.crimson_balance`, `parse: {as: sensitive}` → `SensitiveFields` → the shared content gate (#399) drops it **before capture and before the state machine**. Log effect removed (a blocked notification fires nothing).

**Deliberately narrow predicates** (savings jar / building momentum): `earnings_deposit` notifications also say "DoorDash Crimson account", and its fate — plus `transfer_complete`'s ("Transfer complete / funds will arrive shortly") — is an explicit open dev call, not silently decided here. Both still capture today.

## Tests
- `TriageRulesTest`: the balance text now classifies `sensitive.crimson_balance` while the deposit text stays `earnings_deposit` on the same channel — proves priority-0 routing.
- `NotificationClassifierTest` (new): synthetic balance notification (fabricated amount — no real data committed) parses as `SensitiveFields`.
- `ContentGatesTest` (existing): `SensitiveFields` → dropped, notification and screen alike.
- `AllMatchersSuite` + full `:app`/`:core:pipeline` suites green; parse-output golden unchanged.

## Security/privacy posture
Strictly narrows storage: a banking surface moves from captured→blocked at the matcher layer (Pledge: dasher banking never parsed or stored). No new parsing, no new data. On-device stored violations deleted; the local pull archive on the workstation is the developer's call.

### Design-goal review
6 (privacy): the change *is* the principle — matcher-layer block, fail-closed ordering (priority 0, non-overrideable). 5 (SSOT): the block uses the one shared content gate; no parallel drop path. 7 (logging): the drop logs at DEBUG via the existing gate line; no INFO+ change. 8: rule JSON only, no platform literals in code. Field-test checklist item added (Confirmed: 0/2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)