### PR TITLE
fix(#633): reject cross-file rule-id collisions at merge (fail-closed)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,7 +156,10 @@ order-ready customer name via a per-field notif `redact`; store names kept). A r
 **recognized-frame** backstop (`CustomerTextMarkers`, #624 — distinct from `SensitiveTextMarkers`,
 which drops the dasher's banking screens) scrubs a node that ships a customer-PII marker
 ("Deliver to " etc.) a rule forgot to redact; the compiler rejects branch-level `redact` and skips
-a file with duplicate rule ids. UNKNOWN frames and UNKNOWN clicks remain the documented
+a file with duplicate rule ids (#624), and the multi-file loader skips a later file that re-declares
+an id an earlier file already claimed (#633 — cross-file `byId` redact-lookup shadow, fail-closed;
+a no-op on today's prefix-namespaced assets, hardening the #192/#639 multi-file + CDN path).
+UNKNOWN frames and UNKNOWN clicks remain the documented
 debug-only exception (behind the release `NoOpCaptureBus` #346 + the `SensitiveTextMarkers`
 backstop); the id-less building-name line residual is still tracked. `PipelineV2.events` is a HOT `shareIn` stream — one upstream pass feeds
 all collectors, so side effects (captures, dedup state) can never double-run (#361). The merged

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/JsonRuleInterpreter.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/JsonRuleInterpreter.kt
@@ -23,6 +23,9 @@ import javax.inject.Singleton
  * On [loadDefaults], scans the `assets/rules/` directory for per-platform JSON files,
  * validates and compiles each independently, then merges them into the combined rulesets.
  * A malformed file is logged and skipped — it does not prevent other platforms from loading.
+ * A file that re-declares a rule id an earlier-loaded file already claimed is likewise
+ * skipped whole ([acceptNonCollidingFiles], #633) so a later file can't shadow the
+ * byId redact lookup across files.
  *
  * Security checks applied before parsing:
  * - File size ≤ [MAX_FILE_BYTES] (1 MB) per file
@@ -98,33 +101,30 @@ class JsonRuleInterpreter @Inject constructor(
                 return
             }
 
-            val allScreens = mutableListOf<CompiledRule<UiNode>>()
-            val allClicks = mutableListOf<CompiledRule<UiNode>>()
-            val allNotifications = mutableListOf<CompiledRule<RawNotificationData>>()
-            val perFile = mutableListOf<Pair<String, CompiledRuleBundle>>() // path → bundle
-            val seenRuleIds = mutableMapOf<String, String>() // ruleId → first source path
-            var lastFormatVersion: Int? = null
-
+            val perFile = mutableListOf<Pair<String, CompiledRuleBundle>>() // path → bundle, load order
             for (fileName in files) {
                 val path = "$RULES_DIR/$fileName"
                 val json = context.assets.open(path).bufferedReader().readText()
                 val result = loadSingle(json, source = path) ?: continue
                 perFile += path to result
+            }
 
-                // Collision detection (C3): warn if any rule ID appears in multiple files
-                val newIds = result.screens.map { it.id } +
-                    result.clicks.map { it.id } +
-                    result.notifications.map { it.id }
-                for (id in newIds) {
-                    val existingSource = seenRuleIds.put(id, path)
-                    if (existingSource != null) {
-                        Timber.w(
-                            "JsonRuleInterpreter: rule ID '%s' declared in both '%s' and '%s'",
-                            id, existingSource, path,
-                        )
-                    }
-                }
+            // Cross-file rule-id collision policy (C3, #633): drop any LATER file that
+            // re-declares an id an EARLIER file already claimed, BEFORE the merge.
+            // Ruleset.byId is last-wins, so merging the later file would shadow the
+            // capture-redaction lookup (redactFor/notifRedactFor) across files while
+            // priority-ordered matchFirst still recognizes with the earlier rule — the
+            // wrong rule's redact could resolve and ship an id-keyed customer-PII node
+            // raw. Skips the offending file WHOLE (malformed-file-skip policy),
+            // complementing the within-file dup-id reject (#624). Earlier files keep
+            // every rule; other platforms are unaffected (no outage behind #432).
+            val accepted = acceptNonCollidingFiles(perFile)
 
+            val allScreens = mutableListOf<CompiledRule<UiNode>>()
+            val allClicks = mutableListOf<CompiledRule<UiNode>>()
+            val allNotifications = mutableListOf<CompiledRule<RawNotificationData>>()
+            var lastFormatVersion: Int? = null
+            for ((_, result) in accepted) {
                 allScreens += result.screens
                 allClicks += result.clicks
                 allNotifications += result.notifications
@@ -154,7 +154,7 @@ class JsonRuleInterpreter @Inject constructor(
             // check must not have its capabilities granted either. Source is
             // stamped per file so provenance survives the merge.
             reconcileCapabilities(
-                perFile.flatMap { (path, bundle) ->
+                accepted.flatMap { (path, bundle) ->
                     val liveScreens =
                         bundle.screens.filterNot { Platform.fromRuleId(it.id) in uncovered }
                     RuleCompiler.enumerateCapabilities(
@@ -174,7 +174,7 @@ class JsonRuleInterpreter @Inject constructor(
             Timber.i(
                 "JsonRuleInterpreter: loaded %d file(s) from %s/ " +
                     "(screens=%d, clicks=%d, notifications=%d)",
-                files.size, RULES_DIR, allScreens.size, allClicks.size, allNotifications.size,
+                accepted.size, RULES_DIR, allScreens.size, allClicks.size, allNotifications.size,
             )
         } catch (e: Exception) {
             Timber.e(e, "JsonRuleInterpreter: failed to load rules directory")
@@ -316,4 +316,52 @@ fun missingSensitivePlatforms(screens: List<CompiledRule<UiNode>>): Set<Platform
             rules.none { r -> r.branches.any { it.shape == "sensitive" } }
         }
         .keys
+}
+
+/**
+ * Cross-file rule-id collision policy (C3, #633). Given per-file compiled bundles in
+ * LOAD ORDER, return only the files whose top-level rule ids don't collide with an id
+ * an EARLIER-accepted file already claimed; a colliding file is SKIPPED WHOLE and
+ * logged at ERROR (lost coverage), never merged.
+ *
+ * Why skip the LATER file, not the earlier one: [Ruleset]'s `byId` is last-wins, so a
+ * later file re-declaring an id would SHADOW the byId redact lookup
+ * ([JsonRuleInterpreter.redactFor] / [JsonRuleInterpreter.notifRedactFor]) the capture
+ * stage uses, while priority-ordered [Ruleset.matchFirst] still recognizes with a
+ * DIFFERENT rule — the wrong rule's `redact` block resolves and an id-keyed customer-PII
+ * node (no marker prefix, invisible to the #624 screen backstop) could ship raw. Keeping
+ * the earlier file's rules makes byId and matchFirst agree on that id.
+ *
+ * ids come from top-level [CompiledRule.id] only — branches share the parent id and are
+ * NOT in `byId`, so a branch never triggers a collision. Impossible with the current
+ * prefix-namespaced asset bundles (`doordash.` / `uber.`), so this is a no-op today; it
+ * hardens the future multi-file subrepo (#639) + untrusted CDN/fork rule path (#192/#416).
+ *
+ * Pure + top-level so it's unit-testable without an Android Context. The ERROR log names
+ * the colliding id + both file paths ONLY — no rule text / no PII (Principle 7).
+ *
+ * @param files compiled bundles in LOAD ORDER (earlier entries win a collision).
+ */
+fun acceptNonCollidingFiles(
+    files: List<Pair<String, JsonRuleInterpreter.CompiledRuleBundle>>,
+): List<Pair<String, JsonRuleInterpreter.CompiledRuleBundle>> {
+    val claimedBy = HashMap<String, String>() // ruleId → first-claiming file path
+    val accepted = mutableListOf<Pair<String, JsonRuleInterpreter.CompiledRuleBundle>>()
+    for ((path, bundle) in files) {
+        val ids = bundle.screens.map { it.id } +
+            bundle.clicks.map { it.id } +
+            bundle.notifications.map { it.id }
+        val collision = ids.firstOrNull { it in claimedBy }
+        if (collision != null) {
+            Timber.e(
+                "JsonRuleInterpreter: rule id '%s' in '%s' already claimed by '%s' — skipping the " +
+                    "later file (cross-file byId redact-lookup shadow, #633)",
+                collision, path, claimedBy.getValue(collision),
+            )
+            continue
+        }
+        for (id in ids) claimedBy[id] = path
+        accepted += path to bundle
+    }
+    return accepted
 }

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/JsonRuleInterpreter.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/JsonRuleInterpreter.kt
@@ -94,6 +94,7 @@ class JsonRuleInterpreter @Inject constructor(
         try {
             val files = context.assets.list(RULES_DIR)
                 ?.filter { it.endsWith(".json") }
+                ?.sorted() // deterministic load order so the #633 first-file-wins collision policy is reproducible (assets.list ordering is not a documented contract)
                 ?: emptyList()
 
             if (files.isEmpty()) {

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/JsonRuleInterpreterCrossFileCollisionTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/JsonRuleInterpreterCrossFileCollisionTest.kt
@@ -1,0 +1,129 @@
+package cloud.trotter.dashbuddy.core.pipeline.rules
+
+import android.content.Context
+import android.util.Log
+import cloud.trotter.dashbuddy.domain.capability.RuleCapabilityGrants
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import timber.log.Timber
+
+/**
+ * #633 — cross-FILE rule-id collision hardening. [acceptNonCollidingFiles] skips a
+ * LATER file that re-declares an id an EARLIER file already claimed, matching the
+ * malformed-file-skip policy. This is the across-files complement to the within-file
+ * dup-id reject (#624, [JsonRuleInterpreterDupIdTest]).
+ *
+ * The shadow it prevents: [Ruleset.byId] is last-wins, so merging a later file that
+ * re-uses an id would make the capture-redaction lookup (`redactFor`) resolve to the
+ * WRONG rule's `redact` block while priority-ordered [Ruleset.matchFirst] still
+ * recognizes with the earlier rule — a customer-PII node could ship raw. Keeping only
+ * the earlier file makes byId and matchFirst agree.
+ *
+ * loadSingle touches neither the Context nor the grant store, so both are mocked.
+ */
+class JsonRuleInterpreterCrossFileCollisionTest {
+
+    private val interpreter = JsonRuleInterpreter(mock<Context>(), mock<RuleCapabilityGrants>())
+
+    private class CapturingTree : Timber.Tree() {
+        data class Entry(val priority: Int, val message: String)
+        val entries = mutableListOf<Entry>()
+        override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
+            entries += Entry(priority, message)
+        }
+    }
+
+    private val logs = CapturingTree()
+
+    @Before fun plant() = Timber.plant(logs)
+    @After fun uproot() = Timber.uprootAll()
+
+    /** A file re-declaring [sharedId], with a distinctive redact [keepPrefix] marker. */
+    private fun fileDeclaring(platform: String, sharedId: String, keepPrefix: String, ownId: String) = """
+        {
+          "format_version": 2,
+          "platform_id": "$platform",
+          "screens": [
+            {
+              "id": "$sharedId",
+              "priority": 9101,
+              "require": { "exists": { "hasText": "Deliver to" } },
+              "redact": [ { "find": { "hasTextStartsWith": "Deliver to " }, "keepPrefix": ["$keepPrefix"] } ]
+            },
+            { "id": "$ownId", "priority": 9102, "require": { "exists": { "hasText": "X" } } }
+          ]
+        }
+    """.trimIndent()
+
+    private fun disjointFile(platform: String, id: String) = """
+        {
+          "format_version": 2,
+          "platform_id": "$platform",
+          "screens": [
+            { "id": "$id", "priority": 9301, "require": { "exists": { "hasText": "C" } } }
+          ]
+        }
+    """.trimIndent()
+
+    @Test
+    fun `later file colliding on a rule id is skipped, earlier file and other platform survive`() {
+        val shared = "doordash.screen.shared"
+        val alpha = interpreter.loadSingle(
+            fileDeclaring("doordash.driver", shared, "ALPHA ", "doordash.screen.alpha_only"), "alpha.json",
+        )!!
+        // Later file re-declares `shared` with a DIFFERENT redact (the would-be shadow).
+        val beta = interpreter.loadSingle(
+            fileDeclaring("doordash.driver", shared, "BETA ", "doordash.screen.beta_only"), "beta.json",
+        )!!
+        // A disjoint, different platform that must keep loading.
+        val gamma = interpreter.loadSingle(disjointFile("uber.driver", "uber.screen.gamma_only"), "gamma.json")!!
+
+        val accepted = acceptNonCollidingFiles(
+            listOf("alpha.json" to alpha, "beta.json" to beta, "gamma.json" to gamma),
+        )
+
+        // The LATER colliding file (beta) is dropped whole; earlier + disjoint survive.
+        assertEquals(listOf("alpha.json", "gamma.json"), accepted.map { it.first })
+
+        // An ERROR names the colliding id + both files, and leaks no rule text / PII.
+        val err = logs.entries.singleOrNull { it.priority == Log.ERROR }
+        assertNotNull("a cross-file collision must log exactly one ERROR", err)
+        assertTrue(err!!.message.contains(shared))
+        assertTrue(err.message.contains("beta.json"))
+        assertTrue(err.message.contains("alpha.json"))
+
+        // byId/redact consistency: build the SCREEN ruleset exactly as loadDefaults does
+        // and confirm the shared id resolves to the EARLIER (alpha) rule's redact — this
+        // is precisely what redactFor(shared) reads. The would-be shadow (beta) is gone.
+        val screens = Ruleset(accepted.flatMap { it.second.screens })
+        val survivor = screens.ruleById(shared)
+        assertNotNull(survivor)
+        assertEquals(listOf("ALPHA "), survivor!!.redact.entries.single().keepPrefix)
+        // beta contributed nothing at all — not even its own unique rule.
+        assertNull(screens.ruleById("doordash.screen.beta_only"))
+        // the other platform still loaded.
+        assertNotNull(screens.ruleById("uber.screen.gamma_only"))
+    }
+
+    @Test
+    fun `two files with disjoint ids both load fully`() {
+        val one = interpreter.loadSingle(disjointFile("doordash.driver", "doordash.screen.one"), "one.json")!!
+        val two = interpreter.loadSingle(disjointFile("uber.driver", "uber.screen.two"), "two.json")!!
+
+        val accepted = acceptNonCollidingFiles(listOf("one.json" to one, "two.json" to two))
+
+        assertEquals(listOf("one.json", "two.json"), accepted.map { it.first })
+        assertTrue("disjoint ids must not log an ERROR", logs.entries.none { it.priority == Log.ERROR })
+
+        val screens: Ruleset<UiNode> = Ruleset(accepted.flatMap { it.second.screens })
+        assertNotNull(screens.ruleById("doordash.screen.one"))
+        assertNotNull(screens.ruleById("uber.screen.two"))
+    }
+}


### PR DESCRIPTION
Closes #633.

## Problem
`JsonRuleInterpreter.loadDefaults()` merges every `assets/rules/*.json` file. Its cross-file rule-id collision check (the "C3" check) was **WARN-only** while `Ruleset.byId = sorted.associateBy { it.id }` is **last-wins**. So a second file re-declaring an id already claimed by an earlier file SHADOWS the `byId` lookup that `redactFor(ruleId)` / `notifRedactFor(ruleId)` use, while priority-ordered `matchFirst` still recognizes with a *different* rule → the wrong rule's `redact` block resolves → an id-keyed customer-PII node (no marker prefix, invisible to the #624 `CustomerTextMarkers` screen backstop) can ship raw.

This is the exact wrong-rule-redact-shadow class #631 fixed **within** a file (#624 made `loadSingle` reject a single file with duplicate ids), now hardened **across** files. Impossible with today's prefix-namespaced bundles (distinct `doordash.`/`uber.` ids), so this is future-proofing for the multi-file subrepo (#639) + untrusted CDN/fork rules (#192/#416) — **zero behavior change on the current asset set**.

## Change (fail-closed, scoped)
- New pure top-level `acceptNonCollidingFiles(files)` (next to `missingSensitivePlatforms`, testable without a Context). Given per-file compiled bundles in **load order**, it tracks ids claimed by earlier-accepted files and, if a file introduces a colliding id, **skips that whole file** (does not merge any of its rules) — matching the existing malformed-file-skip policy `loadSingle` uses.
- `loadDefaults` now: read+compile all files → `acceptNonCollidingFiles` → merge only the accepted files. The skipped file contributes nothing (no rules, no capabilities, no format_version).
- Logs at **ERROR** (lost coverage) naming the colliding id + both file paths — **no rule text / no PII** (Principle 7).
- ids enumerated from top-level `CompiledRule.id` only. Branches share the parent rule id and are **not** in `byId`, so a branch never triggers a collision.
- `loadSingle`'s within-file dup-id reject (#624) is **unchanged** — this is the complementary cross-file layer.

### Collision-detection point & consistency argument
The detection point is the **merge boundary**, after every file is independently compiled by `loadSingle` (so within-file dup-ids are already rejected) and before `Ruleset` construction. Skipping the **later** file (not the earlier) is what restores the invariant: `byId` (last-wins) and `matchFirst` (priority-ordered) then agree on every id, because only one file owns any given id — so `redactFor(id)` can no longer resolve to a rule other than the one `matchFirst` recognized with.

## Security / privacy posture
- **Trusted:** nothing new. Rule files are still treated as untrusted input.
- **Gated / fail-closed:** a colliding later file is dropped whole rather than merged, so it can never shadow the redact lookup. Earlier files keep every rule (incl. redact); other platforms keep loading (no total sensing outage behind the #432 fail-closed gate). Conservative by design — the flatten across screen/click/notification ids rejects a file that reuses **any** claimed id (matches the prior C3 scope; clean per-file namespacing is the expectation for fork/CDN rules).
- **Scrubbed:** the ERROR log carries only the id + file paths, no rule text or customer PII.
- Hardens the #192/#639 multi-file + CDN untrusted-rule path; no-op on current assets.

## Tests (RED-first intent)
`core/pipeline/.../JsonRuleInterpreterCrossFileCollisionTest`:
- Two files sharing a rule id (+ a third disjoint platform) → the **later** file is skipped, the **earlier** file's rules survive, `Ruleset(mergedScreens).ruleById(shared).redact.keepPrefix == ["ALPHA "]` (proves `redactFor` resolves to the earlier real rule, not the `BETA` shadow — under the old WARN+merge, last-wins would have resolved to `BETA`), an ERROR is logged (id + both paths), and the other platform still loads.
- Control: two disjoint-id files → both load fully, no ERROR.

Production asset load unchanged: `DefaultRulesIntegrationTest` (real `loadDefaults` over the shipped assets) and `AllMatchersSuite` both green — distinct prefixes → no collision → no skip.

Exact counts (`JAVA_HOME=/usr/lib/jvm/java-25-openjdk`):
- `:core:pipeline:testDebugUnitTest` — **230** tests, 0 failures, 0 errors, 0 skipped
- `:app:testDebugUnitTest --tests "*AllMatchersSuite*"` — **595** tests, 0 failures
- `:domain:test` — **241** tests, 0 failures
- `DefaultRulesIntegrationTest` (explicit) — **23** tests, 0 failures

No field-test item added: this is a load-time guard with no observable on-dash behavior (a no-op on the current single-file-per-platform assets).

### Design-goal review
- **P3 (single responsibility):** collision policy extracted into one small pure function; `loadDefaults` reads cleanly (read → filter → merge). Mirrors the existing `missingSensitivePlatforms` seam.
- **P5 (SSOT):** one merge-time owner for the cross-file id-uniqueness invariant; the WARN-only duplicate was removed, not duplicated.
- **P6 (security/privacy):** fail-closed skip of the offending file protects the redact-lookup pledge; ERROR log is PII-free.
- **P7 (semantic logging):** ERROR = lost coverage (a file's rules dropped); message carries id + paths only.
- **P8 (platform-agnostic core):** no platform literals — the check is generic over any rule id; ids resolve only through `CompiledRule.id`. Adding a platform still needs zero `:core:*`/`:domain` edits.

### Adversarial review
Pending — to be run at fable tier (`/code-review` + `/security-review`) before merge, per the #589/#591 loop. Developer gates the merge.

---

### Adversarial review
Independent fable-tier review — **verdict: CLEAN.** Verified the core security property by trace: after `acceptNonCollidingFiles`, every id in the merged screens list is owned by exactly one file, so `Ruleset.byId` (last-wins) never overwrites and `redactFor(matchResult.ruleId)` always resolves to the rule `matchFirst` recognized with — the cross-file shadow leak is closed (within-file dup is #624's `loadSingle` reject; within-file cross-type is harmless since screens/clicks/notifications are three separate `byId` maps). Fail-closed confirmed: a collision skips only the offending (later) file, earlier files keep all rules incl. `redact`, other platforms keep loading (no #432-gate weaponization); capability reconcile enumerates from `accepted` so a skipped file grants nothing. Branch ids can't trigger it (`CompiledBranch` has no id field). P7 (ERROR carries id + paths only, no PII) and P8 (keyed on id/file strings, zero `Platform` references) confirmed. Independently reran `:core:pipeline:testDebugUnitTest` (230) + `:domain:test` (241), both green; the new cross-file test is non-vacuous (real compiled bundles sharing an id → later skipped, earlier's redact is what `ruleById(shared)` returns).

Two advisory findings: (1) **fixed in-PR** (commit adds `.sorted()` on the file list so first-file-wins is deterministic rather than relying on undocumented `assets.list()` ordering — the security property was already order-independent; this only makes which-file-survives reproducible); (2) **for the record** — #624 permits within-file cross-type id sharing while #633 forbids it across files; a documented foot-gun for the #639 multi-file split (loud + fail-closed if ever tripped), no action now.

### Design-goal review
- **P3 (SRP):** the cross-file policy is extracted into one pure top-level `acceptNonCollidingFiles(files)` (mirrors the `missingSensitivePlatforms` seam), unit-testable without a Context.
- **P6 (security):** fail-closed cross-file hardening — a colliding later file is skipped whole, so a collision can no longer shadow `redactFor`; zero behavior change on the current prefix-namespaced assets; hardens the #192/#639 multi-file + untrusted-CDN path.
- **P7:** ERROR log carries id + file paths only (lost-coverage class), no PII.
- **P8 (mandatory):** keyed on id/file strings, no platform literal.
