### PR TITLE
fix(state): #596 — physically-complete jobs close without the receipt: completion minting + absorption fix

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
@@ -865,14 +865,19 @@ class EffectMapTest {
         val (platform, _) = stateWithPlatform()
         val session = Session("sess-1", startedAt = 100L)
         val completedTask = Task(taskId = "task-1", jobId = "job-1", phase = TaskPhase.DROPOFF, storeName = "Chipotle", startedAt = 900L, completedAt = 950L)
+        // #596: a real receipt exit has the job still ACTIVE going in (it closes on this same step),
+        // so completedJobId is non-null → the SCOPED fallback finds the task. The unscoped (job-less)
+        // fallback is now gated when there's genuinely nothing to complete (job already closed, no
+        // active task, no retire pending) — see the amdt-2 unscoped-fallback gate.
+        val job = Job("job-1", offerStoreHint = emptyList(), parentOfferHash = null, startedAt = 100L)
         val prev = AppState(regions = Regions(
             flow = FlowRegion(flow = Flow.PostTask),
-            platforms = mapOf(platform to PlatformRegion(platform, mode = Mode.Online, session = session, recentTasks = listOf(completedTask))),
+            platforms = mapOf(platform to PlatformRegion(platform, mode = Mode.Online, session = session, activeJob = job, recentTasks = listOf(completedTask))),
         ))
 
         val next = AppState(regions = Regions(
             flow = FlowRegion(flow = Flow.Idle),
-            platforms = mapOf(platform to PlatformRegion(platform, mode = Mode.Online, session = session, recentTasks = listOf(completedTask))),
+            platforms = mapOf(platform to PlatformRegion(platform, mode = Mode.Online, session = session, activeJob = job, recentTasks = listOf(completedTask))),
         ))
 
         val effects = effectMap.diff(prev, next, screenObs(flow = Flow.Idle))

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
@@ -577,6 +577,56 @@ class EffectMapTest {
     }
 
     @Test
+    fun `session end does NOT mint a completion for an undelivered active drop (#596 amdt-5, kills M6)`() {
+        // endSession force-stamps completedAt on whatever task is active. The close-out sweep's
+        // qualification rule (already-completed-before-this-step OR active-under-TASK_RETIRE)
+        // must exclude exactly that force-stamp — otherwise ending the dash mid-delivery
+        // fabricates a DELIVERY_COMPLETED for an order still in the car (#518/#564 phantom class).
+        val (platform, base) = stateWithPlatform()
+        val job = Job("job-open", offerStoreHint = emptyList(), parentOfferHash = null, startedAt = 1000L)
+        val active = Task(
+            taskId = "task-undelivered", jobId = "job-open", phase = TaskPhase.DROPOFF,
+            customerNameHash = "abc123", startedAt = 100L, arrivedAt = null, completedAt = null,
+        )
+        // prev: open job, active identity-carrying dropoff, NO retire pending.
+        val prevRegion = base.copy(activeJob = job, activeTask = active, recentTasks = emptyList())
+        val prev = AppState(regions = Regions(flow = FlowRegion(flow = Flow.TaskDropoffNavigation), platforms = mapOf(platform to prevRegion)))
+        // next: endSession applied — session/job/task null, the drop force-stamped into recentTasks.
+        val nextRegion = prevRegion.copy(
+            session = null, activeJob = null, activeTask = null,
+            recentTasks = listOf(active.copy(completedAt = 5_000L)),
+        )
+        val next = AppState(regions = Regions(flow = FlowRegion(flow = Flow.Idle), platforms = mapOf(platform to nextRegion)))
+
+        val effects = effectMap.diff(prev, next, screenObs(flow = Flow.Idle))
+        assertFalse(
+            "ending the session mid-delivery must not fabricate a completion",
+            effects.logEventTypes().contains(AppEventType.DELIVERY_COMPLETED),
+        )
+    }
+
+    @Test
+    fun `PostTask exit with nothing in flight does NOT re-fire a stale completed task (#596 amdt-2, kills M5)`() {
+        // The job was already closed by T1 on a PRIOR step (its completion minted then). A later
+        // PostTask exit with no job, no active task, and no retire pending must not let the
+        // job-less fallback grab the stale completed recentTask and re-emit its key.
+        val (platform, base) = stateWithPlatform()
+        val stale = Task(
+            taskId = "task-done-earlier", jobId = "job-closed", phase = TaskPhase.DROPOFF,
+            customerNameHash = "abc123", startedAt = 100L, arrivedAt = 150L, completedAt = 200L,
+        )
+        val region = base.copy(activeJob = null, activeTask = null, recentTasks = listOf(stale), pendingDestructive = null)
+        val prev = AppState(regions = Regions(flow = FlowRegion(flow = Flow.PostTask), platforms = mapOf(platform to region)))
+        val next = AppState(regions = Regions(flow = FlowRegion(flow = Flow.Idle), platforms = mapOf(platform to region)))
+
+        val effects = effectMap.diff(prev, next, screenObs(flow = Flow.Idle))
+        assertFalse(
+            "a job-less PostTask exit with nothing being completed must not re-fire a stale completion",
+            effects.logEventTypes().contains(AppEventType.DELIVERY_COMPLETED),
+        )
+    }
+
+    @Test
     fun `DELIVERY_COMPLETED does not fire when the retired task is a PICKUP that never reached dropoff (#564)`() {
         val (platform, base) = stateWithPlatform()
         val job = Job("job-new", offerStoreHint = emptyList(), parentOfferHash = null, startedAt = 1000L)

--- a/app/src/test/java/cloud/trotter/dashbuddy/replay/ReceiptSkipReplayTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/replay/ReceiptSkipReplayTest.kt
@@ -1,0 +1,82 @@
+package cloud.trotter.dashbuddy.replay
+
+import cloud.trotter.dashbuddy.domain.model.event.AppEventType
+import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryPayload
+import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.state.OfferIntent
+import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.test.util.SessionReplay
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #596 end-to-end Level-B replay of a real receipt-skip (2026-06-29, redacted): a delivered dropoff
+ * whose post-delivery receipt DoorDash never rendered — the next offer chained straight over it.
+ *
+ * Real capture sequence (`snapshots/sessions/receipt_skip_2026_06_29/`, customer PII redacted
+ * "Deliver to [redacted]" style so the customer hash stays non-null and the #498 guards are
+ * satisfied):
+ *  - `01_dropoff_navigation` → `02_dropoff_handoff` — the drop (ARRIVED, carries the customer)
+ *  - `03_waiting_for_offer` — the receipt-skip moment: task→idle arms the TASK_RETIRE grace
+ *  - injected `graceCommit` past the grace deadline — commits the retire; #596 T1 closes the
+ *    physically-complete job even though no receipt (PostTask) ever appeared
+ *  - `04_offer_popup` + injected accept click + `05_pickup_navigation` — the next INDEPENDENT offer,
+ *    which must start a NEW job, not fold into the never-closed one (the field-observed absorption)
+ *
+ * `05` is the nearest real 06-29 pickup task frame (H-E-B), re-stamped to fall after the offer/click
+ * (there was no real pickup after the offer — it was declined in the field; we inject the accept to
+ * exercise T2's new-job path). Pre-#596 this asserts RED: same jobId, zero completions.
+ */
+class ReceiptSkipReplayTest {
+
+    private val session = "snapshots/sessions/receipt_skip_2026_06_29"
+
+    private fun buildSteps(): List<SessionReplay.ReplayStep> {
+        val screens = SessionReplay.loadSession(session)
+        val waitingMs = screens.first { it.file.contains("waiting_for_offer") }.capturedAtMs
+        val offerMs = screens.first { it.file.contains("offer_popup") }.capturedAtMs
+        // graceCommit strictly past the TASK_RETIRE deadline (idle arm → gracePeriodMs = 10s) and
+        // before the offer pops; the accept click sits between the offer and the pickup pop.
+        val inputs = screens.map { SessionReplay.ScreenInput(it) } +
+            SessionReplay.graceCommit(waitingMs + 10_600L) +
+            SessionReplay.syntheticOfferClick(OfferIntent.ACCEPT, offerMs + 500L)
+        return SessionReplay.reduceMixed(inputs)
+    }
+
+    @Test
+    fun `a receipt-skipped drop completes exactly once and the next offer starts a NEW job (#596)`() {
+        val steps = buildSteps()
+        val completions = steps.flatMap { it.events }.filter { it.type == AppEventType.DELIVERY_COMPLETED }
+
+        // Exactly ONE completion — minted at job close, not on a (never-rendered) receipt.
+        assertEquals("the receipt-skipped drop completes exactly once", 1, completions.size)
+        val payload = completions.single().payload as DeliveryPayload
+        // Receipt-less completion: no receipt fields → null pay (#528's territory), never fabricated.
+        assertNull("a receipt-less completion carries no pay", payload.totalPay)
+        assertNotNull("the completed drop kept its (redacted) customer identity", payload.customerHash)
+        val closedJobId = payload.jobId
+
+        // The job closed on the grace-commit step (T1), BEFORE the next accept.
+        val graceStep = steps.first { it.observation is Observation.Timeout }
+        assertNull(
+            "T1 closes the physically-complete job on the retire commit (no receipt needed)",
+            graceStep.stateAfter.regions.platforms[Platform.DoorDash]?.activeJob,
+        )
+
+        // The injected accept logged OFFER_ACCEPTED and minted a NEW job — absorption broken.
+        assertTrue(
+            "the injected accept resolves the offer",
+            steps.flatMap { it.events }.any { it.type == AppEventType.OFFER_ACCEPTED },
+        )
+        val newJob = steps.last().stateAfter.regions.platforms[Platform.DoorDash]?.activeJob
+        assertNotNull("the next offer starts a job", newJob)
+        assertNotEquals(
+            "the next accepted offer is a NEW job, not absorbed into the never-closed one",
+            closedJobId, newJob?.jobId,
+        )
+    }
+}

--- a/app/src/test/resources/snapshots/sessions/receipt_skip_2026_06_29/01_dropoff_navigation.json
+++ b/app/src/test/resources/snapshots/sessions/receipt_skip_2026_06_29/01_dropoff_navigation.json
@@ -1,0 +1,882 @@
+{
+  "captureId": "0903b6de-747e-4ba4-a593-34ecd1280eda",
+  "pipelineId": "accessibility.window",
+  "schemaId": "uinode.v1",
+  "timestamp": 1782781365414,
+  "platform": "doordash",
+  "ruleId": "doordash.screen.dropoff_navigation",
+  "classificationName": "dropoff_navigation",
+  "metadata": {
+    "engineVersion": 1,
+    "rulesetFormatVersion": 2,
+    "pipelineVersions": {
+      "accessibility": 1,
+      "accessibility.window": 1,
+      "accessibility.click": 1,
+      "accessibility.long_click": 1,
+      "accessibility.scroll": 1,
+      "accessibility.focus": 1,
+      "notification": 1
+    },
+    "stateMachineApiVersion": "1.0",
+    "appVersion": "0.230.0",
+    "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+  },
+  "payload": {
+    "class": "android.widget.FrameLayout",
+    "isEnabled": true,
+    "bounds": {
+      "left": 159,
+      "top": 0,
+      "right": 1239,
+      "bottom": 2400
+    },
+    "children": [
+      {
+        "class": "android.widget.LinearLayout",
+        "isEnabled": true,
+        "bounds": {
+          "left": 18,
+          "top": 0,
+          "right": 1098,
+          "bottom": 2347
+        },
+        "children": [
+          {
+            "class": "android.widget.FrameLayout",
+            "isEnabled": true,
+            "bounds": {
+              "left": 18,
+              "top": 136,
+              "right": 1098,
+              "bottom": 2347
+            },
+            "children": [
+              {
+                "id": "com.doordash.driverapp:id/action_bar_root",
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                  "left": 2,
+                  "top": 136,
+                  "right": 1082,
+                  "bottom": 2347
+                },
+                "children": [
+                  {
+                    "id": "android:id/content",
+                    "class": "android.widget.FrameLayout",
+                    "isEnabled": true,
+                    "bounds": {
+                      "left": 0,
+                      "top": 136,
+                      "right": 1080,
+                      "bottom": 2347
+                    },
+                    "children": [
+                      {
+                        "class": "android.view.ViewGroup",
+                        "isEnabled": true,
+                        "bounds": {
+                          "left": 2,
+                          "top": 136,
+                          "right": 1082,
+                          "bottom": 2347
+                        },
+                        "children": [
+                          {
+                            "id": "com.doordash.driverapp:id/contact_sheet_overlay",
+                            "class": "androidx.compose.ui.platform.ComposeView",
+                            "isEnabled": true,
+                            "bounds": {
+                              "left": 2,
+                              "top": 136,
+                              "right": 1082,
+                              "bottom": 2347
+                            },
+                            "children": [
+                              {
+                                "class": "android.view.View",
+                                "isEnabled": true,
+                                "bounds": {
+                                  "left": 2,
+                                  "top": 136,
+                                  "right": 1082,
+                                  "bottom": 2347
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "id": "com.doordash.driverapp:id/fragment",
+                            "class": "android.widget.FrameLayout",
+                            "isEnabled": true,
+                            "bounds": {
+                              "left": 2,
+                              "top": 136,
+                              "right": 1082,
+                              "bottom": 2347
+                            },
+                            "children": [
+                              {
+                                "id": "com.doordash.driverapp:id/fragment_navigation_container",
+                                "class": "android.view.ViewGroup",
+                                "isEnabled": true,
+                                "bounds": {
+                                  "left": 2,
+                                  "top": 136,
+                                  "right": 1082,
+                                  "bottom": 2347
+                                },
+                                "children": [
+                                  {
+                                    "class": "androidx.compose.ui.platform.ComposeView",
+                                    "isEnabled": true,
+                                    "bounds": {
+                                      "left": 2,
+                                      "top": 136,
+                                      "right": 2,
+                                      "bottom": 136
+                                    },
+                                    "children": [
+                                      {
+                                        "class": "android.view.View",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                          "left": 2,
+                                          "top": 136,
+                                          "right": 2,
+                                          "bottom": 136
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "class": "androidx.compose.ui.platform.ComposeView",
+                                    "isEnabled": true,
+                                    "bounds": {
+                                      "left": 2,
+                                      "top": 136,
+                                      "right": 2,
+                                      "bottom": 136
+                                    },
+                                    "children": [
+                                      {
+                                        "class": "android.view.View",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                          "left": 2,
+                                          "top": 136,
+                                          "right": 2,
+                                          "bottom": 136
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "id": "com.doordash.driverapp:id/navigationView",
+                                    "class": "android.widget.FrameLayout",
+                                    "isEnabled": true,
+                                    "bounds": {
+                                      "left": 2,
+                                      "top": 136,
+                                      "right": 1082,
+                                      "bottom": 2347
+                                    },
+                                    "children": [
+                                      {
+                                        "id": "com.doordash.driverapp:id/mapViewLayout",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                          "left": 2,
+                                          "top": 136,
+                                          "right": 1082,
+                                          "bottom": 2347
+                                        },
+                                        "children": [
+                                          {
+                                            "class": "android.widget.FrameLayout",
+                                            "isEnabled": true,
+                                            "bounds": {
+                                              "left": 2,
+                                              "top": 136,
+                                              "right": 1082,
+                                              "bottom": 2347
+                                            },
+                                            "children": [
+                                              {
+                                                "class": "android.widget.ImageView",
+                                                "isClickable": true,
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                  "left": 2,
+                                                  "top": 2300,
+                                                  "right": 48,
+                                                  "bottom": 2347
+                                                }
+                                              },
+                                              {
+                                                "class": "android.view.SurfaceView",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                  "left": 2,
+                                                  "top": 136,
+                                                  "right": 1082,
+                                                  "bottom": 2347
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "id": "com.doordash.driverapp:id/coordinatorLayout",
+                                        "class": "android.view.ViewGroup",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                          "left": 2,
+                                          "top": 136,
+                                          "right": 1082,
+                                          "bottom": 2347
+                                        },
+                                        "children": [
+                                          {
+                                            "id": "com.doordash.driverapp:id/container",
+                                            "class": "android.view.ViewGroup",
+                                            "isEnabled": true,
+                                            "bounds": {
+                                              "left": 2,
+                                              "top": 136,
+                                              "right": 1082,
+                                              "bottom": 2347
+                                            },
+                                            "children": [
+                                              {
+                                                "id": "com.doordash.driverapp:id/scalebarLayout",
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                  "left": 2,
+                                                  "top": 136,
+                                                  "right": 2,
+                                                  "bottom": 136
+                                                }
+                                              },
+                                              {
+                                                "id": "com.doordash.driverapp:id/guidanceLayout",
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                  "left": 2,
+                                                  "top": 136,
+                                                  "right": 1082,
+                                                  "bottom": 136
+                                                }
+                                              },
+                                              {
+                                                "id": "com.doordash.driverapp:id/speedLimitLayout",
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                  "left": 20,
+                                                  "top": 154,
+                                                  "right": 187,
+                                                  "bottom": 310
+                                                },
+                                                "children": [
+                                                  {
+                                                    "id": "com.doordash.driverapp:id/speedInfoView",
+                                                    "class": "android.widget.FrameLayout",
+                                                    "isClickable": true,
+                                                    "isEnabled": true,
+                                                    "bounds": {
+                                                      "left": 20,
+                                                      "top": 154,
+                                                      "right": 176,
+                                                      "bottom": 310
+                                                    },
+                                                    "children": [
+                                                      {
+                                                        "id": "com.doordash.driverapp:id/speedInfoViennaLayout",
+                                                        "class": "android.view.ViewGroup",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                          "left": 20,
+                                                          "top": 154,
+                                                          "right": 176,
+                                                          "bottom": 310
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "id": "com.doordash.driverapp:id/postedSpeedLayoutVienna",
+                                                            "class": "android.view.ViewGroup",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 20,
+                                                              "top": 154,
+                                                              "right": 176,
+                                                              "bottom": 310
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "text": "--",
+                                                                "id": "com.doordash.driverapp:id/postedSpeedVienna",
+                                                                "class": "android.widget.TextView",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 20,
+                                                                  "top": 190,
+                                                                  "right": 176,
+                                                                  "bottom": 274
+                                                                }
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "id": "com.doordash.driverapp:id/actionListLayout",
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                  "left": 895,
+                                                  "top": 147,
+                                                  "right": 1064,
+                                                  "bottom": 405
+                                                },
+                                                "children": [
+                                                  {
+                                                    "id": "com.doordash.driverapp:id/buttonContainer",
+                                                    "class": "android.widget.LinearLayout",
+                                                    "isEnabled": true,
+                                                    "bounds": {
+                                                      "left": 949,
+                                                      "top": 147,
+                                                      "right": 1064,
+                                                      "bottom": 405
+                                                    },
+                                                    "children": [
+                                                      {
+                                                        "id": "com.doordash.driverapp:id/buttonsContainerTop",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                          "left": 1064,
+                                                          "top": 147,
+                                                          "right": 1064,
+                                                          "bottom": 147
+                                                        }
+                                                      },
+                                                      {
+                                                        "id": "com.doordash.driverapp:id/buttonsContainerCenter",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                          "left": 949,
+                                                          "top": 147,
+                                                          "right": 1064,
+                                                          "bottom": 276
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "id": "com.doordash.driverapp:id/buttonsContainerCompass",
+                                                            "class": "android.widget.FrameLayout",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 949,
+                                                              "top": 147,
+                                                              "right": 949,
+                                                              "bottom": 147
+                                                            }
+                                                          },
+                                                          {
+                                                            "id": "com.doordash.driverapp:id/buttonsContainerCamera",
+                                                            "class": "android.widget.FrameLayout",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 949,
+                                                              "top": 147,
+                                                              "right": 1064,
+                                                              "bottom": 276
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isClickable": true,
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 949,
+                                                                  "top": 154,
+                                                                  "right": 1064,
+                                                                  "bottom": 269
+                                                                },
+                                                                "children": [
+                                                                  {
+                                                                    "id": "com.doordash.driverapp:id/container",
+                                                                    "class": "android.view.ViewGroup",
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": 949,
+                                                                      "top": 154,
+                                                                      "right": 1064,
+                                                                      "bottom": 269
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "id": "com.doordash.driverapp:id/iconImage",
+                                                                        "class": "android.widget.ImageView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 971,
+                                                                          "top": 176,
+                                                                          "right": 1042,
+                                                                          "bottom": 247
+                                                                        }
+                                                                      },
+                                                                      {
+                                                                        "id": "com.doordash.driverapp:id/buttonText",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 1044,
+                                                                          "top": 190,
+                                                                          "right": 1062,
+                                                                          "bottom": 234
+                                                                        }
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "id": "com.doordash.driverapp:id/buttonsContainerRecenter",
+                                                            "class": "android.widget.FrameLayout",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 949,
+                                                              "top": 276,
+                                                              "right": 949,
+                                                              "bottom": 276
+                                                            }
+                                                          },
+                                                          {
+                                                            "id": "com.doordash.driverapp:id/buttonsContainerAudio",
+                                                            "class": "android.widget.FrameLayout",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 949,
+                                                              "top": 276,
+                                                              "right": 949,
+                                                              "bottom": 276
+                                                            }
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "id": "com.doordash.driverapp:id/buttonsContainerBottom",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                          "left": 949,
+                                                          "top": 276,
+                                                          "right": 1064,
+                                                          "bottom": 405
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "class": "android.widget.FrameLayout",
+                                                            "isClickable": true,
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 949,
+                                                              "top": 283,
+                                                              "right": 1064,
+                                                              "bottom": 398
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "id": "com.doordash.driverapp:id/container",
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 949,
+                                                                  "top": 283,
+                                                                  "right": 1064,
+                                                                  "bottom": 398
+                                                                },
+                                                                "children": [
+                                                                  {
+                                                                    "id": "com.doordash.driverapp:id/iconImage",
+                                                                    "class": "android.widget.ImageView",
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": 971,
+                                                                      "top": 305,
+                                                                      "right": 1042,
+                                                                      "bottom": 376
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "id": "com.doordash.driverapp:id/buttonText",
+                                                                    "class": "android.widget.TextView",
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": 1044,
+                                                                      "top": 319,
+                                                                      "right": 1062,
+                                                                      "bottom": 363
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "id": "com.doordash.driverapp:id/emptyLeftContainer",
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                  "left": 20,
+                                                  "top": 1321,
+                                                  "right": 20,
+                                                  "bottom": 1321
+                                                }
+                                              },
+                                              {
+                                                "id": "com.doordash.driverapp:id/emptyRightContainer",
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                  "left": 1064,
+                                                  "top": 1360,
+                                                  "right": 1064,
+                                                  "bottom": 1360
+                                                }
+                                              },
+                                              {
+                                                "id": "com.doordash.driverapp:id/roadNameLayout",
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                  "left": 542,
+                                                  "top": 2314,
+                                                  "right": 542,
+                                                  "bottom": 2314
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "id": "com.doordash.driverapp:id/infoPanelLayout",
+                                            "class": "android.widget.FrameLayout",
+                                            "isEnabled": true,
+                                            "bounds": {
+                                              "left": 2,
+                                              "top": 2347,
+                                              "right": 1082,
+                                              "bottom": 2365
+                                            },
+                                            "children": [
+                                              {
+                                                "id": "com.doordash.driverapp:id/infoPanelContainer",
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                  "left": 2,
+                                                  "top": 2347,
+                                                  "right": 1082,
+                                                  "bottom": 2365
+                                                },
+                                                "children": [
+                                                  {
+                                                    "id": "com.doordash.driverapp:id/infoPanelHeader",
+                                                    "class": "android.widget.FrameLayout",
+                                                    "isEnabled": true,
+                                                    "bounds": {
+                                                      "left": 2,
+                                                      "top": 2347,
+                                                      "right": 1082,
+                                                      "bottom": 2365
+                                                    },
+                                                    "children": [
+                                                      {
+                                                        "id": "com.doordash.driverapp:id/infoPanelHeaderContent",
+                                                        "class": "android.view.ViewGroup",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                          "left": 2,
+                                                          "top": 2347,
+                                                          "right": 1082,
+                                                          "bottom": 2365
+                                                        }
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "id": "com.doordash.driverapp:id/handle",
+                                                    "class": "android.view.View",
+                                                    "isEnabled": true,
+                                                    "bounds": {
+                                                      "left": 489,
+                                                      "top": 2347,
+                                                      "right": 596,
+                                                      "bottom": 2387
+                                                    }
+                                                  },
+                                                  {
+                                                    "id": "com.doordash.driverapp:id/infoPanelContent",
+                                                    "class": "android.widget.FrameLayout",
+                                                    "isEnabled": true,
+                                                    "bounds": {
+                                                      "left": 2,
+                                                      "top": 2347,
+                                                      "right": 1082,
+                                                      "bottom": 2596
+                                                    },
+                                                    "children": [
+                                                      {
+                                                        "id": "com.doordash.driverapp:id/bottom_sheet_in_transit_navigation_container",
+                                                        "class": "android.view.ViewGroup",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                          "left": 0,
+                                                          "top": 2581,
+                                                          "right": 1080,
+                                                          "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "id": "com.doordash.driverapp:id/audio_instructions_group",
+                                                            "class": "android.view.View",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 0,
+                                                              "top": 2581,
+                                                              "right": 1080,
+                                                              "bottom": 2347
+                                                            }
+                                                          },
+                                                          {
+                                                            "text": "Deliver by 8:32 PM",
+                                                            "id": "com.doordash.driverapp:id/bottom_sheet_task_arrive_by",
+                                                            "class": "android.widget.TextView",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 36,
+                                                              "top": 2614,
+                                                              "right": 1044,
+                                                              "bottom": 2347
+                                                            }
+                                                          },
+                                                          {
+                                                            "text": "Deliver to [redacted]",
+                                                            "id": "com.doordash.driverapp:id/bottom_sheet_task_title",
+                                                            "class": "android.widget.TextView",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 36,
+                                                              "top": 2679,
+                                                              "right": 485,
+                                                              "bottom": 2347
+                                                            }
+                                                          },
+                                                          {
+                                                            "text": "[redacted]",
+                                                            "id": "com.doordash.driverapp:id/bottom_sheet_address_line_1",
+                                                            "class": "android.widget.TextView",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 36,
+                                                              "top": 2719,
+                                                              "right": 1044,
+                                                              "bottom": 2347
+                                                            }
+                                                          },
+                                                          {
+                                                            "id": "com.doordash.driverapp:id/bottom_sheet_address_line_2",
+                                                            "class": "android.widget.TextView",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 36,
+                                                              "top": 2821,
+                                                              "right": 1044,
+                                                              "bottom": 2347
+                                                            }
+                                                          },
+                                                          {
+                                                            "id": "com.doordash.driverapp:id/bottom_sheet_call_button",
+                                                            "class": "android.widget.ImageButton",
+                                                            "isClickable": true,
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 36,
+                                                              "top": 2904,
+                                                              "right": 143,
+                                                              "bottom": 2347
+                                                            }
+                                                          },
+                                                          {
+                                                            "id": "com.doordash.driverapp:id/bottom_sheet_text_button",
+                                                            "class": "android.view.ViewGroup",
+                                                            "isClickable": true,
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 179,
+                                                              "top": 2882,
+                                                              "right": 330,
+                                                              "bottom": 2347
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "id": "com.doordash.driverapp:id/chat_button_internal",
+                                                                "class": "android.widget.ImageButton",
+                                                                "isClickable": true,
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 202,
+                                                                  "top": 2847,
+                                                                  "right": 307,
+                                                                  "bottom": 2347
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "text": "Hand it to customer",
+                                                            "id": "com.doordash.driverapp:id/bottom_sheet_instructions_title",
+                                                            "class": "android.widget.TextView",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 36,
+                                                              "top": 2989,
+                                                              "right": 390,
+                                                              "bottom": 2347
+                                                            }
+                                                          },
+                                                          {
+                                                            "text": "[redacted]",
+                                                            "id": "com.doordash.driverapp:id/bottom_sheet_instructions",
+                                                            "class": "android.widget.TextView",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 36,
+                                                              "top": 3054,
+                                                              "right": 1044,
+                                                              "bottom": 2347
+                                                            }
+                                                          },
+                                                          {
+                                                            "text": "Read instructions on arrival",
+                                                            "id": "com.doordash.driverapp:id/bottom_sheet_audio_instructions_toggle_button",
+                                                            "class": "android.widget.TextView",
+                                                            "isClickable": true,
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 0,
+                                                              "top": 3159,
+                                                              "right": 1080,
+                                                              "bottom": 2347
+                                                            }
+                                                          },
+                                                          {
+                                                            "id": "com.doordash.driverapp:id/bottom_sheet_bottom_separator_2",
+                                                            "class": "android.view.View",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 0,
+                                                              "top": 3159,
+                                                              "right": 1080,
+                                                              "bottom": 2347
+                                                            }
+                                                          },
+                                                          {
+                                                            "state": "ON",
+                                                            "id": "com.doordash.driverapp:id/bottom_sheet_audio_instructions_toggle_switch",
+                                                            "class": "android.widget.Switch",
+                                                            "isEnabled": true,
+                                                            "isChecked": 1,
+                                                            "bounds": {
+                                                              "left": 940,
+                                                              "top": 3191,
+                                                              "right": 1044,
+                                                              "bottom": 2347
+                                                            }
+                                                          },
+                                                          {
+                                                            "id": "com.doordash.driverapp:id/bottom_sheet_bottom_separator_3",
+                                                            "class": "android.view.View",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 0,
+                                                              "top": 3283,
+                                                              "right": 1080,
+                                                              "bottom": 2347
+                                                            }
+                                                          },
+                                                          {
+                                                            "text": "Avoid tolls",
+                                                            "id": "com.doordash.driverapp:id/bottom_sheet_avoid_tolls_toggle_button",
+                                                            "class": "android.widget.TextView",
+                                                            "isClickable": true,
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 0,
+                                                              "top": 3242,
+                                                              "right": 1080,
+                                                              "bottom": 2347
+                                                            }
+                                                          },
+                                                          {
+                                                            "state": "OFF",
+                                                            "id": "com.doordash.driverapp:id/bottom_sheet_avoid_tolls_toggle_switch",
+                                                            "class": "android.widget.Switch",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 940,
+                                                              "top": 3275,
+                                                              "right": 1044,
+                                                              "bottom": 2347
+                                                            }
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/app/src/test/resources/snapshots/sessions/receipt_skip_2026_06_29/02_dropoff_handoff.json
+++ b/app/src/test/resources/snapshots/sessions/receipt_skip_2026_06_29/02_dropoff_handoff.json
@@ -1,0 +1,812 @@
+{
+  "captureId": "3b1dff6d-17e3-4dbe-a30d-8e1abb0cb342",
+  "pipelineId": "accessibility.window",
+  "schemaId": "uinode.v1",
+  "timestamp": 1782781521844,
+  "platform": "doordash",
+  "ruleId": "doordash.screen.dropoff_handoff",
+  "classificationName": "dropoff_handoff",
+  "metadata": {
+    "engineVersion": 1,
+    "rulesetFormatVersion": 2,
+    "pipelineVersions": {
+      "accessibility": 1,
+      "accessibility.window": 1,
+      "accessibility.click": 1,
+      "accessibility.long_click": 1,
+      "accessibility.scroll": 1,
+      "accessibility.focus": 1,
+      "notification": 1
+    },
+    "stateMachineApiVersion": "1.0",
+    "appVersion": "0.230.0",
+    "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+  },
+  "payload": {
+    "class": "android.widget.FrameLayout",
+    "isEnabled": true,
+    "bounds": {
+      "left": -213,
+      "top": 0,
+      "right": 866,
+      "bottom": 2400
+    },
+    "children": [
+      {
+        "class": "android.widget.LinearLayout",
+        "isEnabled": true,
+        "bounds": {
+          "left": -213,
+          "top": 0,
+          "right": 866,
+          "bottom": 2347
+        },
+        "children": [
+          {
+            "class": "android.widget.FrameLayout",
+            "isEnabled": true,
+            "bounds": {
+              "left": -213,
+              "top": 136,
+              "right": 866,
+              "bottom": 2347
+            },
+            "children": [
+              {
+                "id": "com.doordash.driverapp:id/action_bar_root",
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                  "left": -213,
+                  "top": 136,
+                  "right": 866,
+                  "bottom": 2347
+                },
+                "children": [
+                  {
+                    "id": "android:id/content",
+                    "class": "android.widget.FrameLayout",
+                    "isEnabled": true,
+                    "bounds": {
+                      "left": -213,
+                      "top": 136,
+                      "right": 866,
+                      "bottom": 2347
+                    },
+                    "children": [
+                      {
+                        "id": "com.doordash.driverapp:id/container",
+                        "class": "android.view.ViewGroup",
+                        "isEnabled": true,
+                        "bounds": {
+                          "left": -213,
+                          "top": 136,
+                          "right": 866,
+                          "bottom": 2347
+                        },
+                        "children": [
+                          {
+                            "id": "com.doordash.driverapp:id/toolbar_container",
+                            "class": "android.widget.LinearLayout",
+                            "isEnabled": true,
+                            "bounds": {
+                              "left": -213,
+                              "top": 136,
+                              "right": 866,
+                              "bottom": 136
+                            }
+                          },
+                          {
+                            "class": "android.widget.FrameLayout",
+                            "isEnabled": true,
+                            "bounds": {
+                              "left": -213,
+                              "top": 136,
+                              "right": 866,
+                              "bottom": 2347
+                            },
+                            "children": [
+                              {
+                                "id": "com.doordash.driverapp:id/fragment",
+                                "class": "android.widget.FrameLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                  "left": -213,
+                                  "top": 136,
+                                  "right": 866,
+                                  "bottom": 2347
+                                },
+                                "children": [
+                                  {
+                                    "class": "android.view.ViewGroup",
+                                    "isEnabled": true,
+                                    "bounds": {
+                                      "left": -213,
+                                      "top": 136,
+                                      "right": 866,
+                                      "bottom": 2347
+                                    },
+                                    "children": [
+                                      {
+                                        "id": "com.doordash.driverapp:id/drop_off_workflow_host_fragment",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                          "left": -213,
+                                          "top": 136,
+                                          "right": 866,
+                                          "bottom": 2347
+                                        },
+                                        "children": [
+                                          {
+                                            "id": "com.doordash.driverapp:id/drop_off_workflow_host_fragment",
+                                            "class": "android.widget.FrameLayout",
+                                            "isEnabled": true,
+                                            "bounds": {
+                                              "left": -213,
+                                              "top": 136,
+                                              "right": 866,
+                                              "bottom": 2347
+                                            },
+                                            "children": [
+                                              {
+                                                "class": "androidx.compose.ui.platform.ComposeView",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                  "left": -213,
+                                                  "top": 136,
+                                                  "right": 866,
+                                                  "bottom": 2347
+                                                },
+                                                "children": [
+                                                  {
+                                                    "class": "android.view.View",
+                                                    "isEnabled": true,
+                                                    "bounds": {
+                                                      "left": -213,
+                                                      "top": 136,
+                                                      "right": 866,
+                                                      "bottom": 2347
+                                                    },
+                                                    "children": [
+                                                      {
+                                                        "class": "android.view.View",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                          "left": -213,
+                                                          "top": 136,
+                                                          "right": 866,
+                                                          "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "class": "android.view.View",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": -213,
+                                                              "top": 243,
+                                                              "right": 866,
+                                                              "bottom": 2032
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "class": "android.view.View",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": -177,
+                                                                  "top": 243,
+                                                                  "right": 830,
+                                                                  "bottom": 535
+                                                                },
+                                                                "children": [
+                                                                  {
+                                                                    "text": "Deliver to [redacted]",
+                                                                    "class": "android.widget.TextView",
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": -177,
+                                                                      "top": 288,
+                                                                      "right": 397,
+                                                                      "bottom": 354
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "text": "by 8:32 PM",
+                                                                    "class": "android.widget.TextView",
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": -177,
+                                                                      "top": 363,
+                                                                      "right": 28,
+                                                                      "bottom": 410
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "class": "android.view.View",
+                                                                    "isClickable": true,
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": -177,
+                                                                      "top": 419,
+                                                                      "right": -9,
+                                                                      "bottom": 526
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "class": "android.view.View",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": -185,
+                                                                          "top": 420,
+                                                                          "right": -79,
+                                                                          "bottom": 526
+                                                                        }
+                                                                      },
+                                                                      {
+                                                                        "text": "Call",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": -105,
+                                                                          "top": 451,
+                                                                          "right": -38,
+                                                                          "bottom": 494
+                                                                        }
+                                                                      },
+                                                                      {
+                                                                        "class": "android.widget.Button",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": -177,
+                                                                          "top": 437,
+                                                                          "right": -9,
+                                                                          "bottom": 508
+                                                                        }
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "class": "android.view.View",
+                                                                    "isClickable": true,
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": 8,
+                                                                      "top": 419,
+                                                                      "right": 258,
+                                                                      "bottom": 526
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "class": "android.view.View",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 0,
+                                                                          "top": 420,
+                                                                          "right": 106,
+                                                                          "bottom": 526
+                                                                        }
+                                                                      },
+                                                                      {
+                                                                        "text": "Message",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 80,
+                                                                          "top": 451,
+                                                                          "right": 229,
+                                                                          "bottom": 494
+                                                                        }
+                                                                      },
+                                                                      {
+                                                                        "class": "android.widget.Button",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 8,
+                                                                          "top": 437,
+                                                                          "right": 258,
+                                                                          "bottom": 508
+                                                                        }
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "class": "android.view.View",
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": 195,
+                                                                      "top": 393,
+                                                                      "right": 302,
+                                                                      "bottom": 500
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "class": "android.view.View",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 196,
+                                                                          "top": 394,
+                                                                          "right": 302,
+                                                                          "bottom": 500
+                                                                        }
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "class": "android.view.View",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": -177,
+                                                                  "top": 571,
+                                                                  "right": 830,
+                                                                  "bottom": 1356
+                                                                },
+                                                                "children": [
+                                                                  {
+                                                                    "class": "android.view.View",
+                                                                    "isClickable": true,
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": -34,
+                                                                      "top": 603,
+                                                                      "right": 794,
+                                                                      "bottom": 710
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "text": "[redacted]",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": -34,
+                                                                          "top": 607,
+                                                                          "right": 534,
+                                                                          "bottom": 659
+                                                                        }
+                                                                      },
+                                                                      {
+                                                                        "text": "[redacted]",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": -34,
+                                                                          "top": 659,
+                                                                          "right": 369,
+                                                                          "bottom": 706
+                                                                        }
+                                                                      },
+                                                                      {
+                                                                        "class": "android.widget.Button",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": -34,
+                                                                          "top": 607,
+                                                                          "right": 794,
+                                                                          "bottom": 706
+                                                                        }
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "class": "android.view.View",
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": -177,
+                                                                      "top": 742,
+                                                                      "right": 830,
+                                                                      "bottom": 1145
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "class": "android.view.View",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": -177,
+                                                                          "top": 690,
+                                                                          "right": 830,
+                                                                          "bottom": 744
+                                                                        }
+                                                                      },
+                                                                      {
+                                                                        "class": "android.view.View",
+                                                                        "isClickable": true,
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": -177,
+                                                                          "top": 744,
+                                                                          "right": 830,
+                                                                          "bottom": 1145
+                                                                        }
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "class": "android.view.View",
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": -177,
+                                                                      "top": 1093,
+                                                                      "right": 830,
+                                                                      "bottom": 1199
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "class": "android.view.View",
+                                                                    "isClickable": true,
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": -35,
+                                                                      "top": 1198,
+                                                                      "right": 777,
+                                                                      "bottom": 1305
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "text": "Apt/Suite",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": -35,
+                                                                          "top": 1200,
+                                                                          "right": 150,
+                                                                          "bottom": 1247
+                                                                        }
+                                                                      },
+                                                                      {
+                                                                        "text": "[redacted]",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": -35,
+                                                                          "top": 1256,
+                                                                          "right": 101,
+                                                                          "bottom": 1303
+                                                                        }
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "class": "android.view.View",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": -177,
+                                                                  "top": 1392,
+                                                                  "right": 830,
+                                                                  "bottom": 1690
+                                                                },
+                                                                "children": [
+                                                                  {
+                                                                    "class": "android.view.View",
+                                                                    "isClickable": true,
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": -34,
+                                                                      "top": 1411,
+                                                                      "right": 794,
+                                                                      "bottom": 1517
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "text": "Hand it to customer",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": -34,
+                                                                          "top": 1438,
+                                                                          "right": 370,
+                                                                          "bottom": 1490
+                                                                        }
+                                                                      },
+                                                                      {
+                                                                        "class": "android.widget.Button",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": -34,
+                                                                          "top": 1438,
+                                                                          "right": 794,
+                                                                          "bottom": 1490
+                                                                        }
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "class": "android.view.View",
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": -177,
+                                                                      "top": 1483,
+                                                                      "right": 830,
+                                                                      "bottom": 1589
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "text": "\"[redacted]\"",
+                                                                    "class": "android.widget.TextView",
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": -35,
+                                                                      "top": 1590,
+                                                                      "right": 777,
+                                                                      "bottom": 1637
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "class": "android.view.View",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": -177,
+                                                                  "top": 1726,
+                                                                  "right": 830,
+                                                                  "bottom": 1869
+                                                                },
+                                                                "children": [
+                                                                  {
+                                                                    "class": "android.view.View",
+                                                                    "isClickable": true,
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": -177,
+                                                                      "top": 1726,
+                                                                      "right": 830,
+                                                                      "bottom": 1869
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "text": "195",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": -34,
+                                                                          "top": 1772,
+                                                                          "right": 37,
+                                                                          "bottom": 1824
+                                                                        }
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "class": "android.view.View",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": -213,
+                                                              "top": 1980,
+                                                              "right": 866,
+                                                              "bottom": 2086
+                                                            }
+                                                          },
+                                                          {
+                                                            "class": "android.view.View",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": -213,
+                                                              "top": 2034,
+                                                              "right": 866,
+                                                              "bottom": 2347
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "class": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": -177,
+                                                                  "top": 2070,
+                                                                  "right": 830,
+                                                                  "bottom": 2177
+                                                                },
+                                                                "children": [
+                                                                  {
+                                                                    "class": "android.widget.Button",
+                                                                    "isClickable": true,
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": -177,
+                                                                      "top": 2070,
+                                                                      "right": 830,
+                                                                      "bottom": 2177
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "text": "Mark as delivered",
+                                                                        "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 145,
+                                                                          "top": 2091,
+                                                                          "right": 507,
+                                                                          "bottom": 2157
+                                                                        }
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "class": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": -177,
+                                                                  "top": 2204,
+                                                                  "right": 830,
+                                                                  "bottom": 2311
+                                                                },
+                                                                "children": [
+                                                                  {
+                                                                    "class": "android.widget.Button",
+                                                                    "isClickable": true,
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": -177,
+                                                                      "top": 2204,
+                                                                      "right": 830,
+                                                                      "bottom": 2311
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "text": "Directions",
+                                                                        "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 221,
+                                                                          "top": 2225,
+                                                                          "right": 432,
+                                                                          "bottom": 2291
+                                                                        }
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "class": "android.view.View",
+                                                            "isClickable": true,
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": -213,
+                                                              "top": 136,
+                                                              "right": -106,
+                                                              "bottom": 243
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "desc": "Settings",
+                                                                "class": "android.view.View",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": -18,
+                                                                  "top": 163,
+                                                                  "right": 34,
+                                                                  "bottom": 216
+                                                                }
+                                                              },
+                                                              {
+                                                                "class": "android.widget.Button",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": -36,
+                                                                  "top": 145,
+                                                                  "right": 52,
+                                                                  "bottom": 234
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "class": "android.view.View",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": -106,
+                                                              "top": 137,
+                                                              "right": 652,
+                                                              "bottom": 243
+                                                            }
+                                                          },
+                                                          {
+                                                            "class": "android.view.View",
+                                                            "isClickable": true,
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 652,
+                                                              "top": 136,
+                                                              "right": 759,
+                                                              "bottom": 243
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "desc": "Safety",
+                                                                "class": "android.view.View",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 847,
+                                                                  "top": 163,
+                                                                  "right": 900,
+                                                                  "bottom": 216
+                                                                }
+                                                              },
+                                                              {
+                                                                "class": "android.widget.Button",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 829,
+                                                                  "top": 145,
+                                                                  "right": 918,
+                                                                  "bottom": 234
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "class": "android.view.View",
+                                                            "isClickable": true,
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 759,
+                                                              "top": 136,
+                                                              "right": 866,
+                                                              "bottom": 243
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "desc": "Help",
+                                                                "class": "android.view.View",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 954,
+                                                                  "top": 163,
+                                                                  "right": 1007,
+                                                                  "bottom": 216
+                                                                }
+                                                              },
+                                                              {
+                                                                "class": "android.widget.Button",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 936,
+                                                                  "top": 145,
+                                                                  "right": 1025,
+                                                                  "bottom": 234
+                                                                }
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/app/src/test/resources/snapshots/sessions/receipt_skip_2026_06_29/02_dropoff_handoff.json
+++ b/app/src/test/resources/snapshots/sessions/receipt_skip_2026_06_29/02_dropoff_handoff.json
@@ -557,7 +557,7 @@
                                                                     },
                                                                     "children": [
                                                                       {
-                                                                        "text": "195",
+                                                                        "text": "[redacted]",
                                                                         "class": "android.widget.TextView",
                                                                         "isEnabled": true,
                                                                         "bounds": {

--- a/app/src/test/resources/snapshots/sessions/receipt_skip_2026_06_29/03_waiting_for_offer.json
+++ b/app/src/test/resources/snapshots/sessions/receipt_skip_2026_06_29/03_waiting_for_offer.json
@@ -1,0 +1,1401 @@
+{
+  "captureId": "773bf0df-55c2-45dc-9967-0423d4942d09",
+  "pipelineId": "accessibility.window",
+  "schemaId": "uinode.v1",
+  "timestamp": 1782781748400,
+  "platform": "doordash",
+  "ruleId": "doordash.screen.waiting_for_offer",
+  "classificationName": "waiting_for_offer",
+  "metadata": {
+    "engineVersion": 1,
+    "rulesetFormatVersion": 2,
+    "pipelineVersions": {
+      "accessibility": 1,
+      "accessibility.window": 1,
+      "accessibility.click": 1,
+      "accessibility.long_click": 1,
+      "accessibility.scroll": 1,
+      "accessibility.focus": 1,
+      "notification": 1
+    },
+    "stateMachineApiVersion": "1.0",
+    "appVersion": "0.230.0",
+    "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+  },
+  "payload": {
+    "class": "android.widget.FrameLayout",
+    "isEnabled": true,
+    "bounds": {
+      "left": 28,
+      "top": 22,
+      "right": 1108,
+      "bottom": 2422
+    },
+    "children": [
+      {
+        "class": "android.widget.LinearLayout",
+        "isEnabled": true,
+        "bounds": {
+          "left": 28,
+          "top": 22,
+          "right": 1108,
+          "bottom": 2422
+        },
+        "children": [
+          {
+            "class": "android.widget.FrameLayout",
+            "isEnabled": true,
+            "bounds": {
+              "left": 28,
+              "top": 22,
+              "right": 1108,
+              "bottom": 2422
+            },
+            "children": [
+              {
+                "id": "com.doordash.driverapp:id/action_bar_root",
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                  "left": 28,
+                  "top": 22,
+                  "right": 1108,
+                  "bottom": 2422
+                },
+                "children": [
+                  {
+                    "id": "android:id/content",
+                    "class": "android.widget.FrameLayout",
+                    "isEnabled": true,
+                    "bounds": {
+                      "left": 28,
+                      "top": 22,
+                      "right": 1108,
+                      "bottom": 2422
+                    },
+                    "children": [
+                      {
+                        "id": "com.doordash.driverapp:id/overlay_gesture_manager",
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                          "left": 28,
+                          "top": 22,
+                          "right": 1108,
+                          "bottom": 2422
+                        },
+                        "children": [
+                          {
+                            "id": "com.doordash.driverapp:id/root_constraint_layout",
+                            "class": "android.view.ViewGroup",
+                            "isEnabled": true,
+                            "bounds": {
+                              "left": 28,
+                              "top": 22,
+                              "right": 1108,
+                              "bottom": 2422
+                            },
+                            "children": [
+                              {
+                                "id": "com.doordash.driverapp:id/side_nav_content_container",
+                                "class": "android.widget.FrameLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                  "left": 28,
+                                  "top": 22,
+                                  "right": 1108,
+                                  "bottom": 2422
+                                },
+                                "children": [
+                                  {
+                                    "id": "com.doordash.driverapp:id/main_fragment",
+                                    "class": "android.widget.FrameLayout",
+                                    "isEnabled": true,
+                                    "bounds": {
+                                      "left": 28,
+                                      "top": 22,
+                                      "right": 1108,
+                                      "bottom": 2422
+                                    },
+                                    "children": [
+                                      {
+                                        "class": "androidx.compose.ui.platform.ComposeView",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                          "left": 28,
+                                          "top": 22,
+                                          "right": 1108,
+                                          "bottom": 2422
+                                        },
+                                        "children": [
+                                          {
+                                            "class": "android.view.View",
+                                            "isEnabled": true,
+                                            "bounds": {
+                                              "left": 28,
+                                              "top": 22,
+                                              "right": 1108,
+                                              "bottom": 2422
+                                            },
+                                            "children": [
+                                              {
+                                                "class": "android.view.View",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                  "left": 28,
+                                                  "top": 22,
+                                                  "right": 1108,
+                                                  "bottom": 2422
+                                                },
+                                                "children": [
+                                                  {
+                                                    "class": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+                                                    "isEnabled": true,
+                                                    "bounds": {
+                                                      "left": 28,
+                                                      "top": 22,
+                                                      "right": 1108,
+                                                      "bottom": 2422
+                                                    },
+                                                    "children": [
+                                                      {
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                          "left": 28,
+                                                          "top": 22,
+                                                          "right": 1108,
+                                                          "bottom": 2422
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "class": "android.widget.FrameLayout",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 28,
+                                                              "top": 22,
+                                                              "right": 1108,
+                                                              "bottom": 2422
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "class": "android.view.TextureView",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 28,
+                                                                  "top": 22,
+                                                                  "right": 1108,
+                                                                  "bottom": 2422
+                                                                }
+                                                              },
+                                                              {
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 28,
+                                                                  "top": 22,
+                                                                  "right": 1108,
+                                                                  "bottom": 2422
+                                                                }
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "class": "android.view.View",
+                                                    "isEnabled": true,
+                                                    "bounds": {
+                                                      "left": 28,
+                                                      "top": 22,
+                                                      "right": 1108,
+                                                      "bottom": 75
+                                                    }
+                                                  },
+                                                  {
+                                                    "class": "android.view.View",
+                                                    "isEnabled": true,
+                                                    "bounds": {
+                                                      "left": 64,
+                                                      "top": 158,
+                                                      "right": 189,
+                                                      "bottom": 283
+                                                    },
+                                                    "children": [
+                                                      {
+                                                        "class": "android.view.View",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                          "left": 64,
+                                                          "top": 158,
+                                                          "right": 189,
+                                                          "bottom": 283
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "class": "android.view.View",
+                                                            "isClickable": true,
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 64,
+                                                              "top": 158,
+                                                              "right": 189,
+                                                              "bottom": 283
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "desc": "Open Settings",
+                                                                "class": "android.view.View",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 73,
+                                                                  "top": 172,
+                                                                  "right": 126,
+                                                                  "bottom": 225
+                                                                }
+                                                              },
+                                                              {
+                                                                "class": "android.widget.Button",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 37,
+                                                                  "top": 136,
+                                                                  "right": 162,
+                                                                  "bottom": 261
+                                                                }
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "class": "android.view.View",
+                                                    "isEnabled": true,
+                                                    "bounds": {
+                                                      "left": 811,
+                                                      "top": 167,
+                                                      "right": 874,
+                                                      "bottom": 230
+                                                    }
+                                                  },
+                                                  {
+                                                    "class": "android.view.View",
+                                                    "isEnabled": true,
+                                                    "bounds": {
+                                                      "left": 922,
+                                                      "top": 137,
+                                                      "right": 1047,
+                                                      "bottom": 262
+                                                    },
+                                                    "children": [
+                                                      {
+                                                        "class": "android.view.View",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                          "left": 922,
+                                                          "top": 137,
+                                                          "right": 1047,
+                                                          "bottom": 262
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "class": "android.view.View",
+                                                            "isClickable": true,
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 921,
+                                                              "top": 136,
+                                                              "right": 1046,
+                                                              "bottom": 261
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "desc": "Help",
+                                                                "class": "android.view.View",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 956,
+                                                                  "top": 172,
+                                                                  "right": 1009,
+                                                                  "bottom": 225
+                                                                }
+                                                              },
+                                                              {
+                                                                "class": "android.widget.Button",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 921,
+                                                                  "top": 136,
+                                                                  "right": 1045,
+                                                                  "bottom": 260
+                                                                }
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "class": "android.view.View",
+                                                    "isEnabled": true,
+                                                    "bounds": {
+                                                      "left": 391,
+                                                      "top": 137,
+                                                      "right": 691,
+                                                      "bottom": 262
+                                                    },
+                                                    "children": [
+                                                      {
+                                                        "class": "android.view.View",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                          "left": 391,
+                                                          "top": 136,
+                                                          "right": 691,
+                                                          "bottom": 261
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "id": "earnings_pill",
+                                                            "class": "android.view.View",
+                                                            "isClickable": true,
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 419,
+                                                              "top": 136,
+                                                              "right": 661,
+                                                              "bottom": 261
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "class": "android.view.View",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 418,
+                                                                  "top": 146,
+                                                                  "right": 660,
+                                                                  "bottom": 252
+                                                                },
+                                                                "children": [
+                                                                  {
+                                                                    "class": "android.view.View",
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": 432,
+                                                                      "top": 127,
+                                                                      "right": 539,
+                                                                      "bottom": 234
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "text": "$",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 473,
+                                                                          "top": 160,
+                                                                          "right": 498,
+                                                                          "bottom": 196
+                                                                        }
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "class": "android.view.View",
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": 457,
+                                                                      "top": 127,
+                                                                      "right": 563,
+                                                                      "bottom": 234
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "text": "2",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 498,
+                                                                          "top": 160,
+                                                                          "right": 522,
+                                                                          "bottom": 196
+                                                                        }
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "class": "android.view.View",
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": 480,
+                                                                      "top": 127,
+                                                                      "right": 586,
+                                                                      "bottom": 201
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "text": "7",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 523,
+                                                                          "top": 160,
+                                                                          "right": 545,
+                                                                          "bottom": 196
+                                                                        }
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "class": "android.view.View",
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": 497,
+                                                                      "top": 127,
+                                                                      "right": 604,
+                                                                      "bottom": 201
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "text": ".",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 545,
+                                                                          "top": 160,
+                                                                          "right": 556,
+                                                                          "bottom": 196
+                                                                        }
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "class": "android.view.View",
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": 515,
+                                                                      "top": 127,
+                                                                      "right": 622,
+                                                                      "bottom": 234
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "text": "9",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 556,
+                                                                          "top": 160,
+                                                                          "right": 581,
+                                                                          "bottom": 196
+                                                                        }
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "class": "android.view.View",
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": 540,
+                                                                      "top": 127,
+                                                                      "right": 647,
+                                                                      "bottom": 234
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "text": "9",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 581,
+                                                                          "top": 160,
+                                                                          "right": 606,
+                                                                          "bottom": 196
+                                                                        }
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "text": "This dash",
+                                                                    "class": "android.widget.TextView",
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": 475,
+                                                                      "top": 201,
+                                                                      "right": 605,
+                                                                      "bottom": 238
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "class": "android.widget.Button",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 419,
+                                                                  "top": 136,
+                                                                  "right": 661,
+                                                                  "bottom": 261
+                                                                }
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "class": "android.view.View",
+                                                    "isEnabled": true,
+                                                    "bounds": {
+                                                      "left": 0,
+                                                      "top": 0,
+                                                      "right": 1080,
+                                                      "bottom": 2400
+                                                    },
+                                                    "children": [
+                                                      {
+                                                        "class": "android.view.View",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                          "left": 0,
+                                                          "top": 0,
+                                                          "right": 1080,
+                                                          "bottom": 2400
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "class": "android.view.View",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 0,
+                                                              "top": 1846,
+                                                              "right": 1080,
+                                                              "bottom": 2400
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "class": "android.view.View",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 0,
+                                                                  "top": 1846,
+                                                                  "right": 1080,
+                                                                  "bottom": 2400
+                                                                },
+                                                                "children": [
+                                                                  {
+                                                                    "class": "android.view.View",
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": 0,
+                                                                      "top": 1846,
+                                                                      "right": 1080,
+                                                                      "bottom": 2400
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "class": "android.widget.ScrollView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 0,
+                                                                          "top": 1846,
+                                                                          "right": 1080,
+                                                                          "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                          {
+                                                                            "class": "android.view.View",
+                                                                            "isEnabled": true,
+                                                                            "bounds": {
+                                                                              "left": 0,
+                                                                              "top": 1846,
+                                                                              "right": 1080,
+                                                                              "bottom": 2387
+                                                                            },
+                                                                            "children": [
+                                                                              {
+                                                                                "class": "android.view.View",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                  "left": 0,
+                                                                                  "top": 1846,
+                                                                                  "right": 1080,
+                                                                                  "bottom": 2387
+                                                                                },
+                                                                                "children": [
+                                                                                  {
+                                                                                    "class": "android.view.View",
+                                                                                    "isEnabled": true,
+                                                                                    "bounds": {
+                                                                                      "left": 36,
+                                                                                      "top": 2015,
+                                                                                      "right": 1044,
+                                                                                      "bottom": 2030
+                                                                                    },
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                          "left": 36,
+                                                                                          "top": 1869,
+                                                                                          "right": 517,
+                                                                                          "bottom": 1882
+                                                                                        }
+                                                                                      },
+                                                                                      {
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                          "left": 36,
+                                                                                          "top": 2015,
+                                                                                          "right": 1044,
+                                                                                          "bottom": 2033
+                                                                                        }
+                                                                                      }
+                                                                                    ]
+                                                                                  },
+                                                                                  {
+                                                                                    "class": "android.view.View",
+                                                                                    "isEnabled": true,
+                                                                                    "bounds": {
+                                                                                      "left": 36,
+                                                                                      "top": 2109,
+                                                                                      "right": 1044,
+                                                                                      "bottom": 2351
+                                                                                    }
+                                                                                  }
+                                                                                ]
+                                                                              },
+                                                                              {
+                                                                                "class": "android.view.View",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                  "left": 0,
+                                                                                  "top": 1846,
+                                                                                  "right": 1080,
+                                                                                  "bottom": 2347
+                                                                                },
+                                                                                "children": [
+                                                                                  {
+                                                                                    "class": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+                                                                                    "isEnabled": true,
+                                                                                    "bounds": {
+                                                                                      "left": 36,
+                                                                                      "top": 1882,
+                                                                                      "right": 1044,
+                                                                                      "bottom": 2015
+                                                                                    },
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "text": "Finding offers.\u200c.\u200c.\u200c",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                          "left": 36,
+                                                                                          "top": 1882,
+                                                                                          "right": 1044,
+                                                                                          "bottom": 2015
+                                                                                        }
+                                                                                      }
+                                                                                    ]
+                                                                                  },
+                                                                                  {
+                                                                                    "class": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+                                                                                    "isEnabled": true,
+                                                                                    "bounds": {
+                                                                                      "left": 36,
+                                                                                      "top": 2033,
+                                                                                      "right": 1044,
+                                                                                      "bottom": 2109
+                                                                                    },
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "text": "You're more likely to get offers at hotspots.",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                          "left": 36,
+                                                                                          "top": 2033,
+                                                                                          "right": 1044,
+                                                                                          "bottom": 2109
+                                                                                        }
+                                                                                      }
+                                                                                    ]
+                                                                                  },
+                                                                                  {
+                                                                                    "class": "android.view.View",
+                                                                                    "isEnabled": true,
+                                                                                    "bounds": {
+                                                                                      "left": 36,
+                                                                                      "top": 2145,
+                                                                                      "right": 1044,
+                                                                                      "bottom": 2311
+                                                                                    },
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                          "left": 36,
+                                                                                          "top": 2145,
+                                                                                          "right": 1044,
+                                                                                          "bottom": 2311
+                                                                                        },
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "class": "android.view.View",
+                                                                                            "isEnabled": true,
+                                                                                            "bounds": {
+                                                                                              "left": 63,
+                                                                                              "top": 2172,
+                                                                                              "right": 1017,
+                                                                                              "bottom": 2284
+                                                                                            },
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "text": "Zone offer wait",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                  "left": 63,
+                                                                                                  "top": 2172,
+                                                                                                  "right": 1017,
+                                                                                                  "bottom": 2219
+                                                                                                }
+                                                                                              },
+                                                                                              {
+                                                                                                "text": "1-3 min",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                  "left": 63,
+                                                                                                  "top": 2237,
+                                                                                                  "right": 1017,
+                                                                                                  "bottom": 2284
+                                                                                                }
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "class": "android.view.View",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                          "left": 27,
+                                                          "top": 1694,
+                                                          "right": 152,
+                                                          "bottom": 1819
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "desc": "Dash Preferences",
+                                                            "class": "android.view.View",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 63,
+                                                              "top": 1730,
+                                                              "right": 116,
+                                                              "bottom": 1783
+                                                            }
+                                                          },
+                                                          {
+                                                            "class": "android.widget.Button",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 27,
+                                                              "top": 1694,
+                                                              "right": 152,
+                                                              "bottom": 1819
+                                                            }
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "class": "android.view.View",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                          "left": 928,
+                                                          "top": 1694,
+                                                          "right": 1053,
+                                                          "bottom": 1819
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "desc": "Safety tools",
+                                                            "class": "android.view.View",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 964,
+                                                              "top": 1730,
+                                                              "right": 1017,
+                                                              "bottom": 1783
+                                                            }
+                                                          },
+                                                          {
+                                                            "class": "android.widget.Button",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 928,
+                                                              "top": 1694,
+                                                              "right": 1053,
+                                                              "bottom": 1819
+                                                            }
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "id": "com.doordash.driverapp:id/side_nav_container",
+                                "class": "android.widget.FrameLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                  "left": 0,
+                                  "top": 0,
+                                  "right": 712,
+                                  "bottom": 2400
+                                },
+                                "children": [
+                                  {
+                                    "class": "android.widget.LinearLayout",
+                                    "isEnabled": true,
+                                    "bounds": {
+                                      "left": 0,
+                                      "top": 0,
+                                      "right": 712,
+                                      "bottom": 2400
+                                    },
+                                    "children": [
+                                      {
+                                        "id": "com.doordash.driverapp:id/side_nav_compose_view",
+                                        "class": "androidx.compose.ui.platform.ComposeView",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                          "left": 0,
+                                          "top": 0,
+                                          "right": 712,
+                                          "bottom": 2400
+                                        },
+                                        "children": [
+                                          {
+                                            "class": "android.view.View",
+                                            "isEnabled": true,
+                                            "bounds": {
+                                              "left": 0,
+                                              "top": 0,
+                                              "right": 712,
+                                              "bottom": 2400
+                                            },
+                                            "children": [
+                                              {
+                                                "class": "android.view.View",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                  "left": 0,
+                                                  "top": 0,
+                                                  "right": 712,
+                                                  "bottom": 2400
+                                                },
+                                                "children": [
+                                                  {
+                                                    "class": "android.view.View",
+                                                    "isEnabled": true,
+                                                    "bounds": {
+                                                      "left": 0,
+                                                      "top": 0,
+                                                      "right": 712,
+                                                      "bottom": 1535
+                                                    },
+                                                    "children": [
+                                                      {
+                                                        "text": "Stephen T",
+                                                        "class": "android.widget.TextView",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                          "left": 36,
+                                                          "top": 167,
+                                                          "right": 423,
+                                                          "bottom": 272
+                                                        }
+                                                      },
+                                                      {
+                                                        "class": "android.view.View",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                          "left": 36,
+                                                          "top": 251,
+                                                          "right": 198,
+                                                          "bottom": 358
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "class": "android.view.View",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 14,
+                                                              "top": 260,
+                                                              "right": 121,
+                                                              "bottom": 367
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "desc": "Silver",
+                                                                "class": "android.widget.ImageView",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 36,
+                                                                  "top": 291,
+                                                                  "right": 81,
+                                                                  "bottom": 336
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "class": "android.view.View",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 95,
+                                                              "top": 260,
+                                                              "right": 202,
+                                                              "bottom": 367
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "text": "Silver",
+                                                                "class": "android.widget.TextView",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 99,
+                                                                  "top": 290,
+                                                                  "right": 198,
+                                                                  "bottom": 337
+                                                                }
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "class": "android.view.View",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                          "left": 0,
+                                                          "top": 338,
+                                                          "right": 712,
+                                                          "bottom": 444
+                                                        }
+                                                      },
+                                                      {
+                                                        "class": "android.view.View",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "isChecked": 1,
+                                                        "bounds": {
+                                                          "left": 36,
+                                                          "top": 418,
+                                                          "right": 676,
+                                                          "bottom": 543
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "desc": "",
+                                                            "class": "android.view.View",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 72,
+                                                              "top": 454,
+                                                              "right": 125,
+                                                              "bottom": 507
+                                                            }
+                                                          },
+                                                          {
+                                                            "text": "Home",
+                                                            "class": "android.widget.TextView",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 152,
+                                                              "top": 455,
+                                                              "right": 275,
+                                                              "bottom": 507
+                                                            }
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "class": "android.view.View",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                          "left": 36,
+                                                          "top": 552,
+                                                          "right": 676,
+                                                          "bottom": 677
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "desc": "",
+                                                            "class": "android.view.View",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 72,
+                                                              "top": 588,
+                                                              "right": 125,
+                                                              "bottom": 641
+                                                            }
+                                                          },
+                                                          {
+                                                            "text": "Schedule",
+                                                            "class": "android.widget.TextView",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 152,
+                                                              "top": 589,
+                                                              "right": 333,
+                                                              "bottom": 641
+                                                            }
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "class": "android.view.View",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                          "left": 36,
+                                                          "top": 686,
+                                                          "right": 676,
+                                                          "bottom": 811
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "desc": "",
+                                                            "class": "android.view.View",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 72,
+                                                              "top": 722,
+                                                              "right": 125,
+                                                              "bottom": 775
+                                                            }
+                                                          },
+                                                          {
+                                                            "text": "Account",
+                                                            "class": "android.widget.TextView",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 152,
+                                                              "top": 723,
+                                                              "right": 316,
+                                                              "bottom": 775
+                                                            }
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "class": "android.view.View",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                          "left": 36,
+                                                          "top": 820,
+                                                          "right": 676,
+                                                          "bottom": 945
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "desc": "",
+                                                            "class": "android.view.View",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 72,
+                                                              "top": 856,
+                                                              "right": 125,
+                                                              "bottom": 909
+                                                            }
+                                                          },
+                                                          {
+                                                            "text": "Ratings",
+                                                            "class": "android.widget.TextView",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 152,
+                                                              "top": 857,
+                                                              "right": 300,
+                                                              "bottom": 909
+                                                            }
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "class": "android.view.View",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                          "left": 36,
+                                                          "top": 954,
+                                                          "right": 676,
+                                                          "bottom": 1079
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "desc": "",
+                                                            "class": "android.view.View",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 72,
+                                                              "top": 990,
+                                                              "right": 125,
+                                                              "bottom": 1043
+                                                            }
+                                                          },
+                                                          {
+                                                            "text": "Earnings",
+                                                            "class": "android.widget.TextView",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 152,
+                                                              "top": 991,
+                                                              "right": 321,
+                                                              "bottom": 1043
+                                                            }
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "class": "android.view.View",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                          "left": 36,
+                                                          "top": 1088,
+                                                          "right": 676,
+                                                          "bottom": 1213
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "desc": "",
+                                                            "class": "android.view.View",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 72,
+                                                              "top": 1124,
+                                                              "right": 125,
+                                                              "bottom": 1177
+                                                            }
+                                                          },
+                                                          {
+                                                            "text": "Promos",
+                                                            "class": "android.widget.TextView",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 152,
+                                                              "top": 1125,
+                                                              "right": 303,
+                                                              "bottom": 1177
+                                                            }
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "class": "android.view.View",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                          "left": 36,
+                                                          "top": 1222,
+                                                          "right": 676,
+                                                          "bottom": 1347
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "desc": "",
+                                                            "class": "android.view.View",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 72,
+                                                              "top": 1258,
+                                                              "right": 125,
+                                                              "bottom": 1311
+                                                            }
+                                                          },
+                                                          {
+                                                            "text": "Preferences",
+                                                            "class": "android.widget.TextView",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 152,
+                                                              "top": 1259,
+                                                              "right": 382,
+                                                              "bottom": 1311
+                                                            }
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "class": "android.view.View",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                          "left": 36,
+                                                          "top": 1365,
+                                                          "right": 676,
+                                                          "bottom": 1490
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "desc": "",
+                                                            "class": "android.view.View",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 72,
+                                                              "top": 1401,
+                                                              "right": 125,
+                                                              "bottom": 1454
+                                                            }
+                                                          },
+                                                          {
+                                                            "text": "Help",
+                                                            "class": "android.widget.TextView",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 152,
+                                                              "top": 1402,
+                                                              "right": 246,
+                                                              "bottom": 1454
+                                                            }
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "class": "android.view.View",
+                                                    "isEnabled": true,
+                                                    "bounds": {
+                                                      "left": 0,
+                                                      "top": 2276,
+                                                      "right": 712,
+                                                      "bottom": 2382
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "id": "com.doordash.driverapp:id/side_nav_header_background",
+                                "class": "androidx.compose.ui.platform.ComposeView",
+                                "isEnabled": true,
+                                "bounds": {
+                                  "left": 0,
+                                  "top": 0,
+                                  "right": 1080,
+                                  "bottom": 356
+                                },
+                                "children": [
+                                  {
+                                    "class": "android.view.View",
+                                    "isEnabled": true,
+                                    "bounds": {
+                                      "left": 0,
+                                      "top": 0,
+                                      "right": 1080,
+                                      "bottom": 356
+                                    },
+                                    "children": [
+                                      {
+                                        "class": "android.view.View",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                          "left": 0,
+                                          "top": 0,
+                                          "right": 1080,
+                                          "bottom": 356
+                                        },
+                                        "children": [
+                                          {
+                                            "class": "android.view.View",
+                                            "isEnabled": true,
+                                            "bounds": {
+                                              "left": 0,
+                                              "top": 0,
+                                              "right": 1080,
+                                              "bottom": 356
+                                            },
+                                            "children": [
+                                              {
+                                                "class": "android.view.View",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                  "left": 0,
+                                                  "top": 0,
+                                                  "right": 712,
+                                                  "bottom": 154
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/app/src/test/resources/snapshots/sessions/receipt_skip_2026_06_29/04_offer_popup.json
+++ b/app/src/test/resources/snapshots/sessions/receipt_skip_2026_06_29/04_offer_popup.json
@@ -1,0 +1,973 @@
+{
+  "captureId": "45203350-3e0a-41a2-bab3-08bc99484719",
+  "pipelineId": "accessibility.window",
+  "schemaId": "uinode.v1",
+  "timestamp": 1782781760355,
+  "platform": "doordash",
+  "ruleId": "doordash.screen.offer_popup",
+  "classificationName": "offer_popup",
+  "metadata": {
+    "engineVersion": 1,
+    "rulesetFormatVersion": 2,
+    "pipelineVersions": {
+      "accessibility": 1,
+      "accessibility.window": 1,
+      "accessibility.click": 1,
+      "accessibility.long_click": 1,
+      "accessibility.scroll": 1,
+      "accessibility.focus": 1,
+      "notification": 1
+    },
+    "stateMachineApiVersion": "1.0",
+    "appVersion": "0.230.0",
+    "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+  },
+  "payload": {
+    "class": "android.widget.FrameLayout",
+    "isEnabled": true,
+    "bounds": {
+      "left": 0,
+      "top": 0,
+      "right": 1080,
+      "bottom": 2400
+    },
+    "children": [
+      {
+        "class": "android.widget.LinearLayout",
+        "isEnabled": true,
+        "bounds": {
+          "left": 0,
+          "top": 0,
+          "right": 1080,
+          "bottom": 2347
+        },
+        "children": [
+          {
+            "class": "android.widget.FrameLayout",
+            "isEnabled": true,
+            "bounds": {
+              "left": 0,
+              "top": 136,
+              "right": 1080,
+              "bottom": 2347
+            },
+            "children": [
+              {
+                "id": "com.doordash.driverapp:id/action_bar_root",
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                  "left": 0,
+                  "top": 136,
+                  "right": 1080,
+                  "bottom": 2347
+                },
+                "children": [
+                  {
+                    "id": "android:id/content",
+                    "class": "android.widget.FrameLayout",
+                    "isEnabled": true,
+                    "bounds": {
+                      "left": 0,
+                      "top": 136,
+                      "right": 1080,
+                      "bottom": 2347
+                    },
+                    "children": [
+                      {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                          "left": 0,
+                          "top": 136,
+                          "right": 1080,
+                          "bottom": 2347
+                        },
+                        "children": [
+                          {
+                            "id": "com.doordash.driverapp:id/accept_decline_fragment_container",
+                            "class": "android.widget.FrameLayout",
+                            "isEnabled": true,
+                            "bounds": {
+                              "left": 0,
+                              "top": 136,
+                              "right": 1080,
+                              "bottom": 2347
+                            },
+                            "children": [
+                              {
+                                "id": "com.doordash.driverapp:id/bottomSheetLayout",
+                                "class": "android.view.ViewGroup",
+                                "isEnabled": true,
+                                "bounds": {
+                                  "left": 0,
+                                  "top": 136,
+                                  "right": 1080,
+                                  "bottom": 2347
+                                },
+                                "children": [
+                                  {
+                                    "id": "com.doordash.driverapp:id/accept_constraint_layout",
+                                    "class": "android.view.ViewGroup",
+                                    "isEnabled": true,
+                                    "bounds": {
+                                      "left": 0,
+                                      "top": 136,
+                                      "right": 1080,
+                                      "bottom": 2347
+                                    },
+                                    "children": [
+                                      {
+                                        "id": "com.doordash.driverapp:id/map_container",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                          "left": 0,
+                                          "top": 136,
+                                          "right": 1080,
+                                          "bottom": 2347
+                                        },
+                                        "children": [
+                                          {
+                                            "class": "android.widget.FrameLayout",
+                                            "isEnabled": true,
+                                            "bounds": {
+                                              "left": 0,
+                                              "top": 136,
+                                              "right": 1080,
+                                              "bottom": 2347
+                                            },
+                                            "children": [
+                                              {
+                                                "class": "android.view.TextureView",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                  "left": 0,
+                                                  "top": 136,
+                                                  "right": 1080,
+                                                  "bottom": 2347
+                                                }
+                                              },
+                                              {
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                  "left": 0,
+                                                  "top": 136,
+                                                  "right": 1080,
+                                                  "bottom": 2347
+                                                }
+                                              },
+                                              {
+                                                "class": "android.widget.ImageView",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                  "left": 5,
+                                                  "top": 1304,
+                                                  "right": 194,
+                                                  "bottom": 1351
+                                                }
+                                              },
+                                              {
+                                                "class": "android.widget.ImageView",
+                                                "isClickable": true,
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                  "left": 200,
+                                                  "top": 1304,
+                                                  "right": 247,
+                                                  "bottom": 1351
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "id": "com.doordash.driverapp:id/secondary_action_button_dash_plus",
+                                        "class": "android.widget.Button",
+                                        "isClickable": true,
+                                        "bounds": {
+                                          "left": 816,
+                                          "top": 172,
+                                          "right": 1044,
+                                          "bottom": 297
+                                        },
+                                        "children": [
+                                          {
+                                            "text": "Decline",
+                                            "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                            "class": "android.widget.TextView",
+                                            "bounds": {
+                                              "left": 852,
+                                              "top": 202,
+                                              "right": 1008,
+                                              "bottom": 268
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "text": "ef25d5da-bd95-41d0-acca-b9ca0adc585c",
+                                        "id": "com.doordash.driverapp:id/assignment_id_text",
+                                        "class": "android.widget.TextView",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                          "left": 704,
+                                          "top": 1310,
+                                          "right": 1080,
+                                          "bottom": 1351
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "id": "com.doordash.driverapp:id/load_progress",
+                                    "class": "android.widget.RelativeLayout",
+                                    "isEnabled": true,
+                                    "bounds": {
+                                      "left": 0,
+                                      "top": 136,
+                                      "right": 1080,
+                                      "bottom": 2347
+                                    },
+                                    "children": [
+                                      {
+                                        "state": "in progress",
+                                        "id": "com.doordash.driverapp:id/progress_bar",
+                                        "class": "android.widget.ProgressBar",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                          "left": 486,
+                                          "top": 1188,
+                                          "right": 593,
+                                          "bottom": 1295
+                                        }
+                                      },
+                                      {
+                                        "id": "com.doordash.driverapp:id/progress_message",
+                                        "class": "android.widget.TextView",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                          "left": 540,
+                                          "top": 1295,
+                                          "right": 540,
+                                          "bottom": 1342
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "id": "com.doordash.driverapp:id/prism_sheet",
+                                    "class": "android.view.ViewGroup",
+                                    "isClickable": true,
+                                    "isEnabled": true,
+                                    "bounds": {
+                                      "left": 0,
+                                      "top": 1351,
+                                      "right": 1080,
+                                      "bottom": 2347
+                                    },
+                                    "children": [
+                                      {
+                                        "id": "com.doordash.driverapp:id/prism_sheet_collar_view",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                          "left": 0,
+                                          "top": 1351,
+                                          "right": 1080,
+                                          "bottom": 1351
+                                        }
+                                      },
+                                      {
+                                        "id": "com.doordash.driverapp:id/extra_space",
+                                        "class": "android.view.View",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                          "left": 0,
+                                          "top": 1351,
+                                          "right": 0,
+                                          "bottom": 1387
+                                        }
+                                      },
+                                      {
+                                        "id": "com.doordash.driverapp:id/prism_sheet_content_parent_container",
+                                        "class": "android.view.ViewGroup",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                          "left": 0,
+                                          "top": 1387,
+                                          "right": 1080,
+                                          "bottom": 2311
+                                        },
+                                        "children": [
+                                          {
+                                            "id": "com.doordash.driverapp:id/nested_scroll_view",
+                                            "class": "android.widget.ScrollView",
+                                            "isEnabled": true,
+                                            "bounds": {
+                                              "left": 0,
+                                              "top": 1387,
+                                              "right": 1080,
+                                              "bottom": 2311
+                                            },
+                                            "children": [
+                                              {
+                                                "id": "com.doordash.driverapp:id/prism_content_container",
+                                                "class": "android.widget.LinearLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                  "left": 0,
+                                                  "top": 1387,
+                                                  "right": 1080,
+                                                  "bottom": 2151
+                                                },
+                                                "children": [
+                                                  {
+                                                    "id": "com.doordash.driverapp:id/bottomsheet_content_container",
+                                                    "class": "android.widget.FrameLayout",
+                                                    "isEnabled": true,
+                                                    "bounds": {
+                                                      "left": 0,
+                                                      "top": 1387,
+                                                      "right": 1080,
+                                                      "bottom": 2151
+                                                    },
+                                                    "children": [
+                                                      {
+                                                        "id": "com.doordash.driverapp:id/accept_decline_recycler_view_container",
+                                                        "class": "android.view.ViewGroup",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                          "left": 0,
+                                                          "top": 1387,
+                                                          "right": 1080,
+                                                          "bottom": 2151
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "id": "com.doordash.driverapp:id/items_recycler_view",
+                                                            "class": "androidx.recyclerview.widget.RecyclerView",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 0,
+                                                              "top": 1387,
+                                                              "right": 1080,
+                                                              "bottom": 2151
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 0,
+                                                                  "top": 1387,
+                                                                  "right": 1080,
+                                                                  "bottom": 1388
+                                                                }
+                                                              },
+                                                              {
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 0,
+                                                                  "top": 1388,
+                                                                  "right": 1080,
+                                                                  "bottom": 1472
+                                                                },
+                                                                "children": [
+                                                                  {
+                                                                    "class": "android.view.ViewGroup",
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": 0,
+                                                                      "top": 1388,
+                                                                      "right": 1080,
+                                                                      "bottom": 1472
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "text": "$8.75  Guaranteed (incl. tips)",
+                                                                        "id": "com.doordash.driverapp:id/text_field",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 36,
+                                                                          "top": 1388,
+                                                                          "right": 1044,
+                                                                          "bottom": 1472
+                                                                        }
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 0,
+                                                                  "top": 1472,
+                                                                  "right": 1080,
+                                                                  "bottom": 1537
+                                                                },
+                                                                "children": [
+                                                                  {
+                                                                    "class": "android.view.ViewGroup",
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": 0,
+                                                                      "top": 1472,
+                                                                      "right": 1080,
+                                                                      "bottom": 1537
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "text": "2.3 mi",
+                                                                        "id": "com.doordash.driverapp:id/text_field",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 36,
+                                                                          "top": 1472,
+                                                                          "right": 1044,
+                                                                          "bottom": 1537
+                                                                        }
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 0,
+                                                                  "top": 1537,
+                                                                  "right": 1080,
+                                                                  "bottom": 1593
+                                                                },
+                                                                "children": [
+                                                                  {
+                                                                    "class": "android.view.ViewGroup",
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": 0,
+                                                                      "top": 1537,
+                                                                      "right": 1080,
+                                                                      "bottom": 1593
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "text": "Deliver by 8:42 PM",
+                                                                        "id": "com.doordash.driverapp:id/text_field",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 36,
+                                                                          "top": 1537,
+                                                                          "right": 1044,
+                                                                          "bottom": 1593
+                                                                        }
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 0,
+                                                                  "top": 1593,
+                                                                  "right": 1080,
+                                                                  "bottom": 1633
+                                                                },
+                                                                "children": [
+                                                                  {
+                                                                    "class": "android.view.View",
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": 36,
+                                                                      "top": 1629,
+                                                                      "right": 1044,
+                                                                      "bottom": 1633
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 0,
+                                                                  "top": 1633,
+                                                                  "right": 1080,
+                                                                  "bottom": 1874
+                                                                },
+                                                                "children": [
+                                                                  {
+                                                                    "class": "android.view.ViewGroup",
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": 0,
+                                                                      "top": 1633,
+                                                                      "right": 1080,
+                                                                      "bottom": 1874
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "id": "com.doordash.driverapp:id/work_unit_icon_container",
+                                                                        "class": "android.widget.FrameLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 45,
+                                                                          "top": 1660,
+                                                                          "right": 99,
+                                                                          "bottom": 1714
+                                                                        },
+                                                                        "children": [
+                                                                          {
+                                                                            "id": "com.doordash.driverapp:id/work_unit_image",
+                                                                            "class": "android.widget.ImageView",
+                                                                            "isEnabled": true,
+                                                                            "bounds": {
+                                                                              "left": 45,
+                                                                              "top": 1660,
+                                                                              "right": 99,
+                                                                              "bottom": 1714
+                                                                            }
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "text": "Shop for items",
+                                                                        "id": "com.doordash.driverapp:id/work_unit_type",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 126,
+                                                                          "top": 1666,
+                                                                          "right": 1080,
+                                                                          "bottom": 1708
+                                                                        }
+                                                                      },
+                                                                      {
+                                                                        "id": "com.doordash.driverapp:id/bottom_vertical_line",
+                                                                        "class": "android.view.View",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 71,
+                                                                          "top": 1714,
+                                                                          "right": 73,
+                                                                          "bottom": 1874
+                                                                        }
+                                                                      },
+                                                                      {
+                                                                        "id": "com.doordash.driverapp:id/display_name_container",
+                                                                        "class": "android.view.ViewGroup",
+                                                                        "isClickable": true,
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 126,
+                                                                          "top": 1726,
+                                                                          "right": 972,
+                                                                          "bottom": 1777
+                                                                        },
+                                                                        "children": [
+                                                                          {
+                                                                            "text": "Dollar General",
+                                                                            "id": "com.doordash.driverapp:id/display_name",
+                                                                            "class": "android.widget.TextView",
+                                                                            "isEnabled": true,
+                                                                            "bounds": {
+                                                                              "left": 126,
+                                                                              "top": 1726,
+                                                                              "right": 431,
+                                                                              "bottom": 1777
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "text": "(13 items \u2022 15 units)",
+                                                                            "id": "com.doordash.driverapp:id/display_name_secondary",
+                                                                            "class": "android.widget.TextView",
+                                                                            "isEnabled": true,
+                                                                            "bounds": {
+                                                                              "left": 431,
+                                                                              "top": 1726,
+                                                                              "right": 779,
+                                                                              "bottom": 1777
+                                                                            }
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "id": "com.doordash.driverapp:id/chevron",
+                                                                        "class": "android.widget.ImageView",
+                                                                        "isClickable": true,
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 1008,
+                                                                          "top": 1737,
+                                                                          "right": 1044,
+                                                                          "bottom": 1777
+                                                                        }
+                                                                      },
+                                                                      {
+                                                                        "id": "com.doordash.driverapp:id/requirements_container",
+                                                                        "class": "android.view.ViewGroup",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 126,
+                                                                          "top": 1795,
+                                                                          "right": 1044,
+                                                                          "bottom": 1874
+                                                                        },
+                                                                        "children": [
+                                                                          {
+                                                                            "class": "android.view.ViewGroup",
+                                                                            "isEnabled": true,
+                                                                            "bounds": {
+                                                                              "left": 126,
+                                                                              "top": 1795,
+                                                                              "right": 391,
+                                                                              "bottom": 1874
+                                                                            },
+                                                                            "children": [
+                                                                              {
+                                                                                "class": "android.view.ViewGroup",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                  "left": 126,
+                                                                                  "top": 1795,
+                                                                                  "right": 391,
+                                                                                  "bottom": 1874
+                                                                                },
+                                                                                "children": [
+                                                                                  {
+                                                                                    "text": "Red Card",
+                                                                                    "id": "com.doordash.driverapp:id/tag",
+                                                                                    "class": "android.widget.TextView",
+                                                                                    "isEnabled": true,
+                                                                                    "bounds": {
+                                                                                      "left": 126,
+                                                                                      "top": 1799,
+                                                                                      "right": 373,
+                                                                                      "bottom": 1870
+                                                                                    }
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 0,
+                                                                  "top": 1874,
+                                                                  "right": 1080,
+                                                                  "bottom": 1955
+                                                                },
+                                                                "children": [
+                                                                  {
+                                                                    "class": "android.view.ViewGroup",
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": 0,
+                                                                      "top": 1874,
+                                                                      "right": 1080,
+                                                                      "bottom": 1955
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "id": "com.doordash.driverapp:id/top_vertical_line",
+                                                                        "class": "android.view.View",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 71,
+                                                                          "top": 1874,
+                                                                          "right": 73,
+                                                                          "bottom": 1901
+                                                                        }
+                                                                      },
+                                                                      {
+                                                                        "id": "com.doordash.driverapp:id/work_unit_image",
+                                                                        "class": "android.widget.ImageView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 45,
+                                                                          "top": 1901,
+                                                                          "right": 99,
+                                                                          "bottom": 1955
+                                                                        }
+                                                                      },
+                                                                      {
+                                                                        "text": "Customer dropoff",
+                                                                        "id": "com.doordash.driverapp:id/display_name",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 126,
+                                                                          "top": 1907,
+                                                                          "right": 424,
+                                                                          "bottom": 1949
+                                                                        }
+                                                                      },
+                                                                      {
+                                                                        "id": "com.doordash.driverapp:id/display_name_secondary",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 433,
+                                                                          "top": 1907,
+                                                                          "right": 1080,
+                                                                          "bottom": 1949
+                                                                        }
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 0,
+                                                                  "top": 1955,
+                                                                  "right": 1080,
+                                                                  "bottom": 1995
+                                                                },
+                                                                "children": [
+                                                                  {
+                                                                    "class": "android.view.View",
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": 36,
+                                                                      "top": 1991,
+                                                                      "right": 1044,
+                                                                      "bottom": 1995
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 0,
+                                                                  "top": 1995,
+                                                                  "right": 1080,
+                                                                  "bottom": 2073
+                                                                },
+                                                                "children": [
+                                                                  {
+                                                                    "class": "android.view.ViewGroup",
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": 0,
+                                                                      "top": 1995,
+                                                                      "right": 1080,
+                                                                      "bottom": 2073
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "id": "com.doordash.driverapp:id/callout_image",
+                                                                        "class": "android.widget.ImageView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 45,
+                                                                          "top": 2013,
+                                                                          "right": 99,
+                                                                          "bottom": 2067
+                                                                        }
+                                                                      },
+                                                                      {
+                                                                        "text": "May need returns",
+                                                                        "id": "com.doordash.driverapp:id/callout_text",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 117,
+                                                                          "top": 2013,
+                                                                          "right": 1035,
+                                                                          "bottom": 2073
+                                                                        }
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 0,
+                                                                  "top": 2073,
+                                                                  "right": 1080,
+                                                                  "bottom": 2151
+                                                                },
+                                                                "children": [
+                                                                  {
+                                                                    "class": "android.view.ViewGroup",
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": 0,
+                                                                      "top": 2073,
+                                                                      "right": 1080,
+                                                                      "bottom": 2151
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "id": "com.doordash.driverapp:id/callout_image",
+                                                                        "class": "android.widget.ImageView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 45,
+                                                                          "top": 2091,
+                                                                          "right": 99,
+                                                                          "bottom": 2145
+                                                                        }
+                                                                      },
+                                                                      {
+                                                                        "text": "Items can be added before checkout",
+                                                                        "id": "com.doordash.driverapp:id/callout_text",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 117,
+                                                                          "top": 2091,
+                                                                          "right": 1035,
+                                                                          "bottom": 2151
+                                                                        }
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "id": "com.doordash.driverapp:id/prism_sheet_footer_divider",
+                                    "class": "android.view.View",
+                                    "isEnabled": true,
+                                    "bounds": {
+                                      "left": 0,
+                                      "top": 2147,
+                                      "right": 1080,
+                                      "bottom": 2151
+                                    }
+                                  },
+                                  {
+                                    "id": "com.doordash.driverapp:id/prism_sheet_footer_container",
+                                    "class": "android.widget.LinearLayout",
+                                    "isEnabled": true,
+                                    "bounds": {
+                                      "left": 0,
+                                      "top": 2151,
+                                      "right": 1080,
+                                      "bottom": 2347
+                                    },
+                                    "children": [
+                                      {
+                                        "id": "com.doordash.driverapp:id/accept_decline_footer_container",
+                                        "class": "android.view.ViewGroup",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                          "left": 0,
+                                          "top": 2151,
+                                          "right": 1080,
+                                          "bottom": 2347
+                                        },
+                                        "children": [
+                                          {
+                                            "id": "com.doordash.driverapp:id/accept_button",
+                                            "class": "android.widget.Button",
+                                            "isClickable": true,
+                                            "isEnabled": true,
+                                            "bounds": {
+                                              "left": 36,
+                                              "top": 2187,
+                                              "right": 1044,
+                                              "bottom": 2311
+                                            },
+                                            "children": [
+                                              {
+                                                "text": "Accept",
+                                                "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                "class": "android.widget.TextView",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                  "left": 467,
+                                                  "top": 2216,
+                                                  "right": 613,
+                                                  "bottom": 2282
+                                                }
+                                              },
+                                              {
+                                                "id": "com.doordash.driverapp:id/textSwitcher_prism_button_end_text",
+                                                "class": "android.widget.TextSwitcher",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                  "left": 938,
+                                                  "top": 2219,
+                                                  "right": 1008,
+                                                  "bottom": 2279
+                                                },
+                                                "children": [
+                                                  {
+                                                    "text": "39",
+                                                    "id": "com.doordash.driverapp:id/textView_prism_button_end_text_2",
+                                                    "class": "android.widget.TextView",
+                                                    "isEnabled": true,
+                                                    "bounds": {
+                                                      "left": 956,
+                                                      "top": 2219,
+                                                      "right": 1003,
+                                                      "bottom": 2279
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/app/src/test/resources/snapshots/sessions/receipt_skip_2026_06_29/05_pickup_navigation.json
+++ b/app/src/test/resources/snapshots/sessions/receipt_skip_2026_06_29/05_pickup_navigation.json
@@ -1,0 +1,1347 @@
+{
+  "captureId": "62af6a0f-b65b-4796-b203-dd20c7a9047d",
+  "pipelineId": "accessibility.window",
+  "schemaId": "uinode.v1",
+  "timestamp": 1782781765355,
+  "platform": "doordash",
+  "ruleId": "doordash.screen.pickup_navigation",
+  "classificationName": "pickup_navigation",
+  "metadata": {
+    "engineVersion": 1,
+    "rulesetFormatVersion": 2,
+    "pipelineVersions": {
+      "accessibility": 1,
+      "accessibility.window": 1,
+      "accessibility.click": 1,
+      "accessibility.long_click": 1,
+      "accessibility.scroll": 1,
+      "accessibility.focus": 1,
+      "notification": 1
+    },
+    "stateMachineApiVersion": "1.0",
+    "appVersion": "0.230.0",
+    "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+  },
+  "payload": {
+    "class": "android.widget.FrameLayout",
+    "isEnabled": true,
+    "bounds": {
+      "left": 0,
+      "top": 0,
+      "right": 1080,
+      "bottom": 2400
+    },
+    "children": [
+      {
+        "class": "android.widget.LinearLayout",
+        "isEnabled": true,
+        "bounds": {
+          "left": 0,
+          "top": 0,
+          "right": 1080,
+          "bottom": 2347
+        },
+        "children": [
+          {
+            "class": "android.widget.FrameLayout",
+            "isEnabled": true,
+            "bounds": {
+              "left": 0,
+              "top": 136,
+              "right": 1080,
+              "bottom": 2347
+            },
+            "children": [
+              {
+                "id": "com.doordash.driverapp:id/action_bar_root",
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                  "left": 0,
+                  "top": 136,
+                  "right": 1080,
+                  "bottom": 2347
+                },
+                "children": [
+                  {
+                    "id": "android:id/content",
+                    "class": "android.widget.FrameLayout",
+                    "isEnabled": true,
+                    "bounds": {
+                      "left": 0,
+                      "top": 136,
+                      "right": 1080,
+                      "bottom": 2347
+                    },
+                    "children": [
+                      {
+                        "id": "com.doordash.driverapp:id/container",
+                        "class": "android.view.ViewGroup",
+                        "isEnabled": true,
+                        "bounds": {
+                          "left": 0,
+                          "top": 136,
+                          "right": 1080,
+                          "bottom": 2347
+                        },
+                        "children": [
+                          {
+                            "id": "com.doordash.driverapp:id/toolbar_container",
+                            "class": "android.widget.LinearLayout",
+                            "isEnabled": true,
+                            "bounds": {
+                              "left": 0,
+                              "top": 136,
+                              "right": 1080,
+                              "bottom": 136
+                            }
+                          },
+                          {
+                            "class": "android.widget.FrameLayout",
+                            "isEnabled": true,
+                            "bounds": {
+                              "left": 0,
+                              "top": 136,
+                              "right": 1080,
+                              "bottom": 2347
+                            },
+                            "children": [
+                              {
+                                "id": "com.doordash.driverapp:id/fragment",
+                                "class": "android.widget.FrameLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                  "left": 0,
+                                  "top": 136,
+                                  "right": 1080,
+                                  "bottom": 2347
+                                },
+                                "children": [
+                                  {
+                                    "id": "com.doordash.driverapp:id/fragment_navigation_container",
+                                    "class": "android.view.ViewGroup",
+                                    "isEnabled": true,
+                                    "bounds": {
+                                      "left": 0,
+                                      "top": 136,
+                                      "right": 1080,
+                                      "bottom": 2347
+                                    },
+                                    "children": [
+                                      {
+                                        "class": "androidx.compose.ui.platform.ComposeView",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                          "left": 0,
+                                          "top": 136,
+                                          "right": 0,
+                                          "bottom": 136
+                                        },
+                                        "children": [
+                                          {
+                                            "class": "android.view.View",
+                                            "isEnabled": true,
+                                            "bounds": {
+                                              "left": 0,
+                                              "top": 136,
+                                              "right": 0,
+                                              "bottom": 136
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "class": "androidx.compose.ui.platform.ComposeView",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                          "left": 0,
+                                          "top": 136,
+                                          "right": 0,
+                                          "bottom": 136
+                                        },
+                                        "children": [
+                                          {
+                                            "class": "android.view.View",
+                                            "isEnabled": true,
+                                            "bounds": {
+                                              "left": 0,
+                                              "top": 136,
+                                              "right": 0,
+                                              "bottom": 136
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "id": "com.doordash.driverapp:id/navigationView",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                          "left": 0,
+                                          "top": 136,
+                                          "right": 1080,
+                                          "bottom": 2347
+                                        },
+                                        "children": [
+                                          {
+                                            "id": "com.doordash.driverapp:id/mapViewLayout",
+                                            "class": "android.widget.FrameLayout",
+                                            "isEnabled": true,
+                                            "bounds": {
+                                              "left": 0,
+                                              "top": 136,
+                                              "right": 1080,
+                                              "bottom": 2347
+                                            },
+                                            "children": [
+                                              {
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                  "left": 0,
+                                                  "top": 136,
+                                                  "right": 1080,
+                                                  "bottom": 2347
+                                                },
+                                                "children": [
+                                                  {
+                                                    "class": "android.widget.ImageView",
+                                                    "isClickable": true,
+                                                    "isEnabled": true,
+                                                    "bounds": {
+                                                      "left": 0,
+                                                      "top": 2300,
+                                                      "right": 46,
+                                                      "bottom": 2347
+                                                    }
+                                                  },
+                                                  {
+                                                    "class": "android.view.SurfaceView",
+                                                    "isEnabled": true,
+                                                    "bounds": {
+                                                      "left": 0,
+                                                      "top": 136,
+                                                      "right": 1080,
+                                                      "bottom": 2347
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "id": "com.doordash.driverapp:id/coordinatorLayout",
+                                            "class": "android.view.ViewGroup",
+                                            "isEnabled": true,
+                                            "bounds": {
+                                              "left": 0,
+                                              "top": 136,
+                                              "right": 1080,
+                                              "bottom": 2347
+                                            },
+                                            "children": [
+                                              {
+                                                "id": "com.doordash.driverapp:id/container",
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                  "left": 0,
+                                                  "top": 136,
+                                                  "right": 1080,
+                                                  "bottom": 2347
+                                                },
+                                                "children": [
+                                                  {
+                                                    "id": "com.doordash.driverapp:id/guidanceLayout",
+                                                    "class": "android.widget.FrameLayout",
+                                                    "isEnabled": true,
+                                                    "bounds": {
+                                                      "left": 0,
+                                                      "top": 136,
+                                                      "right": 1080,
+                                                      "bottom": 848
+                                                    },
+                                                    "children": [
+                                                      {
+                                                        "id": "com.doordash.driverapp:id/maneuverView",
+                                                        "class": "android.view.ViewGroup",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                          "left": 0,
+                                                          "top": 136,
+                                                          "right": 1080,
+                                                          "bottom": 848
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "class": "android.view.ViewGroup",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 9,
+                                                              "top": 145,
+                                                              "right": 1071,
+                                                              "bottom": 839
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "id": "com.doordash.driverapp:id/maneuver",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 9,
+                                                                  "top": 145,
+                                                                  "right": 1071,
+                                                                  "bottom": 839
+                                                                },
+                                                                "children": [
+                                                                  {
+                                                                    "class": "android.view.ViewGroup",
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": 9,
+                                                                      "top": 145,
+                                                                      "right": 1071,
+                                                                      "bottom": 839
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "id": "com.doordash.driverapp:id/mainManeuverLayout",
+                                                                        "class": "android.view.ViewGroup",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 9,
+                                                                          "top": 145,
+                                                                          "right": 1071,
+                                                                          "bottom": 394
+                                                                        },
+                                                                        "children": [
+                                                                          {
+                                                                            "id": "com.doordash.driverapp:id/maneuverIcon",
+                                                                            "class": "android.widget.ImageView",
+                                                                            "isEnabled": true,
+                                                                            "bounds": {
+                                                                              "left": 74,
+                                                                              "top": 181,
+                                                                              "right": 181,
+                                                                              "bottom": 288
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "text": "350 ft",
+                                                                            "id": "com.doordash.driverapp:id/stepDistance",
+                                                                            "class": "android.widget.TextView",
+                                                                            "isEnabled": true,
+                                                                            "bounds": {
+                                                                              "left": 18,
+                                                                              "top": 288,
+                                                                              "right": 237,
+                                                                              "bottom": 376
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "text": "[redacted]",
+                                                                            "id": "com.doordash.driverapp:id/primaryManeuverText",
+                                                                            "class": "android.widget.TextView",
+                                                                            "isEnabled": true,
+                                                                            "bounds": {
+                                                                              "left": 237,
+                                                                              "top": 223,
+                                                                              "right": 1062,
+                                                                              "bottom": 317
+                                                                            }
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "id": "com.doordash.driverapp:id/upcomingManeuverRecycler",
+                                                                        "class": "androidx.recyclerview.widget.RecyclerView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 9,
+                                                                          "top": 394,
+                                                                          "right": 1071,
+                                                                          "bottom": 839
+                                                                        },
+                                                                        "children": [
+                                                                          {
+                                                                            "class": "android.view.ViewGroup",
+                                                                            "isEnabled": true,
+                                                                            "bounds": {
+                                                                              "left": 9,
+                                                                              "top": 394,
+                                                                              "right": 1071,
+                                                                              "bottom": 617
+                                                                            },
+                                                                            "children": [
+                                                                              {
+                                                                                "text": "0.1 mi",
+                                                                                "id": "com.doordash.driverapp:id/stepDistance",
+                                                                                "class": "android.widget.TextView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                  "left": 18,
+                                                                                  "top": 511,
+                                                                                  "right": 237,
+                                                                                  "bottom": 599
+                                                                                }
+                                                                              },
+                                                                              {
+                                                                                "id": "com.doordash.driverapp:id/maneuverIcon",
+                                                                                "class": "android.widget.ImageView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                  "left": 74,
+                                                                                  "top": 417,
+                                                                                  "right": 181,
+                                                                                  "bottom": 524
+                                                                                }
+                                                                              },
+                                                                              {
+                                                                                "text": "[redacted]",
+                                                                                "id": "com.doordash.driverapp:id/primaryManeuverText",
+                                                                                "class": "android.widget.TextView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                  "left": 237,
+                                                                                  "top": 459,
+                                                                                  "right": 1062,
+                                                                                  "bottom": 553
+                                                                                }
+                                                                              }
+                                                                            ]
+                                                                          },
+                                                                          {
+                                                                            "class": "android.view.ViewGroup",
+                                                                            "isEnabled": true,
+                                                                            "bounds": {
+                                                                              "left": 9,
+                                                                              "top": 617,
+                                                                              "right": 1071,
+                                                                              "bottom": 839
+                                                                            },
+                                                                            "children": [
+                                                                              {
+                                                                                "text": "2.3 mi",
+                                                                                "id": "com.doordash.driverapp:id/stepDistance",
+                                                                                "class": "android.widget.TextView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                  "left": 18,
+                                                                                  "top": 734,
+                                                                                  "right": 237,
+                                                                                  "bottom": 822
+                                                                                }
+                                                                              },
+                                                                              {
+                                                                                "id": "com.doordash.driverapp:id/maneuverIcon",
+                                                                                "class": "android.widget.ImageView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                  "left": 74,
+                                                                                  "top": 640,
+                                                                                  "right": 181,
+                                                                                  "bottom": 747
+                                                                                }
+                                                                              },
+                                                                              {
+                                                                                "text": "Turn left ",
+                                                                                "id": "com.doordash.driverapp:id/primaryManeuverText",
+                                                                                "class": "android.widget.TextView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                  "left": 237,
+                                                                                  "top": 682,
+                                                                                  "right": 1062,
+                                                                                  "bottom": 776
+                                                                                }
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "id": "com.doordash.driverapp:id/subManeuverLayout",
+                                                                        "class": "android.view.ViewGroup",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 9,
+                                                                          "top": 394,
+                                                                          "right": 1071,
+                                                                          "bottom": 497
+                                                                        },
+                                                                        "children": [
+                                                                          {
+                                                                            "id": "com.doordash.driverapp:id/subManeuverIcon",
+                                                                            "class": "android.widget.ImageView",
+                                                                            "isEnabled": true,
+                                                                            "bounds": {
+                                                                              "left": 105,
+                                                                              "top": 403,
+                                                                              "right": 172,
+                                                                              "bottom": 470
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "id": "com.doordash.driverapp:id/subManeuverText",
+                                                                            "class": "android.widget.TextView",
+                                                                            "isEnabled": true,
+                                                                            "bounds": {
+                                                                              "left": 258,
+                                                                              "top": 416,
+                                                                              "right": 1062,
+                                                                              "bottom": 475
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "id": "com.doordash.driverapp:id/laneGuidanceRecycler",
+                                                                            "class": "androidx.recyclerview.widget.RecyclerView",
+                                                                            "isEnabled": true,
+                                                                            "bounds": {
+                                                                              "left": 446,
+                                                                              "top": 403,
+                                                                              "right": 634,
+                                                                              "bottom": 488
+                                                                            },
+                                                                            "children": [
+                                                                              {
+                                                                                "class": "android.widget.LinearLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                  "left": 464,
+                                                                                  "top": 412,
+                                                                                  "right": 531,
+                                                                                  "bottom": 479
+                                                                                },
+                                                                                "children": [
+                                                                                  {
+                                                                                    "id": "com.doordash.driverapp:id/itemLaneGuidance",
+                                                                                    "class": "android.widget.ImageView",
+                                                                                    "isEnabled": true,
+                                                                                    "bounds": {
+                                                                                      "left": 464,
+                                                                                      "top": 412,
+                                                                                      "right": 531,
+                                                                                      "bottom": 479
+                                                                                    }
+                                                                                  }
+                                                                                ]
+                                                                              },
+                                                                              {
+                                                                                "class": "android.widget.LinearLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                  "left": 549,
+                                                                                  "top": 412,
+                                                                                  "right": 616,
+                                                                                  "bottom": 479
+                                                                                },
+                                                                                "children": [
+                                                                                  {
+                                                                                    "id": "com.doordash.driverapp:id/itemLaneGuidance",
+                                                                                    "class": "android.widget.ImageView",
+                                                                                    "isEnabled": true,
+                                                                                    "bounds": {
+                                                                                      "left": 549,
+                                                                                      "top": 412,
+                                                                                      "right": 616,
+                                                                                      "bottom": 479
+                                                                                    }
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "id": "com.doordash.driverapp:id/scalebarLayout",
+                                                    "class": "android.widget.FrameLayout",
+                                                    "isEnabled": true,
+                                                    "bounds": {
+                                                      "left": 0,
+                                                      "top": 848,
+                                                      "right": 0,
+                                                      "bottom": 848
+                                                    }
+                                                  },
+                                                  {
+                                                    "id": "com.doordash.driverapp:id/speedLimitLayout",
+                                                    "class": "android.widget.FrameLayout",
+                                                    "isEnabled": true,
+                                                    "bounds": {
+                                                      "left": 18,
+                                                      "top": 866,
+                                                      "right": 185,
+                                                      "bottom": 1049
+                                                    },
+                                                    "children": [
+                                                      {
+                                                        "id": "com.doordash.driverapp:id/speedInfoView",
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                          "left": 18,
+                                                          "top": 866,
+                                                          "right": 168,
+                                                          "bottom": 1049
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "id": "com.doordash.driverapp:id/speedInfoMutcdLayout",
+                                                            "class": "android.view.ViewGroup",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 18,
+                                                              "top": 866,
+                                                              "right": 168,
+                                                              "bottom": 1049
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "id": "com.doordash.driverapp:id/postedSpeedLayoutMutcd",
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 22,
+                                                                  "top": 870,
+                                                                  "right": 164,
+                                                                  "bottom": 1045
+                                                                },
+                                                                "children": [
+                                                                  {
+                                                                    "text": "35",
+                                                                    "id": "com.doordash.driverapp:id/postedSpeedMutcd",
+                                                                    "class": "android.widget.TextView",
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": 22,
+                                                                      "top": 892,
+                                                                      "right": 164,
+                                                                      "bottom": 976
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "text": "mph",
+                                                                    "id": "com.doordash.driverapp:id/postedSpeedUnit",
+                                                                    "class": "android.widget.TextView",
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": 22,
+                                                                      "top": 976,
+                                                                      "right": 164,
+                                                                      "bottom": 1023
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "id": "com.doordash.driverapp:id/actionListLayout",
+                                                    "class": "android.widget.FrameLayout",
+                                                    "isEnabled": true,
+                                                    "bounds": {
+                                                      "left": 893,
+                                                      "top": 859,
+                                                      "right": 1062,
+                                                      "bottom": 1246
+                                                    },
+                                                    "children": [
+                                                      {
+                                                        "id": "com.doordash.driverapp:id/buttonContainer",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                          "left": 947,
+                                                          "top": 859,
+                                                          "right": 1062,
+                                                          "bottom": 1246
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "id": "com.doordash.driverapp:id/buttonsContainerTop",
+                                                            "class": "android.widget.LinearLayout",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 1062,
+                                                              "top": 859,
+                                                              "right": 1062,
+                                                              "bottom": 859
+                                                            }
+                                                          },
+                                                          {
+                                                            "id": "com.doordash.driverapp:id/buttonsContainerCenter",
+                                                            "class": "android.widget.LinearLayout",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 947,
+                                                              "top": 859,
+                                                              "right": 1062,
+                                                              "bottom": 1117
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "id": "com.doordash.driverapp:id/buttonsContainerCompass",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 947,
+                                                                  "top": 859,
+                                                                  "right": 947,
+                                                                  "bottom": 859
+                                                                }
+                                                              },
+                                                              {
+                                                                "id": "com.doordash.driverapp:id/buttonsContainerCamera",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 947,
+                                                                  "top": 859,
+                                                                  "right": 1062,
+                                                                  "bottom": 988
+                                                                },
+                                                                "children": [
+                                                                  {
+                                                                    "class": "android.widget.FrameLayout",
+                                                                    "isClickable": true,
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": 947,
+                                                                      "top": 866,
+                                                                      "right": 1062,
+                                                                      "bottom": 981
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "id": "com.doordash.driverapp:id/container",
+                                                                        "class": "android.view.ViewGroup",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 947,
+                                                                          "top": 866,
+                                                                          "right": 1062,
+                                                                          "bottom": 981
+                                                                        },
+                                                                        "children": [
+                                                                          {
+                                                                            "id": "com.doordash.driverapp:id/iconImage",
+                                                                            "class": "android.widget.ImageView",
+                                                                            "isEnabled": true,
+                                                                            "bounds": {
+                                                                              "left": 969,
+                                                                              "top": 888,
+                                                                              "right": 1040,
+                                                                              "bottom": 959
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "id": "com.doordash.driverapp:id/buttonText",
+                                                                            "class": "android.widget.TextView",
+                                                                            "isEnabled": true,
+                                                                            "bounds": {
+                                                                              "left": 1042,
+                                                                              "top": 902,
+                                                                              "right": 1060,
+                                                                              "bottom": 946
+                                                                            }
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "id": "com.doordash.driverapp:id/buttonsContainerAudio",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 947,
+                                                                  "top": 988,
+                                                                  "right": 1062,
+                                                                  "bottom": 1117
+                                                                },
+                                                                "children": [
+                                                                  {
+                                                                    "class": "android.widget.FrameLayout",
+                                                                    "isClickable": true,
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": 947,
+                                                                      "top": 995,
+                                                                      "right": 1062,
+                                                                      "bottom": 1110
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "id": "com.doordash.driverapp:id/container",
+                                                                        "class": "android.view.ViewGroup",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 947,
+                                                                          "top": 995,
+                                                                          "right": 1062,
+                                                                          "bottom": 1110
+                                                                        },
+                                                                        "children": [
+                                                                          {
+                                                                            "id": "com.doordash.driverapp:id/iconImage",
+                                                                            "class": "android.widget.ImageView",
+                                                                            "isEnabled": true,
+                                                                            "bounds": {
+                                                                              "left": 969,
+                                                                              "top": 1017,
+                                                                              "right": 1040,
+                                                                              "bottom": 1088
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "id": "com.doordash.driverapp:id/buttonText",
+                                                                            "class": "android.widget.TextView",
+                                                                            "isEnabled": true,
+                                                                            "bounds": {
+                                                                              "left": 1042,
+                                                                              "top": 1031,
+                                                                              "right": 1060,
+                                                                              "bottom": 1075
+                                                                            }
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "id": "com.doordash.driverapp:id/buttonsContainerRecenter",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 947,
+                                                                  "top": 1117,
+                                                                  "right": 947,
+                                                                  "bottom": 1117
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "id": "com.doordash.driverapp:id/buttonsContainerBottom",
+                                                            "class": "android.widget.LinearLayout",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 947,
+                                                              "top": 1117,
+                                                              "right": 1062,
+                                                              "bottom": 1246
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isClickable": true,
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 947,
+                                                                  "top": 1124,
+                                                                  "right": 1062,
+                                                                  "bottom": 1239
+                                                                },
+                                                                "children": [
+                                                                  {
+                                                                    "id": "com.doordash.driverapp:id/container",
+                                                                    "class": "android.view.ViewGroup",
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": 947,
+                                                                      "top": 1124,
+                                                                      "right": 1062,
+                                                                      "bottom": 1239
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "id": "com.doordash.driverapp:id/iconImage",
+                                                                        "class": "android.widget.ImageView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 969,
+                                                                          "top": 1146,
+                                                                          "right": 1040,
+                                                                          "bottom": 1217
+                                                                        }
+                                                                      },
+                                                                      {
+                                                                        "id": "com.doordash.driverapp:id/buttonText",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 1042,
+                                                                          "top": 1160,
+                                                                          "right": 1060,
+                                                                          "bottom": 1204
+                                                                        }
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "id": "com.doordash.driverapp:id/emptyLeftContainer",
+                                                    "class": "android.widget.FrameLayout",
+                                                    "isEnabled": true,
+                                                    "bounds": {
+                                                      "left": 18,
+                                                      "top": 1522,
+                                                      "right": 18,
+                                                      "bottom": 1522
+                                                    }
+                                                  },
+                                                  {
+                                                    "id": "com.doordash.driverapp:id/emptyRightContainer",
+                                                    "class": "android.widget.FrameLayout",
+                                                    "isEnabled": true,
+                                                    "bounds": {
+                                                      "left": 1062,
+                                                      "top": 1611,
+                                                      "right": 1062,
+                                                      "bottom": 1611
+                                                    }
+                                                  },
+                                                  {
+                                                    "id": "com.doordash.driverapp:id/roadNameLayout",
+                                                    "class": "android.widget.FrameLayout",
+                                                    "isEnabled": true,
+                                                    "bounds": {
+                                                      "left": 335,
+                                                      "top": 1976,
+                                                      "right": 745,
+                                                      "bottom": 2083
+                                                    },
+                                                    "children": [
+                                                      {
+                                                        "text": "[redacted]",
+                                                        "id": "com.doordash.driverapp:id/roadNameView",
+                                                        "class": "android.widget.TextView",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                          "left": 335,
+                                                          "top": 1976,
+                                                          "right": 745,
+                                                          "bottom": 2083
+                                                        }
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "id": "com.doordash.driverapp:id/infoPanelLayout",
+                                                "class": "android.widget.FrameLayout",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                  "left": 0,
+                                                  "top": 2116,
+                                                  "right": 1080,
+                                                  "bottom": 2347
+                                                },
+                                                "children": [
+                                                  {
+                                                    "id": "com.doordash.driverapp:id/infoPanelContainer",
+                                                    "class": "android.view.ViewGroup",
+                                                    "isEnabled": true,
+                                                    "bounds": {
+                                                      "left": 0,
+                                                      "top": 2116,
+                                                      "right": 1080,
+                                                      "bottom": 2347
+                                                    },
+                                                    "children": [
+                                                      {
+                                                        "id": "com.doordash.driverapp:id/infoPanelHeader",
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                          "left": 0,
+                                                          "top": 2116,
+                                                          "right": 1080,
+                                                          "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "id": "com.doordash.driverapp:id/infoPanelHeaderContent",
+                                                            "class": "android.view.ViewGroup",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 0,
+                                                              "top": 2116,
+                                                              "right": 1080,
+                                                              "bottom": 2347
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 0,
+                                                                  "top": 2116,
+                                                                  "right": 1080,
+                                                                  "bottom": 2332
+                                                                },
+                                                                "children": [
+                                                                  {
+                                                                    "id": "com.doordash.driverapp:id/expand_sheet_button",
+                                                                    "class": "android.widget.ImageButton",
+                                                                    "isClickable": true,
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": 36,
+                                                                      "top": 2180,
+                                                                      "right": 125,
+                                                                      "bottom": 2269
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "id": "com.doordash.driverapp:id/header_container",
+                                                                    "class": "android.view.ViewGroup",
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": 426,
+                                                                      "top": 2116,
+                                                                      "right": 654,
+                                                                      "bottom": 2332
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "text": "7 min",
+                                                                        "id": "com.doordash.driverapp:id/bottom_sheet_remaining_time_v2",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 458,
+                                                                          "top": 2134,
+                                                                          "right": 622,
+                                                                          "bottom": 2267
+                                                                        }
+                                                                      },
+                                                                      {
+                                                                        "text": "2.6 mi",
+                                                                        "id": "com.doordash.driverapp:id/bottom_sheet_remaining_distance_v2",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 426,
+                                                                          "top": 2285,
+                                                                          "right": 534,
+                                                                          "bottom": 2332
+                                                                        }
+                                                                      },
+                                                                      {
+                                                                        "text": "\u2022 19:43",
+                                                                        "id": "com.doordash.driverapp:id/bottom_sheet_eta_v2",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 534,
+                                                                          "top": 2285,
+                                                                          "right": 654,
+                                                                          "bottom": 2332
+                                                                        }
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "desc": "Exit",
+                                                                    "id": "com.doordash.driverapp:id/exit_button",
+                                                                    "class": "android.widget.Button",
+                                                                    "isClickable": true,
+                                                                    "isEnabled": true,
+                                                                    "bounds": {
+                                                                      "left": 914,
+                                                                      "top": 2180,
+                                                                      "right": 1044,
+                                                                      "bottom": 2269
+                                                                    },
+                                                                    "children": [
+                                                                      {
+                                                                        "text": "Exit",
+                                                                        "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                        "class": "android.widget.TextView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                          "left": 941,
+                                                                          "top": 2195,
+                                                                          "right": 1017,
+                                                                          "bottom": 2255
+                                                                        }
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "id": "com.doordash.driverapp:id/handle",
+                                                        "class": "android.view.View",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                          "left": 487,
+                                                          "top": 2138,
+                                                          "right": 594,
+                                                          "bottom": 2149
+                                                        }
+                                                      },
+                                                      {
+                                                        "id": "com.doordash.driverapp:id/infoPanelContent",
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                          "left": 0,
+                                                          "top": 2347,
+                                                          "right": 1080,
+                                                          "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "id": "com.doordash.driverapp:id/bottom_sheet_in_transit_navigation_container",
+                                                            "class": "android.view.ViewGroup",
+                                                            "isEnabled": true,
+                                                            "bounds": {
+                                                              "left": 0,
+                                                              "top": 2347,
+                                                              "right": 1080,
+                                                              "bottom": 2347
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "id": "com.doordash.driverapp:id/delivery_flow_compliance_group",
+                                                                "class": "android.view.View",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 0,
+                                                                  "top": 2347,
+                                                                  "right": 0,
+                                                                  "bottom": 2347
+                                                                }
+                                                              },
+                                                              {
+                                                                "text": "Pick up by 20:03",
+                                                                "id": "com.doordash.driverapp:id/bottom_sheet_task_arrive_by",
+                                                                "class": "android.widget.TextView",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 36,
+                                                                  "top": 2383,
+                                                                  "right": 1044,
+                                                                  "bottom": 2347
+                                                                }
+                                                              },
+                                                              {
+                                                                "text": "Heading to H-E-B",
+                                                                "id": "com.doordash.driverapp:id/bottom_sheet_task_title",
+                                                                "class": "android.widget.TextView",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 36,
+                                                                  "top": 2448,
+                                                                  "right": 400,
+                                                                  "bottom": 2347
+                                                                }
+                                                              },
+                                                              {
+                                                                "text": "[redacted]",
+                                                                "id": "com.doordash.driverapp:id/bottom_sheet_address_line_1",
+                                                                "class": "android.widget.TextView",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 36,
+                                                                  "top": 2500,
+                                                                  "right": 1044,
+                                                                  "bottom": 2347
+                                                                }
+                                                              },
+                                                              {
+                                                                "id": "com.doordash.driverapp:id/bottom_sheet_address_line_2",
+                                                                "class": "android.widget.TextView",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 36,
+                                                                  "top": 2547,
+                                                                  "right": 1044,
+                                                                  "bottom": 2347
+                                                                }
+                                                              },
+                                                              {
+                                                                "id": "com.doordash.driverapp:id/bottom_sheet_call_button",
+                                                                "class": "android.widget.ImageButton",
+                                                                "isClickable": true,
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 36,
+                                                                  "top": 2583,
+                                                                  "right": 143,
+                                                                  "bottom": 2347
+                                                                }
+                                                              },
+                                                              {
+                                                                "text": "Pickup instructions",
+                                                                "id": "com.doordash.driverapp:id/bottom_sheet_instructions_title",
+                                                                "class": "android.widget.TextView",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 36,
+                                                                  "top": 2726,
+                                                                  "right": 381,
+                                                                  "bottom": 2347
+                                                                }
+                                                              },
+                                                              {
+                                                                "text": "Park in the Customer Parking area, shop your order, proceed to the store designated area to perform a 3rd Party Shop Audit.",
+                                                                "id": "com.doordash.driverapp:id/bottom_sheet_instructions",
+                                                                "class": "android.widget.TextView",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 36,
+                                                                  "top": 2791,
+                                                                  "right": 1044,
+                                                                  "bottom": 2347
+                                                                }
+                                                              },
+                                                              {
+                                                                "text": "Stop orders after this delivery",
+                                                                "id": "com.doordash.driverapp:id/bottom_sheet_stop_orders_toggle_button",
+                                                                "class": "android.widget.TextView",
+                                                                "isClickable": true,
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 0,
+                                                                  "top": 3014,
+                                                                  "right": 1080,
+                                                                  "bottom": 2347
+                                                                }
+                                                              },
+                                                              {
+                                                                "id": "com.doordash.driverapp:id/bottom_sheet_bottom_separator_1",
+                                                                "class": "android.view.View",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 0,
+                                                                  "top": 3014,
+                                                                  "right": 1080,
+                                                                  "bottom": 2347
+                                                                }
+                                                              },
+                                                              {
+                                                                "id": "com.doordash.driverapp:id/bottom_sheet_bottom_separator_2",
+                                                                "class": "android.view.View",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 0,
+                                                                  "top": 3014,
+                                                                  "right": 1080,
+                                                                  "bottom": 2347
+                                                                }
+                                                              },
+                                                              {
+                                                                "state": "OFF",
+                                                                "id": "com.doordash.driverapp:id/bottom_sheet_stop_orders_toggle_switch",
+                                                                "class": "android.widget.Switch",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 940,
+                                                                  "top": 3047,
+                                                                  "right": 1044,
+                                                                  "bottom": 2347
+                                                                }
+                                                              },
+                                                              {
+                                                                "text": "Avoid tolls",
+                                                                "id": "com.doordash.driverapp:id/bottom_sheet_avoid_tolls_toggle_button",
+                                                                "class": "android.widget.TextView",
+                                                                "isClickable": true,
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 0,
+                                                                  "top": 3139,
+                                                                  "right": 1080,
+                                                                  "bottom": 2347
+                                                                }
+                                                              },
+                                                              {
+                                                                "id": "com.doordash.driverapp:id/bottom_sheet_bottom_separator_4",
+                                                                "class": "android.view.View",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 0,
+                                                                  "top": 3139,
+                                                                  "right": 1080,
+                                                                  "bottom": 2347
+                                                                }
+                                                              },
+                                                              {
+                                                                "state": "OFF",
+                                                                "id": "com.doordash.driverapp:id/bottom_sheet_avoid_tolls_toggle_switch",
+                                                                "class": "android.widget.Switch",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                  "left": 940,
+                                                                  "top": 3172,
+                                                                  "right": 1044,
+                                                                  "bottom": 2347
+                                                                }
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -334,6 +334,9 @@ class EffectMap @Inject constructor() {
             // has `completedTask` non-null. Skip the rest — without this guard,
             // non-owning platforms emit a degenerate DELIVERY_COMPLETED row via
             // deliveryCompletedPayload's "unknown" fallback.
+            // Task ids the PostTask-exit block emits a DELIVERY_COMPLETED for this step — the #596
+            // close-out block below must NOT re-emit them (dual-mint exclusivity, amdt #2).
+            val emittedThisStep = mutableSetOf<String>()
             if (prevFlow.flow == Flow.PostTask && nextFlow.flow != Flow.PostTask) {
                 val taskCompletedOverride = triggerOverrideEffects(obs, TransitionTrigger.TASK_COMPLETED)
                 if (taskCompletedOverride != null) {
@@ -352,8 +355,18 @@ class EffectMap @Inject constructor() {
                     // is no active job to scope by, keep the prior unscoped behaviour (the payload's
                     // jobId would be null regardless).
                     val completedJobId = p.activeJob?.jobId
+                    // #596 amdt 2: when there's genuinely nothing being completed on this exit —
+                    // job already closed (by T1 on a prior step), no active task, no retire pending —
+                    // the unscoped (job-less) fallback must NOT grab a stale recentTask and re-fire a
+                    // completion the close-out block already minted. The scoped arm (job present) is
+                    // unaffected.
+                    val allowUnscopedFallback =
+                        !(p.activeJob == null && p.activeTask == null &&
+                            p.pendingDestructive?.kind != DestructiveKind.TASK_RETIRE)
                     val completedTask = next.activeTask?.takeIf { it.taskId == p.activeTask?.taskId }
-                        ?: next.recentTasks.lastOrNull { completedJobId == null || it.jobId == completedJobId }
+                        ?: next.recentTasks.lastOrNull {
+                            if (completedJobId == null) allowUnscopedFallback else it.jobId == completedJobId
+                        }
                     // #564: a delivery completes a DROPOFF, never a PICKUP. A mid-stack add-on offer
                     // can grace-retire an in-flight PICKUP task and a transient/misrecognized
                     // delivery-summary frame then drives this PostTask-exit — fabricating a $0,
@@ -379,7 +392,58 @@ class EffectMap @Inject constructor() {
                                 effectKeyOverride = "log:${AppEventType.DELIVERY_COMPLETED}:${completedTask.taskId}",
                             )
                         )
+                        emittedThisStep.add(completedTask.taskId)
                     }
+                }
+            }
+
+            // #596 close-out: a physically-complete job closed WITHOUT the post-delivery receipt
+            // (the stepper's T1/T2 cleared activeJob) still owes a DELIVERY_COMPLETED for each
+            // delivered dropoff — the pre-#596 machine minted that ONLY on a PostTask exit (above),
+            // so a receipt-skip (routine on DoorDash: the next offer chains straight over the drop)
+            // silently lost the completion AND left the job open to absorb later offers. This fires
+            // when the job goes null or is swapped for a new jobId this step. The shared idempotency
+            // key ("log:DELIVERY_COMPLETED:<taskId>") makes a double-mint impossible under the live
+            // engine's effects_fired dedup — if the receipt already completed the task, this is
+            // skipped; if it never rendered, this is the only emission.
+            val closedJob = p.activeJob
+            if (closedJob != null && next.activeJob?.jobId != closedJob.jobId) {
+                val sessionId = next.session?.sessionId ?: p.session?.sessionId
+                val retirePending = p.pendingDestructive?.kind == DestructiveKind.TASK_RETIRE
+                for (task in next.recentTasks) {
+                    if (task.jobId != closedJob.jobId || task.phase != TaskPhase.DROPOFF) continue
+                    val completedAt = task.completedAt ?: continue
+                    // #498 identity firewall (guardrail): never complete an identity-less phantom.
+                    if (task.customerNameHash == null && task.customerAddressHash == null) continue
+                    // amdt #2 exclusivity: the PostTask-exit block already minted this one.
+                    if (task.taskId in emittedThisStep) continue
+                    // amdt #5: qualify ONLY (a) a task already completed BEFORE this step, or (b) the
+                    // active task just retired under a TASK_RETIRE grace. This excludes exactly
+                    // endSession's force-stamp of an active, UNDELIVERED task (T3 false-completion
+                    // guard) — that task carries no TASK_RETIRE pending, so neither arm matches.
+                    val alreadyCompleted =
+                        p.recentTasks.any { it.taskId == task.taskId && it.completedAt != null }
+                    val justRetiredUnderGrace = retirePending && p.activeTask?.taskId == task.taskId
+                    if (!alreadyCompleted && !justRetiredUnderGrace) continue
+                    // amdt #3: attach the receipt's pay ONLY when the receipt was announced for THIS
+                    // task (mirror the PostTask path's per-task pinning). A receipt-less completion
+                    // naturally gets null pay (#528's job), never a normal receipted delivery's pay.
+                    val postTaskFields = p.lastPostTaskFields
+                        ?.takeIf { p.lastAnnouncedPostTaskTaskId == task.taskId }
+                    val payload = deliveryCompletedPayload(
+                        task = task,
+                        jobId = closedJob.jobId,
+                        completedAt = completedAt,
+                        postTaskFields = postTaskFields,
+                        sessionEarnings = next.session?.runningEarnings ?: p.session?.runningEarnings,
+                    )
+                    add(
+                        logEffect(
+                            sessionId, AppEventType.DELIVERY_COMPLETED, obs.timestamp, payload,
+                            effectKeyOverride = "log:${AppEventType.DELIVERY_COMPLETED}:${task.taskId}",
+                        )
+                    )
+                    emittedThisStep.add(task.taskId)
                 }
             }
         }

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
@@ -1063,6 +1063,12 @@ class PlatformRegionStepper @Inject constructor() {
  * [recentTasks] with `completedAt != null`, or it IS [justRetired] — with no unresolved
  * customer-TBD placeholder outstanding, and at least one dropoff actually finished. A zero-dropoff
  * job never qualifies (a healed pickup-only job, or a job whose drops haven't rendered yet).
+ *
+ * Accounted additionally requires ARRIVAL evidence (`arrivedAt != null`, #615 review): a
+ * grace-stamped `completedAt` alone is not delivery proof — a drop retired EN ROUTE (a transient
+ * idle flash → offer → accept inside the grace window, or a mid-route cancel) must never read as
+ * delivered, close the job, and mint a false completion. Fail direction is safe: a missed ARRIVED
+ * frame keeps the job open (the old, lesser bug — absorption), never fabricates a delivery.
  */
 internal fun isJobPhysicallyComplete(
     job: Job,
@@ -1070,10 +1076,16 @@ internal fun isJobPhysicallyComplete(
     justRetired: Task?,
 ): Boolean {
     val completedDropoffIds = recentTasks
-        .filter { it.jobId == job.jobId && it.phase == TaskPhase.DROPOFF && it.completedAt != null }
+        .filter {
+            it.jobId == job.jobId && it.phase == TaskPhase.DROPOFF &&
+                it.completedAt != null && it.arrivedAt != null
+        }
         .mapTo(HashSet()) { it.taskId }
     val retiredDropoffId = justRetired
-        ?.takeIf { it.jobId == job.jobId && it.phase == TaskPhase.DROPOFF && it.completedAt != null }
+        ?.takeIf {
+            it.jobId == job.jobId && it.phase == TaskPhase.DROPOFF &&
+                it.completedAt != null && it.arrivedAt != null
+        }
         ?.taskId
 
     // Every dropoff the job owns must be accounted; any outstanding (incl. a customer-TBD

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
@@ -567,20 +567,50 @@ class PlatformRegionStepper @Inject constructor() {
             // wasn't parsed — the pre-3b behaviour for a single delivery.
             val dropoffCount = parsedOffer?.orders?.size?.takeIf { it > 0 } ?: 1
 
-            if (existing == null) {
-                val jobId = mintId("job", region, obs)
-                // job at offset 0; the N dropoff placeholders at offsets 1..N.
-                return region.copy(
+            // Mint a fresh Job: jobId at offset 0, the N customer-TBD dropoff placeholders at
+            // offsets 1..N off the mint counter, which the copy() advances past. Shared by the
+            // first accept of a job and by #596 T2 (an accept over a physically-complete job).
+            fun startFreshJob(base: PlatformRegion): PlatformRegion {
+                val jobId = mintId("job", base, obs)
+                return base.copy(
                     activeJob = Job(
                         jobId = jobId,
                         offerStoreHint = storeHints,
                         parentOfferHash = pending?.offerHash,
                         acceptedOffers = listOf(economics),
                         startedAt = obs.timestamp,
-                        tasks = preCreatedDropoffs(region, obs, jobId, dropoffCount, startOffset = 1),
+                        tasks = preCreatedDropoffs(base, obs, jobId, dropoffCount, startOffset = 1),
                     ),
-                    mintCounter = region.mintCounter + dropoffCount + 1,
+                    mintCounter = base.mintCounter + dropoffCount + 1,
                 )
+            }
+
+            if (existing == null) return startFreshJob(region)
+
+            // #596 T2: an accept while the active job is already physically complete is an
+            // INDEPENDENT offer, not an add-on — do NOT fold it into a never-closed job (the 06-30
+            // job-61 case: one never-closed job swallowed three offers, $19 of $45.75 unattributed).
+            // Close the old job and mint a fresh one. At accept time the final drop may still be
+            // inside its TASK_RETIRE grace (activeTask not yet retired); commit that retire inline
+            // first (honest completion = pend.since, matching retireActiveTask) so the completeness
+            // check sees the finished drop. Skipped when the retire was armed by deliberating on THIS
+            // add-on offer (armedFromFlow == OfferPresented) — that drop isn't delivered, so it folds.
+            run {
+                val pend = region.pendingDestructive?.takeIf { it.kind == DestructiveKind.TASK_RETIRE }
+                if (pend?.armedFromFlow == Flow.OfferPresented) return@run
+                val justRetired = if (pend != null) region.activeTask?.copy(completedAt = pend.since) else null
+                val recentForCheck =
+                    if (justRetired != null) region.recentTasks + justRetired else region.recentTasks
+                if (isJobPhysicallyComplete(existing, recentForCheck, justRetired)) {
+                    val committed = if (justRetired != null) {
+                        region.copy(
+                            activeTask = null,
+                            recentTasks = recentForCheck.takeLast(MAX_RECENT_TASKS),
+                            pendingDestructive = null,
+                        )
+                    } else region
+                    return startFreshJob(completeActiveJob(committed))
+                }
             }
 
             // Add-on into the active job — append unless this offer was already counted.
@@ -894,10 +924,14 @@ class PlatformRegionStepper @Inject constructor() {
             val pend = if (existing?.kind == DestructiveKind.TASK_RETIRE) {
                 // Already armed (idle-grace, or an earlier receipt frame) —
                 // tighten to the short window; the earliest destructive signal
-                // stays the honest completion time.
+                // stays the honest completion time. The receipt is an authoritative
+                // completion, so re-anchor the provenance to PostTask (#596): a drop
+                // finished at a real receipt is closeable even if an earlier
+                // offer-deliberation had armed the original retire.
                 existing.copy(
                     deadline = minOf(existing.deadline, newDeadline),
                     authoritative = true,
+                    armedFromFlow = Flow.PostTask,
                 )
             } else {
                 PendingDestructive(
@@ -905,6 +939,7 @@ class PlatformRegionStepper @Inject constructor() {
                     since = obs.timestamp,
                     deadline = newDeadline,
                     authoritative = true,
+                    armedFromFlow = Flow.PostTask,
                 )
             }
             return region.copy(pendingDestructive = pend)
@@ -923,6 +958,11 @@ class PlatformRegionStepper @Inject constructor() {
                         since = obs.timestamp,
                         // Through the injected policy (#406): the static constant ignored overrides.
                         deadline = obs.timestamp + policy.gracePeriodMs,
+                        // #596: record where the task was left FOR. A retire armed by the dasher
+                        // deliberating on a mid-route add-on offer (`OfferPresented`) must NOT let
+                        // T1/T2 close-out fire on the still-undelivered final drop; an idle/waiting
+                        // arm (`Idle`) is a genuine receipt-skip and IS closeable.
+                        armedFromFlow = nextFlowVal,
                     ),
                 )
             }
@@ -950,15 +990,34 @@ class PlatformRegionStepper @Inject constructor() {
      * Retire the active task when its retire-grace deadline lazily expires
      * (a sustained idle/offer mid-task). Completes it into recentTasks. Unlike
      * [endSession], the session and job live on — only the task is closed.
+     *
+     * #596 T1: a retire that leaves the job *physically complete* (every dropoff
+     * delivered, nothing outstanding) also closes the job — DoorDash routinely
+     * skips the post-delivery receipt (the pre-#596 machine's only job-exit), so
+     * without this the job never closes and later independent offers get absorbed
+     * into it. Gated on provenance: a retire armed by deliberating on a mid-route
+     * add-on offer ([Flow.OfferPresented]) does NOT close (that drop isn't
+     * delivered — the accept is an add-on).
      */
     private fun retireActiveTask(region: PlatformRegion, timestamp: Long): PlatformRegion {
+        val armedFromFlow = region.pendingDestructive
+            ?.takeIf { it.kind == DestructiveKind.TASK_RETIRE }?.armedFromFlow
         val completed = region.activeTask?.copy(completedAt = timestamp)
             ?: return region.copy(pendingDestructive = null)
-        return region.copy(
+        val recentTasks = (region.recentTasks + completed).takeLast(MAX_RECENT_TASKS)
+        val retired = region.copy(
             activeTask = null,
-            recentTasks = (region.recentTasks + completed).takeLast(MAX_RECENT_TASKS),
+            recentTasks = recentTasks,
             pendingDestructive = null,
         )
+        val job = retired.activeJob
+        return if (job != null && armedFromFlow != Flow.OfferPresented &&
+            isJobPhysicallyComplete(job, recentTasks, justRetired = completed)
+        ) {
+            completeActiveJob(retired)
+        } else {
+            retired
+        }
     }
 
     private fun endSession(region: PlatformRegion, timestamp: Long): PlatformRegion {
@@ -987,6 +1046,47 @@ class PlatformRegionStepper @Inject constructor() {
             lastPostTaskFields = null,
         )
     }
+}
+
+/**
+ * #596: is [job] *physically complete* — every dropoff delivered, nothing outstanding — so it may
+ * close on its next exit signal even when DoorDash skips the post-delivery receipt (the only
+ * job-exit the pre-#596 machine had)?
+ *
+ * Completion truth is computed from [recentTasks] + [justRetired], **never** [Job.tasks]: the
+ * `Job.tasks` mirror re-runs after `stepCore`, so at the moment a retire/accept consults it, its
+ * copy of the just-finished drop is stale (`completedAt` still null — amdt #6). The mirror is used
+ * only for the *placeholder set* (which dropoffs the job owns — reliable, since offer-spawned
+ * placeholders persist there until resolved+completed).
+ *
+ * Complete ⇔ every DROPOFF placeholder the job owns is accounted — its taskId appears in
+ * [recentTasks] with `completedAt != null`, or it IS [justRetired] — with no unresolved
+ * customer-TBD placeholder outstanding, and at least one dropoff actually finished. A zero-dropoff
+ * job never qualifies (a healed pickup-only job, or a job whose drops haven't rendered yet).
+ */
+internal fun isJobPhysicallyComplete(
+    job: Job,
+    recentTasks: List<Task>,
+    justRetired: Task?,
+): Boolean {
+    val completedDropoffIds = recentTasks
+        .filter { it.jobId == job.jobId && it.phase == TaskPhase.DROPOFF && it.completedAt != null }
+        .mapTo(HashSet()) { it.taskId }
+    val retiredDropoffId = justRetired
+        ?.takeIf { it.jobId == job.jobId && it.phase == TaskPhase.DROPOFF && it.completedAt != null }
+        ?.taskId
+
+    // Every dropoff the job owns must be accounted; any outstanding (incl. a customer-TBD
+    // placeholder that never resolved) → not complete, so a later independent offer can't fold in.
+    val allDropoffsAccounted = job.tasks
+        .filter { it.phase == TaskPhase.DROPOFF }
+        .all { it.taskId in completedDropoffIds || it.taskId == retiredDropoffId }
+    if (!allDropoffsAccounted) return false
+
+    // …and at least one dropoff actually finished (guards zero-dropoff jobs).
+    val finished = completedDropoffIds.size +
+        (if (retiredDropoffId != null && retiredDropoffId !in completedDropoffIds) 1 else 0)
+    return finished >= 1
 }
 
 // =========================================================================

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapPayloadTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapPayloadTest.kt
@@ -20,6 +20,7 @@ import cloud.trotter.dashbuddy.domain.state.CrossPlatformRegion
 import cloud.trotter.dashbuddy.domain.state.DestructiveKind
 import cloud.trotter.dashbuddy.domain.state.Flow
 import cloud.trotter.dashbuddy.domain.state.FlowRegion
+import cloud.trotter.dashbuddy.domain.state.Job
 import cloud.trotter.dashbuddy.domain.state.Mode
 import cloud.trotter.dashbuddy.domain.state.ParsedFields
 import cloud.trotter.dashbuddy.domain.state.PendingOffer
@@ -448,6 +449,9 @@ class EffectMapPayloadTest {
             platform = Platform.DoorDash,
             mode = Mode.Online,
             session = Session("s1", startedAt = 500L, runningEarnings = 47.50),
+            // #596: a real receipt exit has the job still active going in (scoped completion path);
+            // the amdt-2 unscoped-fallback gate suppresses a job-less exit (nothing to complete).
+            activeJob = Job("J6", offerStoreHint = emptyList(), parentOfferHash = null, startedAt = 400L),
             recentTasks = listOf(completedTask),
             lastPostTaskFields = postFields,
         )

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/JobCloseOutTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/JobCloseOutTest.kt
@@ -1,0 +1,253 @@
+package cloud.trotter.dashbuddy.core.state
+
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
+import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
+import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
+import cloud.trotter.dashbuddy.domain.evaluation.OfferQuality
+import cloud.trotter.dashbuddy.domain.model.offer.ParsedOffer
+import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.pipeline.TimeoutType
+import cloud.trotter.dashbuddy.domain.state.AcceptedOfferEconomics
+import cloud.trotter.dashbuddy.domain.state.DestructiveKind
+import cloud.trotter.dashbuddy.domain.state.Flow
+import cloud.trotter.dashbuddy.domain.state.FlowRegion
+import cloud.trotter.dashbuddy.domain.state.Job
+import cloud.trotter.dashbuddy.domain.state.Mode
+import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import cloud.trotter.dashbuddy.domain.state.PendingDestructive
+import cloud.trotter.dashbuddy.domain.state.PendingOffer
+import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.domain.state.PlatformRegion
+import cloud.trotter.dashbuddy.domain.state.Session
+import cloud.trotter.dashbuddy.domain.state.Task
+import cloud.trotter.dashbuddy.domain.state.TaskPhase
+import cloud.trotter.dashbuddy.domain.state.TaskSubFlow
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #596 — a *physically-complete* job closes on its next exit signal even when DoorDash skips the
+ * post-delivery receipt (the pre-#596 machine's only job-exit). Covers the pure completeness
+ * predicate, T1 (retire-commit closes a complete job), and T2 (an accept over a complete job starts
+ * a NEW job instead of absorbing the offer), plus the amdt-4 regression (an offer-deliberation retire
+ * must NOT false-close the still-undelivered final drop — that accept is an add-on).
+ */
+class JobCloseOutTest {
+
+    private val stepper = PlatformRegionStepper()
+    private val flowStepper = FlowRegionStepper()
+    private val policy = TransitionPolicy()
+
+    // ---- helpers ----
+
+    private fun onlineRegion(activeJob: Job?) = PlatformRegion(
+        platform = Platform.DoorDash,
+        mode = Mode.Online,
+        session = Session("sess-1", startedAt = 100L),
+        activeJob = activeJob,
+    )
+
+    private fun dropoff(id: String, jobId: String, customer: String?, completedAt: Long? = null) = Task(
+        taskId = id, jobId = jobId, phase = TaskPhase.DROPOFF,
+        customerNameHash = customer, startedAt = 1_000L, arrivedAt = 1_200L, completedAt = completedAt,
+    )
+
+    private fun jobWithDropoffs(jobId: String, tasks: List<Task>) = Job(
+        jobId = jobId,
+        offerStoreHint = emptyList(),
+        parentOfferHash = "offer-0",
+        acceptedOffers = listOf(
+            AcceptedOfferEconomics(offerHash = "offer-0", payAmount = 8.5, netPay = 6.0, estMinutes = 18.0, distanceMiles = 4.0, acceptedAt = 200L),
+        ),
+        startedAt = 900L,
+        tasks = tasks,
+    )
+
+    private fun eval(net: Double = 5.0, est: Double = 12.0, dist: Double = 3.0, pay: Double = 7.0) = OfferEvaluation(
+        action = OfferAction.ACCEPT, score = 75.0, qualityLevel = OfferQuality.GOOD,
+        payAmount = pay, fuelCostEstimate = 0.0, netPayAmount = net,
+        distanceMiles = dist, dollarsPerMile = net / dist, dollarsPerHour = net / (est / 60.0),
+        estimatedTimeMinutes = est, itemCount = 1.0, merchantName = "Test Store",
+    )
+
+    private fun offerFlow(offerHash: String) = FlowRegion(
+        flow = Flow.OfferPresented,
+        pendingOffer = PendingOffer(
+            offerHash = offerHash,
+            offerFields = ParsedFields.OfferFields(
+                parsedOffer = ParsedOffer(offerHash = offerHash, payAmount = 7.0, distanceMiles = 3.0, timeToCompleteMinutes = 12L),
+            ),
+            presentedAt = 500L,
+            evaluation = eval(),
+            returnFlow = Flow.Idle,
+        ),
+    )
+
+    private fun acceptObs(timestamp: Long, store: String) = Observation.Screen(
+        timestamp = timestamp, captureId = null, ruleId = "doordash.screen.pickup_nav",
+        metadata = ReplayMetadata.EMPTY, flow = Flow.TaskPickupNavigation, modeHint = Mode.Online,
+        parsed = ParsedFields.TaskFields(phase = TaskPhase.PICKUP, subFlow = TaskSubFlow.NAVIGATION, storeName = store),
+    )
+
+    private fun graceTimeout(timestamp: Long) = Observation.Timeout(
+        timestamp = timestamp, type = TimeoutType.GRACE_COMMIT, targetPlatform = Platform.DoorDash,
+    )
+
+    private fun stepAccept(prev: PlatformRegion, prevFlow: FlowRegion, obs: Observation): PlatformRegion {
+        val nextFlow = if (obs is Observation.FlowObservation) flowStepper.step(prevFlow, obs) else prevFlow
+        return stepper.step(prev, prevFlow, nextFlow, obs, policy)
+    }
+
+    // ---- predicate (pure) ----
+
+    @Test
+    fun `predicate — a fully delivered job is physically complete`() {
+        val d = dropoff("task-d1", "job-1", customer = "cust-1", completedAt = 3_000L)
+        val job = jobWithDropoffs("job-1", tasks = listOf(d))
+        assertTrue(isJobPhysicallyComplete(job, recentTasks = listOf(d), justRetired = null))
+    }
+
+    @Test
+    fun `predicate — the just-retired drop counts even though the mirror is stale (amdt 6)`() {
+        // At retire time Job.tasks still shows completedAt == null (the mirror re-runs after stepCore).
+        val staleMirror = dropoff("task-d1", "job-1", customer = "cust-1", completedAt = null)
+        val job = jobWithDropoffs("job-1", tasks = listOf(staleMirror))
+        val retired = staleMirror.copy(completedAt = 3_000L)
+        assertTrue(
+            "completion truth comes from justRetired, not the stale mirror",
+            isJobPhysicallyComplete(job, recentTasks = listOf(retired), justRetired = retired),
+        )
+    }
+
+    @Test
+    fun `predicate — an outstanding customer-TBD placeholder keeps the job incomplete`() {
+        val delivered = dropoff("task-d1", "job-1", customer = "cust-1", completedAt = 3_000L)
+        val tbd = dropoff("task-d2", "job-1", customer = null, completedAt = null)
+        val job = jobWithDropoffs("job-1", tasks = listOf(delivered, tbd))
+        assertFalse(isJobPhysicallyComplete(job, recentTasks = listOf(delivered), justRetired = null))
+    }
+
+    @Test
+    fun `predicate — a zero-dropoff (pickup-only) job never qualifies`() {
+        val pickup = Task("task-p", "job-1", TaskPhase.PICKUP, startedAt = 1_000L, completedAt = 2_000L)
+        val job = jobWithDropoffs("job-1", tasks = listOf(pickup))
+        assertFalse(isJobPhysicallyComplete(job, recentTasks = listOf(pickup), justRetired = null))
+    }
+
+    // ---- T1: retire-commit closes a complete job ----
+
+    @Test
+    fun `T1 — retiring the last dropoff closes the job (receipt-skip)`() {
+        val drop = dropoff("task-d1", "job-1", customer = "cust-1")
+        val job = jobWithDropoffs("job-1", tasks = listOf(drop))
+        val region = onlineRegion(job).copy(
+            activeTask = drop,
+            recentTasks = emptyList(),
+            pendingDestructive = PendingDestructive(
+                kind = DestructiveKind.TASK_RETIRE, since = 2_000L, deadline = 3_000L, armedFromFlow = Flow.Idle,
+            ),
+        )
+        // GRACE_COMMIT past the deadline → lazy-expiry retire → T1 close.
+        val r = stepper.step(region, FlowRegion(flow = Flow.Idle), FlowRegion(flow = Flow.Idle), graceTimeout(3_001L), policy)
+        assertNull("a physically-complete job closes on the retire commit", r.activeJob)
+        assertNull(r.activeTask)
+        assertTrue("the drop completed into recentTasks", r.recentTasks.any { it.taskId == "task-d1" && it.completedAt != null })
+    }
+
+    @Test
+    fun `T1 — retiring one drop while another placeholder is outstanding keeps the job open`() {
+        val active = dropoff("task-d1", "job-1", customer = "cust-1")
+        val outstanding = dropoff("task-d2", "job-1", customer = null, completedAt = null)
+        val job = jobWithDropoffs("job-1", tasks = listOf(active, outstanding))
+        val region = onlineRegion(job).copy(
+            activeTask = active,
+            pendingDestructive = PendingDestructive(
+                kind = DestructiveKind.TASK_RETIRE, since = 2_000L, deadline = 3_000L, armedFromFlow = Flow.Idle,
+            ),
+        )
+        val r = stepper.step(region, FlowRegion(flow = Flow.Idle), FlowRegion(flow = Flow.Idle), graceTimeout(3_001L), policy)
+        assertNotNull("an outstanding dropoff keeps the job open", r.activeJob)
+        assertEquals("job-1", r.activeJob?.jobId)
+    }
+
+    @Test
+    fun `T1 — an offer-armed retire does NOT close the still-undelivered final drop (amdt 4)`() {
+        val drop = dropoff("task-d1", "job-1", customer = "cust-1")
+        val job = jobWithDropoffs("job-1", tasks = listOf(drop))
+        val region = onlineRegion(job).copy(
+            activeTask = drop,
+            pendingDestructive = PendingDestructive(
+                kind = DestructiveKind.TASK_RETIRE, since = 2_000L, deadline = 3_000L, armedFromFlow = Flow.OfferPresented,
+            ),
+        )
+        val r = stepper.step(region, FlowRegion(flow = Flow.Idle), FlowRegion(flow = Flow.Idle), graceTimeout(3_001L), policy)
+        assertNotNull("a retire armed by offer-deliberation must not close the job", r.activeJob)
+        assertNull("the task still retires (it's the visual task closing), only the job survives", r.activeTask)
+    }
+
+    // ---- T2: accept never folds into a complete job ----
+
+    @Test
+    fun `T2 — accepting over a physically-complete job starts a NEW job`() {
+        val delivered = dropoff("task-old", "job-old", customer = "cust-old", completedAt = 500L)
+        val oldJob = jobWithDropoffs("job-old", tasks = listOf(delivered))
+        val region = onlineRegion(oldJob).copy(activeTask = null, recentTasks = listOf(delivered))
+        val r = stepAccept(region, offerFlow("offer-1"), acceptObs(2_000L, "Chipotle"))
+        assertNotNull(r.activeJob)
+        assertNotEquals("an accept over a complete job is an independent job, not an add-on", "job-old", r.activeJob?.jobId)
+        assertEquals("the new job carries only the new offer", 1, r.activeJob?.acceptedOffers?.size)
+    }
+
+    @Test
+    fun `T2 — accepting over an in-grace final drop closes it inline and starts a NEW job`() {
+        // The final drop is still ACTIVE inside its TASK_RETIRE grace (idle-armed) at accept time.
+        val drop = dropoff("task-old", "job-old", customer = "cust-old")
+        val oldJob = jobWithDropoffs("job-old", tasks = listOf(drop))
+        val region = onlineRegion(oldJob).copy(
+            activeTask = drop,
+            pendingDestructive = PendingDestructive(
+                kind = DestructiveKind.TASK_RETIRE, since = 1_500L, deadline = 11_500L, armedFromFlow = Flow.Idle,
+            ),
+        )
+        val r = stepAccept(region, offerFlow("offer-1"), acceptObs(2_000L, "Chipotle"))
+        assertNotEquals("the complete old job is closed; a fresh job is minted", "job-old", r.activeJob?.jobId)
+        // Honest completion time = the grace-arm `since`, not obs.timestamp (retireActiveTask semantics).
+        assertTrue(
+            "the old drop was committed inline at pend.since",
+            r.recentTasks.any { it.taskId == "task-old" && it.completedAt == 1_500L },
+        )
+    }
+
+    @Test
+    fun `T2 — accepting into an incomplete job still folds in as an add-on (add-on regression guard)`() {
+        val active = dropoff("task-active", "job-old", customer = "cust-1", completedAt = null)
+        val oldJob = jobWithDropoffs("job-old", tasks = listOf(active))
+        val region = onlineRegion(oldJob).copy(activeTask = active)
+        val r = stepAccept(region, offerFlow("offer-2"), acceptObs(2_000L, "Chipotle"))
+        assertEquals("an add-on into an incomplete job stays the same job (#499/#503)", "job-old", r.activeJob?.jobId)
+        assertEquals("the add-on offer accumulates onto the job", 2, r.activeJob?.acceptedOffers?.size)
+    }
+
+    @Test
+    fun `T2 — accepting while the final drop has an OFFER-armed retire folds in as an add-on (amdt 4)`() {
+        // The dasher is deliberating on THIS add-on offer (>10s), which armed a retire on the
+        // undelivered final drop. That accept is the add-on the interlude belongs to — it must fold
+        // in, not start a new job or complete the drop.
+        val finalDrop = dropoff("task-final", "job-old", customer = "cust-1")
+        val oldJob = jobWithDropoffs("job-old", tasks = listOf(finalDrop))
+        val region = onlineRegion(oldJob).copy(
+            activeTask = finalDrop,
+            pendingDestructive = PendingDestructive(
+                kind = DestructiveKind.TASK_RETIRE, since = 1_500L, deadline = 11_500L, armedFromFlow = Flow.OfferPresented,
+            ),
+        )
+        val r = stepAccept(region, offerFlow("offer-2"), acceptObs(2_000L, "Chipotle"))
+        assertEquals("an offer-armed retire means this accept folds in — same job", "job-old", r.activeJob?.jobId)
+        assertEquals(2, r.activeJob?.acceptedOffers?.size)
+    }
+}

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -73,6 +73,21 @@ card's **mechanical** half, #577 (re-confirmed, 24/24, ~0.55 s — with a new po
 that entry's Bug #1), the #457 path, and #554 ShadowProjector (2/2). The #462/#460 dropoff item
 was found **broken-in-part** (raw PII in capture envelopes) and moved to that entry's Bug #7.)_
 
+- **🔧 FIX SHIPPED — receipt-skipped deliveries still close + log a completion, and the next offer starts a NEW job (#596).**
+  DoorDash routinely skips the post-delivery receipt (the next offer chains straight over the drop);
+  pre-#596 that was the machine's ONLY job-exit, so the delivery never logged `DELIVERY_COMPLETED`
+  and the never-closed job absorbed later independent offers (06-29 Pizza Hut job swallowed the next
+  H-E-B $13.50; 06-30 job-61 spanned three offers). Now a *physically-complete* job (final drop
+  delivered, nothing outstanding) closes on its next exit signal even with no receipt: the drop logs
+  one `DELIVERY_COMPLETED` and the next accepted offer mints a fresh jobId.
+  **Confirm on next pull: 0/2 —** after a delivery where DoorDash skips the receipt (you go from the
+  drop's handoff/nav straight to waiting-for-offer or the next offer, no earnings summary), the db
+  should still show a `DELIVERY_COMPLETED` for that drop, and the next accepted offer should carry a
+  **distinct jobId** (no multi-offer job unless it's a genuine mid-route add-on you accepted while
+  still delivering). Broken = a receipt-skipped drop with no completion, or two independent offers
+  sharing one jobId. **Watch the guard:** a genuine mid-shop/mid-route add-on (accepted while a drop
+  is still undelivered) must STILL fold into the same job — it must not regress into a new jobId
+  (#499/#503).
 - **🔧 FIX SHIPPED — click captures record every rule-matched tap + UNKNOWN cap re-arms after quiet (#597). READ THE PULL AFTER A DASH.**
   The week-long a11y process turned two per-process guards into forever-guards: click captures
   deduped to zero by day 3 (repeat taps hash identically), and the UNKNOWN cap (200) went blind

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/PlatformRegion.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/PlatformRegion.kt
@@ -89,6 +89,17 @@ data class PendingDestructive(
      */
     val authoritative: Boolean = false,
     /**
+     * The [Flow] this pending was armed *toward* — the destination screen whose
+     * appearance armed the transition (#596). Recorded only for `TASK_RETIRE`:
+     * the idle/offer arm stamps the flow it left the task for (`Idle`,
+     * `OfferPresented`), the receipt arm stamps `PostTask`. A physically-complete
+     * job is allowed to close on a retire commit (#596 T1/T2) **only when this is
+     * not [Flow.OfferPresented]** — a retire armed by the dasher deliberating on a
+     * mid-route add-on offer must NOT false-complete the still-undelivered final
+     * drop; that accept is an add-on, not an independent job.
+     */
+    val armedFromFlow: Flow? = null,
+    /**
      * The summary screen's parsed fields, stashed at arm time (#431) so the
      * deferred commit's DASH_STOP payload keeps full fidelity (earnings,
      * duration, offer counts) even though the committing observation is a


### PR DESCRIPTION
Closes #596. Field week: DoorDash frequently skips the per-delivery receipt — 6 of 21 confirmed dropoffs never got DELIVERY_COMPLETED, and the never-closed job absorbed later independent offers (a Pizza Hut job swallowed the next H-E-B accept; one 06-30 job spans THREE offers, $19 of $45.75 unattributed per-delivery).

## Fix (built by an opus agent from a fable-vetted plan; the vet caught two plan-sinking defects pre-build)
**Concept:** a job is *physically complete* when every dropoff placeholder is accounted (completed in `recentTasks` or just-retired; no customer-TBD placeholder outstanding; ≥1 dropoff finished) — truth from `recentTasks`+`justRetired`, never the stale `Job.tasks` mirror.
- **T1**: a TASK_RETIRE commit that leaves the job complete also closes it (`retireActiveTask` → `completeActiveJob`).
- **T2**: an accept over a complete job **starts a new job** instead of appending (commits an in-grace retire inline first, honest-timestamp `pend.since`); genuine mid-job add-ons still fold in.
- **T3**: session end sweeps outstanding completions — with a qualification rule (already-completed, or active-under-TASK_RETIRE) that excludes `endSession`'s force-stamp on an undelivered drop.
- **Arm provenance** (`PendingDestructive.armedFromFlow`): a retire armed by an offer interlude (dasher deliberating on an add-on mid-final-drop) can NEVER close the job — the vet-caught #499/#503 regression, with its own regression test.
- **Emission** (EffectMap): job-close diff mints `DELIVERY_COMPLETED` per delivered dropoff under the SAME idempotency key as the receipt path, with **diff-level mutual exclusivity** (same-step skip + gated job-less fallback) so replay streams can't double-mint — plus receipt-pay pinning so a timer-closed receipted delivery keeps its pay breakdown. #498 identity firewall retained.

## Tests
`JobCloseOutTest` (11: predicate/T1/T2/add-on guard/offer-armed guard), `ReceiptSkipReplayTest` (real 06-29 Pizza-Hut-receipt-skip captures + graceCommit + accept: 1 completion with null pay, job closed pre-accept, **distinct jobIds**) — **proven red pre-fix** (0 completions, absorbed). `:core:state` 94/94, `:app` 810/810 — incl. SingleDeliveryReplayTest (exclusivity holds) and both #518 cross-job tests. Fixtures PII-redacted per convention and re-scanned.

## Residuals (documented)
Receipt-less completions carry null pay (money attribution = #528, now unblocked); a receipt arriving after job close (>10s idle first) loses pay vs today; multi-drop receipt-then-close re-emission is engine-deduped live, replay-visible.

### Design-goal review
1 (UDF): stepper pure, `obs.timestamp`/`pend.since` only. 5 (SSOT): one completeness predicate, one idempotency key family shared by both mint sites. 6: identity firewall unchanged; fixtures redacted. 8: no platform literals — triggers ride Flow/TaskPhase vocabulary.

### Adversarial review
Fable design-vet pre-build (6 binding amendments, 2 plan-sinking); fable post-build PR check to follow as a comment before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)