### PR TITLE
fix(state): #594 — decline-commit latch: a committed decline cannot be overridden by a later Accept click

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
@@ -7,6 +7,7 @@ import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
 import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
 import cloud.trotter.dashbuddy.domain.model.chat.ChatPersona
 import cloud.trotter.dashbuddy.domain.model.event.AppEventType
+import cloud.trotter.dashbuddy.domain.model.event.payload.OfferPayload
 import cloud.trotter.dashbuddy.domain.model.offer.ParsedOffer
 import cloud.trotter.dashbuddy.domain.model.order.OrderType
 import cloud.trotter.dashbuddy.domain.model.order.ParsedOrder
@@ -270,6 +271,61 @@ class EffectMapTest {
 
         val effects = effectMap.diff(prev, next, screenObs(flow = Flow.Idle))
         assertTrue(effects.logEventTypes().contains(AppEventType.OFFER_DECLINED))
+    }
+
+    @Test
+    fun `the decline-commit latch beats a later ACCEPT lastClickIntent (#594)`() {
+        // The dasher committed the decline (confirm sheet) then hit Review offer→Accept: the latch is
+        // set and lastClickIntent is the racing accept. The outcome must still be OFFER_DECLINED — the
+        // latch wins over lastClickIntent — and the payload records the race for forensics.
+        val prev = AppState(regions = Regions(
+            flow = FlowRegion(
+                flow = Flow.OfferPresented,
+                pendingOffer = testPendingOffer.copy(
+                    declineCommittedAt = 900L,
+                    lastClickIntent = "accept_offer",
+                ),
+            ),
+        ))
+        val next = AppState(regions = Regions(flow = FlowRegion(flow = Flow.Idle)))
+
+        val effects = effectMap.diff(prev, next, screenObs(flow = Flow.Idle))
+        assertTrue(
+            "a committed decline resolves DECLINED even when the last click was ACCEPT",
+            effects.logEventTypes().contains(AppEventType.OFFER_DECLINED),
+        )
+        assertFalse(
+            "the racing Accept must not log OFFER_ACCEPTED",
+            effects.logEventTypes().contains(AppEventType.OFFER_ACCEPTED),
+        )
+        val declined = effects.logEvents().first { it.event.type == AppEventType.OFFER_DECLINED }
+        val payload = declined.event.payload as OfferPayload
+        assertTrue(
+            "payload describes the accept-after-decline race",
+            payload.description?.contains("decline stands") == true,
+        )
+    }
+
+    @Test
+    fun `an ACCEPT click after a committed decline shows the race bubble, not Offer Accepted (#594)`() {
+        val prev = AppState(regions = Regions(
+            flow = FlowRegion(
+                flow = Flow.OfferPresented,
+                pendingOffer = testPendingOffer.copy(declineCommittedAt = 900L),
+            ),
+        ))
+        // A click doesn't change flow by itself; the latch survives on the pending offer.
+        val next = prev
+
+        val effects = effectMap.diff(prev, next, clickObs(intent = "accept_offer"))
+        assertTrue(
+            "the accept race is surfaced honestly",
+            effects.any { it is AppEffect.UpdateBubble && it.text == "Decline already submitted — Accept won't take" },
+        )
+        assertFalse(
+            "the contradictory Offer Accepted bubble must not fire",
+            effects.any { it is AppEffect.UpdateBubble && it.text == "Offer Accepted" },
+        )
     }
 
     @Test

--- a/app/src/test/java/cloud/trotter/dashbuddy/replay/DeclineRaceReplayTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/replay/DeclineRaceReplayTest.kt
@@ -1,0 +1,83 @@
+package cloud.trotter.dashbuddy.replay
+
+import cloud.trotter.dashbuddy.domain.model.event.AppEventType
+import cloud.trotter.dashbuddy.domain.model.event.payload.OfferPayload
+import cloud.trotter.dashbuddy.domain.state.OfferIntent
+import cloud.trotter.dashbuddy.test.util.SessionReplay
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * [SessionReplay] regression for the #594 "decline race": on 2026-06-30 16:59 the dasher DECLINED a
+ * Burger King $6.25 offer, confirmed it on the confirm sheet (server-side commit), then — via
+ * DoorDash's "Review offer" affordance — hit Accept ~1.2s later. The machine trusted the last click
+ * and logged `OFFER_ACCEPTED`, contradicting DoorDash's own dash summary (3 accepts, $45.75, no
+ * $6.25; no job/pickup ever formed). The fix: a DECLINE-intent click (which can only come from the
+ * confirm sheet, since the `decline_offer` click rule is screen-scoped there) latches
+ * `PendingOffer.declineCommittedAt`, and `EffectMap.resolveOfferOutcome` checks the latch FIRST —
+ * so a later Accept click can no longer un-decline a committed decline.
+ *
+ * Fixtures: `snapshots/sessions/decline_race_2026_06_30/` — real device captures from the incident
+ * (customer-PII-scanned; the navigation frame's turn-by-turn road names were redacted — it is a
+ * route back to a zone, not a customer address). Click envelopes weren't persisted that week (#597),
+ * so the three clicks (initial decline → confirm commit → the racing accept) are synthetic, injected
+ * while the offer card is up, exactly like the field sequence.
+ *   `01_offer_popup_bk` — the BK $6.25 offer (flow OfferPresented, pushes the pending offer)
+ *   `04_navigation_pop` — the post-decision navigation frame (turn-by-turn branch → flow idle, so
+ *       this is the frame that pops the offer and resolves it DECLINED)
+ *   `05_dash_along_the_way` — repositioning to zone (flow idle) — a redundant idle tail; the offer
+ *       has already popped by here. The assertions are outcome-count based, so they hold whichever
+ *       idle frame does the popping.
+ */
+class DeclineRaceReplayTest {
+
+    private val session = "snapshots/sessions/decline_race_2026_06_30"
+
+    @Test
+    fun `a committed decline stands even when Accept is clicked after it (#594, Level B)`() {
+        val frames = SessionReplay.loadSession(session)
+        val offerFrame = frames.first { it.file.contains("offer_popup") }
+        val t0 = offerFrame.capturedAtMs
+
+        val inputs = listOf(
+            SessionReplay.ScreenInput(offerFrame),
+            // The offer-screen first decline — a separate intent (no OfferIntent constant); must NOT
+            // latch and must fall through as a non-outcome.
+            SessionReplay.syntheticOfferClick("initial_decline", atMs = t0 + 2_000L),
+            // The confirm-sheet commit — this is the server-side decline; it latches the outcome.
+            SessionReplay.syntheticOfferClick(OfferIntent.DECLINE, atMs = t0 + 3_000L),
+            // The "Review offer"→Accept race ~1.2s later — must NOT override the committed decline.
+            SessionReplay.syntheticOfferClick(OfferIntent.ACCEPT, atMs = t0 + 5_000L),
+        ) + frames.filterNot { it.file.contains("offer_popup") }.map { SessionReplay.ScreenInput(it) }
+
+        val steps = SessionReplay.reduceMixed(inputs.sortedBy { it.atMs })
+        println(SessionReplay.trace(steps))
+        val events = steps.flatMap { it.events }
+
+        assertEquals(
+            "exactly one OFFER_RECEIVED (the BK offer)",
+            1, events.count { it.type == AppEventType.OFFER_RECEIVED },
+        )
+        assertEquals(
+            "the committed decline resolves to exactly one OFFER_DECLINED",
+            1, events.count { it.type == AppEventType.OFFER_DECLINED },
+        )
+        assertEquals(
+            "the racing Accept must NOT log OFFER_ACCEPTED (the pre-fix red signal)",
+            0, events.count { it.type == AppEventType.OFFER_ACCEPTED },
+        )
+        assertEquals(
+            "no job/pickup ever formed — the decline stood",
+            0, events.count { it.type.name.startsWith("PICKUP") },
+        )
+
+        // The forensic payload records that Accept came after the decline was committed.
+        val declined = events.first { it.type == AppEventType.OFFER_DECLINED }
+        val description = (declined.payload as OfferPayload).description
+        assertTrue(
+            "the OFFER_DECLINED payload describes the decline race, got: $description",
+            description?.contains("decline", ignoreCase = true) == true,
+        )
+    }
+}

