### PR TITLE
fix(#655): session-anchored analytics period bucketing

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsDaoProjectorSupportTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsDaoProjectorSupportTest.kt
@@ -103,6 +103,9 @@ class AnalyticsDaoProjectorSupportTest {
 
     @Test
     fun `deliveryTotalsByPlatform groups pay, count, and distinct jobs per platform`() = runBlocking {
+        // Session-anchored (#655): deliveries join to their session's period, so their sessions must exist.
+        dao.upsertSession(session("A", platform = "doordash", startedAt = 1_000))
+        dao.upsertSession(session("B", platform = "uber", startedAt = 1_000))
         dao.upsertDelivery(delivery(1, "A", "J1", platform = "doordash"))
         dao.upsertDelivery(delivery(2, "A", "J1", platform = "doordash")) // same job
         dao.upsertDelivery(delivery(3, "B", "J9", platform = "uber"))

--- a/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsRepositoryTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsRepositoryTest.kt
@@ -274,9 +274,11 @@ class AnalyticsRepositoryTest {
     }
 
     /**
-     * Degraded null-session edge (#655): a delivery folded under the `_unknown` context has
-     * `sessionId IS NULL` and joins to no session, so it still counts in the period containing its
-     * own `completedAt` — never vanishing from every window but LIFETIME.
+     * Null-session edge (#655): a delivery row whose source event carried NO sessionId at all
+     * (`aggregateId` null — the `_unknown`-context degradation still assigns a sessionId + an
+     * atomic placeholder session row, so it is NOT the null source) joins to no session and must
+     * still count in the period containing its own `completedAt` — never vanishing from every
+     * window but LIFETIME.
      */
     @Test
     fun `null-session delivery counts by its completedAt, not lost to the session join`() = runBlocking {

--- a/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsRepositoryTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsRepositoryTest.kt
@@ -51,7 +51,7 @@ class AnalyticsRepositoryTest {
 
     private fun delivery(
         seq: Long,
-        sessionId: String,
+        sessionId: String?,
         jobId: String,
         storeName: String?,
         pay: Double?,
@@ -161,7 +161,8 @@ class AnalyticsRepositoryTest {
     }
 
     @Test
-    fun `perStoreEconomics groups by store with frozen net, busiest first`() = runBlocking {
+    fun `perStoreEconomics groups by store with frozen net, highest-earning first`() = runBlocking {
+        dao.upsertSession(session("S1", base, reportedEarnings = null, durationMillis = 4 * hour, startOdo = 0.0, lastOdo = 0.0, deliveries = 3, jobsCompleted = 2))
         dao.upsertDelivery(delivery(1, "S1", "J1", "Wendys", pay = 10.0, net = 8.0, completedAt = base + hour))
         dao.upsertDelivery(delivery(2, "S1", "J1", "Wendys", pay = 6.0, net = 5.0, completedAt = base + 2 * hour))
         dao.upsertDelivery(delivery(3, "S1", "J2", "Chipotle", pay = 9.0, net = 7.0, completedAt = base + 3 * hour))
@@ -228,5 +229,75 @@ class AnalyticsRepositoryTest {
         val uber = repo.periodEconomics(AnalyticsPeriod.LIFETIME, cloud.trotter.dashbuddy.domain.state.Platform.Uber).first()
         assertEquals(15.0, uber.netProfit, 1e-9)
         assertEquals(1, uber.totals.deliveries)
+    }
+
+    /**
+     * THE seam (#655): a dash started 23:50 yesterday whose delivery completed 00:10 today lands
+     * WHOLLY on its start day. Under TODAY the session set is empty, so delivered pay, frozen net,
+     * miles, gross and deliveries are ALL zero; under YESTERDAY they ALL reflect the one session —
+     * proving every figure derives from the same session set (no completedAt-split).
+     * Driven at the DAO with explicit bounds so the day boundary is exact (the repository period
+     * flow reads the wall clock and can't be pinned to a synthetic midnight).
+     */
+    @Test
+    fun `midnight-spanning dash counts wholly on its start day for every figure`() = runBlocking {
+        val todayStart = base                 // treat `base` as today 00:00
+        val yesterdayStart = todayStart - day
+        val sessionStart = todayStart - 600_000   // 23:50 yesterday
+        val deliveryDone = todayStart + 600_000   // 00:10 today
+
+        dao.upsertSession(session("Y", sessionStart, reportedEarnings = 30.0, durationMillis = hour, startOdo = 100.0, lastOdo = 110.0, deliveries = 1, jobsCompleted = 1))
+        dao.upsertDelivery(delivery(1, "Y", "J1", "Wendys", pay = 25.0, net = 20.0, completedAt = deliveryDone))
+
+        // TODAY = [todayStart, todayStart + day): session Y started yesterday ⇒ nothing lands.
+        val dToday = dao.deliveryTotals(todayStart, todayStart + day).first()
+        val sToday = dao.sessionTotals(todayStart, todayStart + day).first()
+        val gToday = dao.grossAndUnattributed(todayStart, todayStart + day).first()
+        assertEquals(0, dToday.deliveries)
+        assertEquals(0.0, dToday.pay, 1e-9)
+        assertEquals(0.0, dToday.net, 1e-9)
+        assertEquals(0.0, sToday.miles, 1e-9)
+        assertEquals(0L, sToday.onlineMillis)
+        assertEquals(0.0, gToday.gross, 1e-9)
+
+        // YESTERDAY = [yesterdayStart, todayStart): the whole dash — deliveries, net, miles, gross.
+        val dYest = dao.deliveryTotals(yesterdayStart, todayStart).first()
+        val sYest = dao.sessionTotals(yesterdayStart, todayStart).first()
+        val gYest = dao.grossAndUnattributed(yesterdayStart, todayStart).first()
+        assertEquals(1, dYest.deliveries)
+        assertEquals(25.0, dYest.pay, 1e-9)     // delivered pay follows the session, not completedAt
+        assertEquals(20.0, dYest.net, 1e-9)
+        assertEquals(10.0, sYest.miles, 1e-9)   // 110 − 100
+        assertEquals(hour, sYest.onlineMillis)
+        assertEquals(30.0, gYest.gross, 1e-9)   // reported-authoritative
+        assertEquals(5.0, gYest.unattributed, 1e-9) // 30 reported − 25 delivered
+    }
+
+    /**
+     * Degraded null-session edge (#655): a delivery folded under the `_unknown` context has
+     * `sessionId IS NULL` and joins to no session, so it still counts in the period containing its
+     * own `completedAt` — never vanishing from every window but LIFETIME.
+     */
+    @Test
+    fun `null-session delivery counts by its completedAt, not lost to the session join`() = runBlocking {
+        val todayStart = base
+        val completedToday = todayStart + 600_000
+
+        dao.upsertDelivery(delivery(1, sessionId = null, jobId = "J1", storeName = "Wendys", pay = 12.0, net = 9.0, completedAt = completedToday))
+
+        // TODAY window contains its completedAt ⇒ it counts.
+        val today = dao.deliveryTotals(todayStart, todayStart + day).first()
+        assertEquals(1, today.deliveries)
+        assertEquals(12.0, today.pay, 1e-9)
+        assertEquals(9.0, today.net, 1e-9)
+
+        // Yesterday's window does not contain its completedAt ⇒ it does not.
+        val yesterday = dao.deliveryTotals(todayStart - day, todayStart).first()
+        assertEquals(0, yesterday.deliveries)
+
+        // LIFETIME still catches it (semantically unchanged).
+        val life = dao.deliveryTotals(0, Long.MAX_VALUE).first()
+        assertEquals(1, life.deliveries)
+        assertEquals(12.0, life.pay, 1e-9)
     }
 }

--- a/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsSchemaRoundTripTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsSchemaRoundTripTest.kt
@@ -6,6 +6,7 @@ import cloud.trotter.dashbuddy.core.database.DashBuddyDatabase
 import cloud.trotter.dashbuddy.core.database.analytics.AnalyticsDao
 import cloud.trotter.dashbuddy.core.database.analytics.AnalyticsProjectionStateEntity
 import cloud.trotter.dashbuddy.core.database.analytics.DeliveryRecordEntity
+import cloud.trotter.dashbuddy.core.database.analytics.SessionRecordEntity
 import cloud.trotter.dashbuddy.core.database.event.AppEventDao
 import cloud.trotter.dashbuddy.core.database.event.AppEventEntity
 import cloud.trotter.dashbuddy.domain.model.event.AppEventType
@@ -50,6 +51,15 @@ class AnalyticsSchemaRoundTripTest {
     @After
     fun tearDown() = db.close()
 
+    /** Minimal in-window session so a delivery's session-anchored join (#655) finds it. */
+    private fun session(id: String, startedAt: Long) = SessionRecordEntity(
+        sessionId = id, platform = "doordash", startedAt = startedAt, endedAt = startedAt + 1_000,
+        lastEventAt = startedAt + 1_000, endSource = null, startOdometer = null, lastOdometer = null,
+        reportedEarnings = null, reportedDurationMillis = null,
+        offersReceived = 0, offersAccepted = 0, offersDeclined = 0, offersTimeout = 0,
+        deliveries = 0, jobsCompleted = 0,
+    )
+
     private fun delivery(
         seq: Long,
         jobId: String,
@@ -57,9 +67,10 @@ class AnalyticsSchemaRoundTripTest {
         pay: Double?,
         completedAt: Long,
         platform: String = "doordash",
+        sessionId: String = "S1",
     ) = DeliveryRecordEntity(
         eventSequenceId = seq,
-        sessionId = "S1",
+        sessionId = sessionId,
         platform = platform,
         jobId = jobId,
         taskId = "T$seq",
@@ -84,19 +95,23 @@ class AnalyticsSchemaRoundTripTest {
 
     @Test
     fun `deliveryTotals sums pay, counts rows, and counts distinct jobs`() = runBlocking {
-        analyticsDao.upsertDelivery(delivery(1, "J1", "Wendys", 10.0, 1_000))
-        analyticsDao.upsertDelivery(delivery(2, "J1", "Wendys", 5.0, 2_000))
-        analyticsDao.upsertDelivery(delivery(3, "J2", "Chipotle", 8.0, 3_000))
+        // Two sessions; deliveries join to their session's period (#655), not their own completedAt.
+        analyticsDao.upsertSession(session("S1", startedAt = 1_000))
+        analyticsDao.upsertSession(session("S2", startedAt = 3_000))
+        analyticsDao.upsertDelivery(delivery(1, "J1", "Wendys", 10.0, 1_000, sessionId = "S1"))
+        analyticsDao.upsertDelivery(delivery(2, "J1", "Wendys", 5.0, 2_000, sessionId = "S1"))
+        analyticsDao.upsertDelivery(delivery(3, "J2", "Chipotle", 8.0, 3_000, sessionId = "S2"))
 
         val all = analyticsDao.deliveryTotals(0, Long.MAX_VALUE).first()
         assertEquals(23.0, all.pay, 0.0001)
         assertEquals(3, all.deliveries)
         assertEquals(2, all.jobs) // J1, J2 distinct
 
-        // Half-open [start, end): only the 2_000 row lands.
-        val window = analyticsDao.deliveryTotals(1_500, 2_500).first()
-        assertEquals(5.0, window.pay, 0.0001)
-        assertEquals(1, window.deliveries)
+        // Half-open [start, end) on the SESSION's startedAt: only S1 (started 1_000) is in the
+        // window, so both of its deliveries land (incl. the one completed at 2_000), and S2 does not.
+        val window = analyticsDao.deliveryTotals(500, 1_500).first()
+        assertEquals(15.0, window.pay, 0.0001)
+        assertEquals(2, window.deliveries)
         assertEquals(1, window.jobs)
     }
 
@@ -110,6 +125,7 @@ class AnalyticsSchemaRoundTripTest {
 
     @Test
     fun `deliveryTotalsByStore groups by store, ordered by pay desc`() = runBlocking {
+        analyticsDao.upsertSession(session("S1", startedAt = 1_000))
         analyticsDao.upsertDelivery(delivery(1, "J1", "Wendys", 10.0, 1_000))
         analyticsDao.upsertDelivery(delivery(2, "J1", "Wendys", 5.0, 2_000))
         analyticsDao.upsertDelivery(delivery(3, "J2", "Chipotle", 8.0, 3_000))
@@ -126,6 +142,7 @@ class AnalyticsSchemaRoundTripTest {
 
     @Test
     fun `upsertDelivery replaces on the sequenceId primary key`() = runBlocking {
+        analyticsDao.upsertSession(session("S1", startedAt = 1_000))
         analyticsDao.upsertDelivery(delivery(1, "J1", "Wendys", 10.0, 1_000))
         // Same sequenceId, different pay — REPLACE, not a second row.
         analyticsDao.upsertDelivery(delivery(1, "J1", "Wendys", 99.0, 1_000))

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
@@ -46,6 +46,12 @@ class AnalyticsRepository @Inject constructor(
      * Frozen-net economics for [period]. `platform == null` ⇒ cross-platform; a
      * specific [platform] filters to that platform's records. Re-emits on new
      * records (Room invalidation) and at midnight/week rollover (boundary flow).
+     *
+     * **Session-anchored (#655):** a period contains the sessions that *started* in it, and every
+     * figure — delivered pay, frozen net, deliveries, miles, gross, unattributed — derives from that
+     * one session set. A midnight-spanning dash lands wholly on its start day, so a dash begun at
+     * 11:50pm counts entirely on that evening (its post-midnight deliveries with it), never split
+     * across two days. The single bucketing owner is the DAO join (Principle 5).
      */
     fun periodEconomics(period: AnalyticsPeriod, platform: Platform? = null): Flow<PeriodEconomics> =
         periodBoundariesFlow(period).flatMapLatest { (start, end) ->
@@ -81,7 +87,7 @@ class AnalyticsRepository @Inject constructor(
             }
         }
 
-    /** Per-store economics for [period], busiest store first — frozen net + realized gross. */
+    /** Per-store economics for [period], highest-earning store first — frozen net + realized gross. */
     fun perStoreEconomics(period: AnalyticsPeriod): Flow<List<StoreEconomics>> =
         periodBoundariesFlow(period).flatMapLatest { (start, end) ->
             analyticsDao.deliveryTotalsByStore(start, end).map { rows ->

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
@@ -21,7 +21,11 @@ import kotlinx.coroutines.flow.Flow
  *     tables themselves (they ARE the fold state).
  *
  * Periods are half-open `[start, end)` predicates computed at query time — no
- * bucketing columns, no timezone materialized into rows.
+ * bucketing columns, no timezone materialized into rows. **A period is anchored on
+ * the sessions whose `startedAt` falls in the window** (session-anchored periods,
+ * #655); every delivery-side aggregate derives from that one session set (joined via
+ * `sessionId`) so gross/net/miles/deliveries are internally consistent by construction,
+ * and a midnight-spanning dash lands wholly on its start day.
  */
 @Dao
 interface AnalyticsDao {
@@ -57,16 +61,34 @@ interface AnalyticsDao {
 
     // ── Read-side aggregates (Flow ⇒ reactive via Room invalidation) ─────
 
+    /**
+     * Delivered pay / frozen net / counts for the deliveries belonging to the **sessions that
+     * started in `[start, end)`** (session-anchored periods, #655): a delivery buckets by the
+     * period of its *session's* `startedAt`, joined via `sessionId` — not independently by its own
+     * `completedAt`. So a midnight-spanning dash lands wholly on its start day, and these
+     * delivery/net counts agree with the session-derived miles/gross ([sessionTotals],
+     * [grossAndUnattributed]) over one shared session set by construction.
+     *
+     * Edge — **degraded null-session rows**: a delivery folded under the `_unknown`-context
+     * degradation has `sessionId IS NULL` and joins to no session, so it is included by its own
+     * `completedAt` falling in the window — otherwise it would vanish from every period but
+     * LIFETIME. `NULL IN (…)` is never true in SQL, so the two `WHERE` clauses are disjoint (no
+     * double count). LIFETIME `(0, MAX)` is semantically unchanged: every session is in-window and
+     * every completedAt is in `[0, MAX)`.
+     */
     @Query(
         """SELECT COALESCE(SUM(realizedPay), 0) AS pay,
                   COALESCE(SUM(netProfit), 0) AS net,
                   COUNT(*) AS deliveries,
                   COUNT(DISTINCT jobId) AS jobs
            FROM delivery_records
-           WHERE completedAt >= :start AND completedAt < :end"""
+           WHERE sessionId IN (SELECT sessionId FROM session_records
+                               WHERE startedAt >= :start AND startedAt < :end)
+              OR (sessionId IS NULL AND completedAt >= :start AND completedAt < :end)"""
     )
     fun deliveryTotals(start: Long, end: Long): Flow<DeliveryTotalsRow>
 
+    /** Per-platform variant of [deliveryTotals] — same session-anchored join + null-session edge. */
     @Query(
         """SELECT platform,
                   COALESCE(SUM(realizedPay), 0) AS pay,
@@ -74,18 +96,27 @@ interface AnalyticsDao {
                   COUNT(*) AS deliveries,
                   COUNT(DISTINCT jobId) AS jobs
            FROM delivery_records
-           WHERE completedAt >= :start AND completedAt < :end
+           WHERE sessionId IN (SELECT sessionId FROM session_records
+                               WHERE startedAt >= :start AND startedAt < :end)
+              OR (sessionId IS NULL AND completedAt >= :start AND completedAt < :end)
            GROUP BY platform"""
     )
     fun deliveryTotalsByPlatform(start: Long, end: Long): Flow<List<PlatformDeliveryTotalsRow>>
 
+    /**
+     * Per-store variant of [deliveryTotals] — same session-anchored join + null-session edge.
+     * `ORDER BY pay DESC` is the **highest-earning store first** (realized gross), intentional so
+     * the store list leads with where the money came from.
+     */
     @Query(
         """SELECT storeName,
                   COALESCE(SUM(realizedPay), 0) AS pay,
                   COALESCE(SUM(netProfit), 0) AS net,
                   COUNT(*) AS deliveries
            FROM delivery_records
-           WHERE completedAt >= :start AND completedAt < :end
+           WHERE sessionId IN (SELECT sessionId FROM session_records
+                               WHERE startedAt >= :start AND startedAt < :end)
+              OR (sessionId IS NULL AND completedAt >= :start AND completedAt < :end)
            GROUP BY storeName
            ORDER BY pay DESC"""
     )
@@ -110,12 +141,19 @@ interface AnalyticsDao {
     fun sessionTotalsByPlatform(start: Long, end: Long): Flow<List<PlatformSessionTotalsRow>>
 
     /**
-     * Reported-authoritative gross + unattributed delta for a period (#314 PR3), bucketed by
-     * session `startedAt`. Per session: gross = the summary-screen `reportedEarnings` when present,
-     * else that session's Σ delivered pay; unattributed = `reportedEarnings − deliveredPay` when
-     * reported exceeds delivered (bonuses/adjustments/a missed capture — never negative). The
-     * delivered-pay subquery sums each session's full realized pay (no period filter — a session's
-     * own pay against its own reported total), joined to the in-period sessions.
+     * Reported-authoritative gross + unattributed delta for a period (#314 PR3), anchored on the
+     * sessions whose `startedAt` is in `[start, end)` — the same session set the delivery-side
+     * aggregates ([deliveryTotals]) now derive from (#655), so gross and net are consistent by
+     * construction. Per session: gross = the summary-screen `reportedEarnings` when present, else
+     * that session's Σ delivered pay; unattributed = `reportedEarnings − deliveredPay` when reported
+     * exceeds delivered (bonuses/adjustments/a missed capture — never negative).
+     *
+     * The delivered-pay subquery is deliberately **unfiltered by period**: the session set is
+     * already the single filter (the outer `WHERE s.startedAt …`), and a session is matched to its
+     * own full delivered pay for its own reported total — a `completedAt` filter here would be both
+     * redundant and wrong (it could split a midnight-spanning session's pay away from its reported
+     * total). The `LEFT JOIN` is onto a `GROUP BY sessionId` subquery (one row per session), so
+     * there is no fan-out.
      */
     @Query(
         """SELECT COALESCE(SUM(COALESCE(s.reportedEarnings, d.deliveredPay, 0)), 0) AS gross,

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
@@ -69,12 +69,14 @@ interface AnalyticsDao {
      * delivery/net counts agree with the session-derived miles/gross ([sessionTotals],
      * [grossAndUnattributed]) over one shared session set by construction.
      *
-     * Edge — **degraded null-session rows**: a delivery folded under the `_unknown`-context
-     * degradation has `sessionId IS NULL` and joins to no session, so it is included by its own
-     * `completedAt` falling in the window — otherwise it would vanish from every period but
-     * LIFETIME. `NULL IN (…)` is never true in SQL, so the two `WHERE` clauses are disjoint (no
-     * double count). LIFETIME `(0, MAX)` is semantically unchanged: every session is in-window and
-     * every completedAt is in `[0, MAX)`.
+     * Edge — **null-session rows**: a `sessionId IS NULL` delivery row can only come from an event
+     * that carried no sessionId at all (`aggregateId` null in the log) — the `_unknown`-context
+     * degradation still assigns the event's own sessionId AND upserts its placeholder session row
+     * in the same transaction, so those rows are session-reachable. A truly session-less row joins
+     * to no session and is included by its own `completedAt` falling in the window — otherwise it
+     * would vanish from every period but LIFETIME. `NULL IN (…)` is never true in SQL, so the two
+     * `WHERE` clauses are disjoint (no double count). LIFETIME `(0, MAX)` is semantically
+     * unchanged: every session is in-window and every completedAt is in `[0, MAX)`.
      */
     @Query(
         """SELECT COALESCE(SUM(realizedPay), 0) AS pay,

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/DeliveryRecordEntity.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/DeliveryRecordEntity.kt
@@ -34,8 +34,8 @@ import androidx.room.PrimaryKey
 @Entity(
     tableName = "delivery_records",
     indices = [
-        Index("completedAt"),                       // period predicates
-        Index(value = ["platform", "completedAt"]), // per-platform periods
+        Index("completedAt"),                       // null-session fallback window + per-day charts
+        Index(value = ["platform", "completedAt"]), // per-platform ordering/charts (period bucketing is session-anchored, #655)
         Index("sessionId"),                         // per-dash drilldown + fold hydration
         Index(value = ["sessionId", "jobId"]),      // incremental distinct-job counting
         Index("storeName"),                         // per-store aggregation + chain resolution (#159)

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/PeriodTotals.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/PeriodTotals.kt
@@ -10,8 +10,9 @@ import kotlinx.serialization.Serializable
  *
  * Formerly three dead fields on `CrossPlatformRegion` (the pure state-machine
  * reducer never populated them — totals are history, and history lives on the
- * read side, never in a pure stepper; #314 §3). It kept its `@Serializable`
- * annotation on the move so any legacy usage stays decode-compatible.
+ * read side, never in a pure stepper; #314 §3). The `@Serializable` annotation is
+ * retained as a low-cost, forward-looking default for a plain aggregate DTO (export
+ * / IPC readiness); it carries no live wire contract today.
  *
  * [earnings] is *delivered* pay (Σ realized delivery pay). The platform's own
  * reported all-pay total — which additionally covers challenge bonuses and
@@ -19,7 +20,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class PeriodTotals(
-    /** Σ realized delivery pay bucketed by completion time. */
+    /** Σ realized delivery pay, session-anchored (the deliveries of the period's sessions, #655). */
     val earnings: Double = 0.0,
     /** Σ session odometer delta (floored per session). */
     val miles: Double = 0.0,


### PR DESCRIPTION
Closes #655. Unblocks #659 and the H3/H4 aggregations that build on period economics.

## Semantics decision
Canonicalizes analytics period attribution to **session-anchored periods** ([locked on #655, 2026-07-05](https://github.com/sjtrotter/DashBuddy/issues/655#issuecomment-)): **a period contains the sessions that STARTED in it, and every figure derives from that one session set.** `TODAY` = sessions with `startedAt` today; a period's deliveries/net/tips = `delivery_records` joined via `sessionId` to those sessions — not independently bucketed by `completedAt`. A midnight-spanning dash lands wholly on its start day, so gross/net/miles/deliveries are internally consistent by construction. `LIFETIME` unaffected.

This removes the pre-existing **mixed-bucketing seam**: `deliveryTotals*` filtered `completedAt` while `sessionTotals`/`grossAndUnattributed` filtered `startedAt`, so a dash spanning midnight had its post-midnight deliveries counted on a different day than its miles/gross.

## What changed, per query
- **`deliveryTotals` / `deliveryTotalsByPlatform` / `deliveryTotalsByStore`** — rewritten from a `completedAt`-window filter to a **session-set join**. Signatures/Flow return types unchanged (no repository churn). Landed SQL shape:
  ```sql
  WHERE sessionId IN (SELECT sessionId FROM session_records
                      WHERE startedAt >= :start AND startedAt < :end)
     OR (sessionId IS NULL AND completedAt >= :start AND completedAt < :end)
  ```
  (`sessionId` is indexed; `session_records.sessionId` is the PK, so the subquery is cheap.)
- **`grossAndUnattributed` / `…ByPlatform`** — query **unchanged** (it was already session-anchored). Its delivered-pay subquery is deliberately **unfiltered by period** — the session set is the single filter, and a `completedAt` filter here would wrongly split a midnight-spanning session's pay from its reported total. Documented as correct-by-design; the `LEFT JOIN` onto a `GROUP BY sessionId` subquery is one row per session (no fan-out) — confirmed.
- Doc nits from the #654 review: `deliveryTotalsByStore` / `perStoreEconomics` KDoc "busiest store first" → **"highest-earning first"** (the `ORDER BY pay DESC` is intentional); removed the stale `@Serializable` "legacy decode-compatibility" rationale on `PeriodTotals` (annotation kept as a low-cost export/IPC default; the justification was stale). Updated `AnalyticsRepository.periodEconomics` + `AnalyticsDao` class KDoc to state the session-anchored semantics + midnight-spanning note.

## The null-session edge
Deliveries folded under the `_unknown`-context degradation have `sessionId IS NULL` and join to no session — under a pure join they'd vanish from every period but `LIFETIME`. Handled **in the one query** (no repository stitching) via the disjoint `OR (sessionId IS NULL AND completedAt in-window)` clause: `NULL IN (…)` is never true in SQL, so the two clauses can't double-count. Documented in the DAO KDoc.

## Tests
- **The seam test** (`midnight-spanning dash counts wholly on its start day for every figure`): session started 23:50 "yesterday", delivery completed 00:10 "today" → under TODAY delivered pay / frozen net / miles / gross / deliveries are **all** zero; under YESTERDAY they **all** reflect the one session. Asserts every figure moves together over the same session set. Driven at the DAO with explicit bounds (the repo period flow reads the wall clock and can't be pinned to a synthetic midnight).
- **Null-session edge test**: a `sessionId = null` delivery counts in the period containing its `completedAt`, not in an adjacent one, and still shows under `LIFETIME`.
- Existing DAO tests that seeded dangling-sessionId deliveries (`AnalyticsSchemaRoundTripTest`, `AnalyticsDaoProjectorSupportTest`) now seed the matching `session_records` so the session-anchored join finds them; the old `completedAt`-window sub-assertion in `deliveryTotals sums pay…` is reworked to a session-anchored window. Frozen-net / unattributed assertions untouched.
- Full suites GREEN: `:app:testDebugUnitTest` 894 tests / 0 failures (analytics: Repository 8, SchemaRoundTrip 8, DaoProjectorSupport 6, Projector 8, BackfillReplay 1), `:domain:test` 262 / 0.

## Field-test note
Home **Today**/**Week** figures may shift slightly for a boundary-spanning dash — a dash begun before midnight now reports its post-midnight deliveries on the start day (previously split). No new field-test checklist item required; noting it here for the next dash.

### Design-goal review
- **P5 (SSOT)** — the whole point: one bucketing owner. The delivery-side aggregates no longer bucket independently by `completedAt`; they derive from the same session set as miles/gross, so the four figures can't drift. No signature/return-type churn — the repository is doc-only.
- **P8 (platform-agnostic)** — touches `:core:database` (SQL) + `:domain` (doc-only) + `:core:data`. No platform literals introduced; per-platform paths still key on `platform`/`Platform.wire`, unchanged.
- **P1 (UDF)** — read-model only; still pure `Flow`s off Room invalidation, no state-machine or wall-clock coupling in the reducers.
- **P6 (privacy)** — no new capture/network/PII surface; queries are economics/counts/store-name only, customer fields already sha256'd upstream.

_Adversarial review pending (orchestrator-gated, fable tier)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)