### PR TITLE
fix(privacy): #598 — rule-declared capture redaction: customer PII masked in envelopes at the device edge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,7 +145,9 @@ gate, #399), then **disabled-platform** (defense-in-depth), then **UNKNOWN** (ca
 triage, never forwarded to the state machine). Snapshots are attributed to the window's *real* package (not the event's), so
 our own overlay is dropped (#4 / PR #334). Frame admission is `FrameGate` (identity dedup +
 content-hash rolling suppression of UNKNOWN frames, #360); envelope assembly is the shared
-`CaptureWriter` (#361); `PipelineV2.events` is a HOT `shareIn` stream — one upstream pass feeds
+`CaptureWriter` (#361), which also applies **rule-declared capture redaction** — a recognized
+rule's `redact` block masks customer name/address/gate-code node text in the serialized envelope
+only, so recognized captures are PII-hashed-at-edge on disk (#598); `PipelineV2.events` is a HOT `shareIn` stream — one upstream pass feeds
 all collectors, so side effects (captures, dedup state) can never double-run (#361). The merged
 upstream is supervised — a crash logs + counts a restart and resubscribes with backoff instead of
 silencing all sensing (#430) — and `PipelineStats` counts every gate decision, mapping failure,
@@ -157,8 +159,11 @@ Recognition is **data, not code**. Per-platform rule files
 (`core/pipeline/src/main/assets/rules/doordash.json`, `uber.json` — spec in ADR-0001, editor schema
 `docs/rules.schema.json`) are compiled by `RuleCompiler` and matched by `ObservationClassifier`.
 Rules carry a `priority` (sensitive rules are priority 0 and `overrideable: false`, blocking all
-further processing of banking/identity screens), `require` predicates, `bind` blocks, and `parse`
-blocks that produce typed fields via `ParsedFieldsFactory`. There are no Kotlin matcher classes —
+further processing of banking/identity screens), `require` predicates, `bind` blocks, `parse`
+blocks that produce typed fields via `ParsedFieldsFactory`, and an optional `redact` block
+(#598) — node predicates whose matched text is masked in the capture envelope (a screen rule
+that hashes PII via the `sha256` transform MUST declare a non-empty `redact`, enforced at compile;
+the mask keeps a `keepPrefix` marker so recognition on replay is unchanged). There are no Kotlin matcher classes —
 changing recognition means editing rule JSON plus corpus tests. **Rules cannot declare actuation**
 (#425): the compiler rejects `click`/gesture effect verbs; rules instead expose well-known *target
 bindings* (`acceptButton`, `declineButton`, `expandButton`) that the app-owned `RuleAction`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,12 @@ our own overlay is dropped (#4 / PR #334). Frame admission is `FrameGate` (ident
 content-hash rolling suppression of UNKNOWN frames, #360); envelope assembly is the shared
 `CaptureWriter` (#361), which also applies **rule-declared capture redaction** — a recognized
 rule's `redact` block masks customer name/address/gate-code node text in the serialized envelope
-only, so recognized captures are PII-hashed-at-edge on disk (#598); `PipelineV2.events` is a HOT `shareIn` stream — one upstream pass feeds
+only, so recognized captures are PII-hashed-at-edge on disk (#598). Coverage now spans the
+recognized offer/pickup/dropoff/chat/nav/camera customer surfaces (customer name, street/apt/
+gate-code lines, chat message bodies); UNKNOWN frames and UNKNOWN clicks remain the documented
+debug-only exception (behind the release `NoOpCaptureBus` #346 + the `SensitiveTextMarkers`
+backstop), and the id-less building-name line + replay-identity residuals are tracked (#623/#624/
+#620). `PipelineV2.events` is a HOT `shareIn` stream — one upstream pass feeds
 all collectors, so side effects (captures, dedup state) can never double-run (#361). The merged
 upstream is supervised — a crash logs + counts a restart and resubscribes with backoff instead of
 silencing all sensing (#430) — and `PipelineStats` counts every gate decision, mapping failure,

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/notification/NotificationPipelineSensitiveOrderingTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/notification/NotificationPipelineSensitiveOrderingTest.kt
@@ -7,6 +7,7 @@ import cloud.trotter.dashbuddy.core.pipeline.CaptureWriter
 import cloud.trotter.dashbuddy.core.pipeline.ObservationClassifier
 import cloud.trotter.dashbuddy.core.pipeline.PipelineStats
 import cloud.trotter.dashbuddy.core.pipeline.rules.JsonRuleInterpreter
+import cloud.trotter.dashbuddy.core.pipeline.rules.ScreenRedactionSource
 import cloud.trotter.dashbuddy.core.pipeline.notification.input.NotificationSource
 import cloud.trotter.dashbuddy.domain.capture.CaptureBus
 import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
@@ -66,7 +67,10 @@ class NotificationPipelineSensitiveOrderingTest {
         source = source,
         filter = NotificationFilter(platformPrefs),
         classifier = classifier,
-        captureWriter = CaptureWriter(captureBus, PipelineStats()),
+        captureWriter = CaptureWriter(
+            captureBus, PipelineStats(),
+            object : ScreenRedactionSource { override fun redactFor(ruleId: String) = null },
+        ),
         platformPreferences = platformPrefs,
         stats = PipelineStats(),
     )

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/CaptureRedactionCorpusTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/CaptureRedactionCorpusTest.kt
@@ -1,0 +1,93 @@
+package cloud.trotter.dashbuddy.core.pipeline.rules
+
+import cloud.trotter.dashbuddy.domain.capture.schema.UiNodeSchema
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import cloud.trotter.dashbuddy.test.util.TestResourceLoader
+import cloud.trotter.dashbuddy.test.util.TestRulesetFactory
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * #598 corpus-level guard — the teeth. Runs the PRODUCTION redact predicates
+ * over a real (already-redacted) dropoff fixture with a synthetic customer name
+ * injected, and pins the fail-closed invariant that every screen rule which
+ * hashes PII (`sha256`) also declares a `redact` block. Redaction is
+ * capture-only, so this asserts on the SERIALIZED envelope payload, never on
+ * recognition (the goldens stay byte-identical).
+ */
+class CaptureRedactionCorpusTest {
+
+    private val rulesDir = File(TestRulesetFactory.rulesDir)
+
+    private fun serialize(tree: UiNode): String = UiNodeSchema.serialize(tree)
+
+    @Test
+    fun `dropoff redact masks an injected customer name but keeps the Deliver to marker`() {
+        // A real, already-redacted en-route dropoff card from the committed corpus.
+        val fixture = File("src/test/resources/snapshots/dropoff_pre_arrival")
+            .listFiles { _, n -> n.endsWith(".json") }!!
+            .sorted().first()
+        val real = TestResourceLoader.loadNode(fixture)
+
+        // Inject a synthetic PII node the way a live (un-redacted) capture would carry it.
+        val injected = UiNode(
+            text = "Deliver to Testname Q",
+            children = real.children,
+        ).restoreParents()
+
+        val rule = TestRulesetFactory.screenRuleset.ruleById("doordash.screen.dropoff_pre_arrival")!!
+        val redactedJson = serialize(rule.redact.apply(injected))
+
+        assertFalse("injected customer name must not persist", redactedJson.contains("Testname Q"))
+        assertTrue("marker kept, name masked", redactedJson.contains("Deliver to [redacted]"))
+    }
+
+    @Test
+    fun `every screen rule that hashes PII declares a redact block`() {
+        var checked = 0
+        rulesDir.listFiles { f -> f.extension == "json" }?.forEach { file ->
+            val root = Json.parseToJsonElement(file.readText()).jsonObject
+            root["screens"]?.jsonArray?.forEach { screen ->
+                val obj = screen.jsonObject
+                if (jsonUsesSha256(obj)) {
+                    checked++
+                    val redact = obj["redact"]?.jsonArray
+                    assertTrue(
+                        "screen rule '${obj["id"]?.jsonPrimitive?.content}' hashes PII (sha256) " +
+                            "but declares no non-empty redact block (#598)",
+                        redact != null && redact.isNotEmpty(),
+                    )
+                }
+            }
+        }
+        // Guard the guard: the 4 known sha256 dropoff/timeline rules must be seen.
+        assertTrue("expected at least the 4 known sha256 screen rules", checked >= 4)
+    }
+
+    @Test
+    fun `the four known sha256 rules expose a redact block via ruleById`() {
+        val ids = listOf(
+            "doordash.screen.timeline",
+            "doordash.screen.dropoff_navigation",
+            "doordash.screen.dropoff_pre_arrival",
+            "doordash.screen.dropoff_pre_arrival_completion",
+        )
+        for (id in ids) {
+            val rule = TestRulesetFactory.screenRuleset.ruleById(id)!!
+            assertFalse("$id must carry a redact block", rule.redact.isEmpty())
+        }
+    }
+
+    private fun jsonUsesSha256(element: kotlinx.serialization.json.JsonElement): Boolean = when (element) {
+        is kotlinx.serialization.json.JsonPrimitive -> element.isString && element.content == "sha256"
+        is kotlinx.serialization.json.JsonObject -> element.values.any { jsonUsesSha256(it) }
+        is kotlinx.serialization.json.JsonArray -> element.any { jsonUsesSha256(it) }
+    }
+}

--- a/core/pipeline/src/main/assets/rules/doordash.json
+++ b/core/pipeline/src/main/assets/rules/doordash.json
@@ -1164,6 +1164,11 @@
     {
       "id": "doordash.screen.pickup_pre_arrival",
       "priority": 71,
+      "redact": [
+        { "find": { "hasIdSuffix": "user_name" } },
+        { "find": { "hasIdSuffix": "address_line_1" } },
+        { "find": { "hasIdSuffix": "address_line_2" } }
+      ],
       "state": {
         "flow": "task:pickup:navigation",
         "modeHint": "online"
@@ -1274,6 +1279,9 @@
     {
       "id": "doordash.screen.pickup_verify_items",
       "priority": 76,
+      "redact": [
+        { "find": { "hasIdSuffix": "order_verification_checklist_title" }, "keepPrefix": [ "Verify items for " ] }
+      ],
       "state": {
         "flow": "task:pickup:arrived",
         "modeHint": "online"
@@ -1368,7 +1376,8 @@
         { "find": { "all": [ { "hasTextMatchesRegex": "^\\d{1,5}\\s+\\S" }, { "hasNoId": true } ] } },
         { "find": { "all": [ { "hasTextMatchesRegex": "\\d{5}" }, { "hasNoId": true } ] } },
         { "find": { "hasTextStartsWith": "Apt " }, "keepPrefix": [ "Apt " ] },
-        { "find": { "hasTextStartsWith": "\"" } }
+        { "find": { "hasTextStartsWith": "\"" } },
+        { "find": { "all": [ { "hasTextMatchesRegex": "^\\d{1,4}[A-Za-z]?$" }, { "hasNoId": true } ] } }
       ],
       "state": {
         "flow": "task:dropoff:navigation",
@@ -1600,7 +1609,8 @@
         { "find": { "all": [ { "hasTextMatchesRegex": "^\\d{1,5}\\s+\\S" }, { "hasNoId": true } ] } },
         { "find": { "all": [ { "hasTextMatchesRegex": "\\d{5}" }, { "hasNoId": true } ] } },
         { "find": { "hasTextStartsWith": "Apt " }, "keepPrefix": [ "Apt " ] },
-        { "find": { "hasTextStartsWith": "\"" } }
+        { "find": { "hasTextStartsWith": "\"" } },
+        { "find": { "all": [ { "hasTextMatchesRegex": "^\\d{1,4}[A-Za-z]?$" }, { "hasNoId": true } ] } }
       ],
       "state": {
         "flow": "task:dropoff:navigation",
@@ -2217,6 +2227,9 @@
     {
       "id": "doordash.screen.waiting_for_offer",
       "priority": 120,
+      "redact": [
+        { "find": { "hasIdSuffix": "user_name" } }
+      ],
       "state": {
         "flow": "idle",
         "modeHint": "online"
@@ -2652,6 +2665,11 @@
     {
       "id": "doordash.screen.dropoff_photo",
       "priority": 62,
+      "comment": "#598 F1: the customer instruction fields on this screen are all id-less free text — the handoff summary, a free-form delivery note (gate codes, custom directions), and the unit line ('Apt/Suite <n>'). None have a stable id or prefix, so the only complete mask is all id-less text (the require anchors — drop_off_workflow_host_fragment + the 'photo of drop-off' step_title — are id-bearing, so recognition on replay is unchanged). The 'Apt/Suite ' label is preserved for debug context; the standard handoff summary and any structural counters are masked too (accepted, capture-only).",
+      "redact": [
+        { "find": { "hasTextStartsWith": "Apt/Suite" }, "keepPrefix": [ "Apt/Suite " ] },
+        { "find": { "hasNoId": true } }
+      ],
       "state": { "flow": "task:dropoff:arrived" },
       "require": {
         "all": [
@@ -2682,7 +2700,8 @@
         { "find": { "all": [ { "hasTextMatchesRegex": "^\\d{1,5}\\s+\\S" }, { "hasNoId": true } ] } },
         { "find": { "all": [ { "hasTextMatchesRegex": "\\d{5}" }, { "hasNoId": true } ] } },
         { "find": { "hasTextStartsWith": "Apt " }, "keepPrefix": [ "Apt " ] },
-        { "find": { "hasTextStartsWith": "\"" } }
+        { "find": { "hasTextStartsWith": "\"" } },
+        { "find": { "all": [ { "hasTextMatchesRegex": "^\\d{1,4}[A-Za-z]?$" }, { "hasNoId": true } ] } }
       ],
       "state": { "flow": "task:dropoff:arrived" },
       "require": {
@@ -2743,6 +2762,11 @@
     {
       "id": "doordash.screen.dropoff_geofence_warning",
       "priority": 84,
+      "redact": [
+        { "find": { "hasIdSuffix": "address_line_1" } },
+        { "find": { "hasIdSuffix": "address_line_2" } },
+        { "find": { "hasIdSuffix": "address_subpremise_line" } }
+      ],
       "require": {
         "exists": { "hasTextContaining": "far away from the customer" }
       }
@@ -2750,6 +2774,9 @@
     {
       "id": "doordash.screen.nav_arriving",
       "priority": 69,
+      "redact": [
+        { "find": { "hasIdSuffix": "arriving_at_title" } }
+      ],
       "require": {
         "any": [
           { "exists": { "hasIdSuffix": "arriving_at_subtitle" } },
@@ -2774,6 +2801,11 @@
     {
       "id": "doordash.screen.camera_capture",
       "priority": 86,
+      "comment": "#598 F1: the id-bearing 'bottom_instruction' node embeds customer PII ('...name: <name>', '...Apt/Suite: <apt>'); mask it whole (the 'title' label stays). The bare-name regex catches a stale bin-scan-overlay customer name (e.g. 'Kris K') among id-less product rows without touching those products; single-token all-caps bare names remain a structural residual (#623/#624).",
+      "redact": [
+        { "find": { "hasIdSuffix": "bottom_instruction" } },
+        { "find": { "all": [ { "hasNoId": true }, { "hasTextMatchesRegex": "^[A-Za-z]{2,}( [A-Z]\\.?){1,2}$" } ] } }
+      ],
       "require": {
         "exists": { "any": [
           { "hasIdSuffix": "camera_preview" },
@@ -2791,6 +2823,12 @@
     {
       "id": "doordash.screen.chat_conversation",
       "priority": 89,
+      "redact": [
+        { "find": { "hasIdSuffix": "textView_navBar_title" } },
+        { "find": { "hasIdSuffix": "message_self_message" } },
+        { "find": { "hasIdSuffix": "message_other_message" } },
+        { "find": { "hasIdSuffix": "admin_message_text" } }
+      ],
       "require": {
         "exists": { "any": [
           { "hasIdSuffix": "ddchat_holder_base" },

--- a/core/pipeline/src/main/assets/rules/doordash.json
+++ b/core/pipeline/src/main/assets/rules/doordash.json
@@ -113,6 +113,18 @@
     {
       "id": "doordash.screen.timeline",
       "priority": 10,
+      "redact": [
+        {
+          "find": {
+            "any": [
+              { "hasTextStartsWith": "Pickup for " },
+              { "hasTextStartsWith": "Deliver to " },
+              { "hasTextStartsWith": "Pickup from " }
+            ]
+          },
+          "keepPrefix": [ "Pickup for ", "Deliver to ", "Pickup from " ]
+        }
+      ],
       "state": {
         "modeHint": "online"
       },
@@ -917,6 +929,12 @@
     {
       "id": "doordash.screen.dropoff_navigation",
       "priority": 61,
+      "redact": [
+        { "find": { "hasIdSuffix": "bottom_sheet_task_title" }, "keepPrefix": [ "Deliver to ", "Heading to " ] },
+        { "find": { "hasIdSuffix": "bottom_sheet_address_line_1" } },
+        { "find": { "hasIdSuffix": "bottom_sheet_address_line_2" } },
+        { "find": { "hasIdSuffix": "bottom_sheet_instructions" } }
+      ],
       "state": {
         "flow": "task:dropoff:navigation",
         "modeHint": "online"
@@ -1046,6 +1064,9 @@
     {
       "id": "doordash.screen.pickup_arrival",
       "priority": 70,
+      "redact": [
+        { "find": { "hasIdSuffix": "customer_name" } }
+      ],
       "state": {
         "flow": "task:pickup:arrived",
         "modeHint": "online"
@@ -1339,6 +1360,16 @@
     {
       "id": "doordash.screen.dropoff_pre_arrival",
       "priority": 73,
+      "redact": [
+        { "find": { "any": [ { "hasTextStartsWith": "Deliver to" }, { "hasTextStartsWith": "Heading to" } ] }, "keepPrefix": [ "Deliver to ", "Heading to " ] },
+        { "find": { "hasIdSuffix": "user_name" } },
+        { "find": { "hasIdSuffix": "address_line_1" } },
+        { "find": { "hasIdSuffix": "address_line_2" } },
+        { "find": { "all": [ { "hasTextMatchesRegex": "^\\d{1,5}\\s+\\S" }, { "hasNoId": true } ] } },
+        { "find": { "all": [ { "hasTextMatchesRegex": "\\d{5}" }, { "hasNoId": true } ] } },
+        { "find": { "hasTextStartsWith": "Apt " }, "keepPrefix": [ "Apt " ] },
+        { "find": { "hasTextStartsWith": "\"" } }
+      ],
       "state": {
         "flow": "task:dropoff:navigation",
         "modeHint": "online"
@@ -1564,6 +1595,13 @@
     {
       "id": "doordash.screen.dropoff_pre_arrival_completion",
       "priority": 74,
+      "redact": [
+        { "find": { "any": [ { "hasTextStartsWith": "Deliver to" }, { "hasTextStartsWith": "Heading to" } ] }, "keepPrefix": [ "Deliver to ", "Heading to " ] },
+        { "find": { "all": [ { "hasTextMatchesRegex": "^\\d{1,5}\\s+\\S" }, { "hasNoId": true } ] } },
+        { "find": { "all": [ { "hasTextMatchesRegex": "\\d{5}" }, { "hasNoId": true } ] } },
+        { "find": { "hasTextStartsWith": "Apt " }, "keepPrefix": [ "Apt " ] },
+        { "find": { "hasTextStartsWith": "\"" } }
+      ],
       "state": {
         "flow": "task:dropoff:navigation",
         "modeHint": "online"
@@ -2639,6 +2677,13 @@
     {
       "id": "doordash.screen.dropoff_handoff",
       "priority": 64,
+      "redact": [
+        { "find": { "any": [ { "hasTextStartsWith": "Deliver to" }, { "hasTextStartsWith": "Heading to" } ] }, "keepPrefix": [ "Deliver to ", "Heading to " ] },
+        { "find": { "all": [ { "hasTextMatchesRegex": "^\\d{1,5}\\s+\\S" }, { "hasNoId": true } ] } },
+        { "find": { "all": [ { "hasTextMatchesRegex": "\\d{5}" }, { "hasNoId": true } ] } },
+        { "find": { "hasTextStartsWith": "Apt " }, "keepPrefix": [ "Apt " ] },
+        { "find": { "hasTextStartsWith": "\"" } }
+      ],
       "state": { "flow": "task:dropoff:arrived" },
       "require": {
         "all": [
@@ -2866,6 +2911,9 @@
       "comment": "Deeper than pickup_select_issue — the resolution panel reached after picking an issue. Keyed on its own distinctive strings so it never overlaps the issue list.",
       "id": "doordash.screen.pickup_resolution_options",
       "priority": 103,
+      "redact": [
+        { "find": { "hasTextStartsWith": "For " }, "keepPrefix": [ "For " ] }
+      ],
       "require": {
         "all": [
           { "exists": { "hasTextContaining": "Resolution options" } },

--- a/core/pipeline/src/main/assets/rules/doordash.json
+++ b/core/pipeline/src/main/assets/rules/doordash.json
@@ -933,6 +933,7 @@
         { "find": { "hasIdSuffix": "bottom_sheet_task_title" }, "keepPrefix": [ "Deliver to ", "Heading to " ] },
         { "find": { "hasIdSuffix": "bottom_sheet_address_line_1" } },
         { "find": { "hasIdSuffix": "bottom_sheet_address_line_2" } },
+        { "find": { "hasIdSuffix": "bottom_sheet_subpremise_line" }, "keepPrefix": [ "Apt/Suite: " ] },
         { "find": { "hasIdSuffix": "bottom_sheet_instructions" } }
       ],
       "state": {
@@ -1373,11 +1374,14 @@
         { "find": { "hasIdSuffix": "user_name" } },
         { "find": { "hasIdSuffix": "address_line_1" } },
         { "find": { "hasIdSuffix": "address_line_2" } },
+        { "find": { "hasIdSuffix": "address_subpremise_line" }, "keepPrefix": [ "Apt/Suite: " ] },
+        { "find": { "hasIdSuffix": "dasher_instruction_content_collapsed" } },
+        { "find": { "hasIdSuffix": "dasher_instruction_content_expanded" } },
         { "find": { "all": [ { "hasTextMatchesRegex": "^\\d{1,5}\\s+\\S" }, { "hasNoId": true } ] } },
         { "find": { "all": [ { "hasTextMatchesRegex": "\\d{5}" }, { "hasNoId": true } ] } },
         { "find": { "hasTextStartsWith": "Apt " }, "keepPrefix": [ "Apt " ] },
         { "find": { "hasTextStartsWith": "\"" } },
-        { "find": { "all": [ { "hasTextMatchesRegex": "^\\d{1,4}[A-Za-z]?$" }, { "hasNoId": true } ] } }
+        { "find": { "all": [ { "hasTextMatchesRegex": "^#?\\s?\\d{1,4}[A-Za-z]?$" }, { "hasNoId": true } ] } }
       ],
       "state": {
         "flow": "task:dropoff:navigation",
@@ -1610,7 +1614,7 @@
         { "find": { "all": [ { "hasTextMatchesRegex": "\\d{5}" }, { "hasNoId": true } ] } },
         { "find": { "hasTextStartsWith": "Apt " }, "keepPrefix": [ "Apt " ] },
         { "find": { "hasTextStartsWith": "\"" } },
-        { "find": { "all": [ { "hasTextMatchesRegex": "^\\d{1,4}[A-Za-z]?$" }, { "hasNoId": true } ] } }
+        { "find": { "all": [ { "hasTextMatchesRegex": "^#?\\s?\\d{1,4}[A-Za-z]?$" }, { "hasNoId": true } ] } }
       ],
       "state": {
         "flow": "task:dropoff:navigation",
@@ -2228,7 +2232,9 @@
       "id": "doordash.screen.waiting_for_offer",
       "priority": 120,
       "redact": [
-        { "find": { "hasIdSuffix": "user_name" } }
+        { "find": { "hasIdSuffix": "user_name" } },
+        { "find": { "hasIdSuffix": "address_line_1" } },
+        { "find": { "hasIdSuffix": "address_line_2" } }
       ],
       "state": {
         "flow": "idle",
@@ -2701,7 +2707,7 @@
         { "find": { "all": [ { "hasTextMatchesRegex": "\\d{5}" }, { "hasNoId": true } ] } },
         { "find": { "hasTextStartsWith": "Apt " }, "keepPrefix": [ "Apt " ] },
         { "find": { "hasTextStartsWith": "\"" } },
-        { "find": { "all": [ { "hasTextMatchesRegex": "^\\d{1,4}[A-Za-z]?$" }, { "hasNoId": true } ] } }
+        { "find": { "all": [ { "hasTextMatchesRegex": "^#?\\s?\\d{1,4}[A-Za-z]?$" }, { "hasNoId": true } ] } }
       ],
       "state": { "flow": "task:dropoff:arrived" },
       "require": {

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CaptureWriter.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CaptureWriter.kt
@@ -3,6 +3,7 @@ package cloud.trotter.dashbuddy.core.pipeline
 import cloud.trotter.dashbuddy.core.pipeline.accessibility.AccessibilityPipeline
 import cloud.trotter.dashbuddy.core.pipeline.accessibility.clickDedupHash
 import cloud.trotter.dashbuddy.core.pipeline.notification.NotificationPipeline
+import cloud.trotter.dashbuddy.core.pipeline.rules.ScreenRedactionSource
 import cloud.trotter.dashbuddy.domain.capture.CaptureBus
 import cloud.trotter.dashbuddy.domain.capture.EnvelopeBuilder
 import cloud.trotter.dashbuddy.domain.capture.WindowContextDto
@@ -31,6 +32,7 @@ import javax.inject.Singleton
 class CaptureWriter @Inject constructor(
     private val captureBus: CaptureBus,
     private val stats: PipelineStats,
+    private val redactionSource: ScreenRedactionSource,
 ) {
 
     fun captureScreen(
@@ -63,13 +65,22 @@ class CaptureWriter @Inject constructor(
                 totalWindowCount = wc.totalWindowCount,
             )
         }
+        // #598: rule-declared capture redaction. A recognized screen persists its
+        // full tree for corpus building, but a rule that RECOGNIZES customer PII
+        // must MASK it in the serialized envelope. The redacted copy is
+        // envelope-only — recognition, parse, the state machine, and the dedup
+        // contentHash all ran / run on the ORIGINAL tree (event.tree). UNKNOWN
+        // frames have no ruleId and are governed by the SensitiveTextMarkers
+        // backstop above instead.
+        val redact = obs.ruleId?.let { redactionSource.redactFor(it) }
+        val payloadTree = redact?.apply(event.tree) ?: event.tree
         val capture = EnvelopeBuilder.build(
             pipelineId = AccessibilityPipeline.SCREEN_PIPELINE_ID,
             schema = UiNodeSchema,
             platform = platform,
             ruleId = obs.ruleId,
             classificationName = obs.target,
-            payload = event.tree,
+            payload = payloadTree,
             contentHash = event.tree.stableHash,
             metadata = obs.metadata,
             windowContext = winCtx,

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/di/PipelineModule.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/di/PipelineModule.kt
@@ -2,6 +2,8 @@ package cloud.trotter.dashbuddy.core.pipeline.di
 
 import cloud.trotter.dashbuddy.domain.capture.ReplayMetadataProvider
 import cloud.trotter.dashbuddy.core.pipeline.ReplayMetadataProviderImpl
+import cloud.trotter.dashbuddy.core.pipeline.rules.JsonRuleInterpreter
+import cloud.trotter.dashbuddy.core.pipeline.rules.ScreenRedactionSource
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -17,4 +19,9 @@ abstract class PipelineModule {
 
     @Binds @Singleton
     abstract fun bindReplayMetadataProvider(impl: ReplayMetadataProviderImpl): ReplayMetadataProvider
+
+    // #598: the capture stage's rule-declared redaction seam is the interpreter
+    // that owns the loaded rulesets.
+    @Binds @Singleton
+    abstract fun bindScreenRedactionSource(impl: JsonRuleInterpreter): ScreenRedactionSource
 }

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/CompiledRules.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/CompiledRules.kt
@@ -73,6 +73,11 @@ data class CompiledBranch<TInput>(
  * Single-target rules normalise to a one-element [branches] list.
  * Rules are sorted ascending by [priority] (lower = evaluated first).
  * Rule-level [bindings] are shared across all branches and resolved once per rule.
+ *
+ * [redact] carries the rule-declared capture-redaction directives (#598) — a
+ * screen-rule concept only. It is applied at capture time to the SERIALIZED
+ * envelope; recognition, parse, and the state machine always run on the
+ * original tree.
  */
 data class CompiledRule<TInput>(
     val id: String,
@@ -80,7 +85,68 @@ data class CompiledRule<TInput>(
     val overrideable: Boolean = true,
     val bindings: List<Binding> = emptyList(),
     val branches: List<CompiledBranch<TInput>>,
+    val redact: CompiledRedact = CompiledRedact.EMPTY,
 )
+
+/**
+ * A single compiled `redact` directive (#598). When [find] matches a node, that
+ * node's `text` and `contentDescription` are masked in the serialized capture
+ * envelope only. [keepPrefix] preserves a leading marker label so a replayed
+ * redacted capture still recognizes — e.g. "Deliver to <name>" is masked to
+ * "Deliver to [redacted]", keeping the "Deliver to " require anchor while the
+ * customer name is dropped. An address node (no marker) takes no keepPrefix and
+ * is masked whole.
+ */
+data class CompiledRedactEntry(
+    val find: (UiNode) -> Boolean,
+    val keepPrefix: List<String> = emptyList(),
+)
+
+/**
+ * The compiled `redact` block for a screen rule (#598) — "recognition is data"
+ * extended to privacy. The mechanism is DECLARED, not inferred from bindings:
+ * most PII-bearing screens (dropoff_handoff, pickup_arrival) bind nothing that
+ * could drive masking, so the rule states which nodes carry customer PII.
+ *
+ * [apply] returns a masked COPY of the tree for envelope serialization; the
+ * original tree is never mutated (parent back-references are dropped on the
+ * copy, which serialization ignores). The rebuild is top-down via
+ * [UiNode.copy]; recognition, parse, and the dedup contentHash all run on the
+ * original tree.
+ */
+data class CompiledRedact(
+    val entries: List<CompiledRedactEntry>,
+) {
+    fun isEmpty(): Boolean = entries.isEmpty()
+
+    /** Return a redacted copy of [tree] with matched node text/desc masked. */
+    fun apply(tree: UiNode): UiNode = maskNode(tree)
+
+    private fun maskNode(node: UiNode): UiNode {
+        val match = entries.firstOrNull { it.find(node) }
+        val maskedText =
+            if (match != null) mask(node.text, match.keepPrefix) else node.text
+        val maskedDesc =
+            if (match != null) mask(node.contentDescription, match.keepPrefix) else node.contentDescription
+        return node.copy(
+            text = maskedText,
+            contentDescription = maskedDesc,
+            children = node.children.map { maskNode(it) },
+        )
+    }
+
+    private fun mask(value: String?, keepPrefix: List<String>): String? {
+        if (value == null) return null
+        val prefix = keepPrefix.firstOrNull { value.startsWith(it, ignoreCase = true) }
+        return if (prefix != null) prefix + REDACTED else REDACTED
+    }
+
+    companion object {
+        /** Masked text written in place of redacted customer PII. */
+        const val REDACTED = "[redacted]"
+        val EMPTY = CompiledRedact(emptyList())
+    }
+}
 
 /**
  * Unified result of matching any rule type (screen, click, or notification).

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/JsonRuleInterpreter.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/JsonRuleInterpreter.kt
@@ -39,7 +39,7 @@ import javax.inject.Singleton
 class JsonRuleInterpreter @Inject constructor(
     @param:ApplicationContext private val context: Context,
     private val capabilityGrants: RuleCapabilityGrants,
-) {
+) : ScreenRedactionSource {
 
     /**
      * The loaded rulesets as ONE immutable bundle behind a single volatile
@@ -54,6 +54,14 @@ class JsonRuleInterpreter @Inject constructor(
     val clickRuleset: Ruleset<UiNode>? get() = current.clicks
     val notificationRuleset: Ruleset<RawNotificationData>? get() = current.notifications
     val loadedFormatVersion: Int? get() = current.formatVersion
+
+    /**
+     * #598: the compiled `redact` block for a recognized screen rule, read off
+     * the live bundle (volatile). Null when the rule declares no redaction, so
+     * the capture stage skips the tree copy entirely.
+     */
+    override fun redactFor(ruleId: String): CompiledRedact? =
+        current.screens?.ruleById(ruleId)?.redact?.takeUnless { it.isEmpty() }
 
     /**
      * True once a ruleset bundle has been published. The pipelines drop (not

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompiler.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompiler.kt
@@ -129,6 +129,25 @@ object RuleCompiler {
         val ruleParseObj = obj["parse"]?.jsonObject
         val ruleParseAs = ruleParseObj?.get("as")?.jsonPrimitive?.content
 
+        // Rule-level redact directives (screen rules only, #598).
+        val redact = if (context == RuleContext.SCREEN) {
+            obj["redact"]?.jsonArray?.let { compileRedactBlock(it) } ?: CompiledRedact.EMPTY
+        } else CompiledRedact.EMPTY
+
+        // #598 fail-closed: a screen rule that hashes customer PII in its parse
+        // (`sha256` transform) MUST declare a non-empty `redact` block. The hash
+        // side (parse output) and the disk side (envelope) can't drift — a rule
+        // that hashes a name but ships the raw text in the capture is the exact
+        // #598 bug. Scoped to SCREEN so a notification sha256 doesn't trip it.
+        if (context == RuleContext.SCREEN && redact.isEmpty() && jsonUsesSha256(obj)) {
+            throw RuleCompileException(
+                "Screen rule '$id' uses the sha256 transform but declares no 'redact' block " +
+                    "(#598): a rule that hashes customer PII in its parse must redact the same raw " +
+                    "nodes from the capture envelope, or the plaintext ships to disk. Add a " +
+                    "top-level \"redact\": [ { \"find\": <nodePred>, \"keepPrefix\": [ ... ] } ].",
+            )
+        }
+
         val branches: List<CompiledBranch<TInput>> = if ("branches" in obj) {
             obj["branches"]!!.jsonArray.map {
                 compileBranch(it.jsonObject, context, ruleState.flow, ruleState.modeHint,
@@ -140,7 +159,38 @@ object RuleCompiler {
                 ruleOutcomes = ruleState.outcomes, ruleId = id))
         }
 
-        return CompiledRule(id, priority, overrideable, ruleBindings, branches)
+        return CompiledRule(id, priority, overrideable, ruleBindings, branches, redact)
+    }
+
+    // ==========================================================================
+    //  Redact block compiler (#598)
+    // ==========================================================================
+
+    /**
+     * Compile a rule's top-level `redact` array. Each entry is an OBJECT:
+     * `{ "find": <nodePred>, "keepPrefix": [ ... ]? }`. The predicate reuses the
+     * exact node-predicate vocabulary of `require`/`bind`; masking happens at
+     * capture time (see [CompiledRedact]).
+     */
+    private fun compileRedactBlock(array: JsonArray): CompiledRedact {
+        val entries = array.map { element ->
+            val obj = element as? JsonObject
+                ?: throw RuleCompileException("redact entry must be an object with a 'find' predicate")
+            val findSpec = obj["find"]
+                ?: throw RuleCompileException("redact entry has no 'find' predicate")
+            val find = compileNodePred(findSpec)
+            val keepPrefix = obj["keepPrefix"]?.jsonArray?.map { it.jsonPrimitive.content }
+                ?: emptyList()
+            CompiledRedactEntry(find, keepPrefix)
+        }
+        return CompiledRedact(entries)
+    }
+
+    /** Recursively scan raw rule JSON for a `"sha256"` transform value (#598). */
+    private fun jsonUsesSha256(element: JsonElement): Boolean = when (element) {
+        is JsonPrimitive -> element.isString && element.content == "sha256"
+        is JsonObject -> element.values.any { jsonUsesSha256(it) }
+        is JsonArray -> element.any { jsonUsesSha256(it) }
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/Ruleset.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/Ruleset.kt
@@ -21,7 +21,14 @@ class Ruleset<TInput>(rules: List<CompiledRule<TInput>>) {
 
     private val sorted: List<CompiledRule<TInput>> = rules.sortedBy { it.priority }
 
+    /** Rule lookup by id (#598) — the capture-redaction seam fetches a
+     *  recognized rule's compiled `redact` block without exposing the list. */
+    private val byId: Map<String, CompiledRule<TInput>> = sorted.associateBy { it.id }
+
     val ruleCount: Int get() = sorted.size
+
+    /** The compiled rule with this id, or null if none. */
+    fun ruleById(id: String): CompiledRule<TInput>? = byId[id]
 
     /**
      * Evaluate the sorted rules against [input] and return the first match,

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/ScreenRedactionSource.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/ScreenRedactionSource.kt
@@ -1,0 +1,17 @@
+package cloud.trotter.dashbuddy.core.pipeline.rules
+
+/**
+ * Narrow read seam (#598) the capture stage uses to fetch a recognized screen
+ * rule's compiled `redact` directives, without depending on the whole rule
+ * interpreter. Implemented by [JsonRuleInterpreter] (Hilt-bound); tests pass a
+ * stub.
+ */
+interface ScreenRedactionSource {
+    /**
+     * The compiled `redact` block for the screen rule [ruleId], or null when the
+     * rule declares none (nothing to mask). UNKNOWN captures have no ruleId and
+     * never reach this — their disk write is governed by the SensitiveTextMarkers
+     * backstop instead.
+     */
+    fun redactFor(ruleId: String): CompiledRedact?
+}

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureRedactionTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureRedactionTest.kt
@@ -1,0 +1,158 @@
+package cloud.trotter.dashbuddy.core.pipeline
+
+import cloud.trotter.dashbuddy.core.pipeline.accessibility.TreeSnapshot
+import cloud.trotter.dashbuddy.core.pipeline.rules.CompiledRedact
+import cloud.trotter.dashbuddy.core.pipeline.rules.CompiledRedactEntry
+import cloud.trotter.dashbuddy.core.pipeline.rules.RuleCompiler
+import cloud.trotter.dashbuddy.core.pipeline.rules.ScreenRedactionSource
+import cloud.trotter.dashbuddy.domain.capture.CaptureBus
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.pipeline.UNKNOWN_TARGET
+import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+/**
+ * #598 — rule-declared capture redaction. A recognized screen whose rule
+ * declares a `redact` block must have the matched node text masked in the
+ * serialized envelope offered to the bus (customer PII never persisted raw),
+ * while recognition/parse/dedup keep running on the ORIGINAL tree.
+ */
+class CaptureRedactionTest {
+
+    private val captureBus: CaptureBus = mock()
+    private val stats = PipelineStats()
+
+    /** A dropoff-shaped redact block: name node keeps its marker, address masked whole. */
+    private val dropoffRedact = CompiledRedact(
+        listOf(
+            CompiledRedactEntry(
+                find = RuleCompiler.compileNodePred(
+                    Json.parseToJsonElement("""{"hasTextStartsWith":"Deliver to"}"""),
+                ),
+                keepPrefix = listOf("Deliver to "),
+            ),
+            CompiledRedactEntry(
+                find = RuleCompiler.compileNodePred(
+                    Json.parseToJsonElement("""{"hasIdSuffix":"address_line_1"}"""),
+                ),
+            ),
+        ),
+    )
+
+    private fun sourceFor(ruleId: String, redact: CompiledRedact) = object : ScreenRedactionSource {
+        override fun redactFor(id: String): CompiledRedact? = redact.takeIf { id == ruleId }
+    }
+
+    private fun writer(source: ScreenRedactionSource) = CaptureWriter(captureBus, stats, source)
+
+    private fun screenEvent(tree: UiNode) = PipelineEvent.Screen(
+        timestamp = 1_000L,
+        tree = tree,
+        snapshot = TreeSnapshot(
+            tree = tree,
+            packageName = "com.doordash.driverapp",
+            source = TreeSnapshot.Source.STATE_CHANGED,
+        ),
+        packageName = "com.doordash.driverapp",
+    )
+
+    private fun recognizedObs(ruleId: String, target: String) = Observation.Screen(
+        timestamp = 1_000L,
+        captureId = null,
+        ruleId = ruleId,
+        metadata = ReplayMetadata.EMPTY,
+        flow = null,
+        modeHint = null,
+        parsed = ParsedFields.None,
+        target = target,
+    )
+
+    /** Grab the envelope JSON string the writer offered to the bus. */
+    private fun capturedEnvelope(): String {
+        val cap = argumentCaptor<String>()
+        // offer(captureId, source, classification, platform, envelopeJson, contentHash)
+        org.mockito.kotlin.verify(captureBus).offer(
+            any(), any(), anyOrNull(), any(), cap.capture(), anyOrNull(),
+        )
+        return cap.lastValue
+    }
+
+    @Test
+    fun `recognized screen with redact block masks PII in the envelope`() {
+        whenever(captureBus.offer(any(), any(), anyOrNull(), any(), any(), anyOrNull()))
+            .thenReturn("cap-1")
+        val tree = UiNode(
+            children = listOf(
+                UiNode(text = "Deliver to Jane Q. Doe"),
+                UiNode(viewIdResourceName = "com.doordash:id/address_line_1", text = "123 Secret St"),
+                UiNode(text = "Directions"),
+            ),
+        )
+        writer(sourceFor("doordash.screen.dropoff_navigation", dropoffRedact))
+            .captureScreen(recognizedObs("doordash.screen.dropoff_navigation", "dropoff_navigation"), screenEvent(tree))
+
+        val json = capturedEnvelope()
+        // PII gone, marker kept, address masked whole, unrelated node intact.
+        assertFalse("customer name must not persist", json.contains("Jane Q. Doe"))
+        assertFalse("street address must not persist", json.contains("123 Secret St"))
+        assertTrue("marker + redacted name", json.contains("Deliver to [redacted]"))
+        assertTrue("address masked whole", json.contains("\"text\": \"[redacted]\""))
+        assertTrue("non-PII node intact", json.contains("Directions"))
+    }
+
+    @Test
+    fun `redaction does not change the dedup contentHash - it uses the original tree`() {
+        whenever(captureBus.offer(any(), any(), anyOrNull(), any(), any(), anyOrNull()))
+            .thenReturn("cap-1")
+        val tree = UiNode(
+            children = listOf(UiNode(text = "Deliver to Jane Q. Doe")),
+        )
+        writer(sourceFor("doordash.screen.dropoff_navigation", dropoffRedact))
+            .captureScreen(recognizedObs("doordash.screen.dropoff_navigation", "dropoff_navigation"), screenEvent(tree))
+
+        val hashCap = argumentCaptor<Int?>()
+        org.mockito.kotlin.verify(captureBus).offer(
+            any(), any(), anyOrNull(), any(), any(), hashCap.capture(),
+        )
+        assertEquals(tree.stableHash, hashCap.lastValue)
+    }
+
+    @Test
+    fun `recognized screen without a redact block persists the tree unchanged`() {
+        whenever(captureBus.offer(any(), any(), anyOrNull(), any(), any(), anyOrNull()))
+            .thenReturn("cap-1")
+        val tree = UiNode(children = listOf(UiNode(text = "Deliver to Jane Q. Doe")))
+        // Source returns null for this ruleId → no redaction.
+        writer(sourceFor("some.other.rule", dropoffRedact))
+            .captureScreen(recognizedObs("doordash.screen.idle_map", "idle_map"), screenEvent(tree))
+
+        val json = capturedEnvelope()
+        assertTrue("no redact declared → raw text persists", json.contains("Deliver to Jane Q. Doe"))
+    }
+
+    @Test
+    fun `UNKNOWN screen never consults the redaction source`() {
+        whenever(captureBus.offer(any(), any(), anyOrNull(), any(), any(), anyOrNull()))
+            .thenReturn("cap-1")
+        val tree = UiNode(children = listOf(UiNode(text = "Some benign promo")))
+        val obs = recognizedObs(UNKNOWN_TARGET, UNKNOWN_TARGET).copy(ruleId = null)
+        // A throwing source would fail the test if consulted.
+        val throwing = object : ScreenRedactionSource {
+            override fun redactFor(ruleId: String): CompiledRedact =
+                throw AssertionError("UNKNOWN path must not consult redaction source")
+        }
+        writer(throwing).captureScreen(obs, screenEvent(tree))
+        assertTrue(capturedEnvelope().contains("Some benign promo"))
+    }
+}

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureScrubTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureScrubTest.kt
@@ -2,6 +2,7 @@ package cloud.trotter.dashbuddy.core.pipeline
 
 import cloud.trotter.dashbuddy.core.pipeline.accessibility.AccessibilityPipeline
 import cloud.trotter.dashbuddy.core.pipeline.accessibility.TreeSnapshot
+import cloud.trotter.dashbuddy.core.pipeline.rules.NoRedaction
 import cloud.trotter.dashbuddy.domain.capture.CaptureBus
 import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
@@ -27,7 +28,7 @@ class CaptureScrubTest {
 
     private val captureBus: CaptureBus = mock()
     private val stats = PipelineStats()
-    private val writer = CaptureWriter(captureBus, stats)
+    private val writer = CaptureWriter(captureBus, stats, NoRedaction)
 
     private fun screenEvent(tree: UiNode) = PipelineEvent.Screen(
         timestamp = 1_000L,

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/ClickCaptureNoDedupTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/ClickCaptureNoDedupTest.kt
@@ -1,5 +1,6 @@
 package cloud.trotter.dashbuddy.core.pipeline
 
+import cloud.trotter.dashbuddy.core.pipeline.rules.NoRedaction
 import cloud.trotter.dashbuddy.domain.capture.CaptureBus
 import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
@@ -28,7 +29,7 @@ import org.mockito.kotlin.whenever
 class ClickCaptureNoDedupTest {
 
     private val captureBus: CaptureBus = mock()
-    private val writer = CaptureWriter(captureBus, PipelineStats())
+    private val writer = CaptureWriter(captureBus, PipelineStats(), NoRedaction)
 
     private fun clickObs(t: Long) = Observation.Click(
         timestamp = t,

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompilerTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompilerTest.kt
@@ -820,6 +820,108 @@ class RuleCompilerTest {
     }
 
     // =========================================================================
+    // redact block + sha256⇒redact enforcement (#598)
+    // =========================================================================
+
+    @Test(expected = RuleCompileException::class)
+    fun `screen rule with sha256 transform but no redact block fails compile`() {
+        val ruleJson = """[{
+            "id": "doordash.screen.leaky",
+            "priority": 10,
+            "require": { "exists": { "hasTextStartsWith": "Deliver to" } },
+            "parse": {
+                "as": "task",
+                "fields": {
+                    "customerNameHash": {
+                        "find": { "hasTextStartsWith": "Deliver to" },
+                        "read": "text",
+                        "transform": [ { "stripPrefixes": ["Deliver to "] }, "sha256" ]
+                    }
+                }
+            }
+        }]"""
+        RuleCompiler.compileRules<UiNode>(
+            Json.parseToJsonElement(ruleJson).jsonArray, RuleContext.SCREEN,
+        )
+    }
+
+    @Test
+    fun `screen rule with sha256 and a redact block compiles and carries the redact`() {
+        val ruleJson = """[{
+            "id": "doordash.screen.safe",
+            "priority": 10,
+            "require": { "exists": { "hasTextStartsWith": "Deliver to" } },
+            "redact": [
+                { "find": { "hasTextStartsWith": "Deliver to" }, "keepPrefix": ["Deliver to "] }
+            ],
+            "parse": {
+                "as": "task",
+                "fields": {
+                    "customerNameHash": {
+                        "find": { "hasTextStartsWith": "Deliver to" },
+                        "read": "text",
+                        "transform": [ { "stripPrefixes": ["Deliver to "] }, "sha256" ]
+                    }
+                }
+            }
+        }]"""
+        val rules = RuleCompiler.compileRules<UiNode>(
+            Json.parseToJsonElement(ruleJson).jsonArray, RuleContext.SCREEN,
+        )
+        assertEquals(1, rules.size)
+        assertFalse(rules[0].redact.isEmpty())
+    }
+
+    @Test
+    fun `redact masks matched node text keeping the declared prefix`() {
+        val ruleJson = """[{
+            "id": "doordash.screen.dropoff",
+            "priority": 10,
+            "require": { "exists": { "hasTextStartsWith": "Deliver to" } },
+            "redact": [
+                { "find": { "hasTextStartsWith": "Deliver to" }, "keepPrefix": ["Deliver to "] },
+                { "find": { "hasIdSuffix": "address_line_1" } }
+            ]
+        }]"""
+        val rule = RuleCompiler.compileRules<UiNode>(
+            Json.parseToJsonElement(ruleJson).jsonArray, RuleContext.SCREEN,
+        )[0]
+        val tree = UiNode(
+            children = listOf(
+                UiNode(text = "Deliver to Jane Q. Doe"),
+                UiNode(viewIdResourceName = "com.x:id/address_line_1", text = "123 Secret St"),
+                UiNode(text = "Directions"),
+            ),
+        )
+        val redacted = rule.redact.apply(tree)
+        assertEquals("Deliver to [redacted]", redacted.children[0].text)
+        assertEquals("[redacted]", redacted.children[1].text)
+        assertEquals("Directions", redacted.children[2].text)
+        // Original tree is untouched.
+        assertEquals("Deliver to Jane Q. Doe", tree.children[0].text)
+    }
+
+    @Test
+    fun `notification rule with sha256 does not require a redact block`() {
+        // Enforcement is scoped to SCREEN; the notification-envelope redaction is
+        // tracked as a separate follow-up (#598 body).
+        val ruleJson = """[{
+            "id": "doordash.notification.customer_message",
+            "priority": 10,
+            "require": { "channelIdContains": "message" },
+            "parse": {
+                "fields": {
+                    "senderHash": { "from": "title", "transform": "sha256" }
+                }
+            }
+        }]"""
+        val rules = RuleCompiler.compileRules<RawNotificationData>(
+            Json.parseToJsonElement(ruleJson).jsonArray, RuleContext.NOTIFICATION,
+        )
+        assertEquals(1, rules.size)
+    }
+
+    // =========================================================================
     // enumeratePermissions
     // =========================================================================
 

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/TestRedactionSources.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/TestRedactionSources.kt
@@ -1,0 +1,10 @@
+package cloud.trotter.dashbuddy.core.pipeline.rules
+
+/**
+ * A [ScreenRedactionSource] that never redacts — the default for capture tests
+ * that don't exercise #598 redaction. Keeps the CaptureWriter direct-construction
+ * sites terse.
+ */
+object NoRedaction : ScreenRedactionSource {
+    override fun redactFor(ruleId: String): CompiledRedact? = null
+}

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -121,22 +121,33 @@ was found **broken-in-part** (raw PII in capture envelopes) and moved to that en
   — not hang or silently succeed. Broken = a shade-tapped action failing closed despite the window
   returning within the budget, or the retry firing/looping on a genuinely-gone app.
 
-- **🔒 FIX SHIPPED — recognized capture envelopes now redact customer PII at the device edge (#598).**
+- **🔒 FIX SHIPPED — recognized capture envelopes now redact customer PII at the device edge (#598, incl. audit F1/F2 coverage extension).**
   Pre-#598 the recognized-screen captures on disk carried raw `Deliver to ‹name›`, full street
-  addresses, and gate codes (`dropoff_handoff` / `dropoff_navigation` / `dropoff_pre_arrival`,
-  `Order for ‹name›` on `pickup_arrival`, `For ‹name› • ‹store›` on `pickup_resolution_options`) —
-  PII was hashed only in the parse output, raw on disk. Now rules DECLARE a `redact` block and the
-  capture stage masks those node texts in the serialized envelope only (recognition/parse/state
-  unchanged); a screen rule that hashes PII (`sha256`) fails compile without a `redact` block.
+  addresses, and gate codes — PII was hashed only in the parse output, raw on disk. Now rules
+  DECLARE a `redact` block and the capture stage masks those node texts in the serialized envelope
+  only (recognition/parse/state unchanged); a screen rule that hashes PII (`sha256`) fails compile
+  without a `redact` block. The audit F1/F2 pass extended coverage from the first 7 rules to **all**
+  recognized customer-PII surfaces: `pickup_pre_arrival` (customer name + store address),
+  `pickup_verify_items` (`Verify items for ‹name›`), `dropoff_photo` (free-form instruction / gate
+  codes / apt — all id-less text), `chat_conversation` (customer name + every chat message body),
+  `camera_capture` (`…name: ‹name›` / `…Apt/Suite: ‹apt›` + a stale bin-scan bare name),
+  `nav_arriving` (arrival street address), `dropoff_geofence_warning` (address/apt lines),
+  `waiting_for_offer` (a stale prior-delivery customer-name bleed), plus a bare-unit-number entry on
+  the id-less dropoff cards (`dropoff_pre_arrival` / `_completion` / `dropoff_handoff`) — on top of
+  the original `dropoff_handoff/navigation/pre_arrival`, `pickup_arrival`, `pickup_resolution_options`.
   **Confirm on next pull: 0/2 —** pull the on-device captures after a dash with real deliveries and
-  grep the `dropoff_*` / `pickup_arrival` / `pickup_resolution_options` envelope JSON: every customer
-  name reads `Deliver to [redacted]` / `Order for` + a separate `[redacted]` name node, addresses
-  and gate codes read `[redacted]`, and NO raw recipient name/street/gate-code survives. Markers
-  (`Deliver to `, `Order for`, `Delivery for`, `Hand it to customer`) must remain so recognition is
-  unchanged — verify the same screens still classify + drive state exactly as before (offers,
-  pickups, dropoffs, completions behave identically). Broken = any raw customer name/address/gate
-  code in a recognized envelope, OR a dropoff/pickup screen that stopped recognizing. (UNKNOWN
-  captures are a documented exception — the `SensitiveTextMarkers` backstop, not name redaction.)
+  grep the recognized envelope JSON for the surfaces above: every customer name reads `[redacted]`
+  (or `Deliver to [redacted]` / `Verify items for [redacted]` where a marker is kept), addresses,
+  apt/unit numbers, gate codes, and chat bodies read `[redacted]`, and NO raw recipient name / street
+  / apt / gate-code / chat text survives. Markers (`Deliver to `, `Order for`, `Delivery for`,
+  `Hand it to customer`, `Your Customer`, `Arriving at`, step titles) must remain so recognition is
+  unchanged — verify the same screens still classify + drive state exactly as before. Broken = any
+  raw customer name/address/apt/gate-code/chat text in a recognized envelope, OR a screen that
+  stopped recognizing. **Documented exceptions (NOT defects):** UNKNOWN frames + UNKNOWN clicks are
+  debug-only (release `NoOpCaptureBus` #346 + the `SensitiveTextMarkers` backstop, not name
+  redaction); the id-less building-NAME line on dropoff cards and the merchant-name-as-product rows
+  are structural residuals (#623/#624); the notification-capture customer-name path is #620; a nav
+  `roadNameView` road-name residual is accepted (F7).
 - **🔧 FIX SHIPPED — receipt-skipped deliveries still close + log a completion, and the next offer starts a NEW job (#596).**
   DoorDash routinely skips the post-delivery receipt (the next offer chains straight over the drop);
   pre-#596 that was the machine's ONLY job-exit, so the delivery never logged `DELIVERY_COMPLETED`

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -121,6 +121,22 @@ was found **broken-in-part** (raw PII in capture envelopes) and moved to that en
   — not hang or silently succeed. Broken = a shade-tapped action failing closed despite the window
   returning within the budget, or the retry firing/looping on a genuinely-gone app.
 
+- **🔒 FIX SHIPPED — recognized capture envelopes now redact customer PII at the device edge (#598).**
+  Pre-#598 the recognized-screen captures on disk carried raw `Deliver to ‹name›`, full street
+  addresses, and gate codes (`dropoff_handoff` / `dropoff_navigation` / `dropoff_pre_arrival`,
+  `Order for ‹name›` on `pickup_arrival`, `For ‹name› • ‹store›` on `pickup_resolution_options`) —
+  PII was hashed only in the parse output, raw on disk. Now rules DECLARE a `redact` block and the
+  capture stage masks those node texts in the serialized envelope only (recognition/parse/state
+  unchanged); a screen rule that hashes PII (`sha256`) fails compile without a `redact` block.
+  **Confirm on next pull: 0/2 —** pull the on-device captures after a dash with real deliveries and
+  grep the `dropoff_*` / `pickup_arrival` / `pickup_resolution_options` envelope JSON: every customer
+  name reads `Deliver to [redacted]` / `Order for` + a separate `[redacted]` name node, addresses
+  and gate codes read `[redacted]`, and NO raw recipient name/street/gate-code survives. Markers
+  (`Deliver to `, `Order for`, `Delivery for`, `Hand it to customer`) must remain so recognition is
+  unchanged — verify the same screens still classify + drive state exactly as before (offers,
+  pickups, dropoffs, completions behave identically). Broken = any raw customer name/address/gate
+  code in a recognized envelope, OR a dropoff/pickup screen that stopped recognizing. (UNKNOWN
+  captures are a documented exception — the `SensitiveTextMarkers` backstop, not name redaction.)
 - **🔧 FIX SHIPPED — receipt-skipped deliveries still close + log a completion, and the next offer starts a NEW job (#596).**
   DoorDash routinely skips the post-delivery receipt (the next offer chains straight over the drop);
   pre-#596 that was the machine's ONLY job-exit, so the delivery never logged `DELIVERY_COMPLETED`

--- a/docs/rules.schema.json
+++ b/docs/rules.schema.json
@@ -65,6 +65,7 @@
         },
         "state": { "$ref": "#/$defs/stateBlock" },
         "bind": { "$ref": "#/$defs/bindBlock" },
+        "redact": { "$ref": "#/$defs/redactBlock" },
         "reject": {
           "type": "array",
           "description": "Phase 2: Fail-fast negative checks. Any match skips this rule/branch.",
@@ -334,6 +335,29 @@
           "type": "boolean",
           "description": "If true, null result doesn't disqualify the rule. Default: false.",
           "default": false
+        }
+      }
+    },
+
+    "redactBlock": {
+      "type": "array",
+      "description": "Rule-declared capture redaction (#598). At CAPTURE time, any node matching an entry's 'find' predicate has its text/contentDescription masked to '[redacted]' in the SERIALIZED envelope only — recognition, parse, the state machine, and the dedup contentHash all run on the ORIGINAL tree. FAIL-CLOSED: any screen rule whose parse uses the 'sha256' transform MUST declare a non-empty redact block (the hash side and the disk side cannot drift). Mask the same customer name/address nodes the parse hashes.",
+      "items": { "$ref": "#/$defs/redactEntry" }
+    },
+
+    "redactEntry": {
+      "type": "object",
+      "description": "A single redaction directive.",
+      "required": ["find"],
+      "properties": {
+        "find": {
+          "$ref": "#/$defs/nodePredicate",
+          "description": "Node predicate selecting nodes whose text/contentDescription to mask."
+        },
+        "keepPrefix": {
+          "type": "array",
+          "description": "Optional leading marker labels to PRESERVE. If the node text starts with one (case-insensitive), the mask is 'prefix + [redacted]' (e.g. 'Deliver to ' → 'Deliver to [redacted]'), keeping the require anchor so a replayed redacted capture still recognizes; otherwise the whole node is masked. Address nodes take no keepPrefix.",
+          "items": { "type": "string" }
         }
       }
     },


### PR DESCRIPTION
Closes #598. The field week found raw customer names, street addresses, and a gate code inside recognized-screen capture envelopes — the pledge is hashed-at-edge-before-persistence; reality was hashed-in-parse-while-raw-on-disk. (Events/logs were verified clean; this is the disk half.)

## Fix (opus build from a fable-vetted plan)
**"Recognition is data" extended to privacy:** screen rules gain a declared `redact` block — `{find: <node predicate>, keepPrefix: [...]?}` objects compiled per rule (`CompiledRedact`), applied by `CaptureWriter` to a **copied tree at envelope-serialization time only**. Recognition, parse, the state machine, and `contentHash` (bus dedup) all run on the ORIGINAL tree; replay reads the payload only. The vet-mandated `keepPrefix` mechanism preserves recognition markers where marker and PII share one node ("Deliver to [redacted]" — the committed-corpus convention).
- **Fail-closed compile enforcement:** any SCREEN rule whose parse uses `sha256` must declare a non-empty `redact` (RuleCompiler throws) — the hash side and the disk side can never drift again. Landed in the same commit as the rule blocks (production JSON satisfies its own gate).
- **7 rules redacted** (doordash.json): the 4 sha256 rules (timeline, dropoff_navigation, dropoff_pre_arrival, dropoff_pre_arrival_completion) + the parse-less PII carriers (dropoff_handoff, pickup_arrival, pickup_resolution_options) — id-suffix predicates preferred, id-less street/zip/apt/quoted-instruction shapes covered, gate codes included. uber.json: zero customer parses, nothing needed.
- **DI seam:** narrow `ScreenRedactionSource` interface (JsonRuleInterpreter implements; tests stub) — no dependency cycle, CaptureWriter test construction unchanged.
- **Verified against real PII envelopes** (3+ from the 06-25→30 pull, scratch harness not committed): names/addresses/gate codes masked; `by 6:32 PM`, `Hand it to customer`, `Order for`, `Delivery for` markers all preserved.

## Grounded deviations (reported by the builder)
Amendment #1's pickup_arrival premise was wrong in one detail — marker and name are separate nodes there, so `customer_name` masks whole (corpus-consistent). `dropoff_completed_confirm` carries no PII (no block needed). The `799` near "Directions" is a map/distance number, not the gate code (the real gate code lives in the instruction nodes, which ARE redacted).

## Tests
`CaptureRedactionTest` (red-first: envelope contained the name pre-wiring), enforcement tests (sha256-without-redact throws — production went red until the blocks landed, then green), `CaptureRedactionCorpusTest` (injected "Deliver to Testname Q" → masked via production predicates + every sha256 rule has redact). Full `:core:pipeline` 201/0 + `:app` 818/0, **goldens byte-identical** (the plan's abort criterion — held).

## Security/privacy posture
Strictly narrows what is persisted; recognized captures now honor the pledge at the disk layer. UNKNOWN captures remain the documented debug-only exception (SensitiveTextMarkers backstop + release NoOpCaptureBus, #346). Follow-up filed: **#620** (notification-envelope redaction — customer_message titles).

### Design-goal review
5 (SSOT): redaction is declared beside the parse that hashes, enforced at compile — one owner. 6: the change IS the principle; fail-closed. 8: mechanism is platform-neutral vocabulary; per-platform data lives in rule JSON. Field checklist item added (0/2).

### Adversarial review
Fable design-vet pre-build (keepPrefix mandate, DI seam, enforcement site — all applied); fable post-build check follows before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)