### PR TITLE
spike(#192): rule-distribution local dev loop PoC + ADR-0009

### DIFF
--- a/core/pipeline/build.gradle.kts
+++ b/core/pipeline/build.gradle.kts
@@ -48,3 +48,61 @@ dependencies {
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.mockito.kotlin)
 }
+
+// ===========================================================================
+// SPIKE (#192) — rule-distribution local dev loop. ALL of this is guarded by
+// `-PuseLocalMatchers` (or omitted entirely); the default build is unchanged.
+// See docs/adr/ADR-0009-rule-distribution-channels.md.
+// ===========================================================================
+if (providers.gradleProperty("useLocalMatchers").isPresent) {
+
+    // ---- OPTION A (composite build / dependency substitution) probe --------
+    // Resolve the canonicalized rules from the included `matchers` build via a
+    // custom attribute-matched configuration. Substituted by `includeBuild`.
+    val matchersRules: Configuration by configurations.creating {
+        isCanBeResolved = true
+        isCanBeConsumed = false
+        attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category::class.java, "matchers-rules"))
+        }
+    }
+    dependencies {
+        add(matchersRules.name, "cloud.trotter.matchers:matchers:0.0.0-local")
+    }
+    val importDir = layout.buildDirectory.dir("generated/matchers-optionA/rules")
+    val importMatchers = tasks.register<Sync>("importMatchersOptionA") {
+        group = "matchers"
+        description = "OPTION A probe: import canonicalized rules resolved from the included matchers build."
+        from(matchersRules)
+        into(importDir)
+    }
+
+    // ---- Faithful-canonicalization PROOF (re-runnable) ---------------------
+    // Assert the canonicalized artifact the app would CONSUME is byte-identical
+    // to the committed baseline asset. This is the spike's strongest claim:
+    // JSON5 source (uber.json5, with a comment + trailing comma) canonicalizes
+    // back to the exact committed uber.json.
+    tasks.register("verifyMatchersCanonical") {
+        group = "matchers"
+        description = "PROOF: canonicalized uber.json == committed assets/rules/uber.json (byte-identical)."
+        dependsOn(importMatchers)
+        val committed = layout.projectDirectory.file("src/main/assets/rules/uber.json")
+        val generated = importDir.map { it.file("uber.json") }
+        inputs.file(committed)
+        inputs.file(generated)
+        doLast {
+            val a = generated.get().asFile.readBytes()
+            val b = committed.asFile.readBytes()
+            if (!a.contentEquals(b)) {
+                throw GradleException(
+                    "Canonicalized uber.json (${a.size} bytes) does NOT match committed " +
+                        "assets/rules/uber.json (${b.size} bytes) — canonicalization is not faithful.",
+                )
+            }
+            logger.lifecycle(
+                "PROOF OK: canonicalized uber.json is byte-identical to committed " +
+                    "assets/rules/uber.json (${a.size} bytes).",
+            )
+        }
+    }
+}

