### PR TITLE
fix(recognition): #595 — offer_popup requires a store leg; teardown frame can no longer mint a ghost offer

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/TriageRulesTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/TriageRulesTest.kt
@@ -406,11 +406,31 @@ class TriageRulesTest {
     fun `navigation_generic — does not steal an offer popup (offer_popup wins)`() {
         // A real offer popup carries the DoorDash accept_button structure (not just the button
         // labels) AND a pay amount — the require demands the structure so our own overlay can't
-        // masquerade as an offer (#4), and the validate demands a parsed payAmount so a blank,
-        // chrome-only frame isn't recognized as an offer (#498).
+        // masquerade as an offer (#4), the validate demands a parsed payAmount so a blank,
+        // chrome-only frame isn't recognized as an offer (#498), and since #595 it must carry a
+        // STORE leg (display_name) so the post-accept teardown frame can't re-mint a ghost.
         assertEquals(
             "offer_popup",
-            screen(tree(node(text = "Decline"), node(text = "Accept"), node(id = "accept_button"), node(text = "$8.50"), node(id = "maneuverView"))),
+            screen(tree(node(text = "Decline"), node(text = "Accept"), node(id = "accept_button"), node(text = "$8.50"), node(id = "display_name", text = "Chipotle"), node(id = "maneuverView"))),
+        )
+    }
+
+    @Test
+    fun `offer_popup — teardown frame with no store leg is NOT an offer (#595)`() {
+        // The post-accept transitional render: pay/distance/Accept/Decline chrome persist, the
+        // store rows are gone — only the 'Customer dropoff' display_name leg remains (plus a raw
+        // UUID in assignment_id_text). Re-parsing this as a new offer REPLACED the real accept
+        // (ghost accept→timeout, 06-28 seq 141/142 + 06-30 seq 241/242). No store leg → UNKNOWN.
+        assertNull(
+            screen(
+                tree(
+                    node(text = "Decline"), node(text = "Accept"), node(id = "accept_button"),
+                    node(id = "assignment_id_text", text = "0f487bb4-c8a8-46b1-8533-c2a0311f9133"),
+                    node(text = "$26.75  Guaranteed (incl. tips)"), node(text = "7.6 mi"),
+                    node(id = "display_name", text = "Customer dropoff"),
+                    node(text = "Items can be added before checkout"),
+                )
+            ),
         )
     }
 

--- a/app/src/test/java/cloud/trotter/dashbuddy/replay/TeardownGhostReplayTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/replay/TeardownGhostReplayTest.kt
@@ -1,0 +1,82 @@
+package cloud.trotter.dashbuddy.replay
+
+import cloud.trotter.dashbuddy.domain.model.event.AppEventType
+import cloud.trotter.dashbuddy.domain.state.OfferIntent
+import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import cloud.trotter.dashbuddy.test.util.SessionReplay
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+/**
+ * [SessionReplay] regression for the #595 "teardown ghost": DoorDash's post-accept transitional
+ * `offer_popup` render keeps the pay/distance/Accept/Decline chrome but drops the STORE rows
+ * (only the 'Customer dropoff' `display_name` leg remains, plus a raw UUID in
+ * `assignment_id_text`). It re-parsed as a NEW degenerate offer (`orders=[]`, `itemCount=0`,
+ * different offerHash) that REPLACED the just-accepted pending offer — bogus TTS/chat
+ * ("Accept. Unknown Store…"), then a user-visible "Offer Timed Out!" and an orphan
+ * `OFFER_TIMEOUT` with no matching `OFFER_RECEIVED` (field week 06-25→30: seq 141/142 on 06-28,
+ * seq 241/242 on 06-30). Fix: `offer_popup` now REQUIRES at least one store leg, so the teardown
+ * frame classifies UNKNOWN and is never forwarded.
+ *
+ * Replays the real 2026-06-28 sequence (all frames are unmodified device captures; the accept
+ * click is synthetic — click envelopes weren't persisted that week, #597):
+ * `01` real H-E-B Shop & Deliver offer ($13.04, 15 units) → synthetic ACCEPT click →
+ * `03` pickup_shopping (pops the offer → OFFER_ACCEPTED) → `04` THE TEARDOWN GHOST ($22.76
+ * chrome, no store rows) → `05` navigation_generic (would pop any ghost-minted offer as a
+ * TIMEOUT — the pre-fix red signal).
+ */
+class TeardownGhostReplayTest {
+
+    private val session = "snapshots/sessions/teardown_ghost_2026_06_28"
+
+    @Test
+    fun `the real offer still recognizes with its scored fields (#595 does not over-reject)`() {
+        val real = SessionReplay.replayRecognition(session).first()
+        assertEquals("offer_popup", real.target)
+        val offer = (real.parsed as ParsedFields.OfferFields).parsedOffer
+        assertEquals(13.04, offer.payAmount!!, 0.001)
+        assertEquals("H-E-B", offer.orders.single().storeName)
+    }
+
+    @Test
+    fun `the teardown ghost is rejected at recognition (#595, Level A)`() {
+        val obs = SessionReplay.replayRecognition(session)
+        val ghost = obs[2] // 01_offer, 03_shopping, 04_ghost, 05_nav (time-ordered)
+        println("ghost → target=${ghost.target} parsed=${ghost.parsed::class.simpleName}")
+        assertFalse(
+            "the store-less teardown frame must not parse to an offer",
+            ghost.parsed is ParsedFields.OfferFields,
+        )
+        assertFalse("…and must not classify as offer_popup", ghost.target == "offer_popup")
+    }
+
+    @Test
+    fun `accept survives the teardown frame - one offer, one accept, zero timeouts (#595, Level B)`() {
+        val frames = SessionReplay.loadSession(session)
+        val offerFrame = frames.first { it.file.contains("real_offer") }
+        val inputs = listOf(
+            SessionReplay.ScreenInput(offerFrame),
+            // The dasher's accept — synthetic (no click envelope existed, #597), injected while
+            // the offer card is up so the later pop records ACCEPTED, exactly like the field.
+            SessionReplay.syntheticOfferClick(OfferIntent.ACCEPT, atMs = offerFrame.capturedAtMs + 2_000L),
+        ) + frames.filterNot { it.file.contains("real_offer") }.map { SessionReplay.ScreenInput(it) }
+
+        val steps = SessionReplay.reduceMixed(inputs.sortedBy { it.atMs })
+        println(SessionReplay.trace(steps))
+        val events = steps.flatMap { it.events }
+
+        assertEquals(
+            "exactly ONE offer received — the teardown frame must not re-mint",
+            1, events.count { it.type == AppEventType.OFFER_RECEIVED },
+        )
+        assertEquals(
+            "the real accept commits exactly once",
+            1, events.count { it.type == AppEventType.OFFER_ACCEPTED },
+        )
+        assertEquals(
+            "no orphan OFFER_TIMEOUT — the ghost's signature (field seq 142/242)",
+            0, events.count { it.type == AppEventType.OFFER_TIMEOUT },
+        )
+    }
+}

--- a/app/src/test/resources/snapshots/sessions/teardown_ghost_2026_06_28/01_real_offer_heb_shop.json
+++ b/app/src/test/resources/snapshots/sessions/teardown_ghost_2026_06_28/01_real_offer_heb_shop.json
@@ -1,0 +1,843 @@
+{
+    "captureId": "6131fa8a-ce8a-4ec2-9331-43975b015a7c",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1782679679450,
+    "platform": "doordash",
+    "ruleId": "doordash.screen.offer_popup",
+    "classificationName": "offer_popup",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 136,
+                            "right": 1080,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 136,
+                                    "right": 1080,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 136,
+                                            "right": 1080,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 136,
+                                                    "right": 1080,
+                                                    "bottom": 2347
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/accept_decline_fragment_container",
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/bottomSheetLayout",
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 136,
+                                                                    "right": 1080,
+                                                                    "bottom": 2347
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/accept_constraint_layout",
+                                                                        "class": "android.view.ViewGroup",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 136,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/map_container",
+                                                                                "class": "android.widget.FrameLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 136,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2347
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 136,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2347
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.view.TextureView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 136,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2347
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 136,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2347
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 5,
+                                                                                                    "top": 1479,
+                                                                                                    "right": 194,
+                                                                                                    "bottom": 1526
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isClickable": true,
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 200,
+                                                                                                    "top": 1479,
+                                                                                                    "right": 247,
+                                                                                                    "bottom": 1526
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/secondary_action_button_dash_plus",
+                                                                                "class": "android.widget.Button",
+                                                                                "isClickable": true,
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 816,
+                                                                                    "top": 172,
+                                                                                    "right": 1044,
+                                                                                    "bottom": 297
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "text": "Decline",
+                                                                                        "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 852,
+                                                                                            "top": 202,
+                                                                                            "right": 1008,
+                                                                                            "bottom": 268
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "text": "9a440d47-a28c-4a31-94b7-a8aa4571ff0b",
+                                                                                "id": "com.doordash.driverapp:id/assignment_id_text",
+                                                                                "class": "android.widget.TextView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 715,
+                                                                                    "top": 1485,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 1526
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/prism_sheet",
+                                                                        "class": "android.view.ViewGroup",
+                                                                        "isClickable": true,
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 1526,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/prism_sheet_collar_view",
+                                                                                "class": "android.widget.FrameLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 1526,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 1526
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/extra_space",
+                                                                                "class": "android.view.View",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 1526,
+                                                                                    "right": 0,
+                                                                                    "bottom": 1562
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/prism_sheet_content_parent_container",
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 1562,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2311
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/nested_scroll_view",
+                                                                                        "class": "android.widget.ScrollView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 1562,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2311
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/prism_content_container",
+                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 1562,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2151
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/bottomsheet_content_container",
+                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 1562,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2151
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.doordash.driverapp:id/accept_decline_recycler_view_container",
+                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 1562,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2151
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "id": "com.doordash.driverapp:id/items_recycler_view",
+                                                                                                                        "class": "androidx.recyclerview.widget.RecyclerView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 1562,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2151
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1562,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 1563
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1563,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 1647
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 1563,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 1647
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "$13.04  Guaranteed (incl. tips)",
+                                                                                                                                                "id": "com.doordash.driverapp:id/text_field",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 1563,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 1647
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1647,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 1712
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 1647,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 1712
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "8.7 mi",
+                                                                                                                                                "id": "com.doordash.driverapp:id/text_field",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 1647,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 1712
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1712,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 1768
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 1712,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 1768
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Deliver by 4:37 PM",
+                                                                                                                                                "id": "com.doordash.driverapp:id/text_field",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 1712,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 1768
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1768,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 1808
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 1804,
+                                                                                                                                            "right": 1044,
+                                                                                                                                            "bottom": 1808
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1808,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 1952
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 1808,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 1952
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/work_unit_icon_container",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 45,
+                                                                                                                                                    "top": 1835,
+                                                                                                                                                    "right": 99,
+                                                                                                                                                    "bottom": 1889
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.doordash.driverapp:id/work_unit_image",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 45,
+                                                                                                                                                            "top": 1835,
+                                                                                                                                                            "right": 99,
+                                                                                                                                                            "bottom": 1889
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "Shop for items",
+                                                                                                                                                "id": "com.doordash.driverapp:id/work_unit_type",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 126,
+                                                                                                                                                    "top": 1841,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 1883
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/bottom_vertical_line",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 71,
+                                                                                                                                                    "top": 1889,
+                                                                                                                                                    "right": 73,
+                                                                                                                                                    "bottom": 1952
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/display_name_container",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isClickable": true,
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 126,
+                                                                                                                                                    "top": 1901,
+                                                                                                                                                    "right": 972,
+                                                                                                                                                    "bottom": 1952
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "text": "H-E-B",
+                                                                                                                                                        "id": "com.doordash.driverapp:id/display_name",
+                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 126,
+                                                                                                                                                            "top": 1901,
+                                                                                                                                                            "right": 264,
+                                                                                                                                                            "bottom": 1952
+                                                                                                                                                        }
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "text": "(15 units)",
+                                                                                                                                                        "id": "com.doordash.driverapp:id/display_name_secondary",
+                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 264,
+                                                                                                                                                            "top": 1901,
+                                                                                                                                                            "right": 429,
+                                                                                                                                                            "bottom": 1952
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/chevron",
+                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                "isClickable": true,
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1008,
+                                                                                                                                                    "top": 1912,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 1952
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1952,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2033
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 1952,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2033
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/top_vertical_line",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 71,
+                                                                                                                                                    "top": 1952,
+                                                                                                                                                    "right": 73,
+                                                                                                                                                    "bottom": 1979
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/work_unit_image",
+                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 45,
+                                                                                                                                                    "top": 1979,
+                                                                                                                                                    "right": 99,
+                                                                                                                                                    "bottom": 2033
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "Customer dropoff",
+                                                                                                                                                "id": "com.doordash.driverapp:id/display_name",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 126,
+                                                                                                                                                    "top": 1985,
+                                                                                                                                                    "right": 424,
+                                                                                                                                                    "bottom": 2027
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/display_name_secondary",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 433,
+                                                                                                                                                    "top": 1985,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2027
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 2033,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2073
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 2069,
+                                                                                                                                            "right": 1044,
+                                                                                                                                            "bottom": 2073
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 2073,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2151
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 2073,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2151
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/callout_image",
+                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 45,
+                                                                                                                                                    "top": 2091,
+                                                                                                                                                    "right": 99,
+                                                                                                                                                    "bottom": 2145
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "Items can be added before checkout",
+                                                                                                                                                "id": "com.doordash.driverapp:id/callout_text",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 117,
+                                                                                                                                                    "top": 2091,
+                                                                                                                                                    "right": 1035,
+                                                                                                                                                    "bottom": 2151
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/prism_sheet_footer_divider",
+                                                                        "class": "android.view.View",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 2147,
+                                                                            "right": 1080,
+                                                                            "bottom": 2151
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/prism_sheet_footer_container",
+                                                                        "class": "android.widget.LinearLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 2151,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/accept_decline_footer_container",
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 2151,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2347
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/accept_button",
+                                                                                        "class": "android.widget.Button",
+                                                                                        "isClickable": true,
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 36,
+                                                                                            "top": 2187,
+                                                                                            "right": 1044,
+                                                                                            "bottom": 2311
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "Accept",
+                                                                                                "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 467,
+                                                                                                    "top": 2216,
+                                                                                                    "right": 613,
+                                                                                                    "bottom": 2282
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/textSwitcher_prism_button_end_text",
+                                                                                                "class": "android.widget.TextSwitcher",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 938,
+                                                                                                    "top": 2219,
+                                                                                                    "right": 1008,
+                                                                                                    "bottom": 2279
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "text": "40",
+                                                                                                        "id": "com.doordash.driverapp:id/textView_prism_button_end_text_2",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 956,
+                                                                                                            "top": 2219,
+                                                                                                            "right": 1008,
+                                                                                                            "bottom": 2279
+                                                                                                        }
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/sessions/teardown_ghost_2026_06_28/03_pickup_shopping.json
+++ b/app/src/test/resources/snapshots/sessions/teardown_ghost_2026_06_28/03_pickup_shopping.json
@@ -1,0 +1,1293 @@
+{
+    "captureId": "e466bc47-04b4-4a60-a32c-5584a3012f28",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1782684974843,
+    "platform": "doordash",
+    "ruleId": "doordash.screen.pickup_shopping",
+    "classificationName": "pickup_shopping",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 136,
+                            "right": 1080,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 136,
+                                    "right": 1080,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 136,
+                                            "right": 1080,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/container",
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 136,
+                                                    "right": 1080,
+                                                    "bottom": 2347
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/toolbar_container",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 136
+                                                        }
+                                                    },
+                                                    {
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/fragment",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 136,
+                                                                    "right": 1080,
+                                                                    "bottom": 2347
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.widget.ScrollView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 136,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "class": "android.widget.LinearLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 136,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 136
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/fragmentContainerView_shopDeliver",
+                                                                                "class": "android.widget.FrameLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 136,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2347
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/fragmentContainerView_shopDeliver",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 136,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2347
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.widget.ScrollView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 136,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2347
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/camera_fragment_container_view",
+                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 136,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2347
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/appBarLayout",
+                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 136,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 385
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.doordash.driverapp:id/materialToolbar",
+                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 136,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 278
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.widget.ImageButton",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 144,
+                                                                                                                            "right": 125,
+                                                                                                                            "bottom": 269
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "text": "Shop and Deliver",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 133,
+                                                                                                                            "top": 174,
+                                                                                                                            "right": 482,
+                                                                                                                            "bottom": 240
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "androidx.appcompat.widget.LinearLayoutCompat",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 866,
+                                                                                                                            "top": 144,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 269
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "id": "com.doordash.driverapp:id/item_in_app_chat",
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 866,
+                                                                                                                                    "top": 153,
+                                                                                                                                    "right": 973,
+                                                                                                                                    "bottom": 260
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 866,
+                                                                                                                                            "top": 153,
+                                                                                                                                            "right": 973,
+                                                                                                                                            "bottom": 260
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "desc": "Messages",
+                                                                                                                                                "id": "com.doordash.driverapp:id/in_app_chat_icon",
+                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 893,
+                                                                                                                                                    "top": 180,
+                                                                                                                                                    "right": 946,
+                                                                                                                                                    "bottom": 233
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "desc": "Help",
+                                                                                                                                "id": "com.doordash.driverapp:id/item_self_help",
+                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                "isClickable": true,
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 973,
+                                                                                                                                    "top": 153,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 260
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "id": "com.doordash.driverapp:id/tab_layout",
+                                                                                                                "class": "android.widget.HorizontalScrollView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 278,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 385
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 278,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 385
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "desc": "To shop (22)",
+                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 278,
+                                                                                                                                    "right": 540,
+                                                                                                                                    "bottom": 385
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "text": "To shop (22)",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 155,
+                                                                                                                                            "top": 306,
+                                                                                                                                            "right": 384,
+                                                                                                                                            "bottom": 356
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "desc": "Done (0)",
+                                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                                "isClickable": true,
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 540,
+                                                                                                                                    "top": 278,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 385
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "text": "Done (0)",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 729,
+                                                                                                                                            "top": 302,
+                                                                                                                                            "right": 891,
+                                                                                                                                            "bottom": 360
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/shopping_tab_container",
+                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 385,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2347
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.doordash.driverapp:id/recyclerView_stickyHeaders",
+                                                                                                                "class": "androidx.recyclerview.widget.RecyclerView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 385,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 482
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 385,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 482
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 385,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 482
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 385,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 482
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Save time! Find an employee for help right away",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 27,
+                                                                                                                                                    "top": 412,
+                                                                                                                                                    "right": 1053,
+                                                                                                                                                    "bottom": 455
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "id": "com.doordash.driverapp:id/shopping_tooltip",
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 540,
+                                                                                                                    "top": 385,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 387
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "id": "com.doordash.driverapp:id/view_pager",
+                                                                                                                "class": "androidx.viewpager.widget.ViewPager",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 482,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2347
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "androidx.recyclerview.widget.RecyclerView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 482,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2347
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 482,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2347
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 482,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2347
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/recycler_view",
+                                                                                                                                                "class": "androidx.recyclerview.widget.RecyclerView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 0,
+                                                                                                                                                    "top": 482,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2347
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 482,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 881
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": 0,
+                                                                                                                                                                    "top": 482,
+                                                                                                                                                                    "right": 1080,
+                                                                                                                                                                    "bottom": 881
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.doordash.driverapp:id/container_item_details",
+                                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": 36,
+                                                                                                                                                                            "top": 482,
+                                                                                                                                                                            "right": 1044,
+                                                                                                                                                                            "bottom": 881
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.doordash.driverapp:id/view_topBorder",
+                                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": -177,
+                                                                                                                                                                                    "top": 403,
+                                                                                                                                                                                    "right": 830,
+                                                                                                                                                                                    "bottom": 482
+                                                                                                                                                                                }
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.doordash.driverapp:id/view_leftBorder",
+                                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": -177,
+                                                                                                                                                                                    "top": 482,
+                                                                                                                                                                                    "right": -175,
+                                                                                                                                                                                    "bottom": 863
+                                                                                                                                                                                }
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.doordash.driverapp:id/compose_itemDetails",
+                                                                                                                                                                                "class": "androidx.compose.ui.platform.ComposeView",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": -175,
+                                                                                                                                                                                    "top": 482,
+                                                                                                                                                                                    "right": 828,
+                                                                                                                                                                                    "bottom": 863
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.view.View",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": -175,
+                                                                                                                                                                                            "top": 403,
+                                                                                                                                                                                            "right": 828,
+                                                                                                                                                                                            "bottom": 863
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": -175,
+                                                                                                                                                                                                    "top": 403,
+                                                                                                                                                                                                    "right": 828,
+                                                                                                                                                                                                    "bottom": 863
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "item_image",
+                                                                                                                                                                                                        "class": "android.view.View",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": -139,
+                                                                                                                                                                                                            "top": 439,
+                                                                                                                                                                                                            "right": 127,
+                                                                                                                                                                                                            "bottom": 706
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": -139,
+                                                                                                                                                                                                                    "top": 439,
+                                                                                                                                                                                                                    "right": 127,
+                                                                                                                                                                                                                    "bottom": 706
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    },
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "text": "Meal Simple by H-E-B Lemon Pepper Salmon, Wild Rice & Broccoli, 12.5 oz",
+                                                                                                                                                                                                        "id": "item_name",
+                                                                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 163,
+                                                                                                                                                                                                            "top": 439,
+                                                                                                                                                                                                            "right": 801,
+                                                                                                                                                                                                            "bottom": 616
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    },
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "text": "$8.40",
+                                                                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 163,
+                                                                                                                                                                                                            "top": 634,
+                                                                                                                                                                                                            "right": 260,
+                                                                                                                                                                                                            "bottom": 677
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    },
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "class": "android.view.View",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 161,
+                                                                                                                                                                                                            "top": 708,
+                                                                                                                                                                                                            "right": 268,
+                                                                                                                                                                                                            "bottom": 814
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "class": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 193,
+                                                                                                                                                                                                                    "top": 731,
+                                                                                                                                                                                                                    "right": 242,
+                                                                                                                                                                                                                    "bottom": 791
+                                                                                                                                                                                                                },
+                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                        "text": "1 ×",
+                                                                                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                            "left": 193,
+                                                                                                                                                                                                                            "top": 731,
+                                                                                                                                                                                                                            "right": 242,
+                                                                                                                                                                                                                            "bottom": 791
+                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                ]
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.doordash.driverapp:id/view_rightBorder",
+                                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 831,
+                                                                                                                                                                                    "top": 482,
+                                                                                                                                                                                    "right": 833,
+                                                                                                                                                                                    "bottom": 863
+                                                                                                                                                                                }
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.doordash.driverapp:id/view_bottomBorder",
+                                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": -174,
+                                                                                                                                                                                    "top": 863,
+                                                                                                                                                                                    "right": 833,
+                                                                                                                                                                                    "bottom": 881
+                                                                                                                                                                                }
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 881,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 1069
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": -210,
+                                                                                                                                                                    "top": 881,
+                                                                                                                                                                    "right": 869,
+                                                                                                                                                                    "bottom": 1069
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.view.View",
+                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": -174,
+                                                                                                                                                                            "top": 917,
+                                                                                                                                                                            "right": 833,
+                                                                                                                                                                            "bottom": 1033
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "text": "On the Right Edge of Meal Simple - Section A4 - Shelf 1",
+                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": -174,
+                                                                                                                                                                                    "top": 917,
+                                                                                                                                                                                    "right": 833,
+                                                                                                                                                                                    "bottom": 1033
+                                                                                                                                                                                }
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 1069,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 1565
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": -210,
+                                                                                                                                                                    "top": 1069,
+                                                                                                                                                                    "right": 869,
+                                                                                                                                                                    "bottom": 1565
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.doordash.driverapp:id/container_item_details",
+                                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": -174,
+                                                                                                                                                                            "top": 1069,
+                                                                                                                                                                            "right": 833,
+                                                                                                                                                                            "bottom": 1565
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.doordash.driverapp:id/view_topBorder",
+                                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": -174,
+                                                                                                                                                                                    "top": 1069,
+                                                                                                                                                                                    "right": 833,
+                                                                                                                                                                                    "bottom": 1087
+                                                                                                                                                                                }
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.doordash.driverapp:id/view_leftBorder",
+                                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": -174,
+                                                                                                                                                                                    "top": 1087,
+                                                                                                                                                                                    "right": -172,
+                                                                                                                                                                                    "bottom": 1547
+                                                                                                                                                                                }
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.doordash.driverapp:id/compose_itemDetails",
+                                                                                                                                                                                "class": "androidx.compose.ui.platform.ComposeView",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": -172,
+                                                                                                                                                                                    "top": 1087,
+                                                                                                                                                                                    "right": 831,
+                                                                                                                                                                                    "bottom": 1547
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.view.View",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": -172,
+                                                                                                                                                                                            "top": 1087,
+                                                                                                                                                                                            "right": 831,
+                                                                                                                                                                                            "bottom": 1547
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": -172,
+                                                                                                                                                                                                    "top": 1087,
+                                                                                                                                                                                                    "right": 831,
+                                                                                                                                                                                                    "bottom": 1547
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "item_image",
+                                                                                                                                                                                                        "class": "android.view.View",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": -136,
+                                                                                                                                                                                                            "top": 1123,
+                                                                                                                                                                                                            "right": 130,
+                                                                                                                                                                                                            "bottom": 1390
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": -136,
+                                                                                                                                                                                                                    "top": 1123,
+                                                                                                                                                                                                                    "right": 130,
+                                                                                                                                                                                                                    "bottom": 1390
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    },
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "text": "Meal Simple by H-E-B Crab-Stuffed Atlantic Salmon & Asparagus, 11 oz",
+                                                                                                                                                                                                        "id": "item_name",
+                                                                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 166,
+                                                                                                                                                                                                            "top": 1123,
+                                                                                                                                                                                                            "right": 804,
+                                                                                                                                                                                                            "bottom": 1300
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    },
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "text": "$9.45",
+                                                                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 166,
+                                                                                                                                                                                                            "top": 1318,
+                                                                                                                                                                                                            "right": 259,
+                                                                                                                                                                                                            "bottom": 1361
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    },
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "class": "android.view.View",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 164,
+                                                                                                                                                                                                            "top": 1392,
+                                                                                                                                                                                                            "right": 271,
+                                                                                                                                                                                                            "bottom": 1498
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "class": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 193,
+                                                                                                                                                                                                                    "top": 1415,
+                                                                                                                                                                                                                    "right": 242,
+                                                                                                                                                                                                                    "bottom": 1475
+                                                                                                                                                                                                                },
+                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                        "text": "1 ×",
+                                                                                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                            "left": 193,
+                                                                                                                                                                                                                            "top": 1415,
+                                                                                                                                                                                                                            "right": 242,
+                                                                                                                                                                                                                            "bottom": 1475
+                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                ]
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.doordash.driverapp:id/view_rightBorder",
+                                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 831,
+                                                                                                                                                                                    "top": 1087,
+                                                                                                                                                                                    "right": 833,
+                                                                                                                                                                                    "bottom": 1547
+                                                                                                                                                                                }
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.doordash.driverapp:id/view_bottomBorder",
+                                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": -174,
+                                                                                                                                                                                    "top": 1547,
+                                                                                                                                                                                    "right": 833,
+                                                                                                                                                                                    "bottom": 1565
+                                                                                                                                                                                }
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 1565,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 1753
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": -210,
+                                                                                                                                                                    "top": 1565,
+                                                                                                                                                                    "right": 869,
+                                                                                                                                                                    "bottom": 1753
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.view.View",
+                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": -174,
+                                                                                                                                                                            "top": 1601,
+                                                                                                                                                                            "right": 833,
+                                                                                                                                                                            "bottom": 1717
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "text": "On the Right Edge of Meal Simple - Section A7 - Shelf 2",
+                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": -174,
+                                                                                                                                                                                    "top": 1601,
+                                                                                                                                                                                    "right": 833,
+                                                                                                                                                                                    "bottom": 1717
+                                                                                                                                                                                }
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 1753,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2193
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": -210,
+                                                                                                                                                                    "top": 1753,
+                                                                                                                                                                    "right": 869,
+                                                                                                                                                                    "bottom": 2193
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "id": "com.doordash.driverapp:id/container_item_details",
+                                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": -174,
+                                                                                                                                                                            "top": 1753,
+                                                                                                                                                                            "right": 833,
+                                                                                                                                                                            "bottom": 2193
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.doordash.driverapp:id/view_topBorder",
+                                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": -174,
+                                                                                                                                                                                    "top": 1753,
+                                                                                                                                                                                    "right": 833,
+                                                                                                                                                                                    "bottom": 1771
+                                                                                                                                                                                }
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.doordash.driverapp:id/view_leftBorder",
+                                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": -174,
+                                                                                                                                                                                    "top": 1771,
+                                                                                                                                                                                    "right": -172,
+                                                                                                                                                                                    "bottom": 2175
+                                                                                                                                                                                }
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.doordash.driverapp:id/compose_itemDetails",
+                                                                                                                                                                                "class": "androidx.compose.ui.platform.ComposeView",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": -172,
+                                                                                                                                                                                    "top": 1771,
+                                                                                                                                                                                    "right": 831,
+                                                                                                                                                                                    "bottom": 2175
+                                                                                                                                                                                },
+                                                                                                                                                                                "children": [
+                                                                                                                                                                                    {
+                                                                                                                                                                                        "class": "android.view.View",
+                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                            "left": -172,
+                                                                                                                                                                                            "top": 1771,
+                                                                                                                                                                                            "right": 831,
+                                                                                                                                                                                            "bottom": 2175
+                                                                                                                                                                                        },
+                                                                                                                                                                                        "children": [
+                                                                                                                                                                                            {
+                                                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                                                "isClickable": true,
+                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                    "left": -172,
+                                                                                                                                                                                                    "top": 1771,
+                                                                                                                                                                                                    "right": 831,
+                                                                                                                                                                                                    "bottom": 2175
+                                                                                                                                                                                                },
+                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "id": "item_image",
+                                                                                                                                                                                                        "class": "android.view.View",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": -136,
+                                                                                                                                                                                                            "top": 1807,
+                                                                                                                                                                                                            "right": 130,
+                                                                                                                                                                                                            "bottom": 2074
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": -136,
+                                                                                                                                                                                                                    "top": 1807,
+                                                                                                                                                                                                                    "right": 130,
+                                                                                                                                                                                                                    "bottom": 2074
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    },
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "text": "Meal Simple by H-E-B Shrimp Scampi & Fettuccine",
+                                                                                                                                                                                                        "id": "item_name",
+                                                                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 166,
+                                                                                                                                                                                                            "top": 1807,
+                                                                                                                                                                                                            "right": 804,
+                                                                                                                                                                                                            "bottom": 1928
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    },
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "text": "$8.89/lb",
+                                                                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 166,
+                                                                                                                                                                                                            "top": 1946,
+                                                                                                                                                                                                            "right": 306,
+                                                                                                                                                                                                            "bottom": 1989
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                    },
+                                                                                                                                                                                                    {
+                                                                                                                                                                                                        "class": "android.view.View",
+                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                            "left": 166,
+                                                                                                                                                                                                            "top": 2020,
+                                                                                                                                                                                                            "right": 391,
+                                                                                                                                                                                                            "bottom": 2126
+                                                                                                                                                                                                        },
+                                                                                                                                                                                                        "children": [
+                                                                                                                                                                                                            {
+                                                                                                                                                                                                                "class": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+                                                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                                                    "left": 193,
+                                                                                                                                                                                                                    "top": 2043,
+                                                                                                                                                                                                                    "right": 364,
+                                                                                                                                                                                                                    "bottom": 2103
+                                                                                                                                                                                                                },
+                                                                                                                                                                                                                "children": [
+                                                                                                                                                                                                                    {
+                                                                                                                                                                                                                        "text": "2 × Items",
+                                                                                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                                                                        "bounds": {
+                                                                                                                                                                                                                            "left": 193,
+                                                                                                                                                                                                                            "top": 2043,
+                                                                                                                                                                                                                            "right": 364,
+                                                                                                                                                                                                                            "bottom": 2103
+                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                ]
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                        ]
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                ]
+                                                                                                                                                                                            }
+                                                                                                                                                                                        ]
+                                                                                                                                                                                    }
+                                                                                                                                                                                ]
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.doordash.driverapp:id/view_rightBorder",
+                                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": 831,
+                                                                                                                                                                                    "top": 1771,
+                                                                                                                                                                                    "right": 833,
+                                                                                                                                                                                    "bottom": 2175
+                                                                                                                                                                                }
+                                                                                                                                                                            },
+                                                                                                                                                                            {
+                                                                                                                                                                                "id": "com.doordash.driverapp:id/view_bottomBorder",
+                                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": -174,
+                                                                                                                                                                                    "top": 2175,
+                                                                                                                                                                                    "right": 833,
+                                                                                                                                                                                    "bottom": 2193
+                                                                                                                                                                                }
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 0,
+                                                                                                                                                            "top": 2193,
+                                                                                                                                                            "right": 1080,
+                                                                                                                                                            "bottom": 2347
+                                                                                                                                                        },
+                                                                                                                                                        "children": [
+                                                                                                                                                            {
+                                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                "bounds": {
+                                                                                                                                                                    "left": -210,
+                                                                                                                                                                    "top": 2193,
+                                                                                                                                                                    "right": 869,
+                                                                                                                                                                    "bottom": 2381
+                                                                                                                                                                },
+                                                                                                                                                                "children": [
+                                                                                                                                                                    {
+                                                                                                                                                                        "class": "android.view.View",
+                                                                                                                                                                        "isClickable": true,
+                                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                                        "bounds": {
+                                                                                                                                                                            "left": -174,
+                                                                                                                                                                            "top": 2229,
+                                                                                                                                                                            "right": 833,
+                                                                                                                                                                            "bottom": 2345
+                                                                                                                                                                        },
+                                                                                                                                                                        "children": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "text": "On the Left Edge of Meal Simple - Section B5 - Shelf 1",
+                                                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                                                "isEnabled": true,
+                                                                                                                                                                                "bounds": {
+                                                                                                                                                                                    "left": -174,
+                                                                                                                                                                                    "top": 2229,
+                                                                                                                                                                                    "right": 833,
+                                                                                                                                                                                    "bottom": 2345
+                                                                                                                                                                                }
+                                                                                                                                                                            }
+                                                                                                                                                                        ]
+                                                                                                                                                                    }
+                                                                                                                                                                ]
+                                                                                                                                                            }
+                                                                                                                                                        ]
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "id": "com.doordash.driverapp:id/image_view_divider",
+                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 1058,
+                                                                                                                    "top": 2347,
+                                                                                                                    "right": 1062,
+                                                                                                                    "bottom": 2347
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/sessions/teardown_ghost_2026_06_28/04_teardown_ghost.json
+++ b/app/src/test/resources/snapshots/sessions/teardown_ghost_2026_06_28/04_teardown_ghost.json
@@ -1,0 +1,853 @@
+{
+    "captureId": "c32e2cec-09ce-480a-87f2-f7d332dc8bb1",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1782684995459,
+    "platform": "doordash",
+    "ruleId": "doordash.screen.offer_popup",
+    "classificationName": "offer_popup",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 136,
+                            "right": 1080,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 136,
+                                    "right": 1080,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 136,
+                                            "right": 1080,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 136,
+                                                    "right": 1080,
+                                                    "bottom": 2347
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/accept_decline_fragment_container",
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/bottomSheetLayout",
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 136,
+                                                                    "right": 1080,
+                                                                    "bottom": 2347
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/accept_constraint_layout",
+                                                                        "class": "android.view.ViewGroup",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 136,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/map_container",
+                                                                                "class": "android.widget.FrameLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 136,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2347
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 136,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2347
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.view.TextureView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 136,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2347
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 136,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2347
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 5,
+                                                                                                    "top": 1282,
+                                                                                                    "right": 194,
+                                                                                                    "bottom": 1329
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isClickable": true,
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 200,
+                                                                                                    "top": 1282,
+                                                                                                    "right": 247,
+                                                                                                    "bottom": 1329
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/secondary_action_button_dash_plus",
+                                                                                "class": "android.widget.Button",
+                                                                                "isClickable": true,
+                                                                                "bounds": {
+                                                                                    "left": 816,
+                                                                                    "top": 172,
+                                                                                    "right": 1044,
+                                                                                    "bottom": 297
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "text": "Decline",
+                                                                                        "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "bounds": {
+                                                                                            "left": 852,
+                                                                                            "top": 202,
+                                                                                            "right": 1008,
+                                                                                            "bottom": 268
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "text": "3dc9aca0-4d8a-4ed8-a028-1cd32e355307",
+                                                                                "id": "com.doordash.driverapp:id/assignment_id_text",
+                                                                                "class": "android.widget.TextView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 700,
+                                                                                    "top": 1288,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 1329
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/load_progress",
+                                                                        "class": "android.widget.RelativeLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 136,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "state": "in progress",
+                                                                                "id": "com.doordash.driverapp:id/progress_bar",
+                                                                                "class": "android.widget.ProgressBar",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 486,
+                                                                                    "top": 1188,
+                                                                                    "right": 593,
+                                                                                    "bottom": 1295
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/progress_message",
+                                                                                "class": "android.widget.TextView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 540,
+                                                                                    "top": 1295,
+                                                                                    "right": 540,
+                                                                                    "bottom": 1342
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/prism_sheet",
+                                                                        "class": "android.view.ViewGroup",
+                                                                        "isClickable": true,
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 1329,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/prism_sheet_collar_view",
+                                                                                "class": "android.widget.FrameLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 1329,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 1526
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/collar_background",
+                                                                                        "class": "android.widget.LinearLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 1329,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 1526
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/custom_view_container",
+                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 1329,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 1508
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/animated_collar_view_container",
+                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 1329,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 1508
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.doordash.driverapp:id/animated_collar_view_icon",
+                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 36,
+                                                                                                                    "top": 1365,
+                                                                                                                    "right": 143,
+                                                                                                                    "bottom": 1472
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "id": "com.doordash.driverapp:id/layout_textContainer",
+                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 161,
+                                                                                                                    "top": 1367,
+                                                                                                                    "right": 1044,
+                                                                                                                    "bottom": 1470
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "You're getting paid more as a Pro",
+                                                                                                                        "id": "com.doordash.driverapp:id/animated_collar_view_title",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 161,
+                                                                                                                            "top": 1367,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 1419
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "text": "High paying offer",
+                                                                                                                        "id": "com.doordash.driverapp:id/animated_collar_view_body",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 161,
+                                                                                                                            "top": 1423,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 1470
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/handle_overlay",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 1499,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 1526
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/extra_space",
+                                                                                "class": "android.view.View",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 1526,
+                                                                                    "right": 0,
+                                                                                    "bottom": 1562
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/prism_sheet_content_parent_container",
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 1562,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2311
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/nested_scroll_view",
+                                                                                        "class": "android.widget.ScrollView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 1562,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2311
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/prism_content_container",
+                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 1562,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2151
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/bottomsheet_content_container",
+                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 1562,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2151
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.doordash.driverapp:id/accept_decline_recycler_view_container",
+                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 1562,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2151
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "id": "com.doordash.driverapp:id/items_recycler_view",
+                                                                                                                        "class": "androidx.recyclerview.widget.RecyclerView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 1562,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2151
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1562,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 1563
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1563,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 1647
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 1563,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 1647
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "$22.76  Guaranteed (incl. tips)",
+                                                                                                                                                "id": "com.doordash.driverapp:id/text_field",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 1563,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 1647
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1647,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 1712
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 1647,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 1712
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "9.0 mi",
+                                                                                                                                                "id": "com.doordash.driverapp:id/text_field",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 1647,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 1712
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1712,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 1768
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 1712,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 1768
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Deliver by 6:00 PM",
+                                                                                                                                                "id": "com.doordash.driverapp:id/text_field",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 1712,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 1768
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1768,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 1808
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 1804,
+                                                                                                                                            "right": 1044,
+                                                                                                                                            "bottom": 1808
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1952,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2033
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 1952,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2033
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/top_vertical_line",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 71,
+                                                                                                                                                    "top": 1952,
+                                                                                                                                                    "right": 73,
+                                                                                                                                                    "bottom": 1979
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/work_unit_image",
+                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 45,
+                                                                                                                                                    "top": 1979,
+                                                                                                                                                    "right": 99,
+                                                                                                                                                    "bottom": 2033
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "Customer dropoff",
+                                                                                                                                                "id": "com.doordash.driverapp:id/display_name",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 126,
+                                                                                                                                                    "top": 1985,
+                                                                                                                                                    "right": 424,
+                                                                                                                                                    "bottom": 2027
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/display_name_secondary",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 433,
+                                                                                                                                                    "top": 1985,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2027
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 2033,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2073
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 2069,
+                                                                                                                                            "right": 1044,
+                                                                                                                                            "bottom": 2073
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 2073,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2151
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 2073,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2151
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/callout_image",
+                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 45,
+                                                                                                                                                    "top": 2091,
+                                                                                                                                                    "right": 99,
+                                                                                                                                                    "bottom": 2145
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "Items can be added before checkout",
+                                                                                                                                                "id": "com.doordash.driverapp:id/callout_text",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 117,
+                                                                                                                                                    "top": 2091,
+                                                                                                                                                    "right": 1035,
+                                                                                                                                                    "bottom": 2151
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/prism_sheet_footer_divider",
+                                                                        "class": "android.view.View",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 2147,
+                                                                            "right": 1080,
+                                                                            "bottom": 2151
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/prism_sheet_footer_container",
+                                                                        "class": "android.widget.LinearLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 2151,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/accept_decline_footer_container",
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 2151,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2347
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/accept_button",
+                                                                                        "class": "android.widget.Button",
+                                                                                        "isClickable": true,
+                                                                                        "bounds": {
+                                                                                            "left": 36,
+                                                                                            "top": 2187,
+                                                                                            "right": 1044,
+                                                                                            "bottom": 2311
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "Accept",
+                                                                                                "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "bounds": {
+                                                                                                    "left": 467,
+                                                                                                    "top": 2216,
+                                                                                                    "right": 613,
+                                                                                                    "bottom": 2282
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/textSwitcher_prism_button_end_text",
+                                                                                                "class": "android.widget.TextSwitcher",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 944,
+                                                                                                    "top": 2219,
+                                                                                                    "right": 1008,
+                                                                                                    "bottom": 2279
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "text": "31",
+                                                                                                        "id": "com.doordash.driverapp:id/textView_prism_button_end_text_1",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "bounds": {
+                                                                                                            "left": 962,
+                                                                                                            "top": 2219,
+                                                                                                            "right": 1001,
+                                                                                                            "bottom": 2279
+                                                                                                        }
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/sessions/teardown_ghost_2026_06_28/05_navigation_generic.json
+++ b/app/src/test/resources/snapshots/sessions/teardown_ghost_2026_06_28/05_navigation_generic.json
@@ -1,0 +1,777 @@
+{
+    "captureId": "8dfb2a16-2f86-46a3-9eaf-a897bf1bedaf",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1782685011964,
+    "platform": "doordash",
+    "ruleId": "doordash.screen.navigation_generic",
+    "classificationName": "navigation_generic",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 136,
+                            "right": 1080,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 136,
+                                    "right": 1080,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 136,
+                                            "right": 1080,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/container",
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 136,
+                                                    "right": 1080,
+                                                    "bottom": 2347
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/toolbar_container",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 136
+                                                        }
+                                                    },
+                                                    {
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/fragment",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 136,
+                                                                    "right": 1080,
+                                                                    "bottom": 2347
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/fragment_navigation_container",
+                                                                        "class": "android.view.ViewGroup",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 136,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "class": "androidx.compose.ui.platform.ComposeView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 136,
+                                                                                    "right": 0,
+                                                                                    "bottom": 136
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 136,
+                                                                                            "right": 0,
+                                                                                            "bottom": 136
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "class": "androidx.compose.ui.platform.ComposeView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 136,
+                                                                                    "right": 0,
+                                                                                    "bottom": 136
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 136,
+                                                                                            "right": 0,
+                                                                                            "bottom": 136
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/navigationView",
+                                                                                "class": "android.widget.FrameLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 136,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2347
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/mapViewLayout",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 136,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2347
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 136,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2347
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.widget.ImageView",
+                                                                                                        "isClickable": true,
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 2300,
+                                                                                                            "right": 46,
+                                                                                                            "bottom": 2347
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "class": "android.view.SurfaceView",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 136,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2347
+                                                                                                        }
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/coordinatorLayout",
+                                                                                        "class": "android.view.ViewGroup",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 136,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2347
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/container",
+                                                                                                "class": "android.view.ViewGroup",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 136,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2347
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/guidanceLayout",
+                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 136,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 403
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.doordash.driverapp:id/maneuverView",
+                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                "isClickable": true,
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 136,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 403
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 9,
+                                                                                                                            "top": 145,
+                                                                                                                            "right": 1071,
+                                                                                                                            "bottom": 394
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "id": "com.doordash.driverapp:id/maneuver",
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 9,
+                                                                                                                                    "top": 145,
+                                                                                                                                    "right": 1071,
+                                                                                                                                    "bottom": 394
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 9,
+                                                                                                                                            "top": 145,
+                                                                                                                                            "right": 1071,
+                                                                                                                                            "bottom": 394
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/mainManeuverLayout",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 9,
+                                                                                                                                                    "top": 145,
+                                                                                                                                                    "right": 1071,
+                                                                                                                                                    "bottom": 394
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.doordash.driverapp:id/maneuverIcon",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 74,
+                                                                                                                                                            "top": 181,
+                                                                                                                                                            "right": 181,
+                                                                                                                                                            "bottom": 288
+                                                                                                                                                        }
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "text": "50 ft",
+                                                                                                                                                        "id": "com.doordash.driverapp:id/stepDistance",
+                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 18,
+                                                                                                                                                            "top": 288,
+                                                                                                                                                            "right": 237,
+                                                                                                                                                            "bottom": 376
+                                                                                                                                                        }
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "text": "Turn right ",
+                                                                                                                                                        "id": "com.doordash.driverapp:id/primaryManeuverText",
+                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 237,
+                                                                                                                                                            "top": 223,
+                                                                                                                                                            "right": 1062,
+                                                                                                                                                            "bottom": 317
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/scalebarLayout",
+                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 403,
+                                                                                                            "right": 0,
+                                                                                                            "bottom": 403
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/speedLimitLayout",
+                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 18,
+                                                                                                            "top": 421,
+                                                                                                            "right": 185,
+                                                                                                            "bottom": 604
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.doordash.driverapp:id/speedInfoView",
+                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                "isClickable": true,
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 18,
+                                                                                                                    "top": 421,
+                                                                                                                    "right": 168,
+                                                                                                                    "bottom": 604
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "id": "com.doordash.driverapp:id/speedInfoMutcdLayout",
+                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 18,
+                                                                                                                            "top": 421,
+                                                                                                                            "right": 168,
+                                                                                                                            "bottom": 604
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "id": "com.doordash.driverapp:id/postedSpeedLayoutMutcd",
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 22,
+                                                                                                                                    "top": 425,
+                                                                                                                                    "right": 164,
+                                                                                                                                    "bottom": 600
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "text": "--",
+                                                                                                                                        "id": "com.doordash.driverapp:id/postedSpeedMutcd",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 22,
+                                                                                                                                            "top": 447,
+                                                                                                                                            "right": 164,
+                                                                                                                                            "bottom": 531
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "text": "mph",
+                                                                                                                                        "id": "com.doordash.driverapp:id/postedSpeedUnit",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 22,
+                                                                                                                                            "top": 531,
+                                                                                                                                            "right": 164,
+                                                                                                                                            "bottom": 578
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/actionListLayout",
+                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 893,
+                                                                                                            "top": 414,
+                                                                                                            "right": 1062,
+                                                                                                            "bottom": 801
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.doordash.driverapp:id/buttonContainer",
+                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 947,
+                                                                                                                    "top": 414,
+                                                                                                                    "right": 1062,
+                                                                                                                    "bottom": 801
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "id": "com.doordash.driverapp:id/buttonsContainerTop",
+                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 1062,
+                                                                                                                            "top": 414,
+                                                                                                                            "right": 1062,
+                                                                                                                            "bottom": 414
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "id": "com.doordash.driverapp:id/buttonsContainerCenter",
+                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 947,
+                                                                                                                            "top": 414,
+                                                                                                                            "right": 1062,
+                                                                                                                            "bottom": 672
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "id": "com.doordash.driverapp:id/buttonsContainerCompass",
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 947,
+                                                                                                                                    "top": 414,
+                                                                                                                                    "right": 947,
+                                                                                                                                    "bottom": 414
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "id": "com.doordash.driverapp:id/buttonsContainerCamera",
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 947,
+                                                                                                                                    "top": 414,
+                                                                                                                                    "right": 1062,
+                                                                                                                                    "bottom": 543
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 947,
+                                                                                                                                            "top": 421,
+                                                                                                                                            "right": 1062,
+                                                                                                                                            "bottom": 536
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/container",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 947,
+                                                                                                                                                    "top": 421,
+                                                                                                                                                    "right": 1062,
+                                                                                                                                                    "bottom": 536
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.doordash.driverapp:id/iconImage",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 969,
+                                                                                                                                                            "top": 443,
+                                                                                                                                                            "right": 1040,
+                                                                                                                                                            "bottom": 514
+                                                                                                                                                        }
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.doordash.driverapp:id/buttonText",
+                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 1042,
+                                                                                                                                                            "top": 457,
+                                                                                                                                                            "right": 1060,
+                                                                                                                                                            "bottom": 501
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "id": "com.doordash.driverapp:id/buttonsContainerAudio",
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 947,
+                                                                                                                                    "top": 543,
+                                                                                                                                    "right": 1062,
+                                                                                                                                    "bottom": 672
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 947,
+                                                                                                                                            "top": 550,
+                                                                                                                                            "right": 1062,
+                                                                                                                                            "bottom": 665
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/container",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 947,
+                                                                                                                                                    "top": 550,
+                                                                                                                                                    "right": 1062,
+                                                                                                                                                    "bottom": 665
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.doordash.driverapp:id/iconImage",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 969,
+                                                                                                                                                            "top": 572,
+                                                                                                                                                            "right": 1040,
+                                                                                                                                                            "bottom": 643
+                                                                                                                                                        }
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.doordash.driverapp:id/buttonText",
+                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 1042,
+                                                                                                                                                            "top": 586,
+                                                                                                                                                            "right": 1060,
+                                                                                                                                                            "bottom": 630
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "id": "com.doordash.driverapp:id/buttonsContainerRecenter",
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 947,
+                                                                                                                                    "top": 672,
+                                                                                                                                    "right": 947,
+                                                                                                                                    "bottom": 672
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "id": "com.doordash.driverapp:id/buttonsContainerBottom",
+                                                                                                                        "class": "android.widget.LinearLayout",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 947,
+                                                                                                                            "top": 672,
+                                                                                                                            "right": 1062,
+                                                                                                                            "bottom": 801
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isClickable": true,
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 947,
+                                                                                                                                    "top": 679,
+                                                                                                                                    "right": 1062,
+                                                                                                                                    "bottom": 794
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "id": "com.doordash.driverapp:id/container",
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 947,
+                                                                                                                                            "top": 679,
+                                                                                                                                            "right": 1062,
+                                                                                                                                            "bottom": 794
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/iconImage",
+                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 969,
+                                                                                                                                                    "top": 701,
+                                                                                                                                                    "right": 1040,
+                                                                                                                                                    "bottom": 772
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/buttonText",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 1042,
+                                                                                                                                                    "top": 715,
+                                                                                                                                                    "right": 1060,
+                                                                                                                                                    "bottom": 759
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/emptyLeftContainer",
+                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 18,
+                                                                                                            "top": 1353,
+                                                                                                            "right": 18,
+                                                                                                            "bottom": 1353
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/emptyRightContainer",
+                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 1062,
+                                                                                                            "top": 1442,
+                                                                                                            "right": 1062,
+                                                                                                            "bottom": 1442
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/roadNameLayout",
+                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 540,
+                                                                                                            "top": 2083,
+                                                                                                            "right": 540,
+                                                                                                            "bottom": 2083
+                                                                                                        }
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/infoPanelLayout",
+                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 2116,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2347
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/core/pipeline/src/main/assets/rules/doordash.json
+++ b/core/pipeline/src/main/assets/rules/doordash.json
@@ -379,6 +379,7 @@
             "exists": {
               "all": [
                 { "hasIdSuffix": "display_name" },
+                { "hasTextMatchesRegex": "\\S" },
                 { "not": { "hasText": "Customer dropoff" } },
                 { "not": { "hasText": "Business handoff" } }
               ]

--- a/core/pipeline/src/main/assets/rules/doordash.json
+++ b/core/pipeline/src/main/assets/rules/doordash.json
@@ -327,6 +327,7 @@
       }
     },
     {
+      "comment": "#595: the require block demands at least one STORE leg (the display_name family the orders parse extracts, excluding 'Customer dropoff'/'Business handoff'). DoorDash's post-accept teardown frame (and arrival pre-render) keeps pay/distance/Accept/Decline chrome but drops the store rows — that frame re-parsed as a NEW degenerate offer (orders=[], itemCount=0, different offerHash) which REPLACED the just-accepted one: ghost accept/timeout, 06-28 seq 141/142 + 06-30 seq 241/242. A frame with no store leg is not an actionable offer; it now classifies UNKNOWN and is never forwarded. Verified against all 43 real offer frames on file (28 device + 15 corpus): every real render carries a store leg.",
       "id": "doordash.screen.offer_popup",
       "priority": 20,
       "state": {
@@ -371,6 +372,15 @@
                 {
                   "hasIdSuffix": "accept_decline_footer_container"
                 }
+              ]
+            }
+          },
+          {
+            "exists": {
+              "all": [
+                { "hasIdSuffix": "display_name" },
+                { "not": { "hasText": "Customer dropoff" } },
+                { "not": { "hasText": "Business handoff" } }
               ]
             }
           }

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -89,6 +89,19 @@ was found **broken-in-part** (raw PII in capture envelopes) and moved to that en
   re-armed` DEBUG line fires after any burst, capped or not — it alone doesn't mean the cap was
   hit.
 
+- **🔧 FIX SHIPPED — post-accept teardown frame no longer mints a ghost offer (#595). CONFIRM ON DASH.**
+  The collapsing offer card after an accept (pay/distance/Accept/Decline chrome, no store rows, a
+  raw UUID where the store name goes) re-parsed as a NEW "Unknown Store" offer that REPLACED the
+  real accept — bogus TTS ("Accept. Unknown Store. 56/hr…"), a bogus [Good Offer] chat card, then
+  "Offer Timed Out!" seconds after "Offer Accepted" (both 06-28 + 06-30). The offer rule now
+  requires at least one STORE leg, so the teardown frame is UNKNOWN and never forwarded.
+  **Confirm on dash: 0/2 —** accept a few offers (especially SHOP offers, where both field ghosts
+  fired): right after tapping Accept there should be NO second offer announcement — no "Unknown
+  Store" TTS, no extra [Good Offer] card, no "Offer Timed Out!" right after "Offer Accepted"; the
+  db should show zero orphan OFFER_TIMEOUTs. **Watch for over-rejection:** a REAL offer failing to
+  announce/card (its frame would land in UNKNOWN captures as an offer-looking screen with store
+  rows) — grab the capture if an offer ever silently fails to appear.
+
 - **🔒 FIX SHIPPED — Crimson Savings Jar balance notification is now pledge-BLOCKED (#599). READ THE PULL AFTER A DASH.**
   The dasher's Crimson/DasherDirect balance notification was being recognized and captured raw
   (9 files found on the 06-25→30 pull — deleted from the device). The rule is now sensitive


### PR DESCRIPTION
Closes #595. Both field-week ghosts (06-28 seq 141/142, 06-30 seq 241/242) came from DoorDash's **post-accept teardown render**: pay/distance/Accept/Decline chrome persists, store rows vanish — the frame re-parsed as a NEW degenerate offer that **replaced the just-accepted one** (bogus "Unknown Store" TTS/chat, orphan `OFFER_TIMEOUT`). The #498 guard keys on missing pay; this frame HAS pay.

## Fix
`offer_popup`'s require gains one clause: **at least one STORE leg** must exist — a `display_name` node that isn't `Customer dropoff`/`Business handoff`, exactly the family the `orders` parse extracts. Store-less frame → UNKNOWN → never forwarded (captured for triage only). Grounding: verified against **all 43 real offer frames on file** (28 device + 15 corpus) — every real render carries a store leg; both ghosts fail it. Structural-id discriminators were rejected after testing: `assignment_id_text` (the UUID view) and `load_progress` appear on real frames too.

## Tests
- **`TeardownGhostReplayTest`** — new session `snapshots/sessions/teardown_ghost_2026_06_28` (four unmodified device captures, PII-scanned): Level A: real H-E-B shop offer still parses ($13.04, store H-E-B), ghost → UNKNOWN against the full production ruleset. Level B (`reduceMixed`, synthetic accept click since click envelopes weren't persisted — #597): exactly **1 OFFER_RECEIVED, 1 OFFER_ACCEPTED, 0 OFFER_TIMEOUT**. **Proven red without the rule change, green with it.**
- `TriageRulesTest`: synthetic teardown → null; the navigation-vs-offer fixture gains a store leg.
- `AllMatchersSuite` + full `:app`/`:core:pipeline` green; parse-output golden unchanged.

## Security/privacy posture
Recognition strictly narrows (a degenerate frame is no longer parsed, evaluated, spoken, or stored as an offer). Committed fixtures carry store/product names only (merchant names aren't PII); scanned for customer names/addresses pre-commit.

## Residual risk (field-gated)
If DoorDash ever ships a legitimate offer layout whose store rows don't use `display_name`, the offer would silently go UNKNOWN — the checklist item's over-rejection watch covers exactly that (an offer-shaped UNKNOWN capture with store rows = the signal). Open question from the field log (arrival-time UUID pre-renders) is also covered: those frames lack store rows too and now correctly wait for the full render.

### Design-goal review
5 (SSOT): the require reuses the same node family the orders parse is built on — recognition and parse can't drift apart on what "an order row" is. 6 (privacy): posture above; fixtures scanned. 7: no logging changes. 8 (platform-agnostic): rule JSON only — no platform literals in code, no new vocabulary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)