### PR TITLE
feat(#528): per-drop realized pay at DELIVERY_COMPLETED (Slice A)

### DIFF
--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -25,6 +25,7 @@ import cloud.trotter.dashbuddy.domain.pipeline.TimeoutType
 import cloud.trotter.dashbuddy.domain.pipeline.TransitionTrigger
 import cloud.trotter.dashbuddy.domain.state.AppState
 import cloud.trotter.dashbuddy.domain.state.DestructiveKind
+import cloud.trotter.dashbuddy.domain.state.DropPayApportioner
 import cloud.trotter.dashbuddy.domain.state.Flow
 import cloud.trotter.dashbuddy.domain.state.FlowRegion
 import cloud.trotter.dashbuddy.domain.state.Mode
@@ -402,12 +403,21 @@ class EffectMap @Inject constructor() {
                     if (completedTask != null && completedTask.phase == TaskPhase.DROPOFF) {
                         val retireSince = p.pendingDestructive
                             ?.takeIf { it.kind == DestructiveKind.TASK_RETIRE }?.since
+                        // #528: attribute this drop's share of the combined receipt. Read the
+                        // receipt from the PREV region's lastPostTaskFields (the singular job
+                        // receipt) directly — NOT the per-task pinning — so every drop of a stack
+                        // gets a share, not just the announced one.
+                        val dropShare = DropPayApportioner.apportion(
+                            parsedPay = p.lastPostTaskFields?.parsedPay,
+                            dropoffTasks = jobDropoffTasks(next, p.activeJob?.jobId),
+                        )[completedTask.taskId]
                         val payload = deliveryCompletedPayload(
                             task = completedTask,
                             jobId = p.activeJob?.jobId,
                             completedAt = completedTask.completedAt ?: retireSince ?: obs.timestamp,
                             postTaskFields = p.lastPostTaskFields,
                             sessionEarnings = next.session?.runningEarnings ?: p.session?.runningEarnings,
+                            dropRealizedPay = dropShare,
                         )
                         // #518: scope idempotency to the completed task, not obs.timestamp, so a
                         // re-entered PostTask receipt can't re-fire (and double-count) the same
@@ -436,6 +446,13 @@ class EffectMap @Inject constructor() {
             if (closedJob != null && next.activeJob?.jobId != closedJob.jobId) {
                 val sessionId = next.session?.sessionId ?: p.session?.sessionId
                 val retirePending = p.pendingDestructive?.kind == DestructiveKind.TASK_RETIRE
+                // #528: split the combined receipt across the job's delivered drops once, so each
+                // close-out completion carries its own share (the receipt-skip null rows and the
+                // one over-full row become per-drop shares that sum to the receipt total).
+                val dropShares = DropPayApportioner.apportion(
+                    parsedPay = p.lastPostTaskFields?.parsedPay,
+                    dropoffTasks = jobDropoffTasks(next, closedJob.jobId),
+                )
                 for (task in next.recentTasks) {
                     if (task.jobId != closedJob.jobId || task.phase != TaskPhase.DROPOFF) continue
                     val completedAt = task.completedAt ?: continue
@@ -462,6 +479,7 @@ class EffectMap @Inject constructor() {
                         completedAt = completedAt,
                         postTaskFields = postTaskFields,
                         sessionEarnings = next.session?.runningEarnings ?: p.session?.runningEarnings,
+                        dropRealizedPay = dropShares[task.taskId],
                     )
                     add(
                         logEffect(
@@ -1327,6 +1345,7 @@ class EffectMap @Inject constructor() {
         completedAt: Long,
         postTaskFields: ParsedFields.PostTaskFields?,
         sessionEarnings: Double?,
+        dropRealizedPay: Double? = null,
     ): DeliveryPayload = DeliveryPayload(
         jobId = jobId ?: task?.jobId ?: "unknown",
         taskId = task?.taskId ?: "unknown",
@@ -1341,7 +1360,25 @@ class EffectMap @Inject constructor() {
         deadlineMillis = task?.deadlineMillis,
         totalPay = postTaskFields?.totalPay,
         parsedPay = postTaskFields?.parsedPay,
+        dropRealizedPay = dropRealizedPay,
         sessionEarningsAtCompletion = sessionEarnings,
     )
 
+    /**
+     * The job's delivered dropoff tasks — the completion rows the [DropPayApportioner] splits the
+     * receipt across (#528). Sourced from the region records at the mint step (`recentTasks` +
+     * the active task, deduped by id), scoped to [jobId] and the DROPOFF phase, and restricted to
+     * identity-bearing drops so it mirrors the close-out's #498 identity firewall — an identity-
+     * less phantom that never mints a completion must not inflate the split denominator.
+     */
+    private fun jobDropoffTasks(region: PlatformRegion, jobId: String?): List<Task> {
+        if (jobId == null) return emptyList()
+        return (region.recentTasks + listOfNotNull(region.activeTask))
+            .filter {
+                it.jobId == jobId &&
+                    it.phase == TaskPhase.DROPOFF &&
+                    (it.customerNameHash != null || it.customerAddressHash != null)
+            }
+            .distinctBy { it.taskId }
+    }
 }

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapDropPayTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapDropPayTest.kt
@@ -1,0 +1,200 @@
+package cloud.trotter.dashbuddy.core.state
+
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
+import cloud.trotter.dashbuddy.domain.model.event.AppEventType
+import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryPayload
+import cloud.trotter.dashbuddy.domain.model.pay.ParsedPay
+import cloud.trotter.dashbuddy.domain.model.pay.ParsedPayItem
+import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.state.AppState
+import cloud.trotter.dashbuddy.domain.state.CrossPlatformRegion
+import cloud.trotter.dashbuddy.domain.state.Flow
+import cloud.trotter.dashbuddy.domain.state.FlowRegion
+import cloud.trotter.dashbuddy.domain.state.Job
+import cloud.trotter.dashbuddy.domain.state.Mode
+import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.domain.state.PlatformRegion
+import cloud.trotter.dashbuddy.domain.state.Regions
+import cloud.trotter.dashbuddy.domain.state.Session
+import cloud.trotter.dashbuddy.domain.state.Task
+import cloud.trotter.dashbuddy.domain.state.TaskPhase
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * #528 Slice A — per-drop realized pay reaches the `DELIVERY_COMPLETED` payload at both mint sites
+ * (the PostTask exit and the #596 close-out). The invariant under test: the `dropRealizedPay`
+ * across a stacked job's completion rows sums EXACTLY to the receipt total (`ParsedPay.total`) in
+ * integer cents — instead of one drop absorbing the whole combined receipt while the others carry
+ * null pay.
+ */
+class EffectMapDropPayTest {
+
+    private val effectMap = EffectMap()
+
+    private fun appState(
+        flow: FlowRegion = FlowRegion(),
+        platforms: Map<Platform, PlatformRegion> = emptyMap(),
+    ) = AppState(
+        regions = Regions(flow = flow, platforms = platforms, crossPlatform = CrossPlatformRegion()),
+    )
+
+    private fun screenObs(flow: Flow?, timestamp: Long) = Observation.Screen(
+        timestamp = timestamp,
+        captureId = null,
+        ruleId = "test.rule",
+        metadata = ReplayMetadata.EMPTY,
+        flow = flow,
+        modeHint = null,
+        parsed = ParsedFields.None,
+    )
+
+    private fun dropoff(
+        id: String,
+        store: String?,
+        cust: String,
+        completedAt: Long? = 400L,
+    ) = Task(
+        taskId = id,
+        jobId = "J",
+        phase = TaskPhase.DROPOFF,
+        storeName = store,
+        customerNameHash = cust,
+        startedAt = 300L,
+        completedAt = completedAt,
+    )
+
+    private fun completedRows(prev: AppState, next: AppState, obs: Observation): List<DeliveryPayload> =
+        effectMap.diff(prev, next, obs)
+            .filterIsInstance<AppEffect.LogEvent>()
+            .filter { it.event.type == AppEventType.DELIVERY_COMPLETED }
+            .map { it.event.payload as DeliveryPayload }
+
+    private fun cents(v: Double): Long = Math.round(v * 100.0)
+
+    @Test
+    fun `stacked close-out — per-drop shares sum to the receipt total`() {
+        val receipt = ParsedPay(
+            appPayComponents = listOf(ParsedPayItem("Base Pay", 8.0)),
+            customerTips = listOf(
+                ParsedPayItem("Target (02426)", 6.0),
+                ParsedPayItem("Maple Street Biscuit - Alamo Ranch", 2.0),
+            ),
+        )
+        val postFields = ParsedFields.PostTaskFields(
+            totalPay = 16.0,
+            parsedPay = receipt,
+            sessionEarnings = 60.0,
+        )
+        val dropA = dropoff("d-target", "Target", "cA", completedAt = 400L)
+        val dropB = dropoff("d-maple", "Maple Street Biscuit Company", "cB", completedAt = 410L)
+
+        val regionPrev = PlatformRegion(
+            platform = Platform.DoorDash,
+            mode = Mode.Online,
+            session = Session("s1", startedAt = 100L, runningEarnings = 60.0),
+            activeJob = Job("J", offerStoreHint = emptyList(), parentOfferHash = null, startedAt = 50L),
+            recentTasks = listOf(dropA, dropB),
+            lastPostTaskFields = postFields,
+            lastAnnouncedPostTaskTaskId = "d-target",
+        )
+        // Job closes this step (activeJob → null) → #596 close-out mints a completion per drop.
+        val regionNext = regionPrev.copy(activeJob = null)
+
+        val prev = appState(FlowRegion(flow = Flow.Idle), mapOf(Platform.DoorDash to regionPrev))
+        val next = appState(FlowRegion(flow = Flow.Idle), mapOf(Platform.DoorDash to regionNext))
+        val obs = screenObs(Flow.Idle, timestamp = 3000L)
+
+        val rows = completedRows(prev, next, obs)
+        assertEquals("both drops complete", 2, rows.size)
+
+        val a = rows.single { it.taskId == "d-target" }
+        val b = rows.single { it.taskId == "d-maple" }
+        assertEquals("exact tip \$6 + base \$8/2", 10.0, a.dropRealizedPay!!, 0.001)
+        assertEquals("exact tip \$2 + base \$4", 6.0, b.dropRealizedPay!!, 0.001)
+
+        // The no-double-count invariant, in integer cents.
+        assertEquals(cents(receipt.total), rows.sumOf { cents(it.dropRealizedPay!!) })
+    }
+
+    @Test
+    fun `single-drop close-out — dropRealizedPay is the whole receipt total`() {
+        val receipt = ParsedPay(
+            appPayComponents = listOf(ParsedPayItem("Base Pay", 4.5)),
+            customerTips = listOf(ParsedPayItem("Wendy's", 3.0)),
+        )
+        val postFields = ParsedFields.PostTaskFields(totalPay = 7.5, parsedPay = receipt, sessionEarnings = 47.5)
+        val drop = dropoff("d1", "Wendy's", "cW", completedAt = 400L)
+
+        val regionPrev = PlatformRegion(
+            platform = Platform.DoorDash,
+            mode = Mode.Online,
+            session = Session("s1", startedAt = 100L, runningEarnings = 47.5),
+            activeJob = Job("J", offerStoreHint = emptyList(), parentOfferHash = null, startedAt = 50L),
+            recentTasks = listOf(drop),
+            lastPostTaskFields = postFields,
+            lastAnnouncedPostTaskTaskId = "d1",
+        )
+        val regionNext = regionPrev.copy(activeJob = null)
+
+        val prev = appState(FlowRegion(flow = Flow.Idle), mapOf(Platform.DoorDash to regionPrev))
+        val next = appState(FlowRegion(flow = Flow.Idle), mapOf(Platform.DoorDash to regionNext))
+
+        val rows = completedRows(prev, next, screenObs(Flow.Idle, timestamp = 3000L))
+        assertEquals(1, rows.size)
+        assertEquals(7.5, rows.single().dropRealizedPay!!, 0.001)
+    }
+
+    @Test
+    fun `receipt-less close-out — dropRealizedPay is null (nothing to attribute)`() {
+        // #596 routine: the next offer chained straight over the drop, no post-delivery receipt.
+        val drop = dropoff("d1", "Chipotle", "cC", completedAt = 400L)
+        val regionPrev = PlatformRegion(
+            platform = Platform.DoorDash,
+            mode = Mode.Online,
+            session = Session("s1", startedAt = 100L, runningEarnings = 20.0),
+            activeJob = Job("J", offerStoreHint = emptyList(), parentOfferHash = null, startedAt = 50L),
+            recentTasks = listOf(drop),
+            lastPostTaskFields = null,
+        )
+        val regionNext = regionPrev.copy(activeJob = null)
+
+        val prev = appState(FlowRegion(flow = Flow.Idle), mapOf(Platform.DoorDash to regionPrev))
+        val next = appState(FlowRegion(flow = Flow.Idle), mapOf(Platform.DoorDash to regionNext))
+
+        val rows = completedRows(prev, next, screenObs(Flow.Idle, timestamp = 3000L))
+        assertEquals(1, rows.size)
+        assertNull("no receipt → null realized pay", rows.single().dropRealizedPay)
+    }
+
+    @Test
+    fun `PostTask exit — single delivery carries dropRealizedPay`() {
+        val receipt = ParsedPay(
+            appPayComponents = listOf(ParsedPayItem("Base Pay", 4.5)),
+            customerTips = listOf(ParsedPayItem("Wendy's", 3.0)),
+        )
+        val postFields = ParsedFields.PostTaskFields(totalPay = 7.5, parsedPay = receipt, sessionEarnings = 47.5)
+        val drop = dropoff("T6", "Wendy's", "cW", completedAt = null)
+
+        val regionPrev = PlatformRegion(
+            platform = Platform.DoorDash,
+            mode = Mode.Online,
+            session = Session("s1", startedAt = 100L, runningEarnings = 47.5),
+            activeJob = Job("J", offerStoreHint = emptyList(), parentOfferHash = null, startedAt = 50L),
+            recentTasks = listOf(drop),
+            lastPostTaskFields = postFields,
+        )
+        val regionNext = regionPrev.copy()
+
+        val prev = appState(FlowRegion(flow = Flow.PostTask), mapOf(Platform.DoorDash to regionPrev))
+        val next = appState(FlowRegion(flow = Flow.Idle), mapOf(Platform.DoorDash to regionNext))
+
+        val rows = completedRows(prev, next, screenObs(Flow.Idle, timestamp = 3000L))
+        assertEquals(1, rows.size)
+        assertNotNull(rows.single().parsedPay)
+        assertEquals(7.5, rows.single().dropRealizedPay!!, 0.001)
+    }
+}

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -73,6 +73,21 @@ card's **mechanical** half, #577 (re-confirmed, 24/24, ~0.55 s — with a new po
 that entry's Bug #1), the #457 path, and #554 ShadowProjector (2/2). The #462/#460 dropoff item
 was found **broken-in-part** (raw PII in capture envelopes) and moved to that entry's Bug #7.)_
 
+- **🔧 FIX SHIPPED — a stacked job's DELIVERY_COMPLETED rows now carry per-drop realized pay (#528 Slice A). READ THE DB AFTER A DASH.**
+  Before, on a multi-store/multi-drop stack, the single combined receipt was attached to just ONE
+  drop (it absorbed the whole total) and every other drop's `DELIVERY_COMPLETED` row recorded null
+  pay. Now each row carries `dropRealizedPay` = the exact per-store tip matched to that drop + an
+  **equal-split** share of the lump base; across the job's drops these sum EXACTLY (to the cent) to
+  the receipt total. Same-store batches and blank/duplicate store names fall back to a pure
+  equal-split, so no drop double-counts a tip line. Tips are exact; **the base split is a v1
+  estimate** (neither offer nor receipt breaks out per-order base). This is a data-fidelity change
+  only — no bubble/HUD copy changed (the card still shows the blended job $/mi; consuming the new
+  field in the UI is a later slice). **Confirm after dash: 0/2 —** run a **multi-store stack**
+  (2+ drops from different stores in one job) to completion, then read the db `app_events`: the
+  `DELIVERY_COMPLETED` rows for that job should each have a non-null `dropRealizedPay`, and summing
+  them should equal the combined receipt total (the `parsedPay.total` on the announced row).
+  Broken = a drop with null `dropRealizedPay` on a receipted stack, or the per-drop shares not
+  summing to the receipt total.
 - **🔧 FIX SHIPPED — offer outcome cards now derive from the committed outcome, not the tap (#601).
   DELIBERATE UX CHANGE — CONFIRM ON DASH.**
   Before, tapping Accept/Decline printed "Offer Accepted"/"Offer Declined" immediately, from the

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -77,10 +77,12 @@ was found **broken-in-part** (raw PII in capture envelopes) and moved to that en
   Before, on a multi-store/multi-drop stack, the single combined receipt was attached to just ONE
   drop (it absorbed the whole total) and every other drop's `DELIVERY_COMPLETED` row recorded null
   pay. Now each row carries `dropRealizedPay` = the exact per-store tip matched to that drop + an
-  **equal-split** share of the lump base; across the job's drops these sum EXACTLY (to the cent) to
-  the receipt total. Same-store batches and blank/duplicate store names fall back to a pure
+  **equal-split** share of the lump base; when the stack settles with a single end-of-job receipt
+  (the normal DoorDash shape) the job's drops sum EXACTLY (to the cent) to the receipt total.
+  Same-store batches and blank/duplicate store names fall back to a pure
   equal-split, so no drop double-counts a tip line. Tips are exact; **the base split is a v1
-  estimate** (neither offer nor receipt breaks out per-order base). This is a data-fidelity change
+  estimate** (neither offer nor receipt breaks out per-order base). (A mid-stack/per-drop receipt
+  can under-attribute — never double-count — tracked as a #528 follow-up.) This is a data-fidelity change
   only — no bubble/HUD copy changed (the card still shows the blended job $/mi; consuming the new
   field in the UI is a later slice). **Confirm after dash: 0/2 —** run a **multi-store stack**
   (2+ drops from different stores in one job) to completion, then read the db `app_events`: the

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/payload/AppEventPayloads.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/payload/AppEventPayloads.kt
@@ -110,6 +110,18 @@ data class DeliveryPayload(
     val totalPay: Double? = null,
     /** Itemized pay breakdown — populated on COMPLETED. */
     val parsedPay: ParsedPay? = null,
+    /**
+     * This drop's attributed share of the job's combined receipt (#528 Slice A) — the exact
+     * per-store tip matched to this drop plus an **equal-split** share of the lump base. The base
+     * split is an honest v1 estimate (neither offer nor receipt breaks out per-order base); the
+     * tip is exact when the drops map 1:1 onto the receipt's tip lines, else the whole receipt is
+     * split evenly. Across a stacked job's DELIVERY_COMPLETED rows these sum EXACTLY to the receipt
+     * total ([cloud.trotter.dashbuddy.domain.model.pay.ParsedPay.total]) in integer cents — no
+     * drop double-counts the combined receipt. Null when there is no itemized receipt to attribute
+     * (a receipt-skipped #596 completion, or a collapsed bare-total receipt). Computed by
+     * [cloud.trotter.dashbuddy.domain.state.DropPayApportioner].
+     */
+    val dropRealizedPay: Double? = null,
     /** Session running total at the moment of completion. */
     val sessionEarningsAtCompletion: Double? = null,
 ) : AppEventPayload

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/payload/AppEventPayloads.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/payload/AppEventPayloads.kt
@@ -115,10 +115,15 @@ data class DeliveryPayload(
      * per-store tip matched to this drop plus an **equal-split** share of the lump base. The base
      * split is an honest v1 estimate (neither offer nor receipt breaks out per-order base); the
      * tip is exact when the drops map 1:1 onto the receipt's tip lines, else the whole receipt is
-     * split evenly. Across a stacked job's DELIVERY_COMPLETED rows these sum EXACTLY to the receipt
-     * total ([cloud.trotter.dashbuddy.domain.model.pay.ParsedPay.total]) in integer cents — no
-     * drop double-counts the combined receipt. Null when there is no itemized receipt to attribute
-     * (a receipt-skipped #596 completion, or a collapsed bare-total receipt). Computed by
+     * split evenly. Under the fielded one-receipt-per-job shape (DoorDash settles a stack with a
+     * single end-of-job receipt), a stacked job's DELIVERY_COMPLETED rows sum EXACTLY to the receipt
+     * total ([cloud.trotter.dashbuddy.domain.model.pay.ParsedPay.total]) in integer cents — within a
+     * single [cloud.trotter.dashbuddy.domain.state.DropPayApportioner.apportion] call the last drop
+     * absorbs the rounding remainder, and no drop double-counts the combined receipt. A platform that
+     * exposes a *mid-stack* receipt (a partial or per-drop receipt that changes between completions)
+     * can under-attribute — the sum degrades below the final total, never above it (tracked as a
+     * #528 follow-up). Null when there is no itemized receipt to attribute (a receipt-skipped #596
+     * completion, or a collapsed bare-total receipt). Computed by
      * [cloud.trotter.dashbuddy.domain.state.DropPayApportioner].
      */
     val dropRealizedPay: Double? = null,

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/DropPayApportioner.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/DropPayApportioner.kt
@@ -1,0 +1,110 @@
+package cloud.trotter.dashbuddy.domain.state
+
+import cloud.trotter.dashbuddy.domain.model.pay.ParsedPay
+import cloud.trotter.dashbuddy.domain.model.pay.ParsedPayItem
+
+/**
+ * Splits one combined delivery receipt ([ParsedPay]) into a per-drop realized-pay share
+ * (#528 Slice A). A stacked job produces a single combined receipt — per-order **tips** keyed by
+ * store, but a **lump** base — so on a stack today one drop absorbs the whole receipt while the
+ * others record null pay. This apportioner gives each drop its own share so the DELIVERY_COMPLETED
+ * rows are individually meaningful.
+ *
+ * Attribution:
+ * - **Tips are EXACT** when the drops map 1:1 onto the receipt's tip lines by store-brand tokens
+ *   ([StoreNameMatch.sharedLeadingTokens]) — the same correlation the store-chain projection uses.
+ * - **Base is an equal-split ESTIMATE.** Neither the offer nor the receipt exposes a per-order
+ *   base, so v1 divides the lump base evenly across the drops. Honest, documented, revisited by a
+ *   later slice.
+ * - **Fallback to a pure equal-split of the receipt total** whenever the drops don't map cleanly
+ *   1:1 onto the tip lines — a blank/duplicate dropoff store name (#526), a same-store batch
+ *   (GoPuff: N customers, 1 store, N same-labelled tip lines), or an unmatched bare-number label
+ *   (#607). This is what keeps a same-store batch from double-counting a single tip line across
+ *   drops.
+ *
+ * The load-bearing property is the **no-double-count invariant**: the shares sum EXACTLY to
+ * [ParsedPay.total] (the *receipt* total — tips adjust post-delivery, so this is authoritative over
+ * the offer-time [Job.totalPayAmount]). Computed in integer cents, the rounding remainder to the
+ * last drop, so summing the emitted shares reproduces the receipt to the cent.
+ *
+ * Pure and side-effect-free (no PII: store names are not PII; customer identity is already hashed
+ * upstream). Reused from `:core:state` at the DELIVERY_COMPLETED mint sites.
+ */
+object DropPayApportioner {
+
+    /**
+     * Per-drop realized-pay shares as `taskId -> dollars`.
+     *
+     * Returns an **empty map** when [parsedPay] is null — no itemized receipt means there is
+     * nothing to attribute, so callers record `null` per drop rather than splitting a bare total
+     * (a mid-job collapsed receipt carries a `totalPay` but no [ParsedPay]; splitting that would
+     * treat one drop's partial as the whole job).
+     *
+     * A single drop maps to the whole [ParsedPay.total] so consumers read one field uniformly.
+     *
+     * [dropoffTasks] is the set of the job's delivered dropoffs (the completion rows that will be
+     * minted); the denominator and the shares are derived from it, deduped by `taskId`.
+     */
+    fun apportion(parsedPay: ParsedPay?, dropoffTasks: List<Task>): Map<String, Double> {
+        if (parsedPay == null) return emptyMap()
+        val drops = dropoffTasks.distinctBy { it.taskId }
+        if (drops.isEmpty()) return emptyMap()
+
+        val totalCents = toCents(parsedPay.total)
+
+        if (drops.size == 1) {
+            return mapOf(drops.first().taskId to totalCents / 100.0)
+        }
+
+        // Raw (double) share per drop, before cent reconciliation.
+        val matchedTips = injectiveTipMatch(drops, parsedPay.customerTips.filter { it.type.isNotBlank() })
+        val rawShares: Map<String, Double> = if (matchedTips != null) {
+            val baseShare = parsedPay.totalBasePay / drops.size
+            drops.associate { it.taskId to (matchedTips.getValue(it.taskId) + baseShare) }
+        } else {
+            val evenShare = parsedPay.total / drops.size
+            drops.associate { it.taskId to evenShare }
+        }
+
+        // Reconcile to integer cents so the shares sum EXACTLY to the receipt total; the rounding
+        // remainder goes to the last drop.
+        val result = LinkedHashMap<String, Double>(drops.size)
+        var assigned = 0L
+        drops.forEachIndexed { index, drop ->
+            val shareCents = if (index == drops.lastIndex) {
+                totalCents - assigned
+            } else {
+                toCents(rawShares.getValue(drop.taskId)).also { assigned += it }
+            }
+            result[drop.taskId] = shareCents / 100.0
+        }
+        return result
+    }
+
+    /**
+     * A clean, unambiguous 1:1 assignment of tip lines to drops, or null when none exists (→ the
+     * caller falls back to an equal split). Requires a true bijection: equal counts, every drop
+     * has a non-blank store name, every drop matches exactly one tip line, and no two drops claim
+     * the same line. A same-store batch (both drops match both lines) fails the "exactly one
+     * candidate" test → null, so a single tip line can never be counted for two drops.
+     */
+    private fun injectiveTipMatch(drops: List<Task>, tips: List<ParsedPayItem>): Map<String, Double>? {
+        if (tips.size != drops.size) return null
+        if (drops.any { it.storeName.isNullOrBlank() }) return null
+        val used = mutableSetOf<Int>()
+        val out = LinkedHashMap<String, Double>(drops.size)
+        for (drop in drops) {
+            val store = drop.storeName!!
+            val candidates = tips.indices.filter {
+                StoreNameMatch.sharedLeadingTokens(tips[it].type, store) >= 1
+            }
+            if (candidates.size != 1) return null          // ambiguous or unmatched → fall back
+            val idx = candidates.single()
+            if (!used.add(idx)) return null                // not injective → fall back
+            out[drop.taskId] = tips[idx].amount
+        }
+        return out
+    }
+
+    private fun toCents(dollars: Double): Long = Math.round(dollars * 100.0)
+}

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/state/DropPayApportionerTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/state/DropPayApportionerTest.kt
@@ -1,0 +1,151 @@
+package cloud.trotter.dashbuddy.domain.state
+
+import cloud.trotter.dashbuddy.domain.model.pay.ParsedPay
+import cloud.trotter.dashbuddy.domain.model.pay.ParsedPayItem
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #528 Slice A — per-drop realized-pay attribution. The apportioner splits ONE combined
+ * delivery receipt into per-drop shares (exact per-store tip + equal-split base) so a stacked
+ * job's DELIVERY_COMPLETED rows each carry their own share instead of one drop absorbing the
+ * whole receipt and the others being null.
+ *
+ * The load-bearing property is the **no-double-count invariant**: the shares sum EXACTLY to the
+ * receipt total (`ParsedPay.total`) in integer cents, with the rounding remainder given to the
+ * last drop.
+ */
+class DropPayApportionerTest {
+
+    private fun cents(v: Double): Long = Math.round(v * 100.0)
+
+    private fun drop(id: String, store: String?, cust: String = "cust-$id") = Task(
+        taskId = id,
+        jobId = "job-1",
+        phase = TaskPhase.DROPOFF,
+        storeName = store,
+        customerNameHash = cust,
+        startedAt = 300L,
+        completedAt = 400L,
+    )
+
+    /** The invariant, asserted in integer cents. */
+    private fun assertSumsToReceipt(shares: Map<String, Double>, receipt: ParsedPay) {
+        val summed = shares.values.sumOf { cents(it) }
+        assertEquals(
+            "sum of dropRealizedPay must equal the receipt total (no double count)",
+            cents(receipt.total),
+            summed,
+        )
+    }
+
+    @Test
+    fun `two-store stack — exact tip plus equal-split base, sums to receipt`() {
+        // base $8 lump, tips Target $6 + Maple $2 → total $16.
+        val receipt = ParsedPay(
+            appPayComponents = listOf(ParsedPayItem("Base Pay", 8.0)),
+            customerTips = listOf(
+                ParsedPayItem("Target (02426)", 6.0),
+                ParsedPayItem("Maple Street Biscuit - Alamo Ranch", 2.0),
+            ),
+        )
+        val drops = listOf(
+            drop("d-target", "Target"),
+            drop("d-maple", "Maple Street Biscuit Company"),
+        )
+
+        val shares = DropPayApportioner.apportion(receipt, drops)
+
+        // Target: exact tip $6 + base $8/2 = $10. Maple: $2 + $4 = $6.
+        assertEquals(10.0, shares.getValue("d-target"), 0.001)
+        assertEquals(6.0, shares.getValue("d-maple"), 0.001)
+        assertSumsToReceipt(shares, receipt)
+    }
+
+    @Test
+    fun `same-store two-drop batch — falls back to equal split, never double counts`() {
+        // GoPuff-style: one store, two customers, two same-labelled tip lines. The tips can't be
+        // injectively assigned (both drops match both lines) → equal-split fallback. Proves the
+        // naive same-store double-count can't happen.
+        val receipt = ParsedPay(
+            appPayComponents = listOf(ParsedPayItem("Base Pay", 8.0)),
+            customerTips = listOf(
+                ParsedPayItem("GoPuff", 3.0),
+                ParsedPayItem("GoPuff", 5.0),
+            ),
+        )
+        val drops = listOf(
+            drop("d1", "GoPuff"),
+            drop("d2", "GoPuff"),
+        )
+
+        val shares = DropPayApportioner.apportion(receipt, drops)
+
+        // Equal split of $16 across 2 drops = $8 each. Neither drop absorbs both tip lines.
+        assertEquals(8.0, shares.getValue("d1"), 0.001)
+        assertEquals(8.0, shares.getValue("d2"), 0.001)
+        assertSumsToReceipt(shares, receipt)
+    }
+
+    @Test
+    fun `blank dropoff store name — equal-split fallback`() {
+        // Real per #526: dropoff cards often have no storeName parse. Can't tip-match → fallback.
+        val receipt = ParsedPay(
+            appPayComponents = listOf(ParsedPayItem("Base Pay", 5.0)),
+            customerTips = listOf(
+                ParsedPayItem("Chipotle", 4.0),
+                ParsedPayItem("Wendy's", 1.0),
+            ),
+        )
+        val drops = listOf(
+            drop("d1", "Chipotle"),
+            drop("d2", null),
+        )
+
+        val shares = DropPayApportioner.apportion(receipt, drops)
+        assertSumsToReceipt(shares, receipt)
+    }
+
+    @Test
+    fun `receipt-less drop — no attribution (null parsedPay yields empty map)`() {
+        val shares = DropPayApportioner.apportion(
+            parsedPay = null,
+            dropoffTasks = listOf(drop("d1", "H-E-B")),
+        )
+        assertTrue("no receipt → nothing to attribute", shares.isEmpty())
+    }
+
+    @Test
+    fun `single-drop job — the whole receipt total`() {
+        val receipt = ParsedPay(
+            appPayComponents = listOf(ParsedPayItem("Base Pay", 4.5)),
+            customerTips = listOf(ParsedPayItem("Wendy's", 3.0)),
+        )
+        val drops = listOf(drop("d1", "Wendy's"))
+
+        val shares = DropPayApportioner.apportion(receipt, drops)
+        assertEquals(7.5, shares.getValue("d1"), 0.001)
+        assertSumsToReceipt(shares, receipt)
+    }
+
+    @Test
+    fun `odd-cent split gives the rounding remainder to the last drop, still exact`() {
+        // total $10.01 across 3 equal-split drops = 3.336.. → 334 + 334 + remainder(333) = 1001c.
+        val receipt = ParsedPay(
+            appPayComponents = listOf(ParsedPayItem("Base Pay", 10.01)),
+            customerTips = listOf(
+                ParsedPayItem("A store", 0.0),
+                ParsedPayItem("A store", 0.0),
+                ParsedPayItem("A store", 0.0),
+            ),
+        )
+        val drops = listOf(
+            drop("d1", "A store"),
+            drop("d2", "A store"),
+            drop("d3", "A store"),
+        )
+        val shares = DropPayApportioner.apportion(receipt, drops)
+        assertSumsToReceipt(shares, receipt)
+    }
+}


### PR DESCRIPTION
## What changed & why

On a stacked / multi-drop job DoorDash renders a **single combined receipt** — per-order tips keyed by store, but a **lump** base. Today that one receipt gets attached to just ONE drop (the announced one, which absorbs the whole total) while every OTHER drop's `DELIVERY_COMPLETED` row records **null pay** (the #596 close-out mints them with `postTaskFields=null`). Those null rows + the one over-full row are the fidelity bug #528 Slice A targets.

This splits the receipt into per-drop shares so each completion row is individually meaningful:

- **domain** — `DeliveryPayload` gains a nullable `dropRealizedPay: Double?` (event-sourced JSON, backward-safe: old rows decode `null`).
- **domain** — new pure `DropPayApportioner`:
  - **Tips are EXACT** when the drops map 1:1 onto the receipt's tip lines by store-brand tokens (`StoreNameMatch.sharedLeadingTokens`, the same correlation the store-chain projection uses — used **directly**, not `StoreChainProjector.project`, which anchors on pickups and collapses same-store links).
  - Assignment is **injective** (each tip line → at most one drop).
  - **Fallback to a pure equal-split of the receipt total** whenever the drops don't map cleanly 1:1 (blank/duplicate dropoff store name, same-store batch = GoPuff N-customers-1-store, unmatched bare-number label #607) — this is what stops a same-store batch from double-counting one tip line across drops.
  - **No-double-count invariant:** shares sum EXACTLY to `parsedPay.total` in **integer cents**, rounding remainder to the last drop.
- **core:state** — both `DELIVERY_COMPLETED` mint sites (PostTask-exit + #596 close-out) read the singular receipt from `p.lastPostTaskFields.parsedPay` **directly** (not the per-task pinning, which is null for non-announced drops) and attribute each drop its share. Denominator = the region's identity-bearing DROPOFF tasks for the job (`recentTasks` + active task, deduped), mirroring the close-out's #498 identity firewall so a phantom can't inflate the split.

### The base split is an estimate
Tips are exact per-store. **The base apportionment is an equal split — an honest v1 estimate**, because neither the offer nor the receipt exposes a per-order base. Documented in the field KDoc and the payload KDoc.

### Deferred (out of scope) — #528 stays open
- **Slice B** — post-hoc GPS realized $/mi from `EventMetadata.odometer` deltas (NAV_STARTED→COMPLETED); needs a reader, home = the #314 read-model.
- **Slice C** — live GPS $/mi on the task card via `Task` odometer population across the pure-stepper boundary.

Also out of scope: consuming `dropRealizedPay` in the UI — the card still shows the blended job $/mi. This PR is a **data-fidelity change only**.

## Security / privacy posture (Principle 6/7)
No raw customer/store PII enters any new log or the payload. `dropRealizedPay` is a **number**; store names are not PII and are only used transiently for token matching (never logged, never persisted here); customer identity is already `sha256`-hashed upstream (`customerNameHash`/`customerAddressHash`). `parsedPay` already existed on the payload — this adds one derived Double. No new log sites.

## Tests (RED-first)
- `DropPayApportionerTest` (`:domain:test`) — pure function: 2-store stack (exact tip + equal base), same-store batch (equal-split fallback, no double count), blank store fallback, receipt-less → empty, single-drop → total, odd-cent remainder. Each asserts the cents-exact invariant.
- `EffectMapDropPayTest` (`:core:state`) — integration through the real `EffectMap.diff`: stacked close-out (per-drop shares sum to receipt total in cents), single-drop close-out → total, receipt-less → null, PostTask-exit single delivery.
- Suites green: `:domain:test` 241/0, `:core:state:testDebugUnitTest` 103/0, `:app:testDebugUnitTest` 845/0.

## Next field test
After a **multi-store stack** completes, the db `DELIVERY_COMPLETED` rows for that job each carry a non-null `dropRealizedPay`, and summing them equals the combined receipt total (`parsedPay.total`). (Checklist item added, Confirmed: 0/2.)

Refs #528 (Slice A).

---

### Design-goal review
Touches `:core:state` + `:domain` (P8 mandatory):
- **P1 (UDF/purity):** conforms — `DropPayApportioner` is a pure `:domain` object (no clock, no Android, deterministic); attribution runs at the `EffectMap` diff edge, not in a reducer.
- **P3 (SRP):** conforms — the apportionment logic is isolated in a small new `:domain` object; the `EffectMap` edits are ~30 lines at the two existing mint sites.
- **P5 (SSOT):** conforms — reuses `StoreNameMatch.sharedLeadingTokens` (no re-implemented matcher) and `ParsedPay.total`; the receipt is read once from `p.lastPostTaskFields`.
- **P6/privacy:** conforms — no new raw PII persisted; the payload gains a `Double?` only (hashes unchanged). Event-sourced + `ignoreUnknownKeys` → old rows decode `dropRealizedPay = null` (backward-safe).
- **P7 (logging):** conforms — zero new log lines.
- **P8 (platform-agnostic, mandatory):** conforms — no platform literal / package / wire string in `DropPayApportioner` or the `EffectMap` edits; keyed by jobId/taskId/phase data. **Recorded seam:** exactness relies on the one-receipt-per-job-at-end behavior that is DoorDash-fielded — a platform with routine mid-job receipts is finding #1 of #630. Filed, not silently assumed.

### Adversarial review
Independent fable-tier reviewer attacked the cross-step cents invariant as the primary target — **verdict: FINDINGS, none merge-blocking**. It traced all four job-close paths and confirmed the invariant is *bulletproof within a single `apportion()` call* (last drop absorbs the remainder) and *holds across the job's completion rows over time* on every fielded DoorDash path (receipt stays alive on `p.lastPostTaskFields`, denominator + order stable across the two mint steps). The constructible breaks all require a **mid-stack expanded receipt** (DoorDash shows one end receipt) or a collapsed re-entry between steps, and every one **under-attributes — never double-counts**. Verified V2 (no attribution from a bare `totalPay`), V3 (same-store GoPuff batch falls to equal-split, non-vacuously tested), V4 (integer-cents, `$10.00/3 → 333+333+334` exact), V5 (backward-compat decode). Independently reran `:domain:test` (241/241) and `:core:state:testDebugUnitTest` (103/103). Triage: softened the two "sums EXACTLY" absolutes to the one-end-receipt precondition **in this PR** (commit `1fa647da`); filed the under-attribution cluster + the P8 seam as **#630** (hardening #2 — don't let a collapsed re-entry overwrite an expanded receipt — is the field-reachable quick win).
