### PR TITLE
feat(#315): Analytics Decisions tab (Phase H3)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsScreen.kt
@@ -87,8 +87,16 @@ fun AnalyticsScreen(
                     )
                 }
 
+                AnalyticsTab.Decisions -> {
+                    PeriodSelector(
+                        selectedPeriod = uiState.selectedPeriod,
+                        onSelectPeriod = viewModel::setPeriod,
+                    )
+                    Spacer(Modifier.height(16.dp))
+                    DecisionsTab(decisions = uiState.decisions)
+                }
+
                 AnalyticsTab.Patterns,
-                AnalyticsTab.Decisions,
                 AnalyticsTab.Time,
                 -> ComingSoonCard(uiState.selectedTab)
             }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsUiState.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsUiState.kt
@@ -1,6 +1,7 @@
 package cloud.trotter.dashbuddy.ui.main.analytics
 
 import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
+import cloud.trotter.dashbuddy.domain.analytics.DecisionEconomics
 import cloud.trotter.dashbuddy.domain.analytics.PeriodEconomics
 import cloud.trotter.dashbuddy.domain.analytics.SessionRecord
 import cloud.trotter.dashbuddy.domain.analytics.StoreEconomics
@@ -38,4 +39,6 @@ data class AnalyticsUiState(
     val topStores: List<StoreEconomics> = emptyList(),
     /** Most recent dash sessions, newest first (not tappable until #650). */
     val recentSessions: List<SessionRecord> = emptyList(),
+    /** Offer-decision economics for [selectedPeriod] — the Decisions tab (#315 H3, frozen est.). */
+    val decisions: DecisionEconomics = DecisionEconomics.EMPTY,
 )

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsViewModel.kt
@@ -4,6 +4,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import cloud.trotter.dashbuddy.core.data.analytics.AnalyticsRepository
 import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
+import cloud.trotter.dashbuddy.domain.analytics.DecisionEconomics
+import cloud.trotter.dashbuddy.domain.analytics.PeriodEconomics
+import cloud.trotter.dashbuddy.domain.analytics.StoreEconomics
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -44,22 +47,27 @@ class AnalyticsViewModel @Inject constructor(
 
     val uiState: StateFlow<AnalyticsUiState> = combine(
         selectedTab,
-        // Re-anchor economics + top stores together on each period switch so a tile never
-        // renders one window's number under another's label.
+        // Re-anchor economics + top stores + decisions together on each period switch so a tile
+        // never renders one window's number under another's label. Decisions is collected
+        // unconditionally (not gated on the selected tab): the source is a cheap Room-invalidation
+        // aggregate and folding it in here keeps one immutable UiState re-anchored atomically with
+        // the period — the simpler correct shape (Principle 1).
         selectedPeriod.flatMapLatest { period ->
             combine(
                 analyticsRepository.periodEconomics(period),
                 analyticsRepository.perStoreEconomics(period),
-            ) { economics, stores -> Triple(period, economics, stores) }
+                analyticsRepository.decisionEconomics(period),
+            ) { economics, stores, decisions -> PeriodData(period, economics, stores, decisions) }
         },
         analyticsRepository.recentSessions(RECENT_SESSIONS_LIMIT),
-    ) { tab, (period, economics, stores), sessions ->
+    ) { tab, data, sessions ->
         AnalyticsUiState(
             selectedTab = tab,
-            selectedPeriod = period,
-            economics = economics,
-            topStores = stores.take(TOP_STORES),
+            selectedPeriod = data.period,
+            economics = data.economics,
+            topStores = data.stores.take(TOP_STORES),
             recentSessions = sessions,
+            decisions = data.decisions,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), AnalyticsUiState())
 
