### PR TITLE
fix(display): #607 — bare-number tip labels render as "Store #<n>" (parse stays faithful)

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -38,7 +38,9 @@ jobs:
         run: ./gradlew :app:assembleDebug
 
       - name: Run unit tests
-        run: ./gradlew testDebugUnitTest
+        # :domain is pure-JVM — its task is `test`, which the Android aggregate does NOT
+        # include; without it every :domain test is CI-invisible (#617 review / #590 gap).
+        run: ./gradlew testDebugUnitTest :domain:test
 
       - name: Upload debug APK
         uses: actions/upload-artifact@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,8 +59,8 @@ academic federation RFC #194.
 # Build the app
 ./gradlew :app:build
 
-# Run all unit tests (across all modules)
-./gradlew testDebugUnitTest
+# Run all unit tests (across all modules — :domain is pure-JVM, its task is `test`)
+./gradlew testDebugUnitTest :domain:test
 
 # Run ONLY the ruleset/recognition regressions (fast pre-PR check — no state
 # machine / DB / UI). Side-effect-free; does NOT sort INBOX or re-triage UNKNOWN.

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardItem.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardItem.kt
@@ -58,6 +58,7 @@ import cloud.trotter.dashbuddy.domain.state.PickupActivity
 import cloud.trotter.dashbuddy.domain.state.flowPhase
 import cloud.trotter.dashbuddy.domain.state.presentation
 import cloud.trotter.dashbuddy.domain.model.event.AppEventType
+import cloud.trotter.dashbuddy.domain.model.pay.displayLabel
 import cloud.trotter.dashbuddy.ui.formatters.color
 import cloud.trotter.dashbuddy.ui.formatters.displayLabel
 import cloud.trotter.dashbuddy.ui.formatters.offerBadgeIcon
@@ -743,7 +744,7 @@ private fun PostTaskBody(snap: FlowCardSnapshot.PostTask) {
                     BreakdownRow(item.type, Formats.money(item.amount))
                 }
                 pay.customerTips.forEach { tip ->
-                    BreakdownRow("tip · ${tip.type}", Formats.money(tip.amount))
+                    BreakdownRow("tip · ${tip.displayLabel}", Formats.money(tip.amount))
                 }
             }
         }

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
@@ -1138,6 +1138,37 @@ class EffectMapTest {
         assertTrue("Bubble should contain store name", bubbles[0].text.contains("Chipotle"))
     }
 
+    @Test
+    fun `expanded PostTask with a bare-number tip label renders as Store number - #607`() {
+        val (platform, _) = stateWithPlatform()
+        val session = Session("sess-1", startedAt = 100L)
+        val task = Task(taskId = "task-1", jobId = "job-1", phase = TaskPhase.DROPOFF, storeName = "618", startedAt = 900L, completedAt = 1000L)
+        val region = PlatformRegion(
+            platform, mode = Mode.Online, session = session, recentTasks = listOf(task),
+            lastAnnouncedPostTaskTaskId = null,
+        )
+        val prev = AppState(regions = Regions(flow = FlowRegion(flow = Flow.PostTask), platforms = mapOf(platform to region)))
+        val next = prev
+        val parsedPay = cloud.trotter.dashbuddy.domain.model.pay.ParsedPay(
+            appPayComponents = listOf(cloud.trotter.dashbuddy.domain.model.pay.ParsedPayItem("DoorDash pay", 8.00)),
+            customerTips = listOf(cloud.trotter.dashbuddy.domain.model.pay.ParsedPayItem("618", 10.00)),
+        )
+        val effects = effectMap.diff(prev, next, screenObs(
+            flow = Flow.PostTask,
+            parsed = ParsedFields.PostTaskFields(totalPay = 18.00, parsedPay = parsedPay),
+        ))
+        val bubbles = effects.filterIsInstance<AppEffect.UpdateBubble>()
+        assertEquals(1, bubbles.size)
+        assertTrue(
+            "Bare-number tip label should render as 'Store #618', not the raw digits",
+            bubbles[0].text.contains("Tip: Store #618 • \$10.00"),
+        )
+        assertFalse(
+            "The raw bare-digit label alone must not appear unqualified",
+            bubbles[0].text.contains("Tip: 618 •"),
+        )
+    }
+
     // =========================================================================
     // APP-OWNED ACTIONS (#425): expand decision + deferred-action round-trip +
     // UiInput accept/decline aimed by rule-bound targets

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -18,6 +18,7 @@ import cloud.trotter.dashbuddy.domain.model.event.payload.SessionPausedPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStartPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStartSource
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStopPayload
+import cloud.trotter.dashbuddy.domain.model.pay.displayLabel
 import cloud.trotter.dashbuddy.domain.state.OfferIntent
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
 import cloud.trotter.dashbuddy.domain.pipeline.ParsedFieldsGate
