### PR TITLE
fix(#620/#623/#624): close the #598 redaction residuals — distinct mask, notif-envelope PII, recognized-frame backstop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,12 +147,18 @@ our own overlay is dropped (#4 / PR #334). Frame admission is `FrameGate` (ident
 content-hash rolling suppression of UNKNOWN frames, #360); envelope assembly is the shared
 `CaptureWriter` (#361), which also applies **rule-declared capture redaction** — a recognized
 rule's `redact` block masks customer name/address/gate-code node text in the serialized envelope
-only, so recognized captures are PII-hashed-at-edge on disk (#598). Coverage now spans the
-recognized offer/pickup/dropoff/chat/nav/camera customer surfaces (customer name, street/apt/
-gate-code lines, chat message bodies); UNKNOWN frames and UNKNOWN clicks remain the documented
+only, so recognized captures are PII-hashed-at-edge on disk (#598). The mask is
+`[redacted:<4hex>]` (#623) — the first 4 hex of the sha256 of the stripped/trimmed customer
+token, so two customers redact distinctly (per-customer replay fidelity) without persisting raw
+PII; fail-closed to plain `[redacted]`. Coverage spans the recognized offer/pickup/dropoff/chat/
+nav/camera **screen** surfaces AND **notification** envelopes (#620 — chat title/body,
+order-ready customer name via a per-field notif `redact`; store names kept). A rules-independent
+**recognized-frame** backstop (`CustomerTextMarkers`, #624 — distinct from `SensitiveTextMarkers`,
+which drops the dasher's banking screens) scrubs a node that ships a customer-PII marker
+("Deliver to " etc.) a rule forgot to redact; the compiler rejects branch-level `redact` and skips
+a file with duplicate rule ids. UNKNOWN frames and UNKNOWN clicks remain the documented
 debug-only exception (behind the release `NoOpCaptureBus` #346 + the `SensitiveTextMarkers`
-backstop), and the id-less building-name line + replay-identity residuals are tracked (#623/#624/
-#620). `PipelineV2.events` is a HOT `shareIn` stream — one upstream pass feeds
+backstop); the id-less building-name line residual is still tracked. `PipelineV2.events` is a HOT `shareIn` stream — one upstream pass feeds
 all collectors, so side effects (captures, dedup state) can never double-run (#361). The merged
 upstream is supervised — a crash logs + counts a restart and resubscribes with backoff instead of
 silencing all sensing (#430) — and `PipelineStats` counts every gate decision, mapping failure,

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureBackstopCorpusTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureBackstopCorpusTest.kt
@@ -1,0 +1,57 @@
+package cloud.trotter.dashbuddy.core.pipeline
+
+import cloud.trotter.dashbuddy.test.util.TestResourceLoader
+import cloud.trotter.dashbuddy.test.util.TestRulesetFactory
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * #624 (VET V2) corpus-validate for the recognized-frame customer-marker backstop.
+ *
+ * It mirrors the production capture flow — recognize the frame, apply that rule's
+ * `redact`, THEN run [CustomerTextMarkers.firstUnredactedMarker] — over EVERY
+ * committed, already-redacted snapshot, and asserts ZERO hits. The corpus is clean
+ * by construction, so ANY hit is a false positive: this is what pins the marker set
+ * (why "Heading to " — a STORE-name prefix on pickup-nav frames — is deliberately
+ * excluded, VET V2) and proves the #624 rule/data fixes (dropoff_reminder,
+ * pickup_verify_items) leave the corpus scrub-free.
+ */
+class CaptureBackstopCorpusTest {
+
+    private val screenRuleset = TestRulesetFactory.screenRuleset
+
+    @Test
+    fun `the customer-marker backstop finds zero leaks across the redacted corpus`() {
+        val base = File("src/test/resources/snapshots")
+        val dirs = base.listFiles { f -> f.isDirectory && f.name !in SKIP }
+            ?.sortedBy { it.name } ?: emptyList()
+
+        var scanned = 0
+        for (dir in dirs) {
+            for ((fn, node, _) in TestResourceLoader.loadSnapshots("snapshots/${dir.name}")) {
+                // UNKNOWN frames route through SensitiveTextMarkers, not this backstop.
+                val match = screenRuleset.matchFirst(node) ?: continue
+                // Mirror captureScreen: recognized rule's redact first, then backstop scan.
+                val redacted = screenRuleset.ruleById(match.ruleId)
+                    ?.redact?.takeUnless { it.isEmpty() }
+                    ?.apply(node)
+                    ?: node
+                val marker = CustomerTextMarkers.firstUnredactedMarker(redacted)
+                assertNull(
+                    "snapshots/${dir.name}/$fn leaked an un-redacted customer marker '$marker' " +
+                        "(rule ${match.ruleId}) — a false positive on a clean corpus; fix the rule's " +
+                        "redact or the marker set",
+                    marker,
+                )
+                scanned++
+            }
+        }
+        assertTrue("expected a non-empty corpus", scanned > 0)
+    }
+
+    companion object {
+        private val SKIP = setOf("INBOX", "UNKNOWN", "SENSITIVE")
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureBackstopCorpusTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureBackstopCorpusTest.kt
@@ -12,11 +12,17 @@ import java.io.File
  *
  * It mirrors the production capture flow — recognize the frame, apply that rule's
  * `redact`, THEN run [CustomerTextMarkers.firstUnredactedMarker] — over EVERY
- * committed, already-redacted snapshot, and asserts ZERO hits. The corpus is clean
- * by construction, so ANY hit is a false positive: this is what pins the marker set
- * (why "Heading to " — a STORE-name prefix on pickup-nav frames — is deliberately
- * excluded, VET V2) and proves the #624 rule/data fixes (dropoff_reminder,
- * pickup_verify_items) leave the corpus scrub-free.
+ * committed, already-redacted snapshot (intent folders AND the nested session
+ * replay fixtures under `sessions`, #620 review F6), and asserts ZERO hits. The
+ * corpus is clean by construction, so ANY hit is a false positive: this is what
+ * pins the marker set (why "Heading to " — a STORE-name prefix on pickup-nav
+ * frames — is deliberately excluded, VET V2) and proves the #624 rule/data fixes
+ * (dropoff_reminder, pickup_verify_items) leave the corpus scrub-free.
+ *
+ * This test walks the tree itself (rather than [TestResourceLoader.loadSnapshots],
+ * which is non-recursive) so the session frames are covered too; the shared loader
+ * stays non-recursive because GoldenSnapshotRegressionTest iterates the session
+ * dir as an intent folder and would break if it recursed.
  */
 class CaptureBackstopCorpusTest {
 
@@ -25,14 +31,24 @@ class CaptureBackstopCorpusTest {
     @Test
     fun `the customer-marker backstop finds zero leaks across the redacted corpus`() {
         val base = File("src/test/resources/snapshots")
-        val dirs = base.listFiles { f -> f.isDirectory && f.name !in SKIP }
-            ?.sortedBy { it.name } ?: emptyList()
+        assertTrue("snapshot corpus dir must exist", base.isDirectory)
 
         var scanned = 0
-        for (dir in dirs) {
-            for ((fn, node, _) in TestResourceLoader.loadSnapshots("snapshots/${dir.name}")) {
+        base.walkTopDown()
+            .filter { it.isFile && it.extension == "json" }
+            .filter { it.relativeTo(base).invariantSeparatorsPath.substringBefore('/') !in SKIP }
+            .sortedBy { it.path }
+            .forEach { file ->
+                // Some session envelopes are click/notification captures whose payload
+                // isn't a UiNode tree — they decode to an empty node (or throw) and
+                // classify UNKNOWN, so they're harmlessly skipped.
+                val node = try {
+                    TestResourceLoader.loadNode(file)
+                } catch (_: Exception) {
+                    return@forEach
+                }
                 // UNKNOWN frames route through SensitiveTextMarkers, not this backstop.
-                val match = screenRuleset.matchFirst(node) ?: continue
+                val match = screenRuleset.matchFirst(node) ?: return@forEach
                 // Mirror captureScreen: recognized rule's redact first, then backstop scan.
                 val redacted = screenRuleset.ruleById(match.ruleId)
                     ?.redact?.takeUnless { it.isEmpty() }
@@ -40,18 +56,20 @@ class CaptureBackstopCorpusTest {
                     ?: node
                 val marker = CustomerTextMarkers.firstUnredactedMarker(redacted)
                 assertNull(
-                    "snapshots/${dir.name}/$fn leaked an un-redacted customer marker '$marker' " +
+                    "${file.path} leaked an un-redacted customer marker '$marker' " +
                         "(rule ${match.ruleId}) — a false positive on a clean corpus; fix the rule's " +
                         "redact or the marker set",
                     marker,
                 )
                 scanned++
             }
-        }
+
         assertTrue("expected a non-empty corpus", scanned > 0)
     }
 
     companion object {
+        /** Top-level snapshot dirs the recognized-frame backstop does not own:
+         *  INBOX/UNKNOWN are unrecognized; SENSITIVE is the dasher-block path. */
         private val SKIP = setOf("INBOX", "UNKNOWN", "SENSITIVE")
     }
 }

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/CaptureRedactionCorpusTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/CaptureRedactionCorpusTest.kt
@@ -224,6 +224,29 @@ class CaptureRedactionCorpusTest {
         assertTrue("new_order carries no customer PII → no redact", rule.notifRedact.isEmpty())
     }
 
+    @Test
+    fun `production uber trip_en_route_dropoff masks the address title (#620 F1)`() {
+        val rule = TestRulesetFactory.notificationRuleset.ruleById("uber.notification.trip_en_route_dropoff")!!
+        assertTrue("trip_en_route_dropoff must carry a notif redact block", !rule.notifRedact.isEmpty())
+        // The title IS the customer address ("Going to <address>"); mask the whole field.
+        val masked = rule.notifRedact.apply(notif(title = "Going to 1600 Amphitheatre Pkwy"))
+        assertFalse("street name gone", masked.title!!.contains("Amphitheatre"))
+        assertFalse("house number gone", masked.title!!.contains("1600"))
+        assertTrue(Regex("""^\[redacted:[0-9a-f]{4}\]$""").matches(masked.title!!))
+    }
+
+    @Test
+    fun `production uber trip_at_dropoff masks the address or name, keeps the lead-in (#620 F1)`() {
+        val rule = TestRulesetFactory.notificationRuleset.ruleById("uber.notification.trip_at_dropoff")!!
+        assertTrue("trip_at_dropoff must carry a notif redact block", !rule.notifRedact.isEmpty())
+        val leave = rule.notifRedact.apply(notif(title = "Leave the order at 1600 Amphitheatre Pkwy"))
+        assertFalse("address gone", leave.title!!.contains("Amphitheatre"))
+        assertTrue(Regex("""^Leave the order at \[redacted:[0-9a-f]{4}\]$""").matches(leave.title!!))
+        val meet = rule.notifRedact.apply(notif(title = "Meet at door for Jane Doe"))
+        assertFalse("customer name gone", meet.title!!.contains("Jane"))
+        assertTrue(Regex("""^Meet at door for \[redacted:[0-9a-f]{4}\]$""").matches(meet.title!!))
+    }
+
     private fun jsonUsesSha256(element: kotlinx.serialization.json.JsonElement): Boolean = when (element) {
         is kotlinx.serialization.json.JsonPrimitive -> element.isString && element.content == "sha256"
         is kotlinx.serialization.json.JsonObject -> element.values.any { jsonUsesSha256(it) }

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/CaptureRedactionCorpusTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/CaptureRedactionCorpusTest.kt
@@ -114,6 +114,24 @@ class CaptureRedactionCorpusTest {
     }
 
     @Test
+    fun `dropoff_reminder redact masks the address after the marker (#624)`() {
+        // The live leak #624 fixes: "Deliver to door of <address>" had no hash and
+        // no redact, so the #598 sha256 gate never fired and the raw address shipped.
+        val rule = TestRulesetFactory.screenRuleset.ruleById("doordash.screen.dropoff_reminder")!!
+        assertTrue("dropoff_reminder must now carry a redact block", !rule.redact.isEmpty())
+
+        val node = UiNode(text = "Deliver to door of 4B, 123 Real Street").restoreParents()
+        val masked = serialize(rule.redact.apply(node))
+
+        assertFalse("street address must not persist", masked.contains("123 Real Street"))
+        assertFalse("apt must not persist", masked.contains("4B"))
+        assertTrue(
+            "marker kept, address masked",
+            Regex("""Deliver to door of \[redacted:[0-9a-f]{4}\]""").containsMatchIn(masked),
+        )
+    }
+
+    @Test
     fun `every screen rule that hashes PII declares a redact block`() {
         var checked = 0
         rulesDir.listFiles { f -> f.extension == "json" }?.forEach { file ->

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/CaptureRedactionCorpusTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/CaptureRedactionCorpusTest.kt
@@ -2,6 +2,7 @@ package cloud.trotter.dashbuddy.core.pipeline.rules
 
 import cloud.trotter.dashbuddy.domain.capture.schema.UiNodeSchema
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData
 import cloud.trotter.dashbuddy.test.util.TestResourceLoader
 import cloud.trotter.dashbuddy.test.util.TestRulesetFactory
 import kotlinx.serialization.json.Json
@@ -165,6 +166,62 @@ class CaptureRedactionCorpusTest {
             val rule = TestRulesetFactory.screenRuleset.ruleById(id)!!
             assertFalse("$id must carry a redact block", rule.redact.isEmpty())
         }
+    }
+
+    // =========================================================================
+    // #620 — production notification redact blocks
+    // =========================================================================
+
+    private fun notif(
+        title: String? = null,
+        text: String? = null,
+        bigText: String? = null,
+        tickerText: String? = null,
+        channelId: String? = null,
+    ) = RawNotificationData(
+        title = title, text = text, bigText = bigText, tickerText = tickerText,
+        packageName = "com.doordash.driverapp", postTime = 0L, isClearable = true,
+        channelId = channelId,
+    )
+
+    @Test
+    fun `production customer_message redact masks the sender and body (#620)`() {
+        val rule = TestRulesetFactory.notificationRuleset.ruleById("doordash.notification.customer_message")!!
+        assertTrue("customer_message must carry a notif redact block", !rule.notifRedact.isEmpty())
+        val masked = rule.notifRedact.apply(
+            notif(
+                title = "Message from Jennifer",
+                text = "The gate code is 4412",
+                tickerText = "The gate code is 4412",
+                channelId = "dasher-notification-channel-inapp-chat",
+            ),
+        )
+        assertFalse("sender name gone", masked.title!!.contains("Jennifer"))
+        assertTrue(Regex("""Message from \[redacted:[0-9a-f]{4}\]""").containsMatchIn(masked.title!!))
+        assertFalse("body gone (text)", masked.text!!.contains("4412"))
+        assertFalse("body gone (tickerText)", masked.tickerText!!.contains("4412"))
+    }
+
+    @Test
+    fun `production order_ready redact masks the customer name but keeps the store (#620)`() {
+        val rule = TestRulesetFactory.notificationRuleset.ruleById("doordash.notification.order_ready")!!
+        assertTrue("order_ready must carry a notif redact block", !rule.notifRedact.isEmpty())
+        val masked = rule.notifRedact.apply(
+            notif(
+                title = "Delivery Update",
+                text = "Adam's order is ready for pickup at 7-Eleven.",
+                channelId = "dasher-notification-channel-delivery-update",
+            ),
+        )
+        assertFalse("customer name gone", masked.text!!.contains("Adam"))
+        assertTrue("store kept — merchants are not PII", masked.text!!.contains("7-Eleven"))
+        assertEquals("title (non-PII) untouched", "Delivery Update", masked.title)
+    }
+
+    @Test
+    fun `a benign notification rule declares no notif redact (#620)`() {
+        val rule = TestRulesetFactory.notificationRuleset.ruleById("doordash.notification.new_order")!!
+        assertTrue("new_order carries no customer PII → no redact", rule.notifRedact.isEmpty())
     }
 
     private fun jsonUsesSha256(element: kotlinx.serialization.json.JsonElement): Boolean = when (element) {

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/CaptureRedactionCorpusTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/CaptureRedactionCorpusTest.kt
@@ -46,7 +46,71 @@ class CaptureRedactionCorpusTest {
         val redactedJson = serialize(rule.redact.apply(injected))
 
         assertFalse("injected customer name must not persist", redactedJson.contains("Testname Q"))
-        assertTrue("marker kept, name masked", redactedJson.contains("Deliver to [redacted]"))
+        // #623: the masked portion carries a `[redacted:<4hex>]` distinctness suffix.
+        assertTrue(
+            "marker kept, name masked",
+            Regex("""Deliver to \[redacted:[0-9a-f]{4}\]""").containsMatchIn(redactedJson),
+        )
+    }
+
+    /**
+     * #623 frame-invariance ACROSS RULES (VET V5): the SAME customer token, seen
+     * under three different production redact blocks (each with a different marker
+     * prefix / node predicate), must redact to the SAME 4hex distinctness suffix —
+     * and a DIFFERENT customer to a DIFFERENT suffix. This is what makes
+     * multi-customer replay possible without persisting raw PII: the suffix is a
+     * stable 16-bit fingerprint of the customer token, aligned with the parse's
+     * strip+trim+sha256, not a per-frame value.
+     */
+    @Test
+    fun `same customer redacts to the same 4hex across dropoff_navigation, timeline, and pickup_verify_items`() {
+        val suffix = Regex("""\[redacted:([0-9a-f]{4})\]""")
+        fun hexOf(masked: String): String =
+            suffix.find(masked)!!.groupValues[1]
+
+        // dropoff_navigation: id-keyed title node, keepPrefix "Deliver to ".
+        val navRule = TestRulesetFactory.screenRuleset.ruleById("doordash.screen.dropoff_navigation")!!
+        val navHex = hexOf(
+            navRule.redact.apply(
+                UiNode(
+                    viewIdResourceName = "com.dd:id/bottom_sheet_task_title",
+                    text = "Deliver to Jane Q Doe",
+                ),
+            ).text!!,
+        )
+
+        // timeline: text-keyed node, keepPrefix "Deliver to " (also "Pickup for ").
+        val timelineRule = TestRulesetFactory.screenRuleset.ruleById("doordash.screen.timeline")!!
+        val timelineHex = hexOf(
+            timelineRule.redact.apply(UiNode(text = "Deliver to Jane Q Doe")).text!!,
+        )
+
+        // pickup_verify_items: different marker ("Verify items for ") + different id.
+        val verifyRule = TestRulesetFactory.screenRuleset.ruleById("doordash.screen.pickup_verify_items")!!
+        val verifyHex = hexOf(
+            verifyRule.redact.apply(
+                UiNode(
+                    viewIdResourceName = "com.dd:id/order_verification_checklist_title",
+                    text = "Verify items for Jane Q Doe",
+                ),
+            ).text!!,
+        )
+
+        assertEquals("same customer must redact to the same 4hex across rules", navHex, timelineHex)
+        assertEquals("same customer must redact to the same 4hex across rules", navHex, verifyHex)
+
+        // The suffix equals the first 4 hex of sha256(token) — the same hash the parse persists.
+        val expected = java.security.MessageDigest.getInstance("SHA-256")
+            .digest("Jane Q Doe".toByteArray(Charsets.UTF_8))
+            .joinToString("") { "%02x".format(it) }
+            .take(4)
+        assertEquals("suffix must be first 4 hex of sha256(token)", expected, navHex)
+
+        // A DIFFERENT customer must produce a DIFFERENT suffix (distinctness).
+        val otherHex = hexOf(
+            timelineRule.redact.apply(UiNode(text = "Deliver to John Smith")).text!!,
+        )
+        assertFalse("different customers must redact to different 4hex", otherHex == navHex)
     }
 
     @Test

--- a/app/src/test/java/cloud/trotter/dashbuddy/test/suites/AllMatchersSuite.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/test/suites/AllMatchersSuite.kt
@@ -1,8 +1,10 @@
 package cloud.trotter.dashbuddy.test.suites
 
+import cloud.trotter.dashbuddy.core.pipeline.CaptureBackstopCorpusTest
 import cloud.trotter.dashbuddy.core.pipeline.accessibility.event.type.view.clicked.ClickClassifierTest
 import cloud.trotter.dashbuddy.core.pipeline.notification.NotificationClassifierTest
 import cloud.trotter.dashbuddy.core.pipeline.recognition.matchers.GoldenSnapshotRegressionTest
+import cloud.trotter.dashbuddy.core.pipeline.rules.CaptureRedactionCorpusTest
 import cloud.trotter.dashbuddy.core.pipeline.rules.ClickRulesetTest
 import cloud.trotter.dashbuddy.core.pipeline.rules.DefaultRulesIntegrationTest
 import cloud.trotter.dashbuddy.core.pipeline.rules.NotificationRulesetTest
@@ -39,6 +41,10 @@ import org.junit.runners.Suite
  * - [TriageRulesTest] — synthetic fixtures for rules added from capture triage.
  * - [DefaultRulesIntegrationTest] — end-to-end rule compilation/wiring.
  * - [NotificationClassifierTest] / [ClickClassifierTest] — classifier behavior.
+ * - [CaptureRedactionCorpusTest] — the #598/#620 redact predicates mask injected
+ *   PII across the corpus + notification redact blocks mask name/body, keep store.
+ * - [CaptureBackstopCorpusTest] — the #624 recognized-frame customer-marker
+ *   backstop finds ZERO leaks over the redacted corpus (false-positive pin).
  */
 @RunWith(Suite::class)
 @Suite.SuiteClasses(
@@ -51,5 +57,7 @@ import org.junit.runners.Suite
     DefaultRulesIntegrationTest::class,
     NotificationClassifierTest::class,
     ClickClassifierTest::class,
+    CaptureRedactionCorpusTest::class,
+    CaptureBackstopCorpusTest::class,
 )
 class AllMatchersSuite

--- a/core/pipeline/src/main/assets/rules/doordash.json
+++ b/core/pipeline/src/main/assets/rules/doordash.json
@@ -3446,6 +3446,12 @@
           { "titleContains": "Message from" }
         ]
       },
+      "redact": {
+        "title": { "keepPrefix": [ "Message from " ] },
+        "text": {},
+        "bigText": {},
+        "tickerText": {}
+      },
       "effects": [
         { "log": { "type": "NOTIFICATION_RECEIVED", "payload": "CUSTOMER_MESSAGE" } }
       ]
@@ -3477,6 +3483,11 @@
           ] },
           { "anyFieldContains": "ready for pickup" }
         ]
+      },
+      "redact": {
+        "text": { "match": "^(.+?)'s order is ready for pickup at ", "maskGroup": 1 },
+        "bigText": { "match": "^(.+?)'s order is ready for pickup at ", "maskGroup": 1 },
+        "tickerText": { "match": "^(.+?)'s order is ready for pickup at ", "maskGroup": 1 }
       },
       "effects": [
         { "log": { "type": "NOTIFICATION_RECEIVED", "payload": "ORDER_READY" } }

--- a/core/pipeline/src/main/assets/rules/doordash.json
+++ b/core/pipeline/src/main/assets/rules/doordash.json
@@ -3074,6 +3074,9 @@
       "comment": "#462 batch 2 — recognize-only idle/lifecycle + pickup/dropoff dialogs that shipped no viewIds and fell to UNKNOWN. No state.flow, no parse.",
       "id": "doordash.screen.dropoff_reminder",
       "priority": 51,
+      "redact": [
+        { "find": { "hasTextStartsWith": "Deliver to door of" }, "keepPrefix": [ "Deliver to door of " ] }
+      ],
       "require": {
         "all": [
           { "exists": { "hasTextStartsWith": "Deliver to door of" } },

--- a/core/pipeline/src/main/assets/rules/uber.json
+++ b/core/pipeline/src/main/assets/rules/uber.json
@@ -775,6 +775,9 @@
       "parse": {
         "as": "notification"
       },
+      "redact": {
+        "title": {}
+      },
       "effects": [
         {
           "log": {
@@ -793,6 +796,9 @@
       "intent": "trip_at_dropoff",
       "parse": {
         "as": "notification"
+      },
+      "redact": {
+        "title": { "keepPrefix": [ "Leave the order at ", "Meet at door for " ] }
       },
       "effects": [
         {

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CaptureWriter.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CaptureWriter.kt
@@ -191,14 +191,25 @@ class CaptureWriter @Inject constructor(
             }
         }
         val platform = Platform.fromPackage(raw.packageName).wire
+        // #620: rule-declared notification-envelope redaction. A recognized
+        // notification (customer chat, order-ready) carries customer PII in its
+        // flat fields; a rule's `redact` block masks the customer name/body in the
+        // serialized envelope only. The masked copy is envelope-only — recognition
+        // and parse ran on the ORIGINAL raw, and its contentHash is the dedup
+        // identity, captured BEFORE masking (a masked .copy() recomputes a
+        // DIFFERENT hash). UNKNOWN notifications have no ruleId and are governed by
+        // the SensitiveTextMarkers backstop above instead.
+        val originalContentHash = raw.contentHash
+        val notifRedact = obs.ruleId?.let { redactionSource.notifRedactFor(it) }
+        val payloadRaw = notifRedact?.apply(raw) ?: raw
         val capture = EnvelopeBuilder.build(
             pipelineId = NotificationPipeline.PIPELINE_ID,
             schema = RawNotificationSchema,
             platform = platform,
             ruleId = obs.ruleId,
             classificationName = obs.target,
-            payload = raw,
-            contentHash = raw.contentHash,
+            payload = payloadRaw,
+            contentHash = originalContentHash,
             metadata = obs.metadata,
         )
         val captureId = captureBus.offer(

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CaptureWriter.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CaptureWriter.kt
@@ -73,7 +73,31 @@ class CaptureWriter @Inject constructor(
         // frames have no ruleId and are governed by the SensitiveTextMarkers
         // backstop above instead.
         val redact = obs.ruleId?.let { redactionSource.redactFor(it) }
-        val payloadTree = redact?.apply(event.tree) ?: event.tree
+        val redactedTree = redact?.apply(event.tree) ?: event.tree
+        // #624 recognized-frame customer-PII backstop (defense-in-depth): the
+        // #598 sha256→redact compile gate only fires for a rule that HASHES PII.
+        // A recognized rule that ships raw customer text with NO redact block (or
+        // a future downloaded rule that simply omits one) stays silent. Scan the
+        // envelope-bound tree for a customer-PII marker whose node was NOT already
+        // redacted and scrub it, so a rule that FORGOT to redact still ships a
+        // scrubbed capture. UNKNOWN frames are handled by SensitiveTextMarkers above.
+        val payloadTree = if (obs.target != UNKNOWN_TARGET) {
+            val marker = CustomerTextMarkers.firstUnredactedMarker(redactedTree)
+            if (marker != null) {
+                stats.onRedactBackstopScrub()
+                // Principle 7: log the MARKER + rule id only — NEVER the leaked value.
+                Timber.w(
+                    "Capture backstop: recognized frame carried un-redacted customer marker '%s' " +
+                        "(ruleId=%s) — scrubbing node from envelope",
+                    marker, obs.ruleId,
+                )
+                CustomerTextMarkers.scrub(redactedTree)
+            } else {
+                redactedTree
+            }
+        } else {
+            redactedTree
+        }
         val capture = EnvelopeBuilder.build(
             pipelineId = AccessibilityPipeline.SCREEN_PIPELINE_ID,
             schema = UiNodeSchema,

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CustomerTextMarkers.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CustomerTextMarkers.kt
@@ -1,0 +1,79 @@
+package cloud.trotter.dashbuddy.core.pipeline
+
+import cloud.trotter.dashbuddy.core.pipeline.rules.CompiledRedact
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+
+/**
+ * App-owned, rules-independent backstop for the CUSTOMER-PII redaction pledge
+ * (#624) — the recognized-frame analogue of [SensitiveTextMarkers].
+ *
+ * The two SSOTs differ in both target and action:
+ * - [SensitiveTextMarkers] guards the UNKNOWN path against the DASHER's OWN
+ *   sensitive screens (banking/identity) by DROPPING the whole capture.
+ * - This SSOT guards RECOGNIZED frames whose rule SHOULD have declared a
+ *   `redact` block but didn't, and it SCRUBS only the offending node to
+ *   `[redacted]` (the capture still ships, minus the leaked PII).
+ *
+ * Why it's needed: the #598 `sha256`→`redact` compile gate only fires for a rule
+ * that HASHES PII in its parse. A rule that ships raw customer text WITHOUT
+ * hashing it (the live `dropoff_reminder` address leak this PR also fixes in
+ * data) stays silent — and once rules are downloaded over a CDN (#192/#416/#419)
+ * a rule that simply omits redaction would leak. This backstop closes that class.
+ *
+ * Markers are customer-PII LABEL PREFIXES: a node whose text starts with one
+ * carries a customer name/identifier immediately after. `"Heading to "` is
+ * deliberately EXCLUDED (VET V2) — it prefixes STORE names on recognized
+ * pickup-nav frames, which are kept (merchants are not PII); the
+ * `CaptureBackstopCorpusTest` pins the set to ZERO false positives on the
+ * committed (already-redacted) corpus.
+ */
+object CustomerTextMarkers {
+
+    /** Customer-PII label prefixes. Case-insensitive `startsWith` match. */
+    val MARKERS: List<String> = listOf(
+        "Deliver to ",
+        "Order for ",
+        "Verify items for ",
+        "Delivery for ",
+    )
+
+    /** Substring that classifies a node's text as already-redacted (VET V1). */
+    private const val REDACTED_MARK = "[redacted"
+
+    /**
+     * The first marker [text] carries UN-redacted, or null when clean. A node
+     * whose text contains "[redacted" anywhere is treated as already-redacted and
+     * skipped (VET V1) — otherwise a rule's OWN redact output ("Deliver to door
+     * of [redacted:…]") would trip the "Deliver to " marker and re-scrub.
+     */
+    fun unredactedMarker(text: String?): String? {
+        if (text.isNullOrEmpty()) return null
+        if (text.contains(REDACTED_MARK)) return null
+        return MARKERS.firstOrNull { text.startsWith(it, ignoreCase = true) }
+    }
+
+    /**
+     * The first un-redacted customer marker anywhere in [tree] (text or
+     * contentDescription of any node), or null when clean. Cheap scan run on
+     * every recognized capture; the [scrub] copy is built only on a hit.
+     */
+    fun firstUnredactedMarker(tree: UiNode): String? =
+        tree.allText.firstNotNullOfOrNull { unredactedMarker(it) }
+
+    /**
+     * Return a copy of [tree] with every node whose `text`/`contentDescription`
+     * carries an un-redacted customer marker scrubbed to [CompiledRedact.REDACTED].
+     * Call only after [firstUnredactedMarker] returned non-null, so the tree copy
+     * never happens on the clean path.
+     */
+    fun scrub(tree: UiNode): UiNode = tree.copy(
+        text = if (unredactedMarker(tree.text) != null) CompiledRedact.REDACTED else tree.text,
+        contentDescription =
+            if (unredactedMarker(tree.contentDescription) != null) {
+                CompiledRedact.REDACTED
+            } else {
+                tree.contentDescription
+            },
+        children = tree.children.map { scrub(it) },
+    )
+}

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/PipelineStats.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/PipelineStats.kt
@@ -34,6 +34,7 @@ class PipelineStats @Inject constructor() {
     private val forwarded = AtomicLong()
     private val droppedAwaitingRules = AtomicLong()
     private val scrubbedUnknownCaptures = AtomicLong()
+    private val redactBackstopScrubs = AtomicLong()
 
     val droppedSensitiveCount: Long get() = droppedSensitive.get()
     val droppedNoiseCount: Long get() = droppedNoise.get()
@@ -45,6 +46,7 @@ class PipelineStats @Inject constructor() {
     val forwardedCount: Long get() = forwarded.get()
     val droppedAwaitingRulesCount: Long get() = droppedAwaitingRules.get()
     val scrubbedUnknownCaptureCount: Long get() = scrubbedUnknownCaptures.get()
+    val redactBackstopScrubCount: Long get() = redactBackstopScrubs.get()
 
     /** A frame the shared content gate dropped (sensitive or noise, #399). */
     fun onContentGateDrop(parsed: ParsedFields) {
@@ -85,6 +87,12 @@ class PipelineStats @Inject constructor() {
         scrubbedUnknownCaptures.incrementAndGet()
     }
 
+    /** A RECOGNIZED frame whose rule shipped an un-redacted customer marker; the
+     *  node was scrubbed in the envelope by the #624 defense-in-depth backstop. */
+    fun onRedactBackstopScrub() {
+        redactBackstopScrubs.incrementAndGet()
+    }
+
     /** The supervised upstream crashed and is resubscribing. Returns the restart ordinal. */
     fun onPipelineRestart(): Long = restarts.incrementAndGet()
 
@@ -108,6 +116,7 @@ class PipelineStats @Inject constructor() {
             " mappingFailures=${mappingFailures.get()}" +
             " awaitingRulesDropped=${droppedAwaitingRules.get()}" +
             " unknownScrubbed=${scrubbedUnknownCaptures.get()}" +
+            " redactBackstopScrubs=${redactBackstopScrubs.get()}" +
             " restarts=${restarts.get()}"
 
     companion object {

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/CompiledRules.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/CompiledRules.kt
@@ -1,6 +1,7 @@
 package cloud.trotter.dashbuddy.core.pipeline.rules
 
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData
 import cloud.trotter.dashbuddy.domain.pipeline.RequestedEffect
 import cloud.trotter.dashbuddy.domain.pipeline.TransitionTrigger
 import cloud.trotter.dashbuddy.domain.state.Flow
@@ -86,7 +87,86 @@ data class CompiledRule<TInput>(
     val bindings: List<Binding> = emptyList(),
     val branches: List<CompiledBranch<TInput>>,
     val redact: CompiledRedact = CompiledRedact.EMPTY,
+    val notifRedact: CompiledNotifRedact = CompiledNotifRedact.EMPTY,
 )
+
+/** The notification fields a [CompiledNotifRedact] can mask (#620). */
+enum class NotifField(val wire: String) {
+    TITLE("title"),
+    TEXT("text"),
+    BIG_TEXT("bigText"),
+    TICKER_TEXT("tickerText"),
+    SUB_TEXT("subText"),
+    ;
+
+    companion object {
+        fun fromWire(wire: String): NotifField? = entries.firstOrNull { it.wire == wire }
+    }
+}
+
+/**
+ * A per-field notification redact masker (#620). Notifications are flat strings
+ * (no tree), so masking is keyed by field name rather than a node predicate.
+ */
+sealed interface NotifFieldMask {
+    /** Mask the whole field value, preserving an optional leading [keepPrefix]. */
+    data class Whole(val keepPrefix: List<String> = emptyList()) : NotifFieldMask
+
+    /**
+     * Mask only the [group] capture of [regex] within the field, keeping the
+     * rest — e.g. the STORE in "<name>'s order is ready for pickup at <store>"
+     * (merchants are not PII).
+     */
+    data class RegexGroup(val regex: Regex, val group: Int) : NotifFieldMask
+}
+
+/**
+ * The compiled `redact` block for a notification rule (#620) — the flat-string
+ * analogue of [CompiledRedact]. Masks recognized customer PII (chat title/body,
+ * order-ready customer name) in the serialized notification envelope only; the
+ * ORIGINAL [RawNotificationData] drove recognition/parse and owns the dedup
+ * `contentHash`. Reuses [CompiledRedact.mask] so notification masks get the same
+ * `[redacted:<4hex>]` distinctness + fail-closed contract as screen redaction.
+ */
+data class CompiledNotifRedact(
+    val fields: Map<NotifField, NotifFieldMask>,
+) {
+    fun isEmpty(): Boolean = fields.isEmpty()
+
+    /**
+     * Return a masked COPY of [raw] for envelope serialization. The original is
+     * never mutated; callers must read the dedup `contentHash` off the ORIGINAL
+     * (a masked copy recomputes a different hash).
+     */
+    fun apply(raw: RawNotificationData): RawNotificationData = raw.copy(
+        title = maskField(NotifField.TITLE, raw.title),
+        text = maskField(NotifField.TEXT, raw.text),
+        bigText = maskField(NotifField.BIG_TEXT, raw.bigText),
+        tickerText = maskField(NotifField.TICKER_TEXT, raw.tickerText),
+        subText = maskField(NotifField.SUB_TEXT, raw.subText),
+    )
+
+    private fun maskField(field: NotifField, value: String?): String? {
+        if (value == null) return null
+        return when (val m = fields[field]) {
+            null -> value
+            is NotifFieldMask.Whole -> CompiledRedact.mask(value, m.keepPrefix)
+            is NotifFieldMask.RegexGroup -> maskGroup(value, m.regex, m.group)
+        }
+    }
+
+    private fun maskGroup(value: String, regex: Regex, group: Int): String {
+        val match = regex.find(value) ?: return value
+        val g = match.groups[group] ?: return value
+        // Reuse the SSOT mask (no keepPrefix — the group IS the token to hash).
+        val masked = CompiledRedact.mask(g.value, emptyList()) ?: CompiledRedact.REDACTED
+        return value.replaceRange(g.range, masked)
+    }
+
+    companion object {
+        val EMPTY = CompiledNotifRedact(emptyMap())
+    }
+}
 
 /**
  * A single compiled `redact` directive (#598). When [find] matches a node, that

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/CompiledRules.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/CompiledRules.kt
@@ -156,8 +156,12 @@ data class CompiledNotifRedact(
     }
 
     private fun maskGroup(value: String, regex: Regex, group: Int): String {
-        val match = regex.find(value) ?: return value
-        val g = match.groups[group] ?: return value
+        // FAIL CLOSED (#620 review F2b): if the capture regex drifts from the
+        // require gate (the rule matched but this pattern doesn't, or the group is
+        // absent), masking the group would ship the RAW field. A recognized frame
+        // must never ship raw PII, so mask the WHOLE field instead.
+        val match = regex.find(value) ?: return CompiledRedact.REDACTED
+        val g = match.groups[group] ?: return CompiledRedact.REDACTED
         // Reuse the SSOT mask (no keepPrefix — the group IS the token to hash).
         val masked = CompiledRedact.mask(g.value, emptyList()) ?: CompiledRedact.REDACTED
         return value.replaceRange(g.range, masked)

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/CompiledRules.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/CompiledRules.kt
@@ -93,9 +93,9 @@ data class CompiledRule<TInput>(
  * node's `text` and `contentDescription` are masked in the serialized capture
  * envelope only. [keepPrefix] preserves a leading marker label so a replayed
  * redacted capture still recognizes — e.g. "Deliver to <name>" is masked to
- * "Deliver to [redacted]", keeping the "Deliver to " require anchor while the
- * customer name is dropped. An address node (no marker) takes no keepPrefix and
- * is masked whole.
+ * "Deliver to [redacted:<4hex>]", keeping the "Deliver to " require anchor while
+ * the customer name is dropped. An address node (no marker) takes no keepPrefix
+ * and is masked whole. The `<4hex>` distinctness suffix is #623 — see [mask].
  */
 data class CompiledRedactEntry(
     val find: (UiNode) -> Boolean,
@@ -135,16 +135,45 @@ data class CompiledRedact(
         )
     }
 
-    private fun mask(value: String?, keepPrefix: List<String>): String? {
-        if (value == null) return null
-        val prefix = keepPrefix.firstOrNull { value.startsWith(it, ignoreCase = true) }
-        return if (prefix != null) prefix + REDACTED else REDACTED
-    }
-
     companion object {
-        /** Masked text written in place of redacted customer PII. */
+        /**
+         * Fail-closed mask written when the distinctness hash can't be computed
+         * (#362/#623): a redacted node still ships redacted, never the raw value.
+         */
         const val REDACTED = "[redacted]"
         val EMPTY = CompiledRedact(emptyList())
+
+        /**
+         * Mask [value], preserving a leading [keepPrefix] marker (#598), and
+         * append a per-customer distinctness suffix (#623): the masked portion
+         * becomes `[redacted:<4hex>]`, where `<4hex>` is the first four hex chars
+         * of the sha256 of the keepPrefix-STRIPPED, TRIMMED token.
+         *
+         * Frame-invariance: the token hashed is the customer string itself (after
+         * stripping the marker prefix and trimming), NOT the whole node text — so
+         * the SAME customer under different frame prefixes ("Deliver to X" vs
+         * "Heading to X" vs "Verify items for X") redacts to the SAME suffix, and
+         * two DIFFERENT customers redact to DIFFERENT suffixes. The strip+trim
+         * mirrors the parse's `stripPrefixes`/`trim`/`sha256` chain, so the suffix
+         * equals the first 4 hex of the `customerNameHash` the parse already
+         * persists — 16 bits of an already-one-way hash, no new information (#623).
+         *
+         * FAIL CLOSED (#362): if [sha256OrNull] returns null, emit the plain
+         * [REDACTED] constant — never the raw [value]. The "[redacted" prefix is
+         * kept so any `contains("[redacted")`/`startsWith` check (the #624
+         * backstop, any test scanner) still classifies the output as redacted.
+         *
+         * `internal` (not private) so the #620 notification per-field maskers
+         * reuse this ONE definition (SSOT) instead of copying it.
+         */
+        internal fun mask(value: String?, keepPrefix: List<String>): String? {
+            if (value == null) return null
+            val prefix = keepPrefix.firstOrNull { value.startsWith(it, ignoreCase = true) }
+            val token = if (prefix != null) value.substring(prefix.length).trim() else value.trim()
+            val hex = sha256OrNull(token)?.take(4)
+            val masked = if (hex != null) "[redacted:$hex]" else REDACTED
+            return if (prefix != null) prefix + masked else masked
+        }
     }
 }
 

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/JsonRuleInterpreter.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/JsonRuleInterpreter.kt
@@ -64,6 +64,14 @@ class JsonRuleInterpreter @Inject constructor(
         current.screens?.ruleById(ruleId)?.redact?.takeUnless { it.isEmpty() }
 
     /**
+     * #620: the compiled notification `redact` block for a recognized notification
+     * rule, read off the live bundle (volatile). Null when the rule declares no
+     * redaction, so the capture stage skips masking entirely.
+     */
+    override fun notifRedactFor(ruleId: String): CompiledNotifRedact? =
+        current.notifications?.ruleById(ruleId)?.notifRedact?.takeUnless { it.isEmpty() }
+
+    /**
      * True once a ruleset bundle has been published. The pipelines drop (not
      * capture) every frame until this flips (#432): the sensitive-screen gate
      * is rule-driven, so a frame classified before rules load would bypass it

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/JsonRuleInterpreter.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/JsonRuleInterpreter.kt
@@ -207,6 +207,22 @@ class JsonRuleInterpreter @Inject constructor(
 
             val formatVersion = root["format_version"]?.jsonPrimitive?.int
 
+            // #624 (VET V4): reject a FILE whose OWN rule ids collide within a rule
+            // type. Ruleset.byId is last-wins, so two same-id rules would let the
+            // capture-redaction lookup (redactFor/notifRedactFor) resolve to the
+            // WRONG rule's block. Skip the offending file per the malformed-file-skip
+            // policy — other platforms still load; NEVER throw into Ruleset.init,
+            // which would blind ALL sensing behind the #432 fail-closed gate.
+            val dupId = firstDuplicateId(screens) ?: firstDuplicateId(clicks) ?: firstDuplicateId(notifications)
+            if (dupId != null) {
+                Timber.e(
+                    "JsonRuleInterpreter: rejected '%s': duplicate rule id '%s' — ids must be unique " +
+                        "per rule type (byId redact lookup would resolve to the wrong rule, #624)",
+                    source, dupId,
+                )
+                return null
+            }
+
             Timber.i(
                 "JsonRuleInterpreter: compiled '$source' " +
                     "(screens=${screens.size}, clicks=${clicks.size}, notifications=${notifications.size})"
@@ -260,6 +276,10 @@ class JsonRuleInterpreter @Inject constructor(
             Timber.e(e, "JsonRuleInterpreter: capability reconcile failed — automation taps stay denied")
         }
     }
+
+    /** The first rule id that appears more than once in [rules], or null (#624). */
+    private fun <T> firstDuplicateId(rules: List<CompiledRule<T>>): String? =
+        rules.groupingBy { it.id }.eachCount().entries.firstOrNull { it.value > 1 }?.key
 
     /** Result of compiling a single rule file. */
     data class CompiledRuleBundle(

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompiler.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompiler.kt
@@ -149,8 +149,22 @@ object RuleCompiler {
         }
 
         val branches: List<CompiledBranch<TInput>> = if ("branches" in obj) {
-            obj["branches"]!!.jsonArray.map {
-                compileBranch(it.jsonObject, context, ruleState.flow, ruleState.modeHint,
+            obj["branches"]!!.jsonArray.map { branchElement ->
+                val branchObj = branchElement.jsonObject
+                // #624 (VET V3): `redact` is a WHOLE-RULE directive — compileBranch
+                // never reads it, so a `redact` inside a branches[] entry would
+                // silently no-op and a rule author would believe their branch masks
+                // capture PII when it does not. Reject at compile time. This is
+                // enforced ONLY for branches[] entries, NOT the branchless whole-rule
+                // compileBranch call below, which legitimately carries top-level redact.
+                if ("redact" in branchObj) {
+                    throw RuleCompileException(
+                        "Rule '$id': a `redact` block inside a branches[] entry is not supported — " +
+                            "redact masks capture-envelope nodes for the ENTIRE recognized frame, " +
+                            "not per-branch. Move it to the rule's top level.",
+                    )
+                }
+                compileBranch(branchObj, context, ruleState.flow, ruleState.modeHint,
                     ruleOutcomes = ruleState.outcomes, ruleId = id,
                     ruleParseBlock = ruleParseObj, ruleParseAs = ruleParseAs, ruleBindObj = ruleBindObj)
             }

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompiler.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompiler.kt
@@ -140,6 +140,17 @@ object RuleCompiler {
             obj["redact"]?.jsonObject?.let { compileNotifRedactBlock(it) } ?: CompiledNotifRedact.EMPTY
         } else CompiledNotifRedact.EMPTY
 
+        // #620 review F5: a `redact` on a CLICK-context rule silently vanishes —
+        // `redact` compiles only for SCREEN, `notifRedact` only for NOTIFICATION —
+        // the same silent-no-op class we reject for branch-level redact (VET V3).
+        // Reject it (click envelopes carry app-vocabulary button labels, no PII).
+        if (context == RuleContext.CLICK && "redact" in obj) {
+            throw RuleCompileException(
+                "Rule '$id': `redact` is not supported on CLICK rules — a click envelope carries " +
+                    "app-vocabulary button labels, not customer PII. Remove the redact block.",
+            )
+        }
+
         // #598 fail-closed: a screen rule that hashes customer PII in its parse
         // (`sha256` transform) MUST declare a non-empty `redact` block. The hash
         // side (parse output) and the disk side (envelope) can't drift — a rule
@@ -205,6 +216,17 @@ object RuleCompiler {
             val masker: NotifFieldMask = if (matchPattern != null) {
                 val regex = compileRegex(matchPattern)
                 val group = specObj["maskGroup"]?.jsonPrimitive?.intOrNull ?: 1
+                // #620 review F3: bound maskGroup at COMPILE time. An out-of-range
+                // group would throw IndexOutOfBoundsException at capture (inside the
+                // supervised upstream) → a crash/restart loop, once per matching
+                // notification arrival. Group 0 is the whole match; 1..N the captures.
+                val groupCount = regex.toPattern().matcher("").groupCount()
+                if (group < 0 || group > groupCount) {
+                    throw RuleCompileException(
+                        "notification redact: field '$fieldName' maskGroup $group is out of range " +
+                            "(pattern '$matchPattern' has $groupCount capturing group(s); valid 0..$groupCount)",
+                    )
+                }
                 NotifFieldMask.RegexGroup(regex, group)
             } else {
                 val keepPrefix = specObj["keepPrefix"]?.jsonArray?.map { it.jsonPrimitive.content }

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompiler.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompiler.kt
@@ -129,10 +129,16 @@ object RuleCompiler {
         val ruleParseObj = obj["parse"]?.jsonObject
         val ruleParseAs = ruleParseObj?.get("as")?.jsonPrimitive?.content
 
-        // Rule-level redact directives (screen rules only, #598).
+        // Rule-level redact directives. Screen rules use a `redact` ARRAY of node
+        // predicates (#598); notification rules use a `redact` OBJECT keyed by
+        // field (#620). Compiled into distinct carriers so neither context can
+        // read the other's shape.
         val redact = if (context == RuleContext.SCREEN) {
             obj["redact"]?.jsonArray?.let { compileRedactBlock(it) } ?: CompiledRedact.EMPTY
         } else CompiledRedact.EMPTY
+        val notifRedact = if (context == RuleContext.NOTIFICATION) {
+            obj["redact"]?.jsonObject?.let { compileNotifRedactBlock(it) } ?: CompiledNotifRedact.EMPTY
+        } else CompiledNotifRedact.EMPTY
 
         // #598 fail-closed: a screen rule that hashes customer PII in its parse
         // (`sha256` transform) MUST declare a non-empty `redact` block. The hash
@@ -173,7 +179,41 @@ object RuleCompiler {
                 ruleOutcomes = ruleState.outcomes, ruleId = id))
         }
 
-        return CompiledRule(id, priority, overrideable, ruleBindings, branches, redact)
+        return CompiledRule(id, priority, overrideable, ruleBindings, branches, redact, notifRedact)
+    }
+
+    /**
+     * Compile a notification rule's `redact` OBJECT (#620), keyed by field name
+     * (title/text/bigText/tickerText/subText). Each value is either a whole-field
+     * spec (optional `keepPrefix`) or a regex-capture spec (`match` + `maskGroup`,
+     * default group 1). Regexes go through the bounded [compileRegex]/[RegexSafety]
+     * guard — notification rules are untrusted input on the #192 CDN path too.
+     */
+    private fun compileNotifRedactBlock(obj: JsonObject): CompiledNotifRedact {
+        val fields = obj.entries.associate { (fieldName, spec) ->
+            val field = NotifField.fromWire(fieldName)
+                ?: throw RuleCompileException(
+                    "notification redact: unknown field '$fieldName' " +
+                        "(expected one of ${NotifField.entries.map { it.wire }})",
+                )
+            val specObj = spec as? JsonObject
+                ?: throw RuleCompileException(
+                    "notification redact: field '$fieldName' must be an object " +
+                        "({ \"keepPrefix\": [...] } or { \"match\": <regex>, \"maskGroup\": <int> })",
+                )
+            val matchPattern = specObj["match"]?.jsonPrimitive?.content
+            val masker: NotifFieldMask = if (matchPattern != null) {
+                val regex = compileRegex(matchPattern)
+                val group = specObj["maskGroup"]?.jsonPrimitive?.intOrNull ?: 1
+                NotifFieldMask.RegexGroup(regex, group)
+            } else {
+                val keepPrefix = specObj["keepPrefix"]?.jsonArray?.map { it.jsonPrimitive.content }
+                    ?: emptyList()
+                NotifFieldMask.Whole(keepPrefix)
+            }
+            field to masker
+        }
+        return CompiledNotifRedact(fields)
     }
 
     // ==========================================================================

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/ScreenRedactionSource.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/ScreenRedactionSource.kt
@@ -14,4 +14,11 @@ interface ScreenRedactionSource {
      * backstop instead.
      */
     fun redactFor(ruleId: String): CompiledRedact?
+
+    /**
+     * The compiled notification `redact` block for [ruleId] (#620), or null when
+     * the rule declares none. The notification analogue of [redactFor]; defaulted
+     * to null so screen-only stubs need not implement it.
+     */
+    fun notifRedactFor(ruleId: String): CompiledNotifRedact? = null
 }

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureRedactionTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureRedactionTest.kt
@@ -136,16 +136,57 @@ class CaptureRedactionTest {
     }
 
     @Test
-    fun `recognized screen without a redact block persists the tree unchanged`() {
+    fun `recognized screen without a redact block persists non-PII text unchanged`() {
         whenever(captureBus.offer(any(), any(), anyOrNull(), any(), any(), anyOrNull()))
             .thenReturn("cap-1")
-        val tree = UiNode(children = listOf(UiNode(text = "Deliver to Jane Q. Doe")))
+        // Non-PII text (no customer marker) → nothing to mask, backstop is inert.
+        val tree = UiNode(children = listOf(UiNode(text = "Nearby high pay")))
         // Source returns null for this ruleId → no redaction.
         writer(sourceFor("some.other.rule", dropoffRedact))
             .captureScreen(recognizedObs("doordash.screen.idle_map", "idle_map"), screenEvent(tree))
 
         val json = capturedEnvelope()
-        assertTrue("no redact declared → raw text persists", json.contains("Deliver to Jane Q. Doe"))
+        assertTrue("no redact + no marker → text persists", json.contains("Nearby high pay"))
+    }
+
+    @Test
+    fun `recognized frame whose rule forgot to redact a customer marker is scrubbed by the backstop`() {
+        // #624: a RECOGNIZED frame carrying "Deliver to <name>" whose rule declared
+        // NO redact block (redactFor returns null) — the customer-marker backstop is
+        // the only thing between the raw name and disk. It scrubs the node.
+        whenever(captureBus.offer(any(), any(), anyOrNull(), any(), any(), anyOrNull()))
+            .thenReturn("cap-1")
+        val tree = UiNode(
+            children = listOf(
+                UiNode(text = "Deliver to Jane Q. Doe"),
+                UiNode(text = "Directions"),
+            ),
+        )
+        writer(sourceFor("some.other.rule", dropoffRedact))
+            .captureScreen(
+                recognizedObs("doordash.screen.dropoff_navigation", "dropoff_navigation"),
+                screenEvent(tree),
+            )
+
+        val json = capturedEnvelope()
+        assertFalse("leaked customer name scrubbed by backstop", json.contains("Jane Q. Doe"))
+        assertTrue("scrubbed node became [redacted]", json.contains("[redacted]"))
+        assertTrue("non-PII node intact", json.contains("Directions"))
+        assertEquals(1L, stats.redactBackstopScrubCount)
+    }
+
+    @Test
+    fun `UNKNOWN frame is not scrubbed by the recognized-frame backstop`() {
+        // The #624 backstop only guards RECOGNIZED frames; UNKNOWN frames route
+        // through the SensitiveTextMarkers drop path instead. A benign UNKNOWN
+        // marker-shaped string must not trip the recognized-frame scrub.
+        whenever(captureBus.offer(any(), any(), anyOrNull(), any(), any(), anyOrNull()))
+            .thenReturn("cap-1")
+        val tree = UiNode(children = listOf(UiNode(text = "Order for pickup nearby")))
+        val obs = recognizedObs(UNKNOWN_TARGET, UNKNOWN_TARGET).copy(ruleId = null)
+        writer(sourceFor("x", dropoffRedact)).captureScreen(obs, screenEvent(tree))
+        assertTrue(capturedEnvelope().contains("Order for pickup nearby"))
+        assertEquals(0L, stats.redactBackstopScrubCount)
     }
 
     @Test

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureRedactionTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureRedactionTest.kt
@@ -104,10 +104,17 @@ class CaptureRedactionTest {
 
         val json = capturedEnvelope()
         // PII gone, marker kept, address masked whole, unrelated node intact.
+        // #623: the masked portion carries a `[redacted:<4hex>]` distinctness suffix.
         assertFalse("customer name must not persist", json.contains("Jane Q. Doe"))
         assertFalse("street address must not persist", json.contains("123 Secret St"))
-        assertTrue("marker + redacted name", json.contains("Deliver to [redacted]"))
-        assertTrue("address masked whole", json.contains("\"text\": \"[redacted]\""))
+        assertTrue(
+            "marker + redacted name",
+            Regex("""Deliver to \[redacted:[0-9a-f]{4}\]""").containsMatchIn(json),
+        )
+        assertTrue(
+            "address masked whole",
+            Regex(""""text": "\[redacted:[0-9a-f]{4}\]"""").containsMatchIn(json),
+        )
         assertTrue("non-PII node intact", json.contains("Directions"))
     }
 

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CustomerTextMarkersTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CustomerTextMarkersTest.kt
@@ -1,0 +1,66 @@
+package cloud.trotter.dashbuddy.core.pipeline
+
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * #624 marker-SSOT unit tests for [CustomerTextMarkers] — the recognized-frame
+ * customer-PII backstop's keyword set and the already-redacted skip rule (VET V1)
+ * plus the deliberate "Heading to " exclusion (VET V2).
+ */
+class CustomerTextMarkersTest {
+
+    @Test
+    fun `a customer marker prefix is detected`() {
+        assertEquals("Deliver to ", CustomerTextMarkers.unredactedMarker("Deliver to Jane Q Doe"))
+        assertEquals("Order for ", CustomerTextMarkers.unredactedMarker("Order for John Smith"))
+        assertEquals("Verify items for ", CustomerTextMarkers.unredactedMarker("Verify items for Jane"))
+        assertEquals("Delivery for ", CustomerTextMarkers.unredactedMarker("Delivery for John"))
+    }
+
+    @Test
+    fun `an already-redacted node is skipped (VET V1)`() {
+        // The distinctness suffix form and the plain form both contain "[redacted".
+        assertNull(CustomerTextMarkers.unredactedMarker("Deliver to [redacted:ab12]"))
+        assertNull(CustomerTextMarkers.unredactedMarker("Deliver to [redacted]"))
+        // The rule's OWN dropoff_reminder output must not re-trip the backstop.
+        assertNull(CustomerTextMarkers.unredactedMarker("Deliver to door of [redacted:ab12]"))
+    }
+
+    @Test
+    fun `Heading to is NOT a marker - it prefixes store names (VET V2)`() {
+        assertNull(CustomerTextMarkers.unredactedMarker("Heading to Chipotle"))
+    }
+
+    @Test
+    fun `Deliver by is NOT a marker - it is a time`() {
+        assertNull(CustomerTextMarkers.unredactedMarker("Deliver by 5:00 PM"))
+    }
+
+    @Test
+    fun `null and blank are clean`() {
+        assertNull(CustomerTextMarkers.unredactedMarker(null))
+        assertNull(CustomerTextMarkers.unredactedMarker(""))
+    }
+
+    @Test
+    fun `firstUnredactedMarker walks the whole tree and scrub masks only the offending node`() {
+        val tree = UiNode(
+            children = listOf(
+                UiNode(text = "Directions"),
+                UiNode(text = "Deliver to Jane Q Doe"),
+                UiNode(text = "Got it"),
+            ),
+        )
+        assertEquals("Deliver to ", CustomerTextMarkers.firstUnredactedMarker(tree))
+
+        val scrubbed = CustomerTextMarkers.scrub(tree)
+        assertEquals("Directions", scrubbed.children[0].text)
+        assertEquals("[redacted]", scrubbed.children[1].text)
+        assertEquals("Got it", scrubbed.children[2].text)
+        // Clean after scrub.
+        assertNull(CustomerTextMarkers.firstUnredactedMarker(scrubbed))
+    }
+}

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/NotificationRedactionTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/NotificationRedactionTest.kt
@@ -1,0 +1,180 @@
+package cloud.trotter.dashbuddy.core.pipeline
+
+import cloud.trotter.dashbuddy.core.pipeline.rules.CompiledNotifRedact
+import cloud.trotter.dashbuddy.core.pipeline.rules.CompiledRedact
+import cloud.trotter.dashbuddy.core.pipeline.rules.RuleCompiler
+import cloud.trotter.dashbuddy.core.pipeline.rules.RuleContext
+import cloud.trotter.dashbuddy.core.pipeline.rules.ScreenRedactionSource
+import cloud.trotter.dashbuddy.domain.capture.CaptureBus
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
+import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData
+import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.pipeline.UNKNOWN_TARGET
+import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+/**
+ * #620 — rule-declared notification-envelope redaction. A recognized notification
+ * whose rule declares a `redact` block must have customer PII masked in the
+ * serialized envelope offered to the bus, while recognition/parse ran on the
+ * ORIGINAL notification and the dedup contentHash is preserved (VET V7).
+ */
+class NotificationRedactionTest {
+
+    private val captureBus: CaptureBus = mock()
+    private val stats = PipelineStats()
+
+    private fun compileNotifRedact(json: String): CompiledNotifRedact =
+        RuleCompiler.compileRules<RawNotificationData>(
+            Json.parseToJsonElement(json).jsonArray, RuleContext.NOTIFICATION,
+        ).single().notifRedact
+
+    private fun sourceFor(ruleId: String, redact: CompiledNotifRedact) = object : ScreenRedactionSource {
+        override fun redactFor(id: String): CompiledRedact? = null
+        override fun notifRedactFor(id: String): CompiledNotifRedact? = redact.takeIf { id == ruleId }
+    }
+
+    private fun writer(source: ScreenRedactionSource) = CaptureWriter(captureBus, stats, source)
+
+    private fun raw(
+        title: String? = null,
+        text: String? = null,
+        bigText: String? = null,
+        tickerText: String? = null,
+        channelId: String? = null,
+    ) = RawNotificationData(
+        title = title, text = text, bigText = bigText, tickerText = tickerText,
+        packageName = "com.doordash.driverapp", postTime = 0L, isClearable = true,
+        channelId = channelId,
+    )
+
+    private fun obs(ruleId: String?, target: String?) = Observation.Notification(
+        timestamp = 1_000L,
+        captureId = null,
+        ruleId = ruleId,
+        metadata = ReplayMetadata.EMPTY,
+        flow = null,
+        modeHint = null,
+        parsed = ParsedFields.None,
+        target = target,
+    )
+
+    private fun capturedEnvelope(): String {
+        val cap = argumentCaptor<String>()
+        org.mockito.kotlin.verify(captureBus).offer(any(), any(), anyOrNull(), any(), cap.capture(), anyOrNull())
+        return cap.lastValue
+    }
+
+    private val customerMessageRedact = compileNotifRedact(
+        """[{
+            "id": "doordash.notification.customer_message",
+            "priority": 22,
+            "require": { "channelIdContains": "chat" },
+            "redact": {
+                "title": { "keepPrefix": [ "Message from " ] },
+                "text": {},
+                "bigText": {},
+                "tickerText": {}
+            }
+        }]""",
+    )
+
+    private val orderReadyRedact = compileNotifRedact(
+        """[{
+            "id": "doordash.notification.order_ready",
+            "priority": 24,
+            "require": { "anyFieldContains": "ready for pickup" },
+            "redact": {
+                "text": { "match": "^(.+?)'s order is ready for pickup at ", "maskGroup": 1 }
+            }
+        }]""",
+    )
+
+    @Test
+    fun `customer_message envelope masks the name and body, keeps the marker`() {
+        whenever(captureBus.offer(any(), any(), anyOrNull(), any(), any(), anyOrNull())).thenReturn("cap-1")
+        val message = raw(
+            title = "Message from Jennifer",
+            text = "The gate code is 4412, leave at door",
+            tickerText = "The gate code is 4412, leave at door",
+            channelId = "dasher-notification-channel-inapp-chat",
+        )
+        writer(sourceFor("doordash.notification.customer_message", customerMessageRedact))
+            .captureNotification(obs("doordash.notification.customer_message", "customer_message"), message)
+
+        val json = capturedEnvelope()
+        assertFalse("sender name gone", json.contains("Jennifer"))
+        assertFalse("body gone", json.contains("gate code is 4412"))
+        assertTrue("marker kept, name masked", Regex("""Message from \[redacted:[0-9a-f]{4}\]""").containsMatchIn(json))
+    }
+
+    @Test
+    fun `notification redaction preserves the ORIGINAL contentHash (VET V7)`() {
+        whenever(captureBus.offer(any(), any(), anyOrNull(), any(), any(), anyOrNull())).thenReturn("cap-1")
+        val message = raw(
+            title = "Message from Jennifer",
+            text = "secret body",
+            channelId = "dasher-notification-channel-inapp-chat",
+        )
+        val originalHash = message.contentHash
+        writer(sourceFor("doordash.notification.customer_message", customerMessageRedact))
+            .captureNotification(obs("doordash.notification.customer_message", "customer_message"), message)
+
+        val hashCap = argumentCaptor<Int?>()
+        org.mockito.kotlin.verify(captureBus).offer(any(), any(), anyOrNull(), any(), any(), hashCap.capture())
+        assertEquals("dedup identity must be the ORIGINAL raw hash, not the masked copy's", originalHash, hashCap.lastValue)
+    }
+
+    @Test
+    fun `order_ready masks the customer name but keeps the store`() {
+        whenever(captureBus.offer(any(), any(), anyOrNull(), any(), any(), anyOrNull())).thenReturn("cap-1")
+        val ready = raw(
+            title = "Delivery Update",
+            text = "Adam's order is ready for pickup at 7-Eleven.",
+            channelId = "dasher-notification-channel-delivery-update",
+        )
+        writer(sourceFor("doordash.notification.order_ready", orderReadyRedact))
+            .captureNotification(obs("doordash.notification.order_ready", "order_ready_for_pickup"), ready)
+
+        val json = capturedEnvelope()
+        assertFalse("customer name gone", json.contains("Adam"))
+        assertTrue("store kept", json.contains("7-Eleven"))
+        assertTrue("title (non-PII) kept", json.contains("Delivery Update"))
+    }
+
+    @Test
+    fun `a benign notification with no redact block is unchanged`() {
+        whenever(captureBus.offer(any(), any(), anyOrNull(), any(), any(), anyOrNull())).thenReturn("cap-1")
+        val newOrder = raw(title = "You have a new order!", text = "Tap to view", channelId = "new-order")
+        // notifRedactFor returns null for this rule id.
+        writer(sourceFor("doordash.notification.customer_message", customerMessageRedact))
+            .captureNotification(obs("doordash.notification.new_order", "new_order"), newOrder)
+
+        val json = capturedEnvelope()
+        assertTrue(json.contains("You have a new order!"))
+        assertTrue(json.contains("Tap to view"))
+    }
+
+    @Test
+    fun `UNKNOWN notification never consults the notif redaction source`() {
+        whenever(captureBus.offer(any(), any(), anyOrNull(), any(), any(), anyOrNull())).thenReturn("cap-1")
+        val benign = raw(title = "Promo", text = "50% off", channelId = "marketing")
+        val throwing = object : ScreenRedactionSource {
+            override fun redactFor(ruleId: String): CompiledRedact? = null
+            override fun notifRedactFor(ruleId: String): CompiledNotifRedact =
+                throw AssertionError("UNKNOWN path must not consult redaction source")
+        }
+        writer(throwing).captureNotification(obs(null, UNKNOWN_TARGET), benign)
+        assertTrue(capturedEnvelope().contains("50% off"))
+    }
+}

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/JsonRuleInterpreterDupIdTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/JsonRuleInterpreterDupIdTest.kt
@@ -1,0 +1,52 @@
+package cloud.trotter.dashbuddy.core.pipeline.rules
+
+import android.content.Context
+import cloud.trotter.dashbuddy.domain.capability.RuleCapabilityGrants
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.mockito.kotlin.mock
+
+/**
+ * #624 (VET V4) — a rule FILE whose own ids collide within a rule type is skipped
+ * per the malformed-file-skip policy, NOT compiled with a shadowed byId map (which
+ * would let the capture-redaction lookup resolve to the wrong rule). Skipping one
+ * file must not blind all sensing (no throw into Ruleset.init).
+ *
+ * loadSingle touches neither the Context nor the grant store, so both are mocked.
+ */
+class JsonRuleInterpreterDupIdTest {
+
+    private val interpreter = JsonRuleInterpreter(mock<Context>(), mock<RuleCapabilityGrants>())
+
+    @Test
+    fun `a file with duplicate screen ids is skipped`() {
+        val json = """
+            {
+              "format_version": 2,
+              "platform_id": "doordash.driver",
+              "screens": [
+                { "id": "doordash.screen.dup", "priority": 9101, "require": { "exists": { "hasText": "A" } } },
+                { "id": "doordash.screen.dup", "priority": 9102, "require": { "exists": { "hasText": "B" } } }
+              ]
+            }
+        """.trimIndent()
+        assertNull("duplicate id must skip the whole file", interpreter.loadSingle(json, "dup.json"))
+    }
+
+    @Test
+    fun `a file with unique ids compiles`() {
+        val json = """
+            {
+              "format_version": 2,
+              "platform_id": "doordash.driver",
+              "screens": [
+                { "id": "doordash.screen.one", "priority": 9101, "require": { "exists": { "hasText": "A" } } },
+                { "id": "doordash.screen.two", "priority": 9102, "require": { "exists": { "hasText": "B" } } }
+              ]
+            }
+        """.trimIndent()
+        val bundle = interpreter.loadSingle(json, "ok.json")
+        assertNotNull("unique ids must compile", bundle)
+    }
+}

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompilerTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompilerTest.kt
@@ -983,4 +983,45 @@ class RuleCompilerTest {
         assertEquals(1000L, effect.throttleMs)
         assertEquals("k", effect.dedupeKey)
     }
+
+    // =========================================================================
+    // redact block placement (#624 VET V3)
+    // =========================================================================
+
+    @Test(expected = RuleCompileException::class)
+    fun `a redact block inside a branches entry is rejected (#624)`() {
+        // compileBranch never reads `redact` — a branch-level redact would silently
+        // no-op, so the author's PII would ship raw. Reject at compile time.
+        val rule = """
+            [{
+              "id": "doordash.screen.branch_redact",
+              "priority": 9001,
+              "branches": [
+                {
+                  "require": { "exists": { "hasText": "x" } },
+                  "redact": [ { "find": { "hasTextStartsWith": "Deliver to " }, "keepPrefix": [ "Deliver to " ] } ]
+                }
+              ]
+            }]
+        """.trimIndent()
+        RuleCompiler.compileRules<UiNode>(parseJson(rule).jsonArray, RuleContext.SCREEN)
+    }
+
+    @Test
+    fun `a top-level redact on a branched rule still compiles (#624)`() {
+        // The reject is scoped to branches[] entries; a whole-rule top-level redact
+        // is the #598 mechanism and must keep compiling.
+        val rule = """
+            [{
+              "id": "doordash.screen.toplevel_redact",
+              "priority": 9002,
+              "redact": [ { "find": { "hasTextStartsWith": "Deliver to " }, "keepPrefix": [ "Deliver to " ] } ],
+              "branches": [
+                { "require": { "exists": { "hasText": "x" } } }
+              ]
+            }]
+        """.trimIndent()
+        val compiled = RuleCompiler.compileRules<UiNode>(parseJson(rule).jsonArray, RuleContext.SCREEN)
+        assertFalse("top-level redact must compile onto the rule", compiled.single().redact.isEmpty())
+    }
 }

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompilerTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompilerTest.kt
@@ -978,6 +978,55 @@ class RuleCompilerTest {
         )
     }
 
+    @Test
+    fun `notification regex-capture mask fails CLOSED when the pattern does not match (F2b)`() {
+        // The require gate admitted the notification but the capture regex drifted
+        // and does not match — masking the group would ship the RAW field. It must
+        // mask the WHOLE field instead.
+        val ruleJson = """[{
+            "id": "doordash.notification.order_ready",
+            "priority": 10,
+            "require": { "anyFieldContains": "ready" },
+            "redact": { "text": { "match": "^(.+?)'s order is ready for pickup at ", "maskGroup": 1 } }
+        }]"""
+        val rule = RuleCompiler.compileRules<RawNotificationData>(
+            Json.parseToJsonElement(ruleJson).jsonArray, RuleContext.NOTIFICATION,
+        ).single()
+        val masked = rule.notifRedact.apply(raw(text = "Your order is ready!"))
+        assertEquals("whole field masked when the capture regex misses", "[redacted]", masked.text)
+    }
+
+    @Test(expected = RuleCompileException::class)
+    fun `notification redact rejects an out-of-range maskGroup (F3)`() {
+        // Pattern has 2 capturing groups; maskGroup 5 would throw
+        // IndexOutOfBoundsException at capture — reject at COMPILE (fail closed).
+        val ruleJson = """[{
+            "id": "doordash.notification.bad_group",
+            "priority": 12,
+            "require": { "channelIdContains": "chat" },
+            "redact": { "text": { "match": "(foo)(bar)", "maskGroup": 5 } }
+        }]"""
+        RuleCompiler.compileRules<RawNotificationData>(
+            Json.parseToJsonElement(ruleJson).jsonArray, RuleContext.NOTIFICATION,
+        )
+    }
+
+    @Test(expected = RuleCompileException::class)
+    fun `a redact on a CLICK rule is rejected (F5)`() {
+        // redact compiles only for SCREEN, notifRedact only for NOTIFICATION — a
+        // CLICK-context redact silently vanishes, so reject it at compile.
+        val ruleJson = """[{
+            "id": "doordash.click.some_button",
+            "priority": 99,
+            "screenIs": "offer_popup",
+            "require": { "hasText": "Accept" },
+            "redact": [ { "find": { "hasTextStartsWith": "Deliver to " } } ]
+        }]"""
+        RuleCompiler.compileRules<UiNode>(
+            Json.parseToJsonElement(ruleJson).jsonArray, RuleContext.CLICK,
+        )
+    }
+
     // =========================================================================
     // enumeratePermissions
     // =========================================================================

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompilerTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompilerTest.kt
@@ -910,8 +910,8 @@ class RuleCompilerTest {
 
     @Test
     fun `notification rule with sha256 does not require a redact block`() {
-        // Enforcement is scoped to SCREEN; the notification-envelope redaction is
-        // tracked as a separate follow-up (#598 body).
+        // The sha256->redact compile gate is SCREEN-scoped. Notification-envelope
+        // redaction is opt-in `redact` vocabulary (#620), not compiler-enforced.
         val ruleJson = """[{
             "id": "doordash.notification.customer_message",
             "priority": 10,
@@ -926,6 +926,56 @@ class RuleCompilerTest {
             Json.parseToJsonElement(ruleJson).jsonArray, RuleContext.NOTIFICATION,
         )
         assertEquals(1, rules.size)
+    }
+
+    // =========================================================================
+    // notification redact block (#620)
+    // =========================================================================
+
+    @Test
+    fun `notification redact compiles both whole-field and regex-capture maskers`() {
+        val ruleJson = """[{
+            "id": "doordash.notification.customer_message",
+            "priority": 10,
+            "require": { "channelIdContains": "chat" },
+            "redact": {
+                "title": { "keepPrefix": [ "Message from " ] },
+                "text": {},
+                "bigText": { "match": "^(.+?)'s order is ready for pickup at ", "maskGroup": 1 }
+            }
+        }]"""
+        val rule = RuleCompiler.compileRules<RawNotificationData>(
+            Json.parseToJsonElement(ruleJson).jsonArray, RuleContext.NOTIFICATION,
+        ).single()
+        assertFalse("notif redact must compile onto the rule", rule.notifRedact.isEmpty())
+
+        val masked = rule.notifRedact.apply(
+            raw(title = "Message from Jennifer", text = "gate code is 4412", bigText = "Adam's order is ready for pickup at 7-Eleven"),
+        )
+        // Whole-field with keepPrefix: marker kept, name masked.
+        assertTrue(Regex("""^Message from \[redacted:[0-9a-f]{4}\]$""").matches(masked.title!!))
+        // Whole-field: body fully masked.
+        assertTrue(Regex("""^\[redacted:[0-9a-f]{4}\]$""").matches(masked.text!!))
+        // Regex-capture: name masked, store kept.
+        assertFalse("customer name gone", masked.bigText!!.contains("Adam"))
+        assertTrue("store kept", masked.bigText!!.contains("7-Eleven"))
+        assertTrue(
+            Regex("""^\[redacted:[0-9a-f]{4}\]'s order is ready for pickup at 7-Eleven$""")
+                .matches(masked.bigText!!),
+        )
+    }
+
+    @Test(expected = RuleCompileException::class)
+    fun `notification redact rejects an unknown field`() {
+        val ruleJson = """[{
+            "id": "doordash.notification.bad_field",
+            "priority": 11,
+            "require": { "channelIdContains": "chat" },
+            "redact": { "notAField": {} }
+        }]"""
+        RuleCompiler.compileRules<RawNotificationData>(
+            Json.parseToJsonElement(ruleJson).jsonArray, RuleContext.NOTIFICATION,
+        )
     }
 
     // =========================================================================

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompilerTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompilerTest.kt
@@ -894,8 +894,15 @@ class RuleCompilerTest {
             ),
         )
         val redacted = rule.redact.apply(tree)
-        assertEquals("Deliver to [redacted]", redacted.children[0].text)
-        assertEquals("[redacted]", redacted.children[1].text)
+        // #623: masked portion carries a `[redacted:<4hex>]` distinctness suffix.
+        assertTrue(
+            "marker kept, name masked with distinctness suffix",
+            Regex("""^Deliver to \[redacted:[0-9a-f]{4}\]$""").matches(redacted.children[0].text!!),
+        )
+        assertTrue(
+            "address masked whole with distinctness suffix",
+            Regex("""^\[redacted:[0-9a-f]{4}\]$""").matches(redacted.children[1].text!!),
+        )
         assertEquals("Directions", redacted.children[2].text)
         // Original tree is untouched.
         assertEquals("Deliver to Jane Q. Doe", tree.children[0].text)

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -90,6 +90,22 @@ was found **broken-in-part** (raw PII in capture envelopes) and moved to that en
   them should equal the combined receipt total (the `parsedPay.total` on the announced row).
   Broken = a drop with null `dropRealizedPay` on a receipted stack, or the per-drop shares not
   summing to the receipt total.
+- **🔒 PLEDGE FIX — recognized-notification captures now mask customer PII (#620).**
+  Send yourself a customer chat ("Message from ‹name›" + a message body) and trigger an order-ready
+  push ("‹name›'s order is ready for pickup at ‹store›"), then pull the capture envelopes off-device.
+  **Working looks like:** the chat capture shows the sender masked (`Message from [redacted:‹4hex›]`)
+  and NO message body; the order-ready capture shows the customer name masked (`[redacted:‹4hex›]`)
+  but **keeps the store name** (merchants aren't PII). If any raw customer name/body survives in a
+  notification envelope, it's broken.
+  - Confirmed: 0/2
+- **🔒 PLEDGE FIX — dropoff-reminder screen capture now masks the address (#624).**
+  Hit the "Deliver to door of ‹address›" reminder card on a dropoff and capture it. **Working looks
+  like:** the envelope shows `Deliver to door of [redacted:‹4hex›]` — the street/apt gone. (This was
+  a live raw-address leak the #598 sha256 gate couldn't catch.) A defense-in-depth backstop also
+  scrubs any recognized screen that ships a "Deliver to "/"Order for " customer line a rule forgot
+  to redact — if you see a `redactBackstopScrubs=` count climb in the PipelineStats log line, note
+  which screen tripped it.
+  - Confirmed: 0/2
 - **🔧 FIX SHIPPED — offer outcome cards now derive from the committed outcome, not the tap (#601).
   DELIBERATE UX CHANGE — CONFIRM ON DASH.**
   Before, tapping Accept/Decline printed "Offer Accepted"/"Offer Declined" immediately, from the

--- a/docs/rules.schema.json
+++ b/docs/rules.schema.json
@@ -279,6 +279,7 @@
           "description": "Positive match condition. Must pass for the rule to match."
         },
         "parse": { "$ref": "#/$defs/notificationParseBlock" },
+        "redact": { "$ref": "#/$defs/notifRedactBlock" },
         "validate": {
           "type": "array",
           "items": { "$ref": "#/$defs/validateEntry" }
@@ -341,7 +342,7 @@
 
     "redactBlock": {
       "type": "array",
-      "description": "Rule-declared capture redaction (#598). At CAPTURE time, any node matching an entry's 'find' predicate has its text/contentDescription masked to '[redacted]' in the SERIALIZED envelope only — recognition, parse, the state machine, and the dedup contentHash all run on the ORIGINAL tree. FAIL-CLOSED: any screen rule whose parse uses the 'sha256' transform MUST declare a non-empty redact block (the hash side and the disk side cannot drift). Mask the same customer name/address nodes the parse hashes.",
+      "description": "Rule-declared capture redaction for SCREEN rules (#598). At CAPTURE time, any node matching an entry's 'find' predicate has its text/contentDescription masked to '[redacted:<4hex>]' in the SERIALIZED envelope only — recognition, parse, the state machine, and the dedup contentHash all run on the ORIGINAL tree. The '<4hex>' suffix (#623) is the first four hex of the sha256 of the keepPrefix-stripped, trimmed token, so two different customers redact distinctly (per-customer replay fidelity) without persisting raw PII; a hash failure falls back to plain '[redacted]' (fail-closed). FAIL-CLOSED: any screen rule whose parse uses the 'sha256' transform MUST declare a non-empty redact block (the hash side and the disk side cannot drift). A 'redact' inside a branches[] entry is REJECTED at compile time (#624) — redact is a whole-rule directive.",
       "items": { "$ref": "#/$defs/redactEntry" }
     },
 
@@ -356,8 +357,42 @@
         },
         "keepPrefix": {
           "type": "array",
-          "description": "Optional leading marker labels to PRESERVE. If the node text starts with one (case-insensitive), the mask is 'prefix + [redacted]' (e.g. 'Deliver to ' → 'Deliver to [redacted]'), keeping the require anchor so a replayed redacted capture still recognizes; otherwise the whole node is masked. Address nodes take no keepPrefix.",
+          "description": "Optional leading marker labels to PRESERVE. If the node text starts with one (case-insensitive), the mask is 'prefix + [redacted:<4hex>]' (e.g. 'Deliver to ' → 'Deliver to [redacted:ab12]'), keeping the require anchor so a replayed redacted capture still recognizes; otherwise the whole node is masked. Address nodes take no keepPrefix.",
           "items": { "type": "string" }
+        }
+      }
+    },
+
+    "notifRedactBlock": {
+      "type": "object",
+      "description": "Rule-declared capture redaction for NOTIFICATION rules (#620). Notifications are flat strings (no tree), so redaction is keyed by field name; each value is either a whole-field mask (optional 'keepPrefix') or a regex-capture mask ('match' + 'maskGroup'). Masks customer PII (chat title/body, order-ready customer name) in the SERIALIZED envelope only — recognition, parse, and the dedup contentHash run on the ORIGINAL notification. Same '[redacted:<4hex>]' distinctness + fail-closed contract as screen redaction. Store/merchant names are NOT PII and should be kept (use 'maskGroup' to mask only the name).",
+      "additionalProperties": false,
+      "properties": {
+        "title": { "$ref": "#/$defs/notifRedactField" },
+        "text": { "$ref": "#/$defs/notifRedactField" },
+        "bigText": { "$ref": "#/$defs/notifRedactField" },
+        "tickerText": { "$ref": "#/$defs/notifRedactField" },
+        "subText": { "$ref": "#/$defs/notifRedactField" }
+      }
+    },
+
+    "notifRedactField": {
+      "type": "object",
+      "description": "A per-field notification mask: whole-field ('keepPrefix') OR regex-capture ('match' + 'maskGroup').",
+      "properties": {
+        "keepPrefix": {
+          "type": "array",
+          "description": "Whole-field mask: preserve a leading marker (e.g. 'Message from ') and mask the rest. Omit to mask the whole field.",
+          "items": { "type": "string" }
+        },
+        "match": {
+          "type": "string",
+          "description": "Regex-capture mask: mask only capture group 'maskGroup' of this pattern, keeping the rest of the field (e.g. mask the name in \"<name>'s order is ready ... at <store>\", keeping the store). Bounded by RegexSafety."
+        },
+        "maskGroup": {
+          "type": "integer",
+          "description": "The capture group of 'match' to mask. Default 1.",
+          "minimum": 0
         }
       }
     },


### PR DESCRIPTION
Closes the three #598 "redaction residuals" as one coherent change on the same files (CaptureWriter / RuleCompiler / CompiledRules / doordash.json). Three self-contained commits, build order #623 → #624 → #620.

## What each commit does

**#623 — distinctness-preserving mask `[redacted:<4hex>]`.** The #598 mask collapsed every customer to the constant `[redacted]`, so `sha256("[redacted]")` was identical for all — the stacked-dropoff divergence guard couldn't tell two customers apart and multi-customer replay fixtures from post-#598 captures were impossible. Mask now emits `<keepPrefix?>[redacted:<4hex>]` where `<4hex>` is the first 4 hex of the sha256 of the keepPrefix-stripped, trimmed customer token. Frame-invariant (same customer under different prefixes → same suffix; the strip+trim mirrors the parse's `stripPrefixes`/`trim`/`sha256`, so the suffix equals the first 4 hex of the `customerNameHash` the parse already persists). Fail-closed to plain `[redacted]`. `mask()` moved to the `CompiledRedact` companion as `internal` (SSOT) for reuse by #620. Live behavior unchanged — parse runs on the original tree; this is test/replay fidelity.

**#624 — recognized-frame customer-marker backstop + compiler hardening + a LIVE leak.** The #598 `sha256`→`redact` compile gate only fires for a rule that HASHES PII; a rule shipping raw customer text without hashing stays silent. (1) **Live leak fixed:** `dropoff_reminder` recognized `"Deliver to door of <address>"` with no hash and no redact → raw customer ADDRESS shipped to disk; adds the masking redact block. (2) **Backstop:** a new `CustomerTextMarkers` SSOT (distinct from `SensitiveTextMarkers`, which drops the dasher's banking screens) scans RECOGNIZED frames after rule redact; a node carrying a customer-PII label prefix (`"Deliver to "`, `"Order for "`, `"Verify items for "`, `"Delivery for "`) that wasn't already redacted is scrubbed to `[redacted]` + WARN (marker + rule id only). `"Heading to "` is excluded — it prefixes STORE names on pickup-nav frames. A corpus-validate test mirrors the pipeline over the committed snapshots and pins ZERO false positives. (3) **Compiler:** a `redact` inside a `branches[]` entry is rejected (it would silently no-op); a file with duplicate rule ids is skipped per the malformed-file-skip policy (byId is last-wins) — never throwing into `Ruleset.init`, which would blind all sensing.

**#620 — notification-envelope PII redaction.** `captureNotification` serialized the raw notification verbatim — customer chat (`"Message from <name>"` + body) and the order-ready push (`"<name>'s order is ready for pickup at <store>"`) leaked. Adds a NOTIFICATION `redact` vocabulary: a per-field object keyed by title/text/bigText/tickerText/subText with two shapes — whole-field-with-optional-keepPrefix and regex-capture `maskGroup` (mask a group, keep the rest). Compiled to `CompiledNotifRedact`, reusing the same `CompiledRedact.mask()` (so notif masks get the identical `[redacted:<4hex>]` + fail-closed). Regexes go through the bounded `RegexSafety` guard. The seam gains `notifRedactFor(ruleId)` (defaulted null so screen-only stubs are unaffected); `captureNotification` passes the ORIGINAL `raw.contentHash` captured **before** masking (a masked `.copy()` recomputes a different hash). `customer_message` masks the sender + body; `order_ready` masks the name, keeps the store.

## Security / privacy posture

Pledge: customer PII hashed/blocked at the edge. This closes three residuals in that pledge — the **live raw-address leak** (`dropoff_reminder`), the **recognized-notification disk leak** (`customer_message`/`order_ready`), and a **defense-in-depth backstop** so a future rule that FORGETS to redact still ships a scrubbed capture. #623 restores per-customer distinctness **without storing raw PII** — a 16-bit prefix of the same one-way sha256 the parse already persists (where normalization aligns, zero new information; elsewhere, 16 bits of a one-way hash in a debug-only envelope — release binds `NoOpCaptureBus`, #346). All three fail closed. This directly hardens the untrusted-CDN-rules path the subrepo split (#192/#416/#419) will depend on: a downloaded rule that omits redaction can no longer leak customer PII to disk. **Trusted:** nothing new — third-party UI / notifications stay untrusted input. **Gated/scrubbed:** recognized screen + notification customer surfaces masked in the envelope only; the recognized-frame backstop scrubs a marker a rule missed; branch-redact + dup-id rejected at compile; notif regexes bounded by RegexSafety. **Capture-only:** recognition, parse, the state machine, and the dedup contentHash all run on the ORIGINAL tree/notification — parse-output golden is byte-unchanged.

## Tests

- `:core:pipeline` **220** passed · `:app` **851** passed · `:domain:test` **235** passed · `AllMatchersSuite` green · **`ParseOutputGoldenTest` green, `approved-parse-output.json` UNCHANGED** (redaction is capture-only).
- New: cross-rule frame-invariance + distinctness (#623); dropoff_reminder mask + backstop scrub + corpus-validate + marker SSOT + branch-redact reject + dup-id skip (#624); notif whole-field/regex-capture compile + envelope mask + contentHash preservation + store-kept + benign-unchanged (#620). #598 mask assertions updated to the new format via regex (committed fixtures NOT regenerated).

## Field validation

Two checklist items added to `docs/field-testing/README.md` (0/2 each): (#620) chat/order-ready captures show masked name/body + kept store; (#624) a dropoff_reminder capture shows a masked address.

### Design-goal review

- **SSOT (5):** one `mask()` on the `CompiledRedact` companion serves screen + notification redaction; `CustomerTextMarkers` is a single backstop keyword list; `[redacted]` fallback references `CompiledRedact.REDACTED`.
- **Security & privacy (6):** the core of the PR — all three defenses fail closed; capture-only, debug-only; no raw PII in logs (backstop + notif WARN log the marker/rule id only, Principle 7); notif regexes bounded (RegexSafety); dup-id/branch-redact rejected at compile.
- **Platform-agnostic core (8):** touches `:core:pipeline` + rule JSON. No platform literals added — the notif `redact` vocabulary is enumerated (`NotifField.fromWire`, load-validated, rejects unknown fields), not a Kotlin `when` on a magic string; markers/rules are per-platform DATA. Adding a platform still needs zero `:core:pipeline` edits.
- **Clean code / SRP (3):** small focused additions; `CustomerTextMarkers` and `CompiledNotifRedact` are new single-responsibility types.
- **Semantic logging (7):** backstop scrub = WARN (a defended invariant fired), marker + rule id only; new `PipelineStats.redactBackstopScrubs` counter.


---

### Design-goal review
Touches `:core:pipeline` + `:domain` + rule JSON (P8 mandatory):
- **P1 (UDF):** conforms — capture is an edge side effect; redaction runs at envelope serialization only, no reducer/state change.
- **P3 (SRP):** conforms — small single-purpose additions (`CustomerTextMarkers`, `CompiledNotifRedact`, the backstop).
- **P4:** conforms — sealed `NotifFieldMask`, enum `NotifField`; no stringly-typed dispatch.
- **P5 (SSOT):** conforms — one `mask()` on the `CompiledRedact` companion serves both screen and notification redaction (not copied); backstop reuses the `REDACTED` constant.
- **P6 (security/privacy):** the PR's substance — closes a live raw-address leak (`dropoff_reminder`, plus the two `uber.json` dropoff rules found in review), the recognized-notification disk leak (`customer_message`/`order_ready`), and adds a rules-independent screen backstop so a rule that forgets to redact still ships scrubbed. `#623` restores per-customer distinctness as a 4-hex prefix of the same one-way hash the parse already persists (no new plaintext; debug-only envelope). All fail closed; regex ingestion bounded (RegexSafety); `maskGroup` bounded at compile.
- **P7 (logging):** conforms — backstop WARN + dup-id ERROR carry marker/id only, never the customer value.
- **P8 (platform-agnostic, mandatory):** conforms — `NotifField.fromWire` is an enumerated, compile-rejecting contract (unknown field → `RuleCompileException`), not a magic-string `when`; per-platform redact vocabulary is rule data. `CustomerTextMarkers` is an app-owned, rules-independent English-label backstop (accepted under the `SensitiveTextMarkers` precedent); its current set is DoorDash-vocabulary in practice — extending it for Uber surfaces is tracked in #632 and flagged for the #585 catalog.

### Adversarial review
Independent fable-tier adversarial + **security** review (Pledge boundary). **Pledge property HOLDS:** redaction is envelope-serialization-only on every path (recognition/parse/dedup read the originals — ParseOutputGolden byte-unchanged, independently reconfirmed), fail-closed (sha256 failure → `[redacted]`, never plaintext), bounded ingestion. It found 7 items; the 5 in-PR ones were fixed in `b37e5ad1` and re-verified FIXES-CLOSED by a focused fable delta-check:
- **F1 (HIGH):** `uber.json` `trip_en_route_dropoff`/`trip_at_dropoff` shipped the dropoff address raw — the exact class #620 closes. Added redact blocks (whole-mask the address-title to avoid a `"Going to "` replay-collision with the pickup variant; keepPrefix for `trip_at_dropoff`) + production-rule corpus assertions. Makes "Closes #620" honest.
- **F2b (MEDIUM, fail-open):** the regex-capture notif masker returned raw on a capture miss — now fails CLOSED to a whole-field mask.
- **F3 (MEDIUM, crash-loop):** `maskGroup` was unbounded → runtime `IndexOutOfBoundsException` in the supervised pipeline → restart loop. Now bounded (`0 ≤ group ≤ groupCount`) at compile → file skipped.
- **F5 (LOW):** a CLICK-context `redact` silently vanished (same class as the branch-level reject) — now a compile error.
- **F6 (LOW):** wired both corpus pins into `AllMatchersSuite` and made the backstop corpus test self-walk `sessions/**` (non-vacuous `scanned > 0` retained).

Two items are CDN-path hardening deferred as follow-ups: **#632** (notification-side recognized-frame backstop — defense-in-depth analogue of the screen backstop) and **#633** (reject cross-file rule-id collisions at merge — `byId` last-wins can shadow `redactFor`). Both harden the untrusted-rules boundary the matchers split (#192/#416/#419) will depend on.
