### PR TITLE
feat(#314): durable analytics read-model schema (PR1)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -166,6 +166,11 @@ dependencies {
     testImplementation(libs.mockito.core)
     testImplementation(libs.mockito.kotlin)
     testImplementation(libs.kotlinx.coroutines.test)
+    // #314 — Robolectric DAO round-trip tests build an in-memory DashBuddyDatabase;
+    // Room's builder API is only transitively runtime-visible via :core:database
+    // (implementation), so surface it on the test compile classpath. room-ktx (the
+    // suspend/Flow DAO runtime) is already transitive on the test runtime classpath.
+    testImplementation(libs.androidx.room.runtime)
 }
 
 kotlin {

--- a/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsSchemaRoundTripTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsSchemaRoundTripTest.kt
@@ -1,0 +1,211 @@
+package cloud.trotter.dashbuddy.analytics
+
+import androidx.room.Room
+import cloud.trotter.dashbuddy.core.data.event.AppEventRepo
+import cloud.trotter.dashbuddy.core.database.DashBuddyDatabase
+import cloud.trotter.dashbuddy.core.database.analytics.AnalyticsDao
+import cloud.trotter.dashbuddy.core.database.analytics.AnalyticsProjectionStateEntity
+import cloud.trotter.dashbuddy.core.database.analytics.DeliveryRecordEntity
+import cloud.trotter.dashbuddy.core.database.event.AppEventDao
+import cloud.trotter.dashbuddy.core.database.event.AppEventEntity
+import cloud.trotter.dashbuddy.domain.model.event.AppEventType
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+/**
+ * #314 PR1 — DAO round-trip + aggregate-query correctness for the durable
+ * analytics read-model, plus the `AppEventRepo.getEventsAfter` fold-input
+ * plumbing (sequence + Gson→kotlinx metadata decode). Behavior-inert schema:
+ * nothing populates these tables in the app yet; this test drives the DAO/repo
+ * directly against an in-memory v9 database.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AnalyticsSchemaRoundTripTest {
+
+    private lateinit var db: DashBuddyDatabase
+    private lateinit var analyticsDao: AnalyticsDao
+    private lateinit var eventDao: AppEventDao
+    private lateinit var repo: AppEventRepo
+
+    @Before
+    fun setUp() {
+        val context = RuntimeEnvironment.getApplication()
+        db = Room.inMemoryDatabaseBuilder(context, DashBuddyDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        analyticsDao = db.analyticsDao()
+        eventDao = db.appEventDao()
+        repo = AppEventRepo(db, eventDao, db.effectsFiredDao())
+    }
+
+    @After
+    fun tearDown() = db.close()
+
+    private fun delivery(
+        seq: Long,
+        jobId: String,
+        storeName: String?,
+        pay: Double?,
+        completedAt: Long,
+        platform: String = "doordash",
+    ) = DeliveryRecordEntity(
+        eventSequenceId = seq,
+        sessionId = "S1",
+        platform = platform,
+        jobId = jobId,
+        taskId = "T$seq",
+        storeName = storeName,
+        customerHash = "chash-$seq",
+        addressHash = "ahash-$seq",
+        phaseStartedAt = completedAt - 600_000,
+        arrivedAt = completedAt - 120_000,
+        completedAt = completedAt,
+        deadlineMillis = null,
+        realizedPay = pay,
+        payBasis = "DROP_SHARE",
+        tip = null,
+        basePay = null,
+        odometerAtCompletion = null,
+        realizedMiles = null,
+        realizedMinutes = null,
+        frozenCostPerMile = null,
+        netProfit = null,
+        costBasis = "NONE",
+    )
+
+    @Test
+    fun `deliveryTotals sums pay, counts rows, and counts distinct jobs`() = runBlocking {
+        analyticsDao.upsertDelivery(delivery(1, "J1", "Wendys", 10.0, 1_000))
+        analyticsDao.upsertDelivery(delivery(2, "J1", "Wendys", 5.0, 2_000))
+        analyticsDao.upsertDelivery(delivery(3, "J2", "Chipotle", 8.0, 3_000))
+
+        val all = analyticsDao.deliveryTotals(0, Long.MAX_VALUE).first()
+        assertEquals(23.0, all.pay, 0.0001)
+        assertEquals(3, all.deliveries)
+        assertEquals(2, all.jobs) // J1, J2 distinct
+
+        // Half-open [start, end): only the 2_000 row lands.
+        val window = analyticsDao.deliveryTotals(1_500, 2_500).first()
+        assertEquals(5.0, window.pay, 0.0001)
+        assertEquals(1, window.deliveries)
+        assertEquals(1, window.jobs)
+    }
+
+    @Test
+    fun `deliveryTotals returns zeros over an empty table`() = runBlocking {
+        val totals = analyticsDao.deliveryTotals(0, Long.MAX_VALUE).first()
+        assertEquals(0.0, totals.pay, 0.0001)
+        assertEquals(0, totals.deliveries)
+        assertEquals(0, totals.jobs)
+    }
+
+    @Test
+    fun `deliveryTotalsByStore groups by store, ordered by pay desc`() = runBlocking {
+        analyticsDao.upsertDelivery(delivery(1, "J1", "Wendys", 10.0, 1_000))
+        analyticsDao.upsertDelivery(delivery(2, "J1", "Wendys", 5.0, 2_000))
+        analyticsDao.upsertDelivery(delivery(3, "J2", "Chipotle", 8.0, 3_000))
+
+        val byStore = analyticsDao.deliveryTotalsByStore(0, Long.MAX_VALUE).first()
+        assertEquals(2, byStore.size)
+        assertEquals("Wendys", byStore[0].storeName)
+        assertEquals(15.0, byStore[0].pay, 0.0001)
+        assertEquals(2, byStore[0].deliveries)
+        assertEquals("Chipotle", byStore[1].storeName)
+        assertEquals(8.0, byStore[1].pay, 0.0001)
+        assertEquals(1, byStore[1].deliveries)
+    }
+
+    @Test
+    fun `upsertDelivery replaces on the sequenceId primary key`() = runBlocking {
+        analyticsDao.upsertDelivery(delivery(1, "J1", "Wendys", 10.0, 1_000))
+        // Same sequenceId, different pay — REPLACE, not a second row.
+        analyticsDao.upsertDelivery(delivery(1, "J1", "Wendys", 99.0, 1_000))
+        val totals = analyticsDao.deliveryTotals(0, Long.MAX_VALUE).first()
+        assertEquals(99.0, totals.pay, 0.0001)
+        assertEquals(1, totals.deliveries)
+    }
+
+    @Test
+    fun `watermark get returns null before first set, then round-trips and replaces`() = runBlocking {
+        assertNull(analyticsDao.getWatermark())
+
+        analyticsDao.setWatermark(AnalyticsProjectionStateEntity(watermarkSequenceId = 42, projectorVersion = 3))
+        val first = analyticsDao.getWatermark()
+        assertNotNull(first)
+        assertEquals(42L, first!!.watermarkSequenceId)
+        assertEquals(3, first.projectorVersion)
+        assertEquals(1, first.id) // singleton row
+
+        // REPLACE on the singleton id advances the watermark in place.
+        analyticsDao.setWatermark(AnalyticsProjectionStateEntity(watermarkSequenceId = 99, projectorVersion = 4))
+        val second = analyticsDao.getWatermark()!!
+        assertEquals(99L, second.watermarkSequenceId)
+        assertEquals(4, second.projectorVersion)
+    }
+
+    @Test
+    fun `deleteAll wipes the record table for a version rebuild`() = runBlocking {
+        analyticsDao.upsertDelivery(delivery(1, "J1", "Wendys", 10.0, 1_000))
+        analyticsDao.deleteAllDeliveries()
+        val totals = analyticsDao.deliveryTotals(0, Long.MAX_VALUE).first()
+        assertEquals(0, totals.deliveries)
+    }
+
+    // ── AppEventDao.getEventsAfter / maxSequenceId + repo plumbing ──────
+
+    private fun event(metadata: String?) = AppEventEntity(
+        aggregateId = "S1",
+        eventType = AppEventType.ZONE_SWITCH, // decodes to a null payload — metadata is the focus
+        eventPayload = "{}",
+        occurredAt = 1_000,
+        metadata = metadata,
+    )
+
+    @Test
+    fun `getEventsAfter pages by sequence and maxSequenceId tracks the tail`() = runBlocking {
+        assertNull(eventDao.maxSequenceId().first()) // empty log
+        repeat(5) { eventDao.insert(event(null)) }   // sequenceIds 1..5
+
+        assertEquals(5L, eventDao.maxSequenceId().first())
+
+        val page1 = eventDao.getEventsAfter(after = 0, limit = 2)
+        assertEquals(listOf(1L, 2L), page1.map { it.sequenceId })
+
+        val page2 = eventDao.getEventsAfter(after = 2, limit = 2)
+        assertEquals(listOf(3L, 4L), page2.map { it.sequenceId })
+
+        val page3 = eventDao.getEventsAfter(after = 4, limit = 10)
+        assertEquals(listOf(5L), page3.map { it.sequenceId })
+    }
+
+    @Test
+    fun `repo getEventsAfter carries sequence and decodes Gson-shaped and test-mode metadata`() = runBlocking {
+        val gsonShape = """{"odometer":88.0,"batteryLevel":50,"networkType":"WIFI","appVersion":"1.0"}"""
+        eventDao.insert(event(gsonShape))          // seq 1
+        eventDao.insert(event("""{ "test_mode": true }"""))  // seq 2 — unknown key
+        eventDao.insert(event(null))               // seq 3 — no metadata
+
+        val seq = repo.getEventsAfter(after = 0, limit = 10)
+        assertEquals(listOf(1L, 2L, 3L), seq.map { it.sequenceId })
+
+        // Gson field shape decodes into the odometer the fold needs.
+        assertEquals(88.0, seq[0].metadata!!.odometer!!, 0.0001)
+        assertEquals(50, seq[0].metadata!!.batteryLevel)
+
+        // Test-mode row: object present, unknown key ignored, fields default to null.
+        assertNotNull(seq[1].metadata)
+        assertNull(seq[1].metadata!!.odometer)
+
+        // No metadata column → null metadata (not an empty object).
+        assertNull(seq[2].metadata)
+    }
+}

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/event/AppEventRepo.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/event/AppEventRepo.kt
@@ -9,8 +9,11 @@ import cloud.trotter.dashbuddy.core.database.event.AppEventEntity
 import cloud.trotter.dashbuddy.domain.model.event.AppEvent
 import cloud.trotter.dashbuddy.domain.model.event.AppEventCodec
 import cloud.trotter.dashbuddy.domain.model.event.AppEventType
+import cloud.trotter.dashbuddy.domain.model.event.EventMetadata
+import cloud.trotter.dashbuddy.domain.model.event.SequencedAppEvent
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.serialization.json.Json
 import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -66,6 +69,16 @@ class AppEventRepo @Inject constructor(
     fun getEventsInTimeRange(startTime: Long, endTime: Long): Flow<List<AppEvent>> =
         dao.getEventsInTimeRange(startTime, endTime).map { rows -> rows.map { it.toDomain() } }
 
+    /**
+     * A page of [SequencedAppEvent]s after [after] (exclusive), oldest-first, for
+     * the analytics projector's paged fold (#314). Unlike the other reads, this
+     * carries the entity `sequenceId` and decoded [EventMetadata] the fold needs.
+     * Malformed payload OR metadata degrades to null at this edge (WARN), never a
+     * throw — same fail-null contract as [toDomain].
+     */
+    suspend fun getEventsAfter(after: Long, limit: Int): List<SequencedAppEvent> =
+        dao.getEventsAfter(after, limit).map { it.toSequenced() }
+
     // ── Entity ↔ domain mapping ─────────────────────────────────────────
 
     private fun AppEvent.toEntity(metadataJson: String?) = AppEventEntity(
@@ -89,4 +102,28 @@ class AppEventRepo @Inject constructor(
             null
         },
     )
+
+    private fun AppEventEntity.toSequenced() = SequencedAppEvent(
+        sequenceId = sequenceId,
+        event = toDomain(),
+        metadata = metadata?.let { decodeMetadata(it, eventType) },
+    )
+
+    /**
+     * Decode a metadata JSON blob written by Gson (`{"odometer":…}` or the
+     * test-mode `{"test_mode":true}` shape). `ignoreUnknownKeys` + all-default
+     * fields make both shapes parse; a malformed blob fails to null (WARN), never
+     * a throw — a missing odometer must not sink the whole fold batch.
+     */
+    private fun decodeMetadata(json: String, eventType: AppEventType): EventMetadata? =
+        try {
+            metadataJson.decodeFromString<EventMetadata>(json)
+        } catch (e: Exception) {
+            Timber.w(e, "AppEventRepo: failed to decode %s metadata", eventType)
+            null
+        }
+
+    private companion object {
+        private val metadataJson = Json { ignoreUnknownKeys = true }
+    }
 }