--- a/app/src/test/resources/snapshots/sessions/decline_race_2026_06_30/01_offer_popup_bk.json
+++ b/app/src/test/resources/snapshots/sessions/decline_race_2026_06_30/01_offer_popup_bk.json
@@ -1,0 +1,891 @@
+{
+    "captureId": "bcf997a1-b06b-4d38-93ca-7c1d03b11c85",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1782856755061,
+    "platform": "doordash",
+    "ruleId": "doordash.screen.offer_popup",
+    "classificationName": "offer_popup",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 136,
+                            "right": 1080,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 136,
+                                    "right": 1080,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 136,
+                                            "right": 1080,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 136,
+                                                    "right": 1080,
+                                                    "bottom": 2347
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/accept_decline_fragment_container",
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/bottomSheetLayout",
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 136,
+                                                                    "right": 1080,
+                                                                    "bottom": 2347
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/accept_constraint_layout",
+                                                                        "class": "android.view.ViewGroup",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 136,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/map_container",
+                                                                                "class": "android.widget.FrameLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 136,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2347
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 136,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2347
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.view.TextureView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 136,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2347
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 136,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2347
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 5,
+                                                                                                    "top": 1404,
+                                                                                                    "right": 194,
+                                                                                                    "bottom": 1451
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isClickable": true,
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 200,
+                                                                                                    "top": 1404,
+                                                                                                    "right": 247,
+                                                                                                    "bottom": 1451
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/secondary_action_button_dash_plus",
+                                                                                "class": "android.widget.Button",
+                                                                                "isClickable": true,
+                                                                                "bounds": {
+                                                                                    "left": 816,
+                                                                                    "top": 172,
+                                                                                    "right": 1044,
+                                                                                    "bottom": 297
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "text": "Decline",
+                                                                                        "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "bounds": {
+                                                                                            "left": 852,
+                                                                                            "top": 202,
+                                                                                            "right": 1008,
+                                                                                            "bottom": 268
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "text": "637b8130-7c73-4b7d-957a-456f87f154e4",
+                                                                                "id": "com.doordash.driverapp:id/assignment_id_text",
+                                                                                "class": "android.widget.TextView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 715,
+                                                                                    "top": 1410,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 1451
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/load_progress",
+                                                                        "class": "android.widget.RelativeLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 136,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "state": "in progress",
+                                                                                "id": "com.doordash.driverapp:id/progress_bar",
+                                                                                "class": "android.widget.ProgressBar",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 486,
+                                                                                    "top": 1188,
+                                                                                    "right": 593,
+                                                                                    "bottom": 1295
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/progress_message",
+                                                                                "class": "android.widget.TextView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 540,
+                                                                                    "top": 1295,
+                                                                                    "right": 540,
+                                                                                    "bottom": 1342
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/prism_sheet",
+                                                                        "class": "android.view.ViewGroup",
+                                                                        "isClickable": true,
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 1451,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/prism_sheet_collar_view",
+                                                                                "class": "android.widget.FrameLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 1451,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 1644
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/collar_background",
+                                                                                        "class": "android.widget.LinearLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 1451,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 1644
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/custom_view_container",
+                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 1451,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 1626
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/animated_collar_view_container",
+                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 1451,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 1626
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.doordash.driverapp:id/animated_collar_view_icon",
+                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 36,
+                                                                                                                    "top": 1503,
+                                                                                                                    "right": 107,
+                                                                                                                    "bottom": 1574
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "id": "com.doordash.driverapp:id/layout_textContainer",
+                                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 125,
+                                                                                                                    "top": 1487,
+                                                                                                                    "right": 1044,
+                                                                                                                    "bottom": 1590
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "text": "High paying offer!",
+                                                                                                                        "id": "com.doordash.driverapp:id/animated_collar_view_title",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 125,
+                                                                                                                            "top": 1487,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 1539
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "text": "Your Silver status gave you priority for this offer.",
+                                                                                                                        "id": "com.doordash.driverapp:id/animated_collar_view_body",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 125,
+                                                                                                                            "top": 1543,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 1590
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/handle_overlay",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 1617,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 1644
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/extra_space",
+                                                                                "class": "android.view.View",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 1644,
+                                                                                    "right": 0,
+                                                                                    "bottom": 1680
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/prism_sheet_content_parent_container",
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 1680,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2311
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/nested_scroll_view",
+                                                                                        "class": "android.widget.ScrollView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 1680,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2311
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/prism_content_container",
+                                                                                                "class": "android.widget.LinearLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 1680,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2151
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "id": "com.doordash.driverapp:id/bottomsheet_content_container",
+                                                                                                        "class": "android.widget.FrameLayout",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 1680,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2151
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "id": "com.doordash.driverapp:id/accept_decline_recycler_view_container",
+                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 1680,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2151
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "id": "com.doordash.driverapp:id/items_recycler_view",
+                                                                                                                        "class": "androidx.recyclerview.widget.RecyclerView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 1680,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2151
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1680,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 1681
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1681,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 1765
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 1681,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 1765
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "$6.25+  Total will be higher",
+                                                                                                                                                "id": "com.doordash.driverapp:id/text_field",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 1681,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 1765
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1765,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 1830
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 1765,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 1830
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "1.9 mi",
+                                                                                                                                                "id": "com.doordash.driverapp:id/text_field",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 1765,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 1830
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1830,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 1886
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 1830,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 1886
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Deliver by 5:13 PM",
+                                                                                                                                                "id": "com.doordash.driverapp:id/text_field",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 1830,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 1886
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1886,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 1926
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 1922,
+                                                                                                                                            "right": 1044,
+                                                                                                                                            "bottom": 1926
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 1926,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2070
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 1926,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2070
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/work_unit_icon_container",
+                                                                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 45,
+                                                                                                                                                    "top": 1953,
+                                                                                                                                                    "right": 99,
+                                                                                                                                                    "bottom": 2007
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.doordash.driverapp:id/work_unit_image",
+                                                                                                                                                        "class": "android.widget.ImageView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 45,
+                                                                                                                                                            "top": 1953,
+                                                                                                                                                            "right": 99,
+                                                                                                                                                            "bottom": 2007
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "Pickup",
+                                                                                                                                                "id": "com.doordash.driverapp:id/work_unit_type",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 126,
+                                                                                                                                                    "top": 1959,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2001
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/bottom_vertical_line",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 71,
+                                                                                                                                                    "top": 2007,
+                                                                                                                                                    "right": 73,
+                                                                                                                                                    "bottom": 2070
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/display_name_container",
+                                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 126,
+                                                                                                                                                    "top": 2019,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 2070
+                                                                                                                                                },
+                                                                                                                                                "children": [
+                                                                                                                                                    {
+                                                                                                                                                        "text": "Burger King",
+                                                                                                                                                        "id": "com.doordash.driverapp:id/display_name",
+                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 126,
+                                                                                                                                                            "top": 2019,
+                                                                                                                                                            "right": 383,
+                                                                                                                                                            "bottom": 2070
+                                                                                                                                                        }
+                                                                                                                                                    },
+                                                                                                                                                    {
+                                                                                                                                                        "id": "com.doordash.driverapp:id/display_name_secondary",
+                                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                                        "isEnabled": true,
+                                                                                                                                                        "bounds": {
+                                                                                                                                                            "left": 383,
+                                                                                                                                                            "top": 2019,
+                                                                                                                                                            "right": 383,
+                                                                                                                                                            "bottom": 2070
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                ]
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.ViewGroup",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 0,
+                                                                                                                                    "top": 2070,
+                                                                                                                                    "right": 1080,
+                                                                                                                                    "bottom": 2151
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.ViewGroup",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 0,
+                                                                                                                                            "top": 2070,
+                                                                                                                                            "right": 1080,
+                                                                                                                                            "bottom": 2151
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/top_vertical_line",
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 71,
+                                                                                                                                                    "top": 2070,
+                                                                                                                                                    "right": 73,
+                                                                                                                                                    "bottom": 2097
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/work_unit_image",
+                                                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 45,
+                                                                                                                                                    "top": 2097,
+                                                                                                                                                    "right": 99,
+                                                                                                                                                    "bottom": 2151
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "Customer dropoff",
+                                                                                                                                                "id": "com.doordash.driverapp:id/display_name",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 126,
+                                                                                                                                                    "top": 2103,
+                                                                                                                                                    "right": 424,
+                                                                                                                                                    "bottom": 2145
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "id": "com.doordash.driverapp:id/display_name_secondary",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 433,
+                                                                                                                                                    "top": 2103,
+                                                                                                                                                    "right": 1080,
+                                                                                                                                                    "bottom": 2145
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/prism_sheet_footer_divider",
+                                                                        "class": "android.view.View",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 2147,
+                                                                            "right": 1080,
+                                                                            "bottom": 2151
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/prism_sheet_footer_container",
+                                                                        "class": "android.widget.LinearLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 2151,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/accept_decline_footer_container",
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 2151,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2347
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/accept_button",
+                                                                                        "class": "android.widget.Button",
+                                                                                        "isClickable": true,
+                                                                                        "bounds": {
+                                                                                            "left": 36,
+                                                                                            "top": 2187,
+                                                                                            "right": 1044,
+                                                                                            "bottom": 2311
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "Accept",
+                                                                                                "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "bounds": {
+                                                                                                    "left": 467,
+                                                                                                    "top": 2216,
+                                                                                                    "right": 613,
+                                                                                                    "bottom": 2282
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/textSwitcher_prism_button_end_text",
+                                                                                                "class": "android.widget.TextSwitcher",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 943,
+                                                                                                    "top": 2219,
+                                                                                                    "right": 1008,
+                                                                                                    "bottom": 2279
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "text": "34",
+                                                                                                        "id": "com.doordash.driverapp:id/textView_prism_button_end_text_2",
+                                                                                                        "class": "android.widget.TextView",
+                                                                                                        "bounds": {
+                                                                                                            "left": 961,
+                                                                                                            "top": 2219,
+                                                                                                            "right": 1008,
+                                                                                                            "bottom": 2279
+                                                                                                        }
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/sessions/decline_race_2026_06_30/04_navigation_pop.json
+++ b/app/src/test/resources/snapshots/sessions/decline_race_2026_06_30/04_navigation_pop.json
@@ -1,0 +1,1167 @@
+{
+  "captureId": "187ebaea-f0ea-47bd-a780-792fc4ce8bf8",
+  "pipelineId": "accessibility.window",
+  "schemaId": "uinode.v1",
+  "timestamp": 1782856764783,
+  "platform": "doordash",
+  "ruleId": "doordash.screen.navigation_generic",
+  "classificationName": "navigation_generic",
+  "metadata": {
+    "engineVersion": 1,
+    "rulesetFormatVersion": 2,
+    "pipelineVersions": {
+      "accessibility": 1,
+      "accessibility.window": 1,
+      "accessibility.click": 1,
+      "accessibility.long_click": 1,
+      "accessibility.scroll": 1,
+      "accessibility.focus": 1,
+      "notification": 1
+    },
+    "stateMachineApiVersion": "1.0",
+    "appVersion": "0.230.0",
+    "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+  },
+  "payload": {
+    "class": "android.widget.FrameLayout",
+    "isEnabled": true,
+    "bounds": {
+      "left": -213,
+      "top": 0,
+      "right": 866,
+      "bottom": 2400
+    },
+    "children": [
+      {
+        "class": "android.widget.LinearLayout",
+        "isEnabled": true,
+        "bounds": {
+          "left": -213,
+          "top": 0,
+          "right": 866,
+          "bottom": 2347
+        },
+        "children": [
+          {
+            "class": "android.widget.FrameLayout",
+            "isEnabled": true,
+            "bounds": {
+              "left": -213,
+              "top": 136,
+              "right": 866,
+              "bottom": 2347
+            },
+            "children": [
+              {
+                "id": "com.doordash.driverapp:id/action_bar_root",
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                  "left": -213,
+                  "top": 136,
+                  "right": 866,
+                  "bottom": 2347
+                },
+                "children": [
+                  {
+                    "id": "android:id/content",
+                    "class": "android.widget.FrameLayout",
+                    "isEnabled": true,
+                    "bounds": {
+                      "left": -213,
+                      "top": 136,
+                      "right": 866,
+                      "bottom": 2347
+                    },
+                    "children": [
+                      {
+                        "id": "com.doordash.driverapp:id/container",
+                        "class": "android.view.ViewGroup",
+                        "isEnabled": true,
+                        "bounds": {
+                          "left": -213,
+                          "top": 136,
+                          "right": 866,
+                          "bottom": 2347
+                        },
+                        "children": [
+                          {
+                            "id": "com.doordash.driverapp:id/toolbar_container",
+                            "class": "android.widget.LinearLayout",
+                            "isEnabled": true,
+                            "bounds": {
+                              "left": -213,
+                              "top": 136,
+                              "right": 866,
+                              "bottom": 136
+                            }
+                          },
+                          {
+                            "class": "android.widget.FrameLayout",
+                            "isEnabled": true,
+                            "bounds": {
+                              "left": -213,
+                              "top": 136,
+                              "right": 866,
+                              "bottom": 2347
+                            },
+                            "children": [
+                              {
+                                "id": "com.doordash.driverapp:id/fragment",
+                                "class": "android.widget.FrameLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                  "left": -213,
+                                  "top": 136,
+                                  "right": 866,
+                                  "bottom": 2347
+                                },
+                                "children": [
+                                  {
+                                    "id": "com.doordash.driverapp:id/fragment_navigation_container",
+                                    "class": "android.view.ViewGroup",
+                                    "isEnabled": true,
+                                    "bounds": {
+                                      "left": -213,
+                                      "top": 136,
+                                      "right": 866,
+                                      "bottom": 2347
+                                    },
+                                    "children": [
+                                      {
+                                        "class": "androidx.compose.ui.platform.ComposeView",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                          "left": -213,
+                                          "top": 136,
+                                          "right": -213,
+                                          "bottom": 136
+                                        },
+                                        "children": [
+                                          {
+                                            "class": "android.view.View",
+                                            "isEnabled": true,
+                                            "bounds": {
+                                              "left": -213,
+                                              "top": 136,
+                                              "right": -213,
+                                              "bottom": 136
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "class": "androidx.compose.ui.platform.ComposeView",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                          "left": -213,
+                                          "top": 136,
+                                          "right": -213,
+                                          "bottom": 136
+                                        },
+                                        "children": [
+                                          {
+                                            "class": "android.view.View",
+                                            "isEnabled": true,
+                                            "bounds": {
+                                              "left": -213,
+                                              "top": 136,
+                                              "right": -213,
+                                              "bottom": 136
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "id": "com.doordash.driverapp:id/navigationView",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                          "left": -213,
+                                          "top": 136,
+                                          "right": 866,
+                                          "bottom": 2347
+                                        },
+                                        "children": [
+                                          {
+                                            "id": "com.doordash.driverapp:id/mapViewLayout",
+                                            "class": "android.widget.FrameLayout",
+                                            "isEnabled": true,
+                                            "bounds": {
+                                              "left": -213,
+                                              "top": 136,
+                                              "right": 866,
+                                              "bottom": 2347
+                                            },
+                                            "children": [
+                                              {
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                  "left": -213,
+                                                  "top": 136,
+                                                  "right": 866,
+                                                  "bottom": 2347
+                                                },
+                                                "children": [
+                                                  {
+                                                    "class": "android.widget.ImageView",
+                                                    "isClickable": true,
+                                                    "isEnabled": true,
+                                                    "bounds": {
+                                                      "left": -213,
+                                                      "top": 2300,
+                                                      "right": -167,
+                                                      "bottom": 2347
+                                                    }
+                                                  },
+                                                  {
+                                                    "class": "android.view.SurfaceView",
+                                                    "isEnabled": true,
+                                                    "bounds": {
+                                                      "left": -213,
+                                                      "top": 136,
+                                                      "right": 866,
+                                                      "bottom": 2347
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "id": "com.doordash.driverapp:id/coordinatorLayout",
+                                            "class": "android.view.ViewGroup",
+                                            "isEnabled": true,
+                                            "bounds": {
+                                              "left": -213,
+                                              "top": 136,
+                                              "right": 866,
+                                              "bottom": 2347
+                                            },
+                                            "children": [
+                                              {
+                                                "id": "com.doordash.driverapp:id/container",
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                  "left": -213,
+                                                  "top": 136,
+                                                  "right": 866,
+                                                  "bottom": 2347
+                                                },
+                                                "children": [
+                                                  {
+                                                    "id": "com.doordash.driverapp:id/guidanceLayout",
+                                                    "class": "android.widget.FrameLayout",
+                                                    "isEnabled": true,
+                                                    "bounds": {
+                                                      "left": -213,
+                                                      "top": 136,
+                                                      "right": 866,
+                                                      "bottom": 848
+                                                    },
+                                                    "children": [
+                                                      {
+                                                        "id": "com.doordash.driverapp:id/maneuverView",
+                                                        "class": "android.view.ViewGroup",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                          "left": -213,
+                                                          "top": 136,
+                                                          "right": 866,
+                                                          "bottom": 848
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "class": "android.view.ViewGroup",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": -204,
+                                                              "top": 145,
+                                                              "right": 857,
+                                                              "bottom": 839
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "id": "com.doordash.driverapp:id/maneuver",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": -204,
+                                                                  "top": 145,
+                                                                  "right": 857,
+                                                                  "bottom": 839
+                                                                },
+                                                                "children": [
+                                                                  {
+                                                                    "class": "android.view.ViewGroup",
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": -204,
+                                                                      "top": 145,
+                                                                      "right": 857,
+                                                                      "bottom": 839
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "id": "com.doordash.driverapp:id/mainManeuverLayout",
+                                                                        "class": "android.view.ViewGroup",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": -204,
+                                                                          "top": 145,
+                                                                          "right": 857,
+                                                                          "bottom": 394
+                                                                        },
+                                                                        "children": [
+                                                                          {
+                                                                            "id": "com.doordash.driverapp:id/maneuverIcon",
+                                                                            "class": "android.widget.ImageView",
+                                                                            "isEnabled": true,
+                                                                            "bounds": {
+                                                                              "left": -139,
+                                                                              "top": 181,
+                                                                              "right": -32,
+                                                                              "bottom": 288
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "text": "300 ft",
+                                                                            "id": "com.doordash.driverapp:id/stepDistance",
+                                                                            "class": "android.widget.TextView",
+                                                                            "isEnabled": true,
+                                                                            "bounds": {
+                                                                              "left": -195,
+                                                                              "top": 288,
+                                                                              "right": 23,
+                                                                              "bottom": 376
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "text": "[redacted]",
+                                                                            "id": "com.doordash.driverapp:id/primaryManeuverText",
+                                                                            "class": "android.widget.TextView",
+                                                                            "isEnabled": true,
+                                                                            "bounds": {
+                                                                              "left": 23,
+                                                                              "top": 223,
+                                                                              "right": 848,
+                                                                              "bottom": 317
+                                                                            }
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "id": "com.doordash.driverapp:id/upcomingManeuverRecycler",
+                                                                        "class": "androidx.recyclerview.widget.RecyclerView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": -204,
+                                                                          "top": 394,
+                                                                          "right": 857,
+                                                                          "bottom": 839
+                                                                        },
+                                                                        "children": [
+                                                                          {
+                                                                            "class": "android.view.ViewGroup",
+                                                                            "isEnabled": true,
+                                                                            "bounds": {
+                                                                              "left": -204,
+                                                                              "top": 394,
+                                                                              "right": 857,
+                                                                              "bottom": 617
+                                                                            },
+                                                                            "children": [
+                                                                              {
+                                                                                "text": "200 ft",
+                                                                                "id": "com.doordash.driverapp:id/stepDistance",
+                                                                                "class": "android.widget.TextView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                  "left": -195,
+                                                                                  "top": 511,
+                                                                                  "right": 23,
+                                                                                  "bottom": 599
+                                                                                }
+                                                                              },
+                                                                              {
+                                                                                "id": "com.doordash.driverapp:id/maneuverIcon",
+                                                                                "class": "android.widget.ImageView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                  "left": -139,
+                                                                                  "top": 417,
+                                                                                  "right": -32,
+                                                                                  "bottom": 524
+                                                                                }
+                                                                              },
+                                                                              {
+                                                                                "text": "[redacted]",
+                                                                                "id": "com.doordash.driverapp:id/primaryManeuverText",
+                                                                                "class": "android.widget.TextView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                  "left": 23,
+                                                                                  "top": 459,
+                                                                                  "right": 848,
+                                                                                  "bottom": 553
+                                                                                }
+                                                                              }
+                                                                            ]
+                                                                          },
+                                                                          {
+                                                                            "class": "android.view.ViewGroup",
+                                                                            "isEnabled": true,
+                                                                            "bounds": {
+                                                                              "left": -204,
+                                                                              "top": 617,
+                                                                              "right": 857,
+                                                                              "bottom": 839
+                                                                            },
+                                                                            "children": [
+                                                                              {
+                                                                                "text": "0.2 mi",
+                                                                                "id": "com.doordash.driverapp:id/stepDistance",
+                                                                                "class": "android.widget.TextView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                  "left": -195,
+                                                                                  "top": 734,
+                                                                                  "right": 23,
+                                                                                  "bottom": 822
+                                                                                }
+                                                                              },
+                                                                              {
+                                                                                "id": "com.doordash.driverapp:id/maneuverIcon",
+                                                                                "class": "android.widget.ImageView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                  "left": -139,
+                                                                                  "top": 640,
+                                                                                  "right": -32,
+                                                                                  "bottom": 747
+                                                                                }
+                                                                              },
+                                                                              {
+                                                                                "text": "[redacted]",
+                                                                                "id": "com.doordash.driverapp:id/primaryManeuverText",
+                                                                                "class": "android.widget.TextView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                  "left": 23,
+                                                                                  "top": 682,
+                                                                                  "right": 848,
+                                                                                  "bottom": 776
+                                                                                }
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "id": "com.doordash.driverapp:id/subManeuverLayout",
+                                                                        "class": "android.view.ViewGroup",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": -204,
+                                                                          "top": 394,
+                                                                          "right": 857,
+                                                                          "bottom": 479
+                                                                        },
+                                                                        "children": [
+                                                                          {
+                                                                            "id": "com.doordash.driverapp:id/subManeuverIcon",
+                                                                            "class": "android.widget.ImageView",
+                                                                            "isEnabled": true,
+                                                                            "bounds": {
+                                                                              "left": -108,
+                                                                              "top": 403,
+                                                                              "right": -41,
+                                                                              "bottom": 470
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "text": "[redacted]",
+                                                                            "id": "com.doordash.driverapp:id/subManeuverText",
+                                                                            "class": "android.widget.TextView",
+                                                                            "isEnabled": true,
+                                                                            "bounds": {
+                                                                              "left": 44,
+                                                                              "top": 407,
+                                                                              "right": 848,
+                                                                              "bottom": 466
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "id": "com.doordash.driverapp:id/laneGuidanceRecycler",
+                                                                            "class": "androidx.recyclerview.widget.RecyclerView",
+                                                                            "isEnabled": true,
+                                                                            "bounds": {
+                                                                              "left": 317,
+                                                                              "top": 403,
+                                                                              "right": 335,
+                                                                              "bottom": 421
+                                                                            }
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "id": "com.doordash.driverapp:id/scalebarLayout",
+                                                    "class": "android.widget.FrameLayout",
+                                                    "isEnabled": true,
+                                                    "bounds": {
+                                                      "left": -213,
+                                                      "top": 848,
+                                                      "right": -213,
+                                                      "bottom": 848
+                                                    }
+                                                  },
+                                                  {
+                                                    "id": "com.doordash.driverapp:id/speedLimitLayout",
+                                                    "class": "android.widget.FrameLayout",
+                                                    "isEnabled": true,
+                                                    "bounds": {
+                                                      "left": -195,
+                                                      "top": 866,
+                                                      "right": -28,
+                                                      "bottom": 1049
+                                                    },
+                                                    "children": [
+                                                      {
+                                                        "id": "com.doordash.driverapp:id/speedInfoView",
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                          "left": -195,
+                                                          "top": 866,
+                                                          "right": -45,
+                                                          "bottom": 1049
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "id": "com.doordash.driverapp:id/speedInfoMutcdLayout",
+                                                            "class": "android.view.ViewGroup",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": -195,
+                                                              "top": 866,
+                                                              "right": -45,
+                                                              "bottom": 1049
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "id": "com.doordash.driverapp:id/postedSpeedLayoutMutcd",
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": -191,
+                                                                  "top": 870,
+                                                                  "right": -49,
+                                                                  "bottom": 1045
+                                                                },
+                                                                "children": [
+                                                                  {
+                                                                    "text": "--",
+                                                                    "id": "com.doordash.driverapp:id/postedSpeedMutcd",
+                                                                    "class": "android.widget.TextView",
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": 22,
+                                                                      "top": 892,
+                                                                      "right": 164,
+                                                                      "bottom": 976
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "text": "mph",
+                                                                    "id": "com.doordash.driverapp:id/postedSpeedUnit",
+                                                                    "class": "android.widget.TextView",
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": 22,
+                                                                      "top": 976,
+                                                                      "right": 164,
+                                                                      "bottom": 1023
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "id": "com.doordash.driverapp:id/actionListLayout",
+                                                    "class": "android.widget.FrameLayout",
+                                                    "isEnabled": true,
+                                                    "bounds": {
+                                                      "left": 679,
+                                                      "top": 859,
+                                                      "right": 848,
+                                                      "bottom": 1246
+                                                    },
+                                                    "children": [
+                                                      {
+                                                        "id": "com.doordash.driverapp:id/buttonContainer",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                          "left": 733,
+                                                          "top": 859,
+                                                          "right": 848,
+                                                          "bottom": 1246
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "id": "com.doordash.driverapp:id/buttonsContainerTop",
+                                                            "class": "android.widget.LinearLayout",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 1062,
+                                                              "top": 859,
+                                                              "right": 1062,
+                                                              "bottom": 859
+                                                            }
+                                                          },
+                                                          {
+                                                            "id": "com.doordash.driverapp:id/buttonsContainerCenter",
+                                                            "class": "android.widget.LinearLayout",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 947,
+                                                              "top": 859,
+                                                              "right": 1062,
+                                                              "bottom": 1117
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "id": "com.doordash.driverapp:id/buttonsContainerCompass",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 733,
+                                                                  "top": 859,
+                                                                  "right": 733,
+                                                                  "bottom": 859
+                                                                }
+                                                              },
+                                                              {
+                                                                "id": "com.doordash.driverapp:id/buttonsContainerCamera",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 733,
+                                                                  "top": 859,
+                                                                  "right": 848,
+                                                                  "bottom": 988
+                                                                },
+                                                                "children": [
+                                                                  {
+                                                                    "class": "android.widget.FrameLayout",
+                                                                    "isClickable": true,
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": 947,
+                                                                      "top": 866,
+                                                                      "right": 1062,
+                                                                      "bottom": 981
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "id": "com.doordash.driverapp:id/container",
+                                                                        "class": "android.view.ViewGroup",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 733,
+                                                                          "top": 866,
+                                                                          "right": 848,
+                                                                          "bottom": 981
+                                                                        },
+                                                                        "children": [
+                                                                          {
+                                                                            "id": "com.doordash.driverapp:id/iconImage",
+                                                                            "class": "android.widget.ImageView",
+                                                                            "isEnabled": true,
+                                                                            "bounds": {
+                                                                              "left": 969,
+                                                                              "top": 888,
+                                                                              "right": 1040,
+                                                                              "bottom": 959
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "id": "com.doordash.driverapp:id/buttonText",
+                                                                            "class": "android.widget.TextView",
+                                                                            "isEnabled": true,
+                                                                            "bounds": {
+                                                                              "left": 828,
+                                                                              "top": 902,
+                                                                              "right": 846,
+                                                                              "bottom": 946
+                                                                            }
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "id": "com.doordash.driverapp:id/buttonsContainerAudio",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 733,
+                                                                  "top": 988,
+                                                                  "right": 848,
+                                                                  "bottom": 1117
+                                                                },
+                                                                "children": [
+                                                                  {
+                                                                    "class": "android.widget.FrameLayout",
+                                                                    "isClickable": true,
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": 947,
+                                                                      "top": 995,
+                                                                      "right": 1062,
+                                                                      "bottom": 1110
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "id": "com.doordash.driverapp:id/container",
+                                                                        "class": "android.view.ViewGroup",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 947,
+                                                                          "top": 995,
+                                                                          "right": 1062,
+                                                                          "bottom": 1110
+                                                                        },
+                                                                        "children": [
+                                                                          {
+                                                                            "id": "com.doordash.driverapp:id/iconImage",
+                                                                            "class": "android.widget.ImageView",
+                                                                            "isEnabled": true,
+                                                                            "bounds": {
+                                                                              "left": 755,
+                                                                              "top": 1017,
+                                                                              "right": 826,
+                                                                              "bottom": 1088
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "id": "com.doordash.driverapp:id/buttonText",
+                                                                            "class": "android.widget.TextView",
+                                                                            "isEnabled": true,
+                                                                            "bounds": {
+                                                                              "left": 1042,
+                                                                              "top": 1031,
+                                                                              "right": 1060,
+                                                                              "bottom": 1075
+                                                                            }
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "id": "com.doordash.driverapp:id/buttonsContainerRecenter",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 947,
+                                                                  "top": 1117,
+                                                                  "right": 947,
+                                                                  "bottom": 1117
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "id": "com.doordash.driverapp:id/buttonsContainerBottom",
+                                                            "class": "android.widget.LinearLayout",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 947,
+                                                              "top": 1117,
+                                                              "right": 1062,
+                                                              "bottom": 1246
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isClickable": true,
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 947,
+                                                                  "top": 1124,
+                                                                  "right": 1062,
+                                                                  "bottom": 1239
+                                                                },
+                                                                "children": [
+                                                                  {
+                                                                    "id": "com.doordash.driverapp:id/container",
+                                                                    "class": "android.view.ViewGroup",
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": 947,
+                                                                      "top": 1124,
+                                                                      "right": 1062,
+                                                                      "bottom": 1239
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "id": "com.doordash.driverapp:id/iconImage",
+                                                                        "class": "android.widget.ImageView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 969,
+                                                                          "top": 1146,
+                                                                          "right": 1040,
+                                                                          "bottom": 1217
+                                                                        }
+                                                                      },
+                                                                      {
+                                                                        "id": "com.doordash.driverapp:id/buttonText",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 1042,
+                                                                          "top": 1160,
+                                                                          "right": 1060,
+                                                                          "bottom": 1204
+                                                                        }
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "id": "com.doordash.driverapp:id/emptyLeftContainer",
+                                                    "class": "android.widget.FrameLayout",
+                                                    "isEnabled": true,
+                                                    "bounds": {
+                                                      "left": 18,
+                                                      "top": 1575,
+                                                      "right": 18,
+                                                      "bottom": 1575
+                                                    }
+                                                  },
+                                                  {
+                                                    "id": "com.doordash.driverapp:id/emptyRightContainer",
+                                                    "class": "android.widget.FrameLayout",
+                                                    "isEnabled": true,
+                                                    "bounds": {
+                                                      "left": 1062,
+                                                      "top": 1665,
+                                                      "right": 1062,
+                                                      "bottom": 1665
+                                                    }
+                                                  },
+                                                  {
+                                                    "id": "com.doordash.driverapp:id/roadNameLayout",
+                                                    "class": "android.widget.FrameLayout",
+                                                    "isEnabled": true,
+                                                    "bounds": {
+                                                      "left": 540,
+                                                      "top": 2083,
+                                                      "right": 540,
+                                                      "bottom": 2083
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "id": "com.doordash.driverapp:id/infoPanelLayout",
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                  "left": 0,
+                                                  "top": 2116,
+                                                  "right": 1080,
+                                                  "bottom": 2347
+                                                },
+                                                "children": [
+                                                  {
+                                                    "id": "com.doordash.driverapp:id/infoPanelContainer",
+                                                    "class": "android.view.ViewGroup",
+                                                    "isEnabled": true,
+                                                    "bounds": {
+                                                      "left": 0,
+                                                      "top": 2116,
+                                                      "right": 1080,
+                                                      "bottom": 2347
+                                                    },
+                                                    "children": [
+                                                      {
+                                                        "id": "com.doordash.driverapp:id/infoPanelHeader",
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                          "left": 0,
+                                                          "top": 2116,
+                                                          "right": 1080,
+                                                          "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "id": "com.doordash.driverapp:id/infoPanelHeaderContent",
+                                                            "class": "android.view.ViewGroup",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 0,
+                                                              "top": 2116,
+                                                              "right": 1080,
+                                                              "bottom": 2347
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 0,
+                                                                  "top": 2116,
+                                                                  "right": 1080,
+                                                                  "bottom": 2332
+                                                                },
+                                                                "children": [
+                                                                  {
+                                                                    "id": "com.doordash.driverapp:id/expand_sheet_button",
+                                                                    "class": "android.widget.ImageButton",
+                                                                    "isClickable": true,
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": 36,
+                                                                      "top": 2180,
+                                                                      "right": 125,
+                                                                      "bottom": 2269
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "id": "com.doordash.driverapp:id/header_container",
+                                                                    "class": "android.view.ViewGroup",
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": 416,
+                                                                      "top": 2116,
+                                                                      "right": 664,
+                                                                      "bottom": 2332
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "text": "20 min",
+                                                                        "id": "com.doordash.driverapp:id/bottom_sheet_remaining_time_v2",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 416,
+                                                                          "top": 2134,
+                                                                          "right": 664,
+                                                                          "bottom": 2267
+                                                                        }
+                                                                      },
+                                                                      {
+                                                                        "text": "9 mi",
+                                                                        "id": "com.doordash.driverapp:id/bottom_sheet_remaining_distance_v2",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 448,
+                                                                          "top": 2285,
+                                                                          "right": 524,
+                                                                          "bottom": 2332
+                                                                        }
+                                                                      },
+                                                                      {
+                                                                        "text": "\u2022 17:19",
+                                                                        "id": "com.doordash.driverapp:id/bottom_sheet_eta_v2",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 524,
+                                                                          "top": 2285,
+                                                                          "right": 633,
+                                                                          "bottom": 2332
+                                                                        }
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "desc": "Exit",
+                                                                    "id": "com.doordash.driverapp:id/exit_button",
+                                                                    "class": "android.widget.Button",
+                                                                    "isClickable": true,
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": 914,
+                                                                      "top": 2180,
+                                                                      "right": 1044,
+                                                                      "bottom": 2269
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "text": "Exit",
+                                                                        "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 941,
+                                                                          "top": 2195,
+                                                                          "right": 1017,
+                                                                          "bottom": 2255
+                                                                        }
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "id": "com.doordash.driverapp:id/handle",
+                                                        "class": "android.view.View",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                          "left": 487,
+                                                          "top": 2138,
+                                                          "right": 594,
+                                                          "bottom": 2149
+                                                        }
+                                                      },
+                                                      {
+                                                        "id": "com.doordash.driverapp:id/infoPanelContent",
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                          "left": 0,
+                                                          "top": 2347,
+                                                          "right": 1080,
+                                                          "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "id": "com.doordash.driverapp:id/bottom_sheet_in_transit_navigation_container",
+                                                            "class": "android.view.ViewGroup",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 0,
+                                                              "top": 2347,
+                                                              "right": 1080,
+                                                              "bottom": 2347
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "id": "com.doordash.driverapp:id/bottom_sheet_address_line_1",
+                                                                "class": "android.widget.TextView",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 36,
+                                                                  "top": 2347,
+                                                                  "right": 1044,
+                                                                  "bottom": 2347
+                                                                }
+                                                              },
+                                                              {
+                                                                "id": "com.doordash.driverapp:id/bottom_sheet_address_line_2",
+                                                                "class": "android.widget.TextView",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 36,
+                                                                  "top": 2394,
+                                                                  "right": 1044,
+                                                                  "bottom": 2347
+                                                                }
+                                                              },
+                                                              {
+                                                                "text": "Avoid tolls",
+                                                                "id": "com.doordash.driverapp:id/bottom_sheet_avoid_tolls_toggle_button",
+                                                                "class": "android.widget.TextView",
+                                                                "isClickable": true,
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 0,
+                                                                  "top": 2441,
+                                                                  "right": 1080,
+                                                                  "bottom": 2347
+                                                                }
+                                                              },
+                                                              {
+                                                                "id": "com.doordash.driverapp:id/bottom_sheet_bottom_separator_2",
+                                                                "class": "android.view.View",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 0,
+                                                                  "top": 2441,
+                                                                  "right": 1080,
+                                                                  "bottom": 2347
+                                                                }
+                                                              },
+                                                              {
+                                                                "state": "OFF",
+                                                                "id": "com.doordash.driverapp:id/bottom_sheet_avoid_tolls_toggle_switch",
+                                                                "class": "android.widget.Switch",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 940,
+                                                                  "top": 2474,
+                                                                  "right": 1044,
+                                                                  "bottom": 2347
+                                                                }
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/app/src/test/resources/snapshots/sessions/decline_race_2026_06_30/05_dash_along_the_way.json
+++ b/app/src/test/resources/snapshots/sessions/decline_race_2026_06_30/05_dash_along_the_way.json
@@ -1,0 +1,435 @@
+{
+    "captureId": "83193fe1-17e9-48f8-bc4a-e7ad5c23e5a5",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1782856772905,
+    "platform": "doordash",
+    "ruleId": "doordash.screen.dash_along_the_way",
+    "classificationName": "dash_along_the_way",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 136,
+                            "right": 1080,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 136,
+                                    "right": 1080,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 136,
+                                            "right": 1080,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/container",
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 136,
+                                                    "right": 1080,
+                                                    "bottom": 2347
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/toolbar_container",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 278
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/toolbar",
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 136,
+                                                                    "right": 1080,
+                                                                    "bottom": 278
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "desc": "Current dash",
+                                                                        "class": "android.widget.ImageButton",
+                                                                        "isClickable": true,
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 144,
+                                                                            "right": 125,
+                                                                            "bottom": 269
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "text": "Navigate to zone",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 133,
+                                                                            "top": 163,
+                                                                            "right": 448,
+                                                                            "bottom": 213
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "text": "TX: Northwest San Antonio",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 133,
+                                                                            "top": 213,
+                                                                            "right": 514,
+                                                                            "bottom": 251
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "class": "androidx.appcompat.widget.LinearLayoutCompat",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 866,
+                                                                            "top": 144,
+                                                                            "right": 1080,
+                                                                            "bottom": 269
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "desc": "Safety",
+                                                                                "id": "com.doordash.driverapp:id/action_dasher_safety",
+                                                                                "class": "android.widget.Button",
+                                                                                "isClickable": true,
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 866,
+                                                                                    "top": 153,
+                                                                                    "right": 973,
+                                                                                    "bottom": 260
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "desc": "Help",
+                                                                                "id": "com.doordash.driverapp:id/action_self_help",
+                                                                                "class": "android.widget.Button",
+                                                                                "isClickable": true,
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 973,
+                                                                                    "top": 153,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 260
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 278,
+                                                            "right": 1080,
+                                                            "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/fragment",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 278,
+                                                                    "right": 1080,
+                                                                    "bottom": 2347
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/fragment_container",
+                                                                        "class": "android.view.ViewGroup",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 278,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/map_container",
+                                                                                "class": "android.widget.FrameLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 278,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 1959
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 278,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 1959
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "android.view.TextureView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 278,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 1959
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.widget.FrameLayout",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 278,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 1959
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 5,
+                                                                                                    "top": 1859,
+                                                                                                    "right": 194,
+                                                                                                    "bottom": 1906
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isClickable": true,
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 200,
+                                                                                                    "top": 1859,
+                                                                                                    "right": 247,
+                                                                                                    "bottom": 1906
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "state": "in progress",
+                                                                                "id": "com.doordash.driverapp:id/loading_indicator",
+                                                                                "class": "android.widget.ProgressBar",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 487,
+                                                                                    "top": 1259,
+                                                                                    "right": 594,
+                                                                                    "bottom": 1366
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/my_location_button",
+                                                                                "class": "android.widget.Button",
+                                                                                "isClickable": true,
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 955,
+                                                                                    "top": 1789,
+                                                                                    "right": 1044,
+                                                                                    "bottom": 1878
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/imageView_prism_button_icon",
+                                                                                        "class": "android.widget.ImageView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 977,
+                                                                                            "top": 1811,
+                                                                                            "right": 1022,
+                                                                                            "bottom": 1856
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/bottom_spot_info_and_navigate_layout",
+                                                                                "class": "android.widget.LinearLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 1914,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2347
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "text": "We'll look for orders along the way",
+                                                                                        "id": "com.doordash.driverapp:id/bottom_view_info_ctd_v2_title",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 1950,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 1992
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/ctd_v2_title_divider",
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 2010,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2012
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/bottom_view_info_title",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 2048,
+                                                                                            "right": 72,
+                                                                                            "bottom": 2100
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/bottom_view_info_subtitle",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 2109,
+                                                                                            "right": 72,
+                                                                                            "bottom": 2151
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "desc": "Navigate",
+                                                                                        "id": "com.doordash.driverapp:id/navigate_button",
+                                                                                        "class": "android.widget.Button",
+                                                                                        "isClickable": true,
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 36,
+                                                                                            "top": 2204,
+                                                                                            "right": 1044,
+                                                                                            "bottom": 2311
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "com.doordash.driverapp:id/imageView_prism_button_start_icon",
+                                                                                                "class": "android.widget.ImageView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 72,
+                                                                                                    "top": 2231,
+                                                                                                    "right": 143,
+                                                                                                    "bottom": 2284
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "Navigate",
+                                                                                                "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 449,
+                                                                                                    "top": 2225,
+                                                                                                    "right": 632,
+                                                                                                    "bottom": 2291
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -192,10 +192,22 @@ class EffectMap @Inject constructor() {
         // Offer resolved (accepted/declined/timeout)
         if (prevOffer != null && nextOffer == null) {
             val outcome = resolveOfferOutcome(obs, prevOffer)
+            // #594: when the latch forced DECLINED but the last literal click was an ACCEPT, the
+            // dasher hit "Review offer"→Accept after the decline was already committed — record
+            // that the decline stood, for the forensic payload.
+            val raceDescription = if (
+                outcome == AppEventType.OFFER_DECLINED &&
+                prevOffer.declineCommittedAt != null &&
+                prevOffer.lastClickIntent == OfferIntent.ACCEPT
+            ) {
+                "Accept clicked after decline was already committed — decline stands (#594)"
+            } else {
+                null
+            }
             // Abort a notification still waiting out its post delay (#436) —
             // an Accept/Decline heads-up must not land after the offer is gone.
             add(AppEffect.CancelOfferNotification(prevOffer.offerHash))
-            add(logEffect(sessionId, outcome, obs.timestamp, offerPayload(prevOffer, outcome, obs.timestamp)))
+            add(logEffect(sessionId, outcome, obs.timestamp, offerPayload(prevOffer, outcome, obs.timestamp, raceDescription)))
 
             if (outcome == AppEventType.OFFER_TIMEOUT) {
                 add(AppEffect.UpdateBubble("Offer Timed Out!", persona = ChatPersona.Dispatcher))
@@ -205,10 +217,29 @@ class EffectMap @Inject constructor() {
         // Click feedback for offer accept/decline
         if (flowObs is Observation.Click && prev.flow == Flow.OfferPresented) {
             val fields = flowObs.parsed as? ParsedFields.ClickFields
+            // #594: the decline-commit latch set on a prior confirm click (survives on this
+            // click's next.pendingOffer, or prev's if the pop is concurrent).
+            val declineCommitted = next.pendingOffer?.declineCommittedAt ?: prevOffer?.declineCommittedAt
             when (fields?.intent) {
-                OfferIntent.ACCEPT -> add(
-                    AppEffect.UpdateBubble("Offer Accepted", persona = ChatPersona.Dispatcher)
-                )
+                OfferIntent.ACCEPT ->
+                    if (declineCommitted != null) {
+                        // The decline was already committed server-side; this Accept (the
+                        // "Review offer"→Accept race) won't take. Say so instead of the
+                        // contradictory "Offer Accepted", and count the defended invariant
+                        // (Principle 7: WARN = a defended invariant fired; no PII in the line).
+                        Timber.w(
+                            "Accept click ignored (#594): decline already committed at %d — decline stands",
+                            declineCommitted,
+                        )
+                        add(
+                            AppEffect.UpdateBubble(
+                                "Decline already submitted — Accept won't take",
+                                persona = ChatPersona.Dispatcher,
+                            )
+                        )
+                    } else {
+                        add(AppEffect.UpdateBubble("Offer Accepted", persona = ChatPersona.Dispatcher))
+                    }
                 OfferIntent.DECLINE -> add(
                     AppEffect.UpdateBubble("Offer Declined", persona = ChatPersona.Dispatcher)
                 )
@@ -972,6 +1003,11 @@ class EffectMap @Inject constructor() {
     // =========================================================================
 
     private fun resolveOfferOutcome(obs: Observation, prevOffer: PendingOffer? = null): AppEventType {
+        // 0. Decline-commit latch (#594): a DECLINE-intent click already committed this offer's
+        //    decline server-side. That decision is final — a later "Review offer"→Accept click
+        //    cannot un-decline it — so the latch wins over lastClickIntent AND the direct-click
+        //    fallback below.
+        if (prevOffer?.declineCommittedAt != null) return AppEventType.OFFER_DECLINED
         // 1. Stored click intent on PendingOffer — covers the common case where
         //    the click was observed first and the resolving obs is a Screen
         when (prevOffer?.lastClickIntent) {

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -219,7 +219,7 @@ class EffectMap @Inject constructor() {
             val fields = flowObs.parsed as? ParsedFields.ClickFields
             // #594: the decline-commit latch set on a prior confirm click (survives on this
             // click's next.pendingOffer, or prev's if the pop is concurrent).
-            val declineCommitted = next.pendingOffer?.declineCommittedAt ?: prevOffer?.declineCommittedAt
+            val declineCommitted = (next.pendingOffer ?: prevOffer)?.declineCommittedAt
             when (fields?.intent) {
                 OfferIntent.ACCEPT ->
                     if (declineCommitted != null) {

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/FlowRegionStepper.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/FlowRegionStepper.kt
@@ -4,6 +4,7 @@ import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
 import cloud.trotter.dashbuddy.domain.state.Flow
 import cloud.trotter.dashbuddy.domain.state.FlowRegion
+import cloud.trotter.dashbuddy.domain.state.OfferIntent
 import cloud.trotter.dashbuddy.domain.state.ParsedFields
 import cloud.trotter.dashbuddy.domain.state.PendingOffer
 import javax.inject.Inject
@@ -124,10 +125,21 @@ class FlowRegionStepper @Inject constructor() {
         val offer = prev.pendingOffer ?: return prev
         if (prev.flow != Flow.OfferPresented) return prev
         val fields = obs.parsed as? ParsedFields.ClickFields
+        // A DECLINE-intent click is the confirm-sheet commit (the decline_offer click rule is
+        // screen-scoped to offer_popup_confirm_decline), so the platform has already processed
+        // the decline server-side. Latch it — first commit wins, idempotent on repeat confirm
+        // echoes — so a later "Review offer"→Accept race can't override it (#594). lastClickIntent
+        // still records the literal last click for forensics; the latch is the authority.
+        val declineCommittedAt =
+            if (fields?.intent == OfferIntent.DECLINE) offer.declineCommittedAt ?: obs.timestamp
+            else offer.declineCommittedAt
         // Store intent on PendingOffer so EffectMap can resolve outcome
         // even when the resolving observation is a Screen (not a Click)
         return prev.copy(
-            pendingOffer = offer.copy(lastClickIntent = fields?.intent ?: offer.lastClickIntent),
+            pendingOffer = offer.copy(
+                lastClickIntent = fields?.intent ?: offer.lastClickIntent,
+                declineCommittedAt = declineCommittedAt,
+            ),
             lastObservedAt = obs.timestamp,
         )
     }

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/FlowRegionDeclineLatchTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/FlowRegionDeclineLatchTest.kt
@@ -1,0 +1,88 @@
+package cloud.trotter.dashbuddy.core.state
+
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
+import cloud.trotter.dashbuddy.domain.model.offer.ParsedOffer
+import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.state.Flow
+import cloud.trotter.dashbuddy.domain.state.FlowRegion
+import cloud.trotter.dashbuddy.domain.state.OfferIntent
+import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import cloud.trotter.dashbuddy.domain.state.PendingOffer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Unit tests for the #594 decline-commit latch in [FlowRegionStepper.handleOfferClick].
+ *
+ * A DECLINE-intent click can only come from the confirm sheet (the `decline_offer` click rule is
+ * screen-scoped to `offer_popup_confirm_decline`), i.e. the server-side commit. Once observed, the
+ * offer's outcome is DECLINED for good — a later "Review offer"→Accept race must not un-decline it.
+ * `lastClickIntent` keeps recording the literal last click (forensics); `declineCommittedAt` is the
+ * latch that decides the outcome (resolved in [EffectMap.resolveOfferOutcome]).
+ */
+class FlowRegionDeclineLatchTest {
+
+    private val stepper = FlowRegionStepper()
+
+    private val pendingOffer = PendingOffer(
+        offerHash = "hash-bk",
+        offerFields = ParsedFields.OfferFields(parsedOffer = ParsedOffer(offerHash = "hash-bk", payAmount = 6.25)),
+        presentedAt = 1_000L,
+        returnFlow = Flow.Idle,
+    )
+
+    private val offerPresented = FlowRegion(
+        flow = Flow.OfferPresented,
+        pendingOffer = pendingOffer,
+        lastObservedAt = 1_000L,
+    )
+
+    private fun click(intent: String, timestamp: Long) = Observation.Click(
+        timestamp = timestamp,
+        captureId = null,
+        ruleId = "doordash.click.$intent",
+        metadata = ReplayMetadata.EMPTY,
+        flow = null,
+        modeHint = null,
+        parsed = ParsedFields.ClickFields(intent = intent),
+    )
+
+    @Test
+    fun `a DECLINE-intent click sets declineCommittedAt to the click timestamp`() {
+        val next = stepper.step(offerPresented, click(OfferIntent.DECLINE, timestamp = 2_000L))
+        assertEquals(2_000L, next.pendingOffer?.declineCommittedAt)
+        assertEquals(OfferIntent.DECLINE, next.pendingOffer?.lastClickIntent)
+    }
+
+    @Test
+    fun `a repeat DECLINE click does not move the latch (first commit wins)`() {
+        val first = stepper.step(offerPresented, click(OfferIntent.DECLINE, timestamp = 2_000L))
+        val second = stepper.step(first, click(OfferIntent.DECLINE, timestamp = 2_500L))
+        assertEquals("the latch keeps the first commit timestamp", 2_000L, second.pendingOffer?.declineCommittedAt)
+    }
+
+    @Test
+    fun `an ACCEPT click after a committed decline moves lastClickIntent but not the latch`() {
+        val declined = stepper.step(offerPresented, click(OfferIntent.DECLINE, timestamp = 2_000L))
+        val raced = stepper.step(declined, click(OfferIntent.ACCEPT, timestamp = 3_000L))
+        assertEquals("the literal last click is recorded honestly", OfferIntent.ACCEPT, raced.pendingOffer?.lastClickIntent)
+        assertEquals("the decline latch is unchanged by the later Accept", 2_000L, raced.pendingOffer?.declineCommittedAt)
+    }
+
+    @Test
+    fun `an initial_decline click (the offer screen's first decline) sets neither`() {
+        // The offer-screen first decline is a separate intent (not decline_offer / accept_offer);
+        // it must not latch and must not record an accept/decline outcome — it falls through as today.
+        val next = stepper.step(offerPresented, click("initial_decline", timestamp = 2_000L))
+        assertNull("initial_decline does not commit the decline", next.pendingOffer?.declineCommittedAt)
+        assertEquals("lastClickIntent still records the literal click", "initial_decline", next.pendingOffer?.lastClickIntent)
+    }
+
+    @Test
+    fun `an ACCEPT click with no prior decline leaves the latch null`() {
+        val next = stepper.step(offerPresented, click(OfferIntent.ACCEPT, timestamp = 2_000L))
+        assertNull("a plain accept never sets the decline latch", next.pendingOffer?.declineCommittedAt)
+        assertEquals(OfferIntent.ACCEPT, next.pendingOffer?.lastClickIntent)
+    }
+}

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -89,6 +89,20 @@ was found **broken-in-part** (raw PII in capture envelopes) and moved to that en
   re-armed` DEBUG line fires after any burst, capped or not — it alone doesn't mean the cap was
   hit.
 
+- **🔧 FIX SHIPPED — a committed decline can't be un-declined by a later Accept (#594). CONFIRM ON DASH.**
+  Field 06-30 16:59 (BK $6.25, seq 226/227): declined the offer, confirmed the decline on the sheet
+  (committed server-side), then hit DoorDash's "Review offer" → Accept ~1.2 s later — the app logged
+  **OFFER_ACCEPTED** and flashed both "Offer Declined" and "Offer Accepted", while DoorDash's own dash
+  summary showed the decline stood (3 accepts, $45.75, no $6.25; no job/pickup ever formed). Now a
+  confirm-sheet decline **latches** the outcome: any later Accept still records **OFFER_DECLINED** and
+  the bubble shows a **"Decline already submitted — Accept won't take"** card instead of "Offer
+  Accepted". **Confirm on dash: 0/2 —** decline an offer, confirm it, then tap **Review offer →
+  Accept**: the db must record **OFFER_DECLINED** (no OFFER_ACCEPTED, no PICKUP_* / job), and the
+  bubble shows the "Decline already submitted" card — not "Offer Accepted". **Watch the control
+  case:** a normal accept with NO decline first must **still record ACCEPTED** and form the job.
+  Broken = an OFFER_ACCEPTED after a confirmed decline, or a normal accept that fails to record
+  ACCEPTED. Tag #594.
+
 - **🔧 FIX SHIPPED — post-accept teardown frame no longer mints a ghost offer (#595). CONFIRM ON DASH.**
   The collapsing offer card after an accept (pay/distance/Accept/Decline chrome, no store rows, a
   raw UUID where the store name goes) re-parsed as a NEW "Unknown Store" offer that REPLACED the

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/FlowRegion.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/FlowRegion.kt
@@ -37,13 +37,14 @@ data class FlowRegion(
  *   action is unavailable on this platform.
  * @param sourceRuleId The rule that matched the offer screen and supplied
  *   [targets] — consent-gate provenance (#422/#417).
- * @param declineCommittedAt Set (once) when a DECLINE-intent click is observed — the
- *   confirm-sheet commit, which is screen-scoped to `offer_popup_confirm_decline` so it can
- *   only come from the server-side confirmation. Once set, the offer's outcome is DECLINED
- *   regardless of any later click, because the platform has already processed the decline
- *   server-side — a "Review offer"→Accept race after that point cannot un-decline it (#594).
- *   [lastClickIntent] keeps recording the literal last click for forensics; this latch, not
- *   [lastClickIntent], decides the outcome.
+ * @param declineCommittedAt Set (once) when a DECLINE-intent click is observed. CONTRACT: a
+ *   ruleset must only emit `intent = decline_offer` for the control that COMMITS the decline
+ *   server-side (DoorDash: the confirm sheet's button — its click rule is screen-scoped to
+ *   `offer_popup_confirm_decline`; the offer card's first decline is the separate
+ *   `initial_decline` intent). Once set, the offer's outcome is DECLINED regardless of any
+ *   later click — the platform has already processed the decline, so a "Review offer"→Accept
+ *   race cannot un-decline it (#594). [lastClickIntent] keeps recording the literal last click
+ *   for forensics; this latch, not [lastClickIntent], decides the outcome.
  */
 @Serializable
 data class PendingOffer(

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/FlowRegion.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/FlowRegion.kt
@@ -37,6 +37,13 @@ data class FlowRegion(
  *   action is unavailable on this platform.
  * @param sourceRuleId The rule that matched the offer screen and supplied
  *   [targets] — consent-gate provenance (#422/#417).
+ * @param declineCommittedAt Set (once) when a DECLINE-intent click is observed — the
+ *   confirm-sheet commit, which is screen-scoped to `offer_popup_confirm_decline` so it can
+ *   only come from the server-side confirmation. Once set, the offer's outcome is DECLINED
+ *   regardless of any later click, because the platform has already processed the decline
+ *   server-side — a "Review offer"→Accept race after that point cannot un-decline it (#594).
+ *   [lastClickIntent] keeps recording the literal last click for forensics; this latch, not
+ *   [lastClickIntent], decides the outcome.
  */
 @Serializable
 data class PendingOffer(
@@ -48,4 +55,5 @@ data class PendingOffer(
     val lastClickIntent: String? = null,
     val targets: Map<String, cloud.trotter.dashbuddy.domain.pipeline.NodeRef> = emptyMap(),
     val sourceRuleId: String? = null,
+    val declineCommittedAt: Long? = null,
 )


### PR DESCRIPTION
Closes #594. Field incident (06-30 16:59, BK $6.25, seq 226/227): Decline → confirm sheet → confirm click (server-side commit) → "Review offer" → Accept 1.2s later — the machine logged OFFER_ACCEPTED by last-click-wins while DoorDash's own ledger kept the decline (no job ever formed; dash summary excludes the $6.25).

## Fix (3 files, built by an opus agent from a fable-vetted plan)
The keystone fact (design-vet verified): `doordash.click.decline_offer` is already screen-scoped to the confirm sheet — a click with `intent == OfferIntent.DECLINE` can only be the server-side commit (the #577 auto-confirm's own tap loops back through the same classification). So:
- `PendingOffer.declineCommittedAt` (new, default-null → snapshot-decode-safe) latches on the first DECLINE-intent click; `lastClickIntent` stays the honest last-click record.
- `resolveOfferOutcome` checks the latch FIRST → OFFER_DECLINED regardless of later clicks; the racing-accept case carries payload description "Accept clicked after decline was already committed — decline stands (#594)".
- Click feedback: an Accept after the commit shows "Decline already submitted — Accept won't take" instead of "Offer Accepted" (+ a PII-safe WARN) — kills the field's contradictory chat pair for this class.

## Tests
- `FlowRegionDeclineLatchTest` (5): latch set / idempotent / accept-after-decline / initial_decline sets neither / plain accept.
- `EffectMapTest` +2 (extends the existing lastClickIntent harness): latch beats ACCEPT; race bubble replaces "Offer Accepted".
- `DeclineRaceReplayTest` (real 06-30 BK captures + synthetic initial_decline→DECLINE→ACCEPT clicks): 1 RECEIVED, 1 DECLINED (description present), 0 ACCEPTED, 0 PICKUP_*. **Proven red without the fix** (fails 1-vs-0 on OFFER_DECLINED — the accept wins pre-fix).
- Suites: `:core:state` 88/88, `:app` 838/838 green. Fixtures PII-scanned (nav road names redacted per convention).

## Documented residuals (no code)
- Single-slot `pendingOffer` hazard: a confirm echo after an offer replacement could latch the wrong offer — pre-existing class shared with `lastClickIntent` (#251-adjacent).
- The issue's accept⇒expect-job-formation reconciliation window deliberately not built — the latch covers the observed incident class; reconciliation remains a future design if a new class appears.

### Design-goal review
1 (UDF): stepper stays pure (latch from `obs.timestamp`; no logging in the stepper — the WARN lives at the EffectMap edge). 5 (SSOT): outcome authority is the latch in exactly one place (`resolveOfferOutcome`); `lastClickIntent` remains forensic-only. 7: new WARN is a defended-invariant fire, PII-free. 8: no platform literals — the commit semantic rides the already-enumerated `OfferIntent` contract; zero rule-JSON changes.

### Adversarial review
Plan was design-vetted by a fable adversary pre-build (confirm-sheet flow semantics, latch copy-survival, Uber non-impact, consumer sweep all verified); the fable post-build PR check follows as a comment before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)