### PR TITLE
fix(analytics): DASH_STOP platform refinement + cancellation-safe cpm fallback (retro findings 1+3)

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsProjectorTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsProjectorTest.kt
@@ -26,7 +26,9 @@ import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStopPayload
 import cloud.trotter.dashbuddy.domain.model.offer.ParsedOffer
 import cloud.trotter.dashbuddy.domain.state.Flow
 import cloud.trotter.dashbuddy.domain.state.Platform
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import org.junit.After
@@ -340,5 +342,61 @@ class AnalyticsProjectorTest {
         assertEquals("orphaned session A is inferred-closed across the batch boundary", "inferred", a.endSource)
         assertEquals("A's endedAt is its last event", 2_000L, a.endedAt)
         assertNull("the live session B stays open", analyticsDao.sessionRecord("B")!!.endedAt)
+    }
+
+    @Test
+    fun `a DataStore read failure degrades cpm to null instead of crashing the batch (retro finding 3)`() = runBlocking {
+        // The economy DataStore throws (transient IO) — currentCostPerMile must catch it, log, and
+        // fall back to null (never crash the drain loop or the batch transaction).
+        val failingPrefs = mock<AppPreferencesRepository> {
+            on { userEconomy } doReturn flow { throw RuntimeException("datastore boom") }
+        }
+        insert(
+            AppEventType.DASH_START, "S1", 1_000,
+            SessionStartPayload("S1", Platform.DoorDash.name, 1_000, SessionStartSource.INTERACTION, "x"),
+            odometer = 0.0,
+        )
+        // No preceding offer in this session, so the delivery has no OFFER_FROZEN basis and would
+        // normally fall back to the live economy's cpm.
+        insert(
+            AppEventType.DELIVERY_COMPLETED, "S1", 2_000,
+            DeliveryPayload(jobId = "J1", taskId = "T1", storeName = "StoreX", phaseStartedAt = 1_500, totalPay = 5.0),
+            odometer = 4.0,
+        )
+
+        val projector = AnalyticsProjector(db, repo, eventDao, analyticsDao, failingPrefs)
+        projector.catchUp() // must not throw
+
+        val delivery = analyticsDao.lastDeliveryInSession("S1")!!
+        assertEquals(
+            "no offer basis + a failed cpm read → NONE, never a stale/wrong cpm",
+            "NONE", delivery.costBasis,
+        )
+        assertNull(delivery.frozenCostPerMile)
+        assertNull(delivery.netProfit)
+    }
+
+    @Test(expected = CancellationException::class)
+    fun `currentCostPerMile does not swallow CancellationException (retro finding 3)`(): Unit = runBlocking {
+        // A blanket `runCatching` around the DataStore read would catch a CancellationException too
+        // and quietly degrade to null cpm — violating the drain loop's own never-swallow-cancellation
+        // rule (`start`'s `catch (e: CancellationException) { throw e }`, three lines above the old
+        // `runCatching`). The fix must let it propagate instead of being caught-and-nulled.
+        val cancellingPrefs = mock<AppPreferencesRepository> {
+            on { userEconomy } doReturn flow { throw CancellationException("simulated cooperative cancellation") }
+        }
+        insert(
+            AppEventType.DASH_START, "S1", 1_000,
+            SessionStartPayload("S1", Platform.DoorDash.name, 1_000, SessionStartSource.INTERACTION, "x"),
+            odometer = 0.0,
+        )
+        insert(
+            AppEventType.DELIVERY_COMPLETED, "S1", 2_000,
+            DeliveryPayload(jobId = "J1", taskId = "T1", storeName = "StoreX", phaseStartedAt = 1_500, totalPay = 5.0),
+            odometer = 4.0,
+        )
+
+        val projector = AnalyticsProjector(db, repo, eventDao, analyticsDao, cancellingPrefs)
+        projector.catchUp() // must rethrow, not degrade to a null cpm and continue
     }
 }

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjector.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjector.kt
@@ -213,9 +213,22 @@ class AnalyticsProjector @Inject constructor(
     private suspend fun currentWatermark(): Long =
         analyticsDao.getWatermark()?.watermarkSequenceId ?: 0L
 
-    /** The live economy's operating cost-per-mile — the frozen `CURRENT_FALLBACK` basis only. */
+    /**
+     * The live economy's operating cost-per-mile — the frozen `CURRENT_FALLBACK` basis only. A
+     * `null` here just means this batch's fallback-basis deliveries stamp `CostBasis.NONE` instead
+     * (never a wrong cpm); it must NOT swallow cancellation (the drain loop's own rule, `start`
+     * above) — only a real DataStore read failure is caught, logged, and degraded to `null`.
+     */
     private suspend fun currentCostPerMile(): Double? =
-        runCatching { appPreferencesRepository.userEconomy.first().operatingCostPerMile }.getOrNull()
+        try {
+            appPreferencesRepository.userEconomy.first().operatingCostPerMile
+        } catch (e: CancellationException) {
+            throw e // cooperative cancellation — never swallow it
+        } catch (e: Exception) {
+            // No PII: the failure class only, never preference contents.
+            Timber.tag(TAG).w(e, "currentCostPerMile: economy read failed; falling back to null cpm")
+            null
+        }
 
     // ── Restart-correct context hydration (the record tables ARE the fold state) ──
 

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/RecordFolds.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/RecordFolds.kt
@@ -369,22 +369,38 @@ object RecordFolds {
      * The in-memory/hydrated context for [sid], or a synthesized `_unknown`-platform context when a
      * session-scoped event has no known DASH_START (fold started mid-session past the watermark, or
      * a lost start). A synthesized session degrades to a null-odometer / _unknown-platform row —
-     * never a wrong one. [platformName] refines the synthesized platform when the event itself
-     * carries one (DASH_STOP's #314 stamp).
+     * never a wrong one. [platformName] refines an `_unknown` platform when the event itself carries
+     * one (DASH_STOP's #314 stamp) — whether that `_unknown` context is being synthesized here for
+     * the first time, or was already synthesized by an EARLIER event in the session and is only now
+     * being hydrated/matched by [sid] (a skipped/malformed DASH_START leaves the session `_unknown`
+     * until its DASH_STOP arrives with the real platform; without this, the upgrade path only fired
+     * for a brand-new context and an already-`_unknown` session stayed `_unknown` forever). Never
+     * clobbers a REAL platform — only an `Unknown` one is eligible — and a [platformName] that itself
+     * fails to resolve (or resolves back to [Platform.Unknown]) leaves the context untouched.
      */
     private fun resolveContext(
         context: SessionFoldContext?,
         sid: String,
         occurredAt: Long,
         platformName: String? = null,
-    ): SessionFoldContext =
-        context?.takeIf { it.sessionId == sid }
-            ?: SessionFoldContext(
-                sessionId = sid,
-                platform = platformName?.let { Platform.fromName(it) } ?: Platform.Unknown,
-                startedAt = occurredAt,
-                lastEventAt = occurredAt,
-            )
+    ): SessionFoldContext {
+        val existing = context?.takeIf { it.sessionId == sid }
+        if (existing != null) {
+            if (existing.platform == Platform.Unknown && platformName != null) {
+                val resolved = Platform.fromName(platformName)
+                if (resolved != null && resolved != Platform.Unknown) {
+                    return existing.copy(platform = resolved)
+                }
+            }
+            return existing
+        }
+        return SessionFoldContext(
+            sessionId = sid,
+            platform = platformName?.let { Platform.fromName(it) } ?: Platform.Unknown,
+            startedAt = occurredAt,
+            lastEventAt = occurredAt,
+        )
+    }
 
     private fun SessionFoldContext.advance(occurredAt: Long, odometer: Double?): SessionFoldContext =
         copy(

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/RecordFoldsTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/RecordFoldsTest.kt
@@ -20,6 +20,7 @@ import cloud.trotter.dashbuddy.domain.model.pay.ParsedPayItem
 import cloud.trotter.dashbuddy.domain.state.Flow
 import cloud.trotter.dashbuddy.domain.state.Platform
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Test
 
@@ -107,9 +108,12 @@ class RecordFoldsTest {
         odometer = odo,
     )
 
-    private fun dashStop(sid: String, at: Long, odo: Double?, earnings: Double?) = ev(
+    private fun dashStop(sid: String, at: Long, odo: Double?, earnings: Double?, platform: String? = null) = ev(
         AppEventType.DASH_STOP, sid, at,
-        SessionStopPayload(sid, endedAt = at, source = SessionEndSource.SUMMARY_SCREEN, totalEarnings = earnings),
+        SessionStopPayload(
+            sid, endedAt = at, source = SessionEndSource.SUMMARY_SCREEN, totalEarnings = earnings,
+            platform = platform,
+        ),
         odometer = odo,
     )
 
@@ -322,5 +326,52 @@ class RecordFoldsTest {
         assertEquals(Platform.Unknown.wire, out.delivery!!.platform)
         assertNull(out.delivery!!.sessionId)
         assertNull("no session context is created for a session-less event", out.context)
+    }
+
+    @Test
+    fun `DASH_STOP's platform stamp upgrades an _unknown context left by a skipped DASH_START`() {
+        val s = "S8"
+        // A malformed DASH_START (no payload) is skipped — no context is created.
+        val badStart = SequencedAppEvent(
+            sequenceId = ++seq,
+            event = AppEvent(AppEventType.DASH_START, occurredAt = 1_000, sessionId = s, payload = null),
+        )
+        val skipOut = RecordFolds.foldEvent(badStart, context = null, currentCostPerMile = null)
+        assertNotNull(skipOut.skip)
+        assertNull(skipOut.context)
+
+        // A mid-session offer (no known DASH_START) synthesizes an `_unknown` placeholder context.
+        val offerOut = RecordFolds.foldEvent(
+            offerAccepted(s, 2_000, "h", eval(net = 5.0, dist = 2.0, opCpm = 0.3)),
+            context = skipOut.context,
+            currentCostPerMile = null,
+        )
+        val unknownCtx = offerOut.context
+        assertEquals(Platform.Unknown, unknownCtx!!.platform)
+
+        // DASH_STOP arrives carrying the real platform (#314 stamp) — the `_unknown` context is
+        // upgraded, not left stuck forever.
+        val stopOut = RecordFolds.foldEvent(
+            dashStop(s, 3_000, odo = null, earnings = 10.0, platform = Platform.DoorDash.name),
+            context = unknownCtx,
+            currentCostPerMile = null,
+        )
+        assertEquals("DASH_STOP's platform stamp refines an _unknown session", Platform.DoorDash, stopOut.context!!.platform)
+        assertEquals("doordash", stopOut.context!!.platform.wire)
+    }
+
+    @Test
+    fun `DASH_STOP's platform stamp does NOT clobber an already-real platform`() {
+        val s = "S9"
+        val (outcomes, ctx) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 0.0),
+                // A malformed/mismatched platform stamp on DASH_STOP must never override a real,
+                // already-established session platform.
+                dashStop(s, 2_000, odo = null, earnings = 5.0, platform = Platform.Uber.name),
+            ),
+        )
+        assertEquals("real platform from DASH_START is preserved", Platform.DoorDash, outcomes.last().context!!.platform)
+        assertEquals(Platform.DoorDash, ctx!!.platform)
     }
 }


### PR DESCRIPTION
Implements two findings from a fable retrospective review of the analytics fold/projector family (#314). Both fixes are small and precisely scoped — no other analytics behavior touched.

## Finding 1 (MEDIUM-LOW): DASH_STOP's platform stamp never refines an `_unknown` session context

**Scenario:** a `DASH_START` with a malformed payload is skipped (`RecordFolds.foldDashStart`). A mid-session event (e.g. an accepted offer) then synthesizes an `_unknown`-platform placeholder `SessionFoldContext`. When `DASH_STOP` finally arrives carrying `p.platform` (the #314 stamp), the session context already exists for that `sessionId`, so `resolveContext`'s `context?.takeIf { it.sessionId == sid }` short-circuits and returns the existing context **untouched** — `platformName` was only ever consulted on the *synthesize-a-brand-new-context* branch. The session stays `_unknown` forever and drops out of every per-platform aggregate.

**Fix — locus: `resolveContext`, not `foldDashStop`.** `resolveContext` already owns the `platformName`-refinement contract (its KDoc already promised this refinement pre-fix, but the implementation only delivered it for the synthesize path). Only `foldDashStop` ever passes `platformName`, so refining behavior inside `resolveContext` is a no-op for every other caller (`foldOffer`, `foldDeliveryCompleted`, the generic session-scoped branch) — zero risk of a surprise interaction elsewhere. Doing it in `foldDashStop` instead would have meant duplicating the "is this an eligible upgrade" logic (already-hydrated-vs-brand-new) that `resolveContext` exists to encapsulate.

The upgrade only fires when `existing.platform == Platform.Unknown` **and** `Platform.fromName(platformName)` resolves to something real (not null, not `Platform.Unknown` itself) — so a real platform is never clobbered, and a malformed/garbage stamp leaves the context untouched.

## Finding 3 (LOW): `currentCostPerMile()` swallows `CancellationException` + silent degradation

`runCatching { appPreferencesRepository.userEconomy.first().operatingCostPerMile }.getOrNull()` catches `Throwable`, including `CancellationException` — three lines above it, `AnalyticsProjector.start()`'s own supervision loop explicitly rethrows `CancellationException` ("cooperative cancellation — never swallow it"); `currentCostPerMile` silently violated that same rule. It also degraded any transient DataStore failure to a bare `getOrNull()` with no log line, so an affected batch's fallback-basis deliveries quietly froze at `CostBasis.NONE` with zero visibility.

**Fix:** explicit `try/catch` — rethrow `CancellationException`, WARN-log (under the `Analytics` tag, failure class only — no PII, no preference contents) on any other `Exception`, then fall back to `null` as before.

## Tests (RED verified before commit)

Both fix commits were verified RED against the pre-fix source (reverted the two source files via `git checkout`, ran the new tests, confirmed failure, then restored the fix and reran green) before being committed — the tests genuinely exercise the fixed behavior, not just pass trivially.

- `RecordFoldsTest` (`:domain:test`):
  - `DASH_STOP's platform stamp upgrades an _unknown context left by a skipped DASH_START` — malformed DASH_START → skip; mid-session offer synthesizes `_unknown`; DASH_STOP with a real platform stamp upgrades the context to that platform.
  - `DASH_STOP's platform stamp does NOT clobber an already-real platform` — control: a DASH_STOP carrying a *different* platform than the session's real DASH_START-established platform must not override it.
- `AnalyticsProjectorTest` (`:app:testDebugUnitTest`):
  - `a DataStore read failure degrades cpm to null instead of crashing the batch` — a throwing `userEconomy` flow still yields `CostBasis.NONE` / null net (behavior-preserving; also passes against the pre-fix `runCatching`, since a plain `Exception` was always caught).
  - `currentCostPerMile does not swallow CancellationException` — a `CancellationException` thrown from the `userEconomy` flow now propagates out of `catchUp()` instead of being silently caught-and-nulled. **This is the test that was RED against the old `runCatching` code** (it swallowed the exception and completed the batch silently; `@Test(expected = CancellationException::class)` failed with no exception thrown) — it's the one that actually proves the finding.

## Full test run (JAVA_HOME=/usr/lib/jvm/java-25-openjdk)

- `:domain:test` — 264 tests, 0 failures, 0 errors
- `:core:state:testDebugUnitTest` — 103 tests, 0 failures, 0 errors
- `:app:testDebugUnitTest` — 894 tests, 0 failures, 0 errors

## Design-goal review

- **P1 (UDF/pure fold):** `resolveContext` stays pure — no Android, no wall clock, driven only by `platformName`/`occurredAt` inputs and the existing context; no side effects introduced.
- **P4 (Kotlin/Android practices):** the upgrade check composes with existing null-safety idioms (`?.let`, early-return via `if`); no new mutable state.
- **P5 (SSOT):** no new parallel copy of platform-resolution logic — routes through the existing `Platform.fromName` registry, same as every other call site.
- **P6 (security & privacy):** the WARN log in `currentCostPerMile` logs the exception's class/message only (Timber's `%s`-free `w(e, "…")` form logs the throwable via Timber's own formatter, no preference values interpolated) — no PII, no economy contents. No new untrusted-input surface.
- **P7 (semantic, PII-safe logging):** the new log line is WARN ("a defended invariant fired" — a real DataStore read failure degrading a computed basis) — correct level per the taxonomy; PII-safe by construction (failure only, no data).
- **P8 (platform-agnostic core):** the fix routes the platform stamp through `Platform.fromName` — the same enumerated registry every other resolution path uses; no new platform literal, no `when`/`==` branch on a specific platform.

No field-test item added — both findings are internal to the pure fold/projector (session-context bookkeeping and an in-process exception path), fully exercised by the unit tests above; there's no on-dash-observable behavior to watch for.

## Adversarial review

Not run by this branch — per the workflow, the orchestrator gates the merge and runs the adversarial pass (`/code-review` + `/security-review` at session tier) before merging. Flagging here so it isn't skipped.

Closes findings 1 and 3 of the fable retrospective review referenced against #314 (the analytics read-model epic).
