### PR TITLE
feat(#314): AnalyticsRepository + real "Today" home glance (PR3, completes #314)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardScreen.kt
@@ -46,6 +46,8 @@ import cloud.trotter.dashbuddy.core.designsystem.component.AppCard
 import cloud.trotter.dashbuddy.core.designsystem.component.AppStatTile
 import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
 import cloud.trotter.dashbuddy.core.designsystem.time.rememberNow
+import cloud.trotter.dashbuddy.domain.analytics.PeriodEconomics
+import cloud.trotter.dashbuddy.domain.format.Formats
 import cloud.trotter.dashbuddy.ui.main.navigation.Screen
 import cloud.trotter.dashbuddy.ui.main.setup.permissions.PermissionsBottomSheet
 import cloud.trotter.dashbuddy.util.PermissionUtils
@@ -131,7 +133,8 @@ fun DashboardScreen(
                     ) { Text("Skip for now") }
                 }
 
-                // CASE 3: Ready — status card, live "this dash" glance, entry tiles.
+                // CASE 3: Ready — status card, real "Today" glance (read-model),
+                // the live "this dash" glance while online, then entry tiles.
                 else -> {
                     StatusCard(
                         title = uiState.statusText,
@@ -140,7 +143,11 @@ fun DashboardScreen(
                     )
                     Spacer(modifier = Modifier.height(16.dp))
 
-                    ThisDashGlance(glance = uiState.glance)
+                    TodayGlance(today = uiState.today)
+                    if (uiState.isInSession) {
+                        Spacer(modifier = Modifier.height(12.dp))
+                        ThisDashGlance(glance = uiState.glance)
+                    }
                     Spacer(modifier = Modifier.height(16.dp))
 
                     EntryTileGrid(onNavigate = onNavigate)
@@ -153,6 +160,41 @@ fun DashboardScreen(
                 }
             }
         }
+    }
+}
+
+/**
+ * The primary home glance — real **Today** economics from the durable read model:
+ * True Net · Net $/hr · Miles. Frozen net (Σ each delivery's net against its accepted
+ * cost basis + unattributed pay), so an economy edit never rewrites past days. It
+ * re-renders without a state transition (Reactive UI rule 4): the `today` flow
+ * re-emits on every projector commit (Room invalidation) and at midnight rollover.
+ */
+@Composable
+private fun TodayGlance(today: PeriodEconomics) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        AppStatTile(
+            label = "True Net",
+            value = Formats.money(today.netProfit),
+            sub = "Today",
+            valueColor = if (today.netProfit >= 0.0) AppTheme.colors.good else AppTheme.colors.bad,
+            modifier = Modifier.weight(1f),
+        )
+        AppStatTile(
+            label = "Net/hr",
+            value = today.netPerHour?.let { Formats.money(it) } ?: DashGlance.EMPTY_VALUE,
+            sub = "Today",
+            modifier = Modifier.weight(1f),
+        )
+        AppStatTile(
+            label = "Miles",
+            value = Formats.decimal(today.totals.miles),
+            sub = "Today",
+            modifier = Modifier.weight(1f),
+        )
     }
 }
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardUiState.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardUiState.kt
@@ -1,20 +1,28 @@
 package cloud.trotter.dashbuddy.ui.main.dashboard
 
