### PR TITLE
fix(recognition+state): #603 — dropoff handoff requires the completion CTA; leg-2 dropoffs get DELIVERY_NAV_STARTED

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/TriageRulesTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/TriageRulesTest.kt
@@ -264,11 +264,42 @@ class TriageRulesTest {
     }
 
     @Test
-    fun `dropoff_handoff`() {
+    fun `dropoff_handoff — at-door frame WITH the completion CTA classifies as handoff (#603)`() {
+        // The genuine at-door handoff carries the completion CTA ("Mark as delivered" et al.)
+        // on top of the persistent "Hand it to customer" instruction — the CTA is what makes
+        // it a real arrival (task:dropoff:arrived).
         assertEquals(
             "dropoff_handoff",
-            screen(tree(node(id = "drop_off_workflow_host_fragment"), node(text = "Hand it to customer"))),
+            screen(
+                tree(
+                    node(id = "drop_off_workflow_host_fragment"),
+                    node(text = "Hand it to customer"),
+                    node(text = "Mark as delivered"),
+                ),
+            ),
         )
+    }
+
+    @Test
+    fun `dropoff_handoff — en-route frame WITHOUT a CTA is pre-arrival, not a handoff (#603)`() {
+        // "Hand it to customer" is present the ENTIRE drive, so keying on it alone fired a
+        // FALSE task:dropoff:arrived the instant nav started. With no completion CTA the frame
+        // is still en-route and must fall through to dropoff_pre_arrival (the "Deliver to <name>"
+        // + Directions/Call/Message nav card), NOT masquerade as an at-door handoff.
+        val enRoute = tree(
+            node(id = "drop_off_workflow_host_fragment"),
+            node(text = "Hand it to customer"),
+            node(text = "Deliver to Sample C"),
+            node(text = "Directions"),
+            node(text = "Call"),
+            node(text = "Message"),
+        )
+        assertNotEquals(
+            "an en-route frame (no completion CTA) must not classify as an at-door handoff",
+            "dropoff_handoff",
+            screen(enRoute),
+        )
+        assertEquals("dropoff_pre_arrival", screen(enRoute))
     }
 
     @Test

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/TriageRulesTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/TriageRulesTest.kt
@@ -281,6 +281,26 @@ class TriageRulesTest {
     }
 
     @Test
+    fun `dropoff_handoff — the ID-check steps screen is an at-door handoff (#603 review F1)`() {
+        // The ID-check / barcode-scan handoff STEPS screen is a true at-door surface but uses
+        // its own CTA vocabulary ("Start scanning"/"Verify"/"Recipient signature") — none of the
+        // text CTAs. It carries the arrival-only `steps_screen_content` container, so that id is a
+        // valid completion-CTA discriminator (grounded arrival-only in
+        // docs/capture-analysis/2026-06-dropoff-arrival-signals.md). Without this it fell to
+        // UNKNOWN and the arrival edge could be lost.
+        assertEquals(
+            "dropoff_handoff",
+            screen(
+                tree(
+                    node(id = "drop_off_workflow_host_fragment"),
+                    node(text = "Hand it to customer"),
+                    node(id = "steps_screen_content", text = "Verify recipient's identity"),
+                ),
+            ),
+        )
+    }
+
+    @Test
     fun `dropoff_handoff — en-route frame WITHOUT a CTA is pre-arrival, not a handoff (#603)`() {
         // "Hand it to customer" is present the ENTIRE drive, so keying on it alone fired a
         // FALSE task:dropoff:arrived the instant nav started. With no completion CTA the frame

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
@@ -1034,6 +1034,80 @@ class EffectMapTest {
     }
 
     @Test
+    fun `stacked leg-2 dropoff (dropoff to a new dropoff) mints DELIVERY_NAV_STARTED, ResumeOdometer, and a Heading-to bubble (#603)`() {
+        // A multi-drop stack: leg-1's drop is retired and leg-2's drop becomes active — a
+        // different taskId, freshly minted on THIS frame (startedAt == obs.timestamp). Both
+        // sides are DROPOFF, so the pickup→dropoff branch never sees it; before #603 leg-2 was
+        // a silent drop (no nav event, no odometer resume, no bubble).
+        val (platform, _) = stateWithPlatform()
+        val session = Session("sess-1", startedAt = 100L)
+        val leg1 = Task(
+            taskId = "drop-A", jobId = "job-1", phase = TaskPhase.DROPOFF,
+            storeName = "Panera Bread", startedAt = 800L,
+        )
+        val leg2 = Task(
+            taskId = "drop-B", jobId = "job-1", phase = TaskPhase.DROPOFF,
+            storeName = "Panera Bread", startedAt = 1000L,
+        )
+        val prev = AppState(regions = Regions(
+            flow = FlowRegion(flow = Flow.TaskDropoffArrived),
+            platforms = mapOf(platform to PlatformRegion(platform, mode = Mode.Online, session = session, activeTask = leg1)),
+        ))
+        val next = AppState(regions = Regions(
+            flow = FlowRegion(flow = Flow.TaskDropoffNavigation),
+            platforms = mapOf(platform to PlatformRegion(platform, mode = Mode.Online, session = session, activeTask = leg2)),
+        ))
+
+        val effects = effectMap.diff(prev, next, screenObs(
+            flow = Flow.TaskDropoffNavigation, timestamp = 1000L,
+            parsed = ParsedFields.TaskFields(phase = TaskPhase.DROPOFF, subFlow = TaskSubFlow.NAVIGATION),
+        ))
+
+        assertTrue("leg-2 must mint DELIVERY_NAV_STARTED", effects.logEventTypes().contains(AppEventType.DELIVERY_NAV_STARTED))
+        assertTrue("leg-2 must resume the odometer for its drive", effects.any { it is AppEffect.ResumeOdometer })
+        assertTrue(
+            "leg-1's drop is confirmed as the active task moves on",
+            effects.logEventTypes().contains(AppEventType.DELIVERY_CONFIRMED),
+        )
+        // #568: the leg-2 bubble is store-flavored (never the raw hash).
+        val bubble = effects.effectsOfType<AppEffect.UpdateBubble>().first { it.text.startsWith("Heading to") }
+        assertEquals("Heading to Panera Bread's customer", bubble.text)
+        assertEquals(ChatPersona.Customer("Panera Bread's customer"), bubble.persona)
+    }
+
+    @Test
+    fun `a RESUMED dropoff (startedAt predates the frame) does NOT re-mint DELIVERY_NAV_STARTED (#603)`() {
+        // The new-leg branch is guarded on startedAt == obs.timestamp, so a replay / re-sight of
+        // an already-running drop (which keeps its original startedAt) can't re-fire the nav trio.
+        // Here a null active task is replaced by a dropoff whose startedAt predates this frame — a
+        // resume, not a fresh leg.
+        val (platform, _) = stateWithPlatform()
+        val session = Session("sess-1", startedAt = 100L)
+        val resumed = Task(
+            taskId = "drop-B", jobId = "job-1", phase = TaskPhase.DROPOFF,
+            storeName = "Panera Bread", startedAt = 500L,
+        )
+        val prev = AppState(regions = Regions(
+            flow = FlowRegion(flow = Flow.TaskDropoffNavigation),
+            platforms = mapOf(platform to PlatformRegion(platform, mode = Mode.Online, session = session, activeTask = null)),
+        ))
+        val next = AppState(regions = Regions(
+            flow = FlowRegion(flow = Flow.TaskDropoffNavigation),
+            platforms = mapOf(platform to PlatformRegion(platform, mode = Mode.Online, session = session, activeTask = resumed)),
+        ))
+
+        val effects = effectMap.diff(prev, next, screenObs(
+            flow = Flow.TaskDropoffNavigation, timestamp = 1000L,
+            parsed = ParsedFields.TaskFields(phase = TaskPhase.DROPOFF, subFlow = TaskSubFlow.NAVIGATION),
+        ))
+
+        assertFalse(
+            "a resumed (not freshly-minted) drop must not re-fire the nav trio",
+            effects.logEventTypes().contains(AppEventType.DELIVERY_NAV_STARTED),
+        )
+    }
+
+    @Test
     fun `arrival at pickup emits PauseOdometer and PICKUP_ARRIVED`() {
         val (platform, _) = stateWithPlatform()
         val session = Session("sess-1", startedAt = 100L)

--- a/app/src/test/java/cloud/trotter/dashbuddy/replay/WalgreensPlaceholderReplayTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/replay/WalgreensPlaceholderReplayTest.kt
@@ -17,10 +17,14 @@ import org.junit.Test
  *                            + a customer-TBD placeholder DROPOFF.
  *  2. `pickup_navigation`  — job + placeholder formed; pickup active.
  *  3. `pickup_pre_arrival` — pickup updates.
- *  4. `dropoff_handoff`    — a GENUINE "hand it to customer" handoff screen whose customer name is a
- *                            bare TextView (no resource id) → unparseable → the placeholder dropoff is
- *                            activated **customer-less** (the bubble shows the "the customer" fallback).
- *  5. `dropoff_navigation` — the first frame that parses the customer.
+ *  4. `04_dropoff_handoff.json` — this frame lacks a completion CTA, so since #603 it classifies
+ *                            `dropoff_pre_arrival` (not `dropoff_handoff`) and now DOES parse the
+ *                            customer. The customer-less-activation path this test originally
+ *                            exercised is therefore no longer hit through this fixture; the #565
+ *                            guard it protects is independently covered by the synthetic,
+ *                            classification-independent `PlatformRegionStepperTest` cases. Kept as a
+ *                            green end-to-end regression; the assertions below still hold.
+ *  5. `dropoff_navigation` — a later dropoff frame.
  *
  * The bug: at frame 5 the customer-less placeholder is already the *active* task, so the slice-3
  * resolve path (which excludes the active task) and the resume path (which needs a name match a null

--- a/app/src/test/resources/snapshots/approved-parse-output.json
+++ b/app/src/test/resources/snapshots/approved-parse-output.json
@@ -1661,6 +1661,27 @@
             "subFlow": "NAVIGATION"
         }
     },
+    "dropoff_pre_arrival/2026-06-30__doordash__dropoff_pre_arrival_bjs_enroute__ff724f.json": {
+        "ruleId": "doordash.screen.dropoff_pre_arrival",
+        "intent": "dropoff_pre_arrival",
+        "shape": "task",
+        "fields": {
+            "arrivalConfirmed": false,
+            "customerAddressHash": null,
+            "customerNameHash": "017ad73325fcf108a972edac618f9edfc957c5b1de10f8b371b0a8bfa4f59e2d",
+            "deadline": {
+                "text": "5:02 PM",
+                "time": 1780333320000
+            },
+            "itemsRemaining": null,
+            "itemsShopped": null,
+            "phase": "DROPOFF",
+            "redCardTotal": null,
+            "storeAddress": null,
+            "storeName": null,
+            "subFlow": "NAVIGATION"
+        }
+    },
     "dropoff_pre_arrival/20260128_180652_578_DROPOFF_DETAILS_PRE_ARRIVAL.json": {
         "ruleId": "doordash.screen.dropoff_pre_arrival",
         "intent": "dropoff_pre_arrival",

--- a/app/src/test/resources/snapshots/dropoff_pre_arrival/2026-06-30__doordash__dropoff_pre_arrival_bjs_enroute__ff724f.json
+++ b/app/src/test/resources/snapshots/dropoff_pre_arrival/2026-06-30__doordash__dropoff_pre_arrival_bjs_enroute__ff724f.json
@@ -1,0 +1,697 @@
+{
+    "captureId": "5b1d5e1b-4de5-409e-8e35-69ce3f812166",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1782856018946,
+    "platform": "doordash",
+    "ruleId": "doordash.screen.dropoff_pre_arrival",
+    "classificationName": "dropoff_pre_arrival",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 0,
+            "right": 1080,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 1080,
+                    "bottom": 2347
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 136,
+                            "right": 1080,
+                            "bottom": 2347
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.LinearLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 136,
+                                    "right": 1080,
+                                    "bottom": 2347
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 136,
+                                            "right": 1080,
+                                            "bottom": 2347
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/container",
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 136,
+                                                    "right": 1080,
+                                                    "bottom": 2347
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/toolbar_container",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 136
+                                                        }
+                                                    },
+                                                    {
+                                                        "class": "android.widget.FrameLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 136,
+                                                            "right": 1080,
+                                                            "bottom": 2347
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/fragment",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 136,
+                                                                    "right": 1080,
+                                                                    "bottom": 2347
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.view.ViewGroup",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 136,
+                                                                            "right": 1080,
+                                                                            "bottom": 2347
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/drop_off_workflow_host_fragment",
+                                                                                "class": "android.widget.FrameLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 136,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 2347
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/drop_off_workflow_host_fragment",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 136,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 2347
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "androidx.compose.ui.platform.ComposeView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 136,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 2347
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 136,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 2347
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 0,
+                                                                                                                    "top": 136,
+                                                                                                                    "right": 1080,
+                                                                                                                    "bottom": 2347
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 243,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2166
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 243,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 535
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "text": "Deliver to [redacted]",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 288,
+                                                                                                                                            "right": 636,
+                                                                                                                                            "bottom": 354
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "text": "by 5:02 PM",
+                                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 363,
+                                                                                                                                            "right": 246,
+                                                                                                                                            "bottom": 410
+                                                                                                                                        }
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 419,
+                                                                                                                                            "right": 204,
+                                                                                                                                            "bottom": 526
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 28,
+                                                                                                                                                    "top": 420,
+                                                                                                                                                    "right": 134,
+                                                                                                                                                    "bottom": 526
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "Call",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 108,
+                                                                                                                                                    "top": 451,
+                                                                                                                                                    "right": 175,
+                                                                                                                                                    "bottom": 494
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 437,
+                                                                                                                                                    "right": 204,
+                                                                                                                                                    "bottom": 508
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 222,
+                                                                                                                                            "top": 419,
+                                                                                                                                            "right": 472,
+                                                                                                                                            "bottom": 526
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 214,
+                                                                                                                                                    "top": 420,
+                                                                                                                                                    "right": 320,
+                                                                                                                                                    "bottom": 526
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "Message",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 294,
+                                                                                                                                                    "top": 451,
+                                                                                                                                                    "right": 443,
+                                                                                                                                                    "bottom": 494
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 222,
+                                                                                                                                                    "top": 437,
+                                                                                                                                                    "right": 472,
+                                                                                                                                                    "bottom": 508
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 571,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 1145
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 179,
+                                                                                                                                            "top": 603,
+                                                                                                                                            "right": 1008,
+                                                                                                                                            "bottom": 710
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "[address]",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 179,
+                                                                                                                                                    "top": 607,
+                                                                                                                                                    "right": 472,
+                                                                                                                                                    "bottom": 659
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "[address]",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 179,
+                                                                                                                                                    "top": 659,
+                                                                                                                                                    "right": 596,
+                                                                                                                                                    "bottom": 706
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 179,
+                                                                                                                                                    "top": 607,
+                                                                                                                                                    "right": 1008,
+                                                                                                                                                    "bottom": 706
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    },
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 742,
+                                                                                                                                            "right": 1044,
+                                                                                                                                            "bottom": 1145
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 690,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 744
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isClickable": true,
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 36,
+                                                                                                                                                    "top": 744,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 1145
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 1181,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 1324
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 179,
+                                                                                                                                            "top": 1200,
+                                                                                                                                            "right": 1008,
+                                                                                                                                            "bottom": 1306
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Hand it to customer",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 179,
+                                                                                                                                                    "top": 1227,
+                                                                                                                                                    "right": 584,
+                                                                                                                                                    "bottom": 1279
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 179,
+                                                                                                                                                    "top": 1227,
+                                                                                                                                                    "right": 1008,
+                                                                                                                                                    "bottom": 1279
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 1360,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 1543
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.view.View",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 1360,
+                                                                                                                                            "right": 1044,
+                                                                                                                                            "bottom": 1543
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "class": "android.view.View",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 54,
+                                                                                                                                                    "top": 1398,
+                                                                                                                                                    "right": 161,
+                                                                                                                                                    "bottom": 1505
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "text": "BJ's Restaurant & Brewhouse (Alamo Ranch - 498)",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 179,
+                                                                                                                                                    "top": 1396,
+                                                                                                                                                    "right": 1044,
+                                                                                                                                                    "bottom": 1507
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 2114,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2220
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 2168,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 2347
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "class": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 36,
+                                                                                                                                    "top": 2204,
+                                                                                                                                    "right": 1044,
+                                                                                                                                    "bottom": 2311
+                                                                                                                                },
+                                                                                                                                "children": [
+                                                                                                                                    {
+                                                                                                                                        "class": "android.widget.Button",
+                                                                                                                                        "isClickable": true,
+                                                                                                                                        "isEnabled": true,
+                                                                                                                                        "bounds": {
+                                                                                                                                            "left": 36,
+                                                                                                                                            "top": 2204,
+                                                                                                                                            "right": 1044,
+                                                                                                                                            "bottom": 2311
+                                                                                                                                        },
+                                                                                                                                        "children": [
+                                                                                                                                            {
+                                                                                                                                                "text": "Directions",
+                                                                                                                                                "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                                "isEnabled": true,
+                                                                                                                                                "bounds": {
+                                                                                                                                                    "left": 435,
+                                                                                                                                                    "top": 2225,
+                                                                                                                                                    "right": 646,
+                                                                                                                                                    "bottom": 2291
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ]
+                                                                                                                                    }
+                                                                                                                                ]
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 0,
+                                                                                                                            "top": 136,
+                                                                                                                            "right": 107,
+                                                                                                                            "bottom": 243
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "desc": "Settings",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 27,
+                                                                                                                                    "top": 163,
+                                                                                                                                    "right": 80,
+                                                                                                                                    "bottom": 216
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 9,
+                                                                                                                                    "top": 145,
+                                                                                                                                    "right": 98,
+                                                                                                                                    "bottom": 234
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 107,
+                                                                                                                            "top": 137,
+                                                                                                                            "right": 866,
+                                                                                                                            "bottom": 243
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 866,
+                                                                                                                            "top": 136,
+                                                                                                                            "right": 973,
+                                                                                                                            "bottom": 243
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "desc": "Safety",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 893,
+                                                                                                                                    "top": 163,
+                                                                                                                                    "right": 946,
+                                                                                                                                    "bottom": 216
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 875,
+                                                                                                                                    "top": 145,
+                                                                                                                                    "right": 964,
+                                                                                                                                    "bottom": 234
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 973,
+                                                                                                                            "top": 136,
+                                                                                                                            "right": 1080,
+                                                                                                                            "bottom": 243
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "desc": "Help",
+                                                                                                                                "class": "android.view.View",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 1000,
+                                                                                                                                    "top": 163,
+                                                                                                                                    "right": 1053,
+                                                                                                                                    "bottom": 216
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "class": "android.widget.Button",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 982,
+                                                                                                                                    "top": 145,
+                                                                                                                                    "right": 1071,
+                                                                                                                                    "bottom": 234
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/core/pipeline/src/main/assets/rules/doordash.json
+++ b/core/pipeline/src/main/assets/rules/doordash.json
@@ -2721,7 +2721,8 @@
                 { "hasText": "Continue" },
                 { "hasText": "Complete Delivery" },
                 { "hasText": "Mark as delivered" },
-                { "hasIdSuffix": "complete_delivery_steps_button" }
+                { "hasIdSuffix": "complete_delivery_steps_button" },
+                { "hasIdSuffix": "steps_screen_content" }
               ]
             }
           }

