### PR TITLE
feat(#659): frozen fuel/non-fuel split for the 4-step true-net waterfall

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,17 +251,23 @@ clicks a third-party app, #425), `OfferActionReceiver` (notification Accept/Decl
 
 Analytics is a **CQRS read-model** projected from the durable `app_events` log — the event log is the
 source of truth; the read-model tables are a rebuildable cache. `AnalyticsProjector` (`:core:data`, started
-from `DashBuddyApplication`, runs every launch off-main + supervised) folds `app_events` → three Room v9
+from `DashBuddyApplication`, runs every launch off-main + supervised) folds `app_events` → three Room v10
 tables (`delivery_records`/`session_records`/`offer_records`) via the pure `RecordFolds`/`SessionFoldContext`
 (`:domain`). The fold is **exactly-once** — records + a watermark advance in one `db.withTransaction`, record
 PKs are the source `sequenceId` (REPLACE-idempotent) — so the **one-time backfill is just the first drain from
 watermark 0**, and a `projectorVersion` bump wipes + refolds the whole log (rebuild ≡ backfill). Realized
 inputs come from the log: pay from `DeliveryPayload.dropRealizedPay`/`totalPay` (#528), miles from
 `metadata.odometer` partition deltas, time from timestamps. **Economics are FROZEN per record, never
-recomputed** (dev decision): each `delivery_record` stores `netProfit` + `frozenCostPerMile` + `costBasis`
-computed at projection time against the offer's own frozen `OfferEvaluation.operatingCostPerMile` (session
-granularity — the offer→delivery `jobId` link is absent in the log, but cpm is session-uniform), so editing
-economy settings only affects **future** evaluations — a record is an immutable historical fact. `NetProfit`
+recomputed** (dev decision): each `delivery_record` stores `netProfit` + `frozenCostPerMile` + its frozen
+`frozenFuelPerMile`/`frozenNonFuelPerMile` split (#659, the 4-step true-net waterfall Gross → −Fuel → −Non-fuel
+→ Net; the split rides the SAME frozen `OfferEvaluation` — `fuelCostEstimate`/`nonFuelCostEstimate` ÷
+`distanceMiles`, invariant `fuel+nonfuel ≈ cpm`; null off an `OFFER_FROZEN` basis → the waterfall falls back to
+3-step) + `costBasis`, computed at projection time against the offer's own frozen
+`OfferEvaluation.operatingCostPerMile` (session granularity — the offer→delivery `jobId` link is absent in the
+log, but cpm is session-uniform), so editing economy settings only affects **future** evaluations — a record is
+an immutable historical fact. Session hydration rehydrates `started` from a persisted `session_records.startSource`
+marker (#659, retro finding 2), not the old "has a real platform" heuristic. The v9→v10 migration is
+additive-only (three nullable columns; `PROJECTOR_VERSION` bump refolds them from the log). `NetProfit`
 (`:domain`) is the one shared cost-math SSOT for both the offer estimate and the frozen realized net.
 `AnalyticsRepository` (`:core:data`, **DAO-only — no economy dependency**, so historical net is structurally
 immutable) serves period economics (`SUM(netProfit)` frozen + `unattributedPay`; all-pay gross =

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,7 +267,7 @@ recomputed** (dev decision): each `delivery_record` stores `netProfit` + `frozen
 log, but cpm is session-uniform), so editing economy settings only affects **future** evaluations — a record is
 an immutable historical fact. Session hydration rehydrates `started` from a persisted `session_records.startSource`
 marker (#659, retro finding 2), not the old "has a real platform" heuristic. The v9→v10 migration is
-additive-only (three nullable columns; `PROJECTOR_VERSION` bump refolds them from the log). `NetProfit`
+additive-only (five nullable columns — delivery +2, offer +2, session +1; `PROJECTOR_VERSION` bump refolds them from the log). `NetProfit`
 (`:domain`) is the one shared cost-math SSOT for both the offer estimate and the frozen realized net.
 `AnalyticsRepository` (`:core:data`, **DAO-only — no economy dependency**, so historical net is structurally
 immutable) serves period economics (`SUM(netProfit)` frozen + `unattributedPay`; all-pay gross =

--- a/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsProjectorTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsProjectorTest.kt
@@ -93,15 +93,17 @@ class AnalyticsProjectorTest {
         ),
     )
 
-    private fun eval(opCpm: Double) = OfferEvaluation(
+    private fun eval(opCpm: Double, fuelPerMile: Double = 0.0) = OfferEvaluation(
         action = OfferAction.ACCEPT, score = 80.0, qualityLevel = OfferQuality.GOOD,
-        payAmount = 12.0, fuelCostEstimate = 0.0, operatingCostPerMile = opCpm,
+        payAmount = 12.0,
+        fuelCostEstimate = fuelPerMile * 3.0, nonFuelCostEstimate = (opCpm - fuelPerMile) * 3.0,
+        operatingCostPerMile = opCpm,
         netPayAmount = 12.0 - 3.0 * opCpm, distanceMiles = 3.0,
         dollarsPerMile = 3.0, dollarsPerHour = 20.0, estimatedTimeMinutes = 15.0,
         itemCount = 1.0, merchantName = "StoreX",
     )
 
-    private suspend fun seedFullSession(sid: String = "S1", opCpm: Double = 0.25) {
+    private suspend fun seedFullSession(sid: String = "S1", opCpm: Double = 0.25, fuelPerMile: Double = 0.0) {
         insert(
             AppEventType.DASH_START, sid, 1_000,
             SessionStartPayload(sid, Platform.DoorDash.name, 1_000, SessionStartSource.INTERACTION, "x"),
@@ -112,7 +114,7 @@ class AnalyticsProjectorTest {
             OfferPayload(
                 offerHash = "h1",
                 parsedOffer = ParsedOffer(offerHash = "h1", payAmount = 12.0, distanceMiles = 3.0),
-                evaluation = eval(opCpm), outcome = AppEventType.OFFER_ACCEPTED,
+                evaluation = eval(opCpm, fuelPerMile), outcome = AppEventType.OFFER_ACCEPTED,
                 presentedAt = 1_970, decidedAt = 2_000, returnFlow = Flow.Idle,
             ),
         )
@@ -374,6 +376,91 @@ class AnalyticsProjectorTest {
         )
         assertNull(delivery.frozenCostPerMile)
         assertNull(delivery.netProfit)
+    }
+
+    @Test
+    fun `folds the frozen fuel and non-fuel split onto delivery records and into the period sums (#659)`() = runBlocking {
+        // opCpm 0.25 split fuel 0.10 / non-fuel 0.15 per mile; the delivery ran 5 miles (100→105).
+        seedFullSession(opCpm = 0.25, fuelPerMile = 0.10)
+        projector().catchUp()
+
+        val d = analyticsDao.lastDeliveryInSession("S1")!!
+        assertEquals(0.10, d.frozenFuelPerMile!!, 1e-9)
+        assertEquals(0.15, d.frozenNonFuelPerMile!!, 1e-9)
+        // Invariant: fuel + non-fuel ≈ frozenCostPerMile.
+        assertEquals(d.frozenCostPerMile!!, d.frozenFuelPerMile!! + d.frozenNonFuelPerMile!!, 1e-9)
+
+        // The offer row persisted the per-mile split (rebuild-stable hydration source).
+        assertEquals(0.10, analyticsDao.lastOfferFuelPerMileInSession("S1")!!, 1e-9)
+        assertEquals(0.15, analyticsDao.lastOfferNonFuelPerMileInSession("S1")!!, 1e-9)
+
+        // Period sums = Σ perMile × realizedMiles (5 mi): fuel 0.50, non-fuel 0.75.
+        val totals = analyticsDao.deliveryTotals(0, Long.MAX_VALUE).first()
+        assertEquals(0.50, totals.fuelCost!!, 1e-9)
+        assertEquals(0.75, totals.nonFuelCost!!, 1e-9)
+    }
+
+    @Test
+    fun `no-offer session leaves the frozen split null and the period sums null (3-step fallback, #659)`() = runBlocking {
+        // A delivery with no preceding offer → CURRENT_FALLBACK cpm, no split. The period fuel/non-fuel
+        // SUMs are NULL (no split coverage), the signal the waterfall uses to fall back to 3-step.
+        insert(
+            AppEventType.DASH_START, "S1", 1_000,
+            SessionStartPayload("S1", Platform.DoorDash.name, 1_000, SessionStartSource.INTERACTION, "x"),
+            odometer = 0.0,
+        )
+        insert(
+            AppEventType.DELIVERY_COMPLETED, "S1", 2_000,
+            DeliveryPayload(jobId = "J1", taskId = "T1", storeName = "StoreX", phaseStartedAt = 1_500, totalPay = 5.0),
+            odometer = 4.0,
+        )
+        projector().catchUp()
+
+        val d = analyticsDao.lastDeliveryInSession("S1")!!
+        assertEquals("CURRENT_FALLBACK", d.costBasis)
+        assertNull(d.frozenFuelPerMile)
+        assertNull(d.frozenNonFuelPerMile)
+
+        val totals = analyticsDao.deliveryTotals(0, Long.MAX_VALUE).first()
+        assertNull("no frozen split coverage → null fuel sum", totals.fuelCost)
+        assertNull(totals.nonFuelCost)
+    }
+
+    @Test
+    fun `startSource persists and hydration derives started from it, not from a real platform (retro finding 2)`() = runBlocking {
+        // The retro-2 hazard: a DASH_STOP carrying the real platform stamp (#314) arrives BEFORE its
+        // DASH_START, in an earlier batch. It synthesizes a real-platform placeholder with startedAt =
+        // the STOP time and startSource = null. Under the old `started = platform != Unknown` hydration
+        // that rehydrated as started=true → the DASH_START took the RECOVERY non-clobber arm and the
+        // wrong near-zero-duration startedAt stuck. With startSource-based hydration it rehydrates as
+        // started=false and the DASH_START correctly upgrades startedAt.
+        insert(
+            AppEventType.DASH_STOP, "S1", 5_000,
+            SessionStopPayload(
+                "S1", endedAt = 5_000, source = SessionEndSource.SUMMARY_SCREEN, totalEarnings = 10.0,
+                platform = Platform.DoorDash.name,
+            ),
+            odometer = 20.0,
+        )
+        insert(
+            AppEventType.DASH_START, "S1", 1_000,
+            SessionStartPayload("S1", Platform.DoorDash.name, 1_000, SessionStartSource.INTERACTION, "x"),
+            odometer = 10.0,
+        )
+
+        // Batch 1 folds the DASH_STOP → persists a real-platform placeholder with startSource = null.
+        projector().processBatch(limit = 1)
+        val afterStop = analyticsDao.sessionRecord("S1")!!
+        assertEquals("doordash", afterStop.platform)
+        assertNull("DASH_STOP does not stamp startSource", afterStop.startSource)
+        assertEquals("placeholder startedAt is the stop time", 5_000L, afterStop.startedAt)
+
+        // Batch 2 (fresh projector) HYDRATES the placeholder and folds the DASH_START.
+        projector().processBatch(limit = 1)
+        val s = analyticsDao.sessionRecord("S1")!!
+        assertEquals("the real DASH_START upgraded startedAt (not stuck at the stop time)", 1_000L, s.startedAt)
+        assertEquals("interaction", s.startSource)
+        assertEquals(10.0, s.startOdometer!!, 1e-9)
     }
 
     @Test(expected = CancellationException::class)

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjector.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjector.kt
@@ -240,6 +240,8 @@ class AnalyticsProjector @Inject constructor(
             prevDropOdometer = lastDelivery?.odometerAtCompletion,
             prevDropAt = lastDelivery?.completedAt,
             lastEvaluatedCostPerMile = analyticsDao.lastOfferCostPerMileInSession(sessionId),
+            lastEvaluatedFuelPerMile = analyticsDao.lastOfferFuelPerMileInSession(sessionId),
+            lastEvaluatedNonFuelPerMile = analyticsDao.lastOfferNonFuelPerMileInSession(sessionId),
         )
     }
 
@@ -287,6 +289,7 @@ class AnalyticsProjector @Inject constructor(
         offersTimeout = offersTimeout,
         deliveries = deliveries,
         jobsCompleted = jobsCompleted,
+        startSource = startSource,
     )
 
     private fun SessionRecordEntity.toContext(
@@ -294,6 +297,8 @@ class AnalyticsProjector @Inject constructor(
         prevDropOdometer: Double? = null,
         prevDropAt: Long? = null,
         lastEvaluatedCostPerMile: Double? = null,
+        lastEvaluatedFuelPerMile: Double? = null,
+        lastEvaluatedNonFuelPerMile: Double? = null,
     ) = SessionFoldContext(
         sessionId = sessionId,
         platform = Platform.fromWire(platform) ?: Platform.Unknown,
@@ -313,11 +318,17 @@ class AnalyticsProjector @Inject constructor(
         prevDropOdometer = prevDropOdometer,
         prevDropAt = prevDropAt,
         lastEvaluatedCostPerMile = lastEvaluatedCostPerMile,
-        // A persisted row with a REAL platform is a started session (a RECOVERY re-start must not
-        // clobber it). A still-`_unknown` row is a placeholder persisted before its DASH_START landed
-        // (they arrive in separate 1-event drains at steady state) — NOT started, so the DASH_START
-        // that lands in a later batch upgrades it with the real platform/startedAt (F1).
-        started = Platform.fromWire(platform)?.let { it != Platform.Unknown } ?: false,
+        lastEvaluatedFuelPerMile = lastEvaluatedFuelPerMile,
+        lastEvaluatedNonFuelPerMile = lastEvaluatedNonFuelPerMile,
+        // `started` rehydrates from the persisted [startSource] marker (#659, retro finding 2) — a
+        // real DASH_START stamped it ("interaction"/"recovery"), a placeholder synthesized before its
+        // DASH_START (or by a DASH_STOP that arrived first) left it null. This replaces the old
+        // `platform != Unknown` heuristic, under which a row synthesized by a real-platform DASH_STOP
+        // rehydrated as started and then took the RECOVERY non-clobber arm, keeping a near-zero
+        // startedAt. A still-`_unknown` placeholder (startSource null) is NOT started, so the
+        // DASH_START that lands in a later batch upgrades it with the real platform/startedAt (F1).
+        started = startSource != null,
+        startSource = startSource,
     )
 
     private fun DeliveryFold.toEntity() = DeliveryRecordEntity(
@@ -341,6 +352,8 @@ class AnalyticsProjector @Inject constructor(
         realizedMiles = realizedMiles,
         realizedMinutes = realizedMinutes,
         frozenCostPerMile = frozenCostPerMile,
+        frozenFuelPerMile = frozenFuelPerMile,
+        frozenNonFuelPerMile = frozenNonFuelPerMile,
         netProfit = netProfit,
         costBasis = costBasis,
     )
@@ -365,6 +378,8 @@ class AnalyticsProjector @Inject constructor(
         estDollarsPerMile = estDollarsPerMile,
         estTimeMinutes = estTimeMinutes,
         estOperatingCostPerMile = estOperatingCostPerMile,
+        estFuelPerMile = estFuelPerMile,
+        estNonFuelPerMile = estNonFuelPerMile,
     )
 
     private companion object {
@@ -376,7 +391,12 @@ class AnalyticsProjector @Inject constructor(
         private const val INITIAL_BACKOFF_MS = 1_000L
         private const val MAX_BACKOFF_MS = 60_000L
 
-        /** Fold-logic version — bump to wipe records + refold the whole log on next start. */
-        private const val PROJECTOR_VERSION = 1
+        /**
+         * Fold-logic version — bump to wipe records + refold the whole log on next start.
+         * v2 (#659): frozen fuel/non-fuel per-mile split on delivery_records + estFuel/NonFuelPerMile
+         * on offer_records + startSource on session_records — all populated from the immutable log on
+         * the refold this bump triggers.
+         */
+        private const val PROJECTOR_VERSION = 2
     }
 }

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
@@ -65,6 +65,7 @@ class AnalyticsRepository @Inject constructor(
                         deliveredPay = d.pay, deliveryNet = d.net, deliveries = d.deliveries,
                         jobs = d.jobs, miles = s.miles, onlineMillis = s.onlineMillis,
                         gross = g.gross, unattributed = g.unattributed,
+                        fuelCost = d.fuelCost, nonFuelCost = d.nonFuelCost,
                     )
                 }
             } else {
@@ -82,6 +83,7 @@ class AnalyticsRepository @Inject constructor(
                         deliveries = d?.deliveries ?: 0, jobs = d?.jobs ?: 0,
                         miles = s?.miles ?: 0.0, onlineMillis = s?.onlineMillis ?: 0L,
                         gross = g?.gross ?: 0.0, unattributed = g?.unattributed ?: 0.0,
+                        fuelCost = d?.fuelCost, nonFuelCost = d?.nonFuelCost,
                     )
                 }
             }
@@ -118,6 +120,8 @@ class AnalyticsRepository @Inject constructor(
         onlineMillis: Long,
         gross: Double,
         unattributed: Double,
+        fuelCost: Double?,
+        nonFuelCost: Double?,
     ): PeriodEconomics {
         val net = deliveryNet + unattributed
         val hours = onlineMillis / 3_600_000.0
@@ -134,6 +138,10 @@ class AnalyticsRepository @Inject constructor(
             unattributedPay = unattributed,
             netPerHour = NetProfit.perHour(net, hours),
             netPerMile = NetProfit.perMile(net, miles),
+            // Frozen fuel/non-fuel cost rows for the 4-step waterfall — passed through as the DAO's
+            // nullable SUMs (null = no frozen split coverage → the UI falls back to 3-step, #659).
+            fuelCost = fuelCost,
+            nonFuelCost = nonFuelCost,
         )
     }
 }

