### PR TITLE
fix(effects): #606 — one screenshot owner per surface + effect-arg template lint

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/ParseOutputGoldenTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/ParseOutputGoldenTest.kt
@@ -296,16 +296,27 @@ class ParseOutputGoldenTest {
     // =========================================================================
 
     /**
-     * Dead effect-arg templates already known (ratchet — may only shrink, same
-     * pattern as [knownDeadDedupeTemplates] above):
-     * - `doordash.screen.delivery_summary_collapsed:totalPay` — the mirror
-     *   image of the dead `delivery_summary_collapsed:totalPay` dedupeKey
-     *   entry above: the collapsed receipt never parses `totalPay` non-null
-     *   in the corpus (it's behind the expand), so its
-     *   `"Delivery - {totalPay}"` screenshot-prefix template never
-     *   interpolates either. Pre-existing; out of scope for #606 (which only
-     *   touches `offer_popup`'s prefix and the EffectMap double-fire) — clean
-     *   up when the summary rules are next touched.
+     * Effect-arg templates already known to leave a literal `{field}` in the
+     * saved string on at least one corpus frame (ratchet — may only shrink,
+     * same pattern as [knownDeadDedupeTemplates] above).
+     *
+     * Semantics (differs from the dedupeKey lint's wording): effect args are
+     * scanned POST-resolution — a `{token}` survives in the value ONLY on a
+     * frame where that field parsed null and so did not interpolate. So a key
+     * lands here iff its template failed to interpolate on ≥1 corpus frame,
+     * which is the right bar for a filename (a `Delivery - {totalPay}.png` on
+     * ANY frame is a broken name on that frame).
+     *
+     * - `doordash.screen.delivery_summary_collapsed:totalPay` — the collapsed
+     *   receipt parses `totalPay` non-null on most frames (it's usually behind
+     *   the expand but present on the collapsed card too), yet a couple of
+     *   corpus frames lack it, and each of THOSE saves a literal
+     *   `Delivery - {totalPay}.png` at runtime — real #606-class instances.
+     *   Pre-existing; out of scope for #606 (which only touches `offer_popup`'s
+     *   prefix and the EffectMap double-fire). The `{totalPay}` parse is NOT
+     *   dead — do not delete it as cleanup; fix by making the collapsed prefix
+     *   use a field the rule parses on every frame, when the summary rules are
+     *   next touched.
      * (`doordash.screen.offer_popup:storeName` was the #606 bug itself —
      * `storeName` lives inside the per-order `orders[]` array, never at the
      * rule's top level where template resolution reads from, so
@@ -321,13 +332,15 @@ class ParseOutputGoldenTest {
     @Test
     fun `effect arg templates reference fields the rule actually parses`() {
         val template = Regex("\\{(\\w+)}")
-        // (ruleId, field) → did ANY corpus match of that rule parse it
-        // non-null? Mirrors the dedupeKey lint above, but scans every effect
-        // ARG value (screenshot prefix, bubble text, log payload, …) instead
-        // of just dedupeKey — the #606 bug (`"Offer - {storeName}"` never
-        // interpolating) lived in a `prefix` arg, which the dedupeKey-only
-        // lint never looked at.
-        val seen = mutableMapOf<Pair<String, String>, Boolean>()
+        // A (ruleId, field) whose {token} SURVIVED resolution in an effect arg
+        // on ≥1 corpus frame — i.e. the template failed to interpolate there and
+        // the saved string would carry a literal `{field}`. Args are scanned
+        // post-resolution, so a surviving token IS the failure (no non-null
+        // frame can leave the token behind). Mirrors the dedupeKey lint but
+        // scans every effect ARG value (screenshot prefix, bubble text, log
+        // payload, …) — the #606 bug (`"Offer - {storeName}"`) lived in a
+        // `prefix` arg the dedupeKey-only lint never looked at.
+        val dead = mutableSetOf<Pair<String, String>>()
         val exampleArg = mutableMapOf<Pair<String, String>, String>()
 
         val base = File("src/test/resources/snapshots")
@@ -341,12 +354,13 @@ class ParseOutputGoldenTest {
                 for (effect in result.effects) {
                     for (argValue in effect.args.values) {
                         for (m in template.findAll(argValue)) {
+                            // Any surviving token is a violation. Reserved tokens
+                            // (DedupeTokens, #427) resolve for dedupeKey but NOT
+                            // for args — a `{parsedHash}` in a prefix would ship
+                            // literal, so it must be flagged here, not skipped.
                             val field = m.groupValues[1]
-                            // Reserved tokens resolve post-factory in the
-                            // classifier (DedupeTokens, #427) — never raw fields.
-                            if (field in DedupeTokens.RESERVED_FIELD_NAMES) continue
                             val key = result.ruleId to field
-                            seen[key] = (seen[key] ?: false) || (result.fields[field] != null)
+                            dead += key
                             exampleArg.putIfAbsent(key, argValue)
                         }
                     }
@@ -354,17 +368,17 @@ class ParseOutputGoldenTest {
             }
         }
 
-        val dead = seen.filterValues { !it }.keys
+        val deadStrings = dead
             .map { (rule, field) -> "$rule:$field" }
             .toSet()
         assertEquals(
-            "Dead effect-arg {field} templates changed (fields that never parse non-null " +
-                "anywhere in the rule's corpus — a screenshot/bubble/log template that never " +
-                "interpolates, the #606 class). Fixed one? Remove it from " +
+            "Dead effect-arg {field} templates changed (a screenshot/bubble/log template that " +
+                "left a literal {field} in the saved string on ≥1 corpus frame — i.e. failed to " +
+                "interpolate, the #606 class). Fixed one? Remove it from " +
                 "knownDeadArgTemplates. Introduced one? Fix the rule.\n" +
-                dead.joinToString("\n") { "  $it (e.g. '${exampleArg[it.split(":").let { p -> p[0] to p[1] }]}')" },
+                deadStrings.joinToString("\n") { "  $it (e.g. '${exampleArg[it.split(":").let { p -> p[0] to p[1] }]}')" },
             knownDeadArgTemplates,
-            dead,
+            deadStrings,
         )
     }
 

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/ParseOutputGoldenTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/ParseOutputGoldenTest.kt
@@ -292,6 +292,83 @@ class ParseOutputGoldenTest {
     }
 
     // =========================================================================
+    // 4. Effect-arg {field} template lint (the #606 class)
+    // =========================================================================
+
+    /**
+     * Dead effect-arg templates already known (ratchet — may only shrink, same
+     * pattern as [knownDeadDedupeTemplates] above):
+     * - `doordash.screen.delivery_summary_collapsed:totalPay` — the mirror
+     *   image of the dead `delivery_summary_collapsed:totalPay` dedupeKey
+     *   entry above: the collapsed receipt never parses `totalPay` non-null
+     *   in the corpus (it's behind the expand), so its
+     *   `"Delivery - {totalPay}"` screenshot-prefix template never
+     *   interpolates either. Pre-existing; out of scope for #606 (which only
+     *   touches `offer_popup`'s prefix and the EffectMap double-fire) — clean
+     *   up when the summary rules are next touched.
+     * (`doordash.screen.offer_popup:storeName` was the #606 bug itself —
+     * `storeName` lives inside the per-order `orders[]` array, never at the
+     * rule's top level where template resolution reads from, so
+     * `"Offer - {storeName}"` saved every offer screenshot as the literal
+     * filename `Offer - {storeName}.png`. Fixed by switching to `{payAmount}`,
+     * a field the rule guarantees non-null via its `fieldNotNull` validator.)
+     * Entries are "ruleId:field".
+     */
+    private val knownDeadArgTemplates = setOf(
+        "doordash.screen.delivery_summary_collapsed:totalPay",
+    )
+
+    @Test
+    fun `effect arg templates reference fields the rule actually parses`() {
+        val template = Regex("\\{(\\w+)}")
+        // (ruleId, field) → did ANY corpus match of that rule parse it
+        // non-null? Mirrors the dedupeKey lint above, but scans every effect
+        // ARG value (screenshot prefix, bubble text, log payload, …) instead
+        // of just dedupeKey — the #606 bug (`"Offer - {storeName}"` never
+        // interpolating) lived in a `prefix` arg, which the dedupeKey-only
+        // lint never looked at.
+        val seen = mutableMapOf<Pair<String, String>, Boolean>()
+        val exampleArg = mutableMapOf<Pair<String, String>, String>()
+
+        val base = File("src/test/resources/snapshots")
+        val dirs = base.listFiles { f -> f.isDirectory && f.name !in SKIP }
+            ?.sortedBy { it.name } ?: emptyList()
+        for (dir in dirs) {
+            for ((_, node, _) in TestResourceLoader.loadSnapshots("snapshots/${dir.name}")) {
+                val result = TransformRegistry.withClock(FIXED_NOW_MS, FIXED_ZONE) {
+                    screenRuleset.matchFirst(node)
+                } ?: continue
+                for (effect in result.effects) {
+                    for (argValue in effect.args.values) {
+                        for (m in template.findAll(argValue)) {
+                            val field = m.groupValues[1]
+                            // Reserved tokens resolve post-factory in the
+                            // classifier (DedupeTokens, #427) — never raw fields.
+                            if (field in DedupeTokens.RESERVED_FIELD_NAMES) continue
+                            val key = result.ruleId to field
+                            seen[key] = (seen[key] ?: false) || (result.fields[field] != null)
+                            exampleArg.putIfAbsent(key, argValue)
+                        }
+                    }
+                }
+            }
+        }
+
+        val dead = seen.filterValues { !it }.keys
+            .map { (rule, field) -> "$rule:$field" }
+            .toSet()
+        assertEquals(
+            "Dead effect-arg {field} templates changed (fields that never parse non-null " +
+                "anywhere in the rule's corpus — a screenshot/bubble/log template that never " +
+                "interpolates, the #606 class). Fixed one? Remove it from " +
+                "knownDeadArgTemplates. Introduced one? Fix the rule.\n" +
+                dead.joinToString("\n") { "  $it (e.g. '${exampleArg[it.split(":").let { p -> p[0] to p[1] }]}')" },
+            knownDeadArgTemplates,
+            dead,
+        )
+    }
+
+    // =========================================================================
     // Helpers
     // =========================================================================
 

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
@@ -457,6 +457,16 @@ class EffectMapTest {
         assertTrue("Should emit DASH_STOP", effects.logEventTypes().contains(AppEventType.DASH_STOP))
         assertTrue("Should emit StopOdometer", effects.any { it is AppEffect.StopOdometer })
         assertTrue("Should emit EndSession", effects.any { it is AppEffect.EndSession })
+        // #606: the dash_summary RULE effect (deduped + throttled, fires on
+        // recognition) already owns the DashSummary screenshot. EffectMap's
+        // own SESSION_ENDED commit used to ALSO fire one — effectKey null,
+        // so it bypassed both effects_fired and the throttle — producing two
+        // "DashSummary - <earnings>" captures ~2.5s apart (the
+        // AUTHORITATIVE_GRACE_MS window) for one session end.
+        assertTrue(
+            "Should NOT emit CaptureScreenshot — the dash_summary rule owns it (#606)",
+            effects.none { it is AppEffect.CaptureScreenshot },
+        )
     }
 
     @Test

--- a/core/pipeline/src/main/assets/rules/doordash.json
+++ b/core/pipeline/src/main/assets/rules/doordash.json
@@ -535,7 +535,7 @@
       "effects": [
         {
           "screenshot": {
-            "prefix": "Offer - {storeName}",
+            "prefix": "Offer - {payAmount}",
             "category": "offer"
           },
           "dedupeKey": "offer-ss-{parsedHash}",

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -2,7 +2,6 @@ package cloud.trotter.dashbuddy.core.state
 
 import cloud.trotter.dashbuddy.domain.action.ActionTrigger
 import cloud.trotter.dashbuddy.domain.action.RuleAction
-import cloud.trotter.dashbuddy.domain.config.EvidenceCategory
 import cloud.trotter.dashbuddy.domain.model.cards.FlowCardSnapshot
 import cloud.trotter.dashbuddy.domain.format.Formats
 import cloud.trotter.dashbuddy.domain.model.chat.ChatPersona
@@ -514,12 +513,13 @@ class EffectMap @Inject constructor() {
                         )
                         add(AppEffect.StopOdometer)
                         add(AppEffect.UpdateBubble("Session Ended. Total: $earnings", ChatPersona.Dispatcher))
-                        add(
-                            AppEffect.CaptureScreenshot(
-                                "DashSummary - ${endParsed.totalEarnings}",
-                                category = EvidenceCategory.SESSION_SUMMARY,
-                            ),
-                        )
+                        // #606: no CaptureScreenshot here — the dash_summary
+                        // rule effect (doordash.json) already owns the
+                        // DashSummary screenshot (deduped + throttled, fires
+                        // on recognition). This commit-side add had a null
+                        // effectKey, bypassing both effects_fired and the
+                        // throttle, so a session end double-fired the shot
+                        // ~2.5s apart (the AUTHORITATIVE_GRACE_MS window).
                     } else {
                         add(
                             logEffect(

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -104,12 +104,14 @@ was found **broken-in-part** (raw PII in capture envelopes) and moved to that en
   resolve, so it never interpolated. The prefix now uses `{payAmount}` (a top-level, always-parsed
   field), so filenames read e.g. `Offer - 26.75.png`. A new lint (`ParseOutputGoldenTest`, the
   #433 family) now catches this whole class going forward: any `{field}` template in a rule's
-  screenshot/bubble/log effect args that never resolves non-null anywhere in that rule's corpus
-  fails the build. **Confirm on dash: 0/2 —** after a session ends, `Pictures/DashBuddy` should
-  contain exactly **one** `DashSummary - <earnings>.png` for that end (not two ~2.5s apart), and
-  offer screenshots from that dash should be named `Offer - <pay>.png` (a dollar amount), never
-  the literal `Offer - {storeName}.png`. Broken = a duplicate dash-summary pair, or any offer
-  screenshot with a literal `{storeName}` in the filename.
+  screenshot/bubble/log effect args that leaves a literal `{field}` in the saved string on ≥1
+  corpus frame (i.e. fails to interpolate) fails the build. **Confirm on dash: 0/2 —** after a
+  session ends, `Pictures/DashBuddy` should contain exactly **one** `DashSummary - <earnings>.png`
+  for that end (not two ~2.5s apart), and offer screenshots from that dash should be named
+  `Offer - <pay>.png` (a dollar amount), never the literal `Offer - {storeName}.png`. (Trailing
+  zeros drop — `Offer - 26.7.png` for a $26.70 offer, `Offer - 5.0.png` for $5.00, is correct;
+  only a literal `{storeName}`/`{payAmount}` token is broken.) Broken = a duplicate dash-summary
+  pair, or any offer screenshot with a literal `{storeName}` in the filename.
 - **🔧 FIX SHIPPED — automated taps now rank click candidates by evidence instead of a dead exact-bounds check (#600).**
   Every automated Accept/Decline/Confirm tap re-resolves its target against the live accessibility
   tree, then disambiguates among label-verified candidates. The old disambiguator compared

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -91,6 +91,25 @@ was found **broken-in-part** (raw PII in capture envelopes) and moved to that en
   `NOTIFICATION_RECEIVED`/`NEW_ORDER` log for each such arrival. Broken = a later arrival
   missing **and** a "Skipping already-fired effect" line for it; missing with no skip-line is
   the FrameGate layer (follow-up issue), not a #604 regression.
+- **🔧 FIX SHIPPED — one DashSummary screenshot per session end, and offer screenshots are named
+  with real pay (#606). CONFIRM ON DASH.** Two independent owners were both saving a
+  "DashSummary - \<earnings\>" screenshot at session end: the `dash_summary` rule effect
+  (deduped + throttled, fires on recognition) and EffectMap's own SESSION_ENDED commit — the
+  commit-side add had a null `effectKey`, bypassing both `effects_fired` and the throttle, so
+  every dash produced two near-identical dash-summary captures ~2.5s apart (the
+  `AUTHORITATIVE_GRACE_MS` window). The commit-side add is now deleted; the rule owns the shot.
+  Separately, all 46 offer screenshots that week saved as the literal filename
+  `Offer - {storeName}.png` — the prefix template referenced `storeName`, which lives inside the
+  offer's per-order `orders[]` array, never at the rule's top level where `{field}` templates
+  resolve, so it never interpolated. The prefix now uses `{payAmount}` (a top-level, always-parsed
+  field), so filenames read e.g. `Offer - 26.75.png`. A new lint (`ParseOutputGoldenTest`, the
+  #433 family) now catches this whole class going forward: any `{field}` template in a rule's
+  screenshot/bubble/log effect args that never resolves non-null anywhere in that rule's corpus
+  fails the build. **Confirm on dash: 0/2 —** after a session ends, `Pictures/DashBuddy` should
+  contain exactly **one** `DashSummary - <earnings>.png` for that end (not two ~2.5s apart), and
+  offer screenshots from that dash should be named `Offer - <pay>.png` (a dollar amount), never
+  the literal `Offer - {storeName}.png`. Broken = a duplicate dash-summary pair, or any offer
+  screenshot with a literal `{storeName}` in the filename.
 - **🔧 FIX SHIPPED — automated taps now rank click candidates by evidence instead of a dead exact-bounds check (#600).**
   Every automated Accept/Decline/Confirm tap re-resolves its target against the live accessibility
   tree, then disambiguates among label-verified candidates. The old disambiguator compared


### PR DESCRIPTION
Closes #606. Two grounded findings: (a) DashSummary screenshots fired twice per session end from TWO independent owners — the dash_summary rule effect (deduped+throttled) and an EffectMap SESSION_ENDED `CaptureScreenshot` with a null effectKey that bypassed both gates (the 2.5s gap == the GRACE_COMMIT window); (b) `Offer - {storeName}` never interpolated because `{field}` template resolution is top-level-only and storeName lives inside `orders[]`.

## Fix (sonnet build from a fable-vetted plan)
- Deleted the EffectMap SESSION_ENDED `CaptureScreenshot` add (siblings StopOdometer/UpdateBubble/EndSession kept). Screenshots are rule-owned data; the dash_summary rule's dedupe+throttle already work. `AppEffect.CaptureScreenshot` the CLASS is kept — `screenshotFromArgs` still produces it to route rule screenshots through the #426 evidence gate (vet-confirmed producer).
- `offer_popup` prefix `{storeName}` → `{payAmount}` (top-level, non-null-validated). Filenames become `Offer - 26.75.png`.
- New effect-arg template lint in ParseOutputGoldenTest — scans every screen effect's arg VALUES (prefix/text/payload) against the rule's top-level parsed fields, ratchet-guarded like the dedupeKey lint.

## The lint is empirically red-proven
Run against the UNFIXED repo it failed with exactly `offer_popup:storeName` AND `delivery_summary_collapsed:totalPay` (a pre-existing dead template, mirror of an already-ratcheted dedupeKey entry — **ratcheted, not fixed**, per the vet's "don't fix unrelated rules"). uber.json's identical `{storeName}` bug has zero corpus coverage (pre-existing blind spot, same as the dedupeKey lint) — untouched, consistent with scope.

## Tests
EffectMapTest session-end now asserts no CaptureScreenshot (red-first proven); the lint red→green across the doordash.json fix; AllMatchersSuite green (dash_summary untouched). Full `:app` + `:core:state` + `:domain:test` green. Field-checklist item added (0/2).

### Design-goal review
5 (SSOT): one screenshot owner per surface; the lint makes "a template must reference a real parsed field" a compile-adjacent invariant, closing the class that let `{storeName}` sit dead for weeks. 7: no logging change. 8: rule JSON + lint only.

### Adversarial review
Fable design-vet pre-build (keep-the-class amendment applied); fable post-build check follows before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)