@@ -72,6 +80,14 @@ class AnalyticsViewModel @Inject constructor(
     fun setTab(tab: AnalyticsTab) {
         selectedTab.value = tab
     }
+
+    /** One period switch's worth of read-model, re-anchored atomically under [flatMapLatest]. */
+    private data class PeriodData(
+        val period: AnalyticsPeriod,
+        val economics: PeriodEconomics,
+        val stores: List<StoreEconomics>,
+        val decisions: DecisionEconomics,
+    )
 
     private companion object {
         const val TOP_STORES = 5

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/DecisionsTab.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/DecisionsTab.kt
@@ -1,0 +1,199 @@
+package cloud.trotter.dashbuddy.ui.main.analytics
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import cloud.trotter.dashbuddy.core.designsystem.component.AppCard
+import cloud.trotter.dashbuddy.core.designsystem.component.AppLegend
+import cloud.trotter.dashbuddy.core.designsystem.component.AppSegment
+import cloud.trotter.dashbuddy.core.designsystem.component.AppStackBar
+import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
+import cloud.trotter.dashbuddy.domain.analytics.DecisionEconomics
+import cloud.trotter.dashbuddy.domain.format.Formats
+import kotlin.math.roundToInt
+
+/** Placeholder shown for a figure with no measurable input yet (Money-tab parity). */
+private const val EMPTY_VALUE = "—"
+
+/**
+ * Decisions tab (#315 H3): the frozen-decision review for the selected period, top→bottom — the
+ * offer funnel (accept/decline/timeout + acceptance-rate headline), the value of saying no (Σ est.
+ * net of declines), and score-vs-outcome (avg score + avg est. $/hr, accepted vs declined). Pure
+ * data in ([DecisionEconomics]), no side effects.
+ *
+ * **Everything here is a FROZEN decision-time estimate, not realized net** — labelled "est." at
+ * every economic surface so the dasher reads them as what the verdict projected, never what was
+ * actually earned (an economy edit never re-costs a past offer). Aggregate-only: no per-offer list,
+ * no merchant/customer text (Principle 6/7). Every number routes through the [Formats] SSOT.
+ */
+@Composable
+fun DecisionsTab(
+    decisions: DecisionEconomics,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        OfferFunnelCard(decisions)
+        ValueOfSayingNoCard(decisions)
+        ScoreVsOutcomeCard(decisions)
+    }
+}
+
+/** Offer funnel: acceptance-rate headline + a stacked accept/decline/timeout bar with a legend. */
+@Composable
+private fun OfferFunnelCard(decisions: DecisionEconomics) {
+    val c = AppTheme.colors
+    AppCard(modifier = Modifier.fillMaxWidth()) {
+        Text(text = "OFFER FUNNEL", style = MaterialTheme.typography.labelMedium, color = c.text3)
+        Spacer(Modifier.height(10.dp))
+        if (decisions.received == 0) {
+            EmptyRow("No offers in this period yet.")
+            return@AppCard
+        }
+
+        val rate = decisions.acceptanceRate?.let { "${(it * 100).roundToInt()}%" } ?: EMPTY_VALUE
+        Text(text = rate, style = AppTheme.num.heroNum, color = c.text)
+        Spacer(Modifier.height(2.dp))
+        Text(
+            text = "acceptance rate · ${Formats.commaInt(decisions.received)} " +
+                if (decisions.received == 1) "offer" else "offers",
+            style = MaterialTheme.typography.bodySmall,
+            color = c.text3,
+        )
+        Spacer(Modifier.height(14.dp))
+
+        // Counts drive the bar; the legend surfaces the raw count per segment (the rate is the hero).
+        val segments = listOf(
+            AppSegment("Accepted", decisions.accepted.toFloat(), c.good, note = Formats.commaInt(decisions.accepted)),
+            AppSegment("Declined", decisions.declined.toFloat(), c.bad, note = Formats.commaInt(decisions.declined)),
+            AppSegment("Timed out", decisions.timedOut.toFloat(), c.neutral, note = Formats.commaInt(decisions.timedOut)),
+        )
+        AppStackBar(segments, height = 14.dp)
+        Spacer(Modifier.height(10.dp))
+        AppLegend(segments)
+    }
+}
+
+/**
+ * The "value of saying no": Σ frozen est. net pay of the offers that were declined. It's the money
+ * the dasher chose to skip, by the offer's own decision-time estimate — not a realized figure.
+ */
+@Composable
+private fun ValueOfSayingNoCard(decisions: DecisionEconomics) {
+    val c = AppTheme.colors
+    AppCard(modifier = Modifier.fillMaxWidth()) {
+        Text(text = "VALUE OF SAYING NO", style = MaterialTheme.typography.labelMedium, color = c.text3)
+        Spacer(Modifier.height(10.dp))
+        if (decisions.declined == 0) {
+            Text(text = EMPTY_VALUE, style = AppTheme.num.heroNum, color = c.text2)
+            Spacer(Modifier.height(2.dp))
+            EmptyRow("No declines in this period.")
+            return@AppCard
+        }
+        Text(text = "~${Formats.money(decisions.declinedEstNet)}", style = AppTheme.num.heroNum, color = c.text)
+        Spacer(Modifier.height(2.dp))
+        Text(
+            text = "est. net skipped across ${Formats.commaInt(decisions.declined)} declined " +
+                if (decisions.declined == 1) "offer" else "offers",
+            style = MaterialTheme.typography.bodySmall,
+            color = c.text3,
+        )
+    }
+}
+
+/**
+ * Score vs outcome — a 2-row comparison of the avg frozen score + avg est. $/hr for accepted vs
+ * declined offers: the "is my judgment matching the verdicts" read. Both economic columns are
+ * decision-time estimates (labelled "est.").
+ */
+@Composable
+private fun ScoreVsOutcomeCard(decisions: DecisionEconomics) {
+    val c = AppTheme.colors
+    AppCard(modifier = Modifier.fillMaxWidth()) {
+        Text(text = "SCORE VS OUTCOME", style = MaterialTheme.typography.labelMedium, color = c.text3)
+        Spacer(Modifier.height(10.dp))
+        if (decisions.received == 0) {
+            EmptyRow("No offers in this period yet.")
+            return@AppCard
+        }
+        // Header
+        ComparisonRow(
+            label = "",
+            score = "Avg score",
+            perHour = "Est. \$/hr",
+            labelColor = c.text3,
+            valueStyleHeader = true,
+        )
+        Spacer(Modifier.height(8.dp))
+        ComparisonRow(
+            label = "Accepted",
+            score = decisions.avgScoreAccepted?.let { Formats.decimal(it, 1) } ?: EMPTY_VALUE,
+            perHour = decisions.avgEstPerHourAccepted?.let { Formats.money(it) } ?: EMPTY_VALUE,
+            labelColor = c.good,
+        )
+        Spacer(Modifier.height(8.dp))
+        ComparisonRow(
+            label = "Declined",
+            score = decisions.avgScoreDeclined?.let { Formats.decimal(it, 1) } ?: EMPTY_VALUE,
+            perHour = decisions.avgEstPerHourDeclined?.let { Formats.money(it) } ?: EMPTY_VALUE,
+            labelColor = c.bad,
+        )
+    }
+}
+
+@Composable
+private fun ComparisonRow(
+    label: String,
+    score: String,
+    perHour: String,
+    labelColor: Color,
+    valueStyleHeader: Boolean = false,
+) {
+    val c = AppTheme.colors
+    val valueStyle = if (valueStyleHeader) MaterialTheme.typography.labelSmall else AppTheme.num.smNum
+    val valueColor = if (valueStyleHeader) c.text3 else c.text
+    Row(Modifier.fillMaxWidth()) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = labelColor,
+            modifier = Modifier.weight(1f),
+        )
+        Text(
+            text = score,
+            style = valueStyle,
+            color = valueColor,
+            textAlign = TextAlign.End,
+            modifier = Modifier.width(96.dp),
+        )
+        Spacer(Modifier.width(12.dp))
+        Text(
+            text = perHour,
+            style = valueStyle,
+            color = valueColor,
+            textAlign = TextAlign.End,
+            modifier = Modifier.width(96.dp),
+        )
+    }
+}
+
+@Composable
+private fun EmptyRow(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.bodyMedium,
+        color = AppTheme.colors.text3,
+        modifier = Modifier.padding(vertical = 4.dp),
+    )
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsDecisionsTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsDecisionsTest.kt
@@ -1,0 +1,195 @@
+package cloud.trotter.dashbuddy.analytics
+
+import androidx.room.Room
+import cloud.trotter.dashbuddy.core.data.analytics.AnalyticsRepository
+import cloud.trotter.dashbuddy.core.database.DashBuddyDatabase
+import cloud.trotter.dashbuddy.core.database.analytics.AnalyticsDao
+import cloud.trotter.dashbuddy.core.database.analytics.OfferRecordEntity
+import cloud.trotter.dashbuddy.core.database.analytics.SessionRecordEntity
+import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
+import cloud.trotter.dashbuddy.domain.model.event.AppEventType
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+/**
+ * #315 H3 — the Decisions-tab aggregates over an in-memory v9 database. Proves:
+ *  - `offerOutcomes` / `offerScoreOutcomes` are **session-anchored** (#655), same WHERE shape as
+ *    the delivery aggregates — an offer buckets by its *session's* start day, not its `decidedAt`;
+ *  - the null-session fallback counts by the offer's own `decidedAt`;
+ *  - `AVG(score)`/`AVG(estDollarsPerHour)` skip null rows (no fabricated zero);
+ *  - `AnalyticsRepository.decisionEconomics` folds the two row sets into the funnel counts,
+ *    acceptance rate (null when empty), value-of-saying-no, and per-outcome averages.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AnalyticsDecisionsTest {
+
+    private lateinit var db: DashBuddyDatabase
+    private lateinit var dao: AnalyticsDao
+    private lateinit var repo: AnalyticsRepository
+
+    private val base = 1_600_000_000_000L
+    private val hour = 3_600_000L
+    private val day = 86_400_000L
+
+    @Before
+    fun setUp() {
+        val context = RuntimeEnvironment.getApplication()
+        db = Room.inMemoryDatabaseBuilder(context, DashBuddyDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = db.analyticsDao()
+        repo = AnalyticsRepository(dao)
+    }
+
+    @After
+    fun tearDown() = db.close()
+
+    private fun session(id: String, startedAt: Long, platform: String = "doordash") =
+        SessionRecordEntity(
+            sessionId = id,
+            platform = platform,
+            startedAt = startedAt,
+            endedAt = startedAt + hour,
+            lastEventAt = startedAt + hour,
+            endSource = "summary_screen",
+            startOdometer = 0.0,
+            lastOdometer = 5.0,
+            reportedEarnings = null,
+            reportedDurationMillis = hour,
+            offersReceived = 0,
+            offersAccepted = 0,
+            offersDeclined = 0,
+            offersTimeout = 0,
+            deliveries = 1,
+            jobsCompleted = 1,
+        )
+
+    private fun offer(
+        seq: Long,
+        sessionId: String?,
+        outcome: AppEventType,
+        decidedAt: Long,
+        estNetPay: Double?,
+        score: Double?,
+        estPerHour: Double?,
+        platform: String = "doordash",
+    ) = OfferRecordEntity(
+        eventSequenceId = seq,
+        sessionId = sessionId,
+        platform = platform,
+        offerHash = "oh-$seq",
+        outcome = outcome.name,
+        presentedAt = decidedAt - 30_000,
+        decidedAt = decidedAt,
+        payAmount = 8.0,
+        distanceMiles = 3.0,
+        itemCount = 1,
+        merchantName = "Wendys",
+        score = score,
+        action = "ACCEPT",
+        quality = "GOOD",
+        estNetPay = estNetPay,
+        estDollarsPerHour = estPerHour,
+        estDollarsPerMile = 2.0,
+        estTimeMinutes = 12.0,
+        estOperatingCostPerMile = 0.30,
+    )
+
+    /** An offer decided 00:10 today, in a session started 23:50 yesterday, buckets YESTERDAY. */
+    @Test
+    fun `offerOutcomes is session-anchored, not decidedAt-anchored`() = runBlocking {
+        val todayStart = base
+        val yesterdayStart = todayStart - day
+        val sessionStart = todayStart - 600_000   // 23:50 yesterday
+        val decided = todayStart + 600_000        // 00:10 today
+
+        dao.upsertSession(session("Y", sessionStart))
+        dao.upsertOffer(offer(1, "Y", AppEventType.OFFER_ACCEPTED, decided, estNetPay = 6.0, score = 0.8, estPerHour = 20.0))
+
+        // TODAY: the session started yesterday ⇒ nothing lands here (session-anchored).
+        assertTrue(dao.offerOutcomes(todayStart, todayStart + day).first().isEmpty())
+
+        // YESTERDAY: the whole offer, though its decidedAt is after midnight.
+        val yest = dao.offerOutcomes(yesterdayStart, todayStart).first()
+        assertEquals(1, yest.size)
+        assertEquals(AppEventType.OFFER_ACCEPTED.name, yest[0].outcome)
+        assertEquals(1, yest[0].count)
+        assertEquals(6.0, yest[0].estNetSum, 1e-9)
+    }
+
+    /** A `sessionId IS NULL` offer joins to no session and counts by its own `decidedAt`. */
+    @Test
+    fun `null-session offer counts by its decidedAt`() = runBlocking {
+        val todayStart = base
+        val decidedToday = todayStart + 600_000
+
+        dao.upsertOffer(offer(1, sessionId = null, AppEventType.OFFER_DECLINED, decidedToday, estNetPay = 4.0, score = 0.2, estPerHour = 8.0))
+
+        val today = dao.offerOutcomes(todayStart, todayStart + day).first()
+        assertEquals(1, today.size)
+        assertEquals(4.0, today[0].estNetSum, 1e-9)
+
+        assertTrue(dao.offerOutcomes(todayStart - day, todayStart).first().isEmpty())
+
+        // LIFETIME still catches it.
+        assertEquals(1, dao.offerOutcomes(0, Long.MAX_VALUE).first().size)
+    }
+
+    /** `AVG(score)`/`AVG(estDollarsPerHour)` skip the null-estimate row within a group. */
+    @Test
+    fun `offerScoreOutcomes averages skip nulls`() = runBlocking {
+        dao.upsertSession(session("S1", base))
+        dao.upsertOffer(offer(1, "S1", AppEventType.OFFER_ACCEPTED, base + hour, estNetPay = 6.0, score = 0.8, estPerHour = 20.0))
+        dao.upsertOffer(offer(2, "S1", AppEventType.OFFER_ACCEPTED, base + 2 * hour, estNetPay = 4.0, score = null, estPerHour = null))
+
+        val acc = dao.offerScoreOutcomes(0, Long.MAX_VALUE).first().first { it.outcome == AppEventType.OFFER_ACCEPTED.name }
+        assertEquals(2, acc.count)
+        assertEquals(0.8, acc.avgScore!!, 1e-9)       // the null row is skipped by AVG
+        assertEquals(20.0, acc.avgEstPerHour!!, 1e-9)
+    }
+
+    /** The repository fold: funnel counts, acceptance rate, value-of-saying-no, per-outcome averages. */
+    @Test
+    fun `decisionEconomics folds outcomes into rate + value-of-no + averages`() = runBlocking {
+        dao.upsertSession(session("S1", base))
+        dao.upsertOffer(offer(1, "S1", AppEventType.OFFER_ACCEPTED, base + hour, estNetPay = 6.0, score = 0.8, estPerHour = 20.0))
+        dao.upsertOffer(offer(2, "S1", AppEventType.OFFER_ACCEPTED, base + 2 * hour, estNetPay = 5.0, score = 0.6, estPerHour = 18.0))
+        dao.upsertOffer(offer(3, "S1", AppEventType.OFFER_DECLINED, base + 3 * hour, estNetPay = 2.0, score = 0.1, estPerHour = 6.0))
+        dao.upsertOffer(offer(4, "S1", AppEventType.OFFER_TIMEOUT, base + 4 * hour, estNetPay = 1.0, score = 0.05, estPerHour = 4.0))
+
+        val d = repo.decisionEconomics(AnalyticsPeriod.LIFETIME).first()
+        assertEquals(4, d.received)
+        assertEquals(2, d.accepted)
+        assertEquals(1, d.declined)
+        assertEquals(1, d.timedOut)
+        assertEquals(0.5, d.acceptanceRate!!, 1e-9)          // 2 accepted / 4 received
+        assertEquals(2.0, d.declinedEstNet, 1e-9)            // Σ est net of the declined group only
+        assertEquals(0.7, d.avgScoreAccepted!!, 1e-9)        // (0.8 + 0.6) / 2
+        assertEquals(0.1, d.avgScoreDeclined!!, 1e-9)
+        assertEquals(19.0, d.avgEstPerHourAccepted!!, 1e-9)  // (20 + 18) / 2
+        assertEquals(6.0, d.avgEstPerHourDeclined!!, 1e-9)
+    }
+
+    /** Empty period ⇒ zero counts, null acceptance rate and null averages (no fabricated zeros). */
+    @Test
+    fun `decisionEconomics on empty period is zero-count with null rate and averages`() = runBlocking {
+        val d = repo.decisionEconomics(AnalyticsPeriod.LIFETIME).first()
+        assertEquals(0, d.received)
+        assertEquals(0, d.accepted)
+        assertNull(d.acceptanceRate)
+        assertEquals(0.0, d.declinedEstNet, 1e-9)
+        assertNull(d.avgScoreAccepted)
+        assertNull(d.avgScoreDeclined)
+        assertNull(d.avgEstPerHourAccepted)
+        assertNull(d.avgEstPerHourDeclined)
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsViewModelTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsViewModelTest.kt
@@ -2,6 +2,7 @@ package cloud.trotter.dashbuddy.ui.main.analytics
 
 import cloud.trotter.dashbuddy.core.data.analytics.AnalyticsRepository
 import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
+import cloud.trotter.dashbuddy.domain.analytics.DecisionEconomics
 import cloud.trotter.dashbuddy.domain.analytics.PeriodEconomics
 import cloud.trotter.dashbuddy.domain.analytics.PeriodTotals
 import cloud.trotter.dashbuddy.domain.analytics.SessionRecord
@@ -40,10 +41,28 @@ class AnalyticsViewModelTest {
         period: AnalyticsPeriod,
         economics: PeriodEconomics,
         stores: List<StoreEconomics> = emptyList(),
+        decisions: DecisionEconomics = DecisionEconomics.EMPTY,
     ) {
         whenever(analyticsRepository.periodEconomics(eq(period), anyOrNull())).thenReturn(flowOf(economics))
         whenever(analyticsRepository.perStoreEconomics(eq(period))).thenReturn(flowOf(stores))
+        // The VM collects decisions unconditionally (see AnalyticsViewModel), so every period stub
+        // must supply a decisions flow or the combine would fold a null.
+        whenever(analyticsRepository.decisionEconomics(eq(period))).thenReturn(flowOf(decisions))
     }
+
+    private fun decisions(accepted: Int, declined: Int, timedOut: Int, acceptanceRate: Double?) =
+        DecisionEconomics(
+            received = accepted + declined + timedOut,
+            accepted = accepted,
+            declined = declined,
+            timedOut = timedOut,
+            acceptanceRate = acceptanceRate,
+            declinedEstNet = 12.5,
+            avgScoreAccepted = 0.8,
+            avgScoreDeclined = 0.2,
+            avgEstPerHourAccepted = 22.0,
+            avgEstPerHourDeclined = 7.0,
+        )
 
     private fun stubSessions(sessions: List<SessionRecord>) {
         whenever(analyticsRepository.recentSessions(any())).thenReturn(flowOf(sessions))
@@ -120,14 +139,21 @@ class AnalyticsViewModelTest {
     }
 
     @Test
-    fun `setTab switches the visible tab without touching the period`() = runTest {
+    fun `setTab switches to Decisions and the decision read-model is present in state`() = runTest {
         Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        stubPeriod(AnalyticsPeriod.THIS_WEEK, economics(net = 100.0, netPerHour = 20.0))
+        stubPeriod(
+            AnalyticsPeriod.THIS_WEEK,
+            economics(net = 100.0, netPerHour = 20.0),
+            decisions = decisions(accepted = 3, declined = 5, timedOut = 2, acceptanceRate = 0.3),
+        )
         stubSessions(emptyList())
 
         val viewModel = buildViewModel()
         val job = launch { viewModel.uiState.collect {} }
         testScheduler.advanceUntilIdle()
+
+        // Decisions are collected unconditionally, so they're in state even before the tab switch.
+        assertEquals(3, viewModel.uiState.value.decisions.accepted)
 
         viewModel.setTab(AnalyticsTab.Decisions)
         testScheduler.advanceUntilIdle()
@@ -135,6 +161,10 @@ class AnalyticsViewModelTest {
         val ui = viewModel.uiState.value
         assertEquals(AnalyticsTab.Decisions, ui.selectedTab)
         assertEquals(AnalyticsPeriod.THIS_WEEK, ui.selectedPeriod)
+        assertEquals(10, ui.decisions.received)
+        assertEquals(5, ui.decisions.declined)
+        assertEquals(0.3, ui.decisions.acceptanceRate!!, 1e-9)
+        assertEquals(12.5, ui.decisions.declinedEstNet, 1e-9)
         job.cancel()
     }
 

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
@@ -1,13 +1,17 @@
 package cloud.trotter.dashbuddy.core.data.analytics
 
 import cloud.trotter.dashbuddy.core.database.analytics.AnalyticsDao
+import cloud.trotter.dashbuddy.core.database.analytics.OutcomeCountRow
+import cloud.trotter.dashbuddy.core.database.analytics.ScoreOutcomeRow
 import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
+import cloud.trotter.dashbuddy.domain.analytics.DecisionEconomics
 import cloud.trotter.dashbuddy.domain.analytics.DeliveryRecord
 import cloud.trotter.dashbuddy.domain.analytics.PeriodEconomics
 import cloud.trotter.dashbuddy.domain.analytics.PeriodTotals
 import cloud.trotter.dashbuddy.domain.analytics.SessionRecord
 import cloud.trotter.dashbuddy.domain.analytics.StoreEconomics
 import cloud.trotter.dashbuddy.domain.evaluation.NetProfit
+import cloud.trotter.dashbuddy.domain.model.event.AppEventType
 import cloud.trotter.dashbuddy.domain.state.Platform
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -95,6 +99,29 @@ class AnalyticsRepository @Inject constructor(
             }
         }
 
+    /**
+     * Offer-decision economics for [period] (#315 H3, Decisions tab): the funnel counts, the frozen
+     * est-net of declines ("value of saying no"), and the per-outcome avg score / est-$/hr. Two
+     * session-anchored DAO aggregates ([AnalyticsDao.offerOutcomes] + [AnalyticsDao.offerScoreOutcomes])
+     * combined and folded into one [DecisionEconomics].
+     *
+     * **Session-anchored (#655):** an offer belongs to the period its *session* started in (same
+     * bucketing owner as every other aggregate — the DAO join), with a null-session fallback on the
+     * offer's own `decidedAt`. Re-emits on new offer records (Room invalidation) and at
+     * midnight/week/month rollover (the boundary flow).
+     *
+     * **Estimates are frozen decision-time snapshots, not realized net** — the numbers say what the
+     * verdict projected at decision time; an economy edit never re-costs them (Principle 5). No new
+     * PII surface: counts + frozen economics only.
+     */
+    fun decisionEconomics(period: AnalyticsPeriod): Flow<DecisionEconomics> =
+        periodBoundariesFlow(period).flatMapLatest { (start, end) ->
+            combine(
+                analyticsDao.offerOutcomes(start, end),
+                analyticsDao.offerScoreOutcomes(start, end),
+            ) { outcomes, scores -> assembleDecisions(outcomes, scores) }
+        }
+
     /** Recent dashes, newest first (future hub / #650). */
     fun recentSessions(limit: Int = 20): Flow<List<SessionRecord>> =
         analyticsDao.recentSessions(limit).map { rows -> rows.map { it.toDomain() } }
@@ -134,6 +161,42 @@ class AnalyticsRepository @Inject constructor(
             unattributedPay = unattributed,
             netPerHour = NetProfit.perHour(net, hours),
             netPerMile = NetProfit.perMile(net, miles),
+        )
+    }
+
+    /**
+     * Fold the two per-outcome DAO row sets into [DecisionEconomics]. Outcomes are matched by
+     * [AppEventType] name (the SSOT the projector writes — no magic-string literals): a missing
+     * outcome group means zero of that outcome (never present when its count is zero). The
+     * acceptance rate stays `null` until at least one offer closed; the average score / est-$/hr
+     * pass the DAO's null-safe `AVG` through verbatim (no fabricated zero).
+     */
+    private fun assembleDecisions(
+        outcomes: List<OutcomeCountRow>,
+        scores: List<ScoreOutcomeRow>,
+    ): DecisionEconomics {
+        fun outcome(type: AppEventType) = outcomes.find { it.outcome == type.name }
+        fun scoreOf(type: AppEventType) = scores.find { it.outcome == type.name }
+
+        val accepted = outcome(AppEventType.OFFER_ACCEPTED)?.count ?: 0
+        val declined = outcome(AppEventType.OFFER_DECLINED)?.count ?: 0
+        val timedOut = outcome(AppEventType.OFFER_TIMEOUT)?.count ?: 0
+        val received = accepted + declined + timedOut
+
+        val acceptedScores = scoreOf(AppEventType.OFFER_ACCEPTED)
+        val declinedScores = scoreOf(AppEventType.OFFER_DECLINED)
+
+        return DecisionEconomics(
+            received = received,
+            accepted = accepted,
+            declined = declined,
+            timedOut = timedOut,
+            acceptanceRate = if (received > 0) accepted.toDouble() / received else null,
+            declinedEstNet = outcome(AppEventType.OFFER_DECLINED)?.estNetSum ?: 0.0,
+            avgScoreAccepted = acceptedScores?.avgScore,
+            avgScoreDeclined = declinedScores?.avgScore,
+            avgEstPerHourAccepted = acceptedScores?.avgEstPerHour,
+            avgEstPerHourDeclined = declinedScores?.avgEstPerHour,
         )
     }
 }

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
@@ -191,6 +191,49 @@ interface AnalyticsDao {
     )
     fun grossAndUnattributedByPlatform(start: Long, end: Long): Flow<List<PlatformGrossTotalsRow>>
 
+    // ── Decisions-tab aggregates (#315 H3) ──────────────────────────────
+
+    /**
+     * Per-outcome offer counts + Σ frozen `estNetPay` for a period — the funnel + value-of-saying-no
+     * inputs (#315 H3). **Session-anchored (#655), identical WHERE shape to [deliveryTotals]:** an
+     * offer buckets by the period of its *session's* `startedAt` (joined via `sessionId`); a
+     * `sessionId IS NULL` offer (no session context at all) falls back to its own `decidedAt` falling
+     * in the window — the analog of the delivery-side `completedAt` fallback. `NULL IN (…)` is never
+     * true in SQL, so the two clauses are disjoint (no double count), and LIFETIME `(0, MAX)` keeps
+     * every row. GROUP BY outcome only (no per-offer list yet). Estimates are the offer's frozen
+     * decision-time snapshot, not realized net.
+     */
+    @Query(
+        """SELECT outcome,
+                  COUNT(*) AS count,
+                  COALESCE(SUM(estNetPay), 0) AS estNetSum
+           FROM offer_records
+           WHERE sessionId IN (SELECT sessionId FROM session_records
+                               WHERE startedAt >= :start AND startedAt < :end)
+              OR (sessionId IS NULL AND decidedAt >= :start AND decidedAt < :end)
+           GROUP BY outcome"""
+    )
+    fun offerOutcomes(start: Long, end: Long): Flow<List<OutcomeCountRow>>
+
+    /**
+     * Per-outcome count + `AVG(score)` + `AVG(estDollarsPerHour)` for a period — the score-vs-outcome
+     * read (#315 H3). Same session-anchored WHERE shape + null-session `decidedAt` fallback as
+     * [offerOutcomes]/[deliveryTotals]. `AVG` skips nulls and yields null for an all-null group (no
+     * fabricated 0). Frozen estimates.
+     */
+    @Query(
+        """SELECT outcome,
+                  COUNT(*) AS count,
+                  AVG(score) AS avgScore,
+                  AVG(estDollarsPerHour) AS avgEstPerHour
+           FROM offer_records
+           WHERE sessionId IN (SELECT sessionId FROM session_records
+                               WHERE startedAt >= :start AND startedAt < :end)
+              OR (sessionId IS NULL AND decidedAt >= :start AND decidedAt < :end)
+           GROUP BY outcome"""
+    )
+    fun offerScoreOutcomes(start: Long, end: Long): Flow<List<ScoreOutcomeRow>>
+
     // ── Drill-down list reads (future hub / #650) ────────────────────────
 
     /** Most recent sessions, newest first — the "recent dashes" list. */

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsTotals.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsTotals.kt
@@ -66,3 +66,27 @@ data class PlatformSessionTotalsRow(
     val miles: Double,
     val onlineMillis: Long,
 )
+
+/**
+ * Per-outcome offer counts + Σ frozen `estNetPay` for a period (#315 H3, Decisions tab). One row
+ * per closing [outcome] ("OFFER_ACCEPTED" / "OFFER_DECLINED" / "OFFER_TIMEOUT") — the funnel counts
+ * and the value-of-saying-no input (Σ est net of the declined group). Estimates are the offer's
+ * FROZEN decision-time snapshot (an economy edit never re-costs them), never realized net.
+ */
+data class OutcomeCountRow(
+    val outcome: String,
+    val count: Int,
+    val estNetSum: Double,
+)
+
+/**
+ * Per-outcome score / est-$/hr averages for a period (#315 H3) — the "is my judgment matching the
+ * verdicts" read. [avgScore]/[avgEstPerHour] are SQL `AVG`s (nullable — a group whose rows all
+ * carried a null `score`/`estDollarsPerHour` yields null, never a fabricated 0). Frozen estimates.
+ */
+data class ScoreOutcomeRow(
+    val outcome: String,
+    val count: Int,
+    val avgScore: Double?,
+    val avgEstPerHour: Double?,
+)

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -85,6 +85,19 @@ was found **broken-in-part** (raw PII in capture envelopes) and moved to that en
   with the period, Money ≠ dashboard for the same window, a crash on an empty period, or a "$0.00"
   unattributed callout on a period with none.
   - Confirmed: 0/2
+- **🆕 NEW — Analytics Decisions tab: offer funnel + value-of-saying-no + score-vs-outcome (#315 H3).**
+  In the Analytics hub tap the **Decisions** tab and pick a period (Today / Week / Month / Lifetime).
+  Three sections should appear: an **offer funnel** (a stacked Accepted / Declined / Timed-out bar +
+  legend, with the **acceptance rate** as the big headline and the offer count under it), a **value of
+  saying no** card ("~$X est. net skipped across N declined offers"), and a **score vs outcome**
+  comparison (avg score + avg **est.** $/hr for Accepted vs Declined). How to tell it's working: the
+  Accepted/Declined/Timed-out counts and the acceptance rate should match what you actually did on the
+  dash; value-of-saying-no ≈ the sum of the estimated net of the offers you declined; every economic
+  figure is labelled **"est."** (these are the offer's frozen decision-time estimates, not realized
+  pay). How to tell it's broken: the "coming soon" card still shows, counts don't match the dash,
+  figures don't re-anchor on a period switch, a "$0.00"/blank where an em-dash should be on an empty
+  period, or a crash opening the tab with no offers yet.
+  - Confirmed: 0/2
 - **🆕 NEW — the main dashboard is now a REVIEW surface, not a live bubble mirror (#657 / PR #658).**
   Open the app **after a dash** (not while on a task): the **Today** tiles (True Net / Net $/hr /
   Miles) should already reflect the just-completed dash with no manual refresh (the read-model folds

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/DecisionEconomics.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/DecisionEconomics.kt
@@ -1,0 +1,50 @@
+package cloud.trotter.dashbuddy.domain.analytics
+
+/**
+ * Offer-decision economics for an [AnalyticsPeriod] (#315 H3, Decisions tab) — the read model behind
+ * the offer funnel, the value-of-saying-no callout, and the score-vs-outcome comparison. Aggregated
+ * over the period's **closing** offer records (`offer_records`), grouped by outcome.
+ *
+ * **Every economic figure here is a FROZEN decision-time estimate, never realized net.** The offer's
+ * `estNetPay` / `estDollarsPerHour` are what the evaluator said at the moment of decision — an
+ * economy edit does not re-cost a past offer (Principle 5). The UI labels these "est." so the dasher
+ * reads them as decision-time projections, not what was actually earned.
+ *
+ * Nullable where a denominator/group is empty (no fabricated zeros): [acceptanceRate] is null with no
+ * offers; the average score / est-$/hr fields are null when their outcome group is empty or every
+ * member carried a null estimate.
+ */
+data class DecisionEconomics(
+    /** Closing offers seen = [accepted] + [declined] + [timedOut]. */
+    val received: Int,
+    val accepted: Int,
+    val declined: Int,
+    val timedOut: Int,
+    /** [accepted] ÷ [received], or `null` when no offers closed in the period. */
+    val acceptanceRate: Double?,
+    /** Σ frozen `estNetPay` of the declined offers — the "value of saying no" (est., not realized). */
+    val declinedEstNet: Double,
+    /** Average frozen score of accepted offers, or `null` when none / all-null. */
+    val avgScoreAccepted: Double?,
+    /** Average frozen score of declined offers, or `null` when none / all-null. */
+    val avgScoreDeclined: Double?,
+    /** Average frozen est. $/hr of accepted offers, or `null` when none / all-null. */
+    val avgEstPerHourAccepted: Double?,
+    /** Average frozen est. $/hr of declined offers, or `null` when none / all-null. */
+    val avgEstPerHourDeclined: Double?,
+) {
+    companion object {
+        val EMPTY = DecisionEconomics(
+            received = 0,
+            accepted = 0,
+            declined = 0,
+            timedOut = 0,
+            acceptanceRate = null,
+            declinedEstNet = 0.0,
+            avgScoreAccepted = null,
+            avgScoreDeclined = null,
+            avgEstPerHourAccepted = null,
+            avgEstPerHourDeclined = null,
+        )
+    }
+}


### PR DESCRIPTION
## Phase H3 — Analytics Decisions tab (#315)

Adds the **Decisions tab** to the Analytics hub, projected over the existing `offer_records`
read-model (one row per closing offer decision). Replaces the "coming soon" card when Decisions is
selected; reuses the hub's period selector (now shown for Money and Decisions).

### Scope
- **DAO** (`AnalyticsDao`, session-anchored WHERE): two new aggregates, both `GROUP BY outcome`
  (no per-offer list yet):
  - `offerOutcomes(start,end): Flow<List<OutcomeCountRow>>` — outcome → count + `Σ estNetPay`
    (funnel + value-of-saying-no inputs).
  - `offerScoreOutcomes(start,end): Flow<List<ScoreOutcomeRow>>` — outcome → count, `AVG(score)`,
    `AVG(estDollarsPerHour)` (score-vs-outcome).
- **Repository** (`AnalyticsRepository.decisionEconomics(period): Flow<DecisionEconomics>`) — DAO-only,
  no economy dependency; folds the two row sets into the `:domain` DTO `DecisionEconomics`
  (`received`/`accepted`/`declined`/`timedOut`, `acceptanceRate` null when 0, `declinedEstNet`,
  `avgScore*`/`avgEstPerHour*`). Outcomes matched by `AppEventType.*.name` (the projector's SSOT — no
  magic strings).
- **UI** (`DecisionsTab.kt`): offer funnel (`AppStackBar`+`AppLegend`, acceptance-rate headline),
  value-of-saying-no card, score-vs-outcome 2-row comparison. Per-section empty states.
- **ViewModel / UiState**: `decisions: DecisionEconomics` added to the one immutable `AnalyticsUiState`;
  `decisionEconomics(period)` folded into the period-anchored inner `combine`.

### Session-anchored confirmation (#655)
Both new queries use the **exact** `deliveryTotals` WHERE shape:
`sessionId IN (SELECT sessionId FROM session_records WHERE startedAt >= :start AND startedAt < :end)
OR (sessionId IS NULL AND decidedAt >= :start AND decidedAt < :end)`. An offer buckets by its
*session's* start day (a midnight-spanning dash lands wholly on its start day); the null-session
fallback uses the offer's own `decidedAt` (the analog of the delivery side's `completedAt`). The two
clauses are disjoint (`NULL IN (…)` is never true), and LIFETIME `(0, MAX)` keeps every row. The DAO
join stays the single bucketing owner (P5). A DAO test proves the anchor directly (offer decided
00:10 today in a session started 23:50 yesterday buckets YESTERDAY; null-session falls back to
`decidedAt`).

### "est." labeling honesty
Every economic figure on this tab is the offer's **frozen decision-time estimate** (`estNetPay`,
`estDollarsPerHour`, `score`), never realized net — an economy edit does not re-cost a past offer.
The UI labels these "est." at each surface: "VALUE OF SAYING NO" → "est. net skipped…", the
score-vs-outcome column header → "Est. $/hr". The DTO/KDoc and repository doc restate this so the
next reader can't mistake it for realized pay.

### Collect-strategy call
`decisionEconomics(period)` is collected **unconditionally** (not gated on the selected tab), folded
into the same period-anchored inner `combine` as `periodEconomics`/`perStoreEconomics`. Rationale:
the source is a cheap Room-invalidation aggregate, and folding it there keeps one immutable UiState
that re-anchors atomically with the period (a tile never renders one window's number under another's
label). The simpler correct shape.

### Tests
`app:testDebugUnitTest` **908** / `domain:test` **264** / **AllMatchersSuite** — all green, 0 failures
(`JAVA_HOME=java-25-openjdk`).
- `AnalyticsDecisionsTest` (new, 5): DAO session-anchored, null-session `decidedAt` fallback,
  `AVG` skips null rows, repository rate/value-of-no/averages fold, empty→null rate & averages.
- `AnalyticsViewModelTest` (Decisions collection folded into state).

### Design-goal review
- **P1 (UDF):** pure read-model → one immutable `AnalyticsUiState`; `DecisionsTab` is data-in, no
  side effects; no repo writes from UI.
- **P3 (SRP):** new `DecisionsTab.kt` (small stateless composables); DTO in `:domain`; two focused DAO
  queries — no oversized file touched.
- **P5 (SSOT):** the DAO join is the single bucketing owner (copied from `deliveryTotals`, not
  re-derived); net/estimates read frozen values (repository has no economy input); outcome strings
  come from `AppEventType`, not literals; all display strings route through `Formats`.
- **P6 (privacy):** aggregate-only, no per-offer list, no merchant/customer text in the tab UI; no new
  capture/network surface. Frozen estimates + counts only.
- **P7 (logging):** no new log sites.
- **P8 (platform-agnostic):** touches `:domain` + `:core:data`/`:core:database` — no platform
  literals; outcomes keyed by enum name; aggregates are cross-platform GROUP BY. No `== Platform.X`.
- **Reactive UI:** review surface (frozen historical figures) — no `rememberNow()`; reactive via
  Room-invalidation Flows + the midnight/week/month boundary flow (matches Money tab / #657).

### Adversarial review
Pending — orchestrator gates the merge at fable tier (`/code-review`; the diff touches no
untrusted-input boundary, so `/security-review` optional).

### Field-test item
Added to `## Next field test`: **Decisions tab funnel matches the dash's real accept/decline counts**
(open Analytics → Decisions after a dash; the accepted/declined/timed-out segment counts + acceptance
rate should equal what you actually did; value-of-saying-no ≈ Σ est net of the offers you declined) —
#315 H3, Confirmed: 0/2.

### Parallel-builder note
Disjoint from the #659 fuel/nonfuel + `startSource` work — this PR adds new DAO methods
(`offerOutcomes`/`offerScoreOutcomes`), a new DTO (`DecisionEconomics`), and a new repo method; it
does **not** touch `PeriodEconomics` or the fuel/nonfuel/startSource paths.