--- a/core/pipeline/src/main/assets/rules/doordash.json
+++ b/core/pipeline/src/main/assets/rules/doordash.json
@@ -2700,6 +2700,7 @@
     },
     {
       "id": "doordash.screen.dropoff_handoff",
+      "comment": "#603: the 'hand it to customer' instruction is present the ENTIRE drive (en-route AND at-door), so keying on it alone fired a FALSE task:dropoff:arrived the moment nav started. The completion CTA ('Continue'/'Complete Delivery'/'Mark as delivered'/complete_delivery_steps_button) only appears once the dasher is actually at the door, so it is the real arrival discriminator. The en-route workflow-sheet frame (which lacks the CTA) then falls through to dropoff_pre_arrival (priority 73). KEEP THIS CTA SET IN SYNC with dropoff_navigation's reject and dropoff_pre_arrival_completion's require — all three describe the same 'delivery can be completed now' signal.",
       "priority": 64,
       "redact": [
         { "find": { "any": [ { "hasTextStartsWith": "Deliver to" }, { "hasTextStartsWith": "Heading to" } ] }, "keepPrefix": [ "Deliver to ", "Heading to " ] },
@@ -2713,7 +2714,17 @@
       "require": {
         "all": [
           { "exists": { "hasIdSuffix": "drop_off_workflow_host_fragment" } },
-          { "exists": { "hasTextContaining": "hand it to customer" } }
+          { "exists": { "hasTextContaining": "hand it to customer" } },
+          {
+            "exists": {
+              "any": [
+                { "hasText": "Continue" },
+                { "hasText": "Complete Delivery" },
+                { "hasText": "Mark as delivered" },
+                { "hasIdSuffix": "complete_delivery_steps_button" }
+              ]
+            }
+          }
         ]
       }
     },

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -744,7 +744,9 @@ class EffectMap @Inject constructor() {
                 add(logEffect(sessionId, AppEventType.DELIVERY_CONFIRMED, obs.timestamp, deliveryConfirmed))
             }
 
-            // Task phase changed — pickup → dropoff (pickup confirmed)
+            // Task phase changed — pickup → dropoff (pickup confirmed): the
+            // FIRST leg of a delivery. The stacked leg-2+ case (dropoff→dropoff /
+            // null→dropoff) is handled by the branch just below.
             if (prevTask?.phase == TaskPhase.PICKUP &&
                 nextTask?.phase == TaskPhase.DROPOFF
             ) {
@@ -753,13 +755,8 @@ class EffectMap @Inject constructor() {
                     storeName = prevTask.storeName ?: UNKNOWN_STORE,
                     confirmedAt = obs.timestamp,
                 )
-                val deliveryStart = deliveryPhasePayload(
-                    task = nextTask,
-                    phaseStartedAt = obs.timestamp,
-                )
                 add(logEffect(sessionId, AppEventType.PICKUP_CONFIRMED, obs.timestamp, pickupConfirmed))
-                add(logEffect(sessionId, AppEventType.DELIVERY_NAV_STARTED, obs.timestamp, deliveryStart))
-                add(AppEffect.ResumeOdometer)
+                addAll(deliveryNavStartedEffects(sessionId, nextTask, obs))
 
                 // #556: a completed SHOP pickup feeds the learned items/min. In-store time is
                 // measured arrived→confirmed (the 0.8/min seed basis); the handler floors out noise.
@@ -776,11 +773,27 @@ class EffectMap @Inject constructor() {
                         ),
                     )
                 }
