### PR TITLE
feat(#657): reframe dashboard as a review surface, not a live-glance mirror

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardScreen.kt
@@ -43,9 +43,10 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
 import cloud.trotter.dashbuddy.core.designsystem.component.AppCard
+import cloud.trotter.dashbuddy.core.designsystem.component.AppSegmented
 import cloud.trotter.dashbuddy.core.designsystem.component.AppStatTile
 import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
-import cloud.trotter.dashbuddy.core.designsystem.time.rememberNow
+import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
 import cloud.trotter.dashbuddy.domain.analytics.PeriodEconomics
 import cloud.trotter.dashbuddy.domain.format.Formats
 import cloud.trotter.dashbuddy.ui.main.navigation.Screen
@@ -133,21 +134,27 @@ fun DashboardScreen(
                     ) { Text("Skip for now") }
                 }
 
-                // CASE 3: Ready — status card, real "Today" glance (read-model),
-                // the live "this dash" glance while online, then entry tiles.
+                // CASE 3: Ready — status card, a slim "tap for the bubble" pointer while
+                // dashing, then the read-model period review (the primary economics), the
+                // entry tiles, and a manual bubble trigger.
                 else -> {
                     StatusCard(
                         title = uiState.statusText,
-                        subtitle = if (uiState.isInSession) "You're on the clock." else "All systems go.",
+                        subtitle = if (uiState.isDashing) "You're on the clock." else "All systems go.",
                         containerColor = MaterialTheme.colorScheme.primaryContainer
                     )
                     Spacer(modifier = Modifier.height(16.dp))
 
-                    TodayGlance(today = uiState.today)
-                    if (uiState.isInSession) {
+                    if (uiState.isDashing) {
+                        DashingStatusRow(onTap = { viewModel.showWelcomeBubble() })
                         Spacer(modifier = Modifier.height(12.dp))
-                        ThisDashGlance(glance = uiState.glance)
                     }
+
+                    PeriodReview(
+                        selectedPeriod = uiState.selectedPeriod,
+                        economics = uiState.economics,
+                        onSelectPeriod = viewModel::setPeriod,
+                    )
                     Spacer(modifier = Modifier.height(16.dp))
 
                     EntryTileGrid(onNavigate = onNavigate)
@@ -163,75 +170,83 @@ fun DashboardScreen(
     }
 }
 
+/** Placeholder shown for a rate figure that has no measurable denominator yet. */
+private const val EMPTY_VALUE = "—"
+
+/** The review windows offered by the period selector, in display order. */
+private data class PeriodOption(val period: AnalyticsPeriod, val label: String)
+
+private val PERIOD_OPTIONS = listOf(
+    PeriodOption(AnalyticsPeriod.TODAY, "Today"),
+    PeriodOption(AnalyticsPeriod.THIS_WEEK, "This week"),
+    PeriodOption(AnalyticsPeriod.LIFETIME, "Lifetime"),
+)
+
+private fun periodLabel(period: AnalyticsPeriod): String =
+    PERIOD_OPTIONS.first { it.period == period }.label
+
 /**
- * The primary home glance — real **Today** economics from the durable read model:
- * True Net · Net $/hr · Miles. Frozen net (Σ each delivery's net against its accepted
- * cost basis + unattributed pay), so an economy edit never rewrites past days. It
- * re-renders without a state transition (Reactive UI rule 4): the `today` flow
- * re-emits on every projector commit (Room invalidation) and at midnight rollover.
+ * Slim online pointer (#657): while a dash is active the review surface just points
+ * back to the bubble (the live glance the bubble owns) — it does not mirror it. Tapping
+ * re-shows the bubble via the existing Show-Bubble action.
  */
 @Composable
-private fun TodayGlance(today: PeriodEconomics) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
-    ) {
-        AppStatTile(
-            label = "True Net",
-            value = Formats.money(today.netProfit),
-            sub = "Today",
-            valueColor = if (today.netProfit >= 0.0) AppTheme.colors.good else AppTheme.colors.bad,
-            modifier = Modifier.weight(1f),
-        )
-        AppStatTile(
-            label = "Net/hr",
-            value = today.netPerHour?.let { Formats.money(it) } ?: DashGlance.EMPTY_VALUE,
-            sub = "Today",
-            modifier = Modifier.weight(1f),
-        )
-        AppStatTile(
-            label = "Miles",
-            value = Formats.decimal(today.totals.miles),
-            sub = "Today",
-            modifier = Modifier.weight(1f),
+private fun DashingStatusRow(onTap: () -> Unit) {
+    AppCard(modifier = Modifier.fillMaxWidth().clickable(onClick = onTap)) {
+        Text(
+            text = "🟢 Dashing — tap for the bubble",
+            style = MaterialTheme.typography.titleMedium,
+            color = AppTheme.colors.text,
         )
     }
 }
 
 /**
- * The live "this dash" glance — True Net · Net $/hr · Miles. $/hr and the online
- * timer tick off a `rememberNow()` clock (Reactive UI rules 2/3): the composable
- * derives them from the session anchors so they stay fresh without a state
- * transition. True Net / Miles update reactively through their own state flows.
+ * The primary home economics (#657): a Today / This week / Lifetime selector over the
+ * read-model True Net · Net $/hr · Miles tiles. Frozen net (Σ each delivery's net against
+ * its accepted cost basis + unattributed pay), so an economy edit never rewrites a past
+ * period. Reactive but **not** live-ticking: the `economics` flow re-emits on each
+ * projector commit (Room invalidation) and at midnight/week rollover, so the screen is
+ * fresh-on-open without a `rememberNow()` clock — a historical period's $/hr is a fixed
+ * value, so there is nothing to tick.
  */
 @Composable
-private fun ThisDashGlance(glance: DashGlance) {
-    val now by rememberNow()
+private fun PeriodReview(
+    selectedPeriod: AnalyticsPeriod,
+    economics: PeriodEconomics,
+    onSelectPeriod: (AnalyticsPeriod) -> Unit,
+) {
+    val selectedLabel = periodLabel(selectedPeriod)
+    AppSegmented(
+        options = PERIOD_OPTIONS.map { it.label },
+        selected = selectedLabel,
+        onSelect = { label ->
+            PERIOD_OPTIONS.firstOrNull { it.label == label }?.let { onSelectPeriod(it.period) }
+        },
+        modifier = Modifier.fillMaxWidth(),
+    )
+    Spacer(modifier = Modifier.height(12.dp))
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         AppStatTile(
             label = "True Net",
-            value = glance.trueNetText,
-            sub = "This dash",
-            valueColor = when {
-                !glance.isInSession -> AppTheme.colors.text
-                glance.isPositiveNet -> AppTheme.colors.good
-                else -> AppTheme.colors.bad
-            },
+            value = Formats.money(economics.netProfit),
+            sub = selectedLabel,
+            valueColor = if (economics.netProfit >= 0.0) AppTheme.colors.good else AppTheme.colors.bad,
             modifier = Modifier.weight(1f),
         )
         AppStatTile(
             label = "Net/hr",
-            value = glance.netPerHourText(now),
-            sub = glance.onlineDurationText(now).takeIf { glance.isInSession },
+            value = economics.netPerHour?.let { Formats.money(it) } ?: EMPTY_VALUE,
+            sub = selectedLabel,
             modifier = Modifier.weight(1f),
         )
         AppStatTile(
             label = "Miles",
-            value = glance.milesText,
-            sub = "miles",
+            value = Formats.decimal(economics.totals.miles),
+            sub = selectedLabel,
             modifier = Modifier.weight(1f),
         )
     }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardUiState.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardUiState.kt
@@ -1,85 +1,36 @@
 package cloud.trotter.dashbuddy.ui.main.dashboard
 
+import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
 import cloud.trotter.dashbuddy.domain.analytics.PeriodEconomics
-import cloud.trotter.dashbuddy.domain.evaluation.NetProfit
-import cloud.trotter.dashbuddy.domain.format.Formats
-import cloud.trotter.dashbuddy.domain.format.formatDuration
 
 /**
- * Immutable state for the home (Dashboard) screen (Principle 1 — UDF). Bundles the
- * first-run / status gate with the [today] read-model economics (the primary glance)
- * and the live "this dash" [glance] (shown while online). Permissions stay a
- * composable-local OS re-check (re-read on every `ON_RESUME`), so they are
- * intentionally NOT modelled here.
+ * Immutable state for the home (Dashboard) screen (Principle 1 — UDF).
  *
- * [today] comes from `AnalyticsRepository.periodEconomics(TODAY)` and re-emits as the
- * projector folds each completed delivery (Room invalidation) and at midnight rollover
- * — frozen net, never recomputed against the live economy. [glance] is the live,
- * per-second ticking this-dash view (#320).
+ * The dashboard is a **review / configure** surface, not a live-while-dashing mirror of
+ * the bubble HUD (#657): the bubble owns the strictly-live glance while on a task; the
+ * main app is opened between shifts (parked, on break, planning) to review history and
+ * configure. So the primary economics are the read-model [economics] for the selected
+ * [selectedPeriod] (Today / This week / Lifetime) — reactive to projector commits (Room
+ * invalidation) and midnight/week rollover, but **not** a per-second tick surface: a
+ * historical period's $/hr is a fixed computed value, so the screen is fresh-on-open
+ * without a `rememberNow()` clock.
+ *
+ * [isDashing] only drives a slim "tap for the bubble" pointer shown while a dash is
+ * active; it never brings back the live glance the bubble already owns.
+ *
+ * Permissions stay a composable-local OS re-check (re-read on every `ON_RESUME`), so
+ * they are intentionally NOT modelled here.
  */
 data class DashboardUiState(
     val isFirstRun: Boolean = true,
     val statusText: String = "Offline",
-    val isInSession: Boolean = false,
-    val glance: DashGlance = DashGlance.EMPTY,
-    val today: PeriodEconomics = PeriodEconomics.EMPTY,
-)
-
-/**
- * The live "this dash" glance. Holds the *anchors* (net, miles, session start),
- * not frozen display values — the composable derives the ticking figures ($/hr,
- * online duration) from these + a `rememberNow()` tick so they stay fresh without
- * a state-machine transition (Reactive UI rules 1–3). `trueNet`/`miles` update
- * reactively through their own Flows; only the time-derived rates need the ticker.
- *
- * Labelled "This dash" (not "Today") on purpose: this is the current online
- * session only. Real Today/Week/Lifetime totals arrive with the read-model (#314),
- * out of scope here.
- */
-data class DashGlance(
-    val isInSession: Boolean,
-    /** Net profit so far this dash: session gross − session miles × operating cost/mi. */
-    val trueNet: Double,
-    val miles: Double,
-    /** Session start anchor for the online-duration / $-per-hour derivations; null when idle. */
-    val startedAt: Long?,
-) {
-    val isPositiveNet: Boolean get() = trueNet >= 0.0
-
-    /** True Net as money, or an em dash when not dashing. */
-    val trueNetText: String get() = if (isInSession) Formats.money(trueNet) else EMPTY_VALUE
-
-    /** Session miles with one decimal, or an em dash when not dashing. */
-    val milesText: String get() = if (isInSession) Formats.decimal(miles) else EMPTY_VALUE
-
-    /** Online hours elapsed at [now]; null when idle. Floors at 0 (never negative). */
-    private fun onlineHoursAt(now: Long): Double? =
-        startedAt?.let { (now - it).coerceAtLeast(0L) / 3_600_000.0 }
-
     /**
-     * Net $/hr at wall-clock [now] — the denominator (online time) grows every
-     * second, so this is derived in the composable from a ticker, never frozen in
-     * state. `null` until a measurable slice of time has elapsed.
+     * True while a dash session is active (focused region present, mode != Offline),
+     * registry-resolved (never a `== DoorDash` literal). Drives the bubble pointer only.
      */
-    fun netPerHourAt(now: Long): Double? =
-        onlineHoursAt(now)?.let { NetProfit.perHour(trueNet, it) }
-
-    /** Net $/hr as money at [now], or an em dash when undefined / idle. */
-    fun netPerHourText(now: Long): String =
-        netPerHourAt(now)?.let { Formats.money(it) } ?: EMPTY_VALUE
-
-    /** Online duration string at [now] via the TimeFormats SSOT; em dash when idle. */
-    fun onlineDurationText(now: Long): String =
-        startedAt?.let { formatDuration(now - it) } ?: EMPTY_VALUE
-
-    companion object {
-        /** Placeholder shown for every glance figure when not in a session. */
-        const val EMPTY_VALUE = "—"
-
-        val EMPTY = DashGlance(isInSession = false, trueNet = 0.0, miles = 0.0, startedAt = null)
-
-        /** Build a live glance from the current session's anchors. */
-        fun live(trueNet: Double, miles: Double, startedAt: Long): DashGlance =
-            DashGlance(isInSession = true, trueNet = trueNet, miles = miles, startedAt = startedAt)
-    }
-}
+    val isDashing: Boolean = false,
+    /** The review window the tiles aggregate over; default [AnalyticsPeriod.TODAY]. */
+    val selectedPeriod: AnalyticsPeriod = AnalyticsPeriod.TODAY,
+    /** Frozen-net read-model economics for [selectedPeriod]; fresh-on-open, not live-ticking. */
+    val economics: PeriodEconomics = PeriodEconomics.EMPTY,
+)

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardViewModel.kt
@@ -3,11 +3,8 @@ package cloud.trotter.dashbuddy.ui.main.dashboard
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import cloud.trotter.dashbuddy.core.data.analytics.AnalyticsRepository
-import cloud.trotter.dashbuddy.core.data.location.OdometerRepository
-import cloud.trotter.dashbuddy.core.data.settings.AppPreferencesRepository
 import cloud.trotter.dashbuddy.core.data.state.AppStateRepository
 import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
-import cloud.trotter.dashbuddy.domain.evaluation.NetProfit
 import cloud.trotter.dashbuddy.domain.model.chat.ChatPersona
 import cloud.trotter.dashbuddy.domain.state.AppState
 import cloud.trotter.dashbuddy.domain.state.Flow
@@ -17,70 +14,68 @@ import cloud.trotter.dashbuddy.domain.state.PlatformRegion
 import cloud.trotter.dashbuddy.core.state.StateManagerV2
 import cloud.trotter.dashbuddy.ui.bubble.BubbleManager
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 /**
- * State holder for the home (Dashboard) screen. Exposes one immutable
- * [DashboardUiState] (Principle 1 — UDF) assembled reactively from:
- *  - [StateManagerV2] `AppState` — session running earnings + mode + status,
- *  - [OdometerRepository] session miles (GPS),
- *  - [AppPreferencesRepository.userEconomy] — operating cost/mi, the SAME economy
- *    the offer verdict scores against (so live True Net uses identical cost math),
+ * State holder for the home (Dashboard) screen — a **review / configure** surface, not a
+ * live mirror of the bubble HUD (#657). Exposes one immutable [DashboardUiState]
+ * (Principle 1 — UDF) assembled reactively from:
+ *  - [StateManagerV2] `AppState` — the flow/mode used for the status line + the slim
+ *    "🟢 Dashing — tap for the bubble" pointer ([DashboardUiState.isDashing]),
  *  - [AppStateRepository.isFirstRun] — the setup gate,
- *  - [AnalyticsRepository.periodEconomics] — the real **Today** totals from the durable
- *    read model (frozen net, re-emits as the projector folds each delivery + at midnight).
+ *  - [AnalyticsRepository.periodEconomics] — the durable read-model totals for the
+ *    user-selected window (frozen net, re-emits as the projector folds each delivery and
+ *    at midnight/week rollover). This is the PRIMARY economics now — fresh-on-open, not
+ *    live-ticking (a historical period's $/hr is a fixed value), so no odometer / live
+ *    economy / `rememberNow` plumbing is needed here anymore.
  *
  * The focused platform is resolved through the [Platform] registry (flow's active
  * platform, else most-recent activity) — never a `== DoorDash` literal (Principle 8).
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class DashboardViewModel @Inject constructor(
     private val appStateRepository: AppStateRepository,
-    odometerRepository: OdometerRepository,
-    appPreferencesRepository: AppPreferencesRepository,
     stateManager: StateManagerV2,
     analyticsRepository: AnalyticsRepository,
     private val bubbleManager: BubbleManager,
 ) : ViewModel() {
 
+    /** The user-selected review window (UDF intent target); default Today. */
+    private val selectedPeriod = MutableStateFlow(AnalyticsPeriod.TODAY)
+
     val uiState: StateFlow<DashboardUiState> = combine(
         stateManager.state,
-        odometerRepository.sessionMilesFlow,
-        appPreferencesRepository.userEconomy,
         appStateRepository.isFirstRun,
-        analyticsRepository.periodEconomics(AnalyticsPeriod.TODAY),
-    ) { state, sessionMiles, economy, firstRun, today ->
+        // Re-anchor economics on each period switch; keep the period paired with its own
+        // economics so the tiles never render one window's number under another's label.
+        selectedPeriod.flatMapLatest { period ->
+            analyticsRepository.periodEconomics(period).map { period to it }
+        },
+    ) { state, firstRun, (period, economics) ->
         val region = focusedRegion(state)
-        val inSession = region != null && region.mode != Mode.Offline
-        val session = region?.session
-
-        val glance = if (inSession && session != null) {
-            DashGlance.live(
-                trueNet = NetProfit.net(
-                    grossPay = session.runningEarnings,
-                    miles = sessionMiles,
-                    costPerMile = economy.operatingCostPerMile,
-                ),
-                miles = sessionMiles,
-                startedAt = session.startedAt,
-            )
-        } else {
-            DashGlance.EMPTY
-        }
-
         DashboardUiState(
             isFirstRun = firstRun,
             statusText = statusText(state.regions.flow.flow, region?.mode),
-            isInSession = inSession,
-            glance = glance,
-            today = today,
+            isDashing = region != null && region.mode != Mode.Offline,
+            selectedPeriod = period,
+            economics = economics,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), DashboardUiState())
+
+    /** UDF intent — switch the review window; the economics flow re-anchors reactively. */
+    fun setPeriod(period: AnalyticsPeriod) {
+        selectedPeriod.value = period
+    }
 
     fun completeSetup() = viewModelScope.launch {
         appStateRepository.setFirstRunComplete()
@@ -94,7 +89,7 @@ class DashboardViewModel @Inject constructor(
         )
     }
 
-    /** The platform the home glance attributes to — registry-resolved, not a literal. */
+    /** The platform the home status attributes to — registry-resolved, not a literal. */
     private fun focusedRegion(state: AppState): PlatformRegion? {
         val platform: Platform? = state.regions.flow.activePlatform
             ?: state.regions.crossPlatform.mostRecentActivityPlatform

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardViewModelTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardViewModelTest.kt
@@ -1,14 +1,11 @@
 package cloud.trotter.dashbuddy.ui.main.dashboard
 
 import cloud.trotter.dashbuddy.core.data.analytics.AnalyticsRepository
-import cloud.trotter.dashbuddy.core.data.location.OdometerRepository
-import cloud.trotter.dashbuddy.core.data.settings.AppPreferencesRepository
 import cloud.trotter.dashbuddy.core.data.state.AppStateRepository
 import cloud.trotter.dashbuddy.core.state.StateManagerV2
+import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
 import cloud.trotter.dashbuddy.domain.analytics.PeriodEconomics
 import cloud.trotter.dashbuddy.domain.analytics.PeriodTotals
-import cloud.trotter.dashbuddy.domain.evaluation.UserEconomy
-import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleClass
 import cloud.trotter.dashbuddy.domain.state.AppState
 import cloud.trotter.dashbuddy.domain.state.Flow
 import cloud.trotter.dashbuddy.domain.state.FlowRegion
@@ -30,62 +27,70 @@ import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
 /**
- * #320 — the home glance must compute live True Net / $-per-hr from the session's
- * running earnings, session miles, and the SAME operating cost the offer verdict
- * uses (via the NetProfit SSOT), and stay platform-agnostic (registry-focused).
+ * #657 — the home screen is a **review / configure** surface, not a live mirror of the
+ * bubble HUD. The ViewModel exposes the read-model economics for the user-selected
+ * period (default Today, switchable via [DashboardViewModel.setPeriod]) and a registry-
+ * resolved [DashboardUiState.isDashing] pointer — no live-ticking this-dash glance.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class DashboardViewModelTest {
 
     private val appStateRepository: AppStateRepository = mock()
-    private val odometerRepository: OdometerRepository = mock()
-    private val appPreferencesRepository: AppPreferencesRepository = mock()
     private val stateManager: StateManagerV2 = mock()
     private val analyticsRepository: AnalyticsRepository = mock()
     private val bubbleManager: BubbleManager = mock()
 
-    /** Stub the read-model Today flow; defaults to empty so a test opts in to real totals. */
-    private fun stubToday(today: PeriodEconomics = PeriodEconomics.EMPTY) {
-        whenever(analyticsRepository.periodEconomics(any(), anyOrNull())).thenReturn(flowOf(today))
+    /** Stub a specific period's read-model flow (platform arg defaults to null). */
+    private fun stubPeriod(period: AnalyticsPeriod, economics: PeriodEconomics) {
+        whenever(analyticsRepository.periodEconomics(eq(period), anyOrNull()))
+            .thenReturn(flowOf(economics))
     }
 
-    /** $3.00/gal ÷ 30 mpg = $0.10/mi fuel; every non-fuel cost defaults to 0 → $0.10/mi total. */
-    private val tenCentsPerMile = UserEconomy(
-        vehicleClass = VehicleClass.SEDAN,
-        vehicleMpg = 30.0,
-        gasPricePerGallon = 3.0,
-    )
-
-    private fun appStateOnline(startedAt: Long, earnings: Double): AppState = AppState(
+    private fun onlineState(): AppState = AppState(
         regions = Regions(
             flow = FlowRegion(flow = Flow.Idle, activePlatform = Platform.DoorDash),
             platforms = mapOf(
                 Platform.DoorDash to PlatformRegion(
                     platform = Platform.DoorDash,
                     mode = Mode.Online,
-                    session = Session(
-                        sessionId = "s1",
-                        startedAt = startedAt,
-                        runningEarnings = earnings,
-                    ),
+                    session = Session(sessionId = "s1", startedAt = 1_000_000L),
                 ),
             ),
         ),
     )
 
+    private fun offlineState(): AppState = AppState(
+        regions = Regions(
+            flow = FlowRegion(flow = Flow.Idle, activePlatform = Platform.DoorDash),
+            platforms = mapOf(
+                Platform.DoorDash to PlatformRegion(
+                    platform = Platform.DoorDash,
+                    mode = Mode.Offline,
+                ),
+            ),
+        ),
+    )
+
+    private fun economics(net: Double, miles: Double, netPerHour: Double?): PeriodEconomics =
+        PeriodEconomics(
+            totals = PeriodTotals(earnings = net, miles = miles, deliveries = 1, jobs = 1, onlineDuration = 3_600_000L),
+            grossEarnings = net,
+            netProfit = net,
+            unattributedPay = 0.0,
+            netPerHour = netPerHour,
+            netPerMile = null,
+        )
+
     private fun buildViewModel() = DashboardViewModel(
         appStateRepository = appStateRepository,
-        odometerRepository = odometerRepository,
-        appPreferencesRepository = appPreferencesRepository,
         stateManager = stateManager,
         analyticsRepository = analyticsRepository,
         bubbleManager = bubbleManager,
@@ -95,97 +100,73 @@ class DashboardViewModelTest {
     fun tearDown() = Dispatchers.resetMain()
 
     @Test
-    fun `glance computes trueNet and netPerHour from session, miles and economy`() = runTest {
+    fun `default period is TODAY and its read-model economics map into state`() = runTest {
         Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        val startedAt = 1_000_000L
-        whenever(stateManager.state)
-            .thenReturn(MutableStateFlow(appStateOnline(startedAt, earnings = 20.0)))
-        whenever(odometerRepository.sessionMilesFlow).thenReturn(flowOf(8.0))
-        whenever(appPreferencesRepository.userEconomy).thenReturn(flowOf(tenCentsPerMile))
+        val today = economics(net = 55.0, miles = 20.0, netPerHour = 27.5)
+        whenever(stateManager.state).thenReturn(MutableStateFlow(onlineState()))
         whenever(appStateRepository.isFirstRun).thenReturn(flowOf(false))
-        stubToday()
-
-        val viewModel = buildViewModel()
-        val job = launch { viewModel.uiState.collect {} }
-        testScheduler.advanceUntilIdle()
-
-        val glance = viewModel.uiState.value.glance
-        assertTrue(glance.isInSession)
-        // trueNet = 20.00 − 8 mi × $0.10/mi = 19.20
-        assertEquals(19.20, glance.trueNet, 1e-9)
-        assertEquals(8.0, glance.miles, 1e-9)
-        // one hour after start → $19.20 / 1 h = $19.20/hr
-        assertEquals(19.20, glance.netPerHourAt(startedAt + 3_600_000L)!!, 1e-9)
-        // before any time elapses the rate is undefined (null), not a fake $0/hr
-        assertNull(glance.netPerHourAt(startedAt))
-
-        assertTrue(viewModel.uiState.value.isInSession)
-        assertEquals("Looking for offers...", viewModel.uiState.value.statusText)
-        job.cancel()
-    }
-
-    @Test
-    fun `offline yields an empty glance and not-in-session`() = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        val offline = AppState(
-            regions = Regions(
-                flow = FlowRegion(flow = Flow.Idle, activePlatform = Platform.DoorDash),
-                platforms = mapOf(
-                    Platform.DoorDash to PlatformRegion(
-                        platform = Platform.DoorDash,
-                        mode = Mode.Offline,
-                    ),
-                ),
-            ),
-        )
-        whenever(stateManager.state).thenReturn(MutableStateFlow(offline))
-        whenever(odometerRepository.sessionMilesFlow).thenReturn(flowOf(0.0))
-        whenever(appPreferencesRepository.userEconomy).thenReturn(flowOf(tenCentsPerMile))
-        whenever(appStateRepository.isFirstRun).thenReturn(flowOf(false))
-        stubToday()
+        stubPeriod(AnalyticsPeriod.TODAY, today)
 
         val viewModel = buildViewModel()
         val job = launch { viewModel.uiState.collect {} }
         testScheduler.advanceUntilIdle()
 
         val ui = viewModel.uiState.value
-        assertFalse(ui.isInSession)
-        assertFalse(ui.glance.isInSession)
-        assertEquals(DashGlance.EMPTY_VALUE, ui.glance.trueNetText)
-        assertEquals("Ready to Dash", ui.statusText)
+        assertEquals(AnalyticsPeriod.TODAY, ui.selectedPeriod)
+        assertEquals(today, ui.economics)
+        assertEquals(55.0, ui.economics.netProfit, 1e-9)
         job.cancel()
     }
 
     @Test
-    fun `today read-model economics flow maps into the glance state`() = runTest {
+    fun `setPeriod switches the tiles to the selected window's economics`() = runTest {
         Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        val startedAt = 1_000_000L
-        whenever(stateManager.state)
-            .thenReturn(MutableStateFlow(appStateOnline(startedAt, earnings = 20.0)))
-        whenever(odometerRepository.sessionMilesFlow).thenReturn(flowOf(8.0))
-        whenever(appPreferencesRepository.userEconomy).thenReturn(flowOf(tenCentsPerMile))
+        val today = economics(net = 55.0, miles = 20.0, netPerHour = 27.5)
+        val week = economics(net = 312.0, miles = 140.0, netPerHour = 24.0)
+        whenever(stateManager.state).thenReturn(MutableStateFlow(onlineState()))
         whenever(appStateRepository.isFirstRun).thenReturn(flowOf(false))
-
-        // Real "Today" totals: frozen net independent of the live economy above.
-        val todayEconomics = PeriodEconomics(
-            totals = PeriodTotals(earnings = 60.0, miles = 20.0, deliveries = 4, jobs = 3, onlineDuration = 7_200_000L),
-            grossEarnings = 72.0,
-            netProfit = 55.0,
-            unattributedPay = 12.0,
-            netPerHour = 27.5,
-            netPerMile = 2.75,
-        )
-        stubToday(todayEconomics)
+        stubPeriod(AnalyticsPeriod.TODAY, today)
+        stubPeriod(AnalyticsPeriod.THIS_WEEK, week)
 
         val viewModel = buildViewModel()
         val job = launch { viewModel.uiState.collect {} }
         testScheduler.advanceUntilIdle()
 
-        // The read-model Today is exposed verbatim (frozen net, not the live-economy net).
-        assertEquals(todayEconomics, viewModel.uiState.value.today)
-        assertEquals(55.0, viewModel.uiState.value.today.netProfit, 1e-9)
-        // The live "this dash" glance still computes its own separate net against the live economy.
-        assertEquals(19.20, viewModel.uiState.value.glance.trueNet, 1e-9)
+        // Default window.
+        assertEquals(today, viewModel.uiState.value.economics)
+
+        viewModel.setPeriod(AnalyticsPeriod.THIS_WEEK)
+        testScheduler.advanceUntilIdle()
+
+        val ui = viewModel.uiState.value
+        assertEquals(AnalyticsPeriod.THIS_WEEK, ui.selectedPeriod)
+        assertEquals(week, ui.economics)
+        assertEquals(312.0, ui.economics.netProfit, 1e-9)
         job.cancel()
+    }
+
+    @Test
+    fun `isDashing and statusText reflect the registry-resolved mode`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        whenever(appStateRepository.isFirstRun).thenReturn(flowOf(false))
+        stubPeriod(AnalyticsPeriod.TODAY, PeriodEconomics.EMPTY)
+
+        // Online → dashing + "looking for offers".
+        whenever(stateManager.state).thenReturn(MutableStateFlow(onlineState()))
+        val onlineVm = buildViewModel()
+        val onlineJob = launch { onlineVm.uiState.collect {} }
+        testScheduler.advanceUntilIdle()
+        assertTrue(onlineVm.uiState.value.isDashing)
+        assertEquals("Looking for offers...", onlineVm.uiState.value.statusText)
+        onlineJob.cancel()
+
+        // Offline → not dashing + "ready to dash".
+        whenever(stateManager.state).thenReturn(MutableStateFlow(offlineState()))
+        val offlineVm = buildViewModel()
+        val offlineJob = launch { offlineVm.uiState.collect {} }
+        testScheduler.advanceUntilIdle()
+        assertFalse(offlineVm.uiState.value.isDashing)
+        assertEquals("Ready to Dash", offlineVm.uiState.value.statusText)
+        offlineJob.cancel()
     }
 }

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -73,6 +73,16 @@ card's **mechanical** half, #577 (re-confirmed, 24/24, ~0.55 s — with a new po
 that entry's Bug #1), the #457 path, and #554 ShadowProjector (2/2). The #462/#460 dropoff item
 was found **broken-in-part** (raw PII in capture envelopes) and moved to that entry's Bug #7.)_
 
+- **🆕 NEW — the main dashboard is now a REVIEW surface, not a live bubble mirror (#657 / PR #658).**
+  Open the app **after a dash** (not while on a task): the **Today** tiles (True Net / Net $/hr /
+  Miles) should already reflect the just-completed dash with no manual refresh (the read-model folds
+  each delivery as it completes). Tap the **Today / This week / Lifetime** selector and confirm the
+  three tiles switch to each window's totals. The old live "This dash" ticking hero is **gone** —
+  there should be **no** per-second $/hr counter on this screen. While you're online, a slim
+  "🟢 Dashing — tap for the bubble" row appears above the tiles; tapping it should re-show the bubble.
+  How to tell it's broken: tiles frozen/stale after a dash, the segmented selector not changing the
+  numbers, a live ticking counter still present, or the dashing row showing while offline.
+  - Confirmed: 0/2
 - **🆕 NEW — the analytics read-model projector now folds `app_events` into durable records (#314 PR2). READ THE DB / LOG AFTER THE FIRST DASH POST-UPDATE.**
   The projector runs on `DashBuddyApplication` startup (not debug-gated) and event-sources the
   `app_events` log into `delivery_records` / `session_records` / `offer_records`. On the **first


### PR DESCRIPTION
Closes #657.

## The reframe
The main app dashboard was built mirroring the bubble HUD's live glance, but that no longer holds: while dashing the driver is in DoorDash watching the **bubble** overlay — they don't open the full DashBuddy app. The main screen is used when **not on a task** (parked, on break, planning) to **review history** and **configure**.

**Mental model:** the bubble is the dashboard-in-the-car (strictly live while dashing); the main app is the office/ledger between shifts (review + configure). They stop mirroring each other.

This is safe (not a "freeze") because the #314 read-model already gives the main screen **fresh-on-open for free** — the projector folds each delivery as it completes, so opening the app after a dash already reflects it. We get currency **without** live-ticking: a historical period's $/hr is a fixed computed value, so there is nothing to tick.

## What changed
**Removed (the live glance + its plumbing):**
- The `DashGlance` model and the `ThisDashGlance`/`TodayGlance` composables (incl. the `rememberNow()` ticker).
- The `DashboardViewModel`'s live-economics computation: `OdometerRepository.sessionMilesFlow`, the live `AppPreferencesRepository.userEconomy`, and `NetProfit` net/$-per-hour math. Those deps are dropped from the constructor.

**Added (the period review):**
- A **Today / This week / Lifetime** `AppSegmented` selector over the three `AppStatTile`s (True Net / Net $/hr / Miles), served by `AnalyticsRepository.periodEconomics(selectedPeriod)`.
- `DashboardViewModel` holds `selectedPeriod` (private `MutableStateFlow<AnalyticsPeriod>`, default `TODAY`) + a `setPeriod()` intent; economics resolve via `flatMapLatest`, period paired with its own economics so the tiles never show one window's number under another's label.
- A slim `DashingStatusRow` — "🟢 Dashing — tap for the bubble" — shown only while `isDashing`, tapping the existing Show-Bubble action.

**Kept intact:** the entry-tile grid (Analytics / Ratings / Strategy / Economy), the status card / first-run guide / permission gate, and the Settings FAB.

**Final shapes:**
- `DashboardUiState(isFirstRun, statusText, isDashing, selectedPeriod, economics)` — `isDashing` is registry-resolved from `AppState` mode (`!= Offline`), never a `== DoorDash` literal.
- `DashboardViewModel` deps: `AppStateRepository`, `StateManagerV2`, `AnalyticsRepository`, `BubbleManager`.

## Tests
`DashboardViewModelTest` rewritten (the old live-glance `trueNet == 19.20` assertion is gone): default period is `TODAY` and its read-model economics map into state; `setPeriod(THIS_WEEK)` switches the tiles to the week's `periodEconomics`; `isDashing`/`statusText` reflect the registry-resolved mode (online → dashing / "Looking for offers...", offline → not dashing / "Ready to Dash"). `RatingsViewModelTest` untouched.

- `:app:testDebugUnitTest` — 892 tests, 0 failures (3 Dashboard tests green)
- `:domain:test` — 262 tests, 0 failures
- `:app:testDebugUnitTest --tests "*AllMatchersSuite*"` — green

### Design-goal review
- **P1 (UDF).** State flows down as one immutable `DashboardUiState`; the UI dispatches the `setPeriod` intent up, never writing a repo. Period → economics is a reactive `flatMapLatest`, not imperative refresh.
- **P3 (single responsibility).** ViewModel shrank (three deps removed); the screen's glance composables collapsed into one `PeriodReview` + a slim status row.
- **P5 (SSOT).** Money/decimal via `Formats`; economics are the read-model's frozen net (no second computation) — the reframe deletes the parallel live-net path that duplicated cost math.
- **P8 (platform-agnostic).** `isDashing`/status resolve through the `Platform` registry (`activePlatform` ⇒ `mostRecentActivityPlatform`); no platform literal. Diff touches only `:app` UI, not `:core:state`/`:core:pipeline`/`:domain`/rules.
- **Reactive UI.** The period tiles are reactive (Room-invalidation Flow + midnight/week rollover in the repo) but deliberately **fresh-not-ticking** — no `rememberNow` on a historical period whose $/hr is fixed. This is the correct application of the rules, not a violation: the live-tick bar is the bubble's, and the removed ticker was only needed for the elapsed-time-driven this-dash $/hr.

### Security posture
No new capture, network, or PII surface. The read-model already exposes economics/counts/store-names only (customer PII sha256'd upstream); removing the live glance strictly reduces surface. INFO/PII logging untouched.

## Next field test
- After a dash, open the app → **Today** reflects the just-completed dash without any manual refresh; toggle **Today / This week / Lifetime** and confirm the three tiles switch windows. The old live "This dash" ticking hero is gone, replaced by the period review; while online a "🟢 Dashing — tap for the bubble" row appears and taps re-show the bubble. (#657)

---

### Design-goal review
Bounded `:app` dashboard reframe — a net simplification.
- **P1 (UDF):** immutable `DashboardUiState` down, `setPeriod` intent up, private `selectedPeriod` MutableStateFlow (not leaked as a loose flow).
- **P3 (SRP):** the ViewModel dropped two deps (`OdometerRepository`, live `AppPreferencesRepository`) + the whole live-net computation; `DashGlance` deleted.
- **P8:** `isDashing`/focus resolved via the `Platform` registry (`activePlatform ?: mostRecentActivityPlatform`), no literal.
- **Reactive UI:** the period tiles are fresh-via-read-model-Flow (Room invalidation + midnight/week rollover) but correctly **not** per-second ticking — a historical period's $/hr is a fixed value, so removing `rememberNow` here is the *correct* application of the principle, not a violation. The bubble remains the strict live-glance surface.
- **P7:** economics/counts only rendered; no store/customer text.

### Adversarial review
Independent Opus review (developer waived the Fable gate for this bounded change; Fable exhausted) — **verdict: CLEAN, merge-ready.** Confirmed the live glance is fully removed (`DashGlance`/`ThisDashGlance`/`TodayGlance`/`rememberNow` gone, grep-clean of stale `.glance`/`.isInSession` refs, dropped deps also removed from the test builder). Period selector correct: `flatMapLatest` cancels the prior flow and carries `period to economics` together so a tile can't render one window's number under another's label; single immutable UiState; `AppSegmented` wiring + unique labels verified. `isDashing = mode != Offline` registry-resolved (P8), `DashingStatusRow` reuses the existing Show-Bubble action (no dup logic). No regression — status card / first-run / permission gate / FAB / entry grid intact; the removed live-glance test replaced by 3 non-vacuous period-selection tests (would fail if `setPeriod` didn't re-anchor the flow). `:app` DashboardViewModelTest 3/3, `:domain` green. One cosmetic non-blocking note: the "tap for the bubble" row reuses the welcome-copy bubble action — fine functionally, a dash-appropriate copy tweak is a possible follow-up.