+import cloud.trotter.dashbuddy.domain.analytics.PeriodEconomics
 import cloud.trotter.dashbuddy.domain.evaluation.NetProfit
 import cloud.trotter.dashbuddy.domain.format.Formats
 import cloud.trotter.dashbuddy.domain.format.formatDuration
 
 /**
  * Immutable state for the home (Dashboard) screen (Principle 1 — UDF). Bundles the
- * first-run / status gate with a live "this dash" economics [glance]. Permissions
- * stay a composable-local OS re-check (they must be re-read on every `ON_RESUME`),
- * so they are intentionally NOT modelled here.
+ * first-run / status gate with the [today] read-model economics (the primary glance)
+ * and the live "this dash" [glance] (shown while online). Permissions stay a
+ * composable-local OS re-check (re-read on every `ON_RESUME`), so they are
+ * intentionally NOT modelled here.
+ *
+ * [today] comes from `AnalyticsRepository.periodEconomics(TODAY)` and re-emits as the
+ * projector folds each completed delivery (Room invalidation) and at midnight rollover
+ * — frozen net, never recomputed against the live economy. [glance] is the live,
+ * per-second ticking this-dash view (#320).
  */
 data class DashboardUiState(
     val isFirstRun: Boolean = true,
     val statusText: String = "Offline",
     val isInSession: Boolean = false,
     val glance: DashGlance = DashGlance.EMPTY,
+    val today: PeriodEconomics = PeriodEconomics.EMPTY,
 )
 
 /**

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardViewModel.kt
@@ -2,9 +2,11 @@ package cloud.trotter.dashbuddy.ui.main.dashboard
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import cloud.trotter.dashbuddy.core.data.analytics.AnalyticsRepository
 import cloud.trotter.dashbuddy.core.data.location.OdometerRepository
 import cloud.trotter.dashbuddy.core.data.settings.AppPreferencesRepository
 import cloud.trotter.dashbuddy.core.data.state.AppStateRepository
+import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
 import cloud.trotter.dashbuddy.domain.evaluation.NetProfit
 import cloud.trotter.dashbuddy.domain.model.chat.ChatPersona
 import cloud.trotter.dashbuddy.domain.state.AppState
@@ -29,7 +31,9 @@ import javax.inject.Inject
  *  - [OdometerRepository] session miles (GPS),
  *  - [AppPreferencesRepository.userEconomy] — operating cost/mi, the SAME economy
  *    the offer verdict scores against (so live True Net uses identical cost math),
- *  - [AppStateRepository.isFirstRun] — the setup gate.
+ *  - [AppStateRepository.isFirstRun] — the setup gate,
+ *  - [AnalyticsRepository.periodEconomics] — the real **Today** totals from the durable
+ *    read model (frozen net, re-emits as the projector folds each delivery + at midnight).
  *
  * The focused platform is resolved through the [Platform] registry (flow's active
  * platform, else most-recent activity) — never a `== DoorDash` literal (Principle 8).
@@ -40,6 +44,7 @@ class DashboardViewModel @Inject constructor(
     odometerRepository: OdometerRepository,
     appPreferencesRepository: AppPreferencesRepository,
     stateManager: StateManagerV2,
+    analyticsRepository: AnalyticsRepository,
     private val bubbleManager: BubbleManager,
 ) : ViewModel() {
 
@@ -48,7 +53,8 @@ class DashboardViewModel @Inject constructor(
         odometerRepository.sessionMilesFlow,
         appPreferencesRepository.userEconomy,
         appStateRepository.isFirstRun,
-    ) { state, sessionMiles, economy, firstRun ->
+        analyticsRepository.periodEconomics(AnalyticsPeriod.TODAY),
+    ) { state, sessionMiles, economy, firstRun, today ->
         val region = focusedRegion(state)
         val inSession = region != null && region.mode != Mode.Offline
         val session = region?.session
@@ -72,6 +78,7 @@ class DashboardViewModel @Inject constructor(
             statusText = statusText(state.regions.flow.flow, region?.mode),
             isInSession = inSession,
             glance = glance,
+            today = today,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), DashboardUiState())
 

--- a/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsRepositoryTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsRepositoryTest.kt
@@ -1,0 +1,232 @@
+package cloud.trotter.dashbuddy.analytics
+
+import androidx.room.Room
+import cloud.trotter.dashbuddy.core.data.analytics.AnalyticsRepository
+import cloud.trotter.dashbuddy.core.database.DashBuddyDatabase
+import cloud.trotter.dashbuddy.core.database.analytics.AnalyticsDao
+import cloud.trotter.dashbuddy.core.database.analytics.DeliveryRecordEntity
+import cloud.trotter.dashbuddy.core.database.analytics.SessionRecordEntity
+import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+/**
+ * #314 PR3 — `AnalyticsRepository` over an in-memory v9 database. Proves:
+ *  - period net = Σ **frozen** `netProfit` + unattributed pay (NOT recomputed vs a live economy),
+ *  - gross = reported-total-authoritative per session, summed,
+ *  - unattributed = reported − delivered where reported exceeds delivered,
+ *  - per-store grouping, and the TODAY/THIS_WEEK/LIFETIME windows.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AnalyticsRepositoryTest {
+
+    private lateinit var db: DashBuddyDatabase
+    private lateinit var dao: AnalyticsDao
+    private lateinit var repo: AnalyticsRepository
+
+    private val base = 1_600_000_000_000L // a stable epoch inside every window's LIFETIME
+    private val hour = 3_600_000L
+    private val day = 86_400_000L
+
+    @Before
+    fun setUp() {
+        val context = RuntimeEnvironment.getApplication()
+        db = Room.inMemoryDatabaseBuilder(context, DashBuddyDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = db.analyticsDao()
+        repo = AnalyticsRepository(dao)
+    }
+
+    @After
+    fun tearDown() = db.close()
+
+    private fun delivery(
+        seq: Long,
+        sessionId: String,
+        jobId: String,
+        storeName: String?,
+        pay: Double?,
+        net: Double?,
+        completedAt: Long,
+        platform: String = "doordash",
+    ) = DeliveryRecordEntity(
+        eventSequenceId = seq,
+        sessionId = sessionId,
+        platform = platform,
+        jobId = jobId,
+        taskId = "T$seq",
+        storeName = storeName,
+        customerHash = "chash-$seq",
+        addressHash = "ahash-$seq",
+        phaseStartedAt = completedAt - 600_000,
+        arrivedAt = completedAt - 120_000,
+        completedAt = completedAt,
+        deadlineMillis = null,
+        realizedPay = pay,
+        payBasis = "DROP_SHARE",
+        tip = null,
+        basePay = null,
+        odometerAtCompletion = null,
+        realizedMiles = null,
+        realizedMinutes = null,
+        frozenCostPerMile = 0.30,
+        netProfit = net,
+        costBasis = "OFFER_FROZEN",
+    )
+
+    private fun session(
+        id: String,
+        startedAt: Long,
+        reportedEarnings: Double?,
+        durationMillis: Long,
+        startOdo: Double?,
+        lastOdo: Double?,
+        deliveries: Int,
+        jobsCompleted: Int,
+        platform: String = "doordash",
+    ) = SessionRecordEntity(
+        sessionId = id,
+        platform = platform,
+        startedAt = startedAt,
+        endedAt = startedAt + durationMillis,
+        lastEventAt = startedAt + durationMillis,
+        endSource = "summary_screen",
+        startOdometer = startOdo,
+        lastOdometer = lastOdo,
+        reportedEarnings = reportedEarnings,
+        reportedDurationMillis = durationMillis,
+        offersReceived = 0,
+        offersAccepted = 0,
+        offersDeclined = 0,
+        offersTimeout = 0,
+        deliveries = deliveries,
+        jobsCompleted = jobsCompleted,
+    )
+
+    /**
+     * The core lock: period net = Σ frozen delivery netProfit + unattributed; gross is the
+     * reported total when present, else delivered pay; unattributed is the positive excess.
+     */
+    @Test
+    fun `LIFETIME nets frozen delivery net plus unattributed, gross reported-authoritative`() = runBlocking {
+        // Session 1: reported 50 > delivered 40 → 10 unattributed. Miles 10, 2h.
+        dao.upsertSession(session("S1", base, reportedEarnings = 50.0, durationMillis = 2 * hour, startOdo = 100.0, lastOdo = 110.0, deliveries = 2, jobsCompleted = 1))
+        dao.upsertDelivery(delivery(1, "S1", "J1", "Wendys", pay = 25.0, net = 20.0, completedAt = base + hour))
+        dao.upsertDelivery(delivery(2, "S1", "J1", "Wendys", pay = 15.0, net = 13.0, completedAt = base + 2 * hour))
+        // Session 2: no reported summary → gross falls back to delivered 20, unattributed 0. Miles 5, 1h.
+        dao.upsertSession(session("S2", base + 10 * hour, reportedEarnings = null, durationMillis = hour, startOdo = 200.0, lastOdo = 205.0, deliveries = 1, jobsCompleted = 1))
+        dao.upsertDelivery(delivery(3, "S2", "J2", "Chipotle", pay = 20.0, net = 17.0, completedAt = base + 11 * hour))
+
+        val eco = repo.periodEconomics(AnalyticsPeriod.LIFETIME).first()
+
+        // Frozen delivery net = 20 + 13 + 17 = 50; unattributed = 10; period net = 60.
+        assertEquals(60.0, eco.netProfit, 1e-9)
+        assertEquals(10.0, eco.unattributedPay, 1e-9)
+        // Gross = 50 (S1 reported) + 20 (S2 delivered) = 70.
+        assertEquals(70.0, eco.grossEarnings, 1e-9)
+        // Delivered pay (totals.earnings) = 25 + 15 + 20 = 60.
+        assertEquals(60.0, eco.totals.earnings, 1e-9)
+        assertEquals(3, eco.totals.deliveries)
+        assertEquals(2, eco.totals.jobs)
+        // Miles = 10 + 5 = 15; online = 3h → net/hr = 60/3 = 20, net/mi = 60/15 = 4.
+        assertEquals(15.0, eco.totals.miles, 1e-9)
+        assertEquals(3 * hour, eco.totals.onlineDuration)
+        assertEquals(20.0, eco.netPerHour!!, 1e-9)
+        assertEquals(4.0, eco.netPerMile!!, 1e-9)
+    }
+
+    /**
+     * Net is the FROZEN stored value, not `pay − miles × cpm` against any live economy — the
+     * repository has no economy input at all, so an economy edit cannot move a period's net.
+     */
+    @Test
+    fun `net equals the stored frozen netProfit, not a recomputation`() = runBlocking {
+        // realizedPay 10, but the frozen net is 7 — a recompute against economy would differ.
+        dao.upsertSession(session("S1", base, reportedEarnings = null, durationMillis = hour, startOdo = 0.0, lastOdo = 4.0, deliveries = 1, jobsCompleted = 1))
+        dao.upsertDelivery(delivery(1, "S1", "J1", "Wendys", pay = 10.0, net = 7.0, completedAt = base + 100))
+
+        val eco = repo.periodEconomics(AnalyticsPeriod.LIFETIME).first()
+        assertEquals(7.0, eco.netProfit, 1e-9)     // the stored frozen net, verbatim
+        assertEquals(0.0, eco.unattributedPay, 1e-9)
+        assertEquals(10.0, eco.grossEarnings, 1e-9)
+    }
+
+    @Test
+    fun `perStoreEconomics groups by store with frozen net, busiest first`() = runBlocking {
+        dao.upsertDelivery(delivery(1, "S1", "J1", "Wendys", pay = 10.0, net = 8.0, completedAt = base + hour))
+        dao.upsertDelivery(delivery(2, "S1", "J1", "Wendys", pay = 6.0, net = 5.0, completedAt = base + 2 * hour))
+        dao.upsertDelivery(delivery(3, "S1", "J2", "Chipotle", pay = 9.0, net = 7.0, completedAt = base + 3 * hour))
+
+        val stores = repo.perStoreEconomics(AnalyticsPeriod.LIFETIME).first()
+        assertEquals(2, stores.size)
+        // Ordered by gross (pay) desc: Wendys 16 > Chipotle 9.
+        assertEquals("Wendys", stores[0].storeName)
+        assertEquals(16.0, stores[0].gross, 1e-9)
+        assertEquals(13.0, stores[0].net, 1e-9)
+        assertEquals(2, stores[0].deliveries)
+        assertEquals("Chipotle", stores[1].storeName)
+        assertEquals(9.0, stores[1].gross, 1e-9)
+        assertEquals(7.0, stores[1].net, 1e-9)
+    }
+
+    /** TODAY/THIS_WEEK exclude an old dash; LIFETIME keeps it. Real clock via now-relative seeds. */
+    @Test
+    fun `TODAY and THIS_WEEK window out an old dash that LIFETIME keeps`() = runBlocking {
+        val now = System.currentTimeMillis()
+        val old = now - 10 * day // always in a previous day AND a previous week
+
+        dao.upsertSession(session("SNOW", now, reportedEarnings = null, durationMillis = hour, startOdo = 0.0, lastOdo = 2.0, deliveries = 1, jobsCompleted = 1))
+        dao.upsertDelivery(delivery(1, "SNOW", "J1", "Wendys", pay = 10.0, net = 8.0, completedAt = now))
+        dao.upsertSession(session("SOLD", old, reportedEarnings = null, durationMillis = hour, startOdo = 0.0, lastOdo = 9.0, deliveries = 1, jobsCompleted = 1))
+        dao.upsertDelivery(delivery(2, "SOLD", "J2", "Chipotle", pay = 100.0, net = 90.0, completedAt = old))
+
+        val today = repo.periodEconomics(AnalyticsPeriod.TODAY).first()
+        assertEquals(8.0, today.netProfit, 1e-9)
+        assertEquals(1, today.totals.deliveries)
+
+        val week = repo.periodEconomics(AnalyticsPeriod.THIS_WEEK).first()
+        assertEquals(8.0, week.netProfit, 1e-9)
+        assertEquals(1, week.totals.deliveries)
+
+        val life = repo.periodEconomics(AnalyticsPeriod.LIFETIME).first()
+        assertEquals(98.0, life.netProfit, 1e-9)
+        assertEquals(2, life.totals.deliveries)
+    }
+
+    @Test
+    fun `empty period yields zeros and null rates`() = runBlocking {
+        val eco = repo.periodEconomics(AnalyticsPeriod.LIFETIME).first()
+        assertEquals(0.0, eco.netProfit, 1e-9)
+        assertEquals(0.0, eco.grossEarnings, 1e-9)
+        assertEquals(0.0, eco.unattributedPay, 1e-9)
+        assertEquals(0, eco.totals.deliveries)
+        assertNull(eco.netPerHour)
+        assertNull(eco.netPerMile)
+    }
+
+    /** platform != null filters to that platform's records via the grouped queries. */
+    @Test
+    fun `per-platform periodEconomics filters to one platform`() = runBlocking {
+        dao.upsertSession(session("SDD", base, reportedEarnings = null, durationMillis = hour, startOdo = 0.0, lastOdo = 5.0, deliveries = 1, jobsCompleted = 1, platform = "doordash"))
+        dao.upsertDelivery(delivery(1, "SDD", "J1", "Wendys", pay = 10.0, net = 8.0, completedAt = base + hour, platform = "doordash"))
+        dao.upsertSession(session("SUB", base, reportedEarnings = null, durationMillis = hour, startOdo = 0.0, lastOdo = 3.0, deliveries = 1, jobsCompleted = 1, platform = "uber"))
+        dao.upsertDelivery(delivery(2, "SUB", "J2", "McD", pay = 20.0, net = 15.0, completedAt = base + hour, platform = "uber"))
+
+        val dd = repo.periodEconomics(AnalyticsPeriod.LIFETIME, cloud.trotter.dashbuddy.domain.state.Platform.DoorDash).first()
+        assertEquals(8.0, dd.netProfit, 1e-9)
+        assertEquals(1, dd.totals.deliveries)
+
+        val uber = repo.periodEconomics(AnalyticsPeriod.LIFETIME, cloud.trotter.dashbuddy.domain.state.Platform.Uber).first()
+        assertEquals(15.0, uber.netProfit, 1e-9)
+        assertEquals(1, uber.totals.deliveries)
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/analytics/PeriodBoundsTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/analytics/PeriodBoundsTest.kt
@@ -1,0 +1,80 @@
+package cloud.trotter.dashbuddy.analytics
+
+import cloud.trotter.dashbuddy.core.data.analytics.PeriodBounds
+import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.DayOfWeek
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZoneId
+
+/**
+ * #314 PR3 — query-time period boundaries. Pure `java.time`, no wall clock: [PeriodBounds.of]
+ * takes `now`/`zone`, so the Monday week-anchor and the midnight/week re-anchor (rollover) are
+ * asserted directly. A fixed non-DST July date keeps windows a clean 24h/7d.
+ */
+class PeriodBoundsTest {
+
+    private val zone = ZoneId.of("America/Chicago")
+
+    /** 2026-07-01 14:30 local — a stable weekday inside a DST-free week. */
+    private val nowMillis =
+        LocalDate.of(2026, 7, 1).atTime(14, 30).atZone(zone).toInstant().toEpochMilli()
+
+    private fun local(epochMillis: Long) = Instant.ofEpochMilli(epochMillis).atZone(zone)
+
+    @Test
+    fun `LIFETIME spans all time`() {
+        val b = PeriodBounds.of(AnalyticsPeriod.LIFETIME, nowMillis, zone)
+        assertEquals(0L, b.start)
+        assertEquals(Long.MAX_VALUE, b.end)
+    }
+
+    @Test
+    fun `TODAY is local midnight to next midnight and contains now`() {
+        val b = PeriodBounds.of(AnalyticsPeriod.TODAY, nowMillis, zone)
+        assertEquals(LocalTime.MIDNIGHT, local(b.start).toLocalTime())
+        assertEquals(LocalDate.of(2026, 7, 1), local(b.start).toLocalDate())
+        assertEquals(LocalTime.MIDNIGHT, local(b.end).toLocalTime())
+        assertEquals(LocalDate.of(2026, 7, 2), local(b.end).toLocalDate())
+        assertTrue(nowMillis >= b.start && nowMillis < b.end)
+    }
+
+    @Test
+    fun `THIS_WEEK starts Monday 00 00 local`() {
+        val b = PeriodBounds.of(AnalyticsPeriod.THIS_WEEK, nowMillis, zone)
+        val startZdt = local(b.start)
+        assertEquals(DayOfWeek.MONDAY, startZdt.dayOfWeek)
+        assertEquals(LocalTime.MIDNIGHT, startZdt.toLocalTime())
+        // 2026-07-01 is a Wednesday → the week's Monday is 2026-06-29.
+        assertEquals(LocalDate.of(2026, 6, 29), startZdt.toLocalDate())
+        assertEquals(LocalDate.of(2026, 7, 6), local(b.end).toLocalDate()) // next Monday
+        assertTrue(nowMillis >= b.start && nowMillis < b.end)
+    }
+
+    @Test
+    fun `week boundary splits Sunday 23-59 from Monday 00-01`() {
+        val weekStart = PeriodBounds.of(AnalyticsPeriod.THIS_WEEK, nowMillis, zone).start
+        val mondayDate = local(weekStart).toLocalDate()
+
+        val sundayBefore = mondayDate.minusDays(1).atTime(23, 59).atZone(zone).toInstant().toEpochMilli()
+        val mondayAfter = mondayDate.atTime(0, 1).atZone(zone).toInstant().toEpochMilli()
+
+        assertTrue("Sunday 23:59 is in the previous week", sundayBefore < weekStart)
+        assertTrue("Monday 00:01 is in this week", mondayAfter >= weekStart)
+    }
+
+    @Test
+    fun `TODAY re-anchors to consecutive windows at rollover`() {
+        val today = PeriodBounds.of(AnalyticsPeriod.TODAY, nowMillis, zone)
+        // At the instant the window ends (next midnight), the next call yields the next day —
+        // no gap, no overlap: the flow re-emits [prev.end, prev.end + 1 day).
+        val tomorrow = PeriodBounds.of(AnalyticsPeriod.TODAY, today.end, zone)
+        assertEquals(today.end, tomorrow.start)
+        assertTrue(tomorrow.end > tomorrow.start)
+        assertEquals(LocalDate.of(2026, 7, 2), local(tomorrow.start).toLocalDate())
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardViewModelTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardViewModelTest.kt
@@ -1,9 +1,12 @@
 package cloud.trotter.dashbuddy.ui.main.dashboard
 
+import cloud.trotter.dashbuddy.core.data.analytics.AnalyticsRepository
 import cloud.trotter.dashbuddy.core.data.location.OdometerRepository
 import cloud.trotter.dashbuddy.core.data.settings.AppPreferencesRepository
 import cloud.trotter.dashbuddy.core.data.state.AppStateRepository
 import cloud.trotter.dashbuddy.core.state.StateManagerV2
+import cloud.trotter.dashbuddy.domain.analytics.PeriodEconomics
+import cloud.trotter.dashbuddy.domain.analytics.PeriodTotals
 import cloud.trotter.dashbuddy.domain.evaluation.UserEconomy
 import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleClass
 import cloud.trotter.dashbuddy.domain.state.AppState
@@ -30,6 +33,8 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
@@ -45,7 +50,13 @@ class DashboardViewModelTest {
     private val odometerRepository: OdometerRepository = mock()
     private val appPreferencesRepository: AppPreferencesRepository = mock()
     private val stateManager: StateManagerV2 = mock()
+    private val analyticsRepository: AnalyticsRepository = mock()
     private val bubbleManager: BubbleManager = mock()
+
+    /** Stub the read-model Today flow; defaults to empty so a test opts in to real totals. */
+    private fun stubToday(today: PeriodEconomics = PeriodEconomics.EMPTY) {
+        whenever(analyticsRepository.periodEconomics(any(), anyOrNull())).thenReturn(flowOf(today))
+    }
 
     /** $3.00/gal ÷ 30 mpg = $0.10/mi fuel; every non-fuel cost defaults to 0 → $0.10/mi total. */
     private val tenCentsPerMile = UserEconomy(
@@ -76,6 +87,7 @@ class DashboardViewModelTest {
         odometerRepository = odometerRepository,
         appPreferencesRepository = appPreferencesRepository,
         stateManager = stateManager,
+        analyticsRepository = analyticsRepository,
         bubbleManager = bubbleManager,
     )
 
@@ -91,6 +103,7 @@ class DashboardViewModelTest {
         whenever(odometerRepository.sessionMilesFlow).thenReturn(flowOf(8.0))
         whenever(appPreferencesRepository.userEconomy).thenReturn(flowOf(tenCentsPerMile))
         whenever(appStateRepository.isFirstRun).thenReturn(flowOf(false))
+        stubToday()
 
         val viewModel = buildViewModel()
         val job = launch { viewModel.uiState.collect {} }
@@ -129,6 +142,7 @@ class DashboardViewModelTest {
         whenever(odometerRepository.sessionMilesFlow).thenReturn(flowOf(0.0))
         whenever(appPreferencesRepository.userEconomy).thenReturn(flowOf(tenCentsPerMile))
         whenever(appStateRepository.isFirstRun).thenReturn(flowOf(false))
+        stubToday()
 
         val viewModel = buildViewModel()
         val job = launch { viewModel.uiState.collect {} }
@@ -139,6 +153,39 @@ class DashboardViewModelTest {
         assertFalse(ui.glance.isInSession)
         assertEquals(DashGlance.EMPTY_VALUE, ui.glance.trueNetText)
         assertEquals("Ready to Dash", ui.statusText)
+        job.cancel()
+    }
+
+    @Test
+    fun `today read-model economics flow maps into the glance state`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val startedAt = 1_000_000L
+        whenever(stateManager.state)
+            .thenReturn(MutableStateFlow(appStateOnline(startedAt, earnings = 20.0)))
+        whenever(odometerRepository.sessionMilesFlow).thenReturn(flowOf(8.0))
+        whenever(appPreferencesRepository.userEconomy).thenReturn(flowOf(tenCentsPerMile))
+        whenever(appStateRepository.isFirstRun).thenReturn(flowOf(false))
+
+        // Real "Today" totals: frozen net independent of the live economy above.
+        val todayEconomics = PeriodEconomics(
+            totals = PeriodTotals(earnings = 60.0, miles = 20.0, deliveries = 4, jobs = 3, onlineDuration = 7_200_000L),
+            grossEarnings = 72.0,
+            netProfit = 55.0,
+            unattributedPay = 12.0,
+            netPerHour = 27.5,
+            netPerMile = 2.75,
+        )
+        stubToday(todayEconomics)
+
+        val viewModel = buildViewModel()
+        val job = launch { viewModel.uiState.collect {} }
+        testScheduler.advanceUntilIdle()
+
+        // The read-model Today is exposed verbatim (frozen net, not the live-economy net).
+        assertEquals(todayEconomics, viewModel.uiState.value.today)
+        assertEquals(55.0, viewModel.uiState.value.today.netProfit, 1e-9)
+        // The live "this dash" glance still computes its own separate net against the live economy.
+        assertEquals(19.20, viewModel.uiState.value.glance.trueNet, 1e-9)
         job.cancel()
     }
 }

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsMappers.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsMappers.kt
@@ -1,0 +1,50 @@
+package cloud.trotter.dashbuddy.core.data.analytics
+
+import cloud.trotter.dashbuddy.core.database.analytics.DeliveryRecordEntity
+import cloud.trotter.dashbuddy.core.database.analytics.SessionRecordEntity
+import cloud.trotter.dashbuddy.domain.analytics.DeliveryRecord
+import cloud.trotter.dashbuddy.domain.analytics.SessionRecord
+import cloud.trotter.dashbuddy.domain.state.Platform
+
+/**
+ * Room-entity → domain mappers for the analytics read model (#314 PR3). The
+ * repository maps at the boundary so consumers never see persistence types
+ * (the `AppEventRepo.toDomain` convention). Platform is registry-resolved from the
+ * stored wire string, never compared as a literal (Principle 8).
+ */
+
+internal fun DeliveryRecordEntity.toDomain(): DeliveryRecord = DeliveryRecord(
+    eventSequenceId = eventSequenceId,
+    sessionId = sessionId,
+    platform = Platform.fromWire(platform) ?: Platform.Unknown,
+    jobId = jobId,
+    taskId = taskId,
+    storeName = storeName,
+    completedAt = completedAt,
+    realizedPay = realizedPay,
+    netProfit = netProfit,
+    realizedMiles = realizedMiles,
+    realizedMinutes = realizedMinutes,
+    tip = tip,
+    basePay = basePay,
+)
+
+internal fun SessionRecordEntity.toDomain(): SessionRecord = SessionRecord(
+    sessionId = sessionId,
+    platform = Platform.fromWire(platform) ?: Platform.Unknown,
+    startedAt = startedAt,
+    endedAt = endedAt,
+    reportedEarnings = reportedEarnings,
+    reportedDurationMillis = reportedDurationMillis,
+    miles = if (startOdometer != null && lastOdometer != null) {
+        (lastOdometer!! - startOdometer!!).coerceAtLeast(0.0)
+    } else {
+        null
+    },
+    deliveries = deliveries,
+    jobsCompleted = jobsCompleted,
+    offersReceived = offersReceived,
+    offersAccepted = offersAccepted,
+    offersDeclined = offersDeclined,
+    offersTimeout = offersTimeout,
+)

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
@@ -1,0 +1,133 @@
+package cloud.trotter.dashbuddy.core.data.analytics
+
+import cloud.trotter.dashbuddy.core.database.analytics.AnalyticsDao
+import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
+import cloud.trotter.dashbuddy.domain.analytics.DeliveryRecord
+import cloud.trotter.dashbuddy.domain.analytics.PeriodEconomics
+import cloud.trotter.dashbuddy.domain.analytics.PeriodTotals
+import cloud.trotter.dashbuddy.domain.analytics.SessionRecord
+import cloud.trotter.dashbuddy.domain.analytics.StoreEconomics
+import cloud.trotter.dashbuddy.domain.evaluation.NetProfit
+import cloud.trotter.dashbuddy.domain.state.Platform
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Read-side repository over the durable analytics tables (#314 PR3) — the home
+ * glance and (later) the hub read period economics from here, never from the state
+ * machine (totals are history; a pure stepper must not read the DB — Principle 1).
+ *
+ * **Net is the frozen stored value.** Period net = Σ per-delivery `netProfit`
+ * (frozen by the projector against each accepted offer's cost basis) + unattributed
+ * pay. There is deliberately **no economy dependency**: editing the operating-cost
+ * model must not retroactively rewrite a past period's net (Principle 5 — one owner
+ * for the number, and the owner is the frozen record). The `NetProfit` SSOT is used
+ * only for the null-safe rate math ($/hr, $/mi), not to recompute net.
+ *
+ * **Reactive by construction:** every query is a `Flow`, so Room's invalidation
+ * tracker re-emits on each projector commit; the boundary flow re-anchors at local
+ * midnight / Monday so "today"/"this week" flip without an app restart.
+ *
+ * Privacy: economics/counts/store names only — customer PII is already sha256'd
+ * upstream and never surfaces here; no new capture, network, or PII surface.
+ */
+@Singleton
+@OptIn(ExperimentalCoroutinesApi::class)
+class AnalyticsRepository @Inject constructor(
+    private val analyticsDao: AnalyticsDao,
+) {
+
+    /**
+     * Frozen-net economics for [period]. `platform == null` ⇒ cross-platform; a
+     * specific [platform] filters to that platform's records. Re-emits on new
+     * records (Room invalidation) and at midnight/week rollover (boundary flow).
+     */
+    fun periodEconomics(period: AnalyticsPeriod, platform: Platform? = null): Flow<PeriodEconomics> =
+        periodBoundariesFlow(period).flatMapLatest { (start, end) ->
+            if (platform == null) {
+                combine(
+                    analyticsDao.deliveryTotals(start, end),
+                    analyticsDao.sessionTotals(start, end),
+                    analyticsDao.grossAndUnattributed(start, end),
+                ) { d, s, g ->
+                    assemble(
+                        deliveredPay = d.pay, deliveryNet = d.net, deliveries = d.deliveries,
+                        jobs = d.jobs, miles = s.miles, onlineMillis = s.onlineMillis,
+                        gross = g.gross, unattributed = g.unattributed,
+                    )
+                }
+            } else {
+                val wire = platform.wire
+                combine(
+                    analyticsDao.deliveryTotalsByPlatform(start, end),
+                    analyticsDao.sessionTotalsByPlatform(start, end),
+                    analyticsDao.grossAndUnattributedByPlatform(start, end),
+                ) { dl, sl, gl ->
+                    val d = dl.find { it.platform == wire }
+                    val s = sl.find { it.platform == wire }
+                    val g = gl.find { it.platform == wire }
+                    assemble(
+                        deliveredPay = d?.pay ?: 0.0, deliveryNet = d?.net ?: 0.0,
+                        deliveries = d?.deliveries ?: 0, jobs = d?.jobs ?: 0,
+                        miles = s?.miles ?: 0.0, onlineMillis = s?.onlineMillis ?: 0L,
+                        gross = g?.gross ?: 0.0, unattributed = g?.unattributed ?: 0.0,
+                    )
+                }
+            }
+        }
+
+    /** Per-store economics for [period], busiest store first — frozen net + realized gross. */
+    fun perStoreEconomics(period: AnalyticsPeriod): Flow<List<StoreEconomics>> =
+        periodBoundariesFlow(period).flatMapLatest { (start, end) ->
+            analyticsDao.deliveryTotalsByStore(start, end).map { rows ->
+                rows.map { StoreEconomics(storeName = it.storeName, net = it.net, gross = it.pay, deliveries = it.deliveries) }
+            }
+        }
+
+    /** Recent dashes, newest first (future hub / #650). */
+    fun recentSessions(limit: Int = 20): Flow<List<SessionRecord>> =
+        analyticsDao.recentSessions(limit).map { rows -> rows.map { it.toDomain() } }
+
+    /** Every delivery in a session, completion order (future #650 drill-down). */
+    fun deliveriesForSession(sessionId: String): Flow<List<DeliveryRecord>> =
+        analyticsDao.deliveriesForSession(sessionId).map { rows -> rows.map { it.toDomain() } }
+
+    /**
+     * Fold the DAO period rows into [PeriodEconomics]. Net is frozen (Σ delivery net +
+     * unattributed); the rates divide that frozen net by the period's hours/miles via
+     * the [NetProfit] null-safe helpers (a rate stays `null` until its denominator is
+     * measurable — no fabricated `$0/hr`).
+     */
+    private fun assemble(
+        deliveredPay: Double,
+        deliveryNet: Double,
+        deliveries: Int,
+        jobs: Int,
+        miles: Double,
+        onlineMillis: Long,
+        gross: Double,
+        unattributed: Double,
+    ): PeriodEconomics {
+        val net = deliveryNet + unattributed
+        val hours = onlineMillis / 3_600_000.0
+        return PeriodEconomics(
+            totals = PeriodTotals(
+                earnings = deliveredPay,
+                miles = miles,
+                deliveries = deliveries,
+                jobs = jobs,
+                onlineDuration = onlineMillis,
+            ),
+            grossEarnings = gross,
+            netProfit = net,
+            unattributedPay = unattributed,
+            netPerHour = NetProfit.perHour(net, hours),
+            netPerMile = NetProfit.perMile(net, miles),
+        )
+    }
+}

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/PeriodBounds.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/PeriodBounds.kt
@@ -1,0 +1,67 @@
+package cloud.trotter.dashbuddy.core.data.analytics
+
+import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import java.time.DayOfWeek
+import java.time.Instant
+import java.time.ZoneId
+import java.time.temporal.TemporalAdjusters
+
+/**
+ * Query-time period boundaries for the analytics read model (#314 PR3).
+ *
+ * Half-open `[start, end)` epoch-millis windows computed against the device's local
+ * zone — no timezone is ever materialized into a row. Weeks are Monday-anchored to
+ * match the DoorDash pay week. [of] is pure (inject `now`/`zone`), so the Monday
+ * boundary and midnight/week re-anchor are directly testable without a wall clock.
+ */
+object PeriodBounds {
+
+    data class Bounds(val start: Long, val end: Long)
+
+    /**
+     * The `[start, end)` window for [period], anchored at [nowMillis] in [zone].
+     * TODAY = local midnight → next midnight; THIS_WEEK = Monday 00:00 → next Monday
+     * 00:00; LIFETIME = all time.
+     */
+    fun of(period: AnalyticsPeriod, nowMillis: Long, zone: ZoneId): Bounds {
+        if (period == AnalyticsPeriod.LIFETIME) return Bounds(0L, Long.MAX_VALUE)
+
+        val today = Instant.ofEpochMilli(nowMillis).atZone(zone).toLocalDate()
+        val startDate = when (period) {
+            AnalyticsPeriod.TODAY -> today
+            AnalyticsPeriod.THIS_WEEK -> today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+            AnalyticsPeriod.LIFETIME -> error("handled above")
+        }
+        val startZdt = startDate.atStartOfDay(zone)
+        val endZdt = when (period) {
+            AnalyticsPeriod.TODAY -> startZdt.plusDays(1)
+            AnalyticsPeriod.THIS_WEEK -> startZdt.plusWeeks(1)
+            AnalyticsPeriod.LIFETIME -> error("handled above")
+        }
+        return Bounds(startZdt.toInstant().toEpochMilli(), endZdt.toInstant().toEpochMilli())
+    }
+}
+
+/**
+ * A [PeriodBounds.Bounds] flow that **re-anchors at rollover**: it emits the current
+ * window, then sleeps until that window's `end` and recomputes — so a home glance
+ * bound to it flips "today" at local midnight (and "this week" at Monday 00:00) with
+ * no app restart (Reactive UI rule 4). LIFETIME emits once and completes (it never
+ * rolls over). [now]/[zone] are injectable so a virtual-clock test can drive rollover.
+ */
+internal fun periodBoundariesFlow(
+    period: AnalyticsPeriod,
+    zone: ZoneId = ZoneId.systemDefault(),
+    now: () -> Long = System::currentTimeMillis,
+): Flow<PeriodBounds.Bounds> = flow {
+    while (true) {
+        val current = now()
+        val bounds = PeriodBounds.of(period, current, zone)
+        emit(bounds)
+        if (period == AnalyticsPeriod.LIFETIME) break
+        delay((bounds.end - current).coerceAtLeast(1L))
+    }
+}

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
@@ -59,6 +59,7 @@ interface AnalyticsDao {
 
     @Query(
         """SELECT COALESCE(SUM(realizedPay), 0) AS pay,
+                  COALESCE(SUM(netProfit), 0) AS net,
                   COUNT(*) AS deliveries,
                   COUNT(DISTINCT jobId) AS jobs
            FROM delivery_records
@@ -69,6 +70,7 @@ interface AnalyticsDao {
     @Query(
         """SELECT platform,
                   COALESCE(SUM(realizedPay), 0) AS pay,
+                  COALESCE(SUM(netProfit), 0) AS net,
                   COUNT(*) AS deliveries,
                   COUNT(DISTINCT jobId) AS jobs
            FROM delivery_records
@@ -80,6 +82,7 @@ interface AnalyticsDao {
     @Query(
         """SELECT storeName,
                   COALESCE(SUM(realizedPay), 0) AS pay,
+                  COALESCE(SUM(netProfit), 0) AS net,
                   COUNT(*) AS deliveries
            FROM delivery_records
            WHERE completedAt >= :start AND completedAt < :end
@@ -105,6 +108,58 @@ interface AnalyticsDao {
            GROUP BY platform"""
     )
     fun sessionTotalsByPlatform(start: Long, end: Long): Flow<List<PlatformSessionTotalsRow>>
+
+    /**
+     * Reported-authoritative gross + unattributed delta for a period (#314 PR3), bucketed by
+     * session `startedAt`. Per session: gross = the summary-screen `reportedEarnings` when present,
+     * else that session's Σ delivered pay; unattributed = `reportedEarnings − deliveredPay` when
+     * reported exceeds delivered (bonuses/adjustments/a missed capture — never negative). The
+     * delivered-pay subquery sums each session's full realized pay (no period filter — a session's
+     * own pay against its own reported total), joined to the in-period sessions.
+     */
+    @Query(
+        """SELECT COALESCE(SUM(COALESCE(s.reportedEarnings, d.deliveredPay, 0)), 0) AS gross,
+                  COALESCE(SUM(
+                    CASE WHEN s.reportedEarnings IS NOT NULL
+                              AND s.reportedEarnings > COALESCE(d.deliveredPay, 0)
+                         THEN s.reportedEarnings - COALESCE(d.deliveredPay, 0)
+                         ELSE 0 END), 0) AS unattributed
+           FROM session_records s
+           LEFT JOIN (
+             SELECT sessionId, SUM(realizedPay) AS deliveredPay
+             FROM delivery_records GROUP BY sessionId
+           ) d ON d.sessionId = s.sessionId
+           WHERE s.startedAt >= :start AND s.startedAt < :end"""
+    )
+    fun grossAndUnattributed(start: Long, end: Long): Flow<GrossTotalsRow>
+
+    @Query(
+        """SELECT s.platform AS platform,
+                  COALESCE(SUM(COALESCE(s.reportedEarnings, d.deliveredPay, 0)), 0) AS gross,
+                  COALESCE(SUM(
+                    CASE WHEN s.reportedEarnings IS NOT NULL
+                              AND s.reportedEarnings > COALESCE(d.deliveredPay, 0)
+                         THEN s.reportedEarnings - COALESCE(d.deliveredPay, 0)
+                         ELSE 0 END), 0) AS unattributed
+           FROM session_records s
+           LEFT JOIN (
+             SELECT sessionId, SUM(realizedPay) AS deliveredPay
+             FROM delivery_records GROUP BY sessionId
+           ) d ON d.sessionId = s.sessionId
+           WHERE s.startedAt >= :start AND s.startedAt < :end
+           GROUP BY s.platform"""
+    )
+    fun grossAndUnattributedByPlatform(start: Long, end: Long): Flow<List<PlatformGrossTotalsRow>>
+
+    // ── Drill-down list reads (future hub / #650) ────────────────────────
+
+    /** Most recent sessions, newest first — the "recent dashes" list. */
+    @Query("SELECT * FROM session_records ORDER BY startedAt DESC LIMIT :limit")
+    fun recentSessions(limit: Int): Flow<List<SessionRecordEntity>>
+
+    /** Every delivery in a session, in completion order — the per-dash breakdown. */
+    @Query("SELECT * FROM delivery_records WHERE sessionId = :sessionId ORDER BY completedAt ASC")
+    fun deliveriesForSession(sessionId: String): Flow<List<DeliveryRecordEntity>>
 
     // ── Projector support: restart-correct context hydration (PR2) ───────
 

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsTotals.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsTotals.kt
@@ -7,9 +7,14 @@ package cloud.trotter.dashbuddy.core.database.analytics
  * repository (`:core:data`, PR3) folds economy in on top.
  */
 
-/** Cross-platform delivery totals for a period. */
+/**
+ * Cross-platform delivery totals for a period. [net] is Σ **frozen** per-delivery net
+ * (the projector's `netProfit`, costed against each accepted offer's basis) — an economy
+ * edit never re-costs it (#314 PR3).
+ */
 data class DeliveryTotalsRow(
     val pay: Double,
+    val net: Double,
     val deliveries: Int,
     val jobs: Int,
 )
@@ -18,6 +23,7 @@ data class DeliveryTotalsRow(
 data class PlatformDeliveryTotalsRow(
     val platform: String,
     val pay: Double,
+    val net: Double,
     val deliveries: Int,
     val jobs: Int,
 )
@@ -26,7 +32,26 @@ data class PlatformDeliveryTotalsRow(
 data class StoreTotalsRow(
     val storeName: String?,
     val pay: Double,
+    val net: Double,
     val deliveries: Int,
+)
+
+/**
+ * Reported-authoritative gross + the unattributed delta for a period (#314 PR3).
+ * Computed per session (reported summary total when present, else that session's Σ
+ * delivered pay), then summed. [unattributed] is the excess of reported over delivered
+ * — bonuses/adjustments/a missed capture; a review flag (#650).
+ */
+data class GrossTotalsRow(
+    val gross: Double,
+    val unattributed: Double,
+)
+
+/** Per-platform gross + unattributed (GROUP BY platform). */
+data class PlatformGrossTotalsRow(
+    val platform: String,
+    val gross: Double,
+    val unattributed: Double,
 )
 
 /** Cross-platform session totals for a period: miles = Σ odo delta, onlineMillis = Σ duration. */

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/CrossPlatformRegionStepper.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/CrossPlatformRegionStepper.kt
@@ -30,13 +30,13 @@ class CrossPlatformRegionStepper @Inject constructor() {
         val mostRecent = nextPlatforms.entries
             .maxByOrNull { it.value.lastObservedAt }
 
+        // Period totals are NOT aggregated here — they are history, owned by the
+        // read side (AnalyticsRepository, #314). A pure stepper never reads the DB.
         return prev.copy(
             anyPlatformOnline = anyOnline,
             activeSessionCount = activeSessions,
             mostRecentActivityAt = mostRecent?.value?.lastObservedAt ?: prev.mostRecentActivityAt,
             mostRecentActivityPlatform = mostRecent?.key,
-            // totalsToday/Week/Lifetime are computed from DB aggregation,
-            // not from in-memory state. They remain unchanged here.
         )
     }
 }

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -88,6 +88,21 @@ was found **broken-in-part** (raw PII in capture envelopes) and moved to that en
   (#314 PR2 — projector/backfill/frozen-economy.)
   - Confirmed: 0/2
 
+- **🆕 NEW — the home screen's top glance is now REAL "Today" totals from the read model (#314 PR3, completes #314).**
+  Open the DashBuddy main app (not the bubble). **Working looks like:** the top row of three stat
+  tiles — **True Net · Net/hr · Miles**, each sub-labelled **"Today"** — shows your **whole day's**
+  frozen net (Σ each completed delivery's frozen net + any unattributed pay), not just the current
+  dash, and it **grows within a few seconds of each delivery receipt** (the projector folds the
+  completed delivery → Room re-emits the flow → the tile updates, no app restart, no state
+  transition). While a dash is running a second **"This dash"** row appears below it (the live
+  per-second ticking glance from #320). How to tell it's right: at end of day the Today **True Net**
+  ≈ your DoorDash app's earnings for the day minus your operating costs, and **editing the Economy
+  settings (gas price etc.) must NOT change a past day's Today number** — historical net is frozen.
+  At local **midnight** the Today figures should reset to the new day without reopening the app.
+  Broken = a Today that only reflects the current dash, a number that changes when you edit economy,
+  a Today that never grows after a delivery completes, or one that doesn't roll over at midnight.
+  - Confirmed: 0/2
+
 - **🔧 FIX SHIPPED — a stacked job's DELIVERY_COMPLETED rows now carry per-drop realized pay (#528 Slice A). READ THE DB AFTER A DASH.**
   Before, on a multi-store/multi-drop stack, the single combined receipt was attached to just ONE
   drop (it absorbed the whole total) and every other drop's `DELIVERY_COMPLETED` row recorded null

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/AnalyticsPeriod.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/AnalyticsPeriod.kt
@@ -1,0 +1,21 @@
+package cloud.trotter.dashbuddy.domain.analytics
+
+/**
+ * The rolling report windows the home glance and future hub aggregate over (#314).
+ *
+ * These are *labels*, not materialized buckets — the concrete `[start, end)`
+ * epoch-millis boundaries are computed at query time against the device's local
+ * zone (Monday-anchored weeks match the DoorDash pay week), so "today" flips at
+ * local midnight and "this week" flips Monday 00:00 with no stored timezone and
+ * no app restart.
+ */
+enum class AnalyticsPeriod {
+    /** Local midnight → now. */
+    TODAY,
+
+    /** Monday 00:00 local → now (the pay-week the dasher already sees). */
+    THIS_WEEK,
+
+    /** All records, ever. */
+    LIFETIME,
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/AnalyticsRecords.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/AnalyticsRecords.kt
@@ -1,0 +1,52 @@
+package cloud.trotter.dashbuddy.domain.analytics
+
+import cloud.trotter.dashbuddy.domain.state.Platform
+
+/**
+ * Domain read-models for the durable analytics records (#314) — the repository
+ * boundary maps the Room entities into these so consumers never see persistence
+ * types (the `AppEventRepo.toDomain` convention). Platform is registry-resolved,
+ * never a raw wire string (Principle 8).
+ *
+ * These back the future per-dash drill-down (#650); nothing renders them yet, so
+ * they carry the economically meaningful fields a "recent dashes" list and a
+ * single-dash breakdown need, no more.
+ */
+
+/** One completed delivery. */
+data class DeliveryRecord(
+    val eventSequenceId: Long,
+    val sessionId: String?,
+    val platform: Platform,
+    val jobId: String,
+    val taskId: String,
+    val storeName: String?,
+    val completedAt: Long,
+    /** dropRealizedPay ?: totalPay. */
+    val realizedPay: Double?,
+    /** Frozen realized net against the accepted offer's cost basis — never re-costed. */
+    val netProfit: Double?,
+    val realizedMiles: Double?,
+    val realizedMinutes: Double?,
+    val tip: Double?,
+    val basePay: Double?,
+)
+
+/** One dash session. */
+data class SessionRecord(
+    val sessionId: String,
+    val platform: Platform,
+    val startedAt: Long,
+    val endedAt: Long?,
+    /** Platform summary-screen all-pay total (incl. bonuses/adjustments); null until a summary is seen. */
+    val reportedEarnings: Double?,
+    val reportedDurationMillis: Long?,
+    /** Odometer delta (lastOdometer − startOdometer), floored at 0; null when odometer never seen. */
+    val miles: Double?,
+    val deliveries: Int,
+    val jobsCompleted: Int,
+    val offersReceived: Int,
+    val offersAccepted: Int,
+    val offersDeclined: Int,
+    val offersTimeout: Int,
+)

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/PeriodEconomics.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/PeriodEconomics.kt
@@ -1,0 +1,58 @@
+package cloud.trotter.dashbuddy.domain.analytics
+
+/**
+ * Economics for an [AnalyticsPeriod] (#314) — the home-glance/hub read model.
+ *
+ * **Net is frozen, not recomputed.** [netProfit] sums the per-delivery `netProfit`
+ * the projector already froze against each offer's accepted cost basis, plus
+ * [unattributedPay]. Editing the operating-cost economy later does NOT retroactively
+ * rewrite a historical period's net — a delivery's net is a decision record, not a
+ * cache of the current cost model (Principle 5: one owner for the number; the owner
+ * is the frozen stored value). This is why the repository takes no economy input.
+ *
+ * **Gross is the platform's word.** [grossEarnings] is reported-authoritative all-pay:
+ * per session the summary-screen `reportedEarnings` when present, else that session's
+ * Σ delivered pay; summed over the period's sessions. [unattributedPay] is the excess
+ * of reported over delivered (challenge bonuses, adjustments, or a delivery we failed
+ * to capture) — a per-period review flag (#650 lets the user reclassify it). It has no
+ * captured mileage cost, so it is treated as net-additive; the resulting [netProfit] is
+ * therefore a documented *estimate* (a missed delivery would have carried miles).
+ */
+data class PeriodEconomics(
+    val totals: PeriodTotals,
+    /** Reported-authoritative all-pay (incl. bonuses/adjustments), summed over sessions. */
+    val grossEarnings: Double,
+    /** Σ frozen delivery net + [unattributedPay]. Frozen — economy edits never change it. */
+    val netProfit: Double,
+    /** Σ (reportedEarnings − deliveredPay) where reported exceeds delivered; review flag (#650). */
+    val unattributedPay: Double,
+    /** [netProfit] ÷ online hours, or `null` when no measurable time has accrued. */
+    val netPerHour: Double?,
+    /** [netProfit] ÷ miles, or `null` when no miles are logged. */
+    val netPerMile: Double?,
+) {
+    companion object {
+        val EMPTY = PeriodEconomics(
+            totals = PeriodTotals.EMPTY,
+            grossEarnings = 0.0,
+            netProfit = 0.0,
+            unattributedPay = 0.0,
+            netPerHour = null,
+            netPerMile = null,
+        )
+    }
+}
+
+/**
+ * Per-store economics for a period (#314) — GROUP BY store over the delivery
+ * records. [gross] is Σ realized delivery pay for the store; [net] is Σ frozen
+ * delivery net. Chain/entity resolution (folding "H-E-B #472" and "H-E-B #018"
+ * into one merchant) is deferred to #159 — [storeName] is the raw captured name,
+ * nullable when a delivery record carried none.
+ */
+data class StoreEconomics(
+    val storeName: String?,
+    val net: Double,
+    val gross: Double,
+    val deliveries: Int,
+)

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/PeriodTotals.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/PeriodTotals.kt
@@ -1,0 +1,36 @@
+package cloud.trotter.dashbuddy.domain.analytics
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Raw aggregated counts/sums for a period across all platforms (#314) — the
+ * read-side DTO the [AnalyticsRepository][cloud.trotter.dashbuddy.core.data.analytics.AnalyticsRepository]
+ * assembles from the durable read-model tables. Economics ([PeriodEconomics])
+ * wraps this with frozen net and reported-authoritative gross.
+ *
+ * Formerly three dead fields on `CrossPlatformRegion` (the pure state-machine
+ * reducer never populated them — totals are history, and history lives on the
+ * read side, never in a pure stepper; #314 §3). It kept its `@Serializable`
+ * annotation on the move so any legacy usage stays decode-compatible.
+ *
+ * [earnings] is *delivered* pay (Σ realized delivery pay). The platform's own
+ * reported all-pay total — which additionally covers challenge bonuses and
+ * adjustments — is carried separately as [PeriodEconomics.grossEarnings].
+ */
+@Serializable
+data class PeriodTotals(
+    /** Σ realized delivery pay bucketed by completion time. */
+    val earnings: Double = 0.0,
+    /** Σ session odometer delta (floored per session). */
+    val miles: Double = 0.0,
+    /** Count of completed deliveries. */
+    val deliveries: Int = 0,
+    /** Count of distinct delivered jobs. */
+    val jobs: Int = 0,
+    /** Σ session online duration, millis. */
+    val onlineDuration: Long = 0L,
+) {
+    companion object {
+        val EMPTY = PeriodTotals()
+    }
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/CrossPlatformRegion.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/CrossPlatformRegion.kt
@@ -7,30 +7,17 @@ import kotlinx.serialization.Serializable
  *
  * Derived, read-only from platform regions. Recomputed after Regions 2+ step.
  * The HUD's aggregate tab reads from this region.
+ *
+ * Period totals (today/week/lifetime) are **not** held here: they are history, and
+ * history lives on the read side (`AnalyticsRepository`, #314 §3), never in a pure
+ * stepper — a reducer must not read the DB. The old dead `totals*` fields (the
+ * stepper never populated them) were deleted with #314 PR3; `PeriodTotals` moved to
+ * `domain/analytics/` as the read-side DTO.
  */
 @Serializable
 data class CrossPlatformRegion(
     val anyPlatformOnline: Boolean = false,
     val activeSessionCount: Int = 0,
-    val totalsToday: PeriodTotals = PeriodTotals.EMPTY,
-    val totalsThisWeek: PeriodTotals = PeriodTotals.EMPTY,
-    val totalsLifetime: PeriodTotals = PeriodTotals.EMPTY,
     val mostRecentActivityAt: Long = 0,
     val mostRecentActivityPlatform: Platform? = null,
 )
-
-/**
- * Aggregated totals for a time period across all platforms.
- */
-@Serializable
-data class PeriodTotals(
-    val earnings: Double = 0.0,
-    val miles: Double = 0.0,
-    val deliveries: Int = 0,
-    val jobs: Int = 0,
-    val onlineDuration: Long = 0L,
-) {
-    companion object {
-        val EMPTY = PeriodTotals()
-    }
-}


### PR DESCRIPTION
Completes **#314** (the durable analytics read-model) — PR3, the read side + home-glance wiring. Builds on PR1 (tables/DAO) + PR2 (the event-sourced projector that freezes `netProfit`/`frozenCostPerMile`/`costBasis` per delivery).

## What shipped

**Domain (`domain/analytics/`)**
- `AnalyticsPeriod { TODAY, THIS_WEEK, LIFETIME }`.
- `PeriodTotals` **moved here** from `CrossPlatformRegion` (it was one of three dead fields the pure stepper never populated) — kept `@Serializable`. `earnings` = delivered pay.
- `PeriodEconomics(totals, grossEarnings, netProfit, unattributedPay, netPerHour, netPerMile)` + `StoreEconomics(storeName, net, gross, deliveries)`.
- `DeliveryRecord` / `SessionRecord` read models (registry-resolved `Platform`) for the future #650 drill-down.

**Read side**
- `AnalyticsDao`: `SUM(netProfit) AS net` added to `deliveryTotals` / `deliveryTotalsByPlatform` / `deliveryTotalsByStore`; new `grossAndUnattributed(+ByPlatform)`; new `recentSessions` / `deliveriesForSession` list reads. All `Flow` (Room-invalidation reactive).
- `PeriodBounds` — query-time `[start, end)` windows via `java.time` + `ZoneId.systemDefault()`; **Monday-anchored** weeks (the DoorDash pay week); a boundary flow that **re-anchors at rollover** so "today" flips at local midnight with no restart.
- `AnalyticsRepository` (`@Singleton @Inject`, DAO-only) — `periodEconomics(period, platform?)`, `perStoreEconomics(period)`, `recentSessions(limit)`, `deliveriesForSession(id)`. Enters DI by constructor injection (`provideAnalyticsDao` already existed from PR1).

**Net is FROZEN (developer lock).** Period `netProfit` = `SUM(delivery_records.netProfit)` (the projector's frozen-per-offer-basis net) **+ `unattributedPay`**. The repository has **no economy dependency at all** — editing gas price / costs cannot retroactively rewrite a past period's net. `NetProfit` (the SSOT) is used only for the null-safe `$/hr`·`$/mi` division, not to recompute net.

**All-pay gross + unattributed flag (developer lock).** `grossEarnings` is reported-authoritative: per session the summary-screen `reportedEarnings` when present, else that session's Σ delivered pay, summed over the period's sessions. `unattributedPay` = Σ`(reportedEarnings − deliveredPay)` where reported exceeds delivered (bonuses / adjustments / a missed-capture delivery — a #650 review flag). Because unattributed pay carries no captured mileage cost it's treated as net-additive, so period net is a documented estimate.

**Dead-field removal.** Deleted `CrossPlatformRegion.totalsToday/totalsThisWeek/totalsLifetime` + the stepper's "computed from DB aggregation" comment (grep-confirmed **no** producer/consumer). Snapshot decode stays safe — `StateJson` is `ignoreUnknownKeys = true`, so old recovery blobs carrying the removed keys decode cleanly; `:core:state` (103 tests incl. recovery) green after the removal.

**Home glance.** `DashboardViewModel` gains a `periodEconomics(TODAY)` flow (5th `combine` arm); the 3 `AppStatTile` now show real **Today** True Net / Net $/hr / Miles from the read model, re-emitting on each projector commit (Room invalidation) and at midnight rollover. The live **"This dash"** glance (#320, ticking) is kept below it while online — honestly labelled — so its per-second reactivity is untouched.

## Tests
`:domain:test` **262** · `:core:state:testDebugUnitTest` **103** · `:app:testDebugUnitTest` **892** — all green; `*AllMatchersSuite*` green. New: `AnalyticsRepositoryTest` (6 — frozen net = Σ stored `netProfit` + unattributed, reported-authoritative gross, unattributed delta, per-store grouping, TODAY/WEEK/LIFETIME windowing, per-platform filter), `PeriodBoundsTest` (5 — Monday week-start, Sunday 23:59 vs Monday 00:01 split, midnight re-anchor), `DashboardViewModelTest` (+1 — Today flow maps to the glance, frozen net distinct from the live-economy this-dash net).

## Design-goal review
- **P1 (UDF):** Totals stay OUT of the pure steppers — the dead `CrossPlatformRegion` fields are deleted and the read side (`AnalyticsRepository` Flows) owns period totals; a reducer never reads the DB. The ViewModel observes flows and exposes an immutable `UiState`.
- **P3 (SRP):** Small focused files — DTOs, mappers, bounds, and the repository are each their own file.
- **P5 (SSOT):** Net has exactly one owner — the frozen stored `netProfit` — and the repository *sums* it, never recomputes; the economy is deliberately not an input. Rate math routes through the one `NetProfit` helper. `PeriodTotals` has a single home now (`domain/analytics/`), not a duplicated shape on the state region.
- **P8 (platform-agnostic):** No platform literals in logic — `platform` filtering keys on `Platform.wire` from the registry; entity→domain mapping resolves `Platform.fromWire(...) ?: Unknown`. Adding a platform needs zero edits here. (The `:domain`/`:core:state` diff — the moved DTO + field deletion — introduces no new vocabulary or `when`.)
- **Reactive UI:** The Today glance re-renders without a state transition — its flow re-emits on projector commits and at midnight; the existing ticking this-dash glance is preserved intact.

## Security / privacy posture
No new capture, network, or PII surface. The read model holds economics / counts / **merchant** store names only; customer name/address are already `sha256`'d upstream and never surface here. INFO logging is untouched (no store/customer text added). Trusted input only (our own durable log); nothing here reads third-party UI or remote data.

## Notes vs the plan
The plan's §1a/§4 said "no `netProfit` column; compute Σpay − cpm×Σmiles against the **live** economy." The developer **reversed** that before PR2 (which stored frozen `netProfit`/`frozenCostPerMile`/`costBasis`), so this PR sums the frozen value and has no economy dependency — per the refinement locks. `perStoreEconomics` + the all-pay/unattributed surface are the lock additions on top of the plan's repository sketch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

### Design-goal review
Completes the read-model: `AnalyticsRepository` (`:core:data`) + domain analytics DTOs + home-glance wiring + deleting the dead `CrossPlatformRegion` totals.
- **P1 (UDF):** read-side totals never re-enter the pure steppers — the dead `totalsToday/Week/Lifetime` fields are removed and the repository serves them from the read-model; immutable `DashboardUiState`.
- **P5 (SSOT):** period net is the single **frozen** stored value (`SUM(delivery_records.netProfit)`) — the repository has zero economy dependency, so one owner and no recompute drift; `PeriodTotals` is moved, not duplicated.
- **P8:** platform resolved via the `Platform` registry (`fromWire ?: Unknown`), no literals.
- **P7:** economics/counts + merchant names only (customer PII already sha256'd upstream, none logged).
- **Reactive UI:** the Today glance re-emits on projector commits (Room invalidation) + midnight rollover (`flatMapLatest(periodBoundariesFlow)`); the Phase-1 live "This dash" ticker is untouched; labels honest (Today vs This dash).

### Adversarial review
Independent Opus review (Fable exhausted this session; developer-authorized Opus since Fable did the substantive design + earlier PR reviews) — **verdict: CLEAN, merge-ready.** The frozen-net lock is **structurally enforced**: `AnalyticsRepository @Inject constructor(analyticsDao)` is DAO-only (grep-confirmed no economy/preferences dependency anywhere in the net path; `NetProfit` used only for null-safe $/hr·$/mi division), so editing economy settings is *structurally unable* to rewrite a historical period's net — proven non-vacuously (`net==stored 7` vs `pay 10`). Dead-field removal is safe: repo-wide grep shows zero remaining `totalsToday/…` consumers, all `CrossPlatformRegion(...)` constructions compile, `StateJson ignoreUnknownKeys=true` decodes old snapshots, and 103 `:core:state` recovery tests pass. All-pay/unattributed SQL verified (LEFT JOIN to a per-session GROUP BY → no fan-out; negatives CASE-guarded; NULL reported → delivered fallback). Monday-week boundaries + midnight rollover proven (`PeriodBoundsTest`). Full suite green: `:domain` 262 / `:core:state` 103 / `:app` 892 = 1257, 0 failures. Three non-blocking findings filed as **#655**: a period-boundary bucketing seam (deliveries by `completedAt` vs sessions by `startedAt` → an estimate skew only for boundary-spanning dashes, already documented as an estimate) + two cosmetic doc nits.
