### PR TITLE
chore(#637): license matchers/ under Apache-2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,5 +212,7 @@ architecture, refactoring, and the data-driven recognition engine.
 ## License
 
 The application is licensed under [PolyForm Shield 1.0.0](LICENSE) — Copyright 2026 Stephen
-Trotter. The recognition rules are intended to ship under Apache-2.0 as a separate, forkable layer
-(see [#192](https://github.com/sjtrotter/DashBuddy/issues/192)).
+Trotter. The recognition ruleset in [`matchers/`](matchers/) is **separately licensed under
+[Apache-2.0](matchers/LICENSE)** — a forkable recognition layer (Pillar 2; see
+[#192](https://github.com/sjtrotter/DashBuddy/issues/192)) that can move to its own repo
+unencumbered. It is empirical measurement of the visible offer surface, published as data.

--- a/matchers/.gitignore
+++ b/matchers/.gitignore
@@ -1,2 +1,2 @@
-matchers/build/
+build/
 .gradle/

--- a/matchers/.gitignore
+++ b/matchers/.gitignore
@@ -1,0 +1,2 @@
+matchers/build/
+.gradle/

--- a/matchers/LICENSE
+++ b/matchers/LICENSE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/matchers/NOTICE
+++ b/matchers/NOTICE
@@ -1,0 +1,11 @@
+DashBuddy Matchers
+Copyright 2026 Stephen Trotter
+
+This product includes the DashBuddy recognition ruleset (JSON5 rule source +
+canonicalizer), licensed under the Apache License, Version 2.0.
+
+The ruleset is empirical measurement of the visible offer surface of gig-delivery
+platform apps — the information a driver already sees on their own screen, encoded
+as data so DashBuddy can present it back to the driver. It is not, and must not be
+described as, reverse-engineering, model recovery, or algorithm characterization of
+any platform.

--- a/matchers/README.md
+++ b/matchers/README.md
@@ -2,8 +2,8 @@
 
 This directory owns the **single source of truth for DashBuddy recognition rules**. It is an
 in-repo stand-in for the future separate, forkable, Apache-2.0 **matchers repo** (Pillar 2 /
-Epic #192) — same Gradle topology, so when the repo splits out (gated on the #246 licensing
-decision) this becomes a git **submodule** with no consumer-side change. See
+Epic #192) — same Gradle topology, so when the repo splits out (licensing settled Apache-2.0 per
+#246) this becomes a git **submodule** with no consumer-side change. See
 [`docs/adr/ADR-0009-rule-distribution-channels.md`](../docs/adr/ADR-0009-rule-distribution-channels.md).
 
 It is a self-contained plain-JVM Gradle build (`includeBuild`-ed by the app's root

--- a/matchers/README.md
+++ b/matchers/README.md
@@ -52,3 +52,19 @@ The runtime OTA/CDN channel — signed JSON fetched, verified (#416), capability
 survival across the swap (#419), CDN infra + signing — is greenfield. The bundled baseline here
 remains the first-run seed, the offline fallback, and the fail-closed fallback when signature
 verification fails.
+
+## License
+
+This ruleset is licensed under the **[Apache License 2.0](LICENSE)** (see [`NOTICE`](NOTICE)) —
+separately from the DashBuddy application, which is source-available under PolyForm Shield 1.0.0.
+The Apache-2.0 boundary is deliberate (Pillar 2 / Epic #192): the recognition layer is meant to be
+**forkable** so that if an upstream source is compromised, drivers can switch to another via
+configuration. Keeping the ruleset Apache-2.0 while in this monorepo lets it move to its own repo
+(gated on nothing now that the licensing is settled) with no relicensing step.
+
+**Framing (non-negotiable, per the project framing discipline).** This ruleset is **empirical
+measurement of the visible offer surface** — it encodes the information a driver already sees on
+their own screen so DashBuddy can present it back to them on-device. It is **not** reverse-
+engineering, model recovery, or algorithm characterization of any platform, and public-facing
+descriptions of it must never suggest otherwise (the DoorDash ICA §15.4 prohibits reverse-
+engineering; DashBuddy does not do that).


### PR DESCRIPTION
Settles the matchers-repo licensing (the developer chose **Apache-2.0**, updatable later) and declares the recognition ruleset subtree Apache-2.0 **in-tree**, so it can move to its own repo (N4/#637) with no relicensing step. Common prefix of every repo-creation path (private/public/later) — zero-regret regardless of the visibility decision, which is held for the developer.

## Changes (docs/license only — no compiled code)
- `matchers/LICENSE` — canonical Apache License 2.0 (fetched from GitHub's `/licenses/apache-2.0` API — authoritative, no transcription error).
- `matchers/NOTICE` — copyright (Stephen Trotter, 2026) + the framing-discipline statement.
- `matchers/README.md` — a `## License` section (Apache-2.0, distinct from the app's PolyForm Shield) + the **non-negotiable framing note** (empirical measurement of the visible offer surface; never reverse-engineering — DoorDash ICA §15.4).
- `README.md` — dual-license note: app = PolyForm Shield, `matchers/` = Apache-2.0.
- `matchers/.gitignore` — `build/` + `.gradle/` for standalone-readiness.

## What this does NOT do
The actual `gh repo create` + push + submodule restructure (N4→N5) is **held for the developer's public-vs-private call** — creating a public repo of recognition rules is outward-facing/semi-irreversible and framing-sensitive.

## Security / framing posture
No code, no recognition/redaction/effects change. The one sensitivity here is **public-facing framing**: the NOTICE + README describe the ruleset strictly as *empirical measurement of the visible offer surface*, never reverse-engineering/model-recovery/algorithm-characterization, per the project framing discipline and the ICA §15.4 good-faith interpretation in LEGAL.md.

[skip ci]

Refs #637, #192, #246.

---

### Adversarial review
Independent fable-tier review focused on the two risk surfaces (public-facing framing + license correctness) — **verdict: framing CLEAN, merge recommended.** Every added sentence (NOTICE + both README license sections) uses the approved "empirical measurement of the visible offer surface" formula; the prohibited terms (reverse-engineering / model recovery / algorithm characterization) appear ONLY in explicit negation, matching LEGAL.md's own defensive pattern — no phrasing a hostile reader could quote as ICA §15.4-suggestive. `matchers/LICENSE` verified byte-complete against a canonical Apache-2.0 copy (header, Sections 1–9, APPENDIX — not truncated). Dual-license confirmed unambiguous: root `LICENSE` untouched (still PolyForm Shield), README delineates app vs `matchers/` cleanly; no over-claim (OTA still marked greenfield). Two minor non-blocking findings **fixed in-PR**: F1 (`matchers/.gitignore` `matchers/build/` was directory-relative → dead in the split repo; anchored to `build/`) and F2 (a README licensing-gate self-contradiction reconciled).

### Design-goal review
Docs/license only, no compiled code (`[skip ci]` legitimate). P6/framing: the sole sensitivity is public-facing framing, and it's discipline-compliant (see above). The Apache-2.0 subtree boundary is the deliberate Pillar-2 posture (forkable recognition layer); the app's PolyForm Shield is unchanged.
