### PR TITLE
feat(#315): Analytics hub — Money tab v1 (Phase H1)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/MainActivity.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/MainActivity.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import cloud.trotter.dashbuddy.ui.main.analytics.AnalyticsScreen
 import cloud.trotter.dashbuddy.ui.main.dashboard.DashboardScreen
 import cloud.trotter.dashbuddy.ui.main.navigation.Screen
 import cloud.trotter.dashbuddy.ui.main.ratings.RatingsScreen
@@ -72,10 +73,9 @@ class MainActivity : ComponentActivity() {
                             )
                         }
 
-                        // --- ANALYTICS HUB (Phase 4, #315) — placeholder for now ---
+                        // --- ANALYTICS HUB (#315 H1 — Money tab v1) ---
                         composable(Screen.Analytics.route) {
-                            PlaceholderScreen(
-                                title = "Analytics",
+                            AnalyticsScreen(
                                 onBack = { navController.popBackStack() }
                             )
                         }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsScreen.kt
@@ -1,0 +1,140 @@
+package cloud.trotter.dashbuddy.ui.main.analytics
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.compose.runtime.getValue
+import cloud.trotter.dashbuddy.core.designsystem.component.AppCard
+import cloud.trotter.dashbuddy.core.designsystem.component.AppSegmented
+import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
+import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
+
+/**
+ * The Analytics hub (#315). Ships the real Money / Patterns / Decisions / Time tab bar now so
+ * the structure is stable; only [AnalyticsTab.Money] has content in H1 (the others show a
+ * "coming soon" card — Decisions H3, Time H4, Patterns H5). A **review** surface: UDF state in,
+ * `setTab`/`setPeriod` intents out (Principle 1); reactive-fresh via the read-model Flows, no
+ * `rememberNow()` tick (a historical period's figures are fixed).
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AnalyticsScreen(
+    onBack: () -> Unit,
+    viewModel: AnalyticsViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Analytics") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp)
+                .fillMaxSize(),
+        ) {
+            AppSegmented(
+                options = AnalyticsTab.entries.map { it.label },
+                selected = uiState.selectedTab.label,
+                onSelect = { label ->
+                    AnalyticsTab.entries.firstOrNull { it.label == label }?.let(viewModel::setTab)
+                },
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Spacer(Modifier.height(16.dp))
+
+            when (uiState.selectedTab) {
+                AnalyticsTab.Money -> {
+                    PeriodSelector(
+                        selectedPeriod = uiState.selectedPeriod,
+                        onSelectPeriod = viewModel::setPeriod,
+                    )
+                    Spacer(Modifier.height(16.dp))
+                    MoneyTab(
+                        economics = uiState.economics,
+                        topStores = uiState.topStores,
+                        recentSessions = uiState.recentSessions,
+                    )
+                }
+
+                AnalyticsTab.Patterns,
+                AnalyticsTab.Decisions,
+                AnalyticsTab.Time,
+                -> ComingSoonCard(uiState.selectedTab)
+            }
+        }
+    }
+}
+
+/** The review windows offered by the Money period selector, in display order. */
+private data class PeriodOption(val period: AnalyticsPeriod, val label: String)
+
+private val PERIOD_OPTIONS = listOf(
+    PeriodOption(AnalyticsPeriod.TODAY, "Today"),
+    PeriodOption(AnalyticsPeriod.THIS_WEEK, "Week"),
+    PeriodOption(AnalyticsPeriod.THIS_MONTH, "Month"),
+    PeriodOption(AnalyticsPeriod.LIFETIME, "Lifetime"),
+)
+
+@Composable
+private fun PeriodSelector(
+    selectedPeriod: AnalyticsPeriod,
+    onSelectPeriod: (AnalyticsPeriod) -> Unit,
+) {
+    val selectedLabel = PERIOD_OPTIONS.first { it.period == selectedPeriod }.label
+    AppSegmented(
+        options = PERIOD_OPTIONS.map { it.label },
+        selected = selectedLabel,
+        onSelect = { label ->
+            PERIOD_OPTIONS.firstOrNull { it.label == label }?.let { onSelectPeriod(it.period) }
+        },
+        modifier = Modifier.fillMaxWidth(),
+    )
+}
+
+@Composable
+private fun ComingSoonCard(tab: AnalyticsTab) {
+    AppCard(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = "${tab.label} — coming soon",
+            style = MaterialTheme.typography.titleMedium,
+            color = AppTheme.colors.text,
+        )
+        Spacer(Modifier.height(4.dp))
+        Text(
+            text = "This tab lands in a later Analytics phase.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = AppTheme.colors.text3,
+        )
+    }
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsUiState.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsUiState.kt
@@ -1,0 +1,41 @@
+package cloud.trotter.dashbuddy.ui.main.analytics
+
+import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
+import cloud.trotter.dashbuddy.domain.analytics.PeriodEconomics
+import cloud.trotter.dashbuddy.domain.analytics.SessionRecord
+import cloud.trotter.dashbuddy.domain.analytics.StoreEconomics
+
+/**
+ * The Analytics hub tabs (#315). Only [Money] has content in H1; the rest ship as the
+ * real tab-bar structure with a "coming soon" placeholder so later phases (Decisions H3,
+ * Time H4, Patterns H5) slot in without reshaping navigation.
+ */
+enum class AnalyticsTab(val label: String) {
+    Money("Money"),
+    Patterns("Patterns"),
+    Decisions("Decisions"),
+    Time("Time"),
+}
+
+/**
+ * Immutable state for the Analytics hub (Principle 1 — UDF). A **review** surface opened
+ * between shifts, so — like the reframed dashboard (#657) — the economics are the durable
+ * read-model for the selected [selectedPeriod], reactive to projector commits (Room
+ * invalidation) and midnight/week/month rollover, but **not** a per-second tick surface: a
+ * historical period's $/hr is a fixed value, so no `rememberNow()` clock is needed.
+ *
+ * Defaults differ from the dashboard on purpose: a review hub opens on the week
+ * ([AnalyticsPeriod.THIS_WEEK]) rather than the day, on the [AnalyticsTab.Money] tab.
+ * All economics are frozen-net (an economy edit never rewrites a past period) and all
+ * fields are read-model-only — nothing here re-enters the pure state machine.
+ */
+data class AnalyticsUiState(
+    val selectedTab: AnalyticsTab = AnalyticsTab.Money,
+    val selectedPeriod: AnalyticsPeriod = AnalyticsPeriod.THIS_WEEK,
+    /** Frozen-net economics for [selectedPeriod]; fresh-on-open, not live-ticking. */
+    val economics: PeriodEconomics = PeriodEconomics.EMPTY,
+    /** Top-earning stores for [selectedPeriod] (already capped to the display count). */
+    val topStores: List<StoreEconomics> = emptyList(),
+    /** Most recent dash sessions, newest first (not tappable until #650). */
+    val recentSessions: List<SessionRecord> = emptyList(),
+)

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsViewModel.kt
@@ -1,0 +1,80 @@
+package cloud.trotter.dashbuddy.ui.main.analytics
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import cloud.trotter.dashbuddy.core.data.analytics.AnalyticsRepository
+import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+
+/**
+ * State holder for the Analytics hub (#315 H1) — a **review** surface assembled reactively
+ * from the durable analytics read-model ([AnalyticsRepository]), exposing one immutable
+ * [AnalyticsUiState] (Principle 1 — UDF). Strictly over the EXISTING repository surface:
+ * `periodEconomics` (frozen-net totals), `perStoreEconomics` (top stores), `recentSessions`
+ * (recent dashes) — no new SQL/DAO aggregation (those are later phases; the #655 bucketing
+ * work owns the DAO internals).
+ *
+ * Reactive by construction: every source is a Room-invalidation `Flow`, so the tiles re-emit
+ * as the projector folds each delivery and at midnight/week/month rollover (the boundary
+ * flow) — fresh-on-open, no `rememberNow()` clock (a historical period's $/hr is a fixed
+ * value; same principle as the dashboard reframe #657).
+ *
+ * Privacy: economics/counts/store names only — customer PII is already sha256'd upstream and
+ * never surfaces here (Principle 6); store names are merchants, fine to render (Principle 7
+ * governs logs, not this UI). No platform literals — the recent-dashes chip resolves its
+ * label through the [cloud.trotter.dashbuddy.domain.state.Platform] registry (Principle 8).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@HiltViewModel
+class AnalyticsViewModel @Inject constructor(
+    analyticsRepository: AnalyticsRepository,
+) : ViewModel() {
+
+    /** UDF intent targets — the selected review window and tab. */
+    private val selectedPeriod = MutableStateFlow(AnalyticsPeriod.THIS_WEEK)
+    private val selectedTab = MutableStateFlow(AnalyticsTab.Money)
+
+    val uiState: StateFlow<AnalyticsUiState> = combine(
+        selectedTab,
+        // Re-anchor economics + top stores together on each period switch so a tile never
+        // renders one window's number under another's label.
+        selectedPeriod.flatMapLatest { period ->
+            combine(
+                analyticsRepository.periodEconomics(period),
+                analyticsRepository.perStoreEconomics(period),
+            ) { economics, stores -> Triple(period, economics, stores) }
+        },
+        analyticsRepository.recentSessions(RECENT_SESSIONS_LIMIT),
+    ) { tab, (period, economics, stores), sessions ->
+        AnalyticsUiState(
+            selectedTab = tab,
+            selectedPeriod = period,
+            economics = economics,
+            topStores = stores.take(TOP_STORES),
+            recentSessions = sessions,
+        )
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), AnalyticsUiState())
+
+    /** UDF intent — switch the review window; economics + top stores re-anchor reactively. */
+    fun setPeriod(period: AnalyticsPeriod) {
+        selectedPeriod.value = period
+    }
+
+    /** UDF intent — switch the visible tab. */
+    fun setTab(tab: AnalyticsTab) {
+        selectedTab.value = tab
+    }
+
+    private companion object {
+        const val TOP_STORES = 5
+        const val RECENT_SESSIONS_LIMIT = 10
+    }
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/MoneyTab.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/MoneyTab.kt
@@ -1,0 +1,276 @@
+package cloud.trotter.dashbuddy.ui.main.analytics
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import cloud.trotter.dashbuddy.core.designsystem.component.AppCallout
+import cloud.trotter.dashbuddy.core.designsystem.component.AppCard
+import cloud.trotter.dashbuddy.core.designsystem.component.AppChip
+import cloud.trotter.dashbuddy.core.designsystem.component.AppStatTile
+import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
+import cloud.trotter.dashbuddy.domain.analytics.PeriodEconomics
+import cloud.trotter.dashbuddy.domain.analytics.SessionRecord
+import cloud.trotter.dashbuddy.domain.analytics.StoreEconomics
+import cloud.trotter.dashbuddy.domain.format.Formats
+import cloud.trotter.dashbuddy.domain.format.formatShortDate
+
+/** Placeholder shown for a rate figure that has no measurable denominator yet (dashboard parity). */
+private const val EMPTY_VALUE = "—"
+
+/** Below this the unattributed pay is effectively zero — no callout (avoids a "$0.00" flag). */
+private const val UNATTRIBUTED_EPSILON = 0.005
+
+/**
+ * Money tab v1 (#315 H1): the frozen-net earnings review for the selected period, top→bottom —
+ * earnings hero, 3-step true-net waterfall, stat tiles, the unattributed-pay review flag, top
+ * stores, and recent dashes. Pure data in / [PeriodEconomics] + record lists, no side effects.
+ * Every string routes through the [Formats]/[formatShortDate] SSOT.
+ */
+@Composable
+fun MoneyTab(
+    economics: PeriodEconomics,
+    topStores: List<StoreEconomics>,
+    recentSessions: List<SessionRecord>,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        EarningsHero(economics)
+        TrueNetWaterfall(economics)
+        StatTiles(economics)
+        if (economics.unattributedPay > UNATTRIBUTED_EPSILON) {
+            AppCallout(
+                text = "${Formats.money(economics.unattributedPay)} not attributed to any " +
+                    "delivery — bonuses/adjustments; review coming (#650)",
+                container = AppTheme.colors.warnBg,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+        TopStoresCard(topStores)
+        RecentDashesCard(recentSessions)
+    }
+}
+
+/** Gross headline + True-Net and Net/hr chips. */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun EarningsHero(economics: PeriodEconomics) {
+    val c = AppTheme.colors
+    val netColor = if (economics.netProfit >= 0.0) c.good else c.bad
+    AppCard(modifier = Modifier.fillMaxWidth()) {
+        Text(text = "GROSS EARNINGS", style = MaterialTheme.typography.labelMedium, color = c.text3)
+        Spacer(Modifier.height(4.dp))
+        Text(text = Formats.money(economics.grossEarnings), style = AppTheme.num.heroNum, color = c.text)
+        Spacer(Modifier.height(10.dp))
+        FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            AppChip(
+                text = "True net ${Formats.money(economics.netProfit)}",
+                color = netColor,
+                container = if (economics.netProfit >= 0.0) c.goodBg else c.badBg,
+            )
+            AppChip(
+                text = "Net/hr ${economics.netPerHour?.let { Formats.money(it) } ?: EMPTY_VALUE}",
+                color = c.accent,
+                container = c.accentDim,
+            )
+        }
+    }
+}
+
+/**
+ * The 3-step true-net waterfall (#659 pending 4-step lift): gross → −operating cost → net.
+ * Operating cost is the gap (gross − net); unattributed pay is net-additive, so it flows through
+ * consistently. Each row is a proportional bar against gross — the honest visual of "what stayed".
+ */
+@Composable
+private fun TrueNetWaterfall(economics: PeriodEconomics) {
+    val c = AppTheme.colors
+    val gross = economics.grossEarnings
+    val net = economics.netProfit
+    val cost = gross - net
+    // Bars scale against the largest magnitude so a net > gross (net-additive unattributed) still
+    // renders sanely and a zero period draws empty bars instead of dividing by zero.
+    val scale = maxOf(gross, cost, net, 0.0).takeIf { it > 0.0 } ?: 1.0
+
+    AppCard(modifier = Modifier.fillMaxWidth()) {
+        Text(text = "TRUE NET", style = MaterialTheme.typography.labelMedium, color = c.text3)
+        Spacer(Modifier.height(10.dp))
+        WaterfallRow("Gross", Formats.money(gross), (gross / scale).toFloat(), c.accent, c.text)
+        Spacer(Modifier.height(8.dp))
+        WaterfallRow("Operating cost", "−${Formats.money(cost)}", (cost / scale).toFloat(), c.bad, c.text2)
+        Spacer(Modifier.height(8.dp))
+        WaterfallRow("Net", Formats.money(net), (net / scale).toFloat(), c.good, if (net >= 0.0) c.good else c.bad)
+    }
+}
+
+@Composable
+private fun WaterfallRow(label: String, amount: String, fraction: Float, barColor: Color, amountColor: Color) {
+    val c = AppTheme.colors
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Text(text = label, style = MaterialTheme.typography.bodyMedium, color = c.text2, modifier = Modifier.width(110.dp))
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .height(14.dp)
+                .clip(RoundedCornerShape(7.dp))
+                .background(c.surface3),
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(fraction.coerceIn(0f, 1f))
+                    .height(14.dp)
+                    .clip(RoundedCornerShape(7.dp))
+                    .background(barColor),
+            )
+        }
+        Spacer(Modifier.width(10.dp))
+        Text(
+            text = amount,
+            style = AppTheme.num.smNum,
+            color = amountColor,
+            modifier = Modifier.width(88.dp),
+            textAlign = TextAlign.End,
+        )
+    }
+}
+
+/** 2×2 stat tiles: Net $/hr · Net $/mi · Miles · Deliveries. */
+@Composable
+private fun StatTiles(economics: PeriodEconomics) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            AppStatTile(
+                label = "Net/hr",
+                value = economics.netPerHour?.let { Formats.money(it) } ?: EMPTY_VALUE,
+                modifier = Modifier.weight(1f),
+            )
+            AppStatTile(
+                label = "Net/mi",
+                value = economics.netPerMile?.let { Formats.money(it) } ?: EMPTY_VALUE,
+                modifier = Modifier.weight(1f),
+            )
+        }
+        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            AppStatTile(
+                label = "Miles",
+                value = Formats.decimal(economics.totals.miles),
+                modifier = Modifier.weight(1f),
+            )
+            AppStatTile(
+                label = "Deliveries",
+                value = Formats.commaInt(economics.totals.deliveries),
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}
+
+/** Top-earning stores for the period. Store names are merchants — fine to render (Principle 7 governs logs). */
+@Composable
+private fun TopStoresCard(stores: List<StoreEconomics>) {
+    val c = AppTheme.colors
+    AppCard(modifier = Modifier.fillMaxWidth()) {
+        Text(text = "TOP STORES", style = MaterialTheme.typography.labelMedium, color = c.text3)
+        Spacer(Modifier.height(10.dp))
+        if (stores.isEmpty()) {
+            EmptyRow("No store earnings in this period yet.")
+        } else {
+            stores.forEachIndexed { index, store ->
+                if (index > 0) Spacer(Modifier.height(10.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Column(Modifier.weight(1f)) {
+                        Text(
+                            text = store.storeName ?: "Unknown store",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = c.text,
+                        )
+                        Text(
+                            text = "${Formats.commaInt(store.deliveries)} " +
+                                if (store.deliveries == 1) "delivery" else "deliveries",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = c.text3,
+                        )
+                    }
+                    Text(
+                        text = Formats.money(store.net),
+                        style = AppTheme.num.smNum,
+                        color = if (store.net >= 0.0) c.good else c.bad,
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Recent dashes, newest first. Sessions don't carry a frozen net, so the money column shows the
+ * platform-reported earnings (an em dash until a summary is seen). Not tappable yet — the per-dash
+ * drill-down is #650.
+ */
+@Composable
+private fun RecentDashesCard(sessions: List<SessionRecord>) {
+    val c = AppTheme.colors
+    AppCard(modifier = Modifier.fillMaxWidth()) {
+        Text(text = "RECENT DASHES", style = MaterialTheme.typography.labelMedium, color = c.text3)
+        Spacer(Modifier.height(10.dp))
+        if (sessions.isEmpty()) {
+            EmptyRow("No dashes recorded yet.")
+        } else {
+            sessions.forEachIndexed { index, session ->
+                if (index > 0) Spacer(Modifier.height(10.dp))
+                // TODO(#650): make each dash row tappable → per-dash delivery breakdown.
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Column(Modifier.weight(1f)) {
+                        Text(
+                            text = formatShortDate(session.startedAt),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = c.text,
+                        )
+                        Text(
+                            text = "${Formats.commaInt(session.deliveries)} " +
+                                if (session.deliveries == 1) "delivery" else "deliveries",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = c.text3,
+                        )
+                    }
+                    // Platform label is registry-resolved (never a literal) — Principle 8.
+                    AppChip(text = session.platform.shortName.ifEmpty { session.platform.displayName })
+                    Spacer(Modifier.width(10.dp))
+                    Text(
+                        text = session.reportedEarnings?.let { Formats.money(it) } ?: EMPTY_VALUE,
+                        style = AppTheme.num.smNum,
+                        color = c.text,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmptyRow(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.bodyMedium,
+        color = AppTheme.colors.text3,
+        modifier = Modifier.padding(vertical = 4.dp),
+    )
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardScreen.kt
@@ -179,6 +179,7 @@ private data class PeriodOption(val period: AnalyticsPeriod, val label: String)
 private val PERIOD_OPTIONS = listOf(
     PeriodOption(AnalyticsPeriod.TODAY, "Today"),
     PeriodOption(AnalyticsPeriod.THIS_WEEK, "This week"),
+    PeriodOption(AnalyticsPeriod.THIS_MONTH, "Month"),
     PeriodOption(AnalyticsPeriod.LIFETIME, "Lifetime"),
 )
 
@@ -264,7 +265,7 @@ private fun EntryTileGrid(onNavigate: (String) -> Unit) {
                 icon = Icons.Filled.BarChart,
                 label = "Analytics",
                 modifier = Modifier.weight(1f),
-                // TODO(#315): wire to the analytics hub once :feature:analytics lands.
+                // #315 H1: routes to the Analytics hub (Money tab v1); other tabs stubbed.
                 onClick = { onNavigate(Screen.Analytics.route) },
             )
             EntryTile(

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardScreen.kt
@@ -178,7 +178,7 @@ private data class PeriodOption(val period: AnalyticsPeriod, val label: String)
 
 private val PERIOD_OPTIONS = listOf(
     PeriodOption(AnalyticsPeriod.TODAY, "Today"),
-    PeriodOption(AnalyticsPeriod.THIS_WEEK, "This week"),
+    PeriodOption(AnalyticsPeriod.THIS_WEEK, "Week"),
     PeriodOption(AnalyticsPeriod.THIS_MONTH, "Month"),
     PeriodOption(AnalyticsPeriod.LIFETIME, "Lifetime"),
 )

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/navigation/DashBuddyRoutes.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/navigation/DashBuddyRoutes.kt
@@ -7,7 +7,7 @@ sealed class Screen(val route: String) {
 
     // Analytics surfaces (home-screen entry tiles, epic #320)
     data object Ratings : Screen("ratings")
-    // Analytics hub is Phase 4 (#315) — routes to the placeholder for now.
+    // Analytics hub (#315 H1) — Money tab v1; Patterns/Decisions/Time tabs stubbed.
     data object Analytics : Screen("analytics")
 
     // Settings Hierarchy

--- a/app/src/test/java/cloud/trotter/dashbuddy/analytics/PeriodBoundsTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/analytics/PeriodBoundsTest.kt
@@ -68,6 +68,43 @@ class PeriodBoundsTest {
     }
 
     @Test
+    fun `THIS_MONTH starts on the 1st 00 00 local and ends next month`() {
+        val b = PeriodBounds.of(AnalyticsPeriod.THIS_MONTH, nowMillis, zone)
+        val startZdt = local(b.start)
+        assertEquals(1, startZdt.dayOfMonth)
+        assertEquals(LocalTime.MIDNIGHT, startZdt.toLocalTime())
+        // 2026-07-01 → the month anchor is 2026-07-01, next boundary 2026-08-01.
+        assertEquals(LocalDate.of(2026, 7, 1), startZdt.toLocalDate())
+        assertEquals(LocalDate.of(2026, 8, 1), local(b.end).toLocalDate())
+        assertEquals(LocalTime.MIDNIGHT, local(b.end).toLocalTime())
+        assertTrue(nowMillis >= b.start && nowMillis < b.end)
+    }
+
+    @Test
+    fun `month boundary splits last day 23-59 from the 1st 00-01`() {
+        val monthStart = PeriodBounds.of(AnalyticsPeriod.THIS_MONTH, nowMillis, zone).start
+        val firstOfMonth = local(monthStart).toLocalDate()
+
+        val lastDayBefore = firstOfMonth.minusDays(1).atTime(23, 59).atZone(zone).toInstant().toEpochMilli()
+        val firstAfter = firstOfMonth.atTime(0, 1).atZone(zone).toInstant().toEpochMilli()
+
+        assertTrue("June 30 23:59 is in the previous month", lastDayBefore < monthStart)
+        assertTrue("July 1 00:01 is in this month", firstAfter >= monthStart)
+    }
+
+    @Test
+    fun `THIS_MONTH re-anchors to the next month at rollover`() {
+        val month = PeriodBounds.of(AnalyticsPeriod.THIS_MONTH, nowMillis, zone)
+        // At the instant the window ends (next month's 1st), the next call yields that month —
+        // no gap, no overlap: [prev.end, prev.end + 1 month).
+        val nextMonth = PeriodBounds.of(AnalyticsPeriod.THIS_MONTH, month.end, zone)
+        assertEquals(month.end, nextMonth.start)
+        assertTrue(nextMonth.end > nextMonth.start)
+        assertEquals(LocalDate.of(2026, 8, 1), local(nextMonth.start).toLocalDate())
+        assertEquals(LocalDate.of(2026, 9, 1), local(nextMonth.end).toLocalDate())
+    }
+
+    @Test
     fun `TODAY re-anchors to consecutive windows at rollover`() {
         val today = PeriodBounds.of(AnalyticsPeriod.TODAY, nowMillis, zone)
         // At the instant the window ends (next midnight), the next call yields the next day —

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsViewModelTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsViewModelTest.kt
@@ -1,0 +1,158 @@
+package cloud.trotter.dashbuddy.ui.main.analytics
+
+import cloud.trotter.dashbuddy.core.data.analytics.AnalyticsRepository
+import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
+import cloud.trotter.dashbuddy.domain.analytics.PeriodEconomics
+import cloud.trotter.dashbuddy.domain.analytics.PeriodTotals
+import cloud.trotter.dashbuddy.domain.analytics.SessionRecord
+import cloud.trotter.dashbuddy.domain.analytics.StoreEconomics
+import cloud.trotter.dashbuddy.domain.state.Platform
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+/**
+ * #315 H1 — the Analytics hub ViewModel exposes the read-model economics for the selected
+ * period (default [AnalyticsPeriod.THIS_WEEK], switchable via [AnalyticsViewModel.setPeriod])
+ * on the selected tab (default [AnalyticsTab.Money], switchable via [AnalyticsViewModel.setTab]),
+ * strictly over the existing repository surface. Same stub-flow pattern as DashboardViewModelTest.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class AnalyticsViewModelTest {
+
+    private val analyticsRepository: AnalyticsRepository = mock()
+
+    private fun stubPeriod(
+        period: AnalyticsPeriod,
+        economics: PeriodEconomics,
+        stores: List<StoreEconomics> = emptyList(),
+    ) {
+        whenever(analyticsRepository.periodEconomics(eq(period), anyOrNull())).thenReturn(flowOf(economics))
+        whenever(analyticsRepository.perStoreEconomics(eq(period))).thenReturn(flowOf(stores))
+    }
+
+    private fun stubSessions(sessions: List<SessionRecord>) {
+        whenever(analyticsRepository.recentSessions(any())).thenReturn(flowOf(sessions))
+    }
+
+    private fun economics(net: Double, netPerHour: Double?, unattributed: Double = 0.0): PeriodEconomics =
+        PeriodEconomics(
+            totals = PeriodTotals(earnings = net, miles = 20.0, deliveries = 3, jobs = 2, onlineDuration = 3_600_000L),
+            grossEarnings = net + unattributed,
+            netProfit = net,
+            unattributedPay = unattributed,
+            netPerHour = netPerHour,
+            netPerMile = null,
+        )
+
+    private fun store(name: String, net: Double, deliveries: Int) =
+        StoreEconomics(storeName = name, net = net, gross = net, deliveries = deliveries)
+
+    private fun session(id: String, reported: Double?) = SessionRecord(
+        sessionId = id, platform = Platform.DoorDash, startedAt = 1_700_000_000_000L, endedAt = null,
+        reportedEarnings = reported, reportedDurationMillis = null, miles = 10.0,
+        deliveries = 2, jobsCompleted = 2, offersReceived = 4, offersAccepted = 2,
+        offersDeclined = 2, offersTimeout = 0,
+    )
+
+    private fun buildViewModel() = AnalyticsViewModel(analyticsRepository)
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    @Test
+    fun `defaults to THIS_WEEK on the Money tab and maps the read-model into state`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        stubPeriod(
+            AnalyticsPeriod.THIS_WEEK,
+            economics(net = 312.0, netPerHour = 24.0),
+            stores = listOf(store("H-E-B", 120.0, 5), store("Chili's", 40.0, 2)),
+        )
+        stubSessions(listOf(session("s1", 90.0), session("s2", null)))
+
+        val viewModel = buildViewModel()
+        val job = launch { viewModel.uiState.collect {} }
+        testScheduler.advanceUntilIdle()
+
+        val ui = viewModel.uiState.value
+        assertEquals(AnalyticsPeriod.THIS_WEEK, ui.selectedPeriod)
+        assertEquals(AnalyticsTab.Money, ui.selectedTab)
+        assertEquals(312.0, ui.economics.netProfit, 1e-9)
+        assertEquals(2, ui.topStores.size)
+        assertEquals(2, ui.recentSessions.size)
+        job.cancel()
+    }
+
+    @Test
+    fun `setPeriod re-anchors economics and top stores to the selected window`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        stubPeriod(AnalyticsPeriod.THIS_WEEK, economics(net = 312.0, netPerHour = 24.0), stores = listOf(store("H-E-B", 120.0, 5)))
+        stubPeriod(AnalyticsPeriod.THIS_MONTH, economics(net = 1280.0, netPerHour = 22.0), stores = listOf(store("Target", 400.0, 12)))
+        stubSessions(emptyList())
+
+        val viewModel = buildViewModel()
+        val job = launch { viewModel.uiState.collect {} }
+        testScheduler.advanceUntilIdle()
+        assertEquals(312.0, viewModel.uiState.value.economics.netProfit, 1e-9)
+
+        viewModel.setPeriod(AnalyticsPeriod.THIS_MONTH)
+        testScheduler.advanceUntilIdle()
+
+        val ui = viewModel.uiState.value
+        assertEquals(AnalyticsPeriod.THIS_MONTH, ui.selectedPeriod)
+        assertEquals(1280.0, ui.economics.netProfit, 1e-9)
+        assertEquals("Target", ui.topStores.single().storeName)
+        job.cancel()
+    }
+
+    @Test
+    fun `setTab switches the visible tab without touching the period`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        stubPeriod(AnalyticsPeriod.THIS_WEEK, economics(net = 100.0, netPerHour = 20.0))
+        stubSessions(emptyList())
+
+        val viewModel = buildViewModel()
+        val job = launch { viewModel.uiState.collect {} }
+        testScheduler.advanceUntilIdle()
+
+        viewModel.setTab(AnalyticsTab.Decisions)
+        testScheduler.advanceUntilIdle()
+
+        val ui = viewModel.uiState.value
+        assertEquals(AnalyticsTab.Decisions, ui.selectedTab)
+        assertEquals(AnalyticsPeriod.THIS_WEEK, ui.selectedPeriod)
+        job.cancel()
+    }
+
+    @Test
+    fun `empty read-model maps to a safe zero-state`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        stubPeriod(AnalyticsPeriod.THIS_WEEK, PeriodEconomics.EMPTY, stores = emptyList())
+        stubSessions(emptyList())
+
+        val viewModel = buildViewModel()
+        val job = launch { viewModel.uiState.collect {} }
+        testScheduler.advanceUntilIdle()
+
+        val ui = viewModel.uiState.value
+        assertEquals(0.0, ui.economics.netProfit, 1e-9)
+        assertEquals(null, ui.economics.netPerHour)
+        assertTrue(ui.topStores.isEmpty())
+        assertTrue(ui.recentSessions.isEmpty())
+        job.cancel()
+    }
+}

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/PeriodBounds.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/PeriodBounds.kt
@@ -24,7 +24,7 @@ object PeriodBounds {
     /**
      * The `[start, end)` window for [period], anchored at [nowMillis] in [zone].
      * TODAY = local midnight → next midnight; THIS_WEEK = Monday 00:00 → next Monday
-     * 00:00; LIFETIME = all time.
+     * 00:00; THIS_MONTH = 1st 00:00 → next month's 1st 00:00; LIFETIME = all time.
      */
     fun of(period: AnalyticsPeriod, nowMillis: Long, zone: ZoneId): Bounds {
         if (period == AnalyticsPeriod.LIFETIME) return Bounds(0L, Long.MAX_VALUE)
@@ -33,12 +33,14 @@ object PeriodBounds {
         val startDate = when (period) {
             AnalyticsPeriod.TODAY -> today
             AnalyticsPeriod.THIS_WEEK -> today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+            AnalyticsPeriod.THIS_MONTH -> today.with(TemporalAdjusters.firstDayOfMonth())
             AnalyticsPeriod.LIFETIME -> error("handled above")
         }
         val startZdt = startDate.atStartOfDay(zone)
         val endZdt = when (period) {
             AnalyticsPeriod.TODAY -> startZdt.plusDays(1)
             AnalyticsPeriod.THIS_WEEK -> startZdt.plusWeeks(1)
+            AnalyticsPeriod.THIS_MONTH -> startZdt.plusMonths(1)
             AnalyticsPeriod.LIFETIME -> error("handled above")
         }
         return Bounds(startZdt.toInstant().toEpochMilli(), endZdt.toInstant().toEpochMilli())

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -73,6 +73,18 @@ card's **mechanical** half, #577 (re-confirmed, 24/24, ~0.55 s — with a new po
 that entry's Bug #1), the #457 path, and #554 ShadowProjector (2/2). The #462/#460 dropoff item
 was found **broken-in-part** (raw PII in capture envelopes) and moved to that entry's Bug #7.)_
 
+- **🆕 NEW — Analytics tile now opens the Money tab (#315 H1 / Money tab v1).**
+  From the home screen tap the **Analytics** tile: it should open a real hub (back arrow) with a
+  **Money / Patterns / Decisions / Time** tab bar (the last three show a "coming soon" card). On
+  **Money**, pick **Today / Week / Month / Lifetime** and confirm the figures re-anchor: the earnings
+  hero (gross + True-Net / Net-hr chips), the 3-step **gross → −operating cost → net** waterfall, the
+  2×2 tiles ($/hr · $/mi · Miles · Deliveries), top stores, and recent dashes. Cross-check: for the
+  **same period** the Money numbers should match the dashboard's tiles (both read the same frozen
+  read-model). An **unattributed-pay callout** appears only when that period has bonuses/adjustments.
+  How to tell it's broken: the old "Construction Area 🚧" placeholder still shows, figures don't change
+  with the period, Money ≠ dashboard for the same window, a crash on an empty period, or a "$0.00"
+  unattributed callout on a period with none.
+  - Confirmed: 0/2
 - **🆕 NEW — the main dashboard is now a REVIEW surface, not a live bubble mirror (#657 / PR #658).**
   Open the app **after a dash** (not while on a task): the **Today** tiles (True Net / Net $/hr /
   Miles) should already reflect the just-completed dash with no manual refresh (the read-model folds

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/AnalyticsPeriod.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/AnalyticsPeriod.kt
@@ -16,6 +16,9 @@ enum class AnalyticsPeriod {
     /** Monday 00:00 local → now (the pay-week the dasher already sees). */
     THIS_WEEK,
 
+    /** 1st of the month 00:00 local → now (the calendar-month review window, #315 H1). */
+    THIS_MONTH,
+
     /** All records, ever. */
     LIFETIME,
 }

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/format/TimeFormats.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/format/TimeFormats.kt
@@ -1,5 +1,9 @@
 package cloud.trotter.dashbuddy.domain.format
 
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
 import java.util.Locale
 import java.util.concurrent.TimeUnit
 
@@ -41,3 +45,20 @@ fun formatCountdown(millis: Long): String {
     val seconds = TimeUnit.MILLISECONDS.toSeconds(safe) % 60
     return String.format(Locale.ROOT, "%d:%02d", totalMinutes, seconds)
 }
+
+/**
+ * "Jul 3, 2026" — a calendar date for a review surface (recent-dashes list, #315/#650).
+ *
+ * Unlike the clock/duration strings above, a calendar date is display copy the dasher
+ * reads in their own locale, so it follows the [Formats] display policy: the localized
+ * MEDIUM date in [locale], resolved against the device [zone]. This is the one owner for
+ * a rendered session date — the future #650 drill-down derives from here too (Principle 5).
+ */
+fun formatShortDate(
+    millis: Long,
+    zone: ZoneId = ZoneId.systemDefault(),
+    locale: Locale = Locale.getDefault(),
+): String =
+    DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)
+        .withLocale(locale)
+        .format(Instant.ofEpochMilli(millis).atZone(zone))


### PR DESCRIPTION
## Scope — Phase H1 of the Analytics hub (#315)

Replaces the "Construction Area" placeholder behind the home screen's **Analytics** tile with a real hub, **strictly over the existing `AnalyticsRepository` surface** — no new SQL/DAO aggregations (those are later phases). Deliberately **disjoint from #655** (session-anchored bucketing): this PR only *calls* the repository; it touches no `AnalyticsDao`/`AnalyticsRepository` internals.

### What ships
- **`AnalyticsPeriod.THIS_MONTH`** + the `PeriodBounds` branch (1st of month 00:00 local → next month's 1st; rollover handled by the existing `periodBoundariesFlow` `untilNext` delay). The dashboard selector gains the 4th option for parity.
- **New `ui/main/analytics/` package** (Package by Feature):
  - `AnalyticsScreen` — back nav + a real **Money / Patterns / Decisions / Time** tab bar (`AppSegmented`); the other three tabs show a small "coming soon" card so the structure is real now and later phases (Decisions H3, Time H4, Patterns H5) slot in without reshaping nav.
  - `MoneyTab` — the H1 content.
  - `AnalyticsViewModel` + immutable `AnalyticsUiState` (default **THIS_WEEK** + **Money** — a review hub opens on the week, unlike the dashboard's Today).
- **Money tab v1** (top→bottom): period selector (Today/Week/Month/Lifetime) → earnings hero (gross headline + True-Net & Net/hr chips) → **3-step true-net waterfall** (gross → −operating cost → net; `cost = gross − net`, unattributed flows through net-additive; **4-step fuel/non-fuel split is #659, pending**) → 2×2 stat tiles (Net \$/hr · Net \$/mi · Miles · Deliveries) → **unattributed-pay callout** (`AppCallout`, only when > \$0.005, feeds #650) → **top-5 stores** → **recent dashes** (10, reported earnings ?: "—", platform chip, **not tappable** — drill-down is `// TODO(#650)`).
- **Empty/zero states** per section; null rates render "—" (dashboard `EMPTY_VALUE` parity), no divide-by-zero.
- **`formatShortDate`** added to the `:domain` format SSOT (localized session date — no date formatter existed; TimeFormats owned only clock/duration).
- NavHost route wired; stale `#315` comments refreshed.

### Data mapping (over existing repo)
`periodEconomics(period)` (frozen net/gross/unattributed/rates) · `perStoreEconomics(period)` (top 5) · `recentSessions(10)`. All Room-invalidation Flows — fresh-on-open, re-anchor on projector commit + midnight/week/month rollover.

### UiState shape
`AnalyticsUiState(selectedTab: AnalyticsTab = Money, selectedPeriod: AnalyticsPeriod = THIS_WEEK, economics: PeriodEconomics, topStores: List<StoreEconomics>, recentSessions: List<SessionRecord>)`; intents `setPeriod` / `setTab`.

### Tests
- `AnalyticsViewModelTest` (4): default WEEK+Money, `setPeriod(THIS_MONTH)` re-anchors economics+stores, `setTab` switches, empty-state maps to safe zero-state.
- `PeriodBoundsTest` +3: THIS_MONTH 1st-of-month anchor, month boundary split, rollover.
- Full `:app:testDebugUnitTest` **899 / 0 fail**, `:domain:test` **262 / 0 fail**, `*AllMatchersSuite*` green (JDK 25).

### Design-goal review
- **P1 (UDF):** one immutable `AnalyticsUiState` flows down; `setPeriod`/`setTab` intents up; VM reads the read-model repo only, never writes; composables are stateless data-in/lambdas-out.
- **P3 (SRP):** feature split across UiState / VM / Screen / MoneyTab — no oversized file.
- **P5 (SSOT):** all display strings via `Formats`/`TimeFormats`; added `formatShortDate` as the one owner for a rendered session date (the #650 drill-down derives from it) rather than a feature-local re-impl. Period selector mirrors the dashboard's data-driven option list.
- **P6/P7 (privacy):** read-model exposes economics/counts/store names only (customer PII already sha256'd upstream, never reaches here); store names are merchants rendered in UI, and P7 governs **logs** — this PR adds **no** log sites. No new capture/network/effect surface.
- **P8 (platform-agnostic):** recent-dash platform label resolves via the `Platform` registry (`shortName`/`displayName`), no literal. THIS_MONTH bounds are `java.time`, platform-independent.
- **Reactive UI:** review surface — reactive-fresh via read-model Flows (Room invalidation + boundary rollover), **no `rememberNow` ticker** (a historical period's figures are fixed; same rationale as #657).

### Field test
Added to `docs/field-testing/README.md`: open the Analytics tile → Money tab shows the selected period's real figures and they re-anchor with the selector; the Money numbers match the dashboard's tiles for the same period.

### Adversarial review
Pending — the orchestrator gates the merge with a fable adversarial pass (not self-attested here).