--- a/core/database/schemas/cloud.trotter.dashbuddy.core.database.DashBuddyDatabase/10.json
+++ b/core/database/schemas/cloud.trotter.dashbuddy.core.database.DashBuddyDatabase/10.json
@@ -1,0 +1,855 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 10,
+    "identityHash": "005b02130df84647dd89a37ef64b2cf2",
+    "entities": [
+      {
+        "tableName": "app_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sequenceId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `aggregateId` TEXT, `eventType` TEXT NOT NULL, `eventPayload` TEXT NOT NULL, `occurredAt` INTEGER NOT NULL, `metadata` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "sequenceId",
+            "columnName": "sequenceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "aggregateId",
+            "columnName": "aggregateId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "eventType",
+            "columnName": "eventType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventPayload",
+            "columnName": "eventPayload",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "occurredAt",
+            "columnName": "occurredAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadata",
+            "columnName": "metadata",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "sequenceId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_app_events_aggregateId",
+            "unique": false,
+            "columnNames": [
+              "aggregateId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_app_events_aggregateId` ON `${TABLE_NAME}` (`aggregateId`)"
+          },
+          {
+            "name": "index_app_events_eventType",
+            "unique": false,
+            "columnNames": [
+              "eventType"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_app_events_eventType` ON `${TABLE_NAME}` (`eventType`)"
+          },
+          {
+            "name": "index_app_events_occurredAt",
+            "unique": false,
+            "columnNames": [
+              "occurredAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_app_events_occurredAt` ON `${TABLE_NAME}` (`occurredAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "app_state_snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`correlationVersion` INTEGER NOT NULL, `capturedAt` INTEGER NOT NULL, `sessionId` TEXT, `stateJson` TEXT NOT NULL, PRIMARY KEY(`correlationVersion`))",
+        "fields": [
+          {
+            "fieldPath": "correlationVersion",
+            "columnName": "correlationVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "capturedAt",
+            "columnName": "capturedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "stateJson",
+            "columnName": "stateJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "correlationVersion"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `dashId` TEXT, `text` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `personaType` TEXT NOT NULL, `personaName` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dashId",
+            "columnName": "dashId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personaType",
+            "columnName": "personaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personaName",
+            "columnName": "personaName",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_messages_dashId",
+            "unique": false,
+            "columnNames": [
+              "dashId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_messages_dashId` ON `${TABLE_NAME}` (`dashId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "effects_fired",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `effectKey` TEXT NOT NULL, `firedAt` INTEGER NOT NULL, `correlationVersion` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "effectKey",
+            "columnName": "effectKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firedAt",
+            "columnName": "firedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "correlationVersion",
+            "columnName": "correlationVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_effects_fired_effectKey",
+            "unique": true,
+            "columnNames": [
+              "effectKey"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_effects_fired_effectKey` ON `${TABLE_NAME}` (`effectKey`)"
+          }
+        ]
+      },
+      {
+        "tableName": "observations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sequenceId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `occurredAt` INTEGER NOT NULL, `sessionId` TEXT, `pipelineId` TEXT NOT NULL, `ruleId` TEXT, `platform` TEXT, `flow` TEXT, `modeHint` TEXT, `parsedJson` TEXT NOT NULL, `captureId` TEXT, `metadataJson` TEXT NOT NULL, `correlationVersion` INTEGER NOT NULL, `timeoutType` TEXT, `payloadJson` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "sequenceId",
+            "columnName": "sequenceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "occurredAt",
+            "columnName": "occurredAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pipelineId",
+            "columnName": "pipelineId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ruleId",
+            "columnName": "ruleId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "flow",
+            "columnName": "flow",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "modeHint",
+            "columnName": "modeHint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "parsedJson",
+            "columnName": "parsedJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "captureId",
+            "columnName": "captureId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "metadataJson",
+            "columnName": "metadataJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "correlationVersion",
+            "columnName": "correlationVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeoutType",
+            "columnName": "timeoutType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "payloadJson",
+            "columnName": "payloadJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "sequenceId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_observations_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_observations_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          },
+          {
+            "name": "index_observations_occurredAt",
+            "unique": false,
+            "columnNames": [
+              "occurredAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_observations_occurredAt` ON `${TABLE_NAME}` (`occurredAt`)"
+          },
+          {
+            "name": "index_observations_correlationVersion",
+            "unique": false,
+            "columnNames": [
+              "correlationVersion"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_observations_correlationVersion` ON `${TABLE_NAME}` (`correlationVersion`)"
+          }
+        ]
+      },
+      {
+        "tableName": "delivery_records",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`eventSequenceId` INTEGER NOT NULL, `sessionId` TEXT, `platform` TEXT NOT NULL, `jobId` TEXT NOT NULL, `taskId` TEXT NOT NULL, `storeName` TEXT, `customerHash` TEXT, `addressHash` TEXT, `phaseStartedAt` INTEGER NOT NULL, `arrivedAt` INTEGER, `completedAt` INTEGER NOT NULL, `deadlineMillis` INTEGER, `realizedPay` REAL, `payBasis` TEXT NOT NULL, `tip` REAL, `basePay` REAL, `odometerAtCompletion` REAL, `realizedMiles` REAL, `realizedMinutes` REAL, `frozenCostPerMile` REAL, `frozenFuelPerMile` REAL, `frozenNonFuelPerMile` REAL, `netProfit` REAL, `costBasis` TEXT NOT NULL, PRIMARY KEY(`eventSequenceId`))",
+        "fields": [
+          {
+            "fieldPath": "eventSequenceId",
+            "columnName": "eventSequenceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jobId",
+            "columnName": "jobId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "taskId",
+            "columnName": "taskId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storeName",
+            "columnName": "storeName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customerHash",
+            "columnName": "customerHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addressHash",
+            "columnName": "addressHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "phaseStartedAt",
+            "columnName": "phaseStartedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "arrivedAt",
+            "columnName": "arrivedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deadlineMillis",
+            "columnName": "deadlineMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "realizedPay",
+            "columnName": "realizedPay",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "payBasis",
+            "columnName": "payBasis",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tip",
+            "columnName": "tip",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "basePay",
+            "columnName": "basePay",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "odometerAtCompletion",
+            "columnName": "odometerAtCompletion",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "realizedMiles",
+            "columnName": "realizedMiles",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "realizedMinutes",
+            "columnName": "realizedMinutes",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "frozenCostPerMile",
+            "columnName": "frozenCostPerMile",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "frozenFuelPerMile",
+            "columnName": "frozenFuelPerMile",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "frozenNonFuelPerMile",
+            "columnName": "frozenNonFuelPerMile",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "netProfit",
+            "columnName": "netProfit",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "costBasis",
+            "columnName": "costBasis",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "eventSequenceId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_delivery_records_completedAt",
+            "unique": false,
+            "columnNames": [
+              "completedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_delivery_records_completedAt` ON `${TABLE_NAME}` (`completedAt`)"
+          },
+          {
+            "name": "index_delivery_records_platform_completedAt",
+            "unique": false,
+            "columnNames": [
+              "platform",
+              "completedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_delivery_records_platform_completedAt` ON `${TABLE_NAME}` (`platform`, `completedAt`)"
+          },
+          {
+            "name": "index_delivery_records_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_delivery_records_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          },
+          {
+            "name": "index_delivery_records_sessionId_jobId",
+            "unique": false,
+            "columnNames": [
+              "sessionId",
+              "jobId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_delivery_records_sessionId_jobId` ON `${TABLE_NAME}` (`sessionId`, `jobId`)"
+          },
+          {
+            "name": "index_delivery_records_storeName",
+            "unique": false,
+            "columnNames": [
+              "storeName"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_delivery_records_storeName` ON `${TABLE_NAME}` (`storeName`)"
+          }
+        ]
+      },
+      {
+        "tableName": "session_records",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sessionId` TEXT NOT NULL, `platform` TEXT NOT NULL, `startedAt` INTEGER NOT NULL, `endedAt` INTEGER, `lastEventAt` INTEGER NOT NULL, `endSource` TEXT, `startSource` TEXT, `startOdometer` REAL, `lastOdometer` REAL, `reportedEarnings` REAL, `reportedDurationMillis` INTEGER, `offersReceived` INTEGER NOT NULL, `offersAccepted` INTEGER NOT NULL, `offersDeclined` INTEGER NOT NULL, `offersTimeout` INTEGER NOT NULL, `deliveries` INTEGER NOT NULL, `jobsCompleted` INTEGER NOT NULL, PRIMARY KEY(`sessionId`))",
+        "fields": [
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "startedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endedAt",
+            "columnName": "endedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastEventAt",
+            "columnName": "lastEventAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endSource",
+            "columnName": "endSource",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "startSource",
+            "columnName": "startSource",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "startOdometer",
+            "columnName": "startOdometer",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "lastOdometer",
+            "columnName": "lastOdometer",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "reportedEarnings",
+            "columnName": "reportedEarnings",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "reportedDurationMillis",
+            "columnName": "reportedDurationMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "offersReceived",
+            "columnName": "offersReceived",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "offersAccepted",
+            "columnName": "offersAccepted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "offersDeclined",
+            "columnName": "offersDeclined",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "offersTimeout",
+            "columnName": "offersTimeout",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deliveries",
+            "columnName": "deliveries",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jobsCompleted",
+            "columnName": "jobsCompleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sessionId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_session_records_startedAt",
+            "unique": false,
+            "columnNames": [
+              "startedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_session_records_startedAt` ON `${TABLE_NAME}` (`startedAt`)"
+          },
+          {
+            "name": "index_session_records_platform_startedAt",
+            "unique": false,
+            "columnNames": [
+              "platform",
+              "startedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_session_records_platform_startedAt` ON `${TABLE_NAME}` (`platform`, `startedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "offer_records",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`eventSequenceId` INTEGER NOT NULL, `sessionId` TEXT, `platform` TEXT NOT NULL, `offerHash` TEXT NOT NULL, `outcome` TEXT NOT NULL, `presentedAt` INTEGER NOT NULL, `decidedAt` INTEGER NOT NULL, `payAmount` REAL, `distanceMiles` REAL, `itemCount` INTEGER NOT NULL, `merchantName` TEXT, `score` REAL, `action` TEXT, `quality` TEXT, `estNetPay` REAL, `estDollarsPerHour` REAL, `estDollarsPerMile` REAL, `estTimeMinutes` REAL, `estOperatingCostPerMile` REAL, `estFuelPerMile` REAL, `estNonFuelPerMile` REAL, PRIMARY KEY(`eventSequenceId`))",
+        "fields": [
+          {
+            "fieldPath": "eventSequenceId",
+            "columnName": "eventSequenceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "offerHash",
+            "columnName": "offerHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "outcome",
+            "columnName": "outcome",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "presentedAt",
+            "columnName": "presentedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "decidedAt",
+            "columnName": "decidedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payAmount",
+            "columnName": "payAmount",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "distanceMiles",
+            "columnName": "distanceMiles",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "itemCount",
+            "columnName": "itemCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchantName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "action",
+            "columnName": "action",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "quality",
+            "columnName": "quality",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "estNetPay",
+            "columnName": "estNetPay",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "estDollarsPerHour",
+            "columnName": "estDollarsPerHour",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "estDollarsPerMile",
+            "columnName": "estDollarsPerMile",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "estTimeMinutes",
+            "columnName": "estTimeMinutes",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "estOperatingCostPerMile",
+            "columnName": "estOperatingCostPerMile",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "estFuelPerMile",
+            "columnName": "estFuelPerMile",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "estNonFuelPerMile",
+            "columnName": "estNonFuelPerMile",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "eventSequenceId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_offer_records_decidedAt",
+            "unique": false,
+            "columnNames": [
+              "decidedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offer_records_decidedAt` ON `${TABLE_NAME}` (`decidedAt`)"
+          },
+          {
+            "name": "index_offer_records_platform_decidedAt",
+            "unique": false,
+            "columnNames": [
+              "platform",
+              "decidedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offer_records_platform_decidedAt` ON `${TABLE_NAME}` (`platform`, `decidedAt`)"
+          },
+          {
+            "name": "index_offer_records_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offer_records_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          },
+          {
+            "name": "index_offer_records_offerHash",
+            "unique": false,
+            "columnNames": [
+              "offerHash"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offer_records_offerHash` ON `${TABLE_NAME}` (`offerHash`)"
+          }
+        ]
+      },
+      {
+        "tableName": "analytics_projection_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `watermarkSequenceId` INTEGER NOT NULL, `projectorVersion` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "watermarkSequenceId",
+            "columnName": "watermarkSequenceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "projectorVersion",
+            "columnName": "projectorVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '005b02130df84647dd89a37ef64b2cf2')"
+    ]
+  }
+}

--- a/core/database/src/androidTest/java/cloud/trotter/dashbuddy/core/database/AnalyticsMigration9to10Test.kt
+++ b/core/database/src/androidTest/java/cloud/trotter/dashbuddy/core/database/AnalyticsMigration9to10Test.kt
@@ -1,0 +1,95 @@
+package cloud.trotter.dashbuddy.core.database
+
+import androidx.room.testing.MigrationTestHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * #659 — execute the REAL committed `AutoMigration(9→10)` against a **populated** v9 database and
+ * prove it is additive-only: the pre-existing analytics rows survive and the three new nullable
+ * columns exist afterward (frozen fuel/non-fuel split + startSource), left NULL by the ADD COLUMN
+ * (the `PROJECTOR_VERSION` 1→2 refold repopulates them from the immutable log).
+ *
+ * Instrumented (androidTest) because [MigrationTestHelper] opens an on-disk SQLite DB via the
+ * framework factory and replays the exported schema JSONs. Runs under
+ * `:core:database:connectedAndroidTest`.
+ */
+@RunWith(AndroidJUnit4::class)
+class AnalyticsMigration9to10Test {
+
+    private val dbName = "migration-9-to-10-test"
+
+    @get:Rule
+    val helper = MigrationTestHelper(
+        InstrumentationRegistry.getInstrumentation(),
+        DashBuddyDatabase::class.java,
+        emptyList(),
+        FrameworkSQLiteOpenHelperFactory(),
+    )
+
+    @Test
+    fun migrate9To10_preservesAnalyticsRows_andAddsSplitColumns() {
+        // Create the schema at v9 and seed one row per analytics table (v9 column sets).
+        helper.createDatabase(dbName, 9).use { db ->
+            db.execSQL(
+                """INSERT INTO delivery_records
+                   (eventSequenceId, sessionId, platform, jobId, taskId, storeName, customerHash,
+                    addressHash, phaseStartedAt, arrivedAt, completedAt, deadlineMillis, realizedPay,
+                    payBasis, tip, basePay, odometerAtCompletion, realizedMiles, realizedMinutes,
+                    frozenCostPerMile, netProfit, costBasis)
+                   VALUES (1, 'S1', 'doordash', 'J1', 'T1', 'StoreX', NULL, NULL, 100, NULL, 3000,
+                           NULL, 10.0, 'RECEIPT_TOTAL', NULL, NULL, 105.0, 5.0, 1.0, 0.25, 8.75,
+                           'OFFER_FROZEN')""",
+            )
+            db.execSQL(
+                """INSERT INTO session_records
+                   (sessionId, platform, startedAt, endedAt, lastEventAt, endSource, startOdometer,
+                    lastOdometer, reportedEarnings, reportedDurationMillis, offersReceived,
+                    offersAccepted, offersDeclined, offersTimeout, deliveries, jobsCompleted)
+                   VALUES ('S1', 'doordash', 1000, 4000, 4000, 'summary_screen', 100.0, 110.0, 10.0,
+                           3000, 1, 1, 0, 0, 1, 1)""",
+            )
+            db.execSQL(
+                """INSERT INTO offer_records
+                   (eventSequenceId, sessionId, platform, offerHash, outcome, presentedAt, decidedAt,
+                    payAmount, distanceMiles, itemCount, merchantName, score, action, quality,
+                    estNetPay, estDollarsPerHour, estDollarsPerMile, estTimeMinutes,
+                    estOperatingCostPerMile)
+                   VALUES (2, 'S1', 'doordash', 'h1', 'OFFER_ACCEPTED', 1970, 2000, 12.0, 3.0, 1,
+                           'StoreX', 80.0, 'ACCEPT', 'GOOD', 11.25, 20.0, 3.0, 15.0, 0.25)""",
+            )
+        }
+
+        // Run the real AutoMigration(9→10) and validate against the exported 10.json schema.
+        val db = helper.runMigrationsAndValidate(dbName, 10, true)
+
+        // The pre-existing rows survived (additive-only, not destructive).
+        db.query("SELECT COUNT(*) FROM delivery_records").use { c ->
+            c.moveToFirst()
+            assertEquals("delivery_records preserved across 9→10", 1, c.getInt(0))
+        }
+
+        // The new nullable columns exist and are NULL on the migrated rows (repopulated by the refold).
+        db.query("SELECT frozenFuelPerMile, frozenNonFuelPerMile FROM delivery_records WHERE eventSequenceId = 1").use { c ->
+            c.moveToFirst()
+            assertTrue("frozenFuelPerMile is NULL post-migration", c.isNull(0))
+            assertTrue("frozenNonFuelPerMile is NULL post-migration", c.isNull(1))
+        }
+        db.query("SELECT estFuelPerMile, estNonFuelPerMile FROM offer_records WHERE eventSequenceId = 2").use { c ->
+            c.moveToFirst()
+            assertTrue("estFuelPerMile is NULL post-migration", c.isNull(0))
+            assertTrue("estNonFuelPerMile is NULL post-migration", c.isNull(1))
+        }
+        db.query("SELECT startSource FROM session_records WHERE sessionId = 'S1'").use { c ->
+            c.moveToFirst()
+            assertTrue("startSource is NULL post-migration", c.isNull(0))
+        }
+        db.close()
+    }
+}

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/DashBuddyDatabase.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/DashBuddyDatabase.kt
@@ -33,13 +33,20 @@ import cloud.trotter.dashbuddy.core.database.snapshot.AppStateSnapshotEntity
         OfferRecordEntity::class,
         AnalyticsProjectionStateEntity::class,
     ],
-    version = 9,
+    version = 10,
     exportSchema = true,
     // v8→v9 adds only new tables (the analytics read-model). AutoMigration is a
     // no-op for existing tables, so it CANNOT wipe app_events (unlike the
     // destructive fallback, which is left untouched — the auto-migration provides
     // the path so the fallback never fires on this upgrade).
-    autoMigrations = [AutoMigration(from = 8, to = 9)],
+    // v9→v10 (#659) is additive-only: three new nullable columns —
+    // delivery_records.frozenFuelPerMile/frozenNonFuelPerMile (frozen fuel/non-fuel
+    // split for the 4-step true-net waterfall), offer_records.estFuelPerMile/
+    // estNonFuelPerMile (rebuild-stable split hydration), session_records.startSource
+    // (retro finding 2 — `started` provenance). Every value repopulates from the
+    // immutable log on the PROJECTOR_VERSION 1→2 refold, so the ADD COLUMN nulls are
+    // transient. Additive ⇒ never wipes app_events or the existing analytics rows.
+    autoMigrations = [AutoMigration(from = 8, to = 9), AutoMigration(from = 9, to = 10)],
 )
 @TypeConverters(DataTypeConverters::class)
 abstract class DashBuddyDatabase : RoomDatabase() {

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
@@ -82,7 +82,9 @@ interface AnalyticsDao {
         """SELECT COALESCE(SUM(realizedPay), 0) AS pay,
                   COALESCE(SUM(netProfit), 0) AS net,
                   COUNT(*) AS deliveries,
-                  COUNT(DISTINCT jobId) AS jobs
+                  COUNT(DISTINCT jobId) AS jobs,
+                  SUM(frozenFuelPerMile * realizedMiles) AS fuelCost,
+                  SUM(frozenNonFuelPerMile * realizedMiles) AS nonFuelCost
            FROM delivery_records
            WHERE sessionId IN (SELECT sessionId FROM session_records
                                WHERE startedAt >= :start AND startedAt < :end)
@@ -96,7 +98,9 @@ interface AnalyticsDao {
                   COALESCE(SUM(realizedPay), 0) AS pay,
                   COALESCE(SUM(netProfit), 0) AS net,
                   COUNT(*) AS deliveries,
-                  COUNT(DISTINCT jobId) AS jobs
+                  COUNT(DISTINCT jobId) AS jobs,
+                  SUM(frozenFuelPerMile * realizedMiles) AS fuelCost,
+                  SUM(frozenNonFuelPerMile * realizedMiles) AS nonFuelCost
            FROM delivery_records
            WHERE sessionId IN (SELECT sessionId FROM session_records
                                WHERE startedAt >= :start AND startedAt < :end)
@@ -234,4 +238,25 @@ interface AnalyticsDao {
            ORDER BY eventSequenceId DESC LIMIT 1"""
     )
     suspend fun lastOfferCostPerMileInSession(id: String): Double?
+
+    /**
+     * The most recent closing offer's frozen fuel-per-mile in a session — rehydrates the fold's
+     * session-uniform fuel split basis on a mid-session restart so a delivery folded after the restart
+     * still freezes `frozenFuelPerMile` (#659). Mirrors [lastOfferCostPerMileInSession]; the split is
+     * session-uniform (one economy per session), so it is numerically identical across offers.
+     */
+    @Query(
+        """SELECT estFuelPerMile FROM offer_records
+           WHERE sessionId = :id AND estFuelPerMile IS NOT NULL
+           ORDER BY eventSequenceId DESC LIMIT 1"""
+    )
+    suspend fun lastOfferFuelPerMileInSession(id: String): Double?
+
+    /** The most recent closing offer's frozen non-fuel-per-mile in a session (#659) — see [lastOfferFuelPerMileInSession]. */
+    @Query(
+        """SELECT estNonFuelPerMile FROM offer_records
+           WHERE sessionId = :id AND estNonFuelPerMile IS NOT NULL
+           ORDER BY eventSequenceId DESC LIMIT 1"""
+    )
+    suspend fun lastOfferNonFuelPerMileInSession(id: String): Double?
 }

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsTotals.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsTotals.kt
@@ -17,6 +17,16 @@ data class DeliveryTotalsRow(
     val net: Double,
     val deliveries: Int,
     val jobs: Int,
+    /**
+     * Σ **frozen** fuel dollars for the period = `SUM(frozenFuelPerMile × realizedMiles)` (#659) —
+     * the first-class fuel cost row of the 4-step true-net waterfall. Nullable and left un-`COALESCE`d
+     * on purpose: SQL `SUM` of all-null terms is NULL, which is the "no frozen split coverage" signal
+     * (the waterfall falls back to 3-step). Non-negative by construction (per-mile ≥ 0, miles floored
+     * ≥ 0), so it can never render a negative cost row (the #662-F1 fix — cost is not gross−net).
+     */
+    val fuelCost: Double?,
+    /** Σ frozen non-fuel dollars = `SUM(frozenNonFuelPerMile × realizedMiles)`; same null-coverage rule (#659). */
+    val nonFuelCost: Double?,
 )
 
 /** Per-platform delivery totals (GROUP BY platform). */
@@ -26,6 +36,10 @@ data class PlatformDeliveryTotalsRow(
     val net: Double,
     val deliveries: Int,
     val jobs: Int,
+    /** Σ frozen fuel dollars for the platform's period rows (#659) — see [DeliveryTotalsRow.fuelCost]. */
+    val fuelCost: Double?,
+    /** Σ frozen non-fuel dollars for the platform's period rows (#659). */
+    val nonFuelCost: Double?,
 )
 
 /** Per-store delivery totals (GROUP BY storeName) — per-store + future chain resolution (#159). */

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/DeliveryRecordEntity.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/DeliveryRecordEntity.kt
@@ -81,6 +81,16 @@ data class DeliveryRecordEntity(
     // ── Frozen economics (immutable historical fact — never re-costed on economy edit) ──
     /** Operating cost-per-mile this delivery is costed at, frozen from the accepted offer (PR2). */
     val frozenCostPerMile: Double?,
+    /**
+     * Fuel component of [frozenCostPerMile] (per-mile), frozen from the accepted offer's own
+     * evaluation (#659). Populated only off an `OFFER_FROZEN` basis; null for CURRENT_FALLBACK/NONE
+     * (the live economy read supplies a bare cpm, not its split) → the 4-step true-net waterfall
+     * falls back to 3-step for such rows. `frozenFuelPerMile + frozenNonFuelPerMile ≈
+     * frozenCostPerMile` when all present.
+     */
+    val frozenFuelPerMile: Double? = null,
+    /** Non-fuel component of [frozenCostPerMile] (per-mile), same OFFER_FROZEN-only rule (#659). */
+    val frozenNonFuelPerMile: Double? = null,
     /** Frozen realized net = realizedPay − realizedMiles × frozenCostPerMile (PR2). */
     val netProfit: Double?,
     /** Provenance of the cost basis: "OFFER_FROZEN" | "CAPTURED" | "CURRENT_FALLBACK" | "NONE". */

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/OfferRecordEntity.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/OfferRecordEntity.kt
@@ -52,4 +52,12 @@ data class OfferRecordEntity(
     val estDollarsPerMile: Double?,
     val estTimeMinutes: Double?,
     val estOperatingCostPerMile: Double?,
+    /**
+     * Fuel component of [estOperatingCostPerMile] (per-mile) = `fuelCostEstimate ÷ distanceMiles`;
+     * null when distance ≤ 0. Persisted so the delivery fold's fuel/non-fuel split basis rehydrates
+     * on a mid-session restart from the same offer row as the cpm — rebuild-stable (#659).
+     */
+    val estFuelPerMile: Double? = null,
+    /** Non-fuel component of [estOperatingCostPerMile] (per-mile) = `nonFuelCostEstimate ÷ distanceMiles` (#659). */
+    val estNonFuelPerMile: Double? = null,
 )

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/SessionRecordEntity.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/SessionRecordEntity.kt
@@ -44,6 +44,14 @@ data class SessionRecordEntity(
     val lastEventAt: Long,
     /** "summary_screen" | "early_offline" | "inferred" | null. */
     val endSource: String?,
+    /**
+     * Provenance of the session's start: the DASH_START payload's `source` ("interaction"/"recovery")
+     * once a real start has been folded; null for a placeholder synthesized before its DASH_START
+     * landed (#659, retro finding 2). Hydration rehydrates `started` from THIS marker — not from the
+     * old "has a real platform" heuristic, so a row synthesized by a real-platform DASH_STOP that
+     * arrived before its DASH_START no longer rehydrates as started with a near-zero-duration start.
+     */
+    val startSource: String? = null,
     /** metadata.odometer of DASH_START (first non-null wins). */
     val startOdometer: Double?,
     /** Last non-null metadata.odometer seen — miles = lastOdometer − startOdometer, DERIVED in SQL. */

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/PeriodEconomics.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/PeriodEconomics.kt
@@ -30,6 +30,17 @@ data class PeriodEconomics(
     val netPerHour: Double?,
     /** [netProfit] ÷ miles, or `null` when no miles are logged. */
     val netPerMile: Double?,
+    /**
+     * Σ **frozen** fuel dollars over the period's deliveries (`Σ frozenFuelPerMile × realizedMiles`),
+     * or `null` when no delivery in the period carries a frozen split (#659). The first-class fuel
+     * cost row of the 4-step true-net waterfall (Gross → −Fuel → −Non-fuel → Net); when this (or
+     * [nonFuelCost]) is null the waterfall falls back to the 3-step (Gross → −Operating cost → Net).
+     * Non-negative by construction (per-mile ≥ 0, realized miles floored ≥ 0), so a reported<delivered
+     * session can never render a negative cost row — the cost is not derived as gross−net (#662-F1).
+     */
+    val fuelCost: Double? = null,
+    /** Σ frozen non-fuel dollars over the period's deliveries, or `null` when no frozen split exists (#659). */
+    val nonFuelCost: Double? = null,
 ) {
     companion object {
         val EMPTY = PeriodEconomics(
@@ -39,6 +50,8 @@ data class PeriodEconomics(
             unattributedPay = 0.0,
             netPerHour = null,
             netPerMile = null,
+            fuelCost = null,
+            nonFuelCost = null,
         )
     }
 }

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/RecordFolds.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/RecordFolds.kt
@@ -71,6 +71,10 @@ data class DeliveryFold(
     val realizedMiles: Double?,
     val realizedMinutes: Double?,
     val frozenCostPerMile: Double?,
+    /** Fuel component of [frozenCostPerMile] (per-mile), frozen from the offer basis; null off it (#659). */
+    val frozenFuelPerMile: Double?,
+    /** Non-fuel component of [frozenCostPerMile] (per-mile), frozen from the offer basis; null off it (#659). */
+    val frozenNonFuelPerMile: Double?,
     val netProfit: Double?,
     val costBasis: String,
 )
@@ -96,6 +100,10 @@ data class OfferFold(
     val estDollarsPerMile: Double?,
     val estTimeMinutes: Double?,
     val estOperatingCostPerMile: Double?,
+    /** `fuelCostEstimate ÷ distanceMiles` (per-mile); null when distance ≤ 0. Rebuild-stable split hydration (#659). */
+    val estFuelPerMile: Double?,
+    /** `nonFuelCostEstimate ÷ distanceMiles` (per-mile); null when distance ≤ 0 (#659). */
+    val estNonFuelPerMile: Double?,
 )
 
 /**
@@ -179,6 +187,8 @@ object RecordFolds {
                     startOdometer = context.startOdometer ?: odo,
                     lastEventAt = maxOf(context.lastEventAt, e.occurredAt),
                     lastOdometer = odo ?: context.lastOdometer,
+                    // Already a real start — keep its original startSource; only fill if somehow null.
+                    startSource = context.startSource ?: p.source,
                 ),
             )
         }
@@ -195,6 +205,7 @@ object RecordFolds {
                     lastEventAt = maxOf(context.lastEventAt, e.occurredAt),
                     lastOdometer = odo ?: context.lastOdometer,
                     started = true,
+                    startSource = p.source,
                 ),
                 freshSession = true,
             )
@@ -208,6 +219,7 @@ object RecordFolds {
                 startOdometer = odo,
                 lastOdometer = odo,
                 started = true,
+                startSource = p.source,
             ),
             freshSession = true,
         )
@@ -222,6 +234,14 @@ object RecordFolds {
         val platformWire = ctx?.platform?.wire ?: Platform.Unknown.wire
         val eval = p.evaluation
         val parsed = p.parsedOffer
+        // Per-mile fuel/non-fuel split from the SAME frozen evaluation the cpm comes from: the eval
+        // carries route-total estimates + distance, so per-mile = estimate ÷ distanceMiles. Guard a
+        // non-positive distance → null split (the delivery falls back to the 3-step waterfall). By
+        // construction fuelPerMile + nonFuelPerMile ≈ operatingCostPerMile (both totals are that same
+        // per-mile rate × distance), the invariant the waterfall relies on (#659).
+        val evalDist = eval?.distanceMiles
+        val fuelPerMile = if (eval != null && evalDist != null && evalDist > 0.0) eval.fuelCostEstimate / evalDist else null
+        val nonFuelPerMile = if (eval != null && evalDist != null && evalDist > 0.0) eval.nonFuelCostEstimate / evalDist else null
         val offer = OfferFold(
             eventSequenceId = event.sequenceId,
             sessionId = sid,
@@ -242,13 +262,21 @@ object RecordFolds {
             estDollarsPerMile = eval?.dollarsPerMile,
             estTimeMinutes = eval?.estimatedTimeMinutes,
             estOperatingCostPerMile = eval?.operatingCostPerMile,
+            estFuelPerMile = fuelPerMile,
+            estNonFuelPerMile = nonFuelPerMile,
         )
         val newCtx = ctx?.let {
             it.advance(e.occurredAt, event.metadata?.odometer)
                 .bumpOutcome(e.type)
-                // Capture the session-uniform frozen cpm from any closing offer that carries an
-                // evaluation (accepted/declined/timeout all reflect the same economy).
-                .copy(lastEvaluatedCostPerMile = eval?.operatingCostPerMile ?: it.lastEvaluatedCostPerMile)
+                // Capture the session-uniform frozen cpm AND its fuel/non-fuel split from any closing
+                // offer that carries an evaluation (accepted/declined/timeout all reflect the same
+                // economy). Keep-prior on a null (a distance-0 offer captures cpm but no split) so a
+                // later good split isn't wiped — session-uniformity makes them numerically identical.
+                .copy(
+                    lastEvaluatedCostPerMile = eval?.operatingCostPerMile ?: it.lastEvaluatedCostPerMile,
+                    lastEvaluatedFuelPerMile = fuelPerMile ?: it.lastEvaluatedFuelPerMile,
+                    lastEvaluatedNonFuelPerMile = nonFuelPerMile ?: it.lastEvaluatedNonFuelPerMile,
+                )
         }
         return FoldOutcome(context = newCtx, offer = offer)
     }
@@ -300,6 +328,13 @@ object RecordFolds {
             currentCostPerMile != null -> currentCostPerMile to CostBasis.CURRENT_FALLBACK
             else -> null to CostBasis.NONE
         }
+        // The fuel/non-fuel split is populated ONLY off the OFFER_FROZEN basis — the offer's own
+        // evaluation carried it. CURRENT_FALLBACK/NONE deliveries have no split (the live economy read
+        // supplies a bare cpm, not its components), so they stay null → the 4-step waterfall falls back
+        // to 3-step for those rows (#659). By construction frozenFuelPerMile + frozenNonFuelPerMile ≈
+        // frozenCostPerMile when all present.
+        val frozenFuelPerMile = if (costBasis == CostBasis.OFFER_FROZEN) ctx?.lastEvaluatedFuelPerMile else null
+        val frozenNonFuelPerMile = if (costBasis == CostBasis.OFFER_FROZEN) ctx?.lastEvaluatedNonFuelPerMile else null
         val netProfit = if (frozenCpm != null && realizedPay != null && realizedMiles != null) {
             NetProfit.net(realizedPay, realizedMiles, frozenCpm)
         } else {
@@ -327,6 +362,8 @@ object RecordFolds {
             realizedMiles = realizedMiles,
             realizedMinutes = realizedMinutes,
             frozenCostPerMile = frozenCpm,
+            frozenFuelPerMile = frozenFuelPerMile,
+            frozenNonFuelPerMile = frozenNonFuelPerMile,
             netProfit = netProfit,
             costBasis = costBasis,
         )

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/SessionFoldContext.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/SessionFoldContext.kt
@@ -51,6 +51,15 @@ data class SessionFoldContext(
      */
     val lastEvaluatedCostPerMile: Double? = null,
     /**
+     * The fuel component of [lastEvaluatedCostPerMile] — the most recent closing offer's
+     * `fuelCostEstimate ÷ distanceMiles` (per-mile), session-uniform like the cpm. Null until an
+     * offer with a positive-distance evaluation is seen (a distance-0 offer captures cpm but no
+     * split). The frozen fuel/non-fuel per-mile basis for the 4-step true-net waterfall (#659).
+     */
+    val lastEvaluatedFuelPerMile: Double? = null,
+    /** The non-fuel component of [lastEvaluatedCostPerMile] — `nonFuelCostEstimate ÷ distanceMiles` (#659). */
+    val lastEvaluatedNonFuelPerMile: Double? = null,
+    /**
      * True once a real DASH_START has established this session's platform/startedAt anchor. A context
      * synthesized for a session-scoped event that arrived before its DASH_START (e.g. the
      * OFFER_RECEIVED ordered just ahead of DASH_START at the same instant) is a `_unknown` placeholder
@@ -58,6 +67,15 @@ data class SessionFoldContext(
      * mistaken for a RECOVERY re-start that must not clobber.
      */
     val started: Boolean = false,
+    /**
+     * Provenance of this session's start: the DASH_START payload's `source` (e.g. "interaction",
+     * "recovery") once a real start has been seen; null for a synthesized `_unknown` placeholder that
+     * has not (#659, retro finding 2). The persisted marker the projector rehydrates `started` from —
+     * so hydration no longer infers "saw DASH_START" from "has a real platform" (a row synthesized by
+     * a real-platform DASH_STOP arriving before its DASH_START would otherwise rehydrate as started
+     * and keep a near-zero-duration `startedAt`).
+     */
+    val startSource: String? = null,
 ) {
     val jobsCompleted: Int get() = deliveredJobIds.size
     val offersReceived: Int get() = offersAccepted + offersDeclined + offersTimeout

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/RecordFoldsTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/RecordFoldsTest.kt
@@ -53,12 +53,20 @@ class RecordFoldsTest {
             odometer = odo,
         )
 
-    private fun eval(net: Double, dist: Double, opCpm: Double) = OfferEvaluation(
+    private fun eval(
+        net: Double,
+        dist: Double,
+        opCpm: Double,
+        fuelPerMile: Double = 0.0,
+        nonFuelPerMile: Double = opCpm - fuelPerMile,
+    ) = OfferEvaluation(
         action = OfferAction.ACCEPT,
         score = 80.0,
         qualityLevel = OfferQuality.GOOD,
         payAmount = net + dist * opCpm,
-        fuelCostEstimate = 0.0,
+        // Route-total estimates — the fold divides by distanceMiles to recover the per-mile split.
+        fuelCostEstimate = fuelPerMile * dist,
+        nonFuelCostEstimate = nonFuelPerMile * dist,
         operatingCostPerMile = opCpm,
         netPayAmount = net,
         distanceMiles = dist,
@@ -210,6 +218,126 @@ class RecordFoldsTest {
         assertEquals(CostBasis.NONE, d3.costBasis)
         assertNull(d3.frozenCostPerMile)
         assertNull(d3.netProfit)
+    }
+
+    @Test
+    fun `fuel and non-fuel per-mile split is extracted from the offer eval and frozen on the delivery`() {
+        val s = "F1"
+        val (outcomes, _) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 100.0),
+                // opCpm 0.25 split as fuel 0.10 / non-fuel 0.15 per mile over a 4-mile route.
+                offerAccepted(s, 2_000, "h1", eval(net = 9.0, dist = 4.0, opCpm = 0.25, fuelPerMile = 0.10)),
+                delivery(s, 3_000, "J1", "T1", totalPay = 10.0, odo = 105.0),
+            ),
+        )
+
+        // Offer row carries the per-mile split (route-total estimate ÷ distanceMiles).
+        val offer = outcomes[1].offer!!
+        assertEquals(0.10, offer.estFuelPerMile!!, 1e-9)
+        assertEquals(0.15, offer.estNonFuelPerMile!!, 1e-9)
+
+        // Delivery freezes the same split off the OFFER_FROZEN basis.
+        val d = outcomes[2].delivery!!
+        assertEquals(CostBasis.OFFER_FROZEN, d.costBasis)
+        assertEquals(0.10, d.frozenFuelPerMile!!, 1e-9)
+        assertEquals(0.15, d.frozenNonFuelPerMile!!, 1e-9)
+        // The invariant the 4-step waterfall relies on: fuel + non-fuel ≈ frozenCostPerMile.
+        assertEquals(d.frozenCostPerMile!!, d.frozenFuelPerMile!! + d.frozenNonFuelPerMile!!, 1e-9)
+    }
+
+    @Test
+    fun `a distance-0 offer eval captures cpm but null fuel-non-fuel split (guarded division)`() {
+        val s = "F2"
+        // An eval whose distanceMiles is 0 — the per-mile split would divide by zero, so it stays null
+        // while operatingCostPerMile is still captured. The delivery keeps OFFER_FROZEN cpm, null split
+        // (→ the waterfall falls back to 3-step for this row).
+        val zeroDistEval = eval(net = 5.0, dist = 0.0, opCpm = 0.30, fuelPerMile = 0.12)
+        val (outcomes, _) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 100.0),
+                offerAccepted(s, 2_000, "h1", zeroDistEval),
+                delivery(s, 3_000, "J1", "T1", totalPay = 10.0, odo = 105.0),
+            ),
+        )
+        val offer = outcomes[1].offer!!
+        assertNull(offer.estFuelPerMile)
+        assertNull(offer.estNonFuelPerMile)
+        assertEquals(0.30, offer.estOperatingCostPerMile!!, 1e-9)
+
+        val d = outcomes[2].delivery!!
+        assertEquals(CostBasis.OFFER_FROZEN, d.costBasis)
+        assertEquals(0.30, d.frozenCostPerMile!!, 1e-9)
+        assertNull("no split on a distance-0 offer", d.frozenFuelPerMile)
+        assertNull(d.frozenNonFuelPerMile)
+    }
+
+    @Test
+    fun `CURRENT_FALLBACK and NONE deliveries carry no fuel-non-fuel split`() {
+        val s = "F3"
+        // No offer in the session → CURRENT_FALLBACK cpm, but the live economy read supplies a bare
+        // cpm, not its split → null fuel/non-fuel.
+        val (fallback, _) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 0.0),
+                delivery(s, 3_000, "J1", "T1", totalPay = 10.0, odo = 4.0),
+            ),
+            currentCpm = 0.50,
+        )
+        val dFallback = fallback[1].delivery!!
+        assertEquals(CostBasis.CURRENT_FALLBACK, dFallback.costBasis)
+        assertEquals(0.50, dFallback.frozenCostPerMile!!, 1e-9)
+        assertNull(dFallback.frozenFuelPerMile)
+        assertNull(dFallback.frozenNonFuelPerMile)
+
+        // No offer AND no current economy → NONE, null cpm and null split.
+        val (none, _) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 0.0),
+                delivery(s, 3_000, "J1", "T1", totalPay = 10.0, odo = 4.0),
+            ),
+            currentCpm = null,
+        )
+        val dNone = none[1].delivery!!
+        assertEquals(CostBasis.NONE, dNone.costBasis)
+        assertNull(dNone.frozenFuelPerMile)
+        assertNull(dNone.frozenNonFuelPerMile)
+    }
+
+    @Test
+    fun `startSource is the DASH_START source for a real start and null for a synthesized placeholder`() {
+        // A real DASH_START stamps startSource with the payload's source.
+        val realCtx = RecordFolds.foldEvent(
+            dashStart("G1", 1_000, odo = 0.0, source = SessionStartSource.INTERACTION), null, null,
+        ).context
+        assertEquals(SessionStartSource.INTERACTION, realCtx!!.startSource)
+
+        // An offer arriving before any DASH_START synthesizes an `_unknown` placeholder — startSource
+        // stays null (the retro-finding-2 signal that this session has NOT seen a real start).
+        val placeholderCtx = RecordFolds.foldEvent(
+            offerAccepted("G2", 2_000, "h", eval(net = 5.0, dist = 2.0, opCpm = 0.3)), null, null,
+        ).context
+        assertEquals(Platform.Unknown, placeholderCtx!!.platform)
+        assertNull("a synthesized placeholder has no startSource", placeholderCtx.startSource)
+
+        // The DASH_START that later lands upgrades the placeholder and stamps startSource.
+        val upgraded = RecordFolds.foldEvent(
+            dashStart("G2", 2_100, odo = 10.0, source = SessionStartSource.INTERACTION), placeholderCtx, null,
+        ).context
+        assertEquals(SessionStartSource.INTERACTION, upgraded!!.startSource)
+        assertEquals(2_100L, upgraded.startedAt)
+    }
+
+    @Test
+    fun `RECOVERY re-start keeps the original startSource`() {
+        var ctx: SessionFoldContext? = null
+        ctx = RecordFolds.foldEvent(
+            dashStart("G3", 1_000, odo = 50.0, source = SessionStartSource.INTERACTION), ctx, null,
+        ).context
+        ctx = RecordFolds.foldEvent(
+            dashStart("G3", 9_000, odo = 60.0, source = SessionStartSource.RECOVERY), ctx, null,
+        ).context
+        assertEquals("original interaction source preserved", SessionStartSource.INTERACTION, ctx!!.startSource)
     }
 
     @Test


### PR DESCRIPTION
Phase H2 of the #315 hub plan. Implements #659 (frozen fuel/non-fuel split on `delivery_records`) plus the two scope-adds recorded on the issue: retro **Finding 2** (`startSource` marker) and the #662-**F1** defensive cost-row posture. Closes #659.

## What shipped

**Data side (fully implemented):**
- **`delivery_records.frozenFuelPerMile` / `frozenNonFuelPerMile`** (nullable REAL). The pure fold (`RecordFolds`) extracts both from the SAME frozen `OfferEvaluation` it already reads for `frozenCostPerMile` — `fuelCostEstimate` / `nonFuelCostEstimate` (route totals) ÷ `distanceMiles` = the per-mile rates (guard distance ≤ 0 → null). Populated **only** off an `OFFER_FROZEN` basis; `CURRENT_FALLBACK`/`NONE` deliveries stay null (the live economy read supplies a bare cpm, not its split) → those rows fall back to 3-step.
- **`offer_records.estFuelPerMile` / `estNonFuelPerMile`** — needed for rebuild-stable hydration: on a mid-session restart the fold's split basis rehydrates from the same offer row as the cpm (new `lastOfferFuelPerMileInSession` / `lastOfferNonFuelPerMileInSession`, mirroring `lastOfferCostPerMileInSession`).
- **`session_records.startSource`** (scope-add A / retro Finding 2) — the DASH_START payload `source` the fold stamps ("interaction"/"recovery"); null for a synthesized placeholder. `AnalyticsProjector` hydration now derives `started` from **this column** instead of the `platform != Unknown` heuristic. Fixes the retro-2 hazard: a real-platform DASH_STOP arriving before its DASH_START used to rehydrate as `started=true`, take the RECOVERY non-clobber arm, and keep a near-zero-duration `startedAt`; now it rehydrates `started=false` and the DASH_START upgrades `startedAt` correctly.
- **`PeriodEconomics.fuelCost` / `nonFuelCost`** + DAO period SUMs `SUM(frozenFuelPerMile × realizedMiles)` / `SUM(frozenNonFuelPerMile × realizedMiles)`, nullable (left un-`COALESCE`d — a SQL NULL sum is the "no split coverage" signal → 3-step fallback). Non-negative by construction (per-mile ≥ 0, realized miles floored ≥ 0), so a `reported < delivered` session can never render a negative cost row — the #662-**F1** fix (cost is not derived as gross − net).

**Invariant:** `frozenFuelPerMile + frozenNonFuelPerMile ≈ frozenCostPerMile` when all present — asserted at 1e-9 in both `RecordFoldsTest` and `AnalyticsProjectorTest`.

**Migration posture:** additive-only **v9→v10** (`AutoMigration(9,10)`, three nullable columns, committed `10.json`). `PROJECTOR_VERSION` **1→2** wipes + refolds the whole log, repopulating every new column from the immutable `app_events` — the ADD COLUMN nulls are transient. Cannot wipe `app_events` or existing analytics rows.

## Deferred (follow-up — the orchestrator handles)

**MoneyTab 4-step waterfall UI hookup is NOT in this PR** — PR #662 (Money tab v1) has not merged into master yet, so per the plan I built only the data side + the `PeriodEconomics`/DAO sums and did **not** create a conflicting edit against the unmerged branch. When #662 lands, wire the waterfall to Gross → −Fuel → −Non-fuel → Net when `fuelCost`/`nonFuelCost` are present (both non-null), falling back to the 3-step (Gross → −Operating cost → Net) when null/zero-coverage; derive the cost steps from the summed frozen per-mile × miles values already exposed here (not gross − net), floored/labelled defensively.

## Tests

- **`RecordFoldsTest`** (`:domain`): fuel/non-fuel per-mile extraction, distance-0 guard → null split, the sum invariant, CURRENT_FALLBACK/NONE → null split, `startSource` population (DASH_START vs synthesized placeholder vs RECOVERY-preserved).
- **`AnalyticsProjectorTest`** (`:app`): frozen split folded onto `delivery_records` + into the period SUMs, no-offer session → null split + null period sums (3-step fallback), **`startSource` hydration** (the retro-2 regression guard — real-platform DASH_STOP before DASH_START). The existing placeholder-upgrade cross-batch test (the old heuristic's replacement guard) still passes.
- **`AnalyticsMigration9to10Test`** (androidTest, runs under `connectedAndroidTest` only): additive-only — pre-existing rows survive, the three new columns exist and are NULL post-migration.

Suites green (JAVA_HOME=java-25): `:domain:test` **269**, `:core:state:test` **103**, `:app:testDebugUnitTest` **595** (incl. `AllMatchersSuite`), 0 failures.

## Security/privacy posture

No new capture, network, or PII surface. The projector re-reads a log that already passed the edge hash; the new columns are economics (per-mile rates, dollar sums) and a start-provenance string — no store/customer text. INFO logging unchanged (counts only).

### Design-goal review
- **P1 (UDF / pure fold):** all new arithmetic (per-mile split, startSource stamping) lives in the pure `:domain` `RecordFolds`/`SessionFoldContext`, `:domain:test`-covered; the projector maps at the transaction edge only. No wall clock.
- **P5 (SSOT):** the split is *derived* from the one frozen `OfferEvaluation` (not a second stored economy); `frozenCostPerMile` stays the cpm owner and the split's sum reconciles to it (invariant). `started` gets ONE owner — the persisted `startSource` — replacing the duplicated `platform`-derived inference.
- **P6 (privacy):** economics/provenance only; no raw PII.
- **P8 (platform-agnostic):** no platform literals added; `startSource` is a generic provenance string, split math is platform-independent, platform still resolves through the `Platform` registry.
- **Migration safety:** additive nullable columns, AutoMigration, refold-repopulated — no destructive path.

Do not merge — the orchestrator gates with a fable adversarial review.