@@ -876,7 +877,7 @@ class EffectMap @Inject constructor() {
             buildString {
                 append("Saved: ${Formats.money(payData.total)}")
                 payData.customerTips.forEach { item ->
-                    append("\nTip: ${item.type} • ${Formats.money(item.amount)}")
+                    append("\nTip: ${item.displayLabel} • ${Formats.money(item.amount)}")
                 }
             }
         } else {

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/pay/ParsedPayItem.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/pay/ParsedPayItem.kt
@@ -12,3 +12,26 @@ data class ParsedPayItem(
     val type: String,   // e.g., "Base Pay", "Peak Pay", or for tips, "Sake Cafe"
     val amount: Double
 )
+
+/** Bare-digits store identifier — the shape DoorDash uses as a tip's own label for some merchants. */
+private val BARE_STORE_NUMBER = Regex("^\\d{2,6}$")
+
+/**
+ * Display-only rendering of [ParsedPayItem.type] for human-facing UI (the bubble HUD post-task
+ * receipt, the delivery-summary card).
+ *
+ * For some merchants, DoorDash's own per-tip sub-label (the `pay_line_item_title` node) is a bare
+ * store number (`"618"`) with no fuller name anywhere in the frame — that number IS DoorDash's
+ * label, not junk data (#607); it's stable and recurs across separate deliveries at the same
+ * store. Rendered verbatim it reads as a meaningless number to a driver, so this formats it as
+ * `"Store #618"`.
+ *
+ * [ParsedPayItem.type] itself is left completely untouched everywhere else — in particular,
+ * [cloud.trotter.dashbuddy.domain.state.StoreChainProjector] token-matches the raw `.type`
+ * against pickup store names (and tears a running key out of it), and a normalized `"Store #618"`
+ * would tokenize to `["store", "618"]`, corrupting that match. This property is strictly a
+ * display-site helper — use it only where you're building text for a human to read, never where
+ * you're comparing, keying, or correlating on the value.
+ */
+val ParsedPayItem.displayLabel: String
+    get() = if (BARE_STORE_NUMBER.matches(type)) "Store #$type" else type

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/model/pay/ParsedPayItemTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/model/pay/ParsedPayItemTest.kt
@@ -1,0 +1,61 @@
+package cloud.trotter.dashbuddy.domain.model.pay
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * #607 — DoorDash renders some merchants' per-tip sub-label as a bare store number
+ * (e.g. "618") with no fuller name anywhere in-frame. That number IS DoorDash's own
+ * label, not junk — so [ParsedPayItem.displayLabel] normalizes it to "Store #618" for
+ * a human reader while [ParsedPayItem.type] itself stays completely untouched (it's
+ * still token-matched raw by [cloud.trotter.dashbuddy.domain.state.StoreChainProjector]).
+ */
+class ParsedPayItemTest {
+
+    @Test
+    fun `bare 2-6 digit type displays as Store number`() {
+        assertEquals("Store #618", ParsedPayItem(type = "618", amount = 10.0).displayLabel)
+        assertEquals("Store #99", ParsedPayItem(type = "99", amount = 1.0).displayLabel)
+        assertEquals("Store #123456", ParsedPayItem(type = "123456", amount = 1.0).displayLabel)
+    }
+
+    @Test
+    fun `bare digit type does not mutate the raw type field`() {
+        val item = ParsedPayItem(type = "618", amount = 10.0)
+        assertEquals("618", item.type)
+        assertEquals("Store #618", item.displayLabel)
+    }
+
+    @Test
+    fun `full merchant name passes through verbatim`() {
+        assertEquals("Chipotle", ParsedPayItem(type = "Chipotle", amount = 3.0).displayLabel)
+        assertEquals("Sake Cafe", ParsedPayItem(type = "Sake Cafe", amount = 3.0).displayLabel)
+    }
+
+    @Test
+    fun `app pay labels like Base Pay pass through verbatim`() {
+        assertEquals("Base Pay", ParsedPayItem(type = "Base Pay", amount = 5.0).displayLabel)
+        assertEquals("Peak Pay", ParsedPayItem(type = "Peak Pay", amount = 2.5).displayLabel)
+    }
+
+    @Test
+    fun `single digit is too short to be a store number - passes through verbatim`() {
+        assertEquals("7", ParsedPayItem(type = "7", amount = 1.0).displayLabel)
+    }
+
+    @Test
+    fun `seven-plus digit run is too long to be a store number - passes through verbatim`() {
+        assertEquals("1234567", ParsedPayItem(type = "1234567", amount = 1.0).displayLabel)
+    }
+
+    @Test
+    fun `digits mixed with other characters are not treated as a bare store number`() {
+        assertEquals("Store 618", ParsedPayItem(type = "Store 618", amount = 1.0).displayLabel)
+        assertEquals("618A", ParsedPayItem(type = "618A", amount = 1.0).displayLabel)
+    }
+
+    @Test
+    fun `blank type passes through verbatim`() {
+        assertEquals("", ParsedPayItem(type = "", amount = 0.0).displayLabel)
+    }
+}


### PR DESCRIPTION
Closes #607 — with a reframe from the grounding: '799'/'618' are NOT junk. They are DoorDash's own per-tip sub-labels — stable store numbers ('799' recurs across three separate 06-28 deliveries) that DoorDash renders instead of a full merchant name for some stores. The parser reads the right node; amounts pair correctly; often no fuller name exists in the frame.

## Fix (sonnet build from a fable-vetted plan; the vet REDIRECTED the site)
Display-side only: `ParsedPayItem.displayLabel` (`:domain` SSOT extension) renders a bare 2-6-digit `.type` as `"Store #<n>"`, used at both render sites (the `diffPostTask` bubble line and the receipt card's tip row). `.type` stays raw everywhere — the vet caught that parse-site normalization would have corrupted `StoreChainProjector`'s token matching (it consumes `.type` raw for payout→store attribution; "Store #618" tokenizes to ["store","618"] and creates false matches).

## Tests
New `ParsedPayItemTest` (helper semantics incl. non-normalization of 1/7-digit and alphanumeric) + an end-to-end `diffPostTask` case pinning `"Tip: Store #618 • $10.00"` — both red-first proven. Full suites + AllMatchersSuite green (no rule changes). No field-checklist item (display-only).

### Design-goal review
5 (SSOT): one display helper, two consumers — the label policy can't drift between bubble and card. 3: parse/projection layers untouched. 8: no platform literals.

### Adversarial review
Fable design-vet redirected the normalization site pre-build (the StoreChainProjector catch); fable post-build check follows before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)