--- a/core/database/schemas/cloud.trotter.dashbuddy.core.database.DashBuddyDatabase/9.json
+++ b/core/database/schemas/cloud.trotter.dashbuddy.core.database.DashBuddyDatabase/9.json
@@ -1,0 +1,830 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 9,
+    "identityHash": "a220b0f0919e41c79e091dc7b8201143",
+    "entities": [
+      {
+        "tableName": "app_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sequenceId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `aggregateId` TEXT, `eventType` TEXT NOT NULL, `eventPayload` TEXT NOT NULL, `occurredAt` INTEGER NOT NULL, `metadata` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "sequenceId",
+            "columnName": "sequenceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "aggregateId",
+            "columnName": "aggregateId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "eventType",
+            "columnName": "eventType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventPayload",
+            "columnName": "eventPayload",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "occurredAt",
+            "columnName": "occurredAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadata",
+            "columnName": "metadata",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "sequenceId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_app_events_aggregateId",
+            "unique": false,
+            "columnNames": [
+              "aggregateId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_app_events_aggregateId` ON `${TABLE_NAME}` (`aggregateId`)"
+          },
+          {
+            "name": "index_app_events_eventType",
+            "unique": false,
+            "columnNames": [
+              "eventType"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_app_events_eventType` ON `${TABLE_NAME}` (`eventType`)"
+          },
+          {
+            "name": "index_app_events_occurredAt",
+            "unique": false,
+            "columnNames": [
+              "occurredAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_app_events_occurredAt` ON `${TABLE_NAME}` (`occurredAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "app_state_snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`correlationVersion` INTEGER NOT NULL, `capturedAt` INTEGER NOT NULL, `sessionId` TEXT, `stateJson` TEXT NOT NULL, PRIMARY KEY(`correlationVersion`))",
+        "fields": [
+          {
+            "fieldPath": "correlationVersion",
+            "columnName": "correlationVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "capturedAt",
+            "columnName": "capturedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "stateJson",
+            "columnName": "stateJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "correlationVersion"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `dashId` TEXT, `text` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `personaType` TEXT NOT NULL, `personaName` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dashId",
+            "columnName": "dashId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personaType",
+            "columnName": "personaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personaName",
+            "columnName": "personaName",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_messages_dashId",
+            "unique": false,
+            "columnNames": [
+              "dashId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_messages_dashId` ON `${TABLE_NAME}` (`dashId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "effects_fired",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `effectKey` TEXT NOT NULL, `firedAt` INTEGER NOT NULL, `correlationVersion` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "effectKey",
+            "columnName": "effectKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firedAt",
+            "columnName": "firedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "correlationVersion",
+            "columnName": "correlationVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_effects_fired_effectKey",
+            "unique": true,
+            "columnNames": [
+              "effectKey"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_effects_fired_effectKey` ON `${TABLE_NAME}` (`effectKey`)"
+          }
+        ]
+      },
+      {
+        "tableName": "observations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sequenceId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `occurredAt` INTEGER NOT NULL, `sessionId` TEXT, `pipelineId` TEXT NOT NULL, `ruleId` TEXT, `platform` TEXT, `flow` TEXT, `modeHint` TEXT, `parsedJson` TEXT NOT NULL, `captureId` TEXT, `metadataJson` TEXT NOT NULL, `correlationVersion` INTEGER NOT NULL, `timeoutType` TEXT, `payloadJson` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "sequenceId",
+            "columnName": "sequenceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "occurredAt",
+            "columnName": "occurredAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pipelineId",
+            "columnName": "pipelineId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ruleId",
+            "columnName": "ruleId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "flow",
+            "columnName": "flow",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "modeHint",
+            "columnName": "modeHint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "parsedJson",
+            "columnName": "parsedJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "captureId",
+            "columnName": "captureId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "metadataJson",
+            "columnName": "metadataJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "correlationVersion",
+            "columnName": "correlationVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeoutType",
+            "columnName": "timeoutType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "payloadJson",
+            "columnName": "payloadJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "sequenceId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_observations_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_observations_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          },
+          {
+            "name": "index_observations_occurredAt",
+            "unique": false,
+            "columnNames": [
+              "occurredAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_observations_occurredAt` ON `${TABLE_NAME}` (`occurredAt`)"
+          },
+          {
+            "name": "index_observations_correlationVersion",
+            "unique": false,
+            "columnNames": [
+              "correlationVersion"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_observations_correlationVersion` ON `${TABLE_NAME}` (`correlationVersion`)"
+          }
+        ]
+      },
+      {
+        "tableName": "delivery_records",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`eventSequenceId` INTEGER NOT NULL, `sessionId` TEXT, `platform` TEXT NOT NULL, `jobId` TEXT NOT NULL, `taskId` TEXT NOT NULL, `storeName` TEXT, `customerHash` TEXT, `addressHash` TEXT, `phaseStartedAt` INTEGER NOT NULL, `arrivedAt` INTEGER, `completedAt` INTEGER NOT NULL, `deadlineMillis` INTEGER, `realizedPay` REAL, `payBasis` TEXT NOT NULL, `tip` REAL, `basePay` REAL, `odometerAtCompletion` REAL, `realizedMiles` REAL, `realizedMinutes` REAL, `frozenCostPerMile` REAL, `netProfit` REAL, `costBasis` TEXT NOT NULL, PRIMARY KEY(`eventSequenceId`))",
+        "fields": [
+          {
+            "fieldPath": "eventSequenceId",
+            "columnName": "eventSequenceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jobId",
+            "columnName": "jobId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "taskId",
+            "columnName": "taskId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storeName",
+            "columnName": "storeName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customerHash",
+            "columnName": "customerHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addressHash",
+            "columnName": "addressHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "phaseStartedAt",
+            "columnName": "phaseStartedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "arrivedAt",
+            "columnName": "arrivedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deadlineMillis",
+            "columnName": "deadlineMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "realizedPay",
+            "columnName": "realizedPay",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "payBasis",
+            "columnName": "payBasis",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tip",
+            "columnName": "tip",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "basePay",
+            "columnName": "basePay",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "odometerAtCompletion",
+            "columnName": "odometerAtCompletion",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "realizedMiles",
+            "columnName": "realizedMiles",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "realizedMinutes",
+            "columnName": "realizedMinutes",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "frozenCostPerMile",
+            "columnName": "frozenCostPerMile",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "netProfit",
+            "columnName": "netProfit",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "costBasis",
+            "columnName": "costBasis",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "eventSequenceId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_delivery_records_completedAt",
+            "unique": false,
+            "columnNames": [
+              "completedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_delivery_records_completedAt` ON `${TABLE_NAME}` (`completedAt`)"
+          },
+          {
+            "name": "index_delivery_records_platform_completedAt",
+            "unique": false,
+            "columnNames": [
+              "platform",
+              "completedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_delivery_records_platform_completedAt` ON `${TABLE_NAME}` (`platform`, `completedAt`)"
+          },
+          {
+            "name": "index_delivery_records_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_delivery_records_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          },
+          {
+            "name": "index_delivery_records_sessionId_jobId",
+            "unique": false,
+            "columnNames": [
+              "sessionId",
+              "jobId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_delivery_records_sessionId_jobId` ON `${TABLE_NAME}` (`sessionId`, `jobId`)"
+          },
+          {
+            "name": "index_delivery_records_storeName",
+            "unique": false,
+            "columnNames": [
+              "storeName"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_delivery_records_storeName` ON `${TABLE_NAME}` (`storeName`)"
+          }
+        ]
+      },
+      {
+        "tableName": "session_records",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sessionId` TEXT NOT NULL, `platform` TEXT NOT NULL, `startedAt` INTEGER NOT NULL, `endedAt` INTEGER, `lastEventAt` INTEGER NOT NULL, `endSource` TEXT, `startOdometer` REAL, `lastOdometer` REAL, `reportedEarnings` REAL, `reportedDurationMillis` INTEGER, `offersReceived` INTEGER NOT NULL, `offersAccepted` INTEGER NOT NULL, `offersDeclined` INTEGER NOT NULL, `offersTimeout` INTEGER NOT NULL, `deliveries` INTEGER NOT NULL, `jobsCompleted` INTEGER NOT NULL, PRIMARY KEY(`sessionId`))",
+        "fields": [
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "startedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endedAt",
+            "columnName": "endedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastEventAt",
+            "columnName": "lastEventAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endSource",
+            "columnName": "endSource",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "startOdometer",
+            "columnName": "startOdometer",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "lastOdometer",
+            "columnName": "lastOdometer",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "reportedEarnings",
+            "columnName": "reportedEarnings",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "reportedDurationMillis",
+            "columnName": "reportedDurationMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "offersReceived",
+            "columnName": "offersReceived",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "offersAccepted",
+            "columnName": "offersAccepted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "offersDeclined",
+            "columnName": "offersDeclined",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "offersTimeout",
+            "columnName": "offersTimeout",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deliveries",
+            "columnName": "deliveries",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jobsCompleted",
+            "columnName": "jobsCompleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sessionId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_session_records_startedAt",
+            "unique": false,
+            "columnNames": [
+              "startedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_session_records_startedAt` ON `${TABLE_NAME}` (`startedAt`)"
+          },
+          {
+            "name": "index_session_records_platform_startedAt",
+            "unique": false,
+            "columnNames": [
+              "platform",
+              "startedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_session_records_platform_startedAt` ON `${TABLE_NAME}` (`platform`, `startedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "offer_records",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`eventSequenceId` INTEGER NOT NULL, `sessionId` TEXT, `platform` TEXT NOT NULL, `offerHash` TEXT NOT NULL, `outcome` TEXT NOT NULL, `presentedAt` INTEGER NOT NULL, `decidedAt` INTEGER NOT NULL, `payAmount` REAL, `distanceMiles` REAL, `itemCount` INTEGER NOT NULL, `merchantName` TEXT, `score` REAL, `action` TEXT, `quality` TEXT, `estNetPay` REAL, `estDollarsPerHour` REAL, `estDollarsPerMile` REAL, `estTimeMinutes` REAL, `estOperatingCostPerMile` REAL, PRIMARY KEY(`eventSequenceId`))",
+        "fields": [
+          {
+            "fieldPath": "eventSequenceId",
+            "columnName": "eventSequenceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "offerHash",
+            "columnName": "offerHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "outcome",
+            "columnName": "outcome",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "presentedAt",
+            "columnName": "presentedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "decidedAt",
+            "columnName": "decidedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payAmount",
+            "columnName": "payAmount",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "distanceMiles",
+            "columnName": "distanceMiles",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "itemCount",
+            "columnName": "itemCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchantName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "action",
+            "columnName": "action",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "quality",
+            "columnName": "quality",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "estNetPay",
+            "columnName": "estNetPay",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "estDollarsPerHour",
+            "columnName": "estDollarsPerHour",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "estDollarsPerMile",
+            "columnName": "estDollarsPerMile",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "estTimeMinutes",
+            "columnName": "estTimeMinutes",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "estOperatingCostPerMile",
+            "columnName": "estOperatingCostPerMile",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "eventSequenceId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_offer_records_decidedAt",
+            "unique": false,
+            "columnNames": [
+              "decidedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offer_records_decidedAt` ON `${TABLE_NAME}` (`decidedAt`)"
+          },
+          {
+            "name": "index_offer_records_platform_decidedAt",
+            "unique": false,
+            "columnNames": [
+              "platform",
+              "decidedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offer_records_platform_decidedAt` ON `${TABLE_NAME}` (`platform`, `decidedAt`)"
+          },
+          {
+            "name": "index_offer_records_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offer_records_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          },
+          {
+            "name": "index_offer_records_offerHash",
+            "unique": false,
+            "columnNames": [
+              "offerHash"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offer_records_offerHash` ON `${TABLE_NAME}` (`offerHash`)"
+          }
+        ]
+      },
+      {
+        "tableName": "analytics_projection_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `watermarkSequenceId` INTEGER NOT NULL, `projectorVersion` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "watermarkSequenceId",
+            "columnName": "watermarkSequenceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "projectorVersion",
+            "columnName": "projectorVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'a220b0f0919e41c79e091dc7b8201143')"
+    ]
+  }
+}

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/DashBuddyDatabase.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/DashBuddyDatabase.kt
@@ -1,8 +1,14 @@
 package cloud.trotter.dashbuddy.core.database
 
+import androidx.room.AutoMigration
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
+import cloud.trotter.dashbuddy.core.database.analytics.AnalyticsDao
+import cloud.trotter.dashbuddy.core.database.analytics.AnalyticsProjectionStateEntity
+import cloud.trotter.dashbuddy.core.database.analytics.DeliveryRecordEntity
+import cloud.trotter.dashbuddy.core.database.analytics.OfferRecordEntity
+import cloud.trotter.dashbuddy.core.database.analytics.SessionRecordEntity
 import cloud.trotter.dashbuddy.core.database.chat.ChatDao
 import cloud.trotter.dashbuddy.core.database.chat.ChatMessageEntity
 import cloud.trotter.dashbuddy.core.database.effects.EffectsFiredDao
@@ -21,9 +27,19 @@ import cloud.trotter.dashbuddy.core.database.snapshot.AppStateSnapshotEntity
         ChatMessageEntity::class,
         EffectsFiredEntity::class,
         ObservationEntity::class,
+        // Analytics read-model (#314) — purely additive; folded from app_events.
+        DeliveryRecordEntity::class,
+        SessionRecordEntity::class,
+        OfferRecordEntity::class,
+        AnalyticsProjectionStateEntity::class,
     ],
-    version = 8,
-    exportSchema = true
+    version = 9,
+    exportSchema = true,
+    // v8→v9 adds only new tables (the analytics read-model). AutoMigration is a
+    // no-op for existing tables, so it CANNOT wipe app_events (unlike the
+    // destructive fallback, which is left untouched — the auto-migration provides
+    // the path so the fallback never fires on this upgrade).
+    autoMigrations = [AutoMigration(from = 8, to = 9)],
 )
 @TypeConverters(DataTypeConverters::class)
 abstract class DashBuddyDatabase : RoomDatabase() {
@@ -34,5 +50,6 @@ abstract class DashBuddyDatabase : RoomDatabase() {
     abstract fun chatDao(): ChatDao
     abstract fun effectsFiredDao(): EffectsFiredDao
     abstract fun observationDao(): ObservationDao
+    abstract fun analyticsDao(): AnalyticsDao
 
 }

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
@@ -1,0 +1,121 @@
+package cloud.trotter.dashbuddy.core.database.analytics
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * DAO for the durable analytics read-model (#314).
+ *
+ * Three responsibilities:
+ *  1. **Projector writes** — record upserts (`REPLACE`, keyed on the source
+ *     event's sequenceId so a refold/replay is a no-op), watermark get/set, and
+ *     `deleteAll*` for a `projectorVersion` rebuild. The projector (PR2) does all
+ *     of these inside one `db.withTransaction` for exactly-once folding.
+ *  2. **Read-side aggregates** — `SUM`/`COUNT` over the record tables, returned as
+ *     `Flow` so Room's invalidation tracker re-emits on every projector commit
+ *     (reactive totals for the home glance/hub, no rollup table needed).
+ *  3. **Projector support** — restart-correct context hydration from the record
+ *     tables themselves (they ARE the fold state).
+ *
+ * Periods are half-open `[start, end)` predicates computed at query time — no
+ * bucketing columns, no timezone materialized into rows.
+ */
+@Dao
+interface AnalyticsDao {
+
+    // ── Projector writes ────────────────────────────────────────────────
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertDelivery(record: DeliveryRecordEntity)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertSession(record: SessionRecordEntity)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertOffer(record: OfferRecordEntity)
+
+    /** Read the singleton watermark row, or null before the first fold. */
+    @Query("SELECT * FROM analytics_projection_state WHERE id = 1")
+    suspend fun getWatermark(): AnalyticsProjectionStateEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun setWatermark(state: AnalyticsProjectionStateEntity)
+
+    // ── Version rebuild (projectorVersion bump ⇒ wipe + refold from 0) ───
+
+    @Query("DELETE FROM delivery_records")
+    suspend fun deleteAllDeliveries()
+
+    @Query("DELETE FROM session_records")
+    suspend fun deleteAllSessions()
+
+    @Query("DELETE FROM offer_records")
+    suspend fun deleteAllOffers()
+
+    // ── Read-side aggregates (Flow ⇒ reactive via Room invalidation) ─────
+
+    @Query(
+        """SELECT COALESCE(SUM(realizedPay), 0) AS pay,
+                  COUNT(*) AS deliveries,
+                  COUNT(DISTINCT jobId) AS jobs
+           FROM delivery_records
+           WHERE completedAt >= :start AND completedAt < :end"""
+    )
+    fun deliveryTotals(start: Long, end: Long): Flow<DeliveryTotalsRow>
+
+    @Query(
+        """SELECT platform,
+                  COALESCE(SUM(realizedPay), 0) AS pay,
+                  COUNT(*) AS deliveries,
+                  COUNT(DISTINCT jobId) AS jobs
+           FROM delivery_records
+           WHERE completedAt >= :start AND completedAt < :end
+           GROUP BY platform"""
+    )
+    fun deliveryTotalsByPlatform(start: Long, end: Long): Flow<List<PlatformDeliveryTotalsRow>>
+
+    @Query(
+        """SELECT storeName,
+                  COALESCE(SUM(realizedPay), 0) AS pay,
+                  COUNT(*) AS deliveries
+           FROM delivery_records
+           WHERE completedAt >= :start AND completedAt < :end
+           GROUP BY storeName
+           ORDER BY pay DESC"""
+    )
+    fun deliveryTotalsByStore(start: Long, end: Long): Flow<List<StoreTotalsRow>>
+
+    @Query(
+        """SELECT COALESCE(SUM(MAX(lastOdometer - startOdometer, 0)), 0) AS miles,
+                  COALESCE(SUM(COALESCE(endedAt, lastEventAt) - startedAt), 0) AS onlineMillis
+           FROM session_records
+           WHERE startedAt >= :start AND startedAt < :end"""
+    )
+    fun sessionTotals(start: Long, end: Long): Flow<SessionTotalsRow>
+
+    @Query(
+        """SELECT platform,
+                  COALESCE(SUM(MAX(lastOdometer - startOdometer, 0)), 0) AS miles,
+                  COALESCE(SUM(COALESCE(endedAt, lastEventAt) - startedAt), 0) AS onlineMillis
+           FROM session_records
+           WHERE startedAt >= :start AND startedAt < :end
+           GROUP BY platform"""
+    )
+    fun sessionTotalsByPlatform(start: Long, end: Long): Flow<List<PlatformSessionTotalsRow>>
+
+    // ── Projector support: restart-correct context hydration (PR2) ───────
+
+    @Query("SELECT * FROM session_records WHERE sessionId = :id")
+    suspend fun sessionRecord(id: String): SessionRecordEntity?
+
+    /** The prevDropAnchor for a mid-session restart: (odometerAtCompletion, completedAt). */
+    @Query("SELECT * FROM delivery_records WHERE sessionId = :id ORDER BY eventSequenceId DESC LIMIT 1")
+    suspend fun lastDeliveryInSession(id: String): DeliveryRecordEntity?
+
+    /** Still-live sessions for a platform — the next DASH_START infers their close. */
+    @Query("SELECT * FROM session_records WHERE platform = :platform AND endedAt IS NULL")
+    suspend fun openSessions(platform: String): List<SessionRecordEntity>
+}

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsProjectionStateEntity.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsProjectionStateEntity.kt
@@ -1,0 +1,26 @@
+package cloud.trotter.dashbuddy.core.database.analytics
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * The analytics projector's watermark (#314) — a singleton row.
+ *
+ * Lives in **Room, not DataStore**, so the projector can write records AND
+ * advance the watermark in one `db.withTransaction`, making the fold exactly-once
+ * by construction (a second commit domain would re-process or silently skip a
+ * batch on a crash between the two writes).
+ *
+ * [projectorVersion] is the event-sourcing dividend: bumping the constant makes
+ * the next start drop all record rows, reset the watermark to 0, and re-fold the
+ * whole durable log — backfill and rebuild are the same code path (PR2).
+ */
+@Entity(tableName = "analytics_projection_state")
+data class AnalyticsProjectionStateEntity(
+    /** Singleton row. */
+    @PrimaryKey val id: Int = 1,
+    /** Last app_events.sequenceId folded. */
+    val watermarkSequenceId: Long,
+    /** Fold-logic version; mismatch ⇒ wipe records + refold from 0. */
+    val projectorVersion: Int,
+)

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsTotals.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsTotals.kt
@@ -1,0 +1,43 @@
+package cloud.trotter.dashbuddy.core.database.analytics
+
+/**
+ * Aggregate query-result projections for [AnalyticsDao] (#314). Plain POJOs Room
+ * maps SUM/COUNT rows into — NOT entities, NOT persisted. They stay in
+ * `:core:database` next to the DAO whose queries produce them; the read-side
+ * repository (`:core:data`, PR3) folds economy in on top.
+ */
+
+/** Cross-platform delivery totals for a period. */
+data class DeliveryTotalsRow(
+    val pay: Double,
+    val deliveries: Int,
+    val jobs: Int,
+)
+
+/** Per-platform delivery totals (GROUP BY platform). */
+data class PlatformDeliveryTotalsRow(
+    val platform: String,
+    val pay: Double,
+    val deliveries: Int,
+    val jobs: Int,
+)
+
+/** Per-store delivery totals (GROUP BY storeName) — per-store + future chain resolution (#159). */
+data class StoreTotalsRow(
+    val storeName: String?,
+    val pay: Double,
+    val deliveries: Int,
+)
+
+/** Cross-platform session totals for a period: miles = Σ odo delta, onlineMillis = Σ duration. */
+data class SessionTotalsRow(
+    val miles: Double,
+    val onlineMillis: Long,
+)
+
+/** Per-platform session totals (GROUP BY platform). */
+data class PlatformSessionTotalsRow(
+    val platform: String,
+    val miles: Double,
+    val onlineMillis: Long,
+)

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/DeliveryRecordEntity.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/DeliveryRecordEntity.kt
@@ -1,0 +1,88 @@
+package cloud.trotter.dashbuddy.core.database.analytics
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * Durable analytics read-model row — one per `DELIVERY_COMPLETED` event (#314).
+ *
+ * A record is an **immutable historical fact**, not a cache of live state. The
+ * projector ([cloud.trotter.dashbuddy.core.data.analytics.AnalyticsProjector], PR2)
+ * folds the `app_events` log into these rows; the primary key is the *source*
+ * event's `sequenceId`, which is both its provenance and its idempotency key
+ * (replay/refold with `@Insert(onConflict = REPLACE)` is a byte-identical no-op).
+ *
+ * Miles/minutes are stored as **partition deltas** — the odometer/time gap since
+ * the previous `DELIVERY_COMPLETED` in the same session (or `DASH_START` for the
+ * first drop) — so Σ per-drop deltas + the session tail equals the session
+ * odometer delta with nothing double-counted. Task-scoped anchors
+ * (`phaseStartedAt`/`arrivedAt`) are kept so task-scoped views stay derivable.
+ *
+ * **Frozen economics** ([frozenCostPerMile]/[netProfit]/[costBasis]) freeze the
+ * operating-cost basis this delivery was costed at (inherited in PR2 from the
+ * accepted offer's `OfferEvaluation.operatingCostPerMile`). Because a record is a
+ * historical fact, a later economy edit MUST NOT retroactively change these —
+ * they are a frozen decision, not a stale cache. [costBasis] records provenance
+ * exactly as [payBasis] does for realized pay.
+ *
+ * `storeName` is a **merchant** name, not customer PII — fine at rest in the DB,
+ * never emitted in INFO+ logs. `customerHash`/`addressHash` are already sha256'd
+ * upstream at the edge; kept here for dedup/correlation and future chain/entity
+ * resolution (#159), which becomes a clean additive later-add.
+ */
+@Entity(
+    tableName = "delivery_records",
+    indices = [
+        Index("completedAt"),                       // period predicates
+        Index(value = ["platform", "completedAt"]), // per-platform periods
+        Index("sessionId"),                         // per-dash drilldown + fold hydration
+        Index(value = ["sessionId", "jobId"]),      // incremental distinct-job counting
+        Index("storeName"),                         // per-store aggregation + chain resolution (#159)
+    ]
+)
+data class DeliveryRecordEntity(
+    /** sequenceId of the source DELIVERY_COMPLETED row in app_events — provenance AND idempotency. */
+    @PrimaryKey val eventSequenceId: Long,
+    /** app_events.aggregateId (nullable there → nullable here). */
+    val sessionId: String?,
+    /** Platform.wire ("doordash"), resolved from session context — NEVER id-parsed. */
+    val platform: String,
+    val jobId: String,
+    val taskId: String,
+    /** Merchant name — not customer PII; fine at rest, never in INFO logs. */
+    val storeName: String?,
+    /** Already sha256'd upstream (DeliveryPayload.customerHash). */
+    val customerHash: String?,
+    /** Already sha256'd upstream (DeliveryPayload.addressHash) — chain-resolution readiness (#159). */
+    val addressHash: String?,
+    val phaseStartedAt: Long,
+    /** dwell = completedAt − arrivedAt is DERIVED, not stored. */
+    val arrivedAt: Long?,
+    /** payload.completedAt ?: event.occurredAt — the period bucket key. */
+    val completedAt: Long,
+    /** On-time margin for the Phase-4 Time tab — free to carry now. */
+    val deadlineMillis: Long?,
+    /** dropRealizedPay ?: totalPay. */
+    val realizedPay: Double?,
+    /** "DROP_SHARE" | "RECEIPT_TOTAL" | "NONE" — per-row honesty. */
+    val payBasis: String,
+    /** parsedPay.totalTip — ONLY when this is the job's sole drop, else null. */
+    val tip: Double?,
+    /** parsedPay.totalBasePay — same single-drop-only rule. */
+    val basePay: Double?,
+    /** Raw metadata.odometer reading — the next drop's delta anchor. */
+    val odometerAtCompletion: Double?,
+    /** Partition delta: odo(this) − odo(prev completion | DASH_START). */
+    val realizedMiles: Double?,
+    /** Partition delta: (completedAt − prev anchor time) / 60_000. */
+    val realizedMinutes: Double?,
+
+    // ── Frozen economics (immutable historical fact — never re-costed on economy edit) ──
+    /** Operating cost-per-mile this delivery is costed at, frozen from the accepted offer (PR2). */
+    val frozenCostPerMile: Double?,
+    /** Frozen realized net = realizedPay − realizedMiles × frozenCostPerMile (PR2). */
+    val netProfit: Double?,
+    /** Provenance of the cost basis: "OFFER_FROZEN" | "CAPTURED" | "CURRENT_FALLBACK" | "NONE". */
+    val costBasis: String,
+)

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/OfferRecordEntity.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/OfferRecordEntity.kt
@@ -1,0 +1,55 @@
+package cloud.trotter.dashbuddy.core.database.analytics
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * Durable analytics read-model row — one per **closing** offer event (#314):
+ * `OFFER_ACCEPTED` / `OFFER_DECLINED` / `OFFER_TIMEOUT`. The closing `OfferPayload`
+ * alone carries `parsedOffer + evaluation + outcome + presentedAt + decidedAt`, so
+ * `OFFER_RECEIVED` rows are skipped (an offer that never closed produces no record).
+ *
+ * The primary key is the source event's `sequenceId` (provenance + idempotency).
+ * The `est*` fields are a **frozen decision snapshot** — legitimately frozen,
+ * because this row records "what the verdict said at decision time", unlike a
+ * realized-net cache. This is the Phase-4 Decisions tab's entire input (offer
+ * funnel, value-of-saying-no, score-vs-outcome).
+ */
+@Entity(
+    tableName = "offer_records",
+    indices = [
+        Index("decidedAt"),                       // period predicates
+        Index(value = ["platform", "decidedAt"]), // per-platform periods
+        Index("sessionId"),
+        Index("offerHash"),
+    ]
+)
+data class OfferRecordEntity(
+    /** sequenceId of the source closing offer event — provenance AND idempotency. */
+    @PrimaryKey val eventSequenceId: Long,
+    val sessionId: String?,
+    /** Platform.wire, resolved from session context. */
+    val platform: String,
+    val offerHash: String,
+    /** "OFFER_ACCEPTED" | "OFFER_DECLINED" | "OFFER_TIMEOUT" (AppEventType.name). */
+    val outcome: String,
+    val presentedAt: Long,
+    val decidedAt: Long,
+
+    // From parsedOffer:
+    val payAmount: Double?,
+    val distanceMiles: Double?,
+    val itemCount: Int,
+    val merchantName: String?,
+
+    // Frozen estimate snapshot from evaluation (a DECISION record, legitimately frozen):
+    val score: Double?,
+    val action: String?,
+    val quality: String?,
+    val estNetPay: Double?,
+    val estDollarsPerHour: Double?,
+    val estDollarsPerMile: Double?,
+    val estTimeMinutes: Double?,
+    val estOperatingCostPerMile: Double?,
+)

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/SessionRecordEntity.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/SessionRecordEntity.kt
@@ -1,0 +1,64 @@
+package cloud.trotter.dashbuddy.core.database.analytics
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * Durable analytics read-model row — one per dash session, upserted incrementally
+ * as the projector folds each session-attributed event (#314).
+ *
+ * The natural key is the `sessionId`, so upserts are idempotent. Counters
+ * ([offersReceived]…[jobsCompleted]) are folded (not derived-only) because the
+ * transactional watermark makes each source event exactly-once, and a
+ * self-contained row is the "recent dashes" list item the future hub renders.
+ *
+ * Session **miles** and **delivered pay** are deliberately NOT columns (SSOT,
+ * Principle 5): miles = `lastOdometer − startOdometer` (a SQL expression), pay =
+ * SUM over `delivery_records`. Storing them would be a second owner for the same
+ * number. [reportedEarnings]/[reportedDurationMillis] are the platform's own
+ * summary-screen totals (incl. bonuses/adjustments) — kept so the "unattributed"
+ * delta (reported − Σdeliveries) is a repository-level review flag later (PR3),
+ * needing no extra column.
+ *
+ * Closes the named session-miles capture gap: `SessionStopPayload` omits miles,
+ * so they are recovered from the odometer delta across the session's event rows.
+ */
+@Entity(
+    tableName = "session_records",
+    indices = [
+        Index("startedAt"),                     // period predicates for sessions
+        Index(value = ["platform", "startedAt"]), // per-platform periods
+    ]
+)
+data class SessionRecordEntity(
+    /** Natural key; upsert-idempotent. */
+    @PrimaryKey val sessionId: String,
+    /** Platform.wire, from SessionStartPayload.platform via Platform.fromName. */
+    val platform: String,
+    /** Period bucket key for sessions. */
+    val startedAt: Long,
+    /** Null while live / crash-orphaned. */
+    val endedAt: Long?,
+    /** Advanced on EVERY session event — open-session duration + inferred close. */
+    val lastEventAt: Long,
+    /** "summary_screen" | "early_offline" | "inferred" | null. */
+    val endSource: String?,
+    /** metadata.odometer of DASH_START (first non-null wins). */
+    val startOdometer: Double?,
+    /** Last non-null metadata.odometer seen — miles = lastOdometer − startOdometer, DERIVED in SQL. */
+    val lastOdometer: Double?,
+    /** SessionStopPayload.totalEarnings (summary screen only) — all-pay, incl. bonuses. */
+    val reportedEarnings: Double?,
+    /** SessionStopPayload.sessionDurationMillis. */
+    val reportedDurationMillis: Long?,
+    // Folded outcome counts:
+    val offersReceived: Int,
+    val offersAccepted: Int,
+    val offersDeclined: Int,
+    val offersTimeout: Int,
+    /** Folded count of DELIVERY_COMPLETED. */
+    val deliveries: Int,
+    /** Folded count of distinct jobIds delivered. */
+    val jobsCompleted: Int,
+)

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/di/DatabaseModule.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/di/DatabaseModule.kt
@@ -3,6 +3,7 @@ package cloud.trotter.dashbuddy.core.database.di
 import android.content.Context
 import androidx.room.Room
 import cloud.trotter.dashbuddy.core.database.DashBuddyDatabase
+import cloud.trotter.dashbuddy.core.database.analytics.AnalyticsDao
 import cloud.trotter.dashbuddy.core.database.chat.ChatDao
 import cloud.trotter.dashbuddy.core.database.effects.EffectsFiredDao
 import cloud.trotter.dashbuddy.core.database.event.AppEventDao
@@ -54,6 +55,11 @@ object DatabaseModule {
     @Provides
     fun provideObservationDao(db: DashBuddyDatabase): ObservationDao {
         return db.observationDao()
+    }
+
+    @Provides
+    fun provideAnalyticsDao(db: DashBuddyDatabase): AnalyticsDao {
+        return db.analyticsDao()
     }
 
 }

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/event/AppEventDao.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/event/AppEventDao.kt
@@ -49,4 +49,20 @@ interface AppEventDao {
      */
     @Query("SELECT * FROM app_events WHERE occurredAt BETWEEN :startTime AND :endTime ORDER BY occurredAt ASC")
     fun getEventsInTimeRange(startTime: Long, endTime: Long): Flow<List<AppEventEntity>>
+
+    /**
+     * A page of events after [after] (exclusive), oldest-first, capped at [limit].
+     * The analytics projector's paged fold input (#314): it walks the log forward
+     * from its watermark in bounded batches, so memory stays flat over a long log.
+     */
+    @Query("SELECT * FROM app_events WHERE sequenceId > :after ORDER BY sequenceId ASC LIMIT :limit")
+    suspend fun getEventsAfter(after: Long, limit: Int): List<AppEventEntity>
+
+    /**
+     * The highest sequenceId in the log, or null when the log is empty. The
+     * analytics projector's trigger (#314): Room invalidation re-emits this on
+     * every insert, so a rising max wakes the catch-up fold.
+     */
+    @Query("SELECT MAX(sequenceId) FROM app_events")
+    fun maxSequenceId(): Flow<Long?>
 }

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/EventMetadata.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/EventMetadata.kt
@@ -1,5 +1,17 @@
 package cloud.trotter.dashbuddy.domain.model.event
 
+import kotlinx.serialization.Serializable
+
+/**
+ * Device state stamped onto each app-event row (odometer/battery/network/version).
+ *
+ * Historically written by Gson (`DashBuddyApplication.createMetadata`) as a plain
+ * field object, incl. the test-mode `{"test_mode": true}` shape. Now `@Serializable`
+ * so the analytics projector (#314) can decode it with kotlinx: every field has a
+ * default and the reader uses `ignoreUnknownKeys`, so both the Gson field shape and
+ * the historical test-mode row parse cleanly; a decode failure fails to null (WARN).
+ */
+@Serializable
 data class EventMetadata(
     /** The odometer reading in miles at the time of the event. */
     val odometer: Double? = null,

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/SequencedAppEvent.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/SequencedAppEvent.kt
@@ -1,0 +1,17 @@
+package cloud.trotter.dashbuddy.domain.model.event
+
+/**
+ * An [AppEvent] paired with its storage-layer sequence id and device [metadata]
+ * (#314). The domain [AppEvent] deliberately carries neither — those are Room
+ * entity concerns mapped at the repository boundary — but the analytics projector
+ * needs both: the [sequenceId] is its watermark/idempotency key, and [metadata]
+ * (odometer) is the only durable mileage signal.
+ *
+ * Assembled by `AppEventRepo.getEventsAfter` at the same decode edge as `AppEvent`,
+ * so a malformed payload/metadata keeps the existing WARN-and-null contract.
+ */
+data class SequencedAppEvent(
+    val sequenceId: Long,
+    val event: AppEvent,
+    val metadata: EventMetadata? = null,
+)

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/model/event/EventMetadataSerializationTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/model/event/EventMetadataSerializationTest.kt
@@ -1,0 +1,63 @@
+package cloud.trotter.dashbuddy.domain.model.event
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * #314 — [EventMetadata] gained `@Serializable` so the analytics projector can
+ * decode device metadata with kotlinx. The historical rows were written by Gson
+ * (`DashBuddyApplication.createMetadata`), so kotlinx must parse both the Gson
+ * field shape and the test-mode `{"test_mode": true}` shape without throwing.
+ */
+class EventMetadataSerializationTest {
+
+    // Mirrors AppEventRepo's metadata reader: unknown keys tolerated (the Gson
+    // test-mode row carries a key the class doesn't have).
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun `round-trips a fully populated metadata object`() {
+        val original = EventMetadata(
+            odometer = 12345.6,
+            batteryLevel = 82,
+            networkType = "WIFI",
+            appVersion = "1.2.3",
+        )
+        val decoded = json.decodeFromString<EventMetadata>(json.encodeToString(original))
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun `parses the Gson field shape written on device`() {
+        // Exactly what com.google.gson.Gson().toJson(EventMetadata(...)) emits.
+        val gsonShape = """{"odometer":42.0,"batteryLevel":57,"networkType":"UNKNOWN","appVersion":"1.0.5"}"""
+        val decoded = json.decodeFromString<EventMetadata>(gsonShape)
+        assertEquals(42.0, decoded.odometer!!, 0.0)
+        assertEquals(57, decoded.batteryLevel)
+        assertEquals("UNKNOWN", decoded.networkType)
+        assertEquals("1.0.5", decoded.appVersion)
+    }
+
+    @Test
+    fun `parses the historical test-mode row via ignoreUnknownKeys`() {
+        // DashBuddyApplication.createMetadata() returns this before Hilt is up.
+        val testMode = """{ "test_mode": true }"""
+        val decoded = json.decodeFromString<EventMetadata>(testMode)
+        // Unknown key ignored; every field falls back to its default (null).
+        assertNull(decoded.odometer)
+        assertNull(decoded.batteryLevel)
+        assertNull(decoded.networkType)
+        assertNull(decoded.appVersion)
+    }
+
+    @Test
+    fun `parses a partial row where Gson omitted null fields`() {
+        // Gson omits nulls by default, so an odometer-only stamp is legal.
+        val partial = """{"odometer":7.5}"""
+        val decoded = json.decodeFromString<EventMetadata>(partial)
+        assertEquals(7.5, decoded.odometer!!, 0.0)
+        assertNull(decoded.batteryLevel)
+    }
+}


### PR DESCRIPTION
PR1 of #314 — the durable analytics read-model **schema only**. This is the foundation of the event-sourced CQRS projection over `app_events`. It is **behavior-inert**: nothing in the app consumes the new tables yet (the projector is PR2; the repository + home-glance swap is PR3).

## What shipped

**Room v8 → v9** (`:core:database`, new `analytics/` package):

- **`delivery_records`** (PK = `eventSequenceId`) — one row per `DELIVERY_COMPLETED`. Partition-delta miles/minutes; task-scoped anchors kept.
- **`session_records`** (PK = `sessionId`) — one row per dash, upserted incrementally; folded counters.
- **`offer_records`** (PK = `eventSequenceId`) — one row per **closing** offer event; a frozen decision snapshot.
- **`analytics_projection_state`** — the singleton watermark row (in Room, so PR2's records-write + watermark-advance is one `withTransaction` ⇒ exactly-once).
- **`AnalyticsDao`** — `REPLACE` upserts, watermark get/set, `deleteAll*` (version rebuild), reactive aggregate queries (`deliveryTotals` / `sessionTotals` [+ per-platform], `deliveryTotalsByStore`), and projector-support reads (`sessionRecord` / `lastDeliveryInSession` / `openSessions`).

**Migration:** `AutoMigration(from = 8, to = 9)`, purely additive (4 new tables). `9.json` committed; the diff is **additive-only** — all 5 existing tables (`app_events`, `app_state_snapshots`, `chat_messages`, `effects_fired`, `observations`) are byte-identical, 4 tables added, none removed/changed. `fallbackToDestructiveMigration` left untouched — the auto-migration provides the upgrade path so the fallback never fires on 8→9.

**Event-read plumbing** (the projector's fold input, defined now, consumed in PR2):

- `AppEventDao.getEventsAfter(after, limit)` (paged fold input) + `maxSequenceId(): Flow<Long?>` (the projector's trigger).
- `SequencedAppEvent(sequenceId, event, metadata)` in `:domain` — the domain `AppEvent` carries neither sequence nor metadata; the projector needs both.
- `EventMetadata` is now `@Serializable`. It was written by Gson as a plain field object (incl. the `{"test_mode": true}` shape); kotlinx with `ignoreUnknownKeys` + all-default fields parses every historical row.
- `AppEventRepo.getEventsAfter(after, limit): List<SequencedAppEvent>` maps at the existing `toDomain` decode edge; a malformed payload **or** metadata degrades to null with a WARN (the existing fail-null contract), never a throw.

## Design context (developer-approved refinements folded in)

- **Frozen economy** (reverses the plan's "no netProfit column"): a record is an **immutable historical fact**, not a cache. `delivery_records` carries `frozenCostPerMile` / `netProfit` / `costBasis` (provenance: `OFFER_FROZEN` | `CAPTURED` | `CURRENT_FALLBACK` | `NONE`, analogous to `payBasis`). PR2 populates them from the accepted offer's frozen `OfferEvaluation.operatingCostPerMile`; a later economy edit must **not** retroactively change a shipped record.
- **Chain-resolution readiness (#159):** `storeName` + `customerHash` + `addressHash` are kept on `delivery_records`, and `deliveryTotalsByStore` (GROUP BY `storeName`) makes per-store aggregation — and future chain/entity resolution — a clean additive later-add.
- **All-pay earnings:** `session_records.reportedEarnings` (platform total incl. bonuses). Period earnings will be reported-total-authoritative in PR3; the "unattributed" delta (reported − Σdeliveries) is a repository-level computed flag then — no extra column here.

## Column lists (as generated in `9.json`)

- **`delivery_records`:** eventSequenceId(PK), sessionId, platform, jobId, taskId, storeName, customerHash, addressHash, phaseStartedAt, arrivedAt, completedAt, deadlineMillis, realizedPay, payBasis, tip, basePay, odometerAtCompletion, realizedMiles, realizedMinutes, frozenCostPerMile, netProfit, costBasis. Indices: `completedAt`, `(platform, completedAt)`, `sessionId`, `(sessionId, jobId)`, `storeName`.
- **`session_records`:** sessionId(PK), platform, startedAt, endedAt, lastEventAt, endSource, startOdometer, lastOdometer, reportedEarnings, reportedDurationMillis, offersReceived, offersAccepted, offersDeclined, offersTimeout, deliveries, jobsCompleted. Indices: `startedAt`, `(platform, startedAt)`.
- **`offer_records`:** eventSequenceId(PK), sessionId, platform, offerHash, outcome, presentedAt, decidedAt, payAmount, distanceMiles, itemCount, merchantName, score, action, quality, estNetPay, estDollarsPerHour, estDollarsPerMile, estTimeMinutes, estOperatingCostPerMile. Indices: `decidedAt`, `(platform, decidedAt)`, `sessionId`, `offerHash`.

## Tests

- `app/.../analytics/AnalyticsSchemaRoundTripTest` (Robolectric + `Room.inMemoryDatabaseBuilder`): `deliveryTotals` sums pay / counts rows / counts distinct jobs; half-open `[start,end)` period; `REPLACE` on the sequenceId PK; `deliveryTotalsByStore` grouping ordered by pay; empty-table zeros; watermark null→set→replace; `deleteAll`; `getEventsAfter` paging + `maxSequenceId`; `AppEventRepo.getEventsAfter` sequence + Gson-shaped & test-mode metadata decode.
- `domain/.../event/EventMetadataSerializationTest`: kotlinx round-trip of the full object, the on-device Gson field shape, the `{"test_mode": true}` unknown-key row, and a null-omitted partial row.

**Counts:** `:app:testDebugUnitTest` 865 tests / 44 classes, `:domain:test` 252 tests / 31 classes, `AllMatchersSuite` — all green, 0 failures. Full clean re-run (`--rerun-tasks`).

## Security & privacy posture (Principle 6)

No new capture, no network, no new PII surface. The read-model re-reads a log that already passed the edge hash — records store **merchant names** (not customer PII) plus already-`sha256`'d `customerHash`/`addressHash` and economics. INFO logging is unchanged (this PR adds no log sites).

## Design-goal review

- **P5 (SSOT):** session miles and delivered pay are **not** columns — miles = `lastOdometer − startOdometer` (SQL), pay = `SUM(delivery_records)`; one owner per number. The one deliberate exception is the **frozen economics** on `delivery_records`, which is not a cache of a live value but a historical fact (a shipped record must not move when the economy editor changes) — stated explicitly per the "say so in the PR" rule.
- **P8 (platform-agnostic):** `platform` is a `String` column populated from session context (`Platform.wire`) in PR2 — never id-parsed, no `== Platform.X` literal; per-platform aggregates are `GROUP BY platform`, keyed by data, not a global.
- **P6 (security/privacy):** as above — no new trusted-input boundary, capture, or network; PII stays hashed-at-edge.
- **P3 (single responsibility):** new focused files under `analytics/`; query-projection DTOs split into `AnalyticsTotals.kt`; no oversized file touched.
- **P2 (MAD):** Room + KSP + AutoMigration + committed schema; version catalog for the one new test dep.

Adversarial `/code-review` + `/security-review` to run pre-merge per workflow. **Do not merge — the developer gates this.**


---

### Design-goal review
Read-model schema (`:core:database` + `:domain`/`:core:data` plumbing), behavior-inert.
- **P5 (SSOT):** `session_records` miles/pay are derived (SQL SUM), not stored — one owner per number; single `Json { ignoreUnknownKeys }` instance owns metadata decode.
- **P8 (platform-agnostic):** `platform` is a data-sourced column (`Platform.wire`), not an id-parsed literal or a `when`.
- Migration safety: additive-only AutoMigration 8→9, `fallbackToDestructiveMigration` untouched (the path exists so it can't fire on this upgrade). Data-safety follow-up (retire the destructive fallback once analytics is the source of truth) tracked for a later PR.

### Adversarial review
Independent fable-tier review — **verdict: CLEAN, merge recommended.** Migration proven **non-destructive**: a programmatic byte-diff of `8.json` vs `9.json` shows all 5 pre-existing tables (`app_events` incl.) byte-identical (createSql + fields + indices); v9 adds exactly the 4 analytics tables; the compiler-generated `AutoMigration(8→9)` with no spec can only emit CREATE TABLE/INDEX (a destructive change would require a `@Delete*` spec or fail compile). `EventMetadata` Gson→kotlinx compat proven against the real writer's shapes (property-name fields, nulls-omitted, the `{"test_mode":true}` historical row) → the exact `ignoreUnknownKeys` decoder + all-default fields parse them; decode failure → WARN+null (existing fail-null contract). Schema/DAO correct (frozen-economy trio present, indices, Room-legal types, SQL column names match). Confirmed **behavior-inert** — `AnalyticsDao`/`getEventsAfter`/`SequencedAppEvent` are consumed only by tests + the DI provider; no projector/UI/new-event-types. Tests non-vacuous (`AnalyticsSchemaRoundTripTest` 8/8 through real in-memory Room; `EventMetadataSerializationTest` 4/4); `:app` 865/865, `:domain` 252/252. 4 minor findings, none blocking — folded into PR2's test work: a `MigrationTestHelper` 8→9-against-populated-DB test, and coverage of the projector-support DAO queries (esp. `sessionTotals`' `MAX(x,0)` null-skip).
