### PR TITLE
fix: FrameGate mixes content hash into notification identity dedup (#619)

### DIFF
--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/FrameGate.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/FrameGate.kt
@@ -31,22 +31,54 @@ internal class FrameGate(
     private var lastIdentity: ObservationIdentity? = null
 
     /**
+     * Content hash of the last admitted *notification* sharing [lastIdentity]
+     * (#619). Only ever set/read for [Observation.Notification] — screens
+     * never touch it, so their dedup stays pure-identity.
+     */
+    private var lastNotificationContentHash: Int? = null
+
+    /**
      * @param contentHash content-bearing hash for UNKNOWN frames (null = no
      *   content available; the frame is then admitted — never silently lose a
-     *   triage-able capture for want of a hash).
+     *   triage-able capture for want of a hash) AND, for a recognized
+     *   notification, the identity-dedup content discriminator (#619, see
+     *   [mixNotificationContent]).
+     * @param mixNotificationContent (#619) Parse-less notification rules
+     *   (e.g. `new_order`) have a CONSTANT [ObservationIdentity] — target +
+     *   `fieldsHash` (a hash of always-null fields) + modeHint never change —
+     *   so two observably-distinct arrivals back-to-back (e.g. two
+     *   different-store `new_order` pushes with nothing recognized between)
+     *   collapsed into one at this layer. When true (the default) and [obs]
+     *   is an [Observation.Notification], [contentHash] is mixed into the
+     *   identity comparison so a distinct content hash still admits even
+     *   when the identity is unchanged; an identical repost (same
+     *   [contentHash]) still dedups. Screens are NEVER mixed — their
+     *   identity is already content-bearing via the tree `stableHash` path
+     *   upstream, so pure-identity dedup is unchanged for them. Callers can
+     *   pass false to opt a specific notification out entirely (e.g. an
+     *   ongoing heartbeat notification whose body may churn on every
+     *   repost, where mixing would turn a benign repost into per-repost
+     *   spam) — it then keeps the old pure-identity dedup.
      * @return true if the frame should be captured (and, for known targets,
      *   forwarded onward).
      */
-    fun admit(obs: Observation, contentHash: Int?): Boolean {
+    fun admit(obs: Observation, contentHash: Int?, mixNotificationContent: Boolean = true): Boolean {
         // Null identity = never dedup (#366: clicks). It still CLEARS
         // lastIdentity below, preserving the old behavior where a click's
         // unique hash reset screen dedup (same screen re-forwards after it).
         val identity = obs.identity()
-        if (identity != null && identity == lastIdentity) return false
+        val isMixableNotification = mixNotificationContent && obs is Observation.Notification
+        if (identity != null && identity == lastIdentity) {
+            val contentChanged = isMixableNotification &&
+                contentHash != null &&
+                contentHash != lastNotificationContentHash
+            if (!contentChanged) return false
+        }
 
         val target = (obs as? Observation.FlowObservation)?.target
         if (target != UNKNOWN_TARGET) {
             lastIdentity = identity
+            lastNotificationContentHash = if (isMixableNotification) contentHash else null
             return true
         }
         if (contentHash == null) return true

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/notification/NotificationPipeline.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/notification/NotificationPipeline.kt
@@ -73,10 +73,20 @@ class NotificationPipeline @Inject constructor(
             if (!allowed) stats.onDisabledPlatformDrop()
             allowed
         }
-        // Dedup + Capture: known notifications dedup by identity; UNKNOWN by
-        // content hash in a rolling seen-set (#360).
+        // Dedup + Capture: known notifications dedup by identity, mixed with
+        // content hash so two distinct arrivals sharing a parse-less rule's
+        // constant identity aren't collapsed into one (#619); UNKNOWN by
+        // content hash in a rolling seen-set (#360). `isOngoing` notifications
+        // (e.g. `dash_status_ongoing`, the persistent "still dashing" status
+        // heartbeat) opt OUT of content-mixing (#619 V3 precaution): it
+        // reposts constantly and whether its body churns per repost (e.g. a
+        // live counter) is unconfirmed against real captures — mixing there
+        // could turn a benign repost into per-repost NOTIFICATION_RECEIVED
+        // spam, so it keeps the old pure-identity dedup instead. This does
+        // NOT affect UNKNOWN suppression, which always reads `raw.contentHash`
+        // directly regardless of `isOngoing`.
         .mapNotNull { (obs, raw) ->
-            if (!frameGate.admit(obs, raw.contentHash)) {
+            if (!frameGate.admit(obs, raw.contentHash, mixNotificationContent = !raw.isOngoing)) {
                 stats.onDuplicateSuppressed()
                 return@mapNotNull null
             }

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/FrameGateTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/FrameGateTest.kt
@@ -33,6 +33,66 @@ class FrameGateTest {
     private fun unknown(t: Long = 1_000L) =
         screen(target = "UNKNOWN", ruleId = null, t = t)
 
+    private fun notification(target: String, ruleId: String? = "doordash.notification.$target", t: Long = 1_000L) =
+        Observation.Notification(
+            timestamp = t,
+            captureId = null,
+            ruleId = ruleId,
+            metadata = ReplayMetadata.EMPTY,
+            flow = Flow.Idle,
+            modeHint = Mode.Online,
+            parsed = ParsedFields.None,
+            target = target,
+        )
+
+    // #619: parse-less notification rules (e.g. `new_order`) have a CONSTANT
+    // identity (target + fieldsHash(null fields) + modeHint never change), so
+    // two observably-distinct arrivals back-to-back collapsed into one at the
+    // identity-dedup layer. FrameGate now mixes the notification content hash
+    // into the comparison — but ONLY for notifications (V1), never screens
+    // (V2), and callers can opt a specific notification out of the mixing
+    // entirely (V3, e.g. an ongoing heartbeat notification whose body may
+    // churn per repost).
+
+    @Test
+    fun `recognized notifications with same identity but different content BOTH admit (#619 fix)`() {
+        val gate = FrameGate()
+        assertTrue(gate.admit(notification("new_order"), contentHash = 111))
+        assertTrue(gate.admit(notification("new_order"), contentHash = 222))
+    }
+
+    @Test
+    fun `recognized notifications with same identity and same content still dedup (re-render preserved)`() {
+        val gate = FrameGate()
+        assertTrue(gate.admit(notification("new_order"), contentHash = 111))
+        assertFalse(gate.admit(notification("new_order"), contentHash = 111))
+    }
+
+    @Test
+    fun `a notification with no content hash falls back to pure identity dedup`() {
+        val gate = FrameGate()
+        assertTrue(gate.admit(notification("new_order"), contentHash = null))
+        assertFalse(gate.admit(notification("new_order"), contentHash = null))
+    }
+
+    @Test
+    fun `V2 - recognized SCREEN with same identity but different content STILL dedups (screens unaffected)`() {
+        val gate = FrameGate()
+        assertTrue(gate.admit(screen("main_map_idle"), contentHash = 111))
+        assertFalse(gate.admit(screen("main_map_idle"), contentHash = 222))
+    }
+
+    @Test
+    fun `V3 - a notification opted out of content-mixing keeps pure identity dedup, e-g an ongoing heartbeat`() {
+        val gate = FrameGate()
+        assertTrue(
+            gate.admit(notification("dash_status_ongoing"), contentHash = 111, mixNotificationContent = false),
+        )
+        assertFalse(
+            gate.admit(notification("dash_status_ongoing"), contentHash = 222, mixNotificationContent = false),
+        )
+    }
+
     @Test
     fun `identical UNKNOWN frames capture exactly once`() {
         val gate = FrameGate()

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -130,7 +130,9 @@ was found **broken-in-part** (raw PII in capture envelopes) and moved to that en
   real — the resume should surface within ~8 s (a known ≤8 s lag; if it feels too slow on-dash, the
   follow-up is wiring the `resume_dash` click to commit instantly). Broken = two or more "Dash Paused!"
   in a row, or a "resumed" card appearing while you're still paused.
-- **🔧 FIX SHIPPED — rule effects from notifications key per-arrival, not per-install (#604). CONFIRM ON DASH.**
+- **🔧 FIX SHIPPED — rule effects from notifications key per-arrival, not per-install (#604), AND
+  FrameGate no longer collapses two distinct notification arrivals sharing a contentless identity
+  (#619). CONFIRM ON DASH.**
   A rule-declared log effect attached to a notification with no `dedupeKey` (e.g.
   `doordash.notification.new_order`) built its `effects_fired` idempotency key from the rule id
   alone — a GLOBAL forever-key. The first `new_order` notification of the week fired it; every
@@ -139,15 +141,27 @@ was found **broken-in-part** (raw PII in capture envelopes) and moved to that en
   The key now includes the notification's own timestamp (postTime, replay-stable), so each
   distinct arrival gets its own key; an identical repost (same postTime) still dedups correctly.
   Screen-effect dedup is unchanged (intended cross-frame behavior, e.g. `offer-ss-{parsedHash}`).
-  **KNOWN SECOND LAYER (not fixed by #604 — see the FrameGate contentless-identity follow-up):**
-  the pipeline's identity dedup can still suppress a CONSECUTIVE `new_order` arrival upstream
-  (the rule has no parse, so its notification identity is contentless with no TTL) — that
-  suppression is a FrameGate duplicate, NOT a "Skipping already-fired effect".
-  **Confirm on dash: 0/2 —** a valid probe needs some OTHER recognized notification between the
-  two `new_order` arrivals (routine in a real dash). Check `app_events` for a
-  `NOTIFICATION_RECEIVED`/`NEW_ORDER` log for each such arrival. Broken = a later arrival
-  missing **and** a "Skipping already-fired effect" line for it; missing with no skip-line is
-  the FrameGate layer (follow-up issue), not a #604 regression.
+  **SECOND LAYER — NOW ALSO FIXED (#619):** parse-less notification rules (e.g. `new_order`) have
+  a CONSTANT `ObservationIdentity` (no parsed fields to hash), so the pipeline's identity-dedup
+  layer (`FrameGate`) could still suppress a CONSECUTIVE `new_order` arrival even with #604's
+  per-arrival effect key fixed. `FrameGate` now mixes the notification's content hash into the
+  identity comparison for recognized notifications ONLY (screens are unaffected — pinned by a new
+  test); two observably-distinct arrivals (different store/text) both admit, while an identical
+  repost (same content) still dedups. **Accepted residual (documented, not a bug):** two
+  same-store distinct offers back-to-back have identical notification text, hence identical
+  content hash, and still dedup — the only full separator would be `postTime`, which risks turning
+  every re-render/repost into a fresh forward, so it was deliberately not used. **Precaution:** the
+  `dash_status_ongoing` "still dashing" heartbeat notification (reposts constantly; whether its
+  body churns per repost is unconfirmed against real captures) is excluded from content-mixing at
+  the call site and keeps the old pure-identity dedup, so it can't regress into per-repost spam.
+  **Confirm on dash: 0/2 —** two **different-store** `new_order` notifications in one dash with
+  **nothing recognized in between** (previously required something else between them to prove
+  #604 alone) should now BOTH produce a `NOTIFICATION_RECEIVED`/`NEW_ORDER` row in `app_events`.
+  Also watch that the `dash_status_ongoing` heartbeat does NOT spam `NOTIFICATION_RECEIVED` rows
+  once per repost. Broken = a later distinct-store arrival missing from `app_events` with no
+  "Skipping already-fired effect" line for it (a FrameGate regression), or a flood of
+  `DASH_STATUS_ONGOING` log rows (the precaution failed to hold).
+  - Confirmed: 0/2
 - **🔧 FIX SHIPPED — one DashSummary screenshot per session end, and offer screenshots are named
   with real pay (#606). CONFIRM ON DASH.** Two independent owners were both saving a
   "DashSummary - \<earnings\>" screenshot at session end: the `dash_summary` rule effect


### PR DESCRIPTION
## What changed + why

Fixes #619: **FrameGate's identity-dedup layer could suppress a consecutive, observably-distinct notification arrival.**

Parse-less notification rules (e.g. `doordash.notification.new_order`) have a **CONSTANT** `ObservationIdentity` — it's built from `target` + `fieldsHash(parsed fields)` + `modeHint`, and a rule with no `parse` block always hashes the same (null) fields. So two genuinely different arrivals sharing that rule (e.g. two different-store `new_order` pushes back-to-back with nothing else recognized between them) produced identical identities and the second was silently dropped by `FrameGate.admit`'s pure-identity dedup — upstream of, and independent from, #604's per-arrival `effects_fired` key fix (which only stops a *fired* notification's rule effect from no-opping; it can't forward an arrival FrameGate never let through in the first place).

`FrameGate.admit` now mixes the notification's content hash into the identity comparison, but **only** for `Observation.Notification` — an identity match plus a *different* content hash still admits; an identity match plus the *same* content hash (a genuine re-render/repost) still dedups as before.

- `core/pipeline/.../FrameGate.kt` — new `mixNotificationContent: Boolean = true` parameter on `admit()`; a `lastNotificationContentHash` slot tracked only for notifications. Screens are gated out by an explicit `obs is Observation.Notification` check, not by contentHash nullability (a screen's `contentHash` is non-null too — the tree `stableHash` — so gating on nullability alone would have silently changed screen dedup).
- `core/pipeline/.../NotificationPipeline.kt` — call site passes `mixNotificationContent = !raw.isOngoing` (see precaution below). UNKNOWN suppression is untouched — it still reads `raw.contentHash` directly at the FrameGate's UNKNOWN branch, regardless of `isOngoing`.
- `core/pipeline/.../FrameGateTest.kt` — 5 new cases (RED-first): same identity + different content → both admit (the fix); same identity + same content → still dedups (repost dedup preserved); no content hash → falls back to pure identity dedup; a recognized **screen** with same identity + different content → **still dedups** (proves screens are unaffected by the notification-only gate); a notification with `mixNotificationContent = false` → pure identity dedup regardless of content (the precaution below).

## Security / privacy posture (Principle 7)

Dedup-only change — no new log sites, no new persisted/uploaded data, no PII touched. The mixed-in value is a hash (`RawNotificationData.contentHash`, already computed and already passed into `FrameGate.admit` today for UNKNOWN suppression); nothing new is logged or captured, and no raw notification text is added to any INFO+ log line or effect payload. The change only decides whether an already-classified, already-redaction-covered observation is forwarded once or twice.

## Accepted residual (V4 — documented, not fixed)

Two **same-store** distinct offers back-to-back produce identical notification text (title/body have no per-offer distinguishing content beyond store name), hence identical content hash, and **still dedup**. This is "observably identical arrivals" — there's no content-level way to tell them apart. The only full separator would be `postTime`/`obs.timestamp`, which is deliberately **not** folded in here: #604 already uses `postTime` at the `effects_fired` layer for per-arrival idempotency, and folding it into FrameGate's identity dedup too would mean *any* repost at a new `postTime` forwards again — re-opening exactly the kind of repost-spam this PR is careful to avoid for `dash_status_ongoing` (see precaution below). `contentHash`-only mixing is the deliberate design point: dedup-iff-observably-identical.

## `dash_status_ongoing` — precaution, not grounded evidence

I could not find committed capture/snapshot evidence pinning down whether `dash_status_ongoing`'s body (the persistent "You're still dashing…" heartbeat, channel `dasher-notification-channel-status`) varies per repost (e.g. an embedded timer/counter) or is static. `docs/capture-analysis/2026-05-unknown-triage.md` only records that it "re-posts constantly" as a foreground-service heartbeat — no per-repost text sample is on file, and no `RawNotificationData`/snapshot fixture for it exists in the committed corpus.

Per the build plan's V3 correction, I applied the **defensive precaution**: `NotificationPipeline` passes `mixNotificationContent = !raw.isOngoing`, so any `isOngoing` notification (this heartbeat is the only current example) keeps the old pure-identity dedup and cannot regress into a `NOTIFICATION_RECEIVED` event per repost, whether or not its body actually churns. UNKNOWN suppression's own content-hash path is untouched by this flag.

## Next field test

Add to `docs/field-testing/README.md` under "Next field test — things to look for" (done in this PR, merged into the existing #604 item since it's the same probe): **two different-store `new_order` notifications in one dash with nothing else recognized in between should now BOTH log a `NOTIFICATION_RECEIVED`/`NEW_ORDER` row in `app_events`** (previously the second could be silently dropped). Also watch that the `dash_status_ongoing` heartbeat does **not** start spamming a `NOTIFICATION_RECEIVED` row on every repost — that would mean the precaution needs to flip (its body is confirmed static and mixing could be safely enabled). Confirmed: 0/2.

## Tests

- `:core:pipeline:testDebugUnitTest` — 206/206 passing (includes `FrameGateTest` 17/17: 12 pre-existing + 5 new).
- `:app:testDebugUnitTest` — 845/845 passing.

Ref #619.

---

### Design-goal review
Walked principles 1–8 against the diff (`:core:pipeline` — P8 mandatory):
- **P1 (UDF/purity):** conforms — pipeline-edge dedup, event-driven, no wall clock.
- **P3 (SRP):** conforms — mechanism in `FrameGate`, the `isOngoing` policy exception at the call site.
- **P5 (SSOT):** conforms — one owner for the mixing decision; reuses the existing `RawNotificationData.contentHash`, not a recomputed copy.
- **P6 (security/privacy):** conforms — sensitive gate precedes FrameGate; UNKNOWN backstop unchanged; the suppression set only *shrank* (admits more of already-recognized, already-content-gated observations) so no fail-open; new state is one bounded `Int?`.
- **P7 (logging):** conforms — zero new log sites; no notification text/hash logged anywhere.
- **P8 (platform-agnostic, mandatory):** conforms — gating keys are the observation **type** (`obs is Observation.Notification`) and the OS-level `isOngoing` flag; no platform literal / package / wire string / rule-id in logic (rule ids appear only in comments + test data).

### Adversarial review
Independent fable-tier reviewer attacked the diff on correctness, design, and security — **verdict: CLEAN, merge recommended**. Verified all five vet corrections by code trace (not by comment): V1 the discriminator is observation-type, not contentHash-nullability, so recognized screens (whose contentHash is the non-null tree `stableHash`) are provably unaffected — pinned by a real, non-vacuous screen test (V2); V3 `isOngoing` excluded at the call site without disabling UNKNOWN-path dedup; V4 no `postTime`/timestamp folded in; V5 single bounded `Int?` slot, no seen-set. Both `admit()` call sites traced; the new suppression condition is a strict subset of the old (nothing that previously forwarded now drops). Independently reran `:core:pipeline:testDebugUnitTest` → 206/206. Two low-severity, non-blocking observations (an `isOngoing`→non-ongoing content flip could admit one extra already-forwarded arrival; alternating-content reposts admit on each flip) are already covered by the field-test watch item.
