### PR TITLE
fix(#632): notification-side recognized-frame customer-PII backstop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,8 +175,9 @@ order-ready customer name via a per-field notif `redact`; store names kept). A r
 which drops the dasher's banking screens) scrubs a node (screen tree) or whole field (notification —
 #632) that ships a customer-PII marker a rule forgot to redact; the marker SSOT is cross-platform
 DATA ("Deliver to "/"Message from " for DoorDash, "Leave the order at "/"Meet at door for " for Uber
-pushes, #585 — not DoorDash-only), with a documented residual for no-lead-in shapes (a whole-address
-title, a name-at-start body) that only the rule-declared `redact` can mask; the compiler rejects branch-level `redact` and skips
+pushes, #585 — not DoorDash-only), with a documented residual for shapes a prefix scan can't own (a
+name-at-start body, and store-ambiguous prefixes like Uber's "Going to " that precede stores AND
+addresses) where the rule-declared `redact` is the primary control; the compiler rejects branch-level `redact` and skips
 a file with duplicate rule ids (#624), and the multi-file loader skips a later file that re-declares
 an id an earlier file already claimed (#633 — cross-file `byId` redact-lookup shadow, fail-closed;
 a no-op on today's prefix-namespaced assets, hardening the #192/#639 multi-file + CDN path).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,9 +171,12 @@ token, so two customers redact distinctly (per-customer replay fidelity) without
 PII; fail-closed to plain `[redacted]`. Coverage spans the recognized offer/pickup/dropoff/chat/
 nav/camera **screen** surfaces AND **notification** envelopes (#620 — chat title/body,
 order-ready customer name via a per-field notif `redact`; store names kept). A rules-independent
-**recognized-frame** backstop (`CustomerTextMarkers`, #624 — distinct from `SensitiveTextMarkers`,
-which drops the dasher's banking screens) scrubs a node that ships a customer-PII marker
-("Deliver to " etc.) a rule forgot to redact; the compiler rejects branch-level `redact` and skips
+**recognized-frame** backstop (`CustomerTextMarkers`, #624/#632 — distinct from `SensitiveTextMarkers`,
+which drops the dasher's banking screens) scrubs a node (screen tree) or whole field (notification —
+#632) that ships a customer-PII marker a rule forgot to redact; the marker SSOT is cross-platform
+DATA ("Deliver to "/"Message from " for DoorDash, "Leave the order at "/"Meet at door for " for Uber
+pushes, #585 — not DoorDash-only), with a documented residual for no-lead-in shapes (a whole-address
+title, a name-at-start body) that only the rule-declared `redact` can mask; the compiler rejects branch-level `redact` and skips
 a file with duplicate rule ids (#624), and the multi-file loader skips a later file that re-declares
 an id an earlier file already claimed (#633 — cross-file `byId` redact-lookup shadow, fail-closed;
 a no-op on today's prefix-namespaced assets, hardening the #192/#639 multi-file + CDN path).

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CaptureWriter.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CaptureWriter.kt
@@ -201,7 +201,34 @@ class CaptureWriter @Inject constructor(
         // the SensitiveTextMarkers backstop above instead.
         val originalContentHash = raw.contentHash
         val notifRedact = obs.ruleId?.let { redactionSource.notifRedactFor(it) }
-        val payloadRaw = notifRedact?.apply(raw) ?: raw
+        val redactedRaw = notifRedact?.apply(raw) ?: raw
+        // #632 recognized-notification customer-PII backstop (defense-in-depth):
+        // the notif analogue of the #624 screen backstop. The #598 sha256→redact
+        // compile gate only fires for a rule that HASHES PII; a recognized
+        // notification rule that ships raw customer text with NO redact block (or a
+        // future downloaded rule that omits one) stays silent. Scan the masked flat
+        // fields for a customer-PII marker whose field was NOT already redacted and
+        // scrub the whole field, so a rule that FORGOT to redact still ships a
+        // scrubbed envelope. The contentHash is still originalContentHash (the dedup
+        // identity, #620 VET V7). UNKNOWN notifications are handled by
+        // SensitiveTextMarkers above; here they have no ruleId so nothing changes.
+        val payloadRaw = if (obs.target != UNKNOWN_TARGET) {
+            val marker = CustomerTextMarkers.firstUnredactedMarkerInNotif(redactedRaw)
+            if (marker != null) {
+                stats.onNotifRedactBackstopScrub()
+                // Principle 7: log the MARKER + rule id only — NEVER the leaked value.
+                Timber.w(
+                    "Capture backstop: recognized notification carried un-redacted customer " +
+                        "marker '%s' (ruleId=%s) — scrubbing field from envelope",
+                    marker, obs.ruleId,
+                )
+                CustomerTextMarkers.scrubNotif(redactedRaw)
+            } else {
+                redactedRaw
+            }
+        } else {
+            redactedRaw
+        }
         val capture = EnvelopeBuilder.build(
             pipelineId = NotificationPipeline.PIPELINE_ID,
             schema = RawNotificationSchema,

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CustomerTextMarkers.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CustomerTextMarkers.kt
@@ -30,13 +30,16 @@ import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData
  * vocabulary (DoorDash screens/pushes AND Uber pushes) so the backstop is not
  * DoorDash-only — cross-platform marker DATA in one SSOT, not per-platform Kotlin
  * (#585 platform-coupling catalog: recognition vocabulary is data). Deliberate
- * exclusions (VET V2): `"Heading to "` prefixes STORE names on pickup-nav frames,
- * and `"Your delivery from "` prefixes a STORE (merchants are not PII). Two
- * residual shapes CANNOT be caught by a prefix scan and rely on the rule-declared
- * `redact` as the primary control: Uber's `trip_en_route_dropoff` title is a WHOLE
- * address with no lead-in, and DoorDash's `order_ready` puts the customer name at
- * the START (`"<name>'s order is ready…"`). The `CaptureBackstopCorpusTest` pins
- * the set to ZERO false positives on the committed (already-redacted) corpus.
+ * exclusions (VET V2): `"Heading to "` and `"Your delivery from "` prefix STORE
+ * names (merchants are not PII), and Uber's `"Going to "` is excluded for the
+ * same reason — it prefixes a STORE on `trip_en_route_pickup` (`^Going to (?!\d)`)
+ * and only an address on `trip_en_route_dropoff` (`^Going to \d`); a plain prefix
+ * scan can't tell them apart, so that dropoff title relies on the rule-declared
+ * `redact` as the primary control (store-FP risk, the "Heading to " precedent —
+ * NOT because the title lacks a lead-in). DoorDash's `order_ready` is a true
+ * no-marker residual: the customer name sits at the START (`"<name>'s order is
+ * ready…"`), so no prefix precedes it. The `CaptureBackstopCorpusTest` pins the
+ * set to ZERO false positives on the committed (already-redacted) corpus.
  */
 object CustomerTextMarkers {
 

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CustomerTextMarkers.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CustomerTextMarkers.kt
@@ -2,39 +2,56 @@ package cloud.trotter.dashbuddy.core.pipeline
 
 import cloud.trotter.dashbuddy.core.pipeline.rules.CompiledRedact
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData
 
 /**
  * App-owned, rules-independent backstop for the CUSTOMER-PII redaction pledge
- * (#624) — the recognized-frame analogue of [SensitiveTextMarkers].
+ * (#624/#632) — the recognized-frame analogue of [SensitiveTextMarkers], shared
+ * by BOTH the screen ([firstUnredactedMarker]/[scrub], a UiNode tree) and the
+ * notification ([firstUnredactedMarkerInNotif]/[scrubNotif], flat fields) capture
+ * paths off one marker SSOT.
  *
  * The two SSOTs differ in both target and action:
  * - [SensitiveTextMarkers] guards the UNKNOWN path against the DASHER's OWN
  *   sensitive screens (banking/identity) by DROPPING the whole capture.
  * - This SSOT guards RECOGNIZED frames whose rule SHOULD have declared a
- *   `redact` block but didn't, and it SCRUBS only the offending node to
+ *   `redact` block but didn't, and it SCRUBS only the offending node/field to
  *   `[redacted]` (the capture still ships, minus the leaked PII).
  *
  * Why it's needed: the #598 `sha256`→`redact` compile gate only fires for a rule
  * that HASHES PII in its parse. A rule that ships raw customer text WITHOUT
- * hashing it (the live `dropoff_reminder` address leak this PR also fixes in
- * data) stays silent — and once rules are downloaded over a CDN (#192/#416/#419)
- * a rule that simply omits redaction would leak. This backstop closes that class.
+ * hashing it (the live `dropoff_reminder` screen leak / the `trip_*_dropoff`
+ * notification leak #631 found+fixed) stays silent — and once rules are
+ * downloaded over a CDN (#192/#416/#419) a rule that simply omits redaction would
+ * leak. This backstop closes that class on both sensor paths.
  *
- * Markers are customer-PII LABEL PREFIXES: a node whose text starts with one
- * carries a customer name/identifier immediately after. `"Heading to "` is
- * deliberately EXCLUDED (VET V2) — it prefixes STORE names on recognized
- * pickup-nav frames, which are kept (merchants are not PII); the
- * `CaptureBackstopCorpusTest` pins the set to ZERO false positives on the
- * committed (already-redacted) corpus.
+ * Markers are customer-PII LABEL PREFIXES: text that starts with one carries a
+ * customer name/address immediately after. The set spans BOTH platforms'
+ * vocabulary (DoorDash screens/pushes AND Uber pushes) so the backstop is not
+ * DoorDash-only — cross-platform marker DATA in one SSOT, not per-platform Kotlin
+ * (#585 platform-coupling catalog: recognition vocabulary is data). Deliberate
+ * exclusions (VET V2): `"Heading to "` prefixes STORE names on pickup-nav frames,
+ * and `"Your delivery from "` prefixes a STORE (merchants are not PII). Two
+ * residual shapes CANNOT be caught by a prefix scan and rely on the rule-declared
+ * `redact` as the primary control: Uber's `trip_en_route_dropoff` title is a WHOLE
+ * address with no lead-in, and DoorDash's `order_ready` puts the customer name at
+ * the START (`"<name>'s order is ready…"`). The `CaptureBackstopCorpusTest` pins
+ * the set to ZERO false positives on the committed (already-redacted) corpus.
  */
 object CustomerTextMarkers {
 
     /** Customer-PII label prefixes. Case-insensitive `startsWith` match. */
     val MARKERS: List<String> = listOf(
+        // DoorDash screen + notification vocabulary.
         "Deliver to ",
         "Order for ",
         "Verify items for ",
         "Delivery for ",
+        "Message from ", // DoorDash in-app chat push title -> customer name.
+        // Uber notification vocabulary (#632) — the keepPrefix lead-ins the
+        // uber.json5 trip_at_dropoff redact declares.
+        "Leave the order at ", // Uber trip_at_dropoff title -> dropoff ADDRESS.
+        "Meet at door for ", // Uber trip_at_dropoff title -> customer name.
     )
 
     /** Substring that classifies a node's text as already-redacted (VET V1). */
@@ -76,4 +93,37 @@ object CustomerTextMarkers {
             },
         children = tree.children.map { scrub(it) },
     )
+
+    // --- Notification path (#632) --------------------------------------------
+    // Notification captures are FLAT fields, not a UiNode tree — so a hit scrubs
+    // the WHOLE offending field (there are no children to isolate). Same
+    // already-redacted skip (VET V1) and same marker SSOT as the screen path.
+
+    /**
+     * The first un-redacted customer marker across [raw]'s flat text fields
+     * (title/text/bigText/tickerText/subText), or null when clean. Cheap scan run
+     * on every recognized notification capture; the [scrubNotif] copy is built
+     * only on a hit.
+     */
+    fun firstUnredactedMarkerInNotif(raw: RawNotificationData): String? =
+        notifFields(raw).firstNotNullOfOrNull { unredactedMarker(it) }
+
+    /**
+     * A copy of [raw] with every flat field carrying an un-redacted customer
+     * marker scrubbed WHOLE to [CompiledRedact.REDACTED]. Call only after
+     * [firstUnredactedMarkerInNotif] returned non-null.
+     */
+    fun scrubNotif(raw: RawNotificationData): RawNotificationData = raw.copy(
+        title = scrubField(raw.title),
+        text = scrubField(raw.text),
+        bigText = scrubField(raw.bigText),
+        tickerText = scrubField(raw.tickerText),
+        subText = scrubField(raw.subText),
+    )
+
+    private fun notifFields(raw: RawNotificationData): List<String?> =
+        listOf(raw.title, raw.text, raw.bigText, raw.tickerText, raw.subText)
+
+    private fun scrubField(field: String?): String? =
+        if (unredactedMarker(field) != null) CompiledRedact.REDACTED else field
 }

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/PipelineStats.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/PipelineStats.kt
@@ -35,6 +35,7 @@ class PipelineStats @Inject constructor() {
     private val droppedAwaitingRules = AtomicLong()
     private val scrubbedUnknownCaptures = AtomicLong()
     private val redactBackstopScrubs = AtomicLong()
+    private val notifRedactBackstopScrubs = AtomicLong()
 
     val droppedSensitiveCount: Long get() = droppedSensitive.get()
     val droppedNoiseCount: Long get() = droppedNoise.get()
@@ -47,6 +48,7 @@ class PipelineStats @Inject constructor() {
     val droppedAwaitingRulesCount: Long get() = droppedAwaitingRules.get()
     val scrubbedUnknownCaptureCount: Long get() = scrubbedUnknownCaptures.get()
     val redactBackstopScrubCount: Long get() = redactBackstopScrubs.get()
+    val notifRedactBackstopScrubCount: Long get() = notifRedactBackstopScrubs.get()
 
     /** A frame the shared content gate dropped (sensitive or noise, #399). */
     fun onContentGateDrop(parsed: ParsedFields) {
@@ -93,6 +95,13 @@ class PipelineStats @Inject constructor() {
         redactBackstopScrubs.incrementAndGet()
     }
 
+    /** A RECOGNIZED NOTIFICATION whose rule shipped an un-redacted customer marker;
+     *  the offending flat field was scrubbed in the envelope by the #632
+     *  defense-in-depth notification backstop (the notif analogue of #624). */
+    fun onNotifRedactBackstopScrub() {
+        notifRedactBackstopScrubs.incrementAndGet()
+    }
+
     /** The supervised upstream crashed and is resubscribing. Returns the restart ordinal. */
     fun onPipelineRestart(): Long = restarts.incrementAndGet()
 
@@ -117,6 +126,7 @@ class PipelineStats @Inject constructor() {
             " awaitingRulesDropped=${droppedAwaitingRules.get()}" +
             " unknownScrubbed=${scrubbedUnknownCaptures.get()}" +
             " redactBackstopScrubs=${redactBackstopScrubs.get()}" +
+            " notifRedactBackstopScrubs=${notifRedactBackstopScrubs.get()}" +
             " restarts=${restarts.get()}"
 
     companion object {

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CustomerTextMarkersTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CustomerTextMarkersTest.kt
@@ -1,16 +1,29 @@
 package cloud.trotter.dashbuddy.core.pipeline
 
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 
 /**
- * #624 marker-SSOT unit tests for [CustomerTextMarkers] — the recognized-frame
+ * #624/#632 marker-SSOT unit tests for [CustomerTextMarkers] — the recognized-frame
  * customer-PII backstop's keyword set and the already-redacted skip rule (VET V1)
- * plus the deliberate "Heading to " exclusion (VET V2).
+ * plus the deliberate "Heading to " exclusion (VET V2), across BOTH the screen
+ * (UiNode tree) and notification (flat field) helpers.
  */
 class CustomerTextMarkersTest {
+
+    private fun notif(
+        title: String? = null,
+        text: String? = null,
+        bigText: String? = null,
+        tickerText: String? = null,
+        subText: String? = null,
+    ) = RawNotificationData(
+        title = title, text = text, bigText = bigText, tickerText = tickerText,
+        subText = subText, packageName = "pkg", postTime = 0L, isClearable = true,
+    )
 
     @Test
     fun `a customer marker prefix is detected`() {
@@ -62,5 +75,61 @@ class CustomerTextMarkersTest {
         assertEquals("Got it", scrubbed.children[2].text)
         // Clean after scrub.
         assertNull(CustomerTextMarkers.firstUnredactedMarker(scrubbed))
+    }
+
+    // --- Notification path (#632) --------------------------------------------
+
+    @Test
+    fun `cross-platform notif customer lead-ins are detected (#632)`() {
+        // Uber notification vocabulary.
+        assertEquals(
+            "Leave the order at ",
+            CustomerTextMarkers.unredactedMarker("Leave the order at 123 Main St, Apt 4"),
+        )
+        assertEquals(
+            "Meet at door for ",
+            CustomerTextMarkers.unredactedMarker("Meet at door for Jane Q Doe"),
+        )
+        // DoorDash chat push title.
+        assertEquals("Message from ", CustomerTextMarkers.unredactedMarker("Message from Jennifer"))
+    }
+
+    @Test
+    fun `firstUnredactedMarkerInNotif scans flat fields and scrubNotif masks the whole field`() {
+        val raw = notif(
+            title = "Leave the order at 123 Main St, Apt 4",
+            text = "Your delivery from H-E-B", // store-only, kept
+        )
+        assertEquals("Leave the order at ", CustomerTextMarkers.firstUnredactedMarkerInNotif(raw))
+
+        val scrubbed = CustomerTextMarkers.scrubNotif(raw)
+        // Whole-field scrub (flat strings, not a tree).
+        assertEquals("[redacted]", scrubbed.title)
+        // Store-only field is untouched (merchants are not PII).
+        assertEquals("Your delivery from H-E-B", scrubbed.text)
+        // Clean after scrub.
+        assertNull(CustomerTextMarkers.firstUnredactedMarkerInNotif(scrubbed))
+    }
+
+    @Test
+    fun `an already-redacted notif field is skipped (VET V1)`() {
+        val raw = notif(title = "Leave the order at [redacted:ab12]")
+        assertNull(CustomerTextMarkers.firstUnredactedMarkerInNotif(raw))
+    }
+
+    @Test
+    fun `store-only notif text is NOT a customer marker`() {
+        // "Your delivery from <store>" prefixes a MERCHANT, not customer data.
+        assertNull(CustomerTextMarkers.unredactedMarker("Your delivery from H-E-B"))
+        assertNull(CustomerTextMarkers.firstUnredactedMarkerInNotif(notif(text = "Your delivery from H-E-B")))
+    }
+
+    @Test
+    fun `no-lead-in customer shapes are the documented residual the rule redact owns`() {
+        // Uber trip_en_route_dropoff title is a WHOLE address with NO lead-in marker —
+        // a prefix scan cannot catch it; the rule-declared `redact` is the control.
+        assertNull(CustomerTextMarkers.unredactedMarker("123 Main Street, Austin"))
+        // DoorDash order_ready puts the customer name at the START (no lead-in).
+        assertNull(CustomerTextMarkers.unredactedMarker("Adam's order is ready for pickup at 7-Eleven"))
     }
 }

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/NotificationRedactionTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/NotificationRedactionTest.kt
@@ -244,9 +244,12 @@ class NotificationRedactionTest {
     }
 
     @Test
-    fun `#632 backstop cannot catch a no-lead-in address (residual - rule redact owns it)`() {
+    fun `#632 backstop cannot catch an unmarked address (residual - rule redact owns it)`() {
         whenever(captureBus.offer(any(), any(), anyOrNull(), any(), any(), anyOrNull())).thenReturn("cap-1")
-        // Uber trip_en_route_dropoff title is a WHOLE address with no lead-in marker.
+        // An address with no scannable marker. (The real trip_en_route_dropoff title is
+        // "Going to <addr>" — "Going to " is deliberately NOT a marker because it also
+        // prefixes STORES on trip_en_route_pickup; either way the prefix scan cannot fire
+        // and the rule's own `redact` is the primary control. Synthetic bare-address shape.)
         val residual = raw(title = "123 Main Street, Austin")
         writer(noRedactSource)
             .captureNotification(obs("uber.notification.trip_en_route_dropoff", "trip_en_route_dropoff"), residual)

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/NotificationRedactionTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/NotificationRedactionTest.kt
@@ -165,6 +165,97 @@ class NotificationRedactionTest {
         assertTrue(json.contains("Tap to view"))
     }
 
+    // --- #632 rules-independent notification customer-PII backstop ------------
+
+    /** notifRedactFor never matches -> simulates a recognized rule that FORGOT redact. */
+    private val noRedactSource = object : ScreenRedactionSource {
+        override fun redactFor(ruleId: String): CompiledRedact? = null
+        override fun notifRedactFor(ruleId: String): CompiledNotifRedact? = null
+    }
+
+    @Test
+    fun `#632 backstop scrubs a recognized notification whose rule forgot to redact`() {
+        whenever(captureBus.offer(any(), any(), anyOrNull(), any(), any(), anyOrNull())).thenReturn("cap-1")
+        // Uber trip_at_dropoff push with the customer ADDRESS after the lead-in, but the
+        // rule shipped NO redact block (noRedactSource) — the backstop is the only net.
+        val leak = raw(title = "Leave the order at 123 Main St, Apt 4")
+        writer(noRedactSource)
+            .captureNotification(obs("uber.notification.trip_at_dropoff", "trip_at_dropoff"), leak)
+
+        val json = capturedEnvelope()
+        assertFalse("leaked address gone", json.contains("123 Main St"))
+        assertTrue("field scrubbed whole", json.contains("[redacted]"))
+        assertEquals(1L, stats.notifRedactBackstopScrubCount)
+    }
+
+    @Test
+    fun `#632 backstop scrubs a forgotten DoorDash chat name`() {
+        whenever(captureBus.offer(any(), any(), anyOrNull(), any(), any(), anyOrNull())).thenReturn("cap-1")
+        val leak = raw(title = "Message from Jennifer", text = "The gate code is 4412")
+        writer(noRedactSource)
+            .captureNotification(obs("doordash.notification.customer_message", "customer_message"), leak)
+
+        val json = capturedEnvelope()
+        assertFalse("customer name gone", json.contains("Jennifer"))
+        assertEquals(1L, stats.notifRedactBackstopScrubCount)
+    }
+
+    @Test
+    fun `#632 backstop preserves the ORIGINAL contentHash on a scrub`() {
+        whenever(captureBus.offer(any(), any(), anyOrNull(), any(), any(), anyOrNull())).thenReturn("cap-1")
+        val leak = raw(title = "Leave the order at 123 Main St")
+        val originalHash = leak.contentHash
+        writer(noRedactSource)
+            .captureNotification(obs("uber.notification.trip_at_dropoff", "trip_at_dropoff"), leak)
+
+        val hashCap = argumentCaptor<Int?>()
+        org.mockito.kotlin.verify(captureBus).offer(any(), any(), anyOrNull(), any(), any(), hashCap.capture())
+        assertEquals("dedup identity stays the ORIGINAL raw hash", originalHash, hashCap.lastValue)
+    }
+
+    @Test
+    fun `#632 backstop leaves a properly rule-redacted notification untouched (no double-scrub)`() {
+        whenever(captureBus.offer(any(), any(), anyOrNull(), any(), any(), anyOrNull())).thenReturn("cap-1")
+        val message = raw(
+            title = "Message from Jennifer",
+            text = "secret body",
+            channelId = "dasher-notification-channel-inapp-chat",
+        )
+        writer(sourceFor("doordash.notification.customer_message", customerMessageRedact))
+            .captureNotification(obs("doordash.notification.customer_message", "customer_message"), message)
+
+        // The rule redacted; the backstop found nothing to scrub.
+        assertEquals(0L, stats.notifRedactBackstopScrubCount)
+        assertTrue(
+            "the rule's own keepPrefix mask stays, not double-scrubbed to whole-field [redacted]",
+            Regex("""Message from \[redacted:[0-9a-f]{4}\]""").containsMatchIn(capturedEnvelope()),
+        )
+    }
+
+    @Test
+    fun `#632 backstop does not scrub store-only text`() {
+        whenever(captureBus.offer(any(), any(), anyOrNull(), any(), any(), anyOrNull())).thenReturn("cap-1")
+        val storeOnly = raw(title = "Order confirmed", text = "Your delivery from H-E-B")
+        writer(noRedactSource)
+            .captureNotification(obs("doordash.notification.some_promo", "some_promo"), storeOnly)
+
+        assertTrue("store kept", capturedEnvelope().contains("H-E-B"))
+        assertEquals(0L, stats.notifRedactBackstopScrubCount)
+    }
+
+    @Test
+    fun `#632 backstop cannot catch a no-lead-in address (residual - rule redact owns it)`() {
+        whenever(captureBus.offer(any(), any(), anyOrNull(), any(), any(), anyOrNull())).thenReturn("cap-1")
+        // Uber trip_en_route_dropoff title is a WHOLE address with no lead-in marker.
+        val residual = raw(title = "123 Main Street, Austin")
+        writer(noRedactSource)
+            .captureNotification(obs("uber.notification.trip_en_route_dropoff", "trip_en_route_dropoff"), residual)
+
+        // Honest residual: the prefix backstop does NOT fire here; the rule's
+        // `redact { title {} }` is the primary control for this shape.
+        assertEquals(0L, stats.notifRedactBackstopScrubCount)
+    }
+
     @Test
     fun `UNKNOWN notification never consults the notif redaction source`() {
         whenever(captureBus.offer(any(), any(), anyOrNull(), any(), any(), anyOrNull())).thenReturn("cap-1")


### PR DESCRIPTION
Closes #632.

Follow-up from the #620/#624 security review (PR #631). #624 built the **screen**-side rules-independent customer-PII backstop (`CustomerTextMarkers` scans a recognized frame's serialized tree after rule redaction; an un-redacted customer marker → WARN + scrub node). The **notification** path had no such net — a recognized notification relied entirely on its rule declaring `notifRedact` (#620). #631 proved the class real (the Uber `trip_en_route_dropoff`/`trip_at_dropoff` dropoff-address leak it found + fixed). This adds the notification analogue.

## What changed
- **`CaptureWriter.captureNotification`** — AFTER `notifRedact` masking, scan the masked `RawNotificationData` flat fields (title/text/bigText/tickerText/subText) for a customer marker whose field is not already `[redacted`. On a hit: WARN (marker + ruleId only), scrub the **whole field** to `[redacted]` (flat strings, not a tree), bump the new counter. Skips UNKNOWN (those route through `SensitiveTextMarkers`, unchanged).
- **`CustomerTextMarkers`** — now the ONE cross-platform marker SSOT shared by both sensor backstops; adds `firstUnredactedMarkerInNotif` / `scrubNotif` (flat-field helpers reusing the same `unredactedMarker` + VET-V1 already-redacted skip).
- **`PipelineStats`** — new `notifRedactBackstopScrubs` counter (mirrors `redactBackstopScrubs`), in `summary()`.
- **CLAUDE.md** — architecture blurb updated (screen + notif coverage, cross-platform marker vocabulary, residual noted).

## Marker additions (each justified)
- **`"Message from "`** — DoorDash in-app chat push title lead-in; the text after it is the **customer name** (`doordash.notification.customer_message` keepPrefix). A chat rule that loses its redact still gets scrubbed.
- **`"Leave the order at "`** — Uber `trip_at_dropoff` push title lead-in; the text after it is the **dropoff address** (customer PII). Exactly the `uber.json5` keepPrefix.
- **`"Meet at door for "`** — Uber `trip_at_dropoff` alternate title lead-in; the text after it is the **customer name**. Exactly the `uber.json5` keepPrefix.
- **Deliberately excluded:** `"Heading to "` (VET V2 — prefixes STORE names) and `"Your delivery from "` (prefixes a MERCHANT). Merchants are not PII; scrubbing them would be a false positive. Grep confirms none of the added/excluded markers occur in the committed screen corpus → zero new false positives (`CaptureBackstopCorpusTest` green).

## Security / privacy posture (Pledge)
- **Closes the notification half of the defense-in-depth gap.** The #598 `sha256`→`redact` compile gate only fires for a rule that HASHES PII; a rule that ships raw customer text with NO redact (or a future downloaded CDN/fork rule that omits one, #192/#416/#419) stays silent. This backstop is the net **under** the rules — the rule-declared `notifRedact` remains the primary control.
- **Fail-closed scrub:** whole-field mask; over-scrub (e.g. a merchant message) is harmless, under-scrub (a leak) is what's prevented.
- **P7-clean WARN:** logs the marker + ruleId only, never the leaked value.
- **Dedup identity preserved:** `contentHash` stays the ORIGINAL raw hash (#620 VET V7) — the scrub happens after the hash is captured.
- **Honest residual:** a customer field with **no lead-in marker** — Uber `trip_en_route_dropoff`'s whole-address title, DoorDash `order_ready`'s name-at-start body (`"<name>'s order is ready…"`) — **cannot** be caught by a prefix scan. Those rely on the rule-declared `redact` (both known instances already carry it, #631). Stated in code, tests, and the marker-set doc.

## #585 platform-coupling note
The marker set is now cross-platform recognition **DATA** in one SSOT (DoorDash + Uber vocabulary), not a DoorDash-only Kotlin backstop. No platform literal enters logic; the backstop is vocabulary-driven and extends to a new platform by adding a marker string (or by the platform's own rule `redact`). No `== Platform.X` introduced.

## Tests
RED-first unit + integration tests; all green (`JAVA_HOME=java-25-openjdk`):
- `CustomerTextMarkersTest` 6 → **11** (notif helpers: cross-platform lead-ins, flat-field scan + whole-field scrub, already-redacted skip, store-only not-a-marker, no-lead-in residual).
- `NotificationRedactionTest` 5 → **11** (through `captureNotification`: forgot-redact address + chat-name → scrubbed + counter=1; original contentHash preserved on scrub; properly-redacted → no double-scrub, counter=0; store-only → kept; no-lead-in residual → not caught).
- **Suites:** `:core:pipeline` 241, `:app` 892 (incl. `AllMatchersSuite` + `CaptureBackstopCorpusTest` zero-FP pin), `:domain` 262 — **0 failures / 0 errors**.

## Field test
None needed — capture-time internal (envelope-only masking; no on-dash/HUD/recognition-vocabulary behavior change), fully covered by unit + corpus tests.

### Design-goal review
- **6 (security & privacy):** primary subject — fail-closed backstop under the rules, P7-clean WARN, original-hash dedup, residual documented. Conforms.
- **5 (SSOT):** one marker set drives both sensor backstops; no duplicated marker list.
- **7 (logging):** one new WARN (a defended invariant fired), marker + ruleId only, no PII.
- **8 (platform-agnostic):** marker vocabulary is cross-platform DATA, not per-platform Kotlin; no platform literal in logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)