### PR TITLE
fix(state): #605 — grace the screen-implied pause→online resume so a receipt-under-modal can't flap DASH_PAUSED

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,7 +178,7 @@ registry (`:domain`) consumes — see `docs/design/rule-capability-consent.md`.
 
 Observations reduce into `AppState(regions)` (`:domain`): **`FlowRegion`** (R0 — ground-truth
 screen interpretation; holds the pending offer), one **`PlatformRegion`** per platform
-(session/task lifecycle; unified grace via `pendingDestructive` — destructive commits are graced, incl. short authoritative windows for the dash summary AND the delivery receipt, and woken by `GRACE_COMMIT` timers, #431), and **`CrossPlatformRegion`**
+(session/task lifecycle; unified grace via `pendingDestructive` — destructive commits are graced, incl. short authoritative windows for the dash summary AND the delivery receipt, and woken by `GRACE_COMMIT` timers, #431 — plus a separate `pendingModeResume`/`MODE_RESUME_COMMIT` grace that debounces a screen-implied Paused→Online *resume* so a pause-sheet-over-receipt can't flap `DASH_PAUSED`, #605), and **`CrossPlatformRegion`**
 (derived aggregates). The steppers (`FlowRegionStepper`, `PlatformRegionStepper`,
 `CrossPlatformRegionStepper`) are pure and driven by `obs.timestamp` — never a wall clock — so
 crash recovery can replay observations over the last snapshot. `StateManagerV2` hosts the

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
@@ -672,6 +672,75 @@ class EffectMapTest {
     }
 
     // =========================================================================
+    // PAUSE-FLAP EDGE ELIMINATION (#605)
+    // =========================================================================
+
+    /**
+     * The 06-28 receipt: DoorDash's pause sheet is a modal on top of the just-completed
+     * delivery summary, so accessibility frames alternate `dash_paused` ↔
+     * `delivery_summary_collapsed` (modeHint online) for a few seconds. Before #605 each
+     * online→paused edge re-minted `DASH_PAUSED` + "Dash Paused!" and each paused→online edge
+     * fired a spurious "Session resumed (grace)" card while the dasher was still paused.
+     *
+     * Driven through the REAL state machine (the fix is edge-flap elimination in the stepper, so
+     * hand-built diff pairs can't exercise it): the whole flap must collapse to exactly ONE
+     * DASH_PAUSED, ONE "Dash Paused!", and ZERO resume cards.
+     */
+    @Test
+    fun `#605 the 06-28 pause-flap collapses to one DASH_PAUSED and no spurious resume card`() {
+        val machine = StateMachine(
+            flowStepper = FlowRegionStepper(),
+            platformStepper = PlatformRegionStepper(),
+            crossPlatformStepper = CrossPlatformRegionStepper(),
+            transitionPolicy = TransitionPolicy(),
+            effectMap = EffectMap(),
+        )
+        var state = AppState()
+        val all = mutableListOf<AppEffect>()
+        var ts = 1_000_000L
+        fun feed(obs: Observation) {
+            val t = machine.step(state, obs)
+            state = t.newState
+            all += t.effects
+        }
+        fun at() = (ts + 1000L).also { ts = it }
+
+        // A live delivery (online) right before the pause.
+        feed(screenObs(flow = Flow.OfferPresented, parsed = testOfferFields, timestamp = at()))
+        // The ONE real pause.
+        feed(screenObs(
+            modeHint = Mode.Paused,
+            parsed = ParsedFields.PausedFields(remainingText = "5:00", remainingMillis = 300_000),
+            timestamp = at(),
+        ))
+        // The flap — receipt (delivery_summary, online) ↔ pause, all inside the 8s grace.
+        repeat(2) {
+            feed(screenObs(
+                flow = Flow.PostTask, modeHint = Mode.Online,
+                parsed = ParsedFields.PostTaskFields(totalPay = 0.0), timestamp = at(),
+            ))
+            feed(screenObs(
+                modeHint = Mode.Paused,
+                parsed = ParsedFields.PausedFields(remainingText = "4:00", remainingMillis = 240_000),
+                timestamp = at(),
+            ))
+        }
+
+        assertEquals(
+            "exactly one DASH_PAUSED across the whole flap",
+            1, all.logEventTypes().count { it == AppEventType.DASH_PAUSED },
+        )
+        assertEquals(
+            "exactly one 'Dash Paused!' card",
+            1, all.count { it is AppEffect.UpdateBubble && it.text.contains("Dash Paused!") },
+        )
+        assertFalse(
+            "no spurious 'Session resumed (grace)' card while the pause sheet is up",
+            all.any { it is AppEffect.UpdateBubble && it.text.contains("resumed") },
+        )
+    }
+
+    // =========================================================================
     // TASK EFFECTS
     // =========================================================================
 

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/state/StateMachineTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/state/StateMachineTest.kt
@@ -21,6 +21,7 @@ import cloud.trotter.dashbuddy.domain.state.TaskPhase
 import cloud.trotter.dashbuddy.domain.state.TaskSubFlow
 import cloud.trotter.dashbuddy.domain.state.TransitionKind
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -752,6 +753,108 @@ class StateMachineTest {
         assertNotNull(result.session) // session preserved during grace
         assertNotNull(result.pendingDestructive)
         assertEquals(DestructiveKind.SESSION_END, result.pendingDestructive?.kind)
+    }
+
+    // =========================================================================
+    // PAUSE → ONLINE RESUME GRACE (#605)
+    // =========================================================================
+
+    private fun dd(state: AppState) = state.regions.platforms[Platform.DoorDash]!!
+
+    private fun pauseFrame(remainingText: String = "5:00", remainingMillis: Long = 300_000) = screenObs(
+        modeHint = Mode.Paused,
+        parsed = ParsedFields.PausedFields(remainingText = remainingText, remainingMillis = remainingMillis),
+    )
+
+    @Test
+    fun `#605 — screen-implied resume out of Paused is graced, a paused frame within grace cancels it`() {
+        var state = AppState()
+        // Online (a live delivery), then Paused.
+        state = machine.step(state, screenObs(flow = Flow.OfferPresented, parsed = offerFields())).newState
+        state = machine.step(state, pauseFrame()).newState
+        assertEquals(Mode.Paused, dd(state).mode)
+
+        // An online-implying receipt frame while Paused must NOT flip immediately — it arms the grace.
+        state = machine.step(state, screenObs(modeHint = Mode.Online)).newState
+        assertEquals("an online frame while Paused must not flip immediately", Mode.Paused, dd(state).mode)
+        assertNotNull("resume grace armed", dd(state).pendingModeResume)
+
+        // A Paused frame within the grace window CANCELS the pending — the modal is still up.
+        state = machine.step(state, pauseFrame(remainingText = "4:00", remainingMillis = 240_000)).newState
+        assertEquals(Mode.Paused, dd(state).mode)
+        assertNull("a paused frame cancels the resume grace", dd(state).pendingModeResume)
+    }
+
+    @Test
+    fun `#605 — sustained online past the grace commits the resume once via MODE_RESUME_COMMIT`() {
+        var state = AppState()
+        state = machine.step(state, screenObs(flow = Flow.OfferPresented, parsed = offerFields())).newState
+        val sessionId = dd(state).session!!.sessionId
+        state = machine.step(state, pauseFrame()).newState
+        assertEquals(Mode.Paused, dd(state).mode)
+
+        // Online frame arms the grace and schedules a MODE_RESUME_COMMIT wake timer (NOT GRACE_COMMIT).
+        val arm = machine.step(state, screenObs(modeHint = Mode.Online))
+        state = arm.newState
+        assertEquals(Mode.Paused, dd(state).mode)
+        val pend = dd(state).pendingModeResume!!
+        assertTrue("arm schedules a MODE_RESUME_COMMIT timer", arm.effects.any {
+            it is AppEffect.ScheduleTimeout && it.type == TimeoutType.MODE_RESUME_COMMIT
+        })
+        assertFalse("arm does NOT schedule a GRACE_COMMIT (would cross-cancel a destructive grace)", arm.effects.any {
+            it is AppEffect.ScheduleTimeout && it.type == TimeoutType.GRACE_COMMIT
+        })
+
+        // The wake timer fires past the deadline → lazy expiry commits the resume, exactly once.
+        val fire = machine.step(state, timeoutObs(
+            type = TimeoutType.MODE_RESUME_COMMIT,
+            timestamp = pend.deadline + 1,
+            targetPlatform = Platform.DoorDash,
+        ))
+        state = fire.newState
+        assertEquals("resume commits to Online", Mode.Online, dd(state).mode)
+        assertNull(dd(state).pendingModeResume)
+        assertEquals("same session resumes, not a new one", sessionId, dd(state).session!!.sessionId)
+        assertTrue("emits the resume card once", fire.effects.any {
+            it is AppEffect.UpdateBubble && it.text.contains("resumed")
+        })
+    }
+
+    @Test
+    fun `#605 — an OfferPresented screen commits the resume immediately (offer proves online)`() {
+        var state = AppState()
+        state = machine.step(state, screenObs(flow = Flow.OfferPresented, parsed = offerFields())).newState
+        state = machine.step(state, pauseFrame()).newState
+        assertEquals(Mode.Paused, dd(state).mode)
+
+        // A fresh offer while Paused is authoritative online evidence — flip immediately, no grace.
+        state = machine.step(state, screenObs(
+            flow = Flow.OfferPresented, parsed = offerFields(hash = "hash-2"),
+        )).newState
+        assertEquals("an offer while Paused flips immediately", Mode.Online, dd(state).mode)
+        assertNull("no lingering resume grace after an instant commit", dd(state).pendingModeResume)
+    }
+
+    @Test
+    fun `#605 — the pause safety timeout out of a graced Paused clears the pending resume`() {
+        val stepper = PlatformRegionStepper()
+        val policy = TransitionPolicy()
+        val pausedRegion = PlatformRegion(
+            platform = Platform.DoorDash,
+            mode = Mode.Paused,
+            session = cloud.trotter.dashbuddy.domain.state.Session("sess-1", startedAt = 100L),
+            // Grace still un-expired at the timeout instant (deadline in the future) so the
+            // safety-timeout path — not lazy expiry — resolves the pending.
+            pendingModeResume = cloud.trotter.dashbuddy.domain.state.PendingModeResume(since = 4_000L, deadline = 12_000L),
+        )
+        val flow = FlowRegion(flow = Flow.Idle)
+        val result = stepper.step(
+            pausedRegion, flow, flow,
+            timeoutObs(type = TimeoutType.SESSION_PAUSED_SAFETY, timestamp = 5_000L),
+            policy,
+        )
+        assertEquals(Mode.Offline, result.mode)
+        assertNull("a committed transition out of Paused clears the resume grace", result.pendingModeResume)
     }
 
     // =========================================================================

--- a/app/src/test/java/cloud/trotter/dashbuddy/test/util/SessionReplay.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/test/util/SessionReplay.kt
@@ -232,6 +232,11 @@ object SessionReplay {
     fun graceCommit(atMs: Long, platform: Platform = Platform.DoorDash): TimeoutInput =
         TimeoutInput(TimeoutType.GRACE_COMMIT, platform, atMs)
 
+    /** A `MODE_RESUME_COMMIT` timeout scoped to [platform], at [atMs] (#605) — must be strictly
+     *  greater than the armed resume-grace deadline so lazy expiry commits the Paused→Online resume. */
+    fun modeResumeCommit(atMs: Long, platform: Platform = Platform.DoorDash): TimeoutInput =
+        TimeoutInput(TimeoutType.MODE_RESUME_COMMIT, platform, atMs)
+
     /**
      * Level B, heterogeneous — fold a timestamp-ordered mix of real screen/click captures and
      * synthetic click/timeout observations through the REAL [StateMachine]. ONE classifier instance

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -347,6 +347,7 @@ class EffectMap @Inject constructor() {
         return buildList {
             addAll(diffMode(p, next, obs))
             addAll(diffGraceTimer(p, next, obs))
+            addAll(diffModeResumeTimer(p, next, obs))
             addAll(diffTask(p, next, prevFlow, nextFlow, obs))
             addAll(diffPostTask(p, next, nextFlow, obs))
             addAll(diffNotification(obs))
@@ -680,6 +681,38 @@ class EffectMap @Inject constructor() {
                 )
             prevPend != null && nextPend == null ->
                 listOf(AppEffect.CancelTimeout(TimeoutType.GRACE_COMMIT))
+            else -> emptyList()
+        }
+    }
+
+    /**
+     * Schedule/cancel the wake-up timer for a graced screen-implied resume out of
+     * Paused (#605) — the [PlatformRegion.pendingModeResume] mirror of
+     * [diffGraceTimer]. A SEPARATE [TimeoutType.MODE_RESUME_COMMIT] (not a shared
+     * GRACE_COMMIT) because SideEffectEngine.activeTimers is keyed by TimeoutType
+     * alone: a resume-grace GRACE_COMMIT would cross-cancel a live destructive grace
+     * timer. Arm (or a re-arm with a new deadline) schedules; a cancel (paused frame
+     * within the window, or the resume committing) cancels. A commit lands in the
+     * cancel branch too — harmless, the timer has already fired or no-ops.
+     */
+    private fun diffModeResumeTimer(
+        prev: PlatformRegion,
+        next: PlatformRegion,
+        obs: Observation,
+    ): List<AppEffect> {
+        val prevPend = prev.pendingModeResume
+        val nextPend = next.pendingModeResume
+        return when {
+            nextPend != null && (prevPend == null || prevPend.deadline != nextPend.deadline) ->
+                listOf(
+                    AppEffect.ScheduleTimeout(
+                        durationMs = (nextPend.deadline - obs.timestamp).coerceAtLeast(1L),
+                        type = TimeoutType.MODE_RESUME_COMMIT,
+                        platform = next.platform,
+                    ),
+                )
+            prevPend != null && nextPend == null ->
+                listOf(AppEffect.CancelTimeout(TimeoutType.MODE_RESUME_COMMIT))
             else -> emptyList()
         }
     }

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
@@ -11,6 +11,7 @@ import cloud.trotter.dashbuddy.domain.state.Job
 import cloud.trotter.dashbuddy.domain.state.Mode
 import cloud.trotter.dashbuddy.domain.state.ParsedFields
 import cloud.trotter.dashbuddy.domain.state.PendingDestructive
+import cloud.trotter.dashbuddy.domain.state.PendingModeResume
 import cloud.trotter.dashbuddy.domain.state.PlatformRegion
 import cloud.trotter.dashbuddy.domain.state.Session
 import cloud.trotter.dashbuddy.domain.state.SessionType
@@ -177,6 +178,20 @@ class PlatformRegionStepper @Inject constructor() {
             }
         }
 
+        // #605: lazy expiry of a graced screen-implied resume out of Paused. A
+        // sustained online past the deadline (no intervening paused frame cancelled
+        // it) commits the resume once — flip Paused→Online. Runs BEFORE the timeout
+        // branch so the MODE_RESUME_COMMIT wake timer (a non-flow observation) can
+        // commit an overdue resume, exactly like the destructive lazy expiry above.
+        // Driven by obs.timestamp (never a wall clock) so crash-recovery replay
+        // matches. Independent of pendingDestructive: during the field flap that slot
+        // is BUSY holding the just-completed delivery's TASK_RETIRE grace.
+        current.pendingModeResume?.let { pend ->
+            if (obs.timestamp > pend.deadline) {
+                current = commitModeResume(current, obs, policy)
+            }
+        }
+
         // Handle timeout-driven transitions
         if (obs is Observation.Timeout) return handleTimeout(current, obs, policy)
 
@@ -203,14 +218,39 @@ class PlatformRegionStepper @Inject constructor() {
             // No mode signal
             impliedMode == null -> current.copy(lastObservedAt = obs.timestamp)
 
-            // Same mode — confirmed
+            // Same mode — confirmed. A Paused-implying frame also CANCELS any armed
+            // resume grace (#605): the modal is still up, the online flap was noise.
             impliedMode == current.mode -> current.copy(
                 lastObservedAt = obs.timestamp,
                 lastTransitionKind = TransitionKind.Confirmed,
+                pendingModeResume = if (impliedMode == Mode.Paused) null else current.pendingModeResume,
             )
 
             // Click — records user intent, does NOT drive mode
             flowObs is Observation.Click -> current.copy(lastObservedAt = obs.timestamp)
+
+            // #605: a screen-implied resume OUT of Paused is GRACED, not immediate.
+            // DoorDash's pause sheet sits on the just-completed delivery summary, so
+            // frames flap paused ↔ online; flipping on the first online frame re-mints
+            // DASH_PAUSED and a spurious resume card on every edge. Arm a short pending
+            // (keeping the original `since` so repeated online frames don't push the
+            // deadline out) and STAY Paused: a paused frame cancels it (above), sustained
+            // online past the deadline commits it (lazy expiry / MODE_RESUME_COMMIT timer),
+            // and an OfferPresented screen — authoritative online evidence, structurally
+            // absent from the flap — commits immediately (excluded here → falls to the
+            // authoritative else). Screen-only: notifications carry no mode hints (verified),
+            // and keeping the grace to the screen channel matches the observed defect.
+            current.mode == Mode.Paused && impliedMode == Mode.Online &&
+                obs is Observation.Screen && flowObs.flow != Flow.OfferPresented -> {
+                val since = current.pendingModeResume?.since ?: obs.timestamp
+                current.copy(
+                    lastObservedAt = obs.timestamp,
+                    pendingModeResume = PendingModeResume(
+                        since = since,
+                        deadline = since + policy.pauseResumeGraceMs,
+                    ),
+                )
+            }
 
             // Screen or Notification — authoritative, apply immediately
             else -> {
@@ -297,8 +337,30 @@ class PlatformRegionStepper @Inject constructor() {
             }
         }
 
+        // #605: any COMMITTED mode transition out of Paused resolves a graced
+        // screen-implied resume — clear the pending. Covers all three exits: a
+        // sustained-online commit (Paused→Online), an instant OfferPresented commit
+        // (Paused→Online), and the pause-safety timeout (Paused→Offline).
+        if (prev.mode == Mode.Paused && newMode != Mode.Paused) {
+            region = region.copy(pendingModeResume = null)
+        }
+
         return region
     }
+
+    /**
+     * Commit a graced screen-implied resume out of [Mode.Paused] (#605) — the grace
+     * lapsed sustained-online (lazy expiry / `MODE_RESUME_COMMIT` wake timer) or an
+     * `OfferPresented` screen proved online. Mirrors [applyModeTransition]'s
+     * Paused→Online path (same-session grace-resume vs. fresh-session logic); that
+     * function also nulls [PendingModeResume] on any transition out of Paused.
+     */
+    private fun commitModeResume(
+        region: PlatformRegion,
+        obs: Observation,
+        policy: TransitionPolicy,
+    ): PlatformRegion =
+        applyModeTransition(region, Mode.Online, obs, TransitionKind.Expected, policy)
 
     /**
      * When an unexpected transition fires (e.g., app launched mid-pickup),

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/TransitionPolicy.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/TransitionPolicy.kt
@@ -29,11 +29,23 @@ class TransitionPolicy @Inject constructor() {
          * short enough that real session ends commit promptly.
          */
         const val AUTHORITATIVE_GRACE_MS = 2_500L
+
+        /**
+         * Grace for a screen-implied resume out of [Mode.Paused] (#605). Must
+         * exceed the observed ~4.3s under-modal receipt-flap window with margin
+         * (DoorDash's pause sheet sits on the just-completed delivery summary,
+         * so frames flap paused ↔ online) yet stay short enough that a real
+         * resume's card/log lands promptly — the resume is not glance-critical,
+         * so a ≤8s lag after the dasher taps Resume is acceptable.
+         */
+        const val PAUSE_RESUME_GRACE_MS = 8_000L
     }
 
     val gracePeriodMs: Long = DEFAULT_GRACE_MS
 
     val authoritativeGraceMs: Long = AUTHORITATIVE_GRACE_MS
+
+    val pauseResumeGraceMs: Long = PAUSE_RESUME_GRACE_MS
 
     /**
      * Determine what mode a flow + modeHint combination implies.

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/SerializationRoundTripTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/SerializationRoundTripTest.kt
@@ -16,6 +16,7 @@ import cloud.trotter.dashbuddy.domain.state.Job
 import cloud.trotter.dashbuddy.domain.state.Mode
 import cloud.trotter.dashbuddy.domain.state.ParsedFields
 import cloud.trotter.dashbuddy.domain.state.PendingDestructive
+import cloud.trotter.dashbuddy.domain.state.PendingModeResume
 import cloud.trotter.dashbuddy.domain.state.PendingOffer
 import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.domain.state.PlatformRegion
@@ -152,6 +153,7 @@ class SerializationRoundTripTest {
                         pendingDestructive = PendingDestructive(
                             DestructiveKind.TASK_RETIRE, since = 800L, deadline = 1_000L,
                         ),
+                        pendingModeResume = PendingModeResume(since = 700L, deadline = 8_700L),
                         ratings = RatingsSnapshot(customerRating = 4.97, capturedAt = 900L),
                         lastPostTaskFields = ParsedFields.PostTaskFields(totalPay = 9.75),
                         mintCounter = 3L,

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -116,6 +116,20 @@ was found **broken-in-part** (raw PII in capture envelopes) and moved to that en
   `DELIVERY_NAV_STARTED`. (Note: leg-2's store label may read the generic "the customer" until #526
   widens store re-attribution — that's expected, not a regression.)
   - Confirmed: 0/2
+- **🔧 FIX SHIPPED — pausing during/after a delivery shows exactly one "Dash Paused!", no phantom "resumed" flap (#605). CONFIRM ON DASH.**
+  DoorDash's pause sheet is a modal on top of the just-completed delivery summary, so accessibility
+  frames alternate `dash_paused` (paused) ↔ `delivery_summary_collapsed` (online) for a few seconds.
+  Before #605 the state machine flipped mode on every edge — re-minting `DASH_PAUSED` + "Dash Paused!"
+  on each online→paused and firing a spurious "Session resumed (grace)" card on each paused→online,
+  while the dasher was still paused (06-28 15:04:32–38 receipt). Now a screen-implied resume OUT of
+  Paused is **graced** (8 s): an online frame while paused arms a pending resume instead of flipping;
+  a paused frame within the window cancels it; only sustained online past the grace (or an incoming
+  offer) actually commits the resume. **Confirm on dash: 0/2 —** pause once during/right after a
+  delivery and watch the bubble/notification stream: it should show **exactly one** "Dash Paused!"
+  and **no** "Session resumed (grace)" card while the pause sheet is still up. Then tap **Resume** for
+  real — the resume should surface within ~8 s (a known ≤8 s lag; if it feels too slow on-dash, the
+  follow-up is wiring the `resume_dash` click to commit instantly). Broken = two or more "Dash Paused!"
+  in a row, or a "resumed" card appearing while you're still paused.
 - **🔧 FIX SHIPPED — rule effects from notifications key per-arrival, not per-install (#604). CONFIRM ON DASH.**
   A rule-declared log effect attached to a notification with no `dedupeKey` (e.g.
   `doordash.notification.new_order`) built its `effects_fired` idempotency key from the rule id

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/Observation.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/Observation.kt
@@ -163,4 +163,15 @@ enum class TimeoutType {
      * expiry (which runs before timeout handling) performs the commit.
      */
     GRACE_COMMIT,
+
+    /**
+     * Wakes the state machine when a `PendingModeResume` grace deadline lapses
+     * (#605), committing a graced screen-implied resume out of [Mode.Paused].
+     * Like [GRACE_COMMIT] it carries no handler logic — the stepper's lazy
+     * expiry performs the mode flip. A SEPARATE type (not [GRACE_COMMIT] reuse)
+     * is REQUIRED because `SideEffectEngine.activeTimers` is keyed by
+     * [TimeoutType] alone: sharing [GRACE_COMMIT] would cross-cancel a live
+     * `TASK_RETIRE`/`SESSION_END` grace timer (re-opening #431).
+     */
+    MODE_RESUME_COMMIT,
 }

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/PlatformRegion.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/PlatformRegion.kt
@@ -63,6 +63,39 @@ data class PlatformRegion(
      * starts (its taskId differs from this stored value).
      */
     val lastAnnouncedPostTaskTaskId: String? = null,
+    /**
+     * A graced screen-implied resume out of [Mode.Paused] (#605), provisional
+     * until committed. See [PendingModeResume]. Default-null so existing
+     * snapshots deserialize unchanged. Distinct from [pendingDestructive]
+     * because during the field flap that pending is BUSY holding the
+     * just-completed delivery's `TASK_RETIRE` grace — the two slots cannot share.
+     */
+    val pendingModeResume: PendingModeResume? = null,
+)
+
+/**
+ * A provisional screen-implied resume out of [Mode.Paused], pending confirmation
+ * (#605). DoorDash's pause sheet is a `BottomSheetModal` on top of the just-
+ * completed delivery summary, so accessibility frames alternate paused ↔ online;
+ * flipping mode on the first online frame re-mints `DASH_PAUSED` and a spurious
+ * "resumed" card on every edge. Instead, an online-implying **Screen** while
+ * Paused arms this pending and stays Paused: a Paused-implying frame inside the
+ * window CANCELS it (the modal is still up — the 06-28 case, receipt visible
+ * ~4.3s < grace), sustained online past [deadline] COMMITS the resume once (lazy
+ * expiry + a `MODE_RESUME_COMMIT` wake timer), and an `OfferPresented` screen
+ * commits immediately (an offer is authoritative online evidence, structurally
+ * absent from the flap).
+ *
+ * Plain data (kotlinx-serializable) so it survives crash-recovery replay;
+ * resolution is driven by `obs.timestamp`, never a wall clock, keeping the
+ * reducer pure.
+ */
+@Serializable
+data class PendingModeResume(
+    /** The obs.timestamp of the first online frame that armed it. */
+    val since: Long,
+    /** Once an observation's timestamp passes this, the resume is committed. */
+    val deadline: Long,
 )
 
 /**


### PR DESCRIPTION
Closes #605. DoorDash's pause sheet is a BottomSheetModal on top of the just-completed delivery summary, so accessibility frames alternate `dash_paused` (paused) ↔ `delivery_summary_collapsed` (online). The stepper applied each screen-implied mode change immediately → Paused→Online→Paused within ~6s (field: 06-28 seq 119/121, two "Dash Paused!" cards + a spurious "Session resumed (grace)"). The countdown re-parse theory the issue filed is REFUTED — it's a modal-window mode flap.

## Fix (opus build from a fable-vetted plan; the vet adjudicated all 3 design questions)
The resume EDGE is the defect, so it's graced — pure edge-flap elimination in the stepper; EffectMap's pause/resume emission blocks are untouched.
- While `mode == Paused`, an online-implying SCREEN frame does NOT flip immediately — it arms `PendingModeResume(since, deadline = since + 8s)`. A paused-implying frame within the window cancels it (the modal is still up); sustained-online past the deadline commits once via lazy expiry + a wake timer.
- **New `TimeoutType.MODE_RESUME_COMMIT`** — NOT GRACE_COMMIT reuse: `SideEffectEngine.activeTimers` is keyed by TimeoutType alone, so sharing it would cross-cancel the live TASK_RETIRE grace timer (re-opening #431). Separate type, separate `diffGraceTimer` mirror.
- **Instant-commit on `Flow.OfferPresented` screens** (offers are authoritative online evidence, structurally absent from the flap); everything else graces.
- `pendingModeResume` clears on ANY commit out of Paused (incl. SESSION_PAUSED_SAFETY→Offline). `pauseResumeGraceMs = 8_000` on TransitionPolicy. Pausing stays IMMEDIATE (only resuming is graced).

Result: the 06-28 sequence → exactly ONE DASH_PAUSED, ONE "Dash Paused!", ZERO resume cards, ZERO timer churn.

## Tests
StateMachineTest #605 section (flap stays Paused; sustained-online commits once via MODE_RESUME_COMMIT not GRACE_COMMIT; OfferPresented instant-commit; safety-timeout clears the pending) + EffectMapTest (the 06-28 shape through a real StateMachine → one pause, no resume card) + SerializationRoundTrip (new field). **Red-first proven.** StateMachineTest:372 (pausing immediate) stays green; the #431/#518/#596 grace+job suites all stay green (new type doesn't perturb activeTimers keying). Field-checklist item (0/2).

## Deviations (reported)
No replay fixture session — the dedup layer eats repeated `dash_paused` frames, so a faithful chronological pair isn't reliably captured; the full-machine EffectMapTest covers the emergent behavior. The `resume_dash` click rule isn't wired (it fires before any pending is armed) — the ≤8s lag is a field-checklist follow-up.

### Design-goal review
1 (UDF): stepper stays pure, `obs.timestamp`-driven (the grace deadline is event-time). 4: new field is @Serializable default-null (snapshot-compat); new TimeoutType is enumerated vocabulary. 5: the resume grace mirrors the existing pendingDestructive grace pattern rather than a parallel mechanism. 8: no platform literals.

### Adversarial review
Fable design-vet pre-build adjudicated the field/timer-type/instant-commit questions; fable post-build check follows before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)