+            }
 
-                // #568: store-flavored label ("Heading to H-E-B's customer") — friendlier than the
-                // raw 6-char hash and it disambiguates a multi-store stack's drops.
-                val customer = customerLabel(nextTask.storeName)
-                add(AppEffect.UpdateBubble("Heading to $customer", ChatPersona.Customer(customer), dedupeScope = nextTask.taskId))
+            // New dropoff leg — the active task became a DIFFERENT dropoff (#603).
+            // The pickup→dropoff branch above only mints DELIVERY_NAV_STARTED on
+            // the first leg; a stacked leg-2 (or later) drop arrives as
+            // dropoff→dropoff, or as null→dropoff once leg-1 has been
+            // grace-retired. Without this the second drop was silent — no nav
+            // event, no odometer resume, no "Heading to" bubble.
+            // Guards:
+            //  - a genuinely new task (taskId changed),
+            //  - that started on THIS frame (fresh mint AND placeholder-resolve
+            //    both stamp startedAt = obs.timestamp; a RESUMED task keeps its
+            //    old startedAt, so a replay/re-sight can't re-fire the nav),
+            //  - whose predecessor was NOT a pickup (the pickup→dropoff case is
+            //    already handled above — this keeps the two branches disjoint).
+            if (nextTask?.phase == TaskPhase.DROPOFF &&
+                nextTask.taskId != prevTask?.taskId &&
+                nextTask.startedAt == obs.timestamp &&
+                prevTask?.phase != TaskPhase.PICKUP
+            ) {
+                addAll(deliveryNavStartedEffects(sessionId, nextTask, obs))
             }
 
             // Arrival detection — task subflow changed to ARRIVED
@@ -857,6 +870,39 @@ class EffectMap @Inject constructor() {
                 add(AppEffect.ResumeOdometer)
             }
         }
+    }
+
+    /**
+     * The "delivery nav started" effect trio emitted when a NEW dropoff task
+     * becomes the active task: the DELIVERY_NAV_STARTED log event (phase clock
+     * stamped to this frame), the odometer resume, and the store-flavored
+     * "Heading to <customer>" bubble. Shared by the first-leg pickup→dropoff
+     * transition and the stacked leg-2 dropoff→dropoff / null→dropoff transition
+     * (#603) so a stacked drop gets the exact same driver-facing treatment as
+     * the first — one silent-second-drop bug, not two code paths that can drift.
+     *
+     * [task]'s storeName may be null on a leg-2 drop the dropoff screen didn't
+     * carry a store for; [customerLabel] then falls back to the generic
+     * recipient (never the hash). Leg-2 store re-attribution is #526's scope.
+     */
+    private fun deliveryNavStartedEffects(
+        sessionId: String?,
+        task: Task,
+        obs: Observation,
+    ): List<AppEffect> = buildList {
+        add(
+            logEffect(
+                sessionId,
+                AppEventType.DELIVERY_NAV_STARTED,
+                obs.timestamp,
+                deliveryPhasePayload(task = task, phaseStartedAt = obs.timestamp),
+            ),
+        )
+        add(AppEffect.ResumeOdometer)
+        // #568: store-flavored label ("Heading to H-E-B's customer") — friendlier
+        // than the raw 6-char hash, and it disambiguates a multi-store stack's drops.
+        val customer = customerLabel(task.storeName)
+        add(AppEffect.UpdateBubble("Heading to $customer", ChatPersona.Customer(customer), dedupeScope = task.taskId))
     }
 
     /**

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -95,6 +95,27 @@ was found **broken-in-part** (raw PII in capture envelopes) and moved to that en
   Accept): the race warning ("Decline already submitted — Accept won't take") should show at tap
   time (not "Accepting…"), then "Offer Declined" at resolution. Broken = an ack that never resolves
   into a matching outcome card, or any card text that doesn't match what the db logs for that offer.
+- **🔧 FIX SHIPPED — dropoff handoff waits for the completion CTA + stacked leg-2 drops get their own nav (#603). CONFIRM ON DASH.**
+  Two coupled fixes for the false-early "arrived" + silent second-drop pair:
+  (a) **No more false ARRIVED at the start of the drive.** `dropoff_handoff` used to fire
+  `task:dropoff:arrived` the instant nav started, because it keyed only on the "Hand it to
+  customer" instruction — which is on screen the ENTIRE drive. It now also requires the completion
+  CTA ("Mark as delivered" / "Continue" / "Complete Delivery" / the complete-delivery button), which
+  only shows once you're at the door. The en-route frame now recognizes as `dropoff_pre_arrival`
+  (correct nav card). **How to tell it works:** on a drop with a real drive, the arrival card /
+  `DELIVERY_ARRIVED` should appear only when you actually reach the customer, NOT the moment you
+  start driving. In `app_events` the drop's `arrivedAt` should be meaningfully later than its
+  `phaseStartedAt` (not the same second). Broken = the "arrived"/hand-off card popping up while
+  you're still driving, or `arrivedAt == phaseStartedAt`.
+  (b) **Leg-2 of a stack gets its own "Heading to" bubble.** A stacked multi-drop's second (and
+  later) dropoff previously got no nav event — no `DELIVERY_NAV_STARTED`, no odometer resume, no
+  bubble — because the mint only fired on pickup→dropoff, and leg-2 is dropoff→dropoff. **How to
+  tell it works:** on a stack with 2+ drops, after finishing drop 1 you should see a fresh "Heading
+  to …" bubble for drop 2 and a `DELIVERY_NAV_STARTED` row for it in `app_events` (and the odometer
+  resumes for that leg). Broken = the second drop starting silently with no bubble / no
+  `DELIVERY_NAV_STARTED`. (Note: leg-2's store label may read the generic "the customer" until #526
+  widens store re-attribution — that's expected, not a regression.)
+  - Confirmed: 0/2
 - **🔧 FIX SHIPPED — rule effects from notifications key per-arrival, not per-install (#604). CONFIRM ON DASH.**
   A rule-declared log effect attached to a notification with no `dedupeKey` (e.g.
   `doordash.notification.new_order`) built its `effects_fired` idempotency key from the rule id


### PR DESCRIPTION
Closes #603. Two coupled field-week defects. (a) `dropoff_handoff` keyed on "hand it to customer" — an instruction present the ENTIRE drive — so an en-route frame classified as ARRIVED (arrivedAt == phaseStartedAt on 2 of 3 drops 06-30). (b) A stacked leg-2 dropoff got no DELIVERY_NAV_STARTED / ResumeOdometer / "Heading to" bubble.

## Fix (opus build from a fable-vetted plan)
- **Recognition:** `dropoff_handoff`'s require gains the completion-CTA gate (`Continue`/`Complete Delivery`/`Mark as delivered`/`complete_delivery_steps_button`), copied verbatim from `dropoff_pre_arrival_completion` with a keep-in-sync comment. Corpus-grounded: ~20 June deliveries each pair an en-route frame (no CTA) with a true at-door frame (CTA). The real en-route frame now classifies **`dropoff_pre_arrival`** (priority 73) — better than UNKNOWN: correct nav card + customer still hashed.
- **State:** a new DROPOFF→DROPOFF / null→DROPOFF branch in diffTask fires the same trio as PICKUP→DROPOFF (extracted `deliveryNavStartedEffects` helper; RecordShopRate stays first-leg). Condition `nextTask.phase==DROPOFF && taskId≠prev && startedAt==obs.timestamp && prev.phase≠PICKUP` — covers a grace-retired leg-1 (null→DROPOFF), excludes the first leg (no double-emit) and a resumed drop (startedAt predates the frame).

## Tests
TriageRulesTest: CTA-present → dropoff_handoff; en-route (no CTA) → dropoff_pre_arrival (not UNKNOWN). EffectMapTest: leg-2 mints the trio; a resumed drop mints nothing. New redacted corpus fixture (the real 06-30 BJ's en-route frame, PII-scanned clean); approved-parse-output.json regenerated (one reviewed key). **Red-first proven** (3 fail against pre-fix). Full `:app`+`:core:state`+`:core:pipeline`+`:domain:test` green; goldens survive (the one committed handoff snapshot carries a CTA). Field-checklist item (0/2).

## Residual (tracked)
Leg-2 `storeName` stays null when unparsed → generic recipient label (that's #526's widened dropoff-store scope, not this fix).

### Design-goal review
5 (SSOT): the CTA predicate is copied from the sibling rule with a sync comment; the leg-2 trio reuses the first-leg helper — no divergent second emission path. 8: rule JSON + Flow/TaskPhase vocabulary, no platform literals in logic. 1 (UDF): stepper/diff stay pure.

### Adversarial review
Fable design-vet pre-build (the en-route-classifies-pre_arrival correction + the null→DROPOFF condition were vet amendments); fable post-build check follows before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)