### PR TITLE
feat(#314): analytics projector — event-sourced fold of app_events (PR2)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/DashBuddyApplication.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/DashBuddyApplication.kt
@@ -55,6 +55,9 @@ class DashBuddyApplication : Application(), Configuration.Provider {
     @Inject
     lateinit var shadowStoreChainLogger: cloud.trotter.dashbuddy.state.shadow.ShadowStoreChainLogger
 
+    @Inject
+    lateinit var analyticsProjector: cloud.trotter.dashbuddy.core.data.analytics.AnalyticsProjector
+
     // Global Context Accessor (Still useful for Utils, but avoid if possible)
     companion object {
         lateinit var instance: DashBuddyApplication
@@ -122,6 +125,11 @@ class DashBuddyApplication : Application(), Configuration.Provider {
         if (BuildConfig.DEBUG) {
             shadowStoreChainLogger.start(applicationScope)
         }
+
+        // 3c. Analytics read-model projector (#314): the event-sourced fold of app_events into the
+        // durable read-model tables (backfill on first launch, then incremental). NOT debug-gated —
+        // this is the product's historical earnings/miles source of truth, not debug telemetry.
+        analyticsProjector.start(applicationScope)
 
         // 4. Schedule Background Tasks
         scheduleBackgroundWorkers()

--- a/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsBackfillReplayTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsBackfillReplayTest.kt
@@ -1,0 +1,135 @@
+package cloud.trotter.dashbuddy.analytics
+
+import androidx.room.Room
+import cloud.trotter.dashbuddy.core.data.analytics.AnalyticsProjector
+import cloud.trotter.dashbuddy.core.data.event.AppEventRepo
+import cloud.trotter.dashbuddy.core.data.settings.AppPreferencesRepository
+import cloud.trotter.dashbuddy.core.database.DashBuddyDatabase
+import cloud.trotter.dashbuddy.core.database.analytics.AnalyticsDao
+import cloud.trotter.dashbuddy.core.database.event.AppEventDao
+import cloud.trotter.dashbuddy.core.database.event.AppEventEntity
+import cloud.trotter.dashbuddy.domain.evaluation.UserEconomy
+import cloud.trotter.dashbuddy.domain.model.event.AppEvent
+import cloud.trotter.dashbuddy.domain.model.event.AppEventCodec
+import cloud.trotter.dashbuddy.domain.model.event.AppEventType
+import cloud.trotter.dashbuddy.test.util.SessionReplay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+/**
+ * #314 PR2 — the realistic backfill: a real captured session ([SessionReplay] of the redacted
+ * 2026-06-16 single delivery) is folded through the REAL StateMachine into an `app_events` trace,
+ * persisted to an in-memory v9 DB, then the projector backfills it from watermark 0. Assertions are
+ * hand-authored correct-behaviour invariants (never `replay == db`), the same oracle discipline as
+ * `SingleDeliveryReplayTest`.
+ *
+ * The replay's domain events carry no device metadata (that is stamped at write time in `:app`,
+ * which the replay bypasses), so the test stamps a monotonic odometer as it persists — the honest
+ * analogue of the on-device stamp — which lets the partition-miles invariant be checked.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AnalyticsBackfillReplayTest {
+
+    private val session = "snapshots/sessions/single_delivery_2026_06_16"
+
+    private lateinit var db: DashBuddyDatabase
+    private lateinit var analyticsDao: AnalyticsDao
+    private lateinit var eventDao: AppEventDao
+    private lateinit var repo: AppEventRepo
+    private lateinit var prefs: AppPreferencesRepository
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(RuntimeEnvironment.getApplication(), DashBuddyDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        analyticsDao = db.analyticsDao()
+        eventDao = db.appEventDao()
+        repo = AppEventRepo(db, eventDao, db.effectsFiredDao())
+        prefs = mock { on { userEconomy } doReturn flowOf(UserEconomy()) }
+    }
+
+    @After
+    fun tearDown() = db.close()
+
+    /** Replay the session (screens + real accept click + grace timer) into an app_events trace. */
+    private fun replayEvents(): List<AppEvent> {
+        val screens = SessionReplay.loadSession(session).map { SessionReplay.ScreenInput(it) }
+        val click = SessionReplay.loadClickFrame("$session/02_accept_offer_click.json")
+        val receiptMs = screens.maxOf { it.atMs }
+        val timer = SessionReplay.graceCommit(receiptMs + 2_500L + 1L)
+        return SessionReplay.reduceMixed(screens + click + timer).flatMap { it.events }
+    }
+
+    /** Persist the trace with a monotonic odometer stamp (the write-time analogue). */
+    private suspend fun persist(events: List<AppEvent>, startOdometer: Double = 100.0) {
+        events.forEachIndexed { i, e ->
+            eventDao.insert(
+                AppEventEntity(
+                    aggregateId = e.sessionId,
+                    eventType = e.type,
+                    eventPayload = e.payload?.let(AppEventCodec::encodePayload) ?: "{}",
+                    occurredAt = e.occurredAt,
+                    metadata = """{"odometer":${startOdometer + i}}""",
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `backfilling a real single-delivery session folds to the correct records`() = runBlocking {
+        val events = replayEvents()
+        persist(events)
+
+        val projector = AnalyticsProjector(db, repo, eventDao, analyticsDao, prefs)
+        val stats = projector.catchUp()
+
+        // The backfill saw the whole trace and produced one delivery.
+        assertEquals(events.size, stats.events)
+        assertEquals(1, stats.deliveries)
+
+        // Invariant 1: exactly ONE delivery, exactly ONE job (the #498/#503 single-drop guarantee).
+        val totals = analyticsDao.deliveryTotals(0, Long.MAX_VALUE).first()
+        assertEquals("exactly one delivery record", 1, totals.deliveries)
+        assertEquals("exactly one job", 1, totals.jobs)
+        assertEquals("realized pay is the apportioned drop share", 3.1, totals.pay, 1e-9)
+
+        // Invariant 2: one session row with folded counters.
+        val sessions = analyticsDao.sessionRecord(events.first().sessionId!!)!!
+        assertEquals("doordash", sessions.platform)
+        assertEquals(1, sessions.deliveries)
+        assertEquals(1, sessions.jobsCompleted)
+        assertEquals(1, sessions.offersAccepted)
+        assertEquals(1, sessions.offersReceived)
+
+        // Invariant 3: session miles == the odometer delta across the session (startOdometer is the
+        // DASH_START reading, lastOdometer the final event; both recovered from the odometer stamps).
+        val session = analyticsDao.sessionTotals(0, Long.MAX_VALUE).first()
+        assertEquals(
+            "session miles == lastOdometer − startOdometer",
+            sessions.lastOdometer!! - sessions.startOdometer!!,
+            session.miles,
+            1e-9,
+        )
+
+        // Invariant 4: the single drop's realized miles equal the session delta (Σ over one drop).
+        val delivery = analyticsDao.lastDeliveryInSession(events.first().sessionId!!)!!
+        assertEquals(session.miles, delivery.realizedMiles!!, 1e-9)
+        assertNotNull("net was computed from the fallback economy", delivery.netProfit)
+        assertEquals("no offer evaluation in a screen-only replay ⇒ CURRENT_FALLBACK", "CURRENT_FALLBACK", delivery.costBasis)
+
+        // The watermark advanced to the tail of the log.
+        assertEquals(events.size.toLong(), analyticsDao.getWatermark()!!.watermarkSequenceId)
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsDaoProjectorSupportTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsDaoProjectorSupportTest.kt
@@ -1,0 +1,161 @@
+package cloud.trotter.dashbuddy.analytics
+
+import androidx.room.Room
+import cloud.trotter.dashbuddy.core.database.DashBuddyDatabase
+import cloud.trotter.dashbuddy.core.database.analytics.AnalyticsDao
+import cloud.trotter.dashbuddy.core.database.analytics.DeliveryRecordEntity
+import cloud.trotter.dashbuddy.core.database.analytics.OfferRecordEntity
+import cloud.trotter.dashbuddy.core.database.analytics.SessionRecordEntity
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+/**
+ * #314 — DAO coverage the PR1 round-trip left untested (PR1-review finding 2): the projector-support
+ * queries and the per-platform aggregates. In-memory v9 Room, entities built directly.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AnalyticsDaoProjectorSupportTest {
+
+    private lateinit var db: DashBuddyDatabase
+    private lateinit var dao: AnalyticsDao
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(RuntimeEnvironment.getApplication(), DashBuddyDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = db.analyticsDao()
+    }
+
+    @After
+    fun tearDown() = db.close()
+
+    private fun session(
+        id: String,
+        platform: String = "doordash",
+        startedAt: Long = 1_000,
+        endedAt: Long? = null,
+        lastEventAt: Long = 5_000,
+        startOdo: Double? = 100.0,
+        lastOdo: Double? = 110.0,
+    ) = SessionRecordEntity(
+        sessionId = id, platform = platform, startedAt = startedAt, endedAt = endedAt,
+        lastEventAt = lastEventAt, endSource = null, startOdometer = startOdo, lastOdometer = lastOdo,
+        reportedEarnings = null, reportedDurationMillis = null,
+        offersReceived = 0, offersAccepted = 0, offersDeclined = 0, offersTimeout = 0,
+        deliveries = 0, jobsCompleted = 0,
+    )
+
+    private fun delivery(
+        seq: Long,
+        sessionId: String,
+        jobId: String,
+        platform: String = "doordash",
+        odo: Double? = null,
+        completedAt: Long = 3_000,
+    ) = DeliveryRecordEntity(
+        eventSequenceId = seq, sessionId = sessionId, platform = platform, jobId = jobId, taskId = "T$seq",
+        storeName = "S", customerHash = null, addressHash = null, phaseStartedAt = 0, arrivedAt = null,
+        completedAt = completedAt, deadlineMillis = null, realizedPay = 5.0, payBasis = "RECEIPT_TOTAL",
+        tip = null, basePay = null, odometerAtCompletion = odo, realizedMiles = null, realizedMinutes = null,
+        frozenCostPerMile = null, netProfit = null, costBasis = "NONE",
+    )
+
+    private fun offer(seq: Long, sessionId: String, cpm: Double?) = OfferRecordEntity(
+        eventSequenceId = seq, sessionId = sessionId, platform = "doordash", offerHash = "h$seq",
+        outcome = "OFFER_ACCEPTED", presentedAt = 0, decidedAt = seq * 10,
+        payAmount = 10.0, distanceMiles = 3.0, itemCount = 1, merchantName = "S",
+        score = 80.0, action = "ACCEPT", quality = "GOOD",
+        estNetPay = 9.0, estDollarsPerHour = 20.0, estDollarsPerMile = 3.0, estTimeMinutes = 15.0,
+        estOperatingCostPerMile = cpm,
+    )
+
+    @Test
+    fun `sessionTotals sums miles as a floored odo delta and duration via COALESCE endedAt`() = runBlocking {
+        dao.upsertSession(session("A", startOdo = 100.0, lastOdo = 110.0, startedAt = 0, endedAt = 3_600_000))
+        // A glitched session whose lastOdometer < startOdometer must contribute 0 miles, not −5.
+        dao.upsertSession(session("B", startOdo = 50.0, lastOdo = 45.0, startedAt = 0, endedAt = 1_800_000))
+        // An open session (endedAt null) uses lastEventAt for the online duration.
+        dao.upsertSession(session("C", startOdo = 0.0, lastOdo = 7.0, startedAt = 0, endedAt = null, lastEventAt = 900_000))
+
+        val totals = dao.sessionTotals(0, Long.MAX_VALUE).first()
+        assertEquals("10 + max(0) + 7", 17.0, totals.miles, 1e-9)
+        assertEquals(3_600_000 + 1_800_000 + 900_000, totals.onlineMillis)
+    }
+
+    @Test
+    fun `sessionTotalsByPlatform groups miles and duration per platform`() = runBlocking {
+        dao.upsertSession(session("A", platform = "doordash", startOdo = 0.0, lastOdo = 10.0, endedAt = 1_000))
+        dao.upsertSession(session("B", platform = "uber", startOdo = 0.0, lastOdo = 4.0, endedAt = 1_000))
+
+        val rows = dao.sessionTotalsByPlatform(0, Long.MAX_VALUE).first().associateBy { it.platform }
+        assertEquals(10.0, rows.getValue("doordash").miles, 1e-9)
+        assertEquals(4.0, rows.getValue("uber").miles, 1e-9)
+    }
+
+    @Test
+    fun `deliveryTotalsByPlatform groups pay, count, and distinct jobs per platform`() = runBlocking {
+        dao.upsertDelivery(delivery(1, "A", "J1", platform = "doordash"))
+        dao.upsertDelivery(delivery(2, "A", "J1", platform = "doordash")) // same job
+        dao.upsertDelivery(delivery(3, "B", "J9", platform = "uber"))
+
+        val rows = dao.deliveryTotalsByPlatform(0, Long.MAX_VALUE).first().associateBy { it.platform }
+        assertEquals(2, rows.getValue("doordash").deliveries)
+        assertEquals(1, rows.getValue("doordash").jobs)
+        assertEquals(10.0, rows.getValue("doordash").pay, 1e-9)
+        assertEquals(1, rows.getValue("uber").deliveries)
+    }
+
+    @Test
+    fun `upsertSession and upsertOffer replace on their primary keys`() = runBlocking {
+        dao.upsertSession(session("A", startOdo = 1.0))
+        dao.upsertSession(session("A", startOdo = 2.0)) // REPLACE on sessionId
+        assertEquals(2.0, dao.sessionRecord("A")!!.startOdometer!!, 1e-9)
+
+        dao.upsertOffer(offer(1, "A", cpm = 0.1))
+        dao.upsertOffer(offer(1, "A", cpm = 0.2)) // REPLACE on eventSequenceId
+        assertEquals(0.2, dao.lastOfferCostPerMileInSession("A")!!, 1e-9)
+    }
+
+    @Test
+    fun `sessionRecord, lastDeliveryInSession, and openSessions serve the projector`() = runBlocking {
+        dao.upsertSession(session("A", platform = "doordash", endedAt = null))
+        dao.upsertSession(session("B", platform = "doordash", endedAt = 9_000))
+        dao.upsertDelivery(delivery(1, "A", "J1", odo = 5.0, completedAt = 2_000))
+        dao.upsertDelivery(delivery(2, "A", "J2", odo = 9.0, completedAt = 3_000))
+
+        assertNull(dao.sessionRecord("missing"))
+        assertEquals("doordash", dao.sessionRecord("A")!!.platform)
+
+        // The prevDropAnchor: highest eventSequenceId wins.
+        val last = dao.lastDeliveryInSession("A")!!
+        assertEquals(2L, last.eventSequenceId)
+        assertEquals(9.0, last.odometerAtCompletion!!, 1e-9)
+
+        // Only the open (endedAt null) session for the platform.
+        val open = dao.openSessions("doordash")
+        assertEquals(listOf("A"), open.map { it.sessionId })
+    }
+
+    @Test
+    fun `deliveredJobIdsInSession returns the distinct set and lastOfferCostPerMile prefers the newest`() = runBlocking {
+        dao.upsertDelivery(delivery(1, "A", "J1"))
+        dao.upsertDelivery(delivery(2, "A", "J1")) // dup job
+        dao.upsertDelivery(delivery(3, "A", "J2"))
+        assertEquals(setOf("J1", "J2"), dao.deliveredJobIdsInSession("A").toSet())
+
+        dao.upsertOffer(offer(10, "A", cpm = 0.25))
+        dao.upsertOffer(offer(20, "A", cpm = 0.35)) // newest by eventSequenceId
+        dao.upsertOffer(offer(30, "A", cpm = null))  // null cpm skipped
+        assertEquals("newest non-null offer cpm", 0.35, dao.lastOfferCostPerMileInSession("A")!!, 1e-9)
+        assertNull(dao.lastOfferCostPerMileInSession("nobody"))
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsProjectorTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsProjectorTest.kt
@@ -1,0 +1,277 @@
+package cloud.trotter.dashbuddy.analytics
+
+import androidx.room.Room
+import cloud.trotter.dashbuddy.core.data.analytics.AnalyticsProjector
+import cloud.trotter.dashbuddy.core.data.event.AppEventRepo
+import cloud.trotter.dashbuddy.core.data.settings.AppPreferencesRepository
+import cloud.trotter.dashbuddy.core.database.DashBuddyDatabase
+import cloud.trotter.dashbuddy.core.database.analytics.AnalyticsDao
+import cloud.trotter.dashbuddy.core.database.analytics.AnalyticsProjectionStateEntity
+import cloud.trotter.dashbuddy.core.database.analytics.DeliveryRecordEntity
+import cloud.trotter.dashbuddy.core.database.event.AppEventDao
+import cloud.trotter.dashbuddy.core.database.event.AppEventEntity
+import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
+import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
+import cloud.trotter.dashbuddy.domain.evaluation.OfferQuality
+import cloud.trotter.dashbuddy.domain.evaluation.UserEconomy
+import cloud.trotter.dashbuddy.domain.model.event.AppEventCodec
+import cloud.trotter.dashbuddy.domain.model.event.AppEventType
+import cloud.trotter.dashbuddy.domain.model.event.payload.AppEventPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.OfferPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.SessionEndSource
+import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStartPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStartSource
+import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStopPayload
+import cloud.trotter.dashbuddy.domain.model.offer.ParsedOffer
+import cloud.trotter.dashbuddy.domain.state.Flow
+import cloud.trotter.dashbuddy.domain.state.Platform
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+/**
+ * #314 PR2 — the [AnalyticsProjector] orchestrator against an in-memory v9 Room DB: the watermark
+ * catch-up loop, restart-correct exactly-once folding, re-run idempotency, malformed-payload
+ * fail-soft, and the `projectorVersion` wipe+refold. The fold arithmetic itself is covered purely
+ * in `:domain`'s `RecordFoldsTest`; this proves the durable, transactional edges.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AnalyticsProjectorTest {
+
+    private lateinit var db: DashBuddyDatabase
+    private lateinit var analyticsDao: AnalyticsDao
+    private lateinit var eventDao: AppEventDao
+    private lateinit var repo: AppEventRepo
+    private lateinit var prefs: AppPreferencesRepository
+
+    @Before
+    fun setUp() {
+        val context = RuntimeEnvironment.getApplication()
+        db = Room.inMemoryDatabaseBuilder(context, DashBuddyDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        analyticsDao = db.analyticsDao()
+        eventDao = db.appEventDao()
+        repo = AppEventRepo(db, eventDao, db.effectsFiredDao())
+        prefs = mock { on { userEconomy } doReturn flowOf(UserEconomy()) }
+    }
+
+    @After
+    fun tearDown() = db.close()
+
+    private fun projector() = AnalyticsProjector(db, repo, eventDao, analyticsDao, prefs)
+
+    // ── Seeding ─────────────────────────────────────────────────────────
+
+    private suspend fun insert(
+        type: AppEventType,
+        sessionId: String?,
+        at: Long,
+        payload: AppEventPayload?,
+        odometer: Double? = null,
+    ): Long = eventDao.insert(
+        AppEventEntity(
+            aggregateId = sessionId,
+            eventType = type,
+            eventPayload = payload?.let(AppEventCodec::encodePayload) ?: "{}",
+            occurredAt = at,
+            metadata = odometer?.let { """{"odometer":$it}""" },
+        ),
+    )
+
+    private fun eval(opCpm: Double) = OfferEvaluation(
+        action = OfferAction.ACCEPT, score = 80.0, qualityLevel = OfferQuality.GOOD,
+        payAmount = 12.0, fuelCostEstimate = 0.0, operatingCostPerMile = opCpm,
+        netPayAmount = 12.0 - 3.0 * opCpm, distanceMiles = 3.0,
+        dollarsPerMile = 3.0, dollarsPerHour = 20.0, estimatedTimeMinutes = 15.0,
+        itemCount = 1.0, merchantName = "StoreX",
+    )
+
+    private suspend fun seedFullSession(sid: String = "S1", opCpm: Double = 0.25) {
+        insert(
+            AppEventType.DASH_START, sid, 1_000,
+            SessionStartPayload(sid, Platform.DoorDash.name, 1_000, SessionStartSource.INTERACTION, "x"),
+            odometer = 100.0,
+        )
+        insert(
+            AppEventType.OFFER_ACCEPTED, sid, 2_000,
+            OfferPayload(
+                offerHash = "h1",
+                parsedOffer = ParsedOffer(offerHash = "h1", payAmount = 12.0, distanceMiles = 3.0),
+                evaluation = eval(opCpm), outcome = AppEventType.OFFER_ACCEPTED,
+                presentedAt = 1_970, decidedAt = 2_000, returnFlow = Flow.Idle,
+            ),
+        )
+        insert(
+            AppEventType.DELIVERY_COMPLETED, sid, 3_000,
+            DeliveryPayload(
+                jobId = "J1", taskId = "T1", storeName = "StoreX", customerHash = "c",
+                phaseStartedAt = 2_400, arrivedAt = 2_880, completedAt = 3_000, totalPay = 10.0,
+            ),
+            odometer = 105.0,
+        )
+        insert(
+            AppEventType.DASH_STOP, sid, 4_000,
+            SessionStopPayload(sid, endedAt = 4_000, source = SessionEndSource.SUMMARY_SCREEN, totalEarnings = 10.0),
+            odometer = 110.0,
+        )
+    }
+
+    // ── Tests ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `catchUp folds a full session into records and advances the watermark`() = runBlocking {
+        seedFullSession()
+        projector().catchUp()
+
+        val totals = analyticsDao.deliveryTotals(0, Long.MAX_VALUE).first()
+        assertEquals(10.0, totals.pay, 1e-9)
+        assertEquals(1, totals.deliveries)
+        assertEquals(1, totals.jobs)
+
+        val s = analyticsDao.sessionRecord("S1")!!
+        assertEquals("doordash", s.platform)
+        assertEquals(1, s.deliveries)
+        assertEquals(1, s.jobsCompleted)
+        assertEquals(1, s.offersAccepted)
+        assertEquals(100.0, s.startOdometer!!, 1e-9)
+        assertEquals(110.0, s.lastOdometer!!, 1e-9)
+        assertEquals(4_000L, s.endedAt)
+        assertEquals(SessionEndSource.SUMMARY_SCREEN, s.endSource)
+
+        val sessionMiles = analyticsDao.sessionTotals(0, Long.MAX_VALUE).first()
+        assertEquals(10.0, sessionMiles.miles, 1e-9) // 110 − 100
+
+        assertEquals(4L, analyticsDao.getWatermark()!!.watermarkSequenceId)
+    }
+
+    @Test
+    fun `a restart between batches folds exactly once and hydrates the frozen basis from the db`() = runBlocking {
+        seedFullSession(opCpm = 0.40)
+
+        // Batch 1: DASH_START + OFFER_ACCEPTED only (watermark → 2), then the process "dies".
+        projector().processBatch(limit = 2)
+        assertEquals(2L, analyticsDao.getWatermark()!!.watermarkSequenceId)
+
+        // A brand-new projector instance (fresh in-memory state) resumes from the durable watermark.
+        val resumed = projector()
+        resumed.processBatch(limit = 100)
+        assertNull(resumed.processBatch(limit = 100)) // fully drained
+
+        val totals = analyticsDao.deliveryTotals(0, Long.MAX_VALUE).first()
+        assertEquals("delivery folded exactly once across the restart", 1, totals.deliveries)
+        assertEquals(1, analyticsDao.sessionRecord("S1")!!.deliveries)
+        assertEquals(4L, analyticsDao.getWatermark()!!.watermarkSequenceId)
+
+        // The delivery folded AFTER the restart still resolved its frozen cpm — proof the session's
+        // offer basis was rehydrated from offer_records, not lost with the dead process.
+        val delivery = analyticsDao.lastDeliveryInSession("S1")!!
+        assertEquals("OFFER_FROZEN", delivery.costBasis)
+        assertEquals(0.40, delivery.frozenCostPerMile!!, 1e-9)
+    }
+
+    @Test
+    fun `re-running a drained log rewrites identical tables`() = runBlocking {
+        seedFullSession()
+        projector().catchUp()
+        val firstPay = analyticsDao.deliveryTotals(0, Long.MAX_VALUE).first()
+        val firstWatermark = analyticsDao.getWatermark()!!.watermarkSequenceId
+
+        // Nothing new in the log — a second catch-up is a no-op rewrite.
+        val stats = projector().catchUp()
+        assertEquals(0, stats.events)
+        val secondPay = analyticsDao.deliveryTotals(0, Long.MAX_VALUE).first()
+        assertEquals(firstPay, secondPay)
+        assertEquals(firstWatermark, analyticsDao.getWatermark()!!.watermarkSequenceId)
+    }
+
+    @Test
+    fun `a malformed payload row is skipped and counted while the rest of the batch folds`() = runBlocking {
+        insert(
+            AppEventType.DASH_START, "S1", 1_000,
+            SessionStartPayload("S1", Platform.DoorDash.name, 1_000, SessionStartSource.INTERACTION, "x"),
+            odometer = 0.0,
+        )
+        // A DELIVERY_COMPLETED whose payload never decoded (empty "{}") — must be skipped, not crash.
+        insert(AppEventType.DELIVERY_COMPLETED, "S1", 2_000, payload = null, odometer = 2.0)
+        insert(
+            AppEventType.DELIVERY_COMPLETED, "S1", 3_000,
+            DeliveryPayload(jobId = "J1", taskId = "T1", storeName = "StoreX", phaseStartedAt = 2_400, totalPay = 7.0),
+            odometer = 5.0,
+        )
+
+        projector().catchUp()
+
+        val totals = analyticsDao.deliveryTotals(0, Long.MAX_VALUE).first()
+        assertEquals("only the valid delivery is recorded", 1, totals.deliveries)
+        assertEquals(7.0, totals.pay, 1e-9)
+        // The watermark still advances past the skipped row — the loop can't stall.
+        assertEquals(3L, analyticsDao.getWatermark()!!.watermarkSequenceId)
+    }
+
+    @Test
+    fun `a projectorVersion mismatch wipes and refolds to the same tables as a fresh fold`() = runBlocking {
+        seedFullSession()
+        projector().catchUp()
+        val fresh = analyticsDao.deliveryTotals(0, Long.MAX_VALUE).first()
+
+        // Simulate a stale projection from a different fold version, plus a bogus row that a fresh
+        // fold would never produce.
+        analyticsDao.upsertDelivery(
+            DeliveryRecordEntity(
+                eventSequenceId = 9_999, sessionId = "GHOST", platform = "doordash", jobId = "JX", taskId = "TX",
+                storeName = null, customerHash = null, addressHash = null, phaseStartedAt = 0, arrivedAt = null,
+                completedAt = 5_000, deadlineMillis = null, realizedPay = 999.0, payBasis = "NONE",
+                tip = null, basePay = null, odometerAtCompletion = null, realizedMiles = null, realizedMinutes = null,
+                frozenCostPerMile = null, netProfit = null, costBasis = "NONE",
+            ),
+        )
+        analyticsDao.setWatermark(AnalyticsProjectionStateEntity(watermarkSequenceId = 4, projectorVersion = 99))
+
+        projector().catchUp() // detects 99 ≠ current version → wipe + refold
+
+        val rebuilt = analyticsDao.deliveryTotals(0, Long.MAX_VALUE).first()
+        assertEquals("rebuild == fresh fold (the bogus row is gone)", fresh, rebuilt)
+        assertNotNull(analyticsDao.sessionRecord("S1"))
+        assertNull("the ghost session was wiped", analyticsDao.sessionRecord("GHOST"))
+    }
+
+    @Test
+    fun `a fresh DASH_START infers the close of a crash-orphaned prior session`() = runBlocking {
+        // Session A never gets a DASH_STOP (crash); session B starts later on the same platform.
+        insert(
+            AppEventType.DASH_START, "A", 1_000,
+            SessionStartPayload("A", Platform.DoorDash.name, 1_000, SessionStartSource.INTERACTION, "x"),
+            odometer = 10.0,
+        )
+        insert(
+            AppEventType.DELIVERY_COMPLETED, "A", 2_000,
+            DeliveryPayload(jobId = "J1", taskId = "T1", storeName = "S", phaseStartedAt = 1_500, totalPay = 5.0),
+            odometer = 14.0,
+        )
+        insert(
+            AppEventType.DASH_START, "B", 9_000,
+            SessionStartPayload("B", Platform.DoorDash.name, 9_000, SessionStartSource.INTERACTION, "x"),
+            odometer = 20.0,
+        )
+
+        projector().catchUp()
+
+        val a = analyticsDao.sessionRecord("A")!!
+        assertEquals("orphaned session A is inferred-closed", "inferred", a.endSource)
+        assertEquals("A's endedAt is its last event", 2_000L, a.endedAt)
+        assertNull("the live session B stays open", analyticsDao.sessionRecord("B")!!.endedAt)
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsProjectorTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsProjectorTest.kt
@@ -274,4 +274,71 @@ class AnalyticsProjectorTest {
         assertEquals("A's endedAt is its last event", 2_000L, a.endedAt)
         assertNull("the live session B stays open", analyticsDao.sessionRecord("B")!!.endedAt)
     }
+
+    @Test
+    fun `a placeholder session folded before DASH_START in an earlier batch is upgraded, not left _unknown (F1)`() = runBlocking {
+        // A session-scoped event (OFFER_ACCEPTED) ordered just ahead of DASH_START — the live steady
+        // state, where each app_events insert wakes a 1-event drain, so the two same-timestamp rows
+        // routinely land in SEPARATE batches (also: app killed between them).
+        insert(
+            AppEventType.OFFER_ACCEPTED, "S1", 1_000,
+            OfferPayload(
+                offerHash = "h1",
+                parsedOffer = ParsedOffer(offerHash = "h1", payAmount = 12.0, distanceMiles = 3.0),
+                evaluation = eval(0.30), outcome = AppEventType.OFFER_ACCEPTED,
+                presentedAt = 970, decidedAt = 1_000, returnFlow = Flow.Idle,
+            ),
+        )
+        insert(
+            AppEventType.DASH_START, "S1", 1_000,
+            SessionStartPayload("S1", Platform.DoorDash.name, 1_000, SessionStartSource.INTERACTION, "x"),
+            odometer = 100.0,
+        )
+
+        // Batch 1 folds the offer → persists an `_unknown` placeholder session_record.
+        projector().processBatch(limit = 1)
+        assertEquals("the offer-before-DASH_START synthesized an _unknown placeholder", "_unknown", analyticsDao.sessionRecord("S1")!!.platform)
+
+        // Batch 2 is a FRESH projector instance → it HYDRATES the placeholder from the DB (the F1
+        // locus). Against the old `started = true` hydration this took the RECOVERY non-clobber arm
+        // and the session stayed `_unknown` forever; the fix upgrades it with the real platform +
+        // startedAt (a still-`_unknown` hydrated row is NOT "started").
+        projector().processBatch(limit = 1)
+
+        val s = analyticsDao.sessionRecord("S1")!!
+        assertEquals("DASH_START in a later batch upgrades the placeholder platform", "doordash", s.platform)
+        assertEquals("and adopts the real startedAt", 1_000L, s.startedAt)
+        assertEquals("and the real start odometer", 100.0, s.startOdometer!!, 1e-9)
+    }
+
+    @Test
+    fun `inferred-close of a crash-orphaned session works across a batch boundary via the openSessions DB arm (F6)`() = runBlocking {
+        // Session A never gets a DASH_STOP (crash); it is fully folded in batch 1 by a projector
+        // instance that is then discarded, so A's context survives only in the DB.
+        insert(
+            AppEventType.DASH_START, "A", 1_000,
+            SessionStartPayload("A", Platform.DoorDash.name, 1_000, SessionStartSource.INTERACTION, "x"),
+            odometer = 10.0,
+        )
+        insert(
+            AppEventType.DELIVERY_COMPLETED, "A", 2_000,
+            DeliveryPayload(jobId = "J1", taskId = "T1", storeName = "S", phaseStartedAt = 1_500, totalPay = 5.0),
+            odometer = 14.0,
+        )
+        projector().processBatch(limit = 2)
+
+        // Session B's DASH_START lands in a LATER batch — A is only in the DB, so the inferred-close
+        // must find it via `openSessions` (the DB-row arm), not an in-memory context.
+        insert(
+            AppEventType.DASH_START, "B", 9_000,
+            SessionStartPayload("B", Platform.DoorDash.name, 9_000, SessionStartSource.INTERACTION, "x"),
+            odometer = 20.0,
+        )
+        projector().processBatch(limit = 100)
+
+        val a = analyticsDao.sessionRecord("A")!!
+        assertEquals("orphaned session A is inferred-closed across the batch boundary", "inferred", a.endSource)
+        assertEquals("A's endedAt is its last event", 2_000L, a.endedAt)
+        assertNull("the live session B stays open", analyticsDao.sessionRecord("B")!!.endedAt)
+    }
 }

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjector.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjector.kt
@@ -1,0 +1,337 @@
+package cloud.trotter.dashbuddy.core.data.analytics
+
+import androidx.room.withTransaction
+import cloud.trotter.dashbuddy.core.data.event.AppEventRepo
+import cloud.trotter.dashbuddy.core.data.settings.AppPreferencesRepository
+import cloud.trotter.dashbuddy.core.database.DashBuddyDatabase
+import cloud.trotter.dashbuddy.core.database.analytics.AnalyticsDao
+import cloud.trotter.dashbuddy.core.database.analytics.AnalyticsProjectionStateEntity
+import cloud.trotter.dashbuddy.core.database.analytics.DeliveryRecordEntity
+import cloud.trotter.dashbuddy.core.database.analytics.OfferRecordEntity
+import cloud.trotter.dashbuddy.core.database.analytics.SessionRecordEntity
+import cloud.trotter.dashbuddy.core.database.event.AppEventDao
+import cloud.trotter.dashbuddy.domain.analytics.DeliveryFold
+import cloud.trotter.dashbuddy.domain.analytics.OfferFold
+import cloud.trotter.dashbuddy.domain.analytics.RecordFolds
+import cloud.trotter.dashbuddy.domain.analytics.SessionFoldContext
+import cloud.trotter.dashbuddy.domain.state.Platform
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.conflate
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * The durable analytics read-model projector (#314) — the event-sourced CQRS fold of the
+ * `app_events` log into the `delivery_records` / `session_records` / `offer_records` tables.
+ *
+ * **Trigger:** it observes the DB, not the engine — `AppEventDao.maxSequenceId()` (Room-invalidation
+ * driven) wakes a catch-up drain whenever new events land. The one-time **backfill is just the first
+ * drain from watermark 0** — there is no separate backfill path, so backfill ≡ incremental and every
+ * test of the incremental loop tests the backfill. A `projectorVersion` bump wipes the records and
+ * refolds the whole log (rebuild ≡ backfill).
+ *
+ * **Exactly-once:** each batch writes its records AND advances the watermark in ONE
+ * `db.withTransaction`, so a crash rolls the whole batch back and it re-folds cleanly. The record
+ * PKs are the source event's `sequenceId` with `REPLACE`, so even a re-run is a byte-identical
+ * no-op.
+ *
+ * **Purity boundary:** all fold arithmetic lives in `:domain` [RecordFolds] (pure, `:domain:test`);
+ * this orchestrator owns only the impure edges — paging, restart-correct context hydration from the
+ * record tables, the inferred-close DB query, the live-economy read for the `CURRENT_FALLBACK`
+ * frozen basis, and the transaction.
+ *
+ * **Privacy (Principle 6/7):** no new capture, no network, no new PII surface — it re-reads a log
+ * that already passed the edge hash (`customerHash`/`addressHash` are sha256). The one INFO
+ * milestone and the per-batch DEBUG line carry **counts only**, never store/customer text.
+ */
+@Singleton
+class AnalyticsProjector @Inject constructor(
+    private val db: DashBuddyDatabase,
+    private val appEventRepo: AppEventRepo,
+    private val appEventDao: AppEventDao,
+    private val analyticsDao: AnalyticsDao,
+    private val appPreferencesRepository: AppPreferencesRepository,
+) {
+
+    /** Started from `DashBuddyApplication.onCreate` (NOT debug-gated). */
+    fun start(scope: CoroutineScope) {
+        scope.launch {
+            rebuildIfVersionChanged()
+
+            // The first drain from watermark 0 is the backfill/rebuild; log ONE INFO milestone.
+            val backfillFrom = currentWatermark()
+            val backfill = drain()
+            if (backfillFrom == 0L && backfill.events > 0) {
+                Timber.tag(TAG).i(
+                    "Analytics backfill complete: %d events → %d deliveries, %d sessions, %d offers",
+                    backfill.events, backfill.deliveries, backfill.sessions, backfill.offers,
+                )
+            }
+
+            // Steady state: every new max wakes an incremental drain (per-batch DEBUG only).
+            appEventDao.maxSequenceId().conflate().collect { drain() }
+        }
+    }
+
+    /** Aggregate counts for one drain (a run of catch-up batches). */
+    data class DrainStats(
+        val events: Int = 0,
+        val deliveries: Int = 0,
+        val sessions: Int = 0,
+        val offers: Int = 0,
+    )
+
+    /**
+     * Run the version-rebuild check then drain the log once — the whole projection, synchronously.
+     * `start` uses this shape for the first (backfill) pass; tests drive it directly for a
+     * deterministic fold with no live `maxSequenceId` collector.
+     */
+    suspend fun catchUp(): DrainStats {
+        rebuildIfVersionChanged()
+        return drain()
+    }
+
+    /** Fold catch-up batches until the log is drained past the watermark. */
+    private suspend fun drain(): DrainStats {
+        var acc = DrainStats()
+        while (true) {
+            val batch = processBatch() ?: break
+            acc = DrainStats(
+                events = acc.events + batch.events,
+                deliveries = acc.deliveries + batch.deliveries,
+                sessions = acc.sessions + batch.sessions,
+                offers = acc.offers + batch.offers,
+            )
+        }
+        return acc
+    }
+
+    /**
+     * Fold ONE page of events after the watermark and commit records + the advanced watermark in one
+     * transaction. Returns the batch's counts, or null when the log is already drained. [limit]
+     * pages the fold (bounded memory over a long log); a test passes a small limit to force
+     * multi-batch behaviour and simulate a restart between batches.
+     */
+    suspend fun processBatch(limit: Int = BATCH_SIZE): DrainStats? {
+        val watermark = currentWatermark()
+        val events = appEventRepo.getEventsAfter(after = watermark, limit = limit)
+        if (events.isEmpty()) return null
+
+        val currentCpm = currentCostPerMile()
+        val contexts = HashMap<String, SessionFoldContext>()
+        val touched = LinkedHashSet<String>()
+        val deliveries = ArrayList<DeliveryFold>()
+        val offers = ArrayList<OfferFold>()
+        var skips = 0
+
+        for (ev in events) {
+            val sid = ev.event.sessionId
+            val ctxIn = sid?.let { contexts[it] ?: hydrate(it) }
+            val outcome = RecordFolds.foldEvent(ev, ctxIn, currentCpm)
+
+            if (outcome.skip != null) skips++
+            outcome.delivery?.let { deliveries += it }
+            outcome.offer?.let { offers += it }
+            outcome.context?.let { ctx ->
+                contexts[ctx.sessionId] = ctx
+                touched += ctx.sessionId
+            }
+            // A fresh DASH_START infers the close of any still-open session on the same platform —
+            // a crash-orphaned dash the next one ends. (freshSession is false for a RECOVERY
+            // re-start of an already-started session, so that path does not re-close anything.)
+            if (outcome.freshSession) {
+                outcome.context?.let { inferredCloseOpenSessions(it, contexts, touched) }
+            }
+        }
+
+        val lastSeq = events.last().sequenceId
+        db.withTransaction {
+            deliveries.forEach { analyticsDao.upsertDelivery(it.toEntity()) }
+            offers.forEach { analyticsDao.upsertOffer(it.toEntity()) }
+            touched.forEach { sid -> contexts[sid]?.let { analyticsDao.upsertSession(it.toEntity()) } }
+            analyticsDao.setWatermark(
+                AnalyticsProjectionStateEntity(watermarkSequenceId = lastSeq, projectorVersion = PROJECTOR_VERSION),
+            )
+        }
+
+        Timber.tag(TAG).d(
+            "batch: %d events (→seq %d) → %d deliveries, %d offers, %d sessions, %d skipped",
+            events.size, lastSeq, deliveries.size, offers.size, touched.size, skips,
+        )
+        if (skips > 0) {
+            Timber.tag(TAG).w("batch skipped %d event(s) with a missing/malformed payload", skips)
+        }
+        return DrainStats(events.size, deliveries.size, touched.size, offers.size)
+    }
+
+    // ── Version rebuild ─────────────────────────────────────────────────
+
+    private suspend fun rebuildIfVersionChanged() {
+        val state = analyticsDao.getWatermark() ?: return // no watermark yet → first fold is the backfill
+        if (state.projectorVersion == PROJECTOR_VERSION) return
+        Timber.tag(TAG).i(
+            "projector version %d→%d: wiping records and refolding the log",
+            state.projectorVersion, PROJECTOR_VERSION,
+        )
+        db.withTransaction {
+            analyticsDao.deleteAllDeliveries()
+            analyticsDao.deleteAllSessions()
+            analyticsDao.deleteAllOffers()
+            analyticsDao.setWatermark(
+                AnalyticsProjectionStateEntity(watermarkSequenceId = 0, projectorVersion = PROJECTOR_VERSION),
+            )
+        }
+    }
+
+    private suspend fun currentWatermark(): Long =
+        analyticsDao.getWatermark()?.watermarkSequenceId ?: 0L
+
+    /** The live economy's operating cost-per-mile — the frozen `CURRENT_FALLBACK` basis only. */
+    private suspend fun currentCostPerMile(): Double? =
+        runCatching { appPreferencesRepository.userEconomy.first().operatingCostPerMile }.getOrNull()
+
+    // ── Restart-correct context hydration (the record tables ARE the fold state) ──
+
+    private suspend fun hydrate(sessionId: String): SessionFoldContext? {
+        val session = analyticsDao.sessionRecord(sessionId) ?: return null
+        val lastDelivery = analyticsDao.lastDeliveryInSession(sessionId)
+        return session.toContext(
+            deliveredJobIds = analyticsDao.deliveredJobIdsInSession(sessionId).toSet(),
+            prevDropOdometer = lastDelivery?.odometerAtCompletion,
+            prevDropAt = lastDelivery?.completedAt,
+            lastEvaluatedCostPerMile = analyticsDao.lastOfferCostPerMileInSession(sessionId),
+        )
+    }
+
+    /**
+     * Close every still-open session for [fresh]'s platform except [fresh] itself — the
+     * crash-orphaned dash whose DASH_STOP never fired, ended by the next dash. Handles both the
+     * in-batch open contexts and the DB rows a prior batch left open. Its endedAt/lastOdometer stay
+     * honest (they were advanced while it lived), so its duration/miles remain meaningful.
+     */
+    private suspend fun inferredCloseOpenSessions(
+        fresh: SessionFoldContext,
+        contexts: HashMap<String, SessionFoldContext>,
+        touched: LinkedHashSet<String>,
+    ) {
+        // In-batch open contexts on the same platform.
+        for (ctx in contexts.values.toList()) {
+            if (ctx.sessionId == fresh.sessionId || ctx.platform != fresh.platform || ctx.endedAt != null) continue
+            contexts[ctx.sessionId] = ctx.copy(endedAt = ctx.lastEventAt, endSource = INFERRED)
+            touched += ctx.sessionId
+        }
+        // DB rows still open for this platform, not already handled in this batch.
+        for (row in analyticsDao.openSessions(fresh.platform.wire)) {
+            if (row.sessionId == fresh.sessionId || contexts.containsKey(row.sessionId)) continue
+            contexts[row.sessionId] = row.toContext().copy(endedAt = row.lastEventAt, endSource = INFERRED)
+            touched += row.sessionId
+        }
+    }
+
+    // ── Entity ↔ domain mapping (the storage boundary; :domain cannot see :core:database) ──
+
+    private fun SessionFoldContext.toEntity() = SessionRecordEntity(
+        sessionId = sessionId,
+        platform = platform.wire,
+        startedAt = startedAt,
+        endedAt = endedAt,
+        lastEventAt = lastEventAt,
+        endSource = endSource,
+        startOdometer = startOdometer,
+        lastOdometer = lastOdometer,
+        reportedEarnings = reportedEarnings,
+        reportedDurationMillis = reportedDurationMillis,
+        offersReceived = offersReceived,
+        offersAccepted = offersAccepted,
+        offersDeclined = offersDeclined,
+        offersTimeout = offersTimeout,
+        deliveries = deliveries,
+        jobsCompleted = jobsCompleted,
+    )
+
+    private fun SessionRecordEntity.toContext(
+        deliveredJobIds: Set<String> = emptySet(),
+        prevDropOdometer: Double? = null,
+        prevDropAt: Long? = null,
+        lastEvaluatedCostPerMile: Double? = null,
+    ) = SessionFoldContext(
+        sessionId = sessionId,
+        platform = Platform.fromWire(platform) ?: Platform.Unknown,
+        startedAt = startedAt,
+        lastEventAt = lastEventAt,
+        endedAt = endedAt,
+        endSource = endSource,
+        startOdometer = startOdometer,
+        lastOdometer = lastOdometer,
+        reportedEarnings = reportedEarnings,
+        reportedDurationMillis = reportedDurationMillis,
+        offersAccepted = offersAccepted,
+        offersDeclined = offersDeclined,
+        offersTimeout = offersTimeout,
+        deliveries = deliveries,
+        deliveredJobIds = deliveredJobIds,
+        prevDropOdometer = prevDropOdometer,
+        prevDropAt = prevDropAt,
+        lastEvaluatedCostPerMile = lastEvaluatedCostPerMile,
+        started = true, // a persisted session_record was already started
+    )
+
+    private fun DeliveryFold.toEntity() = DeliveryRecordEntity(
+        eventSequenceId = eventSequenceId,
+        sessionId = sessionId,
+        platform = platform,
+        jobId = jobId,
+        taskId = taskId,
+        storeName = storeName,
+        customerHash = customerHash,
+        addressHash = addressHash,
+        phaseStartedAt = phaseStartedAt,
+        arrivedAt = arrivedAt,
+        completedAt = completedAt,
+        deadlineMillis = deadlineMillis,
+        realizedPay = realizedPay,
+        payBasis = payBasis,
+        tip = tip,
+        basePay = basePay,
+        odometerAtCompletion = odometerAtCompletion,
+        realizedMiles = realizedMiles,
+        realizedMinutes = realizedMinutes,
+        frozenCostPerMile = frozenCostPerMile,
+        netProfit = netProfit,
+        costBasis = costBasis,
+    )
+
+    private fun OfferFold.toEntity() = OfferRecordEntity(
+        eventSequenceId = eventSequenceId,
+        sessionId = sessionId,
+        platform = platform,
+        offerHash = offerHash,
+        outcome = outcome,
+        presentedAt = presentedAt,
+        decidedAt = decidedAt,
+        payAmount = payAmount,
+        distanceMiles = distanceMiles,
+        itemCount = itemCount,
+        merchantName = merchantName,
+        score = score,
+        action = action,
+        quality = quality,
+        estNetPay = estNetPay,
+        estDollarsPerHour = estDollarsPerHour,
+        estDollarsPerMile = estDollarsPerMile,
+        estTimeMinutes = estTimeMinutes,
+        estOperatingCostPerMile = estOperatingCostPerMile,
+    )
+
+    private companion object {
+        private const val TAG = "Analytics"
+        private const val BATCH_SIZE = 500
+        private const val INFERRED = "inferred"
+
+        /** Fold-logic version — bump to wipe records + refold the whole log on next start. */
+        private const val PROJECTOR_VERSION = 1
+    }
+}

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjector.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjector.kt
@@ -15,9 +15,12 @@ import cloud.trotter.dashbuddy.domain.analytics.OfferFold
 import cloud.trotter.dashbuddy.domain.analytics.RecordFolds
 import cloud.trotter.dashbuddy.domain.analytics.SessionFoldContext
 import cloud.trotter.dashbuddy.domain.state.Platform
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
@@ -34,9 +37,11 @@ import javax.inject.Singleton
  * refolds the whole log (rebuild ≡ backfill).
  *
  * **Exactly-once:** each batch writes its records AND advances the watermark in ONE
- * `db.withTransaction`, so a crash rolls the whole batch back and it re-folds cleanly. The record
- * PKs are the source event's `sequenceId` with `REPLACE`, so even a re-run is a byte-identical
- * no-op.
+ * `db.withTransaction`, so a crash rolls the whole batch back and it re-folds cleanly. That atomic
+ * watermark is what makes it exactly-once: a committed batch is never re-folded. (The seq-PK
+ * `REPLACE` on delivery/offer rows makes re-writing THOSE idempotent, but the session counters are
+ * folded increments — re-folding a committed batch would double them, which the watermark prevents;
+ * idempotency does not rest on the PKs alone.)
  *
  * **Purity boundary:** all fold arithmetic lives in `:domain` [RecordFolds] (pure, `:domain:test`);
  * this orchestrator owns only the impure edges — paging, restart-correct context hydration from the
@@ -59,20 +64,39 @@ class AnalyticsProjector @Inject constructor(
     /** Started from `DashBuddyApplication.onCreate` (NOT debug-gated). */
     fun start(scope: CoroutineScope) {
         scope.launch {
-            rebuildIfVersionChanged()
+            var backoffMs = INITIAL_BACKOFF_MS
+            // Supervise the projection (#430 pattern): a transient failure (SQLite IO, disk pressure)
+            // must not silence the projector for the rest of the process. The atomic watermark kept
+            // the committed state intact through any rolled-back batch, so on a crash we log ERROR,
+            // back off, and resubscribe — resuming from where the watermark left off.
+            while (isActive) {
+                try {
+                    rebuildIfVersionChanged()
 
-            // The first drain from watermark 0 is the backfill/rebuild; log ONE INFO milestone.
-            val backfillFrom = currentWatermark()
-            val backfill = drain()
-            if (backfillFrom == 0L && backfill.events > 0) {
-                Timber.tag(TAG).i(
-                    "Analytics backfill complete: %d events → %d deliveries, %d sessions, %d offers",
-                    backfill.events, backfill.deliveries, backfill.sessions, backfill.offers,
-                )
+                    // The first drain from watermark 0 is the backfill/rebuild; log ONE INFO milestone.
+                    val backfillFrom = currentWatermark()
+                    val backfill = drain()
+                    if (backfillFrom == 0L && backfill.events > 0) {
+                        Timber.tag(TAG).i(
+                            "Analytics backfill complete: %d events → %d deliveries, %d sessions, %d offers",
+                            backfill.events, backfill.deliveries, backfill.sessions, backfill.offers,
+                        )
+                    }
+
+                    backoffMs = INITIAL_BACKOFF_MS // healthy — reset the backoff before steady state
+                    // Steady state: every new max wakes an incremental drain (per-batch DEBUG only).
+                    // collect() only returns on cancellation, so control leaves this block only via a
+                    // throw (caught below) or cancellation (rethrown).
+                    appEventDao.maxSequenceId().conflate().collect { drain() }
+                    return@launch
+                } catch (e: CancellationException) {
+                    throw e // cooperative cancellation — never swallow it
+                } catch (e: Exception) {
+                    Timber.tag(TAG).e(e, "Analytics projector crashed; resubscribing in %d ms", backoffMs)
+                    delay(backoffMs)
+                    backoffMs = (backoffMs * 2).coerceAtMost(MAX_BACKOFF_MS)
+                }
             }
-
-            // Steady state: every new max wakes an incremental drain (per-batch DEBUG only).
-            appEventDao.maxSequenceId().conflate().collect { drain() }
         }
     }
 
@@ -276,7 +300,11 @@ class AnalyticsProjector @Inject constructor(
         prevDropOdometer = prevDropOdometer,
         prevDropAt = prevDropAt,
         lastEvaluatedCostPerMile = lastEvaluatedCostPerMile,
-        started = true, // a persisted session_record was already started
+        // A persisted row with a REAL platform is a started session (a RECOVERY re-start must not
+        // clobber it). A still-`_unknown` row is a placeholder persisted before its DASH_START landed
+        // (they arrive in separate 1-event drains at steady state) — NOT started, so the DASH_START
+        // that lands in a later batch upgrades it with the real platform/startedAt (F1).
+        started = Platform.fromWire(platform)?.let { it != Platform.Unknown } ?: false,
     )
 
     private fun DeliveryFold.toEntity() = DeliveryRecordEntity(
@@ -330,6 +358,10 @@ class AnalyticsProjector @Inject constructor(
         private const val TAG = "Analytics"
         private const val BATCH_SIZE = 500
         private const val INFERRED = "inferred"
+
+        /** Supervised-restart backoff bounds after a drain crash (#430 pattern). */
+        private const val INITIAL_BACKOFF_MS = 1_000L
+        private const val MAX_BACKOFF_MS = 60_000L
 
         /** Fold-logic version — bump to wipe records + refold the whole log on next start. */
         private const val PROJECTOR_VERSION = 1

--- a/core/database/build.gradle.kts
+++ b/core/database/build.gradle.kts
@@ -18,6 +18,12 @@ android {
         consumerProguardFiles("consumer-rules.pro")
     }
 
+    // Expose the exported Room schema JSONs to the instrumented tests so MigrationTestHelper can
+    // open a real v8 DB and run the committed AutoMigration(8→9) against it (#314).
+    sourceSets {
+        getByName("androidTest").assets.srcDir("$projectDir/schemas")
+    }
+
     buildTypes {
         release {
             isMinifyEnabled = false
@@ -52,6 +58,7 @@ dependencies {
 
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
+    androidTestImplementation(libs.androidx.room.testing)
 }
 
 ksp {

--- a/core/database/src/androidTest/java/cloud/trotter/dashbuddy/core/database/AnalyticsMigration8to9Test.kt
+++ b/core/database/src/androidTest/java/cloud/trotter/dashbuddy/core/database/AnalyticsMigration8to9Test.kt
@@ -1,0 +1,71 @@
+package cloud.trotter.dashbuddy.core.database
+
+import androidx.room.testing.MigrationTestHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * #314 (PR1-review finding 1) — execute the REAL committed `AutoMigration(8→9)` against a
+ * **populated** v8 database and prove it is non-destructive: the pre-existing `app_events` rows
+ * survive and the four new analytics tables exist afterward.
+ *
+ * Instrumented (androidTest) because [MigrationTestHelper] opens an on-disk SQLite DB via the
+ * framework factory and replays the exported schema JSONs (surfaced to the test assets by the
+ * `androidTest` sourceSet in `build.gradle.kts`). Runs under `:core:database:connectedAndroidTest`.
+ */
+@RunWith(AndroidJUnit4::class)
+class AnalyticsMigration8to9Test {
+
+    private val dbName = "migration-8-to-9-test"
+
+    @get:Rule
+    val helper = MigrationTestHelper(
+        InstrumentationRegistry.getInstrumentation(),
+        DashBuddyDatabase::class.java,
+        emptyList(),
+        FrameworkSQLiteOpenHelperFactory(),
+    )
+
+    @Test
+    fun migrate8To9_preservesAppEvents_andAddsAnalyticsTables() {
+        // Create the schema at v8 and seed two app_events rows.
+        helper.createDatabase(dbName, 8).use { db ->
+            db.execSQL(
+                """INSERT INTO app_events (sequenceId, aggregateId, eventType, eventPayload, occurredAt, metadata)
+                   VALUES (1, 'S1', 'DASH_START', '{}', 1000, NULL)""",
+            )
+            db.execSQL(
+                """INSERT INTO app_events (sequenceId, aggregateId, eventType, eventPayload, occurredAt, metadata)
+                   VALUES (2, 'S1', 'DELIVERY_COMPLETED', '{}', 2000, '{"odometer":5.0}')""",
+            )
+        }
+
+        // Run the real AutoMigration(8→9) and validate against the exported 9.json schema.
+        val db = helper.runMigrationsAndValidate(dbName, 9, true)
+
+        // The pre-existing event rows survived the migration (additive-only, not destructive).
+        db.query("SELECT COUNT(*) FROM app_events").use { c ->
+            c.moveToFirst()
+            assertEquals("app_events rows preserved across 8→9", 2, c.getInt(0))
+        }
+        db.query("SELECT eventType FROM app_events WHERE sequenceId = 2").use { c ->
+            c.moveToFirst()
+            assertEquals("DELIVERY_COMPLETED", c.getString(0))
+        }
+
+        // The four new analytics tables exist after the migration.
+        val expected = setOf("delivery_records", "session_records", "offer_records", "analytics_projection_state")
+        val found = mutableSetOf<String>()
+        db.query("SELECT name FROM sqlite_master WHERE type='table'").use { c ->
+            while (c.moveToNext()) found += c.getString(0)
+        }
+        assertTrue("new analytics tables present: $expected in $found", found.containsAll(expected))
+        db.close()
+    }
+}

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
@@ -118,4 +118,25 @@ interface AnalyticsDao {
     /** Still-live sessions for a platform — the next DASH_START infers their close. */
     @Query("SELECT * FROM session_records WHERE platform = :platform AND endedAt IS NULL")
     suspend fun openSessions(platform: String): List<SessionRecordEntity>
+
+    /**
+     * The distinct delivered jobIds already recorded for a session — rehydrates the fold's
+     * distinct-job set on a mid-session restart so `jobsCompleted` counts a stacked job once even
+     * across a process death (PR2).
+     */
+    @Query("SELECT DISTINCT jobId FROM delivery_records WHERE sessionId = :id")
+    suspend fun deliveredJobIdsInSession(id: String): List<String>
+
+    /**
+     * The most recent closing offer's frozen operating-cost-per-mile in a session — rehydrates the
+     * fold's session-uniform frozen-economy basis on a mid-session restart so a delivery folded
+     * after the restart still resolves `OFFER_FROZEN` (PR2). Prefers offer provenance, never a
+     * prior delivery's possibly-fallback cpm.
+     */
+    @Query(
+        """SELECT estOperatingCostPerMile FROM offer_records
+           WHERE sessionId = :id AND estOperatingCostPerMile IS NOT NULL
+           ORDER BY eventSequenceId DESC LIMIT 1"""
+    )
+    suspend fun lastOfferCostPerMileInSession(id: String): Double?
 }

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -552,6 +552,7 @@ class EffectMap @Inject constructor() {
                                     offersAccepted = endParsed.offersAccepted,
                                     offersTotal = endParsed.offersTotal,
                                     weeklyEarnings = endParsed.weeklyEarnings,
+                                    platform = prev.platform.name, // #314 capture-gap: harden the log
                                 ),
                             ),
                         )
@@ -575,6 +576,7 @@ class EffectMap @Inject constructor() {
                                     endedAt = endedAt,
                                     source = SessionEndSource.EARLY_OFFLINE,
                                     totalEarnings = prevSession.runningEarnings,
+                                    platform = prev.platform.name, // #314 capture-gap: harden the log
                                 ),
                             ),
                         )
@@ -653,6 +655,7 @@ class EffectMap @Inject constructor() {
                             pausedAt = obs.timestamp,
                             remainingText = pausedFields?.remainingText,
                             remainingMillis = pausedFields?.remainingMillis,
+                            platform = next.platform.name, // #314 capture-gap: harden the log
                         )
                         add(logEffect(sessionId, AppEventType.DASH_PAUSED, obs.timestamp, pausePayload))
                         add(

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapPayloadTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapPayloadTest.kt
@@ -539,6 +539,7 @@ class EffectMapPayloadTest {
         assertEquals(5, payload.offersAccepted)
         assertEquals(8, payload.offersTotal)
         assertEquals(6000L, payload.endedAt)
+        assertEquals("DoorDash", payload.platform) // #314 capture-gap stamp
     }
 
     @Test
@@ -559,6 +560,7 @@ class EffectMapPayloadTest {
         val payload = (logs[0].event.payload as SessionStopPayload)
         assertEquals("early_offline", payload.source)
         assertEquals(30.0, payload.totalEarnings!!, 0.001)
+        assertEquals("DoorDash", payload.platform) // #314 capture-gap stamp
     }
 
     @Test
@@ -653,5 +655,6 @@ class EffectMapPayloadTest {
         assertEquals(4000L, payload.pausedAt)
         assertEquals(29 * 60 * 1000L, payload.remainingMillis)
         assertEquals("29:42", payload.remainingText)
+        assertEquals("DoorDash", payload.platform) // #314 capture-gap stamp
     }
 }

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -73,6 +73,21 @@ card's **mechanical** half, #577 (re-confirmed, 24/24, ~0.55 s — with a new po
 that entry's Bug #1), the #457 path, and #554 ShadowProjector (2/2). The #462/#460 dropoff item
 was found **broken-in-part** (raw PII in capture envelopes) and moved to that entry's Bug #7.)_
 
+- **🆕 NEW — the analytics read-model projector now folds `app_events` into durable records (#314 PR2). READ THE DB / LOG AFTER THE FIRST DASH POST-UPDATE.**
+  The projector runs on `DashBuddyApplication` startup (not debug-gated) and event-sources the
+  `app_events` log into `delivery_records` / `session_records` / `offer_records`. On the **first
+  launch after installing this build** it backfills the entire existing log; watch the INFO log for a
+  single line tagged `Analytics`: `Analytics backfill complete: N events → D deliveries, S sessions,
+  O offers` (counts only — it must carry **no** store/customer names). How to tell it's working:
+  after a dash, read the db — `delivery_records` should have one row per completed delivery with
+  `realizedPay`, `realizedMiles` (odometer partition delta), `frozenCostPerMile`/`costBasis`
+  (`OFFER_FROZEN` when the offer was evaluated, else `CURRENT_FALLBACK`), and `netProfit`;
+  `session_records` should have one row per dash whose `deliveries`/`jobsCompleted`/offer counts and
+  `lastOdometer − startOdometer` miles match your memory of the dash. Editing the economy settings
+  must **not** change any already-stored `frozenCostPerMile`/`netProfit` (they're immutable facts).
+  (#314 PR2 — projector/backfill/frozen-economy.)
+  - Confirmed: 0/2
+
 - **🔧 FIX SHIPPED — a stacked job's DELIVERY_COMPLETED rows now carry per-drop realized pay (#528 Slice A). READ THE DB AFTER A DASH.**
   Before, on a multi-store/multi-drop stack, the single combined receipt was attached to just ONE
   drop (it absorbed the whole total) and every other drop's `DELIVERY_COMPLETED` row recorded null

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/RecordFolds.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/RecordFolds.kt
@@ -117,10 +117,13 @@ data class FoldOutcome(
  * The pure event-sourced fold (#314): `(event, session context, current cpm) → record deltas`.
  *
  * No Android, no DB, no wall clock — driven only by the event's own timestamps and metadata, so a
- * backfill from watermark 0 and an incremental catch-up fold are byte-identical, and a
- * `projectorVersion` rebuild reproduces the same rows. The orchestrator owns everything impure:
- * paging, context hydration from the record tables, the inferred-close DB query, and the
- * records+watermark transaction.
+ * backfill from watermark 0 and an incremental catch-up fold produce the same rows, and a
+ * `projectorVersion` rebuild reproduces them. The orchestrator owns everything impure: paging,
+ * context hydration from the record tables, the inferred-close DB query, and the records+watermark
+ * transaction — and that transaction is what makes the fold **exactly-once**: delivery/offer rows
+ * are keyed by source `sequenceId` (REPLACE-idempotent), but the folded session *counters* are not,
+ * so re-processing an already-folded event WOULD double them — which the atomic watermark prevents
+ * (a re-run over a drained log folds nothing; only new events past the watermark are ever folded).
  *
  * [currentCostPerMile] is the live economy's operating cost-per-mile, supplied by the orchestrator
  * only for the [CostBasis.CURRENT_FALLBACK] path (a delivery with no offer basis); it never
@@ -163,10 +166,14 @@ object RecordFolds {
             ?: return FoldOutcome(context = context, skip = "DASH_START: no sessionId")
         val platform = Platform.fromName(p.platform) ?: Platform.Unknown
         val odo = event.metadata?.odometer
-        // A RECOVERY (or any duplicate) re-start of a session ALREADY STARTED must NOT clobber the
-        // original startedAt/platform/startOdometer — keep the earlier anchor, only fill a still-null
-        // odometer and advance liveness. Not a fresh session ⇒ no inferred-close.
-        if (context != null && context.sessionId == sid && context.started) {
+        // A RECOVERY (or any duplicate) re-start of a session that was ALREADY STARTED WITH A REAL
+        // PLATFORM must NOT clobber the original startedAt/platform/startOdometer — keep the earlier
+        // anchor, only fill a still-null odometer and advance liveness. Not a fresh session ⇒ no
+        // inferred-close. The `platform != Unknown` guard is load-bearing: a `_unknown` placeholder
+        // (synthesized for a pre-DASH_START event, possibly PERSISTED and rehydrated across a batch
+        // boundary and thus carrying started=true) must fall through to the upgrade arm below, or the
+        // real platform/startedAt would be discarded and the session would stay `_unknown` forever.
+        if (context != null && context.sessionId == sid && context.started && context.platform != Platform.Unknown) {
             return FoldOutcome(
                 context = context.copy(
                     startOdometer = context.startOdometer ?: odo,
@@ -175,9 +182,10 @@ object RecordFolds {
                 ),
             )
         }
-        // A placeholder synthesized for a session-scoped event ordered just ahead of DASH_START is
-        // UPGRADED here with the real platform/startedAt/startOdometer; its accumulated counters and
-        // liveness carry over. This still counts as a fresh session (its first true start).
+        // A placeholder synthesized for a session-scoped event ordered just ahead of DASH_START (in
+        // the same batch OR persisted and rehydrated in a later one) is UPGRADED here with the real
+        // platform/startedAt/startOdometer; its accumulated counters and liveness carry over. This
+        // still counts as a fresh session (its first true start).
         if (context != null && context.sessionId == sid) {
             return FoldOutcome(
                 context = context.copy(
@@ -278,8 +286,11 @@ object RecordFolds {
         val basePay = if (soleDrop) receipt?.totalBasePay else null
 
         // Partition deltas. Anchor = the previous completion (or DASH_START) in the same session.
+        // Floor the per-row delta at 0 like the session-level SUM (MAX(…,0)): a mid-session odometer
+        // reset yields a NEGATIVE delta, which would otherwise INFLATE this row's netProfit
+        // (pay − negativeMiles × cpm). The next drop re-anchors off this (lower) reading naturally.
         val prevOdo = ctx?.prevDropOdometer ?: ctx?.startOdometer
-        val realizedMiles = if (odo != null && prevOdo != null) odo - prevOdo else null
+        val realizedMiles = if (odo != null && prevOdo != null) (odo - prevOdo).coerceAtLeast(0.0) else null
         val prevAt = ctx?.prevDropAt ?: ctx?.startedAt
         val realizedMinutes = if (prevAt != null) (completedAt - prevAt) / 60_000.0 else null
 

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/RecordFolds.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/RecordFolds.kt
@@ -1,0 +1,390 @@
+package cloud.trotter.dashbuddy.domain.analytics
+
+import cloud.trotter.dashbuddy.domain.evaluation.NetProfit
+import cloud.trotter.dashbuddy.domain.model.event.AppEventType
+import cloud.trotter.dashbuddy.domain.model.event.SequencedAppEvent
+import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.OfferPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStartPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStopPayload
+import cloud.trotter.dashbuddy.domain.state.Platform
+
+/** Provenance of a delivery's realized pay (#314) — mirrors the DB column, owned here as SSOT. */
+object PayBasis {
+    /** The drop's apportioned share of a combined receipt (`DropPayApportioner`, #528). */
+    const val DROP_SHARE = "DROP_SHARE"
+    /** The whole receipt total, stamped on this drop (single-drop / collapsed-receipt shape). */
+    const val RECEIPT_TOTAL = "RECEIPT_TOTAL"
+    /** No pay signal on the completion (receipt-skipped #596). */
+    const val NONE = "NONE"
+}
+
+/**
+ * Provenance of a delivery's frozen operating-cost-per-mile (#314) — an IMMUTABLE fact, never
+ * re-costed when the economy editor changes. Owned here as the SSOT the fold and the DB share.
+ */
+object CostBasis {
+    /**
+     * From a closing offer's frozen `OfferEvaluation.operatingCostPerMile` in the same session.
+     * Correlated at **session** granularity (not a per-job offer↔delivery join, which the event log
+     * cannot express): operating-cost-per-mile derives from the one `UserEconomy` a session runs
+     * under, so every offer in the session shares it and it is the correct basis for any delivery.
+     */
+    const val OFFER_FROZEN = "OFFER_FROZEN"
+
+    /** Stamped self-contained into the completion event (reserved; no live source stamps it yet). */
+    const val CAPTURED = "CAPTURED"
+
+    /**
+     * No offer basis available (a delivery in an offer-less/healed session, or one whose offer
+     * predates the fold watermark) — the current economy's cpm was used. Honestly flagged; NOT
+     * rebuild-stable (a later refold re-stamps it with that day's economy).
+     */
+    const val CURRENT_FALLBACK = "CURRENT_FALLBACK"
+
+    /** Neither an offer basis nor a current economy — no net computable. */
+    const val NONE = "NONE"
+}
+
+/**
+ * A delivery read-model row as produced by the pure fold — the `:domain` shape the projector maps
+ * 1:1 onto `DeliveryRecordEntity` at the transaction edge (`:domain` cannot see `:core:database`).
+ */
+data class DeliveryFold(
+    val eventSequenceId: Long,
+    val sessionId: String?,
+    val platform: String,
+    val jobId: String,
+    val taskId: String,
+    val storeName: String?,
+    val customerHash: String?,
+    val addressHash: String?,
+    val phaseStartedAt: Long,
+    val arrivedAt: Long?,
+    val completedAt: Long,
+    val deadlineMillis: Long?,
+    val realizedPay: Double?,
+    val payBasis: String,
+    val tip: Double?,
+    val basePay: Double?,
+    val odometerAtCompletion: Double?,
+    val realizedMiles: Double?,
+    val realizedMinutes: Double?,
+    val frozenCostPerMile: Double?,
+    val netProfit: Double?,
+    val costBasis: String,
+)
+
+/** An offer read-model row as produced by the pure fold — mapped 1:1 onto `OfferRecordEntity`. */
+data class OfferFold(
+    val eventSequenceId: Long,
+    val sessionId: String?,
+    val platform: String,
+    val offerHash: String,
+    val outcome: String,
+    val presentedAt: Long,
+    val decidedAt: Long,
+    val payAmount: Double?,
+    val distanceMiles: Double?,
+    val itemCount: Int,
+    val merchantName: String?,
+    val score: Double?,
+    val action: String?,
+    val quality: String?,
+    val estNetPay: Double?,
+    val estDollarsPerHour: Double?,
+    val estDollarsPerMile: Double?,
+    val estTimeMinutes: Double?,
+    val estOperatingCostPerMile: Double?,
+)
+
+/**
+ * The result of folding ONE event: the updated session [context] (null when the event carries no
+ * sessionId and so touches no session), any [delivery]/[offer] record it produced, and — for a
+ * DASH_START whose session was not previously known — [freshSession] so the orchestrator can run
+ * the inferred-close of prior open sessions. [skip] names why an event produced nothing (a null/
+ * malformed payload), so the projector can count + WARN per batch.
+ */
+data class FoldOutcome(
+    val context: SessionFoldContext? = null,
+    val delivery: DeliveryFold? = null,
+    val offer: OfferFold? = null,
+    val freshSession: Boolean = false,
+    val skip: String? = null,
+)
+
+/**
+ * The pure event-sourced fold (#314): `(event, session context, current cpm) → record deltas`.
+ *
+ * No Android, no DB, no wall clock — driven only by the event's own timestamps and metadata, so a
+ * backfill from watermark 0 and an incremental catch-up fold are byte-identical, and a
+ * `projectorVersion` rebuild reproduces the same rows. The orchestrator owns everything impure:
+ * paging, context hydration from the record tables, the inferred-close DB query, and the
+ * records+watermark transaction.
+ *
+ * [currentCostPerMile] is the live economy's operating cost-per-mile, supplied by the orchestrator
+ * only for the [CostBasis.CURRENT_FALLBACK] path (a delivery with no offer basis); it never
+ * overrides an [CostBasis.OFFER_FROZEN] basis, so an economy edit cannot move a frozen row that has
+ * one.
+ */
+object RecordFolds {
+
+    fun foldEvent(
+        event: SequencedAppEvent,
+        context: SessionFoldContext?,
+        currentCostPerMile: Double?,
+    ): FoldOutcome {
+        val e = event.event
+        val sid = e.sessionId
+        val odo = event.metadata?.odometer
+        return when (e.type) {
+            AppEventType.DASH_START -> foldDashStart(event, context)
+            AppEventType.OFFER_ACCEPTED,
+            AppEventType.OFFER_DECLINED,
+            AppEventType.OFFER_TIMEOUT -> foldOffer(event, context)
+            AppEventType.DELIVERY_COMPLETED -> foldDeliveryCompleted(event, context, currentCostPerMile)
+            AppEventType.DASH_STOP -> foldDashStop(event, context)
+            // Every other session-attributed event just advances the liveness/odometer anchors so
+            // the open-session duration and lastOdometer stay honest; the watermark still moves past
+            // them. Events with no session touch nothing.
+            else -> {
+                if (sid == null) return FoldOutcome(context = context)
+                val ctx = resolveContext(context, sid, e.occurredAt)
+                FoldOutcome(context = ctx.advance(e.occurredAt, odo))
+            }
+        }
+    }
+
+    private fun foldDashStart(event: SequencedAppEvent, context: SessionFoldContext?): FoldOutcome {
+        val e = event.event
+        val p = e.payload as? SessionStartPayload
+            ?: return FoldOutcome(context = context, skip = "DASH_START: missing/malformed payload")
+        val sid = e.sessionId ?: p.sessionId
+            ?: return FoldOutcome(context = context, skip = "DASH_START: no sessionId")
+        val platform = Platform.fromName(p.platform) ?: Platform.Unknown
+        val odo = event.metadata?.odometer
+        // A RECOVERY (or any duplicate) re-start of a session ALREADY STARTED must NOT clobber the
+        // original startedAt/platform/startOdometer — keep the earlier anchor, only fill a still-null
+        // odometer and advance liveness. Not a fresh session ⇒ no inferred-close.
+        if (context != null && context.sessionId == sid && context.started) {
+            return FoldOutcome(
+                context = context.copy(
+                    startOdometer = context.startOdometer ?: odo,
+                    lastEventAt = maxOf(context.lastEventAt, e.occurredAt),
+                    lastOdometer = odo ?: context.lastOdometer,
+                ),
+            )
+        }
+        // A placeholder synthesized for a session-scoped event ordered just ahead of DASH_START is
+        // UPGRADED here with the real platform/startedAt/startOdometer; its accumulated counters and
+        // liveness carry over. This still counts as a fresh session (its first true start).
+        if (context != null && context.sessionId == sid) {
+            return FoldOutcome(
+                context = context.copy(
+                    platform = platform,
+                    startedAt = p.startedAt,
+                    startOdometer = context.startOdometer ?: odo,
+                    lastEventAt = maxOf(context.lastEventAt, e.occurredAt),
+                    lastOdometer = odo ?: context.lastOdometer,
+                    started = true,
+                ),
+                freshSession = true,
+            )
+        }
+        return FoldOutcome(
+            context = SessionFoldContext(
+                sessionId = sid,
+                platform = platform,
+                startedAt = p.startedAt,
+                lastEventAt = e.occurredAt,
+                startOdometer = odo,
+                lastOdometer = odo,
+                started = true,
+            ),
+            freshSession = true,
+        )
+    }
+
+    private fun foldOffer(event: SequencedAppEvent, context: SessionFoldContext?): FoldOutcome {
+        val e = event.event
+        val p = e.payload as? OfferPayload
+            ?: return FoldOutcome(context = context, skip = "${e.type}: missing/malformed payload")
+        val sid = e.sessionId
+        val ctx = sid?.let { resolveContext(context, it, e.occurredAt) }
+        val platformWire = ctx?.platform?.wire ?: Platform.Unknown.wire
+        val eval = p.evaluation
+        val parsed = p.parsedOffer
+        val offer = OfferFold(
+            eventSequenceId = event.sequenceId,
+            sessionId = sid,
+            platform = platformWire,
+            offerHash = p.offerHash,
+            outcome = e.type.name,
+            presentedAt = p.presentedAt,
+            decidedAt = p.decidedAt,
+            payAmount = parsed.payAmount,
+            distanceMiles = parsed.distanceMiles,
+            itemCount = parsed.itemCount,
+            merchantName = eval?.merchantName ?: parsed.orders.firstOrNull()?.storeName,
+            score = eval?.score,
+            action = eval?.action?.name,
+            quality = eval?.qualityLevel?.name,
+            estNetPay = eval?.netPayAmount,
+            estDollarsPerHour = eval?.dollarsPerHour,
+            estDollarsPerMile = eval?.dollarsPerMile,
+            estTimeMinutes = eval?.estimatedTimeMinutes,
+            estOperatingCostPerMile = eval?.operatingCostPerMile,
+        )
+        val newCtx = ctx?.let {
+            it.advance(e.occurredAt, event.metadata?.odometer)
+                .bumpOutcome(e.type)
+                // Capture the session-uniform frozen cpm from any closing offer that carries an
+                // evaluation (accepted/declined/timeout all reflect the same economy).
+                .copy(lastEvaluatedCostPerMile = eval?.operatingCostPerMile ?: it.lastEvaluatedCostPerMile)
+        }
+        return FoldOutcome(context = newCtx, offer = offer)
+    }
+
+    private fun foldDeliveryCompleted(
+        event: SequencedAppEvent,
+        context: SessionFoldContext?,
+        currentCostPerMile: Double?,
+    ): FoldOutcome {
+        val e = event.event
+        val p = e.payload as? DeliveryPayload
+            ?: return FoldOutcome(context = context, skip = "DELIVERY_COMPLETED: missing/malformed payload")
+        val sid = e.sessionId
+        val ctx = sid?.let { resolveContext(context, it, e.occurredAt) }
+        val platformWire = ctx?.platform?.wire ?: Platform.Unknown.wire
+        val odo = event.metadata?.odometer
+        val completedAt = p.completedAt ?: e.occurredAt
+
+        // Pay + basis. dropRealizedPay is a per-drop share (possibly of a multi-drop receipt);
+        // its absence with a bare totalPay means the whole receipt landed on this one drop.
+        val realizedPay = p.dropRealizedPay ?: p.totalPay
+        val payBasis = when {
+            p.dropRealizedPay != null -> PayBasis.DROP_SHARE
+            p.totalPay != null -> PayBasis.RECEIPT_TOTAL
+            else -> PayBasis.NONE
+        }
+        // tip/basePay only when this drop IS the job's sole drop — i.e. it carries the WHOLE receipt.
+        // The apportioner stamps `dropRealizedPay` even on a single drop (its share == the total), so
+        // a null-drop bare receipt OR a share equal to the receipt total is the sole-drop signal; a
+        // smaller share is a stacked drop, which has no per-drop tip split yet (→ null).
+        val receipt = p.parsedPay
+        val soleDrop = receipt != null &&
+            (p.dropRealizedPay == null || kotlin.math.abs(p.dropRealizedPay - receipt.total) < 0.005)
+        val tip = if (soleDrop) receipt?.totalTip else null
+        val basePay = if (soleDrop) receipt?.totalBasePay else null
+
+        // Partition deltas. Anchor = the previous completion (or DASH_START) in the same session.
+        val prevOdo = ctx?.prevDropOdometer ?: ctx?.startOdometer
+        val realizedMiles = if (odo != null && prevOdo != null) odo - prevOdo else null
+        val prevAt = ctx?.prevDropAt ?: ctx?.startedAt
+        val realizedMinutes = if (prevAt != null) (completedAt - prevAt) / 60_000.0 else null
+
+        // Frozen economy — immutable historical fact.
+        val (frozenCpm, costBasis) = when {
+            ctx?.lastEvaluatedCostPerMile != null -> ctx.lastEvaluatedCostPerMile to CostBasis.OFFER_FROZEN
+            currentCostPerMile != null -> currentCostPerMile to CostBasis.CURRENT_FALLBACK
+            else -> null to CostBasis.NONE
+        }
+        val netProfit = if (frozenCpm != null && realizedPay != null && realizedMiles != null) {
+            NetProfit.net(realizedPay, realizedMiles, frozenCpm)
+        } else {
+            null
+        }
+
+        val delivery = DeliveryFold(
+            eventSequenceId = event.sequenceId,
+            sessionId = sid,
+            platform = platformWire,
+            jobId = p.jobId,
+            taskId = p.taskId,
+            storeName = p.storeName,
+            customerHash = p.customerHash,
+            addressHash = p.addressHash,
+            phaseStartedAt = p.phaseStartedAt,
+            arrivedAt = p.arrivedAt,
+            completedAt = completedAt,
+            deadlineMillis = p.deadlineMillis,
+            realizedPay = realizedPay,
+            payBasis = payBasis,
+            tip = tip,
+            basePay = basePay,
+            odometerAtCompletion = odo,
+            realizedMiles = realizedMiles,
+            realizedMinutes = realizedMinutes,
+            frozenCostPerMile = frozenCpm,
+            netProfit = netProfit,
+            costBasis = costBasis,
+        )
+
+        val newCtx = ctx?.copy(
+            deliveries = ctx.deliveries + 1,
+            deliveredJobIds = ctx.deliveredJobIds + p.jobId,
+            // Advance the miles anchor only when this drop had an odometer, so a null-odometer drop
+            // folds its miles into the next drop instead of resetting the partition; the time anchor
+            // always advances (time is always known).
+            prevDropOdometer = odo ?: ctx.prevDropOdometer,
+            prevDropAt = completedAt,
+            lastEventAt = maxOf(ctx.lastEventAt, e.occurredAt),
+            lastOdometer = odo ?: ctx.lastOdometer,
+        )
+        return FoldOutcome(context = newCtx, delivery = delivery)
+    }
+
+    private fun foldDashStop(event: SequencedAppEvent, context: SessionFoldContext?): FoldOutcome {
+        val e = event.event
+        val p = e.payload as? SessionStopPayload
+            ?: return FoldOutcome(context = context, skip = "DASH_STOP: missing/malformed payload")
+        val sid = e.sessionId ?: p.sessionId
+            ?: return FoldOutcome(context = context, skip = "DASH_STOP: no sessionId")
+        val ctx = resolveContext(context, sid, e.occurredAt, platformName = p.platform)
+        val odo = event.metadata?.odometer
+        return FoldOutcome(
+            context = ctx.copy(
+                endedAt = p.endedAt,
+                endSource = p.source,
+                reportedEarnings = p.totalEarnings ?: ctx.reportedEarnings,
+                reportedDurationMillis = p.sessionDurationMillis ?: ctx.reportedDurationMillis,
+                lastEventAt = maxOf(ctx.lastEventAt, e.occurredAt),
+                lastOdometer = odo ?: ctx.lastOdometer,
+            ),
+        )
+    }
+
+    /**
+     * The in-memory/hydrated context for [sid], or a synthesized `_unknown`-platform context when a
+     * session-scoped event has no known DASH_START (fold started mid-session past the watermark, or
+     * a lost start). A synthesized session degrades to a null-odometer / _unknown-platform row —
+     * never a wrong one. [platformName] refines the synthesized platform when the event itself
+     * carries one (DASH_STOP's #314 stamp).
+     */
+    private fun resolveContext(
+        context: SessionFoldContext?,
+        sid: String,
+        occurredAt: Long,
+        platformName: String? = null,
+    ): SessionFoldContext =
+        context?.takeIf { it.sessionId == sid }
+            ?: SessionFoldContext(
+                sessionId = sid,
+                platform = platformName?.let { Platform.fromName(it) } ?: Platform.Unknown,
+                startedAt = occurredAt,
+                lastEventAt = occurredAt,
+            )
+
+    private fun SessionFoldContext.advance(occurredAt: Long, odometer: Double?): SessionFoldContext =
+        copy(
+            lastEventAt = maxOf(lastEventAt, occurredAt),
+            lastOdometer = odometer ?: lastOdometer,
+        )
+
+    private fun SessionFoldContext.bumpOutcome(type: AppEventType): SessionFoldContext = when (type) {
+        AppEventType.OFFER_ACCEPTED -> copy(offersAccepted = offersAccepted + 1)
+        AppEventType.OFFER_DECLINED -> copy(offersDeclined = offersDeclined + 1)
+        AppEventType.OFFER_TIMEOUT -> copy(offersTimeout = offersTimeout + 1)
+        else -> this
+    }
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/SessionFoldContext.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/SessionFoldContext.kt
@@ -1,0 +1,64 @@
+package cloud.trotter.dashbuddy.domain.analytics
+
+import cloud.trotter.dashbuddy.domain.state.Platform
+
+/**
+ * The running fold state for one dash session (#314) — the analytics projector's per-session
+ * accumulator, threaded through [RecordFolds.foldEvent] one event at a time.
+ *
+ * Pure value object, no Android / DB / wall clock: the projector ([cloud.trotter.dashbuddy.core.data]
+ * `AnalyticsProjector`) hydrates it from the record tables on a mid-session restart and maps it to a
+ * `SessionRecordEntity` at the transaction edge, but the fold arithmetic that advances it lives here
+ * so it is `:domain:test`-able (same placement precedent as `DropPayApportioner`).
+ *
+ * Miles/minutes are **partition** anchors: [prevDropOdometer]/[prevDropAt] mark the previous
+ * `DELIVERY_COMPLETED` in this session (or the DASH_START odometer/time for the first drop), so each
+ * drop's realized miles/minutes are the gap since that anchor and Σ over the session equals the
+ * session odometer/time delta with nothing double-counted.
+ *
+ * [lastEvaluatedCostPerMile] is the session-uniform operating cost-per-mile the offers were
+ * evaluated against — the frozen-economy basis for every delivery in the session (see [RecordFolds]).
+ */
+data class SessionFoldContext(
+    val sessionId: String,
+    val platform: Platform,
+    val startedAt: Long,
+    /** Advanced on EVERY session event — the open-session duration + inferred-close anchor. */
+    val lastEventAt: Long,
+    val endedAt: Long? = null,
+    val endSource: String? = null,
+    /** metadata.odometer of DASH_START (first non-null wins; a RECOVERY re-start must not clobber it). */
+    val startOdometer: Double? = null,
+    /** Last non-null metadata.odometer seen — miles = lastOdometer − startOdometer, derived in SQL. */
+    val lastOdometer: Double? = null,
+    val reportedEarnings: Double? = null,
+    val reportedDurationMillis: Long? = null,
+    val offersAccepted: Int = 0,
+    val offersDeclined: Int = 0,
+    val offersTimeout: Int = 0,
+    val deliveries: Int = 0,
+    /** Distinct delivered jobIds — [jobsCompleted] is its size (counts a stacked job once). */
+    val deliveredJobIds: Set<String> = emptySet(),
+    /** Partition anchor: odometer at the previous completion; null ⇒ fall back to [startOdometer]. */
+    val prevDropOdometer: Double? = null,
+    /** Partition anchor: time at the previous completion; null ⇒ fall back to [startedAt]. */
+    val prevDropAt: Long? = null,
+    /**
+     * The operating cost-per-mile of the most recent closing offer with an evaluation, in this
+     * session. Session-uniform (one `UserEconomy` per session), so it is the correct frozen basis
+     * for any delivery in the session without a per-job offer↔delivery join (which the event log
+     * cannot express — see [RecordFolds]).
+     */
+    val lastEvaluatedCostPerMile: Double? = null,
+    /**
+     * True once a real DASH_START has established this session's platform/startedAt anchor. A context
+     * synthesized for a session-scoped event that arrived before its DASH_START (e.g. the
+     * OFFER_RECEIVED ordered just ahead of DASH_START at the same instant) is a `_unknown` placeholder
+     * with `started=false`; the DASH_START upgrades it (real platform/startedAt) instead of being
+     * mistaken for a RECOVERY re-start that must not clobber.
+     */
+    val started: Boolean = false,
+) {
+    val jobsCompleted: Int get() = deliveredJobIds.size
+    val offersReceived: Int get() = offersAccepted + offersDeclined + offersTimeout
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/payload/AppEventPayloads.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/payload/AppEventPayloads.kt
@@ -161,6 +161,13 @@ data class SessionPausedPayload(
     val pausedAt: Long,
     val remainingText: String? = null,
     val remainingMillis: Long? = null,
+    /**
+     * The platform's enum name (e.g. "DoorDash"), stamped at the mint site (#314). Hardens the
+     * log so a session-scoped fold can resolve platform without a prior DASH_START in the same
+     * batch — the projector still prefers the session context, this is a self-contained fallback.
+     * JSON-only field: adding it needs no Room migration (`AppEventEntity.eventPayload` is text).
+     */
+    val platform: String? = null,
 ) : AppEventPayload
 
 /** Wire values for [SessionStopPayload.source]. Kept as strings on the payload
@@ -191,4 +198,11 @@ data class SessionStopPayload(
     val offersAccepted: Int? = null,
     val offersTotal: Int? = null,
     val weeklyEarnings: Double? = null,
+    /**
+     * The platform's enum name (e.g. "DoorDash"), stamped at the mint site (#314). Recovers the
+     * session-miles capture gap's platform half for a session whose DASH_START predates the fold
+     * watermark — a self-contained fallback; the projector still prefers the session context.
+     * JSON-only field: adding it needs no Room migration (`AppEventEntity.eventPayload` is text).
+     */
+    val platform: String? = null,
 ) : AppEventPayload

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/RecordFoldsTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/RecordFoldsTest.kt
@@ -283,6 +283,22 @@ class RecordFoldsTest {
     }
 
     @Test
+    fun `a mid-session odometer reset floors the per-drop miles at zero (never negative)`() {
+        val s = "S6b"
+        val (outcomes, _) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 100.0),
+                delivery(s, 2_000, "J1", "T1", totalPay = 5.0, odo = 105.0), // +5
+                delivery(s, 3_000, "J2", "T2", totalPay = 5.0, odo = 90.0),  // odometer reset: −15 → 0
+                delivery(s, 4_000, "J3", "T3", totalPay = 5.0, odo = 95.0),  // re-anchored: 95 − 90 = 5
+            ),
+        )
+        assertEquals(5.0, outcomes[1].delivery!!.realizedMiles!!, 1e-9)
+        assertEquals("negative delta floored, never inflates netProfit", 0.0, outcomes[2].delivery!!.realizedMiles!!, 1e-9)
+        assertEquals(5.0, outcomes[3].delivery!!.realizedMiles!!, 1e-9)
+    }
+
+    @Test
     fun `a malformed payload is skipped and reported, not folded`() {
         val s = "S7"
         val bad = SequencedAppEvent(

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/RecordFoldsTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/RecordFoldsTest.kt
@@ -1,0 +1,310 @@
+package cloud.trotter.dashbuddy.domain.analytics
+
+import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
+import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
+import cloud.trotter.dashbuddy.domain.evaluation.OfferQuality
+import cloud.trotter.dashbuddy.domain.model.event.AppEvent
+import cloud.trotter.dashbuddy.domain.model.event.AppEventType
+import cloud.trotter.dashbuddy.domain.model.event.EventMetadata
+import cloud.trotter.dashbuddy.domain.model.event.SequencedAppEvent
+import cloud.trotter.dashbuddy.domain.model.event.payload.AppEventPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.OfferPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.SessionEndSource
+import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStartPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStartSource
+import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStopPayload
+import cloud.trotter.dashbuddy.domain.model.offer.ParsedOffer
+import cloud.trotter.dashbuddy.domain.model.pay.ParsedPay
+import cloud.trotter.dashbuddy.domain.model.pay.ParsedPayItem
+import cloud.trotter.dashbuddy.domain.state.Flow
+import cloud.trotter.dashbuddy.domain.state.Platform
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Pure fold unit tests (#314, `:domain:test`) for [RecordFolds] — no Android, no DB, no wall clock.
+ * The context is threaded by hand exactly as the orchestrator threads it in-batch, so these assert
+ * the fold's record values and the session accumulator directly.
+ */
+class RecordFoldsTest {
+
+    private var seq = 0L
+    private val cpm = 0.30
+
+    private fun ev(
+        type: AppEventType,
+        sessionId: String?,
+        at: Long,
+        payload: AppEventPayload?,
+        odometer: Double? = null,
+    ) = SequencedAppEvent(
+        sequenceId = ++seq,
+        event = AppEvent(type = type, occurredAt = at, sessionId = sessionId, payload = payload),
+        metadata = odometer?.let { EventMetadata(odometer = it) },
+    )
+
+    private fun dashStart(sid: String, at: Long, odo: Double?, source: String = SessionStartSource.INTERACTION) =
+        ev(
+            AppEventType.DASH_START, sid, at,
+            SessionStartPayload(sid, Platform.DoorDash.name, startedAt = at, source = source, startScreen = "x"),
+            odometer = odo,
+        )
+
+    private fun eval(net: Double, dist: Double, opCpm: Double) = OfferEvaluation(
+        action = OfferAction.ACCEPT,
+        score = 80.0,
+        qualityLevel = OfferQuality.GOOD,
+        payAmount = net + dist * opCpm,
+        fuelCostEstimate = 0.0,
+        operatingCostPerMile = opCpm,
+        netPayAmount = net,
+        distanceMiles = dist,
+        dollarsPerMile = if (dist > 0) net / dist else 0.0,
+        dollarsPerHour = 20.0,
+        estimatedTimeMinutes = 15.0,
+        itemCount = 1.0,
+        merchantName = "StoreX",
+    )
+
+    private fun offerAccepted(sid: String, at: Long, hash: String, evaluation: OfferEvaluation?) = ev(
+        AppEventType.OFFER_ACCEPTED, sid, at,
+        OfferPayload(
+            offerHash = hash,
+            parsedOffer = ParsedOffer(offerHash = hash, payAmount = 12.0, distanceMiles = 3.0, itemCount = 1),
+            evaluation = evaluation,
+            outcome = AppEventType.OFFER_ACCEPTED,
+            presentedAt = at - 30_000,
+            decidedAt = at,
+            returnFlow = Flow.Idle,
+        ),
+    )
+
+    private fun parsedPay(base: Double, tip: Double, tipStore: String = "StoreX") = ParsedPay(
+        appPayComponents = listOf(ParsedPayItem(type = "Base Pay", amount = base)),
+        customerTips = listOf(ParsedPayItem(type = tipStore, amount = tip)),
+    )
+
+    private fun delivery(
+        sid: String?,
+        at: Long,
+        jobId: String,
+        taskId: String,
+        totalPay: Double? = null,
+        dropRealizedPay: Double? = null,
+        parsedPay: ParsedPay? = null,
+        odo: Double? = null,
+        phaseStartedAt: Long = at - 600_000,
+    ) = ev(
+        AppEventType.DELIVERY_COMPLETED, sid, at,
+        DeliveryPayload(
+            jobId = jobId, taskId = taskId, storeName = "StoreX",
+            customerHash = "cust-$taskId", addressHash = "addr-$taskId",
+            phaseStartedAt = phaseStartedAt, arrivedAt = at - 120_000, completedAt = at,
+            totalPay = totalPay, parsedPay = parsedPay, dropRealizedPay = dropRealizedPay,
+        ),
+        odometer = odo,
+    )
+
+    private fun dashStop(sid: String, at: Long, odo: Double?, earnings: Double?) = ev(
+        AppEventType.DASH_STOP, sid, at,
+        SessionStopPayload(sid, endedAt = at, source = SessionEndSource.SUMMARY_SCREEN, totalEarnings = earnings),
+        odometer = odo,
+    )
+
+    // Thread a session's events, returning the outcomes in order and the final context.
+    private fun foldSession(events: List<SequencedAppEvent>, currentCpm: Double? = null): Pair<List<FoldOutcome>, SessionFoldContext?> {
+        var ctx: SessionFoldContext? = null
+        val outcomes = events.map { e ->
+            val o = RecordFolds.foldEvent(e, ctx, currentCpm)
+            ctx = o.context ?: ctx
+            o
+        }
+        return outcomes to ctx
+    }
+
+    @Test
+    fun `full single-delivery session folds to expected records`() {
+        val s = "S1"
+        val (outcomes, ctx) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 100.0),
+                offerAccepted(s, 2_000, "h1", eval(net = 9.0, dist = 3.0, opCpm = 0.25)),
+                delivery(s, 3_000, "J1", "T1", totalPay = 10.0, parsedPay = parsedPay(base = 7.0, tip = 3.0), odo = 105.0),
+                dashStop(s, 4_000, odo = 110.0, earnings = 10.0),
+            ),
+        )
+
+        val d = outcomes[2].delivery!!
+        assertEquals("J1", d.jobId)
+        assertEquals(10.0, d.realizedPay!!, 1e-9)
+        assertEquals(PayBasis.RECEIPT_TOTAL, d.payBasis)
+        assertEquals(5.0, d.realizedMiles!!, 1e-9)               // 105 − 100
+        assertEquals((3_000 - 1_000) / 60_000.0, d.realizedMinutes!!, 1e-9)
+        assertEquals(0.25, d.frozenCostPerMile!!, 1e-9)          // from the accepted offer's eval
+        assertEquals(CostBasis.OFFER_FROZEN, d.costBasis)
+        assertEquals(10.0 - 5.0 * 0.25, d.netProfit!!, 1e-9)     // 8.75
+        assertEquals(3.0, d.tip!!, 1e-9)                          // single drop ⇒ tip from parsedPay
+        assertEquals(7.0, d.basePay!!, 1e-9)
+
+        val offer = outcomes[1].offer!!
+        assertEquals("OFFER_ACCEPTED", offer.outcome)
+        assertEquals(0.25, offer.estOperatingCostPerMile!!, 1e-9)
+        assertEquals("doordash", offer.platform)
+
+        assertEquals(1, ctx!!.deliveries)
+        assertEquals(1, ctx.jobsCompleted)
+        assertEquals(1, ctx.offersAccepted)
+        assertEquals(1, ctx.offersReceived)
+        assertEquals(100.0, ctx.startOdometer!!, 1e-9)
+        assertEquals(110.0, ctx.lastOdometer!!, 1e-9)
+        assertEquals(4_000L, ctx.endedAt)
+        assertEquals(SessionEndSource.SUMMARY_SCREEN, ctx.endSource)
+        assertEquals(10.0, ctx.reportedEarnings!!, 1e-9)
+        assertEquals("doordash", ctx.platform.wire)
+    }
+
+    @Test
+    fun `frozen economy - offer basis wins, no offer falls back to current, neither is NONE`() {
+        val s = "S2"
+        // Delivery WITH a preceding accepted offer → OFFER_FROZEN.
+        val (withOffer, _) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 0.0),
+                offerAccepted(s, 2_000, "h", eval(net = 8.0, dist = 4.0, opCpm = 0.40)),
+                delivery(s, 3_000, "J1", "T1", totalPay = 10.0, odo = 4.0),
+            ),
+            currentCpm = 0.99,
+        )
+        val d1 = withOffer[2].delivery!!
+        assertEquals(CostBasis.OFFER_FROZEN, d1.costBasis)
+        assertEquals(0.40, d1.frozenCostPerMile!!, 1e-9)
+
+        // Delivery with NO offer in the session but a current economy → CURRENT_FALLBACK.
+        val (noOffer, _) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 0.0),
+                delivery(s, 3_000, "J1", "T1", totalPay = 10.0, odo = 4.0),
+            ),
+            currentCpm = 0.50,
+        )
+        val d2 = noOffer[1].delivery!!
+        assertEquals(CostBasis.CURRENT_FALLBACK, d2.costBasis)
+        assertEquals(0.50, d2.frozenCostPerMile!!, 1e-9)
+        assertEquals(10.0 - 4.0 * 0.50, d2.netProfit!!, 1e-9)
+
+        // No offer AND no current economy → NONE, null net.
+        val (none, _) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 0.0),
+                delivery(s, 3_000, "J1", "T1", totalPay = 10.0, odo = 4.0),
+            ),
+            currentCpm = null,
+        )
+        val d3 = none[1].delivery!!
+        assertEquals(CostBasis.NONE, d3.costBasis)
+        assertNull(d3.frozenCostPerMile)
+        assertNull(d3.netProfit)
+    }
+
+    @Test
+    fun `RECOVERY re-start does not clobber startedAt or startOdometer`() {
+        val s = "S3"
+        var ctx: SessionFoldContext? = null
+        ctx = RecordFolds.foldEvent(dashStart(s, 1_000, odo = 50.0), ctx, null).context
+        // A crash-recovery re-start of the SAME session at a later time with a later odometer.
+        ctx = RecordFolds.foldEvent(dashStart(s, 9_000, odo = 60.0, source = SessionStartSource.RECOVERY), ctx, null).context
+        assertEquals("startedAt is the original", 1_000L, ctx!!.startedAt)
+        assertEquals("startOdometer is the original", 50.0, ctx.startOdometer!!, 1e-9)
+        assertEquals("lastEventAt advances", 9_000L, ctx.lastEventAt)
+        assertEquals("lastOdometer advances", 60.0, ctx.lastOdometer!!, 1e-9)
+    }
+
+    @Test
+    fun `RECOVERY re-start fills a still-null startOdometer`() {
+        val s = "S3b"
+        var ctx: SessionFoldContext? = null
+        ctx = RecordFolds.foldEvent(dashStart(s, 1_000, odo = null), ctx, null).context
+        ctx = RecordFolds.foldEvent(dashStart(s, 2_000, odo = 42.0, source = SessionStartSource.RECOVERY), ctx, null).context
+        assertEquals(42.0, ctx!!.startOdometer!!, 1e-9)
+    }
+
+    @Test
+    fun `stacked dropRealizedPay rows sum to the receipt and carry no per-drop tip split`() {
+        val s = "S4"
+        // Two drops of one stacked job; the apportioner (upstream) already split the $20 receipt.
+        val (outcomes, ctx) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 0.0),
+                offerAccepted(s, 1_500, "h", eval(net = 15.0, dist = 5.0, opCpm = 0.20)),
+                delivery(s, 3_000, "J1", "T1", dropRealizedPay = 11.34, parsedPay = parsedPay(8.0, 12.0), odo = 5.0),
+                delivery(s, 4_000, "J1", "T2", dropRealizedPay = 8.66, parsedPay = parsedPay(8.0, 12.0), odo = 8.0),
+            ),
+        )
+        val d1 = outcomes[2].delivery!!
+        val d2 = outcomes[3].delivery!!
+        assertEquals(PayBasis.DROP_SHARE, d1.payBasis)
+        assertEquals(20.0, d1.realizedPay!! + d2.realizedPay!!, 1e-9)   // Σ shares == receipt
+        assertNull("no per-drop tip split on a stack", d1.tip)
+        assertNull(d1.basePay)
+        assertEquals("stacked job counted once", 1, ctx!!.jobsCompleted)
+        assertEquals(2, ctx.deliveries)
+    }
+
+    @Test
+    fun `partition miles sum to the session odometer delta`() {
+        val s = "S5"
+        val (outcomes, _) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 100.0),
+                delivery(s, 2_000, "J1", "T1", totalPay = 5.0, odo = 104.0), // 4 mi
+                delivery(s, 3_000, "J2", "T2", totalPay = 5.0, odo = 111.0), // 7 mi
+                delivery(s, 4_000, "J3", "T3", totalPay = 5.0, odo = 120.0), // 9 mi
+            ),
+        )
+        val miles = outcomes.mapNotNull { it.delivery?.realizedMiles }
+        assertEquals(listOf(4.0, 7.0, 9.0), miles)
+        assertEquals("Σ per-drop miles == last − start odo", 20.0, miles.sum(), 1e-9)
+    }
+
+    @Test
+    fun `null odometer drop yields null miles and folds its distance into the next drop`() {
+        val s = "S6"
+        val (outcomes, _) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 100.0),
+                delivery(s, 2_000, "J1", "T1", totalPay = 5.0, odo = null),   // no odo → null miles
+                delivery(s, 3_000, "J2", "T2", totalPay = 5.0, odo = 115.0),  // spans the gap: 115 − 100
+            ),
+        )
+        assertNull(outcomes[1].delivery!!.realizedMiles)
+        assertEquals(15.0, outcomes[2].delivery!!.realizedMiles!!, 1e-9)
+    }
+
+    @Test
+    fun `a malformed payload is skipped and reported, not folded`() {
+        val s = "S7"
+        val bad = SequencedAppEvent(
+            sequenceId = ++seq,
+            event = AppEvent(AppEventType.DELIVERY_COMPLETED, occurredAt = 2_000, sessionId = s, payload = null),
+        )
+        val ctx = RecordFolds.foldEvent(dashStart(s, 1_000, odo = 0.0), null, null).context
+        val out = RecordFolds.foldEvent(bad, ctx, null)
+        assertNull(out.delivery)
+        assertEquals("context is preserved unchanged", ctx, out.context)
+        org.junit.Assert.assertNotNull(out.skip)
+    }
+
+    @Test
+    fun `a delivery with no session id produces an unknown-platform row and no context`() {
+        val out = RecordFolds.foldEvent(
+            delivery(sid = null, at = 2_000, jobId = "J1", taskId = "T1", totalPay = 5.0, odo = 4.0),
+            context = null,
+            currentCostPerMile = null,
+        )
+        assertEquals(Platform.Unknown.wire, out.delivery!!.platform)
+        assertNull(out.delivery!!.sessionId)
+        assertNull("no session context is created for a session-less event", out.context)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,6 +51,7 @@ androidx-room-runtime = { group = "androidx.room", name = "room-runtime", versio
 androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
 androidx-room-paging = { group = "androidx.room", name = "room-paging", version.ref = "room" }
+androidx-room-testing = { group = "androidx.room", name = "room-testing", version.ref = "room" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-fragment-ktx = { module = "androidx.fragment:fragment-ktx", version.ref = "androidxFragmentKtx" }


### PR DESCRIPTION
## What shipped (#314 PR2 — the core of the read-model)

The **analytics projector**: the event-sourced CQRS fold of the durable `app_events` log into the PR1 read-model tables, its one-time backfill, and the FROZEN-economy computation. Consumes the merged PR1 schema (entities/DAO, `SequencedAppEvent`, `AppEventRepo.getEventsAfter`, `AppEventDao.getEventsAfter`/`maxSequenceId`).

**Pure fold → `:domain`** (`analytics/RecordFolds.kt` + `SessionFoldContext.kt`): `(event, session context, current cpm) → record deltas`. No Android/DB/wall-clock (`:domain:test`-able like `DropPayApportioner`), so **backfill ≡ incremental** and a `projectorVersion` rebuild reproduces identical rows. `:domain` can't see `:core:database`, so the fold emits domain `DeliveryFold`/`OfferFold`/`SessionFoldContext` value objects the orchestrator maps 1:1 to entities.

**Orchestrator → `:core:data`** (`analytics/AnalyticsProjector.kt`, `@Singleton @Inject`):
- Trigger = `appEventDao.maxSequenceId()` (Room-invalidation, `.conflate()`); drains paged `getEventsAfter` batches (limit 500).
- **Exactly-once:** records + watermark advance in ONE `db.withTransaction`; record PKs are the source `sequenceId` with `REPLACE` ⇒ a re-run is a byte-identical no-op. **Backfill = the first drain from watermark 0** (no separate path). `projectorVersion` mismatch ⇒ `deleteAll*` + refold ≡ backfill.
- Restart-correct **context hydration** from the record tables (why `odometerAtCompletion` is stored) + distinct-job set + session's last offer cpm; **inferred-close** of crash-orphaned sessions on the next DASH_START.
- **Started from `DashBuddyApplication.onCreate` — NOT debug-gated** (mirrors `shadowStoreChainLogger.start`).

**Capture-gap (refinement 2):** `platform: String? = null` added to `SessionStopPayload`/`SessionPausedPayload` + stamped at the `EffectMap` mint sites (JSON-only, no migration).

**Corrections (refinement 3): OUT OF PR2.** No `MANUAL_DELIVERY`/`PAY_ADJUSTMENT` types here — the fold is a clean generic `when(eventType)` a correction case slots into later with the editing UI (#650).

### Frozen-economy source chosen: (a) `OFFER_FROZEN`, at **session** granularity

I investigated the offer→delivery link and it is **not clean at the event-log level**: `OFFER_ACCEPTED`'s `OfferPayload` carries no `jobId`, `DELIVERY_COMPLETED`'s `DeliveryPayload` carries no `offerHash`, `jobId` is a **minted id** (`mintId("job", …)`) unrelated to `offerHash`, and the only offer→job bridge (`Job.parentOfferHashes` / `AcceptedOfferEconomics`) lives in ephemeral `:core:state` runtime, never persisted to the log. A per-job join is therefore impossible without new plumbing, and a sequence-order correlation is ambiguous under stacks.

**Key insight that avoids the join entirely:** `operatingCostPerMile` derives from the single per-session `UserEconomy`, so it is **session-uniform** — every offer in a session was evaluated against the same cpm. So the fold captures the operating cpm of the most recent closing offer's `OfferEvaluation` into the session context and applies it to every delivery in that session. This is genuinely the offer's frozen economics (`costBasis = OFFER_FROZEN`), correlated at session granularity, and it's **rebuild-stable** (the offers are in the durable log). It also means **no `EffectMap`/`DeliveryPayload` change for economy** — smaller blast radius than the refinement's fallback (b) metadata stamp, which was in fact infeasible cleanly (`createMetadata()` is a device-sensor stamp in `:app` with no access to the offer economics).

Fallbacks: `CURRENT_FALLBACK` (live economy cpm, honestly flagged, for an offer-less/healed session) → `NONE`. `netProfit = NetProfit.net(realizedPay, realizedMiles, frozenCostPerMile)` via the already-merged `NetProfit` SSOT — **immutable**; editing economy settings never moves a stored value.

## Security / privacy posture

No new capture, no network, **no new PII surface** — the projector re-reads a log that already passed the edge hash (`customerHash`/`addressHash` are sha256). The only new writes are the `platform` enum-name stamp (not PII) on two session payloads. **Principle 7:** the single INFO backfill milestone and the per-batch DEBUG line carry **counts only**, never store/customer text (`storeName` is fine at rest in the DB but stays out of INFO+). Malformed/`skip` events are counted and WARN-per-batch (a defended invariant), never crash the loop.

## Tests

| Suite | Where | Count | Proves |
|---|---|---|---|
| `RecordFoldsTest` | `:domain:test` | 9 | pure fold: full session record values; frozen-economy resolution (OFFER_FROZEN / CURRENT_FALLBACK / NONE); RECOVERY re-start non-clobber (+ null-odo fill); stacked `dropRealizedPay` Σ = receipt, no per-drop tip split; partition-miles Σ = session delta; null-odometer → null miles folded into next drop; malformed skip; session-less → `_unknown` row |
| `AnalyticsProjectorTest` | `:app` (Robolectric+Room) | 6 | watermark catch-up; **restart between batches** folds exactly once + rehydrates the frozen basis from the DB; **re-run** identical tables; malformed payload skipped+counted, watermark still advances; `projectorVersion` bump wipe+refold == fresh; inferred-close of a crash-orphaned session |
| `AnalyticsBackfillReplayTest` | `:app` | 1 | real `SessionReplay` (2026-06-16 single delivery) → app_events → projector from 0 → hand-authored invariants (1 delivery, 1 job, session miles == odo delta, drop miles == session delta) — oracle discipline (never `replay == db`) |
| `AnalyticsDaoProjectorSupportTest` | `:app` | 6 | PR1-review finding 2: `sessionTotals` `MAX(…,0)` floor + `COALESCE(endedAt,lastEventAt)`, per-platform aggregates, `upsertSession`/`upsertOffer` REPLACE, `sessionRecord`/`lastDeliveryInSession`/`openSessions` + the two new hydration queries |
| `AnalyticsMigration8to9Test` | `:core:database` **androidTest** | 1 | PR1-review finding 1: populated v8 DB → real `AutoMigration(8→9)` → app_events rows preserved + 4 new tables exist. *(Instrumented — needs a device/`connectedAndroidTest`; not in the unit gate because `MigrationTestHelper` opens on-disk SQLite.)* |

Full unit gate green (`JAVA_HOME=/usr/lib/jvm/java-25-openjdk`): **`:domain:test` 261, `:core:state:testDebugUnitTest` 103, `:app:testDebugUnitTest` 595 — 0 failures**; `AllMatchersSuite` green. (30 of those are new analytics+fold tests.)

### Design-goal review

- **P1 UDF:** the fold is a pure `:domain` function (no wall clock, `obs`/event timestamps only); the projector observes the durable DB, never injects reads into a reducer; totals never enter the state machine. `catchUp()`/`processBatch(limit)` are exposed for deterministic tests, not a UI write path.
- **P3 single responsibility:** pure fold (`:domain`) vs. impure orchestration (`:core:data`) cleanly split; small files.
- **P5 SSOT:** reuses the merged `NetProfit` helper — **no economy math re-implemented**; `PayBasis`/`CostBasis` string vocab owned once in `:domain`; the fold→entity mapping is the standard domain↔persistence boundary (like `AppEvent`↔`AppEventEntity`), not a divergent second copy.
- **P6 security/privacy:** see posture above — no new capture/network/PII; frozen values immutable.
- **P7 logging:** stable `Analytics` tag; INFO = one PII-safe counts-only milestone; DEBUG per-batch; WARN on skips; ERROR path is the transaction (rolls back + retries).
- **P8 platform-agnostic:** platform resolves only through `Platform.fromName`/`fromWire` (never a literal); the fold is a generic `when(eventType)` over the enumerated `AppEventType`; per-session platform is keyed data, never a global. The `EffectMap` platform stamp uses `region.platform.name`, no literal.

### Notes for the gating developer
- Per the *"every PR ships with context updates"* rule, the **memory + CLAUDE.md architecture §** should be updated on merge to record the projector as a live component; I left those to you since you gate this. A **"Next field test"** checklist item was added to `docs/field-testing/README.md` (backfill INFO line appears once; delivery/session counts match the field week; frozen values don't move on economy edits).
- The `AnalyticsMigration8to9Test` is `androidTest` (canonical home for `MigrationTestHelper`); it runs via `:core:database:connectedAndroidTest`, not the unit gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

### Design-goal review
Projector + fold (`:domain` pure fold, `:core:data` orchestrator, `:app` wiring) + a JSON-only platform-stamp on session payloads.
- **P1 (UDF/purity):** `RecordFolds`/`SessionFoldContext` are pure (no Android/DB/wall-clock, driven by `event.occurredAt`); all impurity (paging, hydration, the records+watermark transaction) lives in the `:core:data` orchestrator — the state steppers are untouched.
- **P5 (SSOT):** realized net uses the merged `NetProfit` helper (no cost-math re-implementation); the frozen cpm is inherited from the offer's own evaluation.
- **P8 (platform-agnostic):** platform is resolved via the `Platform` registry (`fromName`/`fromWire`), never id-parsed or literal; the session-payload stamp uses `platform.name` data.
- **P7 (logging):** the INFO backfill milestone + per-batch lines carry counts only — no store/customer text at any level.

### Adversarial review
**Fable initial review (full adversarial pass on the original projector) — CLEAN except one HIGH finding (F1).** It confirmed exactly-once folding (records + watermark in one transaction, seq-PK REPLACE), backfill≡incremental≡rebuild, the session-granularity frozen-economy soundness, miles-partition semantics, restart-correct hydration, and runtime safety (off-main, supervised scope). It found F1 (the OFFER-before-DASH_START placeholder upgrade broke across a batch boundary → sessions permanently mis-platformed) + minor F2/F4/F5/F6, and required F1 fixed in-PR.

**Fix + Opus delta-verification (fable exhausted; developer-authorized Opus for the bounded fix-check since fable did the substantive review) — FIXES-CLOSED.** F1 fixed on both sides — hydration sets `started` from whether the platform is real (`fromWire("_unknown")→Unknown→started=false`), and `foldDashStart` upgrades a still-`_unknown` placeholder while still not clobbering a genuine RECOVERY re-start — proven by a **non-vacuous** cross-batch regression test (fresh projector instance forces the DB-hydration path; fails against the pre-fix code). F2: supervised try/catch with `CancellationException` caught-first-and-rethrown + bounded exponential-backoff resubscribe (#430 pattern); F5: per-row miles floored at 0 (null preserved) + test; F6: inferred-close-across-batch test exercising the `openSessions` DB arm; F4: KDoc exactly-once precision. No regression, no new defects; CI green.

One edge case (identity-less drop in a receipted stack → period double-count, the #517/#518 phantom class surfaced in the fold) is tracked as **#653**.