--- a/docs/adr/ADR-0009-rule-distribution-channels.md
+++ b/docs/adr/ADR-0009-rule-distribution-channels.md
@@ -1,0 +1,265 @@
+# ADR-0009: Rule Distribution Channels and the Single Local Dev Loop
+
+**Status:** Proposed (spike-validated)
+**Issue:** Sub-RFC of Epic #192 (matchers split); gated on #246 (licensing)
+**Date:** 2026-07-03
+**Builds on:** ADR-0001 (matcher rule format), ADR-0003 (versioning and API contracts)
+**Related:** #361 (volatile hot-swap ref), #416 (signature verification), #419 (capability /
+sensitive-rule survival across OTA)
+
+---
+
+## Context
+
+Recognition rules are **data, not code** (ADR-0001). They live today as per-platform JSON
+files bundled into the APK at `core/pipeline/src/main/assets/rules/*.json`
+(`doordash.json` ~104 KB, `uber.json` ~20 KB), loaded at runtime by
+`JsonRuleInterpreter.loadDefaults()` via `context.assets.list("rules")`, and in tests by
+`TestRulesetFactory` (which walks the same directory on the filesystem).
+
+Pillar 2 of the project — **Distributed Integrity (the matchers)** — requires the recognition
+layer to become a **separate, forkable, Apache-2.0 repository**, delivered to running app
+instances by two means: (1) bundled into the APK as a baseline, and (2) fetched over a CDN so
+deployed apps update without a rebuild (#192). The agreed authoring model is **JSON5 source**
+(comments + trailing commas for human editing) → the matchers repo's CI **canonicalizes** it to
+the streamlined JSON the app already consumes → both delivery channels ship that one canonical
+artifact.
+
+The open design question this ADR answers: **how does the developer keep a single local dev
+loop** — edit a rule locally, run tests, no publish step — once the rules live in a separate
+repo? The developer specifically asked about **Gradle composite build / dependency
+substitution** (the "consume a published artifact, but substitute the local source" pattern).
+
+A spike on branch `feature/192-rule-distribution-poc` was built to de-risk the mechanism before
+committing to it. This ADR records the design of record **as validated by that spike** — not a
+hypothetical.
+
+## Decision
+
+### 1. Two channels, one artifact
+
+Both delivery channels consume the **single canonical JSON artifact** the matchers repo's CI
+produces from JSON5 source. Neither channel re-derives it.
+
+| | **Build-time bundle** (baseline) | **Runtime OTA** (Milestone 2) |
+|---|---|---|
+| Source | matchers repo as a **git submodule** of the app repo | matchers repo CI publishes to **CDN** |
+| Wiring | **Gradle composite build** (`includeBuild`) substitutes the local submodule for the pinned artifact | app fetches signed JSON, verifies, hot-swaps |
+| Rebuild to update? | **Yes** — coupled to an app build/release | **No** — deployed apps update in place |
+| Trust | in-tree, pinned by submodule SHA | **untrusted** until signature-verified (#416) |
+| Role | first-run / offline / signature-failure **fallback**, and the CI test corpus baseline | primary update path for fielded apps |
+| Status | spike-validated (this ADR) | greenfield, unbuilt (#416, #419, CDN infra, signing) |
+
+The bundled baseline is **not** retired when OTA lands. It remains the first-run seed (before
+any fetch), the offline fallback, and — critically — the **fail-closed fallback when signature
+verification fails** (#416). The runtime path is a volatile hot-swap of the compiled ruleset
+bundle behind one `@Volatile` reference (#361), already present in `JsonRuleInterpreter`.
+
+### 2. The canonical artifact and canonicalization
+
+JSON5 source → canonical JSON is a **deterministic, byte-stable** transform. The canonical form
+is the pretty-printed, 2-space, insertion-order JSON already committed under `assets/rules/`
+(with the trailing newline). Canonicalization must be **faithful**: a JSON5 file that is the
+canonical file plus JSON5-only affordances (comments, trailing commas) must canonicalize back to
+the exact committed bytes.
+
+The spike implements this as a dependency-free, **string-aware, text-preserving** stripper: it
+removes `//` and `/* */` comments and trailing commas while preserving every other byte (and
+skipping `//` / `,` that appear inside string values). Byte-preservation — rather than
+parse-and-re-serialize — is what guarantees byte-identity against the committed pretty-printed
+file. **This is spike-grade.** Production wants a real JSON5 parser + JSON-Schema validation
+(`docs/rules.schema.json`) + a canonical re-serializer, run in the matchers repo's CI, so the
+canonical form is defined by the serializer rather than by preserving author formatting.
+
+### 3. The single local dev loop — Option A (composite build), recommended
+
+The spike evaluated two mechanisms. **Option A works cleanly and is recommended**; Option B is
+the lighter fallback and the correct pre-split first step (see Migration).
+
+**Option A — composite build + dependency substitution.** The matchers repo is a self-contained
+plain-JVM Gradle build. It owns the JSON5 source **and** the canonicalize task, and exposes the
+canonical output as an outgoing artifact. The app includes it (guarded) and resolves the artifact
+through a custom configuration; `includeBuild` substitutes the local submodule for the coordinates
+the app would otherwise resolve from a repo.
+
+Guarded include in the app's `settings.gradle.kts` (OFF by default):
+
+```kotlin
+// SPIKE (#192) — guarded composite build. OFF by default; opt in with -PuseLocalMatchers.
+if (providers.gradleProperty("useLocalMatchers").isPresent) {
+    includeBuild("matchers")
+}
+```
+
+The matchers build (`matchers/build.gradle.kts`) canonicalizes and publishes the output:
+
+```kotlin
+plugins { base }
+group = "cloud.trotter.matchers"
+version = "0.0.0-local"
+
+val canonicalRulesDir = layout.buildDirectory.dir("canonical/rules")
+val canonicalizeRules = tasks.register("canonicalizeRules") {
+    inputs.dir(layout.projectDirectory.dir("rules")).withPropertyName("json5Source")
+    outputs.dir(canonicalRulesDir).withPropertyName("canonicalOut")
+    doLast { /* strip comments + trailing commas -> build/canonical/rules/*.json */ }
+}
+
+val rulesElements: Configuration by configurations.creating {
+    isCanBeConsumed = true; isCanBeResolved = false
+    attributes { attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category::class.java, "matchers-rules")) }
+}
+artifacts { add(rulesElements.name, canonicalRulesDir) { builtBy(canonicalizeRules) } }
+```
+
+The consumer (`:core:pipeline`, guarded) resolves the substituted artifact through a matching
+custom configuration:
+
+```kotlin
+val matchersRules: Configuration by configurations.creating {
+    isCanBeResolved = true; isCanBeConsumed = false
+    attributes { attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category::class.java, "matchers-rules")) }
+}
+dependencies { add(matchersRules.name, "cloud.trotter.matchers:matchers:0.0.0-local") }
+tasks.register<Sync>("importMatchersOptionA") { from(matchersRules); into(/* generated assets dir */) }
+```
+
+`./gradlew :core:pipeline:dependencies --configuration matchersRules` confirms the substitution
+is real:
+
+```
+matchersRules
+\--- cloud.trotter.matchers:matchers:0.0.0-local -> project :matchers
+```
+
+**Production vs local path.** In production the coordinates `cloud.trotter.matchers:matchers:<pinned>`
+resolve from a repository (a published artifact pinned by version). Locally, the *same* dependency
+is transparently substituted by `includeBuild("matchers")` for the nested submodule — no code
+change, no publish. That symmetry is the whole point of the composite-build pattern.
+
+**How "one place" physically looks.** The matchers repo is nested as a git **submodule** inside
+the app repo (`git clone --recursive`). Editing `matchers/rules/uber.json5` and running a build
+re-runs canonicalize and re-imports the output — **no publish step**. The submodule SHA pins the
+exact rule version the app was built against.
+
+### 4. Option A vs Option B
+
+| | **Option A — composite build** | **Option B — in-app canonicalize task** |
+|---|---|---|
+| `matchers/` shape | a nested **Gradle build** (submodule) | a nested **data dir** of `*.json5` (submodule) |
+| Canonicalize lives in | the **matchers build** (mirrors prod CI topology) | the **app** (`:core:pipeline`) re-implements it |
+| Consumption | resolve + `Sync` the outgoing artifact | task reads `matchers/rules/*.json5`, writes generated assets |
+| Machinery | more (separate build, outgoing/incoming configs, attributes, coordinates) | less (one task, one generated dir) |
+| SSOT of canonicalizer | **one** (in the repo that owns rules) | **two** (matchers CI + app copy) |
+| Matches production | **yes** — app consumes the artifact the matchers CI produces | partially — app re-derives instead of consuming |
+
+**Recommendation: Option A**, because it mirrors the production topology (canonicalization is
+co-located with the rules, exactly where the matchers repo's CI will own it; the app merely
+*consumes* the artifact) and delivers the published-artifact-substitution pattern the developer
+asked about — with, in this project, **no friction**. Option B is strictly less machinery but
+forces the app to carry a second copy of the canonicalizer (an SSOT smell), and does not exercise
+the artifact-consumption path that OTA and the pinned-artifact production build also use.
+
+## What the spike proved
+
+Run with `JAVA_HOME=/usr/lib/jvm/java-25-openjdk` (Gradle 9.3.0, AGP 9.0.1):
+
+1. **Faithful canonicalization (byte-identical).** `matchers/rules/uber.json5` is the committed
+   `uber.json` plus a `//` comment and a trailing comma. Canonicalizing it and comparing against
+   the committed asset:
+   ```
+   ./gradlew -PuseLocalMatchers :core:pipeline:verifyMatchersCanonical
+   > PROOF OK: canonicalized uber.json is byte-identical to committed assets/rules/uber.json (20402 bytes).
+   ```
+2. **Local loop, no publish.** Editing the JSON5 source re-runs `:matchers:canonicalizeRules`
+   (no longer `UP-TO-DATE`) with no publish step; the artifact re-syncs only when the canonical
+   **bytes** actually change (Gradle content-based up-to-date checks). A throwaway `_looptest.json5`
+   with a comment + trailing comma canonicalized to valid comment-free, comma-free JSON.
+3. **Default build unchanged, OFF by default.** With no flag: `./gradlew projects` shows **no**
+   `:matchers` project; `:core:pipeline:tasks --all` shows **no** matchers tasks; the committed
+   assets are untouched; and `./gradlew :core:pipeline:testDebugUnitTest` is **green**. All the
+   spike machinery is created only under `if (providers.gradleProperty("useLocalMatchers").isPresent)`.
+4. **Composite substitution resolves cleanly.** The dependency report shows
+   `cloud.trotter.matchers:matchers:0.0.0-local -> project :matchers`, and the opt-in path
+   coexists with the real `:core:pipeline` tests (both green in one invocation).
+
+### Friction found (and what the plan got wrong)
+
+The plan anticipated Option A hitting **AGP variant-resolution** friction and/or
+`FAIL_ON_PROJECT_REPOS` / version-catalog conflicts, with Option B as the likely fallback. **That
+friction did not materialize.** The reasons are worth recording:
+
+- **Custom resolvable configuration sidesteps AGP attribute matching.** Consuming the artifact
+  through a freshly created `configurations.creating { isCanBeResolved = true }` with a single
+  custom `Category` attribute — rather than an AGP-managed configuration — means AGP injects no
+  Android variant attributes into the request, so there is no "no matching variant" clash with the
+  plain-JVM producer.
+- **`FAIL_ON_PROJECT_REPOS` is irrelevant to composite substitution.** That mode governs
+  *repository* declarations in project builds; `includeBuild` substitution is coordinate matching,
+  not a repository lookup, so it is unaffected.
+- **The version catalog is not shared into the included build,** and does not need to be — the
+  matchers build only needs the `base` plugin, no catalog libraries.
+
+The one genuine cost that remains for **both** options: the resolved/generated canonical files
+still need a final step to land where the runtime loader and `TestRulesetFactory` look. The spike
+deliberately stops at a **generated dir** and does **not** rewire `JsonRuleInterpreter`'s asset
+loading or `TestRulesetFactory` (that is the real migration, below). So the spike proves the
+**mechanism** — canonicalize + faithful output + guarded substitution — standalone; closing the
+loop into the actual test corpus is migration work, not spike work.
+
+## Migration path
+
+1. **In-repo canonicalize first (pre-split).** Before the repo exists, land canonicalization as
+   an in-repo step (Option B shape): JSON5 sources live in the app repo, a Gradle task
+   canonicalizes them into the assets. This is the correct first move because there is no separate
+   build to include yet.
+2. **Create the public Apache-2.0 matchers repo.** **Gated on #246** (the Apache-2.0 relicense /
+   counsel decision) — this is the pacing item, not code.
+3. **Submodule + composite-build consumption.** Nest the matchers repo as a submodule; wire
+   `includeBuild("matchers")` (Option A) for the local loop, with the pinned published artifact as
+   the production path.
+4. **Decouple `TestRulesetFactory` and lock corpus↔rules versions.** `TestRulesetFactory`
+   currently hardcodes `core/pipeline/src/main/assets/rules` filesystem paths; point it at the
+   canonical artifact (generated dir) instead. Establish a **version lock** so the snapshot corpus
+   (`app/src/test/resources/snapshots/`) is always tested against the rules SHA it was captured
+   for (per ADR-0003 compatibility checks).
+5. **Resolve the `doordash.json` per-platform partition in the subrepo** (tracked separately; the
+   ~104 KB monolith is split in the matchers repo, not before).
+6. **Milestone 2 — OTA/CDN.** Signature verification before compile (#416), capability
+   enumeration + sensitive-rule survival across the swap (#419), CDN infrastructure, and signing.
+   All greenfield and unbuilt; the bundled baseline (steps 1–3) remains the fallback throughout.
+
+## Consequences
+
+### Positive
+
+- The developer keeps one local loop: edit `matchers/rules/*.json5`, build, test — no publish.
+- Canonicalization is co-located with the rules (Option A), matching where production CI owns it;
+  one canonicalizer, not two.
+- The bundle and OTA channels consume the *same* artifact, so a rule behaves identically however
+  it was delivered.
+- The mechanism is provably off by default — zero impact on the default build or CI until opted in.
+
+### Negative / Tradeoffs
+
+- **Version-pin discipline.** A submodule SHA (bundle) and a pinned artifact version (OTA) must be
+  managed deliberately; a drifting submodule or an unpinned fetch reintroduces the corpus↔rules
+  skew ADR-0003 guards against.
+- **Greenfield canonicalize/publish CI.** The faithful-canonicalization guarantee moves from the
+  spike's text stripper to a real JSON5-parse + schema-validate + canonical-serialize CI in the
+  matchers repo — which must itself be built and trusted.
+- **`TestRulesetFactory` refactor cost.** Decoupling it from hardcoded asset paths is real work and
+  a prerequisite for the split; the spike intentionally does not touch it.
+- **Licensing paces the split.** Repo creation is gated on #246, a legal/counsel decision, not on
+  engineering — the code side (this spike) is ready ahead of it.
+- **Composite-build ergonomics.** Included builds add a small configuration-time cost when opted in
+  and can interact with the configuration cache / IDE sync in ways worth watching; none blocked the
+  spike, but they are sharper edges than a plain in-app task (Option B).
+
+### Future Work
+
+- Replace the spike's text stripper with a real JSON5 parser + `docs/rules.schema.json` validation
+  in the matchers repo CI.
+- Wire the canonical artifact into `JsonRuleInterpreter` asset loading and `TestRulesetFactory`
+  (migration steps 3–4).
+- OTA/CDN as Milestone 2 (#416, #419).

--- a/matchers/README.md
+++ b/matchers/README.md
@@ -1,0 +1,33 @@
+# matchers/ — SPIKE (#192), throwaway stand-in
+
+This directory is a **proof-of-concept stand-in** for the future separate, forkable,
+Apache-2.0 **matchers repo** (Pillar 2 / Epic #192). It is **not** production wiring — it
+exists to de-risk the rule-distribution local dev loop before the repo split. See
+[`docs/adr/ADR-0009-rule-distribution-channels.md`](../docs/adr/ADR-0009-rule-distribution-channels.md).
+
+It is a self-contained plain-JVM Gradle build that:
+
+- owns the **JSON5 rule source** (`rules/*.json5`), and
+- canonicalizes it to the streamlined JSON the app consumes (`build/canonical/rules/*.json`)
+  via the `canonicalizeRules` task, exposing that output as the `rulesElements` outgoing artifact.
+
+Everything is **OFF by default**. The app build only includes it when opted in:
+
+```bash
+# faithful-canonicalization proof (byte-identical to committed assets/rules/uber.json)
+JAVA_HOME=/usr/lib/jvm/java-25-openjdk ./gradlew -PuseLocalMatchers :core:pipeline:verifyMatchersCanonical
+
+# canonicalize standalone
+JAVA_HOME=/usr/lib/jvm/java-25-openjdk ./gradlew -PuseLocalMatchers :matchers:canonicalizeRules
+```
+
+The JSON5 → canonical stripper here is **spike-grade** (a dependency-free, string-aware
+comment/trailing-comma remover that preserves all other bytes — which is what makes
+canonicalization byte-identical to the committed pretty-printed file). Production wants a real
+JSON5 parser + JSON-Schema validation + canonical re-serializer in the matchers repo's CI.
+
+In the real design this directory becomes a **git submodule** of the app repo, included via
+`includeBuild("matchers")` for the local loop and resolved as a pinned published artifact in
+production. `rules/uber.json5` is the committed `core/pipeline/src/main/assets/rules/uber.json`
+plus a `//` comment and a trailing comma, purely to demonstrate JSON5-ness survives
+canonicalization.

--- a/matchers/build.gradle.kts
+++ b/matchers/build.gradle.kts
@@ -1,0 +1,114 @@
+// SPIKE (#192) — the "matchers repo" build. Owns the JSON5 rule SOURCE
+// (rules/*.json5) and canonicalizes it to the streamlined JSON the app consumes.
+// In production this canonicalize step is the matchers repo's CI; here it is a
+// Gradle task so the local dev loop needs NO publish step.
+plugins {
+    base
+}
+
+// Coordinates the app build substitutes against when this build is included.
+group = "cloud.trotter.matchers"
+version = "0.0.0-local"
+
+// ---------------------------------------------------------------------------
+// Dependency-free JSON5 -> canonical stripper.
+//
+// SPIKE-GRADE: this is a text-preserving comment/trailing-comma remover, NOT a
+// JSON5 parser. It is string-aware (won't touch // or , inside string values)
+// and preserves all other bytes, which is exactly what makes canonicalization
+// byte-identical to the committed pretty-printed rule file. Production wants a
+// real JSON5 parser + JSON-Schema validation + a canonical re-serializer
+// (see ADR-0009). Kept intentionally minimal for the spike.
+// ---------------------------------------------------------------------------
+fun stripComments(src: String): String {
+    val sb = StringBuilder()
+    var i = 0; val n = src.length; var inStr = false
+    while (i < n) {
+        val c = src[i]
+        if (inStr) {
+            sb.append(c)
+            if (c == '\\' && i + 1 < n) { sb.append(src[i + 1]); i += 2; continue }
+            if (c == '"') inStr = false
+            i++; continue
+        }
+        if (c == '"') { inStr = true; sb.append(c); i++; continue }
+        if (c == '/' && i + 1 < n && src[i + 1] == '/') {
+            var j = i + 2
+            while (j < n && src[j] != '\n') j++
+            while (sb.isNotEmpty() && (sb.last() == ' ' || sb.last() == '\t')) sb.deleteCharAt(sb.length - 1)
+            val lineBlank = sb.isEmpty() || sb.last() == '\n'
+            i = j
+            if (lineBlank && i < n && src[i] == '\n') i++ // whole-line comment: drop its newline too
+            continue
+        }
+        if (c == '/' && i + 1 < n && src[i + 1] == '*') {
+            var j = i + 2
+            while (j + 1 < n && !(src[j] == '*' && src[j + 1] == '/')) j++
+            i = j + 2; continue
+        }
+        sb.append(c); i++
+    }
+    return sb.toString()
+}
+
+fun stripTrailingCommas(src: String): String {
+    val sb = StringBuilder()
+    var i = 0; val n = src.length; var inStr = false
+    while (i < n) {
+        val c = src[i]
+        if (inStr) {
+            sb.append(c)
+            if (c == '\\' && i + 1 < n) { sb.append(src[i + 1]); i += 2; continue }
+            if (c == '"') inStr = false
+            i++; continue
+        }
+        if (c == '"') { inStr = true; sb.append(c); i++; continue }
+        if (c == ',') {
+            var j = i + 1
+            while (j < n && src[j].isWhitespace()) j++
+            if (j < n && (src[j] == '}' || src[j] == ']')) { i++; continue } // drop trailing comma, keep whitespace
+        }
+        sb.append(c); i++
+    }
+    return sb.toString()
+}
+
+fun canonicalizeJson5(src: String): String = stripTrailingCommas(stripComments(src))
+
+val canonicalRulesDir: Provider<Directory> = layout.buildDirectory.dir("canonical/rules")
+
+val canonicalizeRules = tasks.register("canonicalizeRules") {
+    group = "matchers"
+    description = "Canonicalize rules/*.json5 -> build/canonical/rules/*.json (streamlined JSON the app consumes)."
+    val srcDir = layout.projectDirectory.dir("rules")
+    val outDir = canonicalRulesDir
+    inputs.dir(srcDir).withPropertyName("json5Source")
+    outputs.dir(outDir).withPropertyName("canonicalOut")
+    doLast {
+        val out = outDir.get().asFile
+        out.mkdirs()
+        out.listFiles()?.forEach { it.delete() }
+        val sources = srcDir.asFile.listFiles { f -> f.extension == "json5" }?.sortedBy { it.name } ?: emptyList()
+        sources.forEach { f ->
+            val canon = canonicalizeJson5(f.readText(Charsets.UTF_8))
+            File(out, f.nameWithoutExtension + ".json").writeText(canon, Charsets.UTF_8)
+            logger.lifecycle("canonicalized ${f.name} -> ${f.nameWithoutExtension}.json (${canon.length} bytes)")
+        }
+    }
+}
+
+// Outgoing artifact for composite-build consumers (Option A dependency substitution).
+val rulesElements: Configuration by configurations.creating {
+    isCanBeConsumed = true
+    isCanBeResolved = false
+    attributes {
+        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category::class.java, "matchers-rules"))
+    }
+}
+artifacts {
+    add(rulesElements.name, canonicalRulesDir) {
+        builtBy(canonicalizeRules)
+    }
+}
+
+tasks.named("assemble") { dependsOn(canonicalizeRules) }

--- a/matchers/rules/uber.json5
+++ b/matchers/rules/uber.json5
@@ -1,0 +1,888 @@
+{
+  // DashBuddy matchers JSON5 source — this comment + the trailing comma below prove JSON5-ness (stripped on canonicalize)
+  "$schema": "../../../../docs/rules.schema.json",
+  "format_version": 2,
+  "platform_id": "uber.driver",
+  "screens": [
+    {
+      "id": "uber.screen.sensitive.known",
+      "priority": 0,
+      "overrideable": false,
+      "parse": {
+        "as": "sensitive"
+      },
+      "branches": [
+        {
+          "intent": "sensitive.wallet",
+          "require": {
+            "exists": {
+              "any": [
+                {
+                  "hasTextContaining": "Instant Pay"
+                },
+                {
+                  "hasTextContaining": "Uber Pro Card"
+                },
+                {
+                  "hasTextContaining": "Available balance"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "intent": "sensitive.cashout",
+          "require": {
+            "exists": {
+              "any": [
+                {
+                  "hasTextContaining": "Cash out"
+                },
+                {
+                  "hasTextContaining": "Transfer to bank"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "intent": "sensitive.bank",
+          "require": {
+            "exists": {
+              "any": [
+                {
+                  "hasTextContaining": "bank account"
+                },
+                {
+                  "hasTextContaining": "Routing number"
+                },
+                {
+                  "hasTextContaining": "Direct deposit"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "intent": "sensitive.identity",
+          "require": {
+            "exists": {
+              "any": [
+                {
+                  "hasTextContaining": "Social Security"
+                },
+                {
+                  "hasTextContaining": "Tax information"
+                },
+                {
+                  "hasTextContaining": "Enter the code we sent"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "uber.screen.sensitive.catchall",
+      "priority": 998,
+      "overrideable": false,
+      "parse": {
+        "as": "sensitive"
+      },
+      "require": {
+        "allTextContainsAny": [
+          "routing number",
+          "social security",
+          "bank account",
+          "available balance",
+          "instant pay",
+          "cash out",
+          "tax form",
+          "direct deposit",
+          "card number",
+          "cvv",
+          "expiry"
+        ]
+      }
+    },
+    {
+      "id": "uber.screen.offer",
+      "priority": 15,
+      "branches": [
+        {
+          "state": {
+            "flow": "offer:presented",
+            "modeHint": "online"
+          },
+          "require": {
+            "all": [
+              {
+                "exists": {
+                  "hasIdSuffix": "primary_touch_area"
+                }
+              },
+              {
+                "exists": {
+                  "hasTextMatchesRegex": "\\$\\d+\\.\\d{2}"
+                }
+              },
+              {
+                "exists": {
+                  "any": [
+                    {
+                      "hasText": "Accept"
+                    },
+                    {
+                      "hasText": "Match"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "parse": {
+            "as": "offer",
+            "fields": {
+              "payAmount": {
+                "find": {
+                  "hasTextMatchesRegex": "\\$\\d"
+                },
+                "read": "text",
+                "transform": "parseCurrency"
+              },
+              "distance": {
+                "find": {
+                  "hasTextMatchesRegex": "\\d[\\d.]*\\s*mi"
+                },
+                "read": "text",
+                "transform": "parseDistance"
+              },
+              "timeToCompleteMinutes": {
+                "find": {
+                  "hasTextMatchesRegex": "\\d+\\s*min"
+                },
+                "read": "text",
+                "transform": "parseLeadingInt"
+              },
+              "orders": {
+                "each": {
+                  "hasClassNameEndsWith": "CardView"
+                },
+                "extract": {
+                  "storeName": {
+                    "find": {
+                      "all": [
+                        {
+                          "hasClassName": "android.widget.TextView"
+                        },
+                        {
+                          "not": {
+                            "any": [
+                              {
+                                "hasTextMatchesRegex": "^\\$"
+                              },
+                              {
+                                "hasTextMatchesRegex": "^\\+"
+                              },
+                              {
+                                "hasTextContaining": "min"
+                              },
+                              {
+                                "hasText": "Accept"
+                              },
+                              {
+                                "hasText": "Match"
+                              },
+                              {
+                                "hasText": "Delivery"
+                              },
+                              {
+                                "hasTextContaining": "Exclusive"
+                              },
+                              {
+                                "hasTextContaining": "Guaranteed"
+                              },
+                              {
+                                "hasTextContaining": "Includes"
+                              },
+                              {
+                                "hasTextContaining": "Add a"
+                              },
+                              {
+                                "hasTextContaining": "Shop &"
+                              },
+                              {
+                                "hasTextMatchesRegex": "^\\d+ items?"
+                              },
+                              {
+                                "hasTextContaining": ", "
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    },
+                    "read": "text"
+                  },
+                  "orderType": {
+                    "literal": "PICKUP"
+                  }
+                }
+              }
+            }
+          },
+          "effects": [
+            {
+              "screenshot": {
+                "prefix": "Offer - {storeName}",
+                "category": "offer"
+              },
+              "dedupeKey": "offer-ss-{parsedHash}",
+              "throttleMs": 60000
+            },
+            {
+              "log": {
+                "type": "OFFER_RECEIVED",
+                "payload": "pay={payAmount} dist={distance}"
+              },
+              "dedupeKey": "offer-log-{parsedHash}",
+              "throttleMs": 60000
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "uber.screen.splash",
+      "priority": 40,
+      "require": {
+        "exists": {
+          "hasIdSuffix": "rootSplashBackground"
+        }
+      }
+    },
+    {
+      "id": "uber.screen.pickup_verification_info",
+      "priority": 50,
+      "state": {
+        "flow": "task:pickup:arrived",
+        "modeHint": "online"
+      },
+      "require": {
+        "all": [
+          {
+            "exists": {
+              "hasIdSuffix": "on_job_view"
+            }
+          },
+          {
+            "exists": {
+              "hasText": "Pickup verification"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "uber.screen.pickup_verification_pin",
+      "priority": 51,
+      "state": {
+        "flow": "task:pickup:arrived",
+        "modeHint": "online"
+      },
+      "require": {
+        "all": [
+          {
+            "exists": {
+              "hasIdSuffix": "on_job_view"
+            }
+          },
+          {
+            "exists": {
+              "hasTextContaining": "Enter Uber Eats order number"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "uber.screen.pickup_verification_items",
+      "priority": 52,
+      "state": {
+        "flow": "task:pickup:arrived",
+        "modeHint": "online"
+      },
+      "require": {
+        "all": [
+          {
+            "exists": {
+              "hasIdSuffix": "on_job_view"
+            }
+          },
+          {
+            "exists": {
+              "hasText": "Verify order"
+            }
+          },
+          {
+            "exists": {
+              "any": [
+                {
+                  "hasText": "Order verified"
+                },
+                {
+                  "hasText": "Issue with order"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "uber.screen.customer_chat",
+      "priority": 55,
+      "state": {
+        "modeHint": "online"
+      },
+      "require": {
+        "all": [
+          {
+            "exists": {
+              "hasIdSuffix": "on_job_view"
+            }
+          },
+          {
+            "exists": {
+              "hasIdSuffix": "ub__intercom_coordinator_layout"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "uber.screen.photo_capture",
+      "priority": 60,
+      "state": {
+        "flow": "task:dropoff:arrived",
+        "modeHint": "online"
+      },
+      "require": {
+        "all": [
+          {
+            "exists": {
+              "hasIdSuffix": "on_job_view"
+            }
+          },
+          {
+            "exists": {
+              "hasIdSuffix": "ub__carbon_facecamera_root_view"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "uber.screen.delivery_confirmation",
+      "priority": 65,
+      "state": {
+        "flow": "task:dropoff:arrived",
+        "modeHint": "online"
+      },
+      "require": {
+        "all": [
+          {
+            "exists": {
+              "hasIdSuffix": "on_job_view"
+            }
+          },
+          {
+            "exists": {
+              "hasIdSuffix": "earner_trip_image_capture_taskbar_container"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "uber.screen.shop_and_pay_list",
+      "priority": 68,
+      "state": {
+        "flow": "task:pickup:arrived",
+        "modeHint": "online"
+      },
+      "require": {
+        "all": [
+          {
+            "exists": {
+              "hasIdSuffix": "on_job_view"
+            }
+          },
+          {
+            "exists": {
+              "hasTextContaining": "Shop priority items"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "uber.screen.shop_and_pay_checkout",
+      "priority": 69,
+      "state": {
+        "flow": "task:pickup:arrived",
+        "modeHint": "online"
+      },
+      "require": {
+        "all": [
+          {
+            "exists": {
+              "hasIdSuffix": "on_job_view"
+            }
+          },
+          {
+            "exists": {
+              "hasTextContaining": "shopping bags"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "uber.screen.post_trip",
+      "priority": 75,
+      "state": {
+        "flow": "post:task",
+        "modeHint": "online"
+      },
+      "require": {
+        "all": [
+          {
+            "exists": {
+              "hasIdSuffix": "on_job_view"
+            }
+          },
+          {
+            "exists": {
+              "hasTextContaining": "more customers order again"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "uber.screen.earnings_activity",
+      "priority": 78,
+      "require": {
+        "all": [
+          {
+            "exists": {
+              "hasText": "Earnings Activity"
+            }
+          },
+          {
+            "exists": {
+              "hasIdSuffix": "recycler_view"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "uber.screen.session_summary",
+      "priority": 80,
+      "state": {
+        "flow": "session:ended",
+        "modeHint": "offline"
+      },
+      "require": {
+        "exists": {
+          "hasTextContaining": "Session summary"
+        }
+      }
+    },
+    {
+      "id": "uber.screen.active_trip",
+      "priority": 100,
+      "state": {
+        "modeHint": "online"
+      },
+      "require": {
+        "exists": {
+          "hasIdSuffix": "on_job_view"
+        }
+      }
+    },
+    {
+      "id": "uber.screen.awaiting_offer",
+      "priority": 110,
+      "state": {
+        "flow": "idle",
+        "modeHint": "online"
+      },
+      "require": {
+        "all": [
+          {
+            "exists": {
+              "hasIdSuffix": "status_assistant"
+            }
+          },
+          {
+            "exists": {
+              "any": [
+                {
+                  "hasTextContaining": "Finding trips"
+                },
+                {
+                  "hasText": "You're online"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "uber.screen.idle_map",
+      "priority": 130,
+      "state": {
+        "flow": "idle",
+        "modeHint": "offline"
+      },
+      "require": {
+        "all": [
+          {
+            "exists": {
+              "hasIdSuffix": "home_screen_overlay_container"
+            }
+          },
+          {
+            "notExists": {
+              "hasText": "You're online"
+            }
+          },
+          {
+            "notExists": {
+              "hasTextContaining": "Finding trips"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "uber.screen.home_dashboard",
+      "priority": 140,
+      "branches": [
+        {
+          "state": {
+            "flow": "idle",
+            "modeHint": "offline"
+          },
+          "require": {
+            "all": [
+              {
+                "exists": {
+                  "hasIdSuffix": "glide_bottom_nav_home"
+                }
+              },
+              {
+                "exists": {
+                  "hasIdSuffix": "go_online_button"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "state": {
+            "flow": "idle",
+            "modeHint": "online"
+          },
+          "require": {
+            "all": [
+              {
+                "exists": {
+                  "hasIdSuffix": "glide_bottom_nav_home"
+                }
+              },
+              {
+                "exists": {
+                  "hasText": "You're online"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "state": {
+            "flow": "idle",
+            "modeHint": "offline"
+          },
+          "require": {
+            "all": [
+              {
+                "exists": {
+                  "hasIdSuffix": "glide_bottom_nav_home"
+                }
+              },
+              {
+                "notExists": {
+                  "hasText": "You're online"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "clicks": [
+    {
+      "id": "uber.click.accept_offer",
+      "priority": 5,
+      "screenIs": "offer",
+      "intent": "accept_offer",
+      "require": {
+        "any": [
+          {
+            "hasText": "Accept"
+          },
+          {
+            "hasText": "Match"
+          }
+        ]
+      }
+    },
+    {
+      "id": "uber.click.go_online",
+      "priority": 10,
+      "intent": "go_online",
+      "state": {
+        "modeHint": "online"
+      },
+      "require": {
+        "hasIdSuffix": "go_online_button"
+      }
+    },
+    {
+      "id": "uber.click.go_offline",
+      "priority": 21,
+      "intent": "go_offline",
+      "state": {
+        "modeHint": "offline"
+      },
+      "require": {
+        "hasIdSuffix": "carbon_action_button"
+      }
+    },
+    {
+      "id": "uber.click.order_verified",
+      "priority": 15,
+      "screenIs": "pickup_verification_items",
+      "intent": "order_verified",
+      "require": {
+        "all": [
+          {
+            "hasText": "Order verified"
+          },
+          {
+            "hasClassName": "android.widget.Button"
+          }
+        ]
+      }
+    },
+    {
+      "id": "uber.click.issue_with_order",
+      "priority": 16,
+      "screenIs": "pickup_verification_items",
+      "intent": "issue_with_order",
+      "require": {
+        "all": [
+          {
+            "hasText": "Issue with order"
+          },
+          {
+            "hasClassName": "android.widget.Button"
+          }
+        ]
+      }
+    },
+    {
+      "id": "uber.click.delivered",
+      "priority": 20,
+      "screenIs": "delivery_confirmation",
+      "intent": "delivered",
+      "require": {
+        "hasIdSuffix": "task_button_button"
+      }
+    },
+    {
+      "id": "uber.click.open_inbox",
+      "priority": 30,
+      "screenIs": "home_dashboard",
+      "intent": "open_inbox",
+      "require": {
+        "hasIdSuffix": "glide_bottom_nav_inbox"
+      }
+    }
+  ],
+  "notifications": [
+    {
+      "id": "uber.notification.trip_en_route_pickup",
+      "priority": 3,
+      "require": {
+        "titleMatchesRegex": "^Going to (?!\\d)"
+      },
+      "intent": "trip_en_route_pickup",
+      "parse": {
+        "as": "notification"
+      },
+      "effects": [
+        {
+          "log": {
+            "type": "NOTIFICATION_RECEIVED",
+            "payload": "TRIP_EN_ROUTE_PICKUP"
+          }
+        }
+      ]
+    },
+    {
+      "id": "uber.notification.trip_arrived_pickup",
+      "priority": 4,
+      "require": {
+        "titleContains": "Arrived at "
+      },
+      "intent": "trip_arrived_pickup",
+      "parse": {
+        "as": "notification"
+      },
+      "effects": [
+        {
+          "log": {
+            "type": "NOTIFICATION_RECEIVED",
+            "payload": "TRIP_ARRIVED_PICKUP"
+          }
+        }
+      ]
+    },
+    {
+      "id": "uber.notification.trip_en_route_dropoff",
+      "priority": 5,
+      "require": {
+        "titleMatchesRegex": "^Going to \\d"
+      },
+      "intent": "trip_en_route_dropoff",
+      "parse": {
+        "as": "notification"
+      },
+      "redact": {
+        "title": {}
+      },
+      "effects": [
+        {
+          "log": {
+            "type": "NOTIFICATION_RECEIVED",
+            "payload": "TRIP_EN_ROUTE_DROPOFF"
+          }
+        }
+      ]
+    },
+    {
+      "id": "uber.notification.trip_at_dropoff",
+      "priority": 6,
+      "require": {
+        "titleMatchesRegex": "(Leave the order at|Meet at door for)"
+      },
+      "intent": "trip_at_dropoff",
+      "parse": {
+        "as": "notification"
+      },
+      "redact": {
+        "title": { "keepPrefix": [ "Leave the order at ", "Meet at door for " ] }
+      },
+      "effects": [
+        {
+          "log": {
+            "type": "NOTIFICATION_RECEIVED",
+            "payload": "TRIP_AT_DROPOFF"
+          }
+        }
+      ]
+    },
+    {
+      "id": "uber.notification.tip_received",
+      "priority": 8,
+      "require": {
+        "titleMatchesRegex": "received a \\$\\d"
+      },
+      "intent": "tip_received",
+      "parse": {
+        "as": "notification"
+      },
+      "effects": [
+        {
+          "log": {
+            "type": "NOTIFICATION_RECEIVED",
+            "payload": "TIP_RECEIVED: {rawText}"
+          }
+        }
+      ]
+    },
+    {
+      "id": "uber.notification.online_status",
+      "priority": 10,
+      "require": {
+        "titleContains": "currently online"
+      },
+      "parse": {
+        "as": "noise"
+      }
+    },
+    {
+      "id": "uber.notification.quest_promo",
+      "priority": 20,
+      "require": {
+        "titleContains": "Quest awaits"
+      },
+      "intent": "quest_promo",
+      "parse": {
+        "as": "notification"
+      },
+      "effects": [
+        {
+          "log": {
+            "type": "NOTIFICATION_RECEIVED",
+            "payload": "QUEST_PROMO"
+          }
+        }
+      ]
+    },
+    {
+      "id": "uber.notification.quest_deadline",
+      "priority": 30,
+      "require": {
+        "all": [
+          {
+            "titleContains": "Last chance"
+          },
+          {
+            "anyFieldContains": "Quest"
+          }
+        ]
+      },
+      "intent": "quest_deadline",
+      "parse": {
+        "as": "notification"
+      },
+      "effects": [
+        {
+          "log": {
+            "type": "NOTIFICATION_RECEIVED",
+            "payload": "QUEST_DEADLINE"
+          }
+        }
+      ]
+    },
+  ]
+}

--- a/matchers/settings.gradle.kts
+++ b/matchers/settings.gradle.kts
@@ -1,0 +1,16 @@
+// SPIKE (#192) — stand-in for the future separate Apache-2.0 "matchers" repo.
+// This is a plain-JVM Gradle build with NO Android deps, includeable into the
+// app build via `includeBuild("matchers")` (guarded by -PuseLocalMatchers).
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+    }
+}
+
+rootProject.name = "matchers"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,6 +19,15 @@ dependencyResolutionManagement {
     }
 }
 
+// SPIKE (#192) — guarded composite build (Option A). OFF by default so the
+// default build is byte-for-byte unchanged; opt in with `-PuseLocalMatchers`.
+// When present, the local `matchers/` build is substituted for the
+// `cloud.trotter.matchers:matchers` coordinates the app would otherwise resolve
+// from a repo. See docs/adr/ADR-0009-rule-distribution-channels.md.
+if (providers.gradleProperty("useLocalMatchers").isPresent) {
+    includeBuild("matchers")
+}
+
 rootProject.name = "DashBuddy"
 include(":app")
 include(":domain")


### PR DESCRIPTION
## What this is

A **spike (throwaway PoC) + ADR** to de-risk the #192 matchers-split rule-distribution
architecture *before* we commit to it. It proves the **single local dev loop** works (edit a
rule locally → build → test, **no publish step**) without destabilizing `master`. Everything is
**opt-in and OFF by default**.

> This does **not** rewire `JsonRuleInterpreter` runtime asset loading or `TestRulesetFactory` —
> that's the real migration, tracked separately. The spike demonstrates the **mechanism**
> standalone (canonicalize + faithful-output proof + guarded wiring).

## Recommendation: **Option A (Gradle composite build / dependency substitution)**

The developer asked about composite build / dependency substitution, and it **works cleanly** in
this project. `matchers/` is a self-contained plain-JVM Gradle build that owns the JSON5 source +
canonicalize task and exposes the canonical output as an outgoing artifact; the app substitutes
it via a guarded `includeBuild("matchers")` and resolves it through a custom attribute-matched
configuration.

The AGP variant / `FAIL_ON_PROJECT_REPOS` / version-catalog friction the plan anticipated **did
not materialize** — a custom resolvable configuration sidesteps AGP attribute injection, and
composite substitution is coordinate matching (not a repository lookup). Option B (an in-app
canonicalize task) is the lighter fallback and the correct pre-split first step, but re-implements
the canonicalizer in the app (an SSOT smell); Option A co-locates canonicalization with the rules,
matching the production CI topology.

## Proofs (JDK 25, Gradle 9.3.0, AGP 9.0.1)

**1. Faithful canonicalization — byte-identical:**
```
$ ./gradlew -PuseLocalMatchers :core:pipeline:verifyMatchersCanonical
> Task :matchers:canonicalizeRules
> Task :core:pipeline:importMatchersOptionA
> Task :core:pipeline:verifyMatchersCanonical
PROOF OK: canonicalized uber.json is byte-identical to committed assets/rules/uber.json (20402 bytes).
BUILD SUCCESSFUL
```
`matchers/rules/uber.json5` = committed `uber.json` + a `//` comment + a trailing comma → canonicalizes back to the exact committed bytes.

**2. Composite substitution is real:**
```
$ ./gradlew -PuseLocalMatchers :core:pipeline:dependencies --configuration matchersRules
matchersRules
\--- cloud.trotter.matchers:matchers:0.0.0-local -> project :matchers
```

**3. Local loop, no publish:** editing `matchers/rules/uber.json5` re-runs `:matchers:canonicalizeRules` (no longer `UP-TO-DATE`) with no publish step; the artifact re-syncs only when canonical bytes change.

**4. Default build UNCHANGED (off by default):** with **no** flag — no `:matchers` project, no matchers tasks in `:core:pipeline`, committed assets untouched, and:
```
$ ./gradlew :core:pipeline:testDebugUnitTest      # no -PuseLocalMatchers
BUILD SUCCESSFUL
```

## ADR

`docs/adr/ADR-0009-rule-distribution-channels.md` — two-channels-one-artifact model (build-time
bundle vs runtime OTA, both consuming the single canonical artifact the matchers repo CI
produces; bundle stays as first-run/offline/sig-failure fallback), the single-local-loop dev
experience with the actual working wiring, the migration path (in-repo canonicalize → Apache-2.0
repo **gated on #246** → submodule + composite consumption → decouple `TestRulesetFactory` +
corpus↔rules version lock → `doordash.json` partition → OTA as Milestone 2), and honest tradeoffs.

Refs #192, #246, #361, #416, #419.

## Files
- `matchers/` — spike stand-in matchers build (settings + build.gradle.kts + `rules/uber.json5` + README)
- `settings.gradle.kts` — guarded `includeBuild("matchers")`
- `core/pipeline/build.gradle.kts` — guarded Option-A consumer + `verifyMatchersCanonical` proof task
- `docs/adr/ADR-0009-rule-distribution-channels.md`

**Do not merge — the developer gates this.**

---

### Design-goal review
This is a guarded spike + an ADR (design of record), not production feature code.
- **P3/P5 (Gradle code):** the JSON5 canonicalizer exists exactly once (producer side, mirroring the future matchers-repo CI topology); the consumer only resolves/syncs/compares — no duplicate canonicalizer (Option A chosen over B specifically to avoid that SSOT smell). Everything is behind the single `-PuseLocalMatchers` guard, so the default build is byte-for-byte unchanged.
- **P8:** N/A to recognition logic — this is build topology; the loaded rules and all recognition/redaction behavior are downstream and untouched.
- Honest scoping: the ADR explicitly states the spike proves the loop only to the generated dir; wiring canonical output into the runtime loader + `TestRulesetFactory` + corpus is named as migration work (issue #635/N1), not claimed here.

### Adversarial review
Independent fable-tier review — **verdict: CLEAN, merge recommended.** Verified empirically in the worktree: (1) the guard is airtight — `./gradlew projects`/`tasks` show no `:matchers`, `git status` clean, default `:core:pipeline:testDebugUnitTest` green with no flag; (2) the byte-identity proof is REAL and NON-VACUOUS — a mutation test (`format_version` 2→3 in the JSON5 source) made `verifyMatchersCanonical` FAIL despite identical byte count, proving the whole JSON5→canonicalize→artifact→substituted-config→compare chain is exercised; (3) the string-aware stripper is correct by inspection and honestly labeled spike-grade (a real JSON5 parser + schema-validate is flagged as production work in #635); (4) the ADR over-claims nowhere — every factual figure spot-checked (uber.json=20402B, doordash.json≈104KB, the loader/TestRulesetFactory citations), OTA honestly marked greenfield, repo creation correctly gated on #246 as a legal-not-code decision. Two INFO notes (the proof corpus happens not to contain a `//`-inside-string, so the string-awareness path rests on inspection; single-quoted JSON5 strings unsupported) are both covered by the explicit "NOT a JSON5 parser" caveat and are exactly what #635's real-parser work closes.
