### PR TITLE
fix(effects): #604 — rule effects from notifications key per-arrival, not per-install

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
@@ -79,8 +79,10 @@ class EffectMapTest {
         deliveredAt: String? = null,
         rawText: String? = null,
         ruleId: String = "doordash.notification.test",
+        timestamp: Long = 1000L,
+        effects: List<RequestedEffect> = emptyList(),
     ) = Observation.Notification(
-        timestamp = 1000L,
+        timestamp = timestamp,
         captureId = null,
         ruleId = ruleId,
         metadata = ReplayMetadata.EMPTY,
@@ -93,6 +95,7 @@ class EffectMapTest {
             deliveredAt = deliveredAt,
             rawText = rawText,
         ),
+        effects = effects,
     )
 
     private fun clickObs(
@@ -1418,6 +1421,92 @@ class EffectMapTest {
         val effects = effectMap.diff(state, state, notificationObs(intent = "new_order"))
         // No hardcoded log effects — logging comes from rule-declared effects
         assertTrue("Should produce no hardcoded effects for new_order", effects.isEmpty())
+    }
+
+    // =========================================================================
+    // PER-NOTIFICATION EFFECT KEYS (#604)
+    //
+    // A notification is a discrete arrival, not an install-once fact: a
+    // rule-declared log effect with no dedupeKey must key per-arrival
+    // (postTime), not "once ever" — otherwise the second `new_order`
+    // notification of the dash silently no-ops against `effects_fired`
+    // (the #604 bug). Screen observations are deliberately NOT suffixed —
+    // their cross-frame dedup (e.g. offer-ss-{parsedHash}) is intended.
+    // =========================================================================
+
+    @Test
+    fun `two notifications with the same rule effect but different timestamps get distinct effectKeys`() {
+        val (platform, onlineRegion) = stateWithPlatform()
+        val state = AppState(regions = Regions(platforms = mapOf(platform to onlineRegion)))
+        val logEffect = listOf(makeRequestedEffect(EffectVerb.LOG, ruleId = "doordash.notification.new_order"))
+
+        val firstArrival = effectMap.diff(
+            state, state,
+            notificationObs(intent = "new_order", timestamp = 1000L, effects = logEffect),
+        ).filterIsInstance<AppEffect.RequestEffect>()
+        val secondArrival = effectMap.diff(
+            state, state,
+            notificationObs(intent = "new_order", timestamp = 2000L, effects = logEffect),
+        ).filterIsInstance<AppEffect.RequestEffect>()
+
+        assertEquals(1, firstArrival.size)
+        assertEquals(1, secondArrival.size)
+        assertNotEquals(
+            "Distinct notification arrivals must not share an idempotency key",
+            firstArrival[0].effectKey,
+            secondArrival[0].effectKey,
+        )
+    }
+
+    @Test
+    fun `two notifications with the same rule effect and same timestamp share an effectKey`() {
+        val (platform, onlineRegion) = stateWithPlatform()
+        val state = AppState(regions = Regions(platforms = mapOf(platform to onlineRegion)))
+        val logEffect = listOf(makeRequestedEffect(EffectVerb.LOG, ruleId = "doordash.notification.new_order"))
+
+        val first = effectMap.diff(
+            state, state,
+            notificationObs(intent = "new_order", timestamp = 1000L, effects = logEffect),
+        ).filterIsInstance<AppEffect.RequestEffect>()
+        val repost = effectMap.diff(
+            state, state,
+            notificationObs(intent = "new_order", timestamp = 1000L, effects = logEffect),
+        ).filterIsInstance<AppEffect.RequestEffect>()
+
+        assertEquals(1, first.size)
+        assertEquals(1, repost.size)
+        assertEquals(
+            "An identical repost (same postTime) must still dedup",
+            first[0].effectKey,
+            repost[0].effectKey,
+        )
+    }
+
+    @Test
+    fun `a Screen observation's rule effect key is unsuffixed - exact string regression pin`() {
+        val logEffect = RequestedEffect(
+            verb = EffectVerb.LOG,
+            ruleId = "doordash.screen.test",
+        )
+        val obs = Observation.Screen(
+            timestamp = 1000L,
+            captureId = "cap-1000",
+            ruleId = "doordash.screen.test",
+            metadata = ReplayMetadata.EMPTY,
+            flow = null,
+            modeHint = null,
+            parsed = ParsedFields.None,
+            effects = listOf(logEffect),
+        )
+
+        val effects = effectMap.diff(AppState(), AppState(), obs).filterIsInstance<AppEffect.RequestEffect>()
+
+        assertEquals(1, effects.size)
+        assertEquals(
+            "Screen rule-effect keys are unsuffixed — cross-frame dedup is intended behavior",
+            "effect:doordash.screen.test:log",
+            effects[0].effectKey,
+        )
     }
 
     // =========================================================================

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/AppEffect.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/AppEffect.kt
@@ -182,10 +182,25 @@ sealed class AppEffect {
         val trigger: ActionTrigger,
     ) : AppEffect()
 
-    /** A rule-originated side effect. */
-    data class RequestEffect(val effect: RequestedEffect) : AppEffect() {
+    /**
+     * A rule-originated side effect.
+     *
+     * [keySuffix] disambiguates otherwise-identical effects across discrete
+     * occurrences of the same rule (#604): a notification's rule-declared
+     * effects have no per-arrival identity of their own (no dedupeKey), so
+     * without a suffix every arrival of e.g. `doordash.notification.new_order`
+     * collapses onto one global `effects_fired` key — the first notification
+     * fires it, every later one silently no-ops as "already fired". Screen
+     * observations pass `null` here: their cross-frame dedup (e.g.
+     * `offer-ss-{parsedHash}`) is intended and must NOT be suffixed.
+     */
+    data class RequestEffect(
+        val effect: RequestedEffect,
+        val keySuffix: String? = null,
+    ) : AppEffect() {
         override val effectKey: String
-            get() = "effect:${effect.ruleId}:${effect.dedupeKey ?: effect.verb.wire}"
+            get() = "effect:${effect.ruleId}:${effect.dedupeKey ?: effect.verb.wire}" +
+                keySuffix?.let { ":$it" }.orEmpty()
     }
 
     data class StartSession(val sessionId: String, val platformName: String) : AppEffect() {

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -949,13 +949,22 @@ class EffectMap @Inject constructor() {
      * [AppEffect.RequestEffect] for each that passes its gate.
      * Runs at top level — NOT inside any region stepper. All rule effects
      * are observational/app-internal (#425) — actuation never rides here.
+     *
+     * A [Observation.Notification] is a discrete arrival, not an
+     * install-once fact (#604): its effects get `keySuffix = timestamp`
+     * (postTime — event time, replay-stable) so each arrival keys its own
+     * `effects_fired` row instead of every notification of that intent
+     * colliding on one global key. Screens keep `keySuffix = null` — their
+     * cross-frame dedup (e.g. `offer-ss-{parsedHash}`) is intended and must
+     * not be disturbed.
      */
     private fun diffRuleEffects(obs: Observation): List<AppEffect> {
         val flowObs = obs as? Observation.FlowObservation ?: return emptyList()
         if (flowObs.effects.isEmpty()) return emptyList()
+        val keySuffix = (obs as? Observation.Notification)?.timestamp?.toString()
         return flowObs.effects
             .filter { evaluateGate(it.onlyIf, flowObs.parsed) }
-            .map { AppEffect.RequestEffect(it) }
+            .map { AppEffect.RequestEffect(it, keySuffix = keySuffix) }
     }
 
     /**

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -73,6 +73,19 @@ card's **mechanical** half, #577 (re-confirmed, 24/24, ~0.55 s — with a new po
 that entry's Bug #1), the #457 path, and #554 ShadowProjector (2/2). The #462/#460 dropoff item
 was found **broken-in-part** (raw PII in capture envelopes) and moved to that entry's Bug #7.)_
 
+- **🔧 FIX SHIPPED — rule effects from notifications key per-arrival, not per-install (#604). CONFIRM ON DASH.**
+  A rule-declared log effect attached to a notification with no `dedupeKey` (e.g.
+  `doordash.notification.new_order`) built its `effects_fired` idempotency key from the rule id
+  alone — a GLOBAL forever-key. The first `new_order` notification of the week fired it; every
+  later `new_order` notification all week silently no-opped as "already fired" (the throttle map
+  is only pruned at engine init, so a long-lived process never recovered). The key now includes
+  the notification's own timestamp (postTime, replay-stable), so each distinct arrival gets its
+  own key; an identical repost (same postTime) still dedups correctly. Screen-effect dedup is
+  unchanged (intended cross-frame behavior, e.g. `offer-ss-{parsedHash}`).
+  **Confirm on dash: 0/2 —** trigger at least two separate `new_order` notifications in one dash,
+  then check the db `app_events` for a `NOTIFICATION_RECEIVED`/`NEW_ORDER` log for **each**
+  arrival, and confirm no "Skipping already-fired effect" DEBUG line for the notification's log
+  effect on the second (or later) arrival. Broken = a later arrival's log effect silently skipped.
 - **🔧 FIX SHIPPED — receipt-skipped deliveries still close + log a completion, and the next offer starts a NEW job (#596).**
   DoorDash routinely skips the post-delivery receipt (the next offer chains straight over the drop);
   pre-#596 that was the machine's ONLY job-exit, so the delivery never logged `DELIVERY_COMPLETED`

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -77,15 +77,20 @@ was found **broken-in-part** (raw PII in capture envelopes) and moved to that en
   A rule-declared log effect attached to a notification with no `dedupeKey` (e.g.
   `doordash.notification.new_order`) built its `effects_fired` idempotency key from the rule id
   alone — a GLOBAL forever-key. The first `new_order` notification of the week fired it; every
-  later `new_order` notification all week silently no-opped as "already fired" (the throttle map
-  is only pruned at engine init, so a long-lived process never recovered). The key now includes
-  the notification's own timestamp (postTime, replay-stable), so each distinct arrival gets its
-  own key; an identical repost (same postTime) still dedups correctly. Screen-effect dedup is
-  unchanged (intended cross-frame behavior, e.g. `offer-ss-{parsedHash}`).
-  **Confirm on dash: 0/2 —** trigger at least two separate `new_order` notifications in one dash,
-  then check the db `app_events` for a `NOTIFICATION_RECEIVED`/`NEW_ORDER` log for **each**
-  arrival, and confirm no "Skipping already-fired effect" DEBUG line for the notification's log
-  effect on the second (or later) arrival. Broken = a later arrival's log effect silently skipped.
+  later `new_order` notification all week silently no-opped as "already fired" (the
+  `effects_fired` table is only pruned at engine init, so a long-lived process never recovered).
+  The key now includes the notification's own timestamp (postTime, replay-stable), so each
+  distinct arrival gets its own key; an identical repost (same postTime) still dedups correctly.
+  Screen-effect dedup is unchanged (intended cross-frame behavior, e.g. `offer-ss-{parsedHash}`).
+  **KNOWN SECOND LAYER (not fixed by #604 — see the FrameGate contentless-identity follow-up):**
+  the pipeline's identity dedup can still suppress a CONSECUTIVE `new_order` arrival upstream
+  (the rule has no parse, so its notification identity is contentless with no TTL) — that
+  suppression is a FrameGate duplicate, NOT a "Skipping already-fired effect".
+  **Confirm on dash: 0/2 —** a valid probe needs some OTHER recognized notification between the
+  two `new_order` arrivals (routine in a real dash). Check `app_events` for a
+  `NOTIFICATION_RECEIVED`/`NEW_ORDER` log for each such arrival. Broken = a later arrival
+  missing **and** a "Skipping already-fired effect" line for it; missing with no skip-line is
+  the FrameGate layer (follow-up issue), not a #604 regression.
 - **🔧 FIX SHIPPED — receipt-skipped deliveries still close + log a completion, and the next offer starts a NEW job (#596).**
   DoorDash routinely skips the post-delivery receipt (the next offer chains straight over the drop);
   pre-#596 that was the machine's ONLY job-exit, so the delivery never logged `DELIVERY_COMPLETED`


### PR DESCRIPTION
Closes #604. `effect:doordash.notification.new_order:log` fired once on 06-25 16:31 and deduped every subsequent new-order notification all week — notification rule effects carried a global forever-key (`effect:<ruleId>:<verb>`, no per-arrival discriminator).

## Fix (sonnet build from a fable-vetted plan)
`AppEffect.RequestEffect` gains `keySuffix` (default null — screens unchanged); `EffectMap.diffRuleEffects` suffixes ONLY `Observation.Notification` effects with `obs.timestamp` (postTime — event-time, replay-stable). A notification is a discrete arrival: "once per notification", never "once per install". Identical reposts (same postTime) still dedup; the suffix flows into the throttle map automatically (keyed on effectKey).

## Tests
3 new EffectMapTest cases: distinct timestamps → distinct keys (**red-first proven** — the only test that needs the fix); same timestamp → shared key (repost dedup pinned); Screen key exact-string regression pin (unsuffixed). Full `:core:state` + `:app` green.

## PR note (vet finding, not fixed here)
`effects_fired.pruneOlderThan` runs only at engine init (48h retention) — a long-lived process never re-prunes, which is why the week stayed dead even past 48h. Orthogonal; follow-up if it bites again.

### Design-goal review
5 (SSOT): one key-construction site; the discriminator policy (notification=per-arrival, screen=cross-frame) is stated where the key is built. 8: no platform literals — keyed on the observation type. 7: no logging changes.

### Adversarial review
Plan design-vetted by fable pre-build (verdict SOUND, no mechanism amendments); fable post-build PR check to follow before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)