### PR TITLE
feat(#320/#316): live home glance + entry tiles + Ratings screen + NetProfit SSOT

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/MainActivity.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/MainActivity.kt
@@ -24,6 +24,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import cloud.trotter.dashbuddy.ui.main.dashboard.DashboardScreen
 import cloud.trotter.dashbuddy.ui.main.navigation.Screen
+import cloud.trotter.dashbuddy.ui.main.ratings.RatingsScreen
 import cloud.trotter.dashbuddy.ui.main.settings.AboutScreen
 import cloud.trotter.dashbuddy.ui.main.settings.EconomySettingsScreen
 import cloud.trotter.dashbuddy.ui.main.settings.EvidenceSettingsScreen
@@ -54,12 +55,28 @@ class MainActivity : ComponentActivity() {
                         // --- MAIN DASHBOARD ---
                         composable(Screen.Dashboard.route) {
                             DashboardScreen(
+                                onNavigate = { route -> navController.navigate(route) },
                                 onNavigateToSettings = {
                                     navController.navigate(Screen.SettingsHome.route)
                                 },
                                 onNavigateToWizard = { // <-- UPDATED CALLBACK
                                     navController.navigate(Screen.Wizard.route)
                                 }
+                            )
+                        }
+
+                        // --- RATINGS (#316) ---
+                        composable(Screen.Ratings.route) {
+                            RatingsScreen(
+                                onBack = { navController.popBackStack() }
+                            )
+                        }
+
+                        // --- ANALYTICS HUB (Phase 4, #315) — placeholder for now ---
+                        composable(Screen.Analytics.route) {
+                            PlaceholderScreen(
+                                title = "Analytics",
+                                onBack = { navController.popBackStack() }
                             )
                         }
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardScreen.kt
@@ -1,13 +1,23 @@
 package cloud.trotter.dashbuddy.ui.main.dashboard
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AttachMoney
+import androidx.compose.material.icons.filled.BarChart
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -26,36 +36,38 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
+import cloud.trotter.dashbuddy.core.designsystem.component.AppCard
+import cloud.trotter.dashbuddy.core.designsystem.component.AppStatTile
+import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
+import cloud.trotter.dashbuddy.core.designsystem.time.rememberNow
+import cloud.trotter.dashbuddy.ui.main.navigation.Screen
 import cloud.trotter.dashbuddy.ui.main.setup.permissions.PermissionsBottomSheet
 import cloud.trotter.dashbuddy.util.PermissionUtils
 
 @Composable
 fun DashboardScreen(
     viewModel: DashboardViewModel = hiltViewModel(),
+    onNavigate: (String) -> Unit,
     onNavigateToSettings: () -> Unit,
     onNavigateToWizard: () -> Unit
 ) {
     val context = LocalContext.current
-    val isFirstRun by viewModel.isFirstRun.collectAsStateWithLifecycle()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
-    // Data State
+    // Permissions are an OS-level fact re-checked on every resume — kept as
+    // composable-local state, not in the UiState, since ON_RESUME owns the read.
     var hasPermissions by remember { mutableStateOf<Boolean?>(null) }
-
-    // UI State for the Bottom Sheet
     var showPermissionSheet by remember { mutableStateOf(false) }
 
-    // Check permissions every time the screen resumes
     LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
         val granted = PermissionUtils.hasAllEssentialPermissions(context)
         hasPermissions = granted
-
-        // Only trigger the sheet to open.
-        // We let the sheet itself tell us when it's done closing!
         if (!granted) {
             showPermissionSheet = true
         }
@@ -66,10 +78,7 @@ fun DashboardScreen(
     // ========================================================================
     if (showPermissionSheet) {
         PermissionsBottomSheet(
-            onAllGranted = {
-                // This callback is fired AFTER the sheet finishes its slide-down animation
-                showPermissionSheet = false
-            }
+            onAllGranted = { showPermissionSheet = false }
         )
     }
 
@@ -83,18 +92,17 @@ fun DashboardScreen(
         Column(
             modifier = Modifier
                 .padding(padding)
+                .verticalScroll(rememberScrollState())
                 .padding(16.dp)
                 .fillMaxSize()
         ) {
             when {
-                // CASE 0: Loading (New) - Prevents the flicker
+                // CASE 0: Loading — prevents the flicker.
                 hasPermissions == null -> {
-                    // Empty state while calculating
+                    // Empty state while calculating.
                 }
 
                 // CASE 1: Permissions Missing (The Gate)
-                // Even though the bottom sheet is showing over this, we render a scary card
-                // in the background so the app state makes sense.
                 hasPermissions == false -> {
                     StatusCard(
                         title = "Permissions Required",
@@ -104,45 +112,151 @@ fun DashboardScreen(
                     )
                 }
 
-                // CASE 2: Permissions Granted, BUT it's the First Run (The Guide)
-                hasPermissions == true && isFirstRun -> {
+                // CASE 2: Permissions Granted, first run (The Guide)
+                uiState.isFirstRun -> {
                     StatusCard(
                         title = "You have the Keys!",
                         subtitle = "Permissions granted. Let's personalize your strategy so DashBuddy knows what offers you like.",
                         containerColor = MaterialTheme.colorScheme.secondaryContainer
                     )
                     Spacer(modifier = Modifier.height(16.dp))
-
                     Button(
                         modifier = Modifier.fillMaxWidth(),
                         onClick = onNavigateToWizard
                     ) { Text("Personalize Strategy") }
-
                     Spacer(modifier = Modifier.height(8.dp))
-
                     TextButton(
                         modifier = Modifier.fillMaxWidth(),
-                        onClick = { viewModel.completeSetup() } // Skips wizard entirely
+                        onClick = { viewModel.completeSetup() }
                     ) { Text("Skip for now") }
                 }
 
-                // CASE 3: Everything is Perfect (Permissions + Not First Run)
-                hasPermissions == true && !isFirstRun -> {
+                // CASE 3: Ready — status card, live "this dash" glance, entry tiles.
+                else -> {
                     StatusCard(
-                        title = "Ready to Dash",
-                        subtitle = "All systems go.",
+                        title = uiState.statusText,
+                        subtitle = if (uiState.isInSession) "You're on the clock." else "All systems go.",
                         containerColor = MaterialTheme.colorScheme.primaryContainer
                     )
                     Spacer(modifier = Modifier.height(16.dp))
+
+                    ThisDashGlance(glance = uiState.glance)
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    EntryTileGrid(onNavigate = onNavigate)
+                    Spacer(modifier = Modifier.height(16.dp))
+
                     Button(
                         modifier = Modifier.fillMaxWidth(),
-                        onClick = {
-                            viewModel.showWelcomeBubble()
-                        }
+                        onClick = { viewModel.showWelcomeBubble() }
                     ) { Text("Show Bubble") }
                 }
             }
         }
+    }
+}
+
+/**
+ * The live "this dash" glance — True Net · Net $/hr · Miles. $/hr and the online
+ * timer tick off a `rememberNow()` clock (Reactive UI rules 2/3): the composable
+ * derives them from the session anchors so they stay fresh without a state
+ * transition. True Net / Miles update reactively through their own state flows.
+ */
+@Composable
+private fun ThisDashGlance(glance: DashGlance) {
+    val now by rememberNow()
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        AppStatTile(
+            label = "True Net",
+            value = glance.trueNetText,
+            sub = "This dash",
+            valueColor = when {
+                !glance.isInSession -> AppTheme.colors.text
+                glance.isPositiveNet -> AppTheme.colors.good
+                else -> AppTheme.colors.bad
+            },
+            modifier = Modifier.weight(1f),
+        )
+        AppStatTile(
+            label = "Net/hr",
+            value = glance.netPerHourText(now),
+            sub = glance.onlineDurationText(now).takeIf { glance.isInSession },
+            modifier = Modifier.weight(1f),
+        )
+        AppStatTile(
+            label = "Miles",
+            value = glance.milesText,
+            sub = "miles",
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+
+/** 2×2 entry tiles: Analytics · Ratings · Strategy · Economy. */
+@Composable
+private fun EntryTileGrid(onNavigate: (String) -> Unit) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            EntryTile(
+                icon = Icons.Filled.BarChart,
+                label = "Analytics",
+                modifier = Modifier.weight(1f),
+                // TODO(#315): wire to the analytics hub once :feature:analytics lands.
+                onClick = { onNavigate(Screen.Analytics.route) },
+            )
+            EntryTile(
+                icon = Icons.Filled.Star,
+                label = "Ratings",
+                modifier = Modifier.weight(1f),
+                onClick = { onNavigate(Screen.Ratings.route) },
+            )
+        }
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            EntryTile(
+                icon = Icons.Filled.Tune,
+                label = "Strategy",
+                modifier = Modifier.weight(1f),
+                onClick = { onNavigate(Screen.StrategySettings.route) },
+            )
+            EntryTile(
+                icon = Icons.Filled.AttachMoney,
+                label = "Economy",
+                modifier = Modifier.weight(1f),
+                onClick = { onNavigate(Screen.EconomySettings.route) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun EntryTile(
+    icon: ImageVector,
+    label: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AppCard(modifier = modifier.clickable(onClick = onClick)) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = AppTheme.colors.accent,
+            modifier = Modifier.size(28.dp),
+        )
+        Spacer(Modifier.height(8.dp))
+        Text(
+            text = label,
+            style = MaterialTheme.typography.titleMedium,
+            color = AppTheme.colors.text,
+        )
     }
 }
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardUiState.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardUiState.kt
@@ -1,0 +1,77 @@
+package cloud.trotter.dashbuddy.ui.main.dashboard
+
+import cloud.trotter.dashbuddy.domain.evaluation.NetProfit
+import cloud.trotter.dashbuddy.domain.format.Formats
+import cloud.trotter.dashbuddy.domain.format.formatDuration
+
+/**
+ * Immutable state for the home (Dashboard) screen (Principle 1 — UDF). Bundles the
+ * first-run / status gate with a live "this dash" economics [glance]. Permissions
+ * stay a composable-local OS re-check (they must be re-read on every `ON_RESUME`),
+ * so they are intentionally NOT modelled here.
+ */
+data class DashboardUiState(
+    val isFirstRun: Boolean = true,
+    val statusText: String = "Offline",
+    val isInSession: Boolean = false,
+    val glance: DashGlance = DashGlance.EMPTY,
+)
+
+/**
+ * The live "this dash" glance. Holds the *anchors* (net, miles, session start),
+ * not frozen display values — the composable derives the ticking figures ($/hr,
+ * online duration) from these + a `rememberNow()` tick so they stay fresh without
+ * a state-machine transition (Reactive UI rules 1–3). `trueNet`/`miles` update
+ * reactively through their own Flows; only the time-derived rates need the ticker.
+ *
+ * Labelled "This dash" (not "Today") on purpose: this is the current online
+ * session only. Real Today/Week/Lifetime totals arrive with the read-model (#314),
+ * out of scope here.
+ */
+data class DashGlance(
+    val isInSession: Boolean,
+    /** Net profit so far this dash: session gross − session miles × operating cost/mi. */
+    val trueNet: Double,
+    val miles: Double,
+    /** Session start anchor for the online-duration / $-per-hour derivations; null when idle. */
+    val startedAt: Long?,
+) {
+    val isPositiveNet: Boolean get() = trueNet >= 0.0
+
+    /** True Net as money, or an em dash when not dashing. */
+    val trueNetText: String get() = if (isInSession) Formats.money(trueNet) else EMPTY_VALUE
+
+    /** Session miles with one decimal, or an em dash when not dashing. */
+    val milesText: String get() = if (isInSession) Formats.decimal(miles) else EMPTY_VALUE
+
+    /** Online hours elapsed at [now]; null when idle. Floors at 0 (never negative). */
+    private fun onlineHoursAt(now: Long): Double? =
+        startedAt?.let { (now - it).coerceAtLeast(0L) / 3_600_000.0 }
+
+    /**
+     * Net $/hr at wall-clock [now] — the denominator (online time) grows every
+     * second, so this is derived in the composable from a ticker, never frozen in
+     * state. `null` until a measurable slice of time has elapsed.
+     */
+    fun netPerHourAt(now: Long): Double? =
+        onlineHoursAt(now)?.let { NetProfit.perHour(trueNet, it) }
+
+    /** Net $/hr as money at [now], or an em dash when undefined / idle. */
+    fun netPerHourText(now: Long): String =
+        netPerHourAt(now)?.let { Formats.money(it) } ?: EMPTY_VALUE
+
+    /** Online duration string at [now] via the TimeFormats SSOT; em dash when idle. */
+    fun onlineDurationText(now: Long): String =
+        startedAt?.let { formatDuration(now - it) } ?: EMPTY_VALUE
+
+    companion object {
+        /** Placeholder shown for every glance figure when not in a session. */
+        const val EMPTY_VALUE = "—"
+
+        val EMPTY = DashGlance(isInSession = false, trueNet = 0.0, miles = 0.0, startedAt = null)
+
+        /** Build a live glance from the current session's anchors. */
+        fun live(trueNet: Double, miles: Double, startedAt: Long): DashGlance =
+            DashGlance(isInSession = true, trueNet = trueNet, miles = miles, startedAt = startedAt)
+    }
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardViewModel.kt
@@ -1,57 +1,79 @@
 package cloud.trotter.dashbuddy.ui.main.dashboard
 
-import android.app.Application
-import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import cloud.trotter.dashbuddy.core.data.location.OdometerRepository
+import cloud.trotter.dashbuddy.core.data.settings.AppPreferencesRepository
 import cloud.trotter.dashbuddy.core.data.state.AppStateRepository
+import cloud.trotter.dashbuddy.domain.evaluation.NetProfit
 import cloud.trotter.dashbuddy.domain.model.chat.ChatPersona
 import cloud.trotter.dashbuddy.domain.state.AppState
-import cloud.trotter.dashbuddy.domain.state.Mode
 import cloud.trotter.dashbuddy.domain.state.Flow
+import cloud.trotter.dashbuddy.domain.state.Mode
 import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.domain.state.PlatformRegion
 import cloud.trotter.dashbuddy.core.state.StateManagerV2
 import cloud.trotter.dashbuddy.ui.bubble.BubbleManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-import cloud.trotter.dashbuddy.domain.format.Formats
 
+/**
+ * State holder for the home (Dashboard) screen. Exposes one immutable
+ * [DashboardUiState] (Principle 1 — UDF) assembled reactively from:
+ *  - [StateManagerV2] `AppState` — session running earnings + mode + status,
+ *  - [OdometerRepository] session miles (GPS),
+ *  - [AppPreferencesRepository.userEconomy] — operating cost/mi, the SAME economy
+ *    the offer verdict scores against (so live True Net uses identical cost math),
+ *  - [AppStateRepository.isFirstRun] — the setup gate.
+ *
+ * The focused platform is resolved through the [Platform] registry (flow's active
+ * platform, else most-recent activity) — never a `== DoorDash` literal (Principle 8).
+ */
 @HiltViewModel
 class DashboardViewModel @Inject constructor(
-    application: Application,
     private val appStateRepository: AppStateRepository,
     odometerRepository: OdometerRepository,
+    appPreferencesRepository: AppPreferencesRepository,
     stateManager: StateManagerV2,
     private val bubbleManager: BubbleManager,
-) : AndroidViewModel(application) {
+) : ViewModel() {
 
-    // 1. Am I Dashing?
-    val isInSession: StateFlow<Boolean> = stateManager.state
-        .map { state ->
-            val dd = state.regions.platforms[Platform.DoorDash]
-            dd != null && dd.mode != Mode.Offline
+    val uiState: StateFlow<DashboardUiState> = combine(
+        stateManager.state,
+        odometerRepository.sessionMilesFlow,
+        appPreferencesRepository.userEconomy,
+        appStateRepository.isFirstRun,
+    ) { state, sessionMiles, economy, firstRun ->
+        val region = focusedRegion(state)
+        val inSession = region != null && region.mode != Mode.Offline
+        val session = region?.session
+
+        val glance = if (inSession && session != null) {
+            DashGlance.live(
+                trueNet = NetProfit.net(
+                    grossPay = session.runningEarnings,
+                    miles = sessionMiles,
+                    costPerMile = economy.operatingCostPerMile,
+                ),
+                miles = sessionMiles,
+                startedAt = session.startedAt,
+            )
+        } else {
+            DashGlance.EMPTY
         }
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
 
-    // 2. Current Status Text
-    val statusText: StateFlow<String> = stateManager.state
-        .map { state -> getStatusText(state) }
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), "Offline")
-
-    // 3. Session Miles — derive from the repository's miles flow (SSOT for the
-    // meters->miles factor); this VM only formats for display.
-    val sessionMiles: StateFlow<String> = odometerRepository.sessionMilesFlow
-        .map { miles -> "${Formats.decimal(miles)} mi" }
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), "0.0 mi")
-
-    // 4. First Run Check
-    val isFirstRun: StateFlow<Boolean> = appStateRepository.isFirstRun
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), true)
+        DashboardUiState(
+            isFirstRun = firstRun,
+            statusText = statusText(state.regions.flow.flow, region?.mode),
+            isInSession = inSession,
+            glance = glance,
+        )
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), DashboardUiState())
 
     fun completeSetup() = viewModelScope.launch {
         appStateRepository.setFirstRunComplete()
@@ -59,23 +81,27 @@ class DashboardViewModel @Inject constructor(
 
     fun showWelcomeBubble() {
         bubbleManager.postMessage(
-            text = "DashBuddy is ready. Open DoorDash and start a dash — I'll track everything from here.",
+            text = "DashBuddy is ready. Open your platform and start a dash — I'll track everything from here.",
             ChatPersona.Dispatcher,
             expand = true
         )
     }
 
-    private fun getStatusText(state: AppState): String {
-        val dd = state.regions.platforms[Platform.DoorDash]
-        val flow = state.regions.flow.flow
+    /** The platform the home glance attributes to — registry-resolved, not a literal. */
+    private fun focusedRegion(state: AppState): PlatformRegion? {
+        val platform: Platform? = state.regions.flow.activePlatform
+            ?: state.regions.crossPlatform.mostRecentActivityPlatform
+        return platform?.let { state.regions.platforms[it] }
+    }
 
-        if (dd == null || dd.mode == Mode.Offline) {
+    private fun statusText(flow: Flow, mode: Mode?): String {
+        if (mode == null || mode == Mode.Offline) {
             return when (flow) {
                 Flow.SessionEnded -> "Dash Complete"
                 else -> "Ready to Dash"
             }
         }
-        if (dd.mode == Mode.Paused) return "Paused"
+        if (mode == Mode.Paused) return "Paused"
 
         return when (flow) {
             Flow.Idle -> "Looking for offers..."

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/navigation/DashBuddyRoutes.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/navigation/DashBuddyRoutes.kt
@@ -5,6 +5,11 @@ sealed class Screen(val route: String) {
     data object Dashboard : Screen("dashboard")
     data object Wizard : Screen("wizard")
 
+    // Analytics surfaces (home-screen entry tiles, epic #320)
+    data object Ratings : Screen("ratings")
+    // Analytics hub is Phase 4 (#315) — routes to the placeholder for now.
+    data object Analytics : Screen("analytics")
+
     // Settings Hierarchy
     // Note: We use "settings/home" as the landing page for settings
     data object SettingsHome : Screen("settings/home")

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/ratings/RatingsScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/ratings/RatingsScreen.kt
@@ -1,0 +1,211 @@
+package cloud.trotter.dashbuddy.ui.main.ratings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import cloud.trotter.dashbuddy.core.designsystem.component.AppCard
+import cloud.trotter.dashbuddy.core.designsystem.component.AppGaugeRing
+import cloud.trotter.dashbuddy.core.designsystem.component.AppStatTile
+import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
+import cloud.trotter.dashbuddy.domain.format.Formats
+
+/**
+ * Ratings screen (#316) — binds the focused platform's `RatingsSnapshot` (already
+ * in app state) via [RatingsViewModel]. Headline standing rates render as
+ * [AppGaugeRing]s; acceptance / delivery counts / shopping-quality render as
+ * [AppStatTile]s. Numbers only — no store/customer text (Principle 7).
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RatingsScreen(
+    onBack: () -> Unit,
+    viewModel: RatingsViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Ratings") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        if (!state.hasData) {
+            RatingsEmpty(
+                platformName = state.platformName,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .padding(24.dp),
+            )
+            return@Scaffold
+        }
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            state.platformName?.let {
+                Text(it, style = AppTheme.num.lgNum, color = AppTheme.colors.text)
+            }
+
+            HeadlineGauges(state)
+
+            StandingTiles(state)
+
+            if (state.hasShoppingQuality) {
+                Text(
+                    "Shopping quality",
+                    style = androidx.compose.material3.MaterialTheme.typography.titleSmall,
+                    color = AppTheme.colors.text2,
+                )
+                ShoppingQualityTiles(state)
+            }
+        }
+    }
+}
+
+/** Customer rating (0–5), on-time and completion (0–100%) as gauge rings. */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun HeadlineGauges(state: RatingsUiState) {
+    FlowRow(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(20.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        state.customerRating?.let {
+            AppGaugeRing(
+                progress = (it / 5.0).toFloat(),
+                value = Formats.decimal(it, digits = 2),
+                label = "Customer",
+                color = AppTheme.colors.accent,
+            )
+        }
+        state.onTimeRate?.let {
+            AppGaugeRing(
+                progress = (it / 100.0).toFloat(),
+                value = percentText(it),
+                label = "On-time",
+                color = AppTheme.colors.accent,
+            )
+        }
+        state.completionRate?.let {
+            AppGaugeRing(
+                progress = (it / 100.0).toFloat(),
+                value = percentText(it),
+                label = "Completion",
+                color = AppTheme.colors.accent,
+            )
+        }
+    }
+}
+
+/** Acceptance rate + 30-day / lifetime delivery counts. */
+@Composable
+private fun StandingTiles(state: RatingsUiState) {
+    val tiles = buildList {
+        state.acceptanceRate?.let { add("Acceptance" to percentText(it)) }
+        state.deliveriesLast30Days?.let { add("Deliveries (30d)" to Formats.commaInt(it)) }
+        state.lifetimeDeliveries?.let { add("Lifetime deliveries" to Formats.commaInt(it)) }
+    }
+    TileGrid(tiles)
+}
+
+/** Shopping-quality percentages + lifetime shop count (shop platforms only). */
+@Composable
+private fun ShoppingQualityTiles(state: RatingsUiState) {
+    val tiles = buildList {
+        state.originalItemsFoundRate?.let { add("Original items found" to percentText(it)) }
+        state.totalItemsFoundRate?.let { add("Total items found" to percentText(it)) }
+        state.substitutionIssuesRate?.let { add("Substitution issues" to percentText(it)) }
+        state.itemsWithQualityIssuesRate?.let { add("Quality issues" to percentText(it)) }
+        state.itemsWrongOrMissingRate?.let { add("Wrong or missing" to percentText(it)) }
+        state.lifetimeShoppingOrders?.let { add("Lifetime shops" to Formats.commaInt(it)) }
+    }
+    TileGrid(tiles)
+}
+
+/** Lays a list of (label, value) tiles two-per-row; the odd tile fills its row. */
+@Composable
+private fun TileGrid(tiles: List<Pair<String, String>>) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        tiles.chunked(2).forEach { pair ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                pair.forEach { (label, value) ->
+                    AppStatTile(
+                        label = label,
+                        value = value,
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+                if (pair.size == 1) Spacer(Modifier.weight(1f))
+            }
+        }
+    }
+}
+
+@Composable
+private fun RatingsEmpty(platformName: String?, modifier: Modifier = Modifier) {
+    Box(modifier = modifier, contentAlignment = Alignment.Center) {
+        AppCard {
+            Text(
+                text = "No ratings yet",
+                style = AppTheme.num.lgNum,
+                color = AppTheme.colors.text,
+            )
+            Spacer(Modifier.height(6.dp))
+            Text(
+                text = buildString {
+                    append("Open your ")
+                    append(platformName ?: "platform")
+                    append(" Ratings screen while DashBuddy is running and they'll show up here.")
+                },
+                style = androidx.compose.material3.MaterialTheme.typography.bodyMedium,
+                color = AppTheme.colors.text2,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+/** Renders a 0–100 rate as an integer percent, e.g. `95.0` → "95%". */
+private fun percentText(rate: Double): String = "${Formats.decimal(rate, digits = 0)}%"

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/ratings/RatingsUiState.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/ratings/RatingsUiState.kt
@@ -1,0 +1,71 @@
+package cloud.trotter.dashbuddy.ui.main.ratings
+
+import cloud.trotter.dashbuddy.domain.model.ratings.RatingsSnapshot
+import cloud.trotter.dashbuddy.domain.state.Platform
+
+/**
+ * Immutable state for the Ratings screen (#316). A pure projection of the
+ * focused platform's [RatingsSnapshot] carried in `PlatformRegion.ratings` — no
+ * new persistence, no re-observation. Rates are stored as the parser emits them:
+ * the standing rates (acceptance/completion/on-time + shopping-quality) are
+ * **percentages 0–100**; [customerRating] is a **0–5 star** value.
+ *
+ * Privacy: ratings are numbers only (Principle 7) — there is no store/customer
+ * text on this surface.
+ */
+data class RatingsUiState(
+    val hasData: Boolean = false,
+    /** Display-only platform label (e.g. "DoorDash"); null when unknown. */
+    val platformName: String? = null,
+    val capturedAt: Long? = null,
+
+    // Headline (gauges): 0–5 star + 0–100 percentages.
+    val customerRating: Double? = null,
+    val onTimeRate: Double? = null,
+    val completionRate: Double? = null,
+
+    // Tiles: 0–100 percentage + counts.
+    val acceptanceRate: Double? = null,
+    val deliveriesLast30Days: Int? = null,
+    val lifetimeDeliveries: Int? = null,
+
+    // Shopping quality (0–100 percentages + count) — only present for shop platforms.
+    val originalItemsFoundRate: Double? = null,
+    val totalItemsFoundRate: Double? = null,
+    val substitutionIssuesRate: Double? = null,
+    val itemsWithQualityIssuesRate: Double? = null,
+    val itemsWrongOrMissingRate: Double? = null,
+    val lifetimeShoppingOrders: Int? = null,
+) {
+    /** True when the snapshot carried at least one shopping-quality metric. */
+    val hasShoppingQuality: Boolean
+        get() = originalItemsFoundRate != null || totalItemsFoundRate != null ||
+            substitutionIssuesRate != null || itemsWithQualityIssuesRate != null ||
+            itemsWrongOrMissingRate != null || lifetimeShoppingOrders != null
+
+    companion object {
+        val EMPTY = RatingsUiState()
+
+        /** Project a snapshot (may be null → empty) onto the UI state. */
+        fun from(platform: Platform?, snapshot: RatingsSnapshot?): RatingsUiState {
+            if (snapshot == null) return EMPTY.copy(platformName = platform?.displayName)
+            return RatingsUiState(
+                hasData = true,
+                platformName = platform?.displayName,
+                capturedAt = snapshot.capturedAt,
+                customerRating = snapshot.customerRating,
+                onTimeRate = snapshot.onTimeRate,
+                completionRate = snapshot.completionRate,
+                acceptanceRate = snapshot.acceptanceRate,
+                deliveriesLast30Days = snapshot.deliveriesLast30Days,
+                lifetimeDeliveries = snapshot.lifetimeDeliveries,
+                originalItemsFoundRate = snapshot.originalItemsFoundRate,
+                totalItemsFoundRate = snapshot.totalItemsFoundRate,
+                substitutionIssuesRate = snapshot.substitutionIssuesRate,
+                itemsWithQualityIssuesRate = snapshot.itemsWithQualityIssuesRate,
+                itemsWrongOrMissingRate = snapshot.itemsWrongOrMissingRate,
+                lifetimeShoppingOrders = snapshot.lifetimeShoppingOrders,
+            )
+        }
+    }
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/ratings/RatingsViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/ratings/RatingsViewModel.kt
@@ -1,0 +1,39 @@
+package cloud.trotter.dashbuddy.ui.main.ratings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import cloud.trotter.dashbuddy.core.state.StateManagerV2
+import cloud.trotter.dashbuddy.domain.state.AppState
+import cloud.trotter.dashbuddy.domain.state.Platform
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+
+/**
+ * State holder for the Ratings screen (#316). Reads the focused platform's
+ * [cloud.trotter.dashbuddy.domain.model.ratings.RatingsSnapshot] out of
+ * [StateManagerV2]'s `AppState` and projects it to an immutable [RatingsUiState].
+ *
+ * The focused platform is registry-resolved (Principle 8) — flow's active
+ * platform, else most-recent activity — never a `== DoorDash` literal.
+ */
+@HiltViewModel
+class RatingsViewModel @Inject constructor(
+    stateManager: StateManagerV2,
+) : ViewModel() {
+
+    val uiState: StateFlow<RatingsUiState> = stateManager.state
+        .map { state ->
+            val platform = focusedPlatform(state)
+            val snapshot = platform?.let { state.regions.platforms[it]?.ratings }
+            RatingsUiState.from(platform, snapshot)
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), RatingsUiState.EMPTY)
+
+    private fun focusedPlatform(state: AppState): Platform? =
+        state.regions.flow.activePlatform
+            ?: state.regions.crossPlatform.mostRecentActivityPlatform
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardViewModelTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardViewModelTest.kt
@@ -1,0 +1,144 @@
+package cloud.trotter.dashbuddy.ui.main.dashboard
+
+import cloud.trotter.dashbuddy.core.data.location.OdometerRepository
+import cloud.trotter.dashbuddy.core.data.settings.AppPreferencesRepository
+import cloud.trotter.dashbuddy.core.data.state.AppStateRepository
+import cloud.trotter.dashbuddy.core.state.StateManagerV2
+import cloud.trotter.dashbuddy.domain.evaluation.UserEconomy
+import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleClass
+import cloud.trotter.dashbuddy.domain.state.AppState
+import cloud.trotter.dashbuddy.domain.state.Flow
+import cloud.trotter.dashbuddy.domain.state.FlowRegion
+import cloud.trotter.dashbuddy.domain.state.Mode
+import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.domain.state.PlatformRegion
+import cloud.trotter.dashbuddy.domain.state.Regions
+import cloud.trotter.dashbuddy.domain.state.Session
+import cloud.trotter.dashbuddy.ui.bubble.BubbleManager
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+/**
+ * #320 — the home glance must compute live True Net / $-per-hr from the session's
+ * running earnings, session miles, and the SAME operating cost the offer verdict
+ * uses (via the NetProfit SSOT), and stay platform-agnostic (registry-focused).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class DashboardViewModelTest {
+
+    private val appStateRepository: AppStateRepository = mock()
+    private val odometerRepository: OdometerRepository = mock()
+    private val appPreferencesRepository: AppPreferencesRepository = mock()
+    private val stateManager: StateManagerV2 = mock()
+    private val bubbleManager: BubbleManager = mock()
+
+    /** $3.00/gal ÷ 30 mpg = $0.10/mi fuel; every non-fuel cost defaults to 0 → $0.10/mi total. */
+    private val tenCentsPerMile = UserEconomy(
+        vehicleClass = VehicleClass.SEDAN,
+        vehicleMpg = 30.0,
+        gasPricePerGallon = 3.0,
+    )
+
+    private fun appStateOnline(startedAt: Long, earnings: Double): AppState = AppState(
+        regions = Regions(
+            flow = FlowRegion(flow = Flow.Idle, activePlatform = Platform.DoorDash),
+            platforms = mapOf(
+                Platform.DoorDash to PlatformRegion(
+                    platform = Platform.DoorDash,
+                    mode = Mode.Online,
+                    session = Session(
+                        sessionId = "s1",
+                        startedAt = startedAt,
+                        runningEarnings = earnings,
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    private fun buildViewModel() = DashboardViewModel(
+        appStateRepository = appStateRepository,
+        odometerRepository = odometerRepository,
+        appPreferencesRepository = appPreferencesRepository,
+        stateManager = stateManager,
+        bubbleManager = bubbleManager,
+    )
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    @Test
+    fun `glance computes trueNet and netPerHour from session, miles and economy`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val startedAt = 1_000_000L
+        whenever(stateManager.state)
+            .thenReturn(MutableStateFlow(appStateOnline(startedAt, earnings = 20.0)))
+        whenever(odometerRepository.sessionMilesFlow).thenReturn(flowOf(8.0))
+        whenever(appPreferencesRepository.userEconomy).thenReturn(flowOf(tenCentsPerMile))
+        whenever(appStateRepository.isFirstRun).thenReturn(flowOf(false))
+
+        val viewModel = buildViewModel()
+        val job = launch { viewModel.uiState.collect {} }
+        testScheduler.advanceUntilIdle()
+
+        val glance = viewModel.uiState.value.glance
+        assertTrue(glance.isInSession)
+        // trueNet = 20.00 − 8 mi × $0.10/mi = 19.20
+        assertEquals(19.20, glance.trueNet, 1e-9)
+        assertEquals(8.0, glance.miles, 1e-9)
+        // one hour after start → $19.20 / 1 h = $19.20/hr
+        assertEquals(19.20, glance.netPerHourAt(startedAt + 3_600_000L)!!, 1e-9)
+        // before any time elapses the rate is undefined (null), not a fake $0/hr
+        assertNull(glance.netPerHourAt(startedAt))
+
+        assertTrue(viewModel.uiState.value.isInSession)
+        assertEquals("Looking for offers...", viewModel.uiState.value.statusText)
+        job.cancel()
+    }
+
+    @Test
+    fun `offline yields an empty glance and not-in-session`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val offline = AppState(
+            regions = Regions(
+                flow = FlowRegion(flow = Flow.Idle, activePlatform = Platform.DoorDash),
+                platforms = mapOf(
+                    Platform.DoorDash to PlatformRegion(
+                        platform = Platform.DoorDash,
+                        mode = Mode.Offline,
+                    ),
+                ),
+            ),
+        )
+        whenever(stateManager.state).thenReturn(MutableStateFlow(offline))
+        whenever(odometerRepository.sessionMilesFlow).thenReturn(flowOf(0.0))
+        whenever(appPreferencesRepository.userEconomy).thenReturn(flowOf(tenCentsPerMile))
+        whenever(appStateRepository.isFirstRun).thenReturn(flowOf(false))
+
+        val viewModel = buildViewModel()
+        val job = launch { viewModel.uiState.collect {} }
+        testScheduler.advanceUntilIdle()
+
+        val ui = viewModel.uiState.value
+        assertFalse(ui.isInSession)
+        assertFalse(ui.glance.isInSession)
+        assertEquals(DashGlance.EMPTY_VALUE, ui.glance.trueNetText)
+        assertEquals("Ready to Dash", ui.statusText)
+        job.cancel()
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/main/ratings/RatingsViewModelTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/main/ratings/RatingsViewModelTest.kt
@@ -1,0 +1,97 @@
+package cloud.trotter.dashbuddy.ui.main.ratings
+
+import cloud.trotter.dashbuddy.core.state.StateManagerV2
+import cloud.trotter.dashbuddy.domain.model.ratings.RatingsSnapshot
+import cloud.trotter.dashbuddy.domain.state.AppState
+import cloud.trotter.dashbuddy.domain.state.Flow
+import cloud.trotter.dashbuddy.domain.state.FlowRegion
+import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.domain.state.PlatformRegion
+import cloud.trotter.dashbuddy.domain.state.Regions
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+/**
+ * #316 — the Ratings screen must project the focused platform's RatingsSnapshot
+ * (already in app state) and stay null-safe when no ratings have been observed.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class RatingsViewModelTest {
+
+    private val stateManager: StateManagerV2 = mock()
+
+    private fun stateWith(ratings: RatingsSnapshot?): AppState = AppState(
+        regions = Regions(
+            flow = FlowRegion(flow = Flow.Idle, activePlatform = Platform.DoorDash),
+            platforms = mapOf(
+                Platform.DoorDash to PlatformRegion(
+                    platform = Platform.DoorDash,
+                    ratings = ratings,
+                ),
+            ),
+        ),
+    )
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    @Test
+    fun `maps a snapshot onto the ui state`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val snapshot = RatingsSnapshot(
+            capturedAt = 42L,
+            acceptanceRate = 71.0,
+            completionRate = 99.0,
+            onTimeRate = 95.0,
+            customerRating = 4.97,
+            deliveriesLast30Days = 120,
+            lifetimeDeliveries = 812,
+            originalItemsFoundRate = 88.0,
+        )
+        whenever(stateManager.state).thenReturn(MutableStateFlow(stateWith(snapshot)))
+
+        val viewModel = RatingsViewModel(stateManager)
+        val job = launch { viewModel.uiState.collect {} }
+        testScheduler.advanceUntilIdle()
+
+        val ui = viewModel.uiState.value
+        assertTrue(ui.hasData)
+        assertEquals("DoorDash", ui.platformName)
+        assertEquals(4.97, ui.customerRating!!, 1e-9)
+        assertEquals(95.0, ui.onTimeRate!!, 1e-9)
+        assertEquals(812, ui.lifetimeDeliveries)
+        assertTrue(ui.hasShoppingQuality) // originalItemsFoundRate present
+        job.cancel()
+    }
+
+    @Test
+    fun `null ratings yields no-data state`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        whenever(stateManager.state).thenReturn(MutableStateFlow(stateWith(null)))
+
+        val viewModel = RatingsViewModel(stateManager)
+        val job = launch { viewModel.uiState.collect {} }
+        testScheduler.advanceUntilIdle()
+
+        val ui = viewModel.uiState.value
+        assertFalse(ui.hasData)
+        assertEquals("DoorDash", ui.platformName) // still labelled for the empty hint
+        assertNull(ui.customerRating)
+        assertFalse(ui.hasShoppingQuality)
+        job.cancel()
+    }
+}

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -106,6 +106,20 @@ was found **broken-in-part** (raw PII in capture envelopes) and moved to that en
   to redact — if you see a `redactBackstopScrubs=` count climb in the PipelineStats log line, note
   which screen tripped it.
   - Confirmed: 0/2
+- **✨ NEW — the home screen now shows a live "This dash" glance + entry tiles (#320/#316).**
+  Open the DashBuddy main app (not the bubble) **while a dash is running**. **Working looks like:**
+  the "Ready to Dash" area shows three stat tiles — **True Net** (green when positive), **Net/hr**,
+  **Miles** — and the Net/hr + its sub-timer **tick up every second** without needing a state change
+  (that's the reactive glance). True Net should equal session earnings minus miles × your operating
+  cost/mi (same math as an offer's net verdict), and Miles should track the GPS session odometer.
+  Below the tiles is a 2×2 grid — **Analytics · Ratings · Strategy · Economy**: tapping **Ratings**
+  opens a screen showing your real customer-rating / on-time / completion gauges + acceptance /
+  delivery-count / shopping-quality tiles (empty-state message if you haven't opened the platform's
+  Ratings screen yet this run); **Strategy** and **Economy** open their existing editors; **Analytics**
+  is a "Construction Area" placeholder for now. Broken = frozen Net/hr (doesn't tick), True Net that
+  disagrees with the offer-card net math, a Ratings screen that's blank when the platform ratings
+  screen was seen, or a tile that navigates nowhere.
+  - Confirmed: 0/2
 - **🔧 FIX SHIPPED — offer outcome cards now derive from the committed outcome, not the tap (#601).
   DELIBERATE UX CHANGE — CONFIRM ON DASH.**
   Before, tapping Accept/Decline printed "Offer Accepted"/"Offer Declined" immediately, from the

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/NetProfit.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/NetProfit.kt
@@ -1,0 +1,37 @@
+package cloud.trotter.dashbuddy.domain.evaluation
+
+/**
+ * True-Net-Profitability arithmetic — the single source of truth (#5) for turning
+ * gross pay + miles + a per-mile operating cost into net profit and its derived
+ * per-hour / per-mile rates.
+ *
+ * Pure, allocation-free, no Android. Extracted from [OfferEvaluator] so the same
+ * cost math backs BOTH the offer-time verdict AND the live "this dash" home-screen
+ * glance — the live True Net a dasher sees is computed byte-for-byte the way the
+ * offer score was, from one definition (there is no second copy to drift). The
+ * read-model projector (#314) reuses it too, applying it to realized pay + miles.
+ *
+ * Denominator guards return `null` (rate undefined) rather than a fabricated 0.0,
+ * so a caller decides how to render "no rate yet" instead of showing a misleading
+ * `$0.00/hr` for a dash that has earned money but not yet accrued measurable time.
+ */
+object NetProfit {
+
+    /** Net pay after operating cost: [grossPay] − [miles] × [costPerMile]. */
+    fun net(grossPay: Double, miles: Double, costPerMile: Double): Double =
+        grossPay - miles * costPerMile
+
+    /**
+     * Net dollars per hour, or `null` when [hours] is not positive (rate
+     * undefined — e.g. a dash with zero elapsed online time).
+     */
+    fun perHour(net: Double, hours: Double): Double? =
+        if (hours > 0.0) net / hours else null
+
+    /**
+     * Net dollars per mile, or `null` when [miles] is not positive (rate
+     * undefined — e.g. a pickup-only leg with no logged distance).
+     */
+    fun perMile(net: Double, miles: Double): Double? =
+        if (miles > 0.0) net / miles else null
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/OfferEvaluator.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/OfferEvaluator.kt
@@ -14,11 +14,14 @@ class OfferEvaluator() {
         val items = offer.itemCount.toDouble()
 
         // Operating cost — full breakdown (fuel + tires + oil + brakes + fluids +
-        // misc + depreciation + amortized fixed costs + phone) and net pay
+        // misc + depreciation + amortized fixed costs + phone) and net pay. Net pay
+        // routes through the NetProfit SSOT (#5) so the live home-screen glance and
+        // this verdict share one definition; the fuel/non-fuel split is kept for the
+        // OfferEvaluation breakdown fields.
         val fuelCost = dist * economy.fuelCostPerMile
         val nonFuelCost = dist * economy.nonFuelCostPerMile
         val operatingCost = fuelCost + nonFuelCost
-        val netPay = grossPay - operatingCost
+        val netPay = NetProfit.net(grossPay, dist, economy.operatingCostPerMile)
 
         // Time estimate = whole-route drive + handling (#556). Handling for a Shop & Deliver order
         // is its item count at the dasher's effective shopping pace (items/min — already absorbs
@@ -37,9 +40,10 @@ class OfferEvaluator() {
         val estTimeMinutes = driveMinutes + handlingMinutes
         val estTimeHours = estTimeMinutes / 60.0
 
-        // Metrics operate on net pay
-        val dpm = if (dist > 0) netPay / dist else 0.0
-        val activeHourly = if (estTimeHours > 0) netPay / estTimeHours else 0.0
+        // Metrics operate on net pay (same NetProfit SSOT; 0.0 when the
+        // denominator is undefined, preserving the prior scoring behavior).
+        val dpm = NetProfit.perMile(netPay, dist) ?: 0.0
+        val activeHourly = NetProfit.perHour(netPay, estTimeHours) ?: 0.0
 
         val joinedStores: String = offer.orders
             .map { order: ParsedOrder -> order.storeName }

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/evaluation/NetProfitTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/evaluation/NetProfitTest.kt
@@ -1,0 +1,51 @@
+package cloud.trotter.dashbuddy.domain.evaluation
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Guards the True-Net SSOT (#5). These are the exact arithmetic the offer verdict
+ * and the live home glance both route through, so a change here is a change to both.
+ */
+class NetProfitTest {
+
+    @Test
+    fun `net subtracts miles times cost-per-mile from gross`() {
+        // $20 gross, 8 mi at $0.25/mi operating cost → $18 net.
+        assertEquals(18.0, NetProfit.net(grossPay = 20.0, miles = 8.0, costPerMile = 0.25), 1e-9)
+    }
+
+    @Test
+    fun `net can go negative when costs exceed pay`() {
+        assertEquals(-5.0, NetProfit.net(grossPay = 5.0, miles = 40.0, costPerMile = 0.25), 1e-9)
+    }
+
+    @Test
+    fun `net with zero cost-per-mile is the gross`() {
+        assertEquals(12.5, NetProfit.net(grossPay = 12.5, miles = 30.0, costPerMile = 0.0), 1e-9)
+    }
+
+    @Test
+    fun `perHour divides net by hours`() {
+        // $18 net over 0.5 h → $36/hr.
+        assertEquals(36.0, NetProfit.perHour(net = 18.0, hours = 0.5)!!, 1e-9)
+    }
+
+    @Test
+    fun `perHour is null for zero or negative hours`() {
+        assertNull(NetProfit.perHour(net = 18.0, hours = 0.0))
+        assertNull(NetProfit.perHour(net = 18.0, hours = -1.0))
+    }
+
+    @Test
+    fun `perMile divides net by miles`() {
+        // $18 net over 8 mi → $2.25/mi.
+        assertEquals(2.25, NetProfit.perMile(net = 18.0, miles = 8.0)!!, 1e-9)
+    }
+
+    @Test
+    fun `perMile is null for zero miles`() {
+        assertNull(NetProfit.perMile(net = 18.0, miles = 0.0))
+    }
+}


### PR DESCRIPTION
Analytics roadmap **Phase 1** (epic #320, ratings #316): put **live** analytics on the home screen and a **Ratings** screen, using data and design-system components that already exist. No new persistence, DB, or network — live-state + existing-data UI only.

## What shipped

**1. `NetProfit` economics SSOT (`:domain`)** — the True-Net math was inline in `OfferEvaluator.evaluate()`. Extracted to a pure, reusable helper:

```kotlin
object NetProfit {
    fun net(grossPay: Double, miles: Double, costPerMile: Double): Double   // gross − miles×cost/mi
    fun perHour(net: Double, hours: Double): Double?                        // null when hours ≤ 0
    fun perMile(net: Double, miles: Double): Double?                       // null when miles ≤ 0
}
```

`OfferEvaluator` now routes `netPay` / `$·mi` / `$·hr` through it (`perMile/perHour ?: 0.0` preserves the exact prior fallback). **Offer-eval behavior is unchanged** — it's a pure extraction; all offer-eval + parse-output tests stay green. The live home "True Net" now uses byte-identical cost math to the offer verdict (Principle 5). The read-model projector (#314) will reuse it too.

**2. `DashboardViewModel` → immutable UiState + live glance** — replaced the four loose, mostly-thrown-away flows with one `DashboardUiState` (UDF) bundling first-run + status + a live **"This dash"** `DashGlance` (anchors: `trueNet`, `miles`, session `startedAt`). Assembled reactively from `AppState.session.runningEarnings`, `OdometerRepository.sessionMilesFlow`, and the **same** `AppPreferencesRepository.userEconomy` the offer verdict scores against (`operatingCostPerMile`). Focused platform is **registry-resolved** (`flow.activePlatform ?: mostRecentActivityPlatform`) — this also **removes the old `== Platform.DoorDash` literals** from the VM (Principle 8). Converted `AndroidViewModel`→`ViewModel` (the `Application` dep was unused).

**3. `DashboardScreen` — glance row + 2×2 entry grid** — a 3× `AppStatTile` glance (True Net / Net·hr / Miles); `$·hr` and the online timer **tick off `rememberNow()`** in the composable (Reactive UI rules 2/3) from the `startedAt` anchor, so they stay fresh without a state transition. A 2×2 entry grid — **Analytics · Ratings · Strategy · Economy** — wired to `Screen.StrategySettings` / `Screen.EconomySettings` (existing), `Screen.Ratings` (new), and a `Screen.Analytics` **placeholder** (`// TODO(#315)`: hub is Phase 4). Status-card states, permission gate, and Settings FAB unchanged.

**4. Ratings screen (#316)** — `RatingsViewModel` reads the focused platform's `RatingsSnapshot` (already carried on `PlatformRegion.ratings`) → immutable `RatingsUiState`. `RatingsScreen` renders headline rates (customer 0–5, on-time/completion 0–100) as `AppGaugeRing`, and acceptance / delivery counts / shopping-quality as `AppStatTile`; graceful null/empty state. New `Screen.Ratings` route in `MainActivity`'s NavHost; the Dashboard tile navigates to it.

## Security / privacy posture (Principle 7)
The glance and Ratings surfaces show **economics and rates only — numbers**. No raw store / customer / address text is read or rendered anywhere in this diff (ratings are percentages + a star value + counts; the glance is money/miles/rates from session anchors). Nothing touches recognition, capture, the sensitive-screen gate, network, or effects. Uses the `Formats`/`TimeFormats` display SSOT throughout.

## Design-goal review
- **P1 (UDF):** one immutable `DashboardUiState` / `RatingsUiState`; state flows down, VMs derive from `StateManagerV2` + repos, no repo writes from UI. Composables are stateless (hoisted anchors).
- **P3 (single responsibility):** small files; UI-state models split out (`DashboardUiState.kt`, `RatingsUiState.kt`); reused existing `App*` components — no new chart primitives.
- **P5 (SSOT):** `NetProfit` is the one net-profit definition (offer verdict + live glance + future projector); economy read from the same `userEconomy` flow the evaluator uses; all display via `Formats`/`TimeFormats`.
- **P8 (platform-agnostic):** both VMs resolve the platform through the `Platform` registry, not a literal; the change **removes** the pre-existing `== Platform.DoorDash` literals in `DashboardViewModel`. No new vocabulary/contracts. (`OfferEvaluator` change is arithmetic only — no platform coupling.)
- **Reactive UI:** the glance holds anchors, not frozen strings; `$·hr` + online timer are derived from `rememberNow()` so they tick. `trueNet`/`miles` update through their own Flows. Deliberate deviation from a literal `netPerHour: Double?` state field: a frozen scalar would violate rule 1 (its denominator is elapsed time), so it's exposed as `glance.netPerHourAt(now)` — pure and unit-tested.

## Adversarial review
Not yet run — leaving the fable-tier `/code-review` (+ it touches no untrusted-input boundary, so `/security-review` is optional) for the pre-merge gate, per the Subagent Model Policy.

## Tests
`NetProfitTest` (7), `DashboardViewModelTest` (2 — glance trueNet/$·hr from known inputs + offline empty state), `RatingsViewModelTest` (2 — maps a snapshot + null-safe). Full runs green: **`:app:testDebugUnitTest` 857**, **`:domain:test` 248**, 0 failures.

## Field test
Added a "Next field test" checklist item (live True Net/$·hr/Miles tick while dashing; Ratings screen shows real rates; #320/#316).

Refs #320, #316. Pre-work-adjacent to #314 (read-model reuses `NetProfit`) and #315 (Analytics hub placeholder).


---

### Design-goal review
Touches `:domain` (economics) + `:app` (UI) — Phase 1 of the analytics roadmap (#320).
- **P1 (UDF):** conforms — `DashboardViewModel`/`RatingsViewModel` each expose one immutable UiState (collapsed the old loose flows); composables render + dispatch only.
- **P5 (SSOT):** the net-profit math is now one `NetProfit` definition in `:domain`, called by both `OfferEvaluator` (estimate) and the home glance (realized) — the home True Net uses byte-identical cost math to the offer verdict.
- **P8 (platform-agnostic, mandatory):** removed the latent `== Platform.DoorDash` literals from `DashboardViewModel`; focus now resolves via the `Platform` registry (`activePlatform ?: mostRecentActivityPlatform`). `NetProfit` is pure arithmetic.
- **P7 (logging/PII):** zero new log lines; the glance/ratings render economics/rates/counts + the platform display name only — no raw store/customer text.
- **Reactive UI:** the glance holds anchors (`trueNet`, `miles`, `startedAt`) and derives `$·/hr` + duration from a 1 Hz `rememberNow()` ticker, so it ticks without a state-machine transition (no frozen values).

### Adversarial review
Independent fable-tier review — **verdict: CLEAN, merge recommended.** Verified the `NetProfit` extraction is algebraically identical to the old inline `OfferEvaluator` math (net, $/mi, $/hr, zero-denominator handling) — offer scoring cannot shift (`:domain:test` 248/248, incl. `OfferEvaluatorTest` 68/68). Confirmed the glance is genuinely reactive (True Net/miles update on the session/odometer/economy flows; $·/hr ticks off the 1 Hz ticker; zero-elapsed → em dash, never a fake $0/hr). Confirmed the P8 literal removal (grep-clean), P7 (no PII rendered/logged), ratings scale math (0–100 rates, 0–5 rating → gauge `progress` correct + clamped, null-snapshot empty state), and nav wiring (no dangling routes). New tests are non-vacuous (DashboardViewModelTest asserts the computed net through the VM combine; RatingsViewModelTest covers the null path). `:app:testDebugUnitTest` 857/0, CI pass. One informational finding (ULP-level FP associativity in the extracted multiply — provably inert to cent-rounded display + score thresholds); no in-PR fix needed.
