### PR TITLE
fix(state): #601 — offer outcome cards derive from the committed outcome (SSOT); click shows an ack, not a claim

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
@@ -389,7 +389,10 @@ class EffectMapTest {
     }
 
     @Test
-    fun `click accept during offer emits UpdateBubble`() {
+    fun `click accept during offer emits an instant ack, not an outcome claim (#601)`() {
+        // #601: a click is a tap acknowledgement, not an outcome — the card that says what
+        // actually happened fires from the resolution pop (see the #601 tests below), off the
+        // same outcome value logged to the ledger.
         val prev = AppState(regions = Regions(
             flow = FlowRegion(flow = Flow.OfferPresented, pendingOffer = testPendingOffer),
         ))
@@ -397,22 +400,177 @@ class EffectMapTest {
         val next = prev
 
         val effects = effectMap.diff(prev, next, clickObs(intent = "accept_offer"))
-        assertTrue(effects.any {
+        assertTrue("the tap acks instantly", effects.any {
+            it is AppEffect.UpdateBubble && it.text == "Accepting…"
+        })
+        assertFalse("a click must never claim the outcome (#601)", effects.any {
             it is AppEffect.UpdateBubble && it.text == "Offer Accepted"
         })
     }
 
     @Test
-    fun `click decline during offer emits UpdateBubble`() {
+    fun `click decline during offer emits an instant ack, not an outcome claim (#601)`() {
         val prev = AppState(regions = Regions(
             flow = FlowRegion(flow = Flow.OfferPresented, pendingOffer = testPendingOffer),
         ))
         val next = prev
 
         val effects = effectMap.diff(prev, next, clickObs(intent = "decline_offer"))
-        assertTrue(effects.any {
+        assertTrue("the tap acks instantly", effects.any {
+            it is AppEffect.UpdateBubble && it.text == "Declining…"
+        })
+        assertFalse("a click must never claim the outcome (#601)", effects.any {
             it is AppEffect.UpdateBubble && it.text == "Offer Declined"
         })
+    }
+
+    // =========================================================================
+    // #601 — outcome cards derive from the committed outcome (SSOT)
+    // =========================================================================
+
+    // ONE function used by every outcome-card assertion below, so a new test can't drift by
+    // hardcoding a fresh string per outcome. Deliberately reimplements (rather than imports)
+    // production's private EffectMap.outcomeCardText table, so a divergence between the two
+    // still fails a test instead of being tautologically hidden.
+    private fun expectedOutcomeCard(outcome: AppEventType, replaced: Boolean = false): String {
+        val base = when (outcome) {
+            AppEventType.OFFER_ACCEPTED -> "Offer Accepted"
+            AppEventType.OFFER_DECLINED -> "Offer Declined"
+            AppEventType.OFFER_TIMEOUT -> "Offer Timed Out!"
+            else -> error("not an offer outcome: $outcome")
+        }
+        return if (replaced) "$base (offer replaced)" else base
+    }
+
+    @Test
+    fun `accept click acks instantly, then the resolution pop shows the matching outcome card (#601)`() {
+        // Step 1 — click: instant ack, no outcome claim yet.
+        val prevAtClick = AppState(regions = Regions(
+            flow = FlowRegion(flow = Flow.OfferPresented, pendingOffer = testPendingOffer),
+        ))
+        val clickEffects = effectMap.diff(prevAtClick, prevAtClick, clickObs(intent = "accept_offer"))
+        assertTrue("instant ack at click time", clickEffects.any {
+            it is AppEffect.UpdateBubble && it.text == "Accepting…"
+        })
+
+        // Step 2 — pop: the offer resolves (screen transition) carrying the click intent the
+        // state machine already recorded from step 1. The card must equal
+        // expectedOutcomeCard(loggedOutcome) — card==ledger by construction, not two hand-kept
+        // strings that happen to agree.
+        val prevAtPop = AppState(regions = Regions(
+            flow = FlowRegion(
+                flow = Flow.OfferPresented,
+                pendingOffer = testPendingOffer.copy(lastClickIntent = OfferIntent.ACCEPT),
+            ),
+        ))
+        val nextAtPop = AppState(regions = Regions(flow = FlowRegion(flow = Flow.TaskPickupNavigation)))
+        val popEffects = effectMap.diff(prevAtPop, nextAtPop, screenObs(flow = Flow.TaskPickupNavigation))
+
+        val outcome = popEffects.logEvents().first { it.event.type == AppEventType.OFFER_ACCEPTED }.event.type
+        assertTrue(
+            "the pop card equals expectedOutcomeCard(loggedOutcome)",
+            popEffects.any { it is AppEffect.UpdateBubble && it.text == expectedOutcomeCard(outcome) },
+        )
+    }
+
+    @Test
+    fun `decline-latch race (#594)- click shows the race warning not an ack, pop logs and shows Declined (#601)`() {
+        // The dasher's decline already committed server-side; a later Accept click races it.
+        val prevAtClick = AppState(regions = Regions(
+            flow = FlowRegion(
+                flow = Flow.OfferPresented,
+                pendingOffer = testPendingOffer.copy(declineCommittedAt = 900L),
+            ),
+        ))
+        val clickEffects = effectMap.diff(prevAtClick, prevAtClick, clickObs(intent = "accept_offer"))
+        assertTrue("the race warning fires instead of an ack", clickEffects.any {
+            it is AppEffect.UpdateBubble && it.text == "Decline already submitted — Accept won't take"
+        })
+        assertFalse("no Accepting… ack when the decline already committed", clickEffects.any {
+            it is AppEffect.UpdateBubble && it.text == "Accepting…"
+        })
+
+        // Pop: the latch wins — OFFER_DECLINED is what's logged and shown, regardless of the
+        // racing Accept click recorded as lastClickIntent.
+        val prevAtPop = AppState(regions = Regions(
+            flow = FlowRegion(
+                flow = Flow.OfferPresented,
+                pendingOffer = testPendingOffer.copy(
+                    declineCommittedAt = 900L,
+                    lastClickIntent = OfferIntent.ACCEPT,
+                ),
+            ),
+        ))
+        val nextAtPop = AppState(regions = Regions(flow = FlowRegion(flow = Flow.Idle)))
+        val popEffects = effectMap.diff(prevAtPop, nextAtPop, screenObs(flow = Flow.Idle))
+
+        assertTrue(popEffects.logEventTypes().contains(AppEventType.OFFER_DECLINED))
+        assertTrue(
+            "card==ledger: OFFER_DECLINED shows the Declined card even though the last click was Accept",
+            popEffects.any {
+                it is AppEffect.UpdateBubble && it.text == expectedOutcomeCard(AppEventType.OFFER_DECLINED)
+            },
+        )
+    }
+
+    @Test
+    fun `no click, timeout pop shows only the outcome card — no ack ever fired (#601)`() {
+        val prev = AppState(regions = Regions(
+            flow = FlowRegion(flow = Flow.OfferPresented, pendingOffer = testPendingOffer),
+        ))
+        val next = AppState(regions = Regions(flow = FlowRegion(flow = Flow.Idle)))
+
+        val effects = effectMap.diff(prev, next, screenObs(flow = Flow.Idle))
+
+        assertTrue(effects.logEventTypes().contains(AppEventType.OFFER_TIMEOUT))
+        val bubbles = effects.filterIsInstance<AppEffect.UpdateBubble>()
+        assertEquals("exactly one card — no click means no ack ever fired", 1, bubbles.size)
+        assertEquals(expectedOutcomeCard(AppEventType.OFFER_TIMEOUT), bubbles[0].text)
+    }
+
+    @Test
+    fun `a replaced offer with a stored ACCEPT intent surfaces the OLD offer's outcome card, suffixed (#601)`() {
+        val prev = AppState(regions = Regions(
+            flow = FlowRegion(
+                flow = Flow.OfferPresented,
+                pendingOffer = testPendingOffer.copy(lastClickIntent = OfferIntent.ACCEPT),
+            ),
+        ))
+        val next = AppState(regions = Regions(
+            flow = FlowRegion(flow = Flow.OfferPresented, pendingOffer = testPendingOffer.copy(offerHash = "hash-456")),
+        ))
+
+        val effects = effectMap.diff(prev, next, screenObs(flow = Flow.OfferPresented))
+
+        assertTrue(
+            "the old offer's OFFER_ACCEPTED is logged even though it was silently replaced",
+            effects.logEventTypes().contains(AppEventType.OFFER_ACCEPTED),
+        )
+        assertTrue(
+            "the card is faithful to the ledger — suffixed so it reads as the OLD offer's fate",
+            effects.any {
+                it is AppEffect.UpdateBubble &&
+                    it.text == expectedOutcomeCard(AppEventType.OFFER_ACCEPTED, replaced = true)
+            },
+        )
+    }
+
+    @Test
+    fun `a replaced offer with no click intent logs and shows OFFER_TIMEOUT, suffixed — no 4th outcome string (#601 vet amdt 1)`() {
+        val prev = AppState(regions = Regions(
+            flow = FlowRegion(flow = Flow.OfferPresented, pendingOffer = testPendingOffer),
+        ))
+        val next = AppState(regions = Regions(
+            flow = FlowRegion(flow = Flow.OfferPresented, pendingOffer = testPendingOffer.copy(offerHash = "hash-456")),
+        ))
+
+        val effects = effectMap.diff(prev, next, screenObs(flow = Flow.OfferPresented))
+
+        assertTrue(effects.logEventTypes().contains(AppEventType.OFFER_TIMEOUT))
+        assertTrue(
+            "faithful to the ledger's OFFER_TIMEOUT — no invented 4th outcome string",
+            effects.any { it is AppEffect.UpdateBubble && it.text == "Offer Timed Out! (offer replaced)" },
+        )
     }
 
     // =========================================================================

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -152,6 +152,16 @@ class EffectMap @Inject constructor() {
             // Log resolution of old offer with full context.
             val outcome = resolveOfferOutcome(obs, prevOffer)
             add(logEffect(sessionId, outcome, obs.timestamp, offerPayload(prevOffer, outcome, obs.timestamp, "Replaced by new offer")))
+            // #601: the ledger records an outcome for the replaced offer even though no card
+            // popped for it before — surface it now (SSOT: same outcome→text table as the
+            // resolution block below), suffixed so it reads as the OLD offer's disposition,
+            // not a claim about the new one on screen.
+            add(
+                AppEffect.UpdateBubble(
+                    "${outcomeCardText(outcome)} (offer replaced)",
+                    persona = ChatPersona.Dispatcher,
+                )
+            )
 
             // #457: dismiss the OLD offer's heads-up now. Its Accept/Decline is a separate, persistent
             // notification (not the self-replacing bubble), so without this the prior banner lingers
@@ -209,12 +219,22 @@ class EffectMap @Inject constructor() {
             add(AppEffect.CancelOfferNotification(prevOffer.offerHash))
             add(logEffect(sessionId, outcome, obs.timestamp, offerPayload(prevOffer, outcome, obs.timestamp, raceDescription)))
 
-            if (outcome == AppEventType.OFFER_TIMEOUT) {
-                add(AppEffect.UpdateBubble("Offer Timed Out!", persona = ChatPersona.Dispatcher))
-            }
+            // #601: the outcome card is derived from the SAME `outcome` value just logged above —
+            // one committed fact, one card. The click-feedback block below no longer claims an
+            // outcome at tap time (it only acks the intent); this is the single place the chat
+            // states what actually happened, so it can never desync from the ledger.
+            add(AppEffect.UpdateBubble(outcomeCardText(outcome), persona = ChatPersona.Dispatcher))
         }
 
         // Click feedback for offer accept/decline
+        //
+        // #601: this is an ACK, not an outcome claim — the dasher gets instant feedback that the
+        // tap registered, but the card that states what actually happened (Accepted/Declined/
+        // Timed Out) fires from the resolution block above, off the SAME `outcome` value that's
+        // logged to the ledger. Before this, a click here printed "Offer Accepted"/"Offer
+        // Declined" independently of resolveOfferOutcome — two code paths that only agreed
+        // because handleOfferClick happened to thread the same intent into both, with no
+        // structural guarantee they couldn't desync.
         if (flowObs is Observation.Click && prev.flow == Flow.OfferPresented) {
             val fields = flowObs.parsed as? ParsedFields.ClickFields
             // #594: the decline-commit latch set on a prior confirm click (survives on this
@@ -225,7 +245,7 @@ class EffectMap @Inject constructor() {
                     if (declineCommitted != null) {
                         // The decline was already committed server-side; this Accept (the
                         // "Review offer"→Accept race) won't take. Say so instead of the
-                        // contradictory "Offer Accepted", and count the defended invariant
+                        // contradictory "Accepting…", and count the defended invariant
                         // (Principle 7: WARN = a defended invariant fired; no PII in the line).
                         Timber.w(
                             "Accept click ignored (#594): decline already committed at %d — decline stands",
@@ -238,10 +258,10 @@ class EffectMap @Inject constructor() {
                             )
                         )
                     } else {
-                        add(AppEffect.UpdateBubble("Offer Accepted", persona = ChatPersona.Dispatcher))
+                        add(AppEffect.UpdateBubble("Accepting…", persona = ChatPersona.Dispatcher))
                     }
                 OfferIntent.DECLINE -> add(
-                    AppEffect.UpdateBubble("Offer Declined", persona = ChatPersona.Dispatcher)
+                    AppEffect.UpdateBubble("Declining…", persona = ChatPersona.Dispatcher)
                 )
             }
         }
@@ -1099,6 +1119,19 @@ class EffectMap @Inject constructor() {
             OfferIntent.DECLINE -> AppEventType.OFFER_DECLINED
             else -> AppEventType.OFFER_TIMEOUT
         }
+    }
+
+    /**
+     * #601: the SSOT for what an offer outcome card says. Both the resolution-block card
+     * (the offer that just pop'd) and the replaced-offer card (the OLD offer, suffixed by the
+     * caller) route through this ONE table, keyed on the exact [AppEventType] that gets logged
+     * to the ledger — so the chat can never claim an outcome the ledger doesn't record.
+     */
+    private fun outcomeCardText(outcome: AppEventType): String = when (outcome) {
+        AppEventType.OFFER_ACCEPTED -> "Offer Accepted"
+        AppEventType.OFFER_DECLINED -> "Offer Declined"
+        AppEventType.OFFER_TIMEOUT -> "Offer Timed Out!"
+        else -> throw IllegalArgumentException("Not an offer outcome: $outcome")
     }
 
     private fun determinePickupPersona(

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -235,7 +235,12 @@ class EffectMap @Inject constructor() {
         // Declined" independently of resolveOfferOutcome — two code paths that only agreed
         // because handleOfferClick happened to thread the same intent into both, with no
         // structural guarantee they couldn't desync.
-        if (flowObs is Observation.Click && prev.flow == Flow.OfferPresented) {
+        // The ack is click-time feedback that a decision is IN FLIGHT — so skip it when this
+        // same click also popped the offer (nextOffer == null): the resolution block above
+        // already emitted the committed outcome card this step, and a trailing "Accepting…"
+        // would be a never-resolving contradiction (#625 review — unreachable with today's
+        // flow-less click rules, but cheap to guard).
+        if (flowObs is Observation.Click && prev.flow == Flow.OfferPresented && nextOffer != null) {
             val fields = flowObs.parsed as? ParsedFields.ClickFields
             // #594: the decline-commit latch set on a prior confirm click (survives on this
             // click's next.pendingOffer, or prev's if the pop is concurrent).
@@ -1131,7 +1136,15 @@ class EffectMap @Inject constructor() {
         AppEventType.OFFER_ACCEPTED -> "Offer Accepted"
         AppEventType.OFFER_DECLINED -> "Offer Declined"
         AppEventType.OFFER_TIMEOUT -> "Offer Timed Out!"
-        else -> throw IllegalArgumentException("Not an offer outcome: $outcome")
+        // Fail OPEN on display text, never on the reducer loop (#625 review): EffectMap
+        // is diffed inside StateManagerV2's event loop, which has no try/catch — a throw
+        // here would freeze the state machine and let the unbounded observation buffer
+        // grow until restart. A neutral string is a harmless card; today the only caller
+        // passes resolveOfferOutcome output, so this is a future-proofing floor.
+        else -> {
+            Timber.e("outcomeCardText got a non-outcome type: %s — using neutral text", outcome)
+            "Offer resolved"
+        }
     }
 
     private fun determinePickupPersona(

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -88,8 +88,10 @@ was found **broken-in-part** (raw PII in capture envelopes) and moved to that en
   **Deliberate UX cost:** the outcome card now pops ~seconds after the tap (BK field timings put the
   resolution frame ~7-8s behind the click) instead of instantly — evaluate whether that delay feels
   acceptable on-dash. **Confirm on dash: 0/2 —** tap Accept: "Accepting…" should show instantly, then
-  "Offer Accepted" when the screen actually advances past the offer. Tap Decline similarly
-  ("Declining…" → "Offer Declined"). Re-run the #594 race (decline → confirm → "Review offer" →
+  "Offer Accepted" when the screen actually advances past the offer. On Decline, the ack appears
+  at the **confirm-sheet** tap (the first Decline tap classifies as `initial_decline` and is
+  silent by design — don't score that as broken): confirm-sheet tap → "Declining…" → "Offer
+  Declined" at resolution. Re-run the #594 race (decline → confirm → "Review offer" →
   Accept): the race warning ("Decline already submitted — Accept won't take") should show at tap
   time (not "Accepting…"), then "Offer Declined" at resolution. Broken = an ack that never resolves
   into a matching outcome card, or any card text that doesn't match what the db logs for that offer.

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -73,6 +73,26 @@ card's **mechanical** half, #577 (re-confirmed, 24/24, ~0.55 s — with a new po
 that entry's Bug #1), the #457 path, and #554 ShadowProjector (2/2). The #462/#460 dropoff item
 was found **broken-in-part** (raw PII in capture envelopes) and moved to that entry's Bug #7.)_
 
+- **🔧 FIX SHIPPED — offer outcome cards now derive from the committed outcome, not the tap (#601).
+  DELIBERATE UX CHANGE — CONFIRM ON DASH.**
+  Before, tapping Accept/Decline printed "Offer Accepted"/"Offer Declined" immediately, from the
+  click alone — a second, independent code path from the one that logs the outcome to the ledger
+  (`resolveOfferOutcome`). They only ever agreed because the click handler happened to thread the
+  same intent into both; the #594 decline-latch race showed they *can* diverge (a card claiming an
+  outcome the ledger didn't record). Now a tap shows an instant **ack** only ("Accepting…" /
+  "Declining…" — the #594 race warning still shows here instead, unchanged), and the real outcome
+  card ("Offer Accepted" / "Offer Declined" / "Offer Timed Out!") fires later, at the resolution pop,
+  off the SAME value that gets logged — card and ledger can no longer disagree by construction. A
+  replaced offer (one that silently vanished under a new one) now also gets its own outcome card,
+  suffixed `(offer replaced)` (e.g. "Offer Accepted (offer replaced)"), which it never got before.
+  **Deliberate UX cost:** the outcome card now pops ~seconds after the tap (BK field timings put the
+  resolution frame ~7-8s behind the click) instead of instantly — evaluate whether that delay feels
+  acceptable on-dash. **Confirm on dash: 0/2 —** tap Accept: "Accepting…" should show instantly, then
+  "Offer Accepted" when the screen actually advances past the offer. Tap Decline similarly
+  ("Declining…" → "Offer Declined"). Re-run the #594 race (decline → confirm → "Review offer" →
+  Accept): the race warning ("Decline already submitted — Accept won't take") should show at tap
+  time (not "Accepting…"), then "Offer Declined" at resolution. Broken = an ack that never resolves
+  into a matching outcome card, or any card text that doesn't match what the db logs for that offer.
 - **🔧 FIX SHIPPED — rule effects from notifications key per-arrival, not per-install (#604). CONFIRM ON DASH.**
   A rule-declared log effect attached to a notification with no `dedupeKey` (e.g.
   `doordash.notification.new_order`) built its `effects_fired` idempotency key from the rule id


### PR DESCRIPTION
Closes #601. The chat/bubble outcome cards contradicted the ledger in every field-week incident window because the accept/decline card fired from the CLICK block while the authoritative outcome (and the timeout card) lived in the resolution block — two code paths that agreed only because handleOfferClick happened to thread the same intent into both. #594/#595 point-patched the two observed contradictions; this makes them structurally impossible.

## Fix (sonnet build from a fable-vetted plan)
- New `outcomeCardText(outcome)` SSOT (ACCEPTED→"Offer Accepted", DECLINED→"Offer Declined", TIMEOUT→"Offer Timed Out!"; else throws — no 4th string invented).
- Resolution block emits the card for ALL three outcomes off the SAME `outcome` value it logs to the ledger. Replaced-offer block now also emits a card for the old offer (`"… (offer replaced)"`) — closing the previously-silent gap where the ledger recorded an outcome the chat never showed.
- Click block: outcome CLAIMS become ACKS — ACCEPT→"Accepting…", DECLINE→"Declining…". The #594 race warning ("Decline already submitted…") is untouched and still slots ahead of the ack.
- resolveOfferOutcome, steppers, the UiInput block, TTS, notifications — all untouched.

## Deliberate UX change (flagged on the checklist)
The outcome card moves from click time to pop time — ~seconds later (the BK incident's clicks were ~7-8s before the pop). Instant tap feedback is preserved via the ack; the outcome *claim* is now SSOT-sourced. Reactive-UI: a delayed-but-correct card beats an immediate-but-contradicted one — but worth the dev evaluating the delay on-dash.

## Tests
5 new EffectMapTest cases route through a shared `expectedOutcomeCard` helper (reimplemented, not imported, so a prod/test divergence still fails): ack→card round trip (card==ledger); the #594 race (warning not ack, DECLINED at pop); timeout (one card, no ack); replaced-offer ACCEPT and TIMEOUT variants. Two existing click-card tests updated to the ack strings. **Red-first proven** (6 fail against pre-#601 EffectMap). DeclineRaceReplayTest (counts, not text) stays green. Full `:app` + `:core:state` + `:domain:test` green. Field-checklist item added (0/2).

### Design-goal review
5 (SSOT): all three outcome cards + the ledger now derive from the single `resolveOfferOutcome` result — card can't disagree with the ledger by construction. 1 (UDF): cards are a pure EffectMap diff of committed state; the ack is click-observation feedback, correctly separated. 8: no platform literals.

### Adversarial review
Fable design-vet pre-build (exact test lines + the no-4th-string rule); fable post-build check follows before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)