### PR TITLE
fix(#666): notif text-field SSOT anchor + actionLabels scrub hardening

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,16 +171,23 @@ token, so two customers redact distinctly (per-customer replay fidelity) without
 PII; fail-closed to plain `[redacted]`. Coverage spans the recognized offer/pickup/dropoff/chat/
 nav/camera **screen** surfaces AND **notification** envelopes (#620 — chat title/body,
 order-ready customer name via a per-field notif `redact`; store names kept). A rules-independent
-**recognized-frame** backstop (`CustomerTextMarkers`, #624/#632 — distinct from `SensitiveTextMarkers`,
+**recognized-frame** backstop (`CustomerTextMarkers`, #624/#632/#666 — distinct from `SensitiveTextMarkers`,
 which drops the dasher's banking screens) scrubs a node (screen tree) or whole field (notification —
-#632) that ships a customer-PII marker a rule forgot to redact; the marker SSOT is cross-platform
-DATA ("Deliver to "/"Message from " for DoorDash, "Leave the order at "/"Meet at door for " for Uber
-pushes, #585 — not DoorDash-only), with a documented residual for shapes a prefix scan can't own (a
-name-at-start body, and store-ambiguous prefixes like Uber's "Going to " that precede stores AND
-addresses) where the rule-declared `redact` is the primary control; the compiler rejects branch-level `redact` and skips
-a file with duplicate rule ids (#624), and the multi-file loader skips a later file that re-declares
-an id an earlier file already claimed (#633 — cross-file `byId` redact-lookup shadow, fail-closed;
-a no-op on today's prefix-namespaced assets, hardening the #192/#639 multi-file + CDN path).
+#632, incl. `actionLabels` — #666) that ships a customer-PII marker a rule forgot to redact; the
+marker SSOT is cross-platform DATA ("Deliver to "/"Message from " for DoorDash, "Leave the order at
+"/"Meet at door for " for Uber pushes, #585 — not DoorDash-only), with a documented residual for
+shapes a prefix scan can't own (a name-at-start body, and store-ambiguous prefixes like Uber's
+"Going to " that precede stores AND addresses) where the rule-declared `redact` is the primary
+control; the compiler rejects branch-level `redact` and skips a file with duplicate rule ids (#624),
+and the multi-file loader skips a later file that re-declares an id an earlier file already claimed
+(#633 — cross-file `byId` redact-lookup shadow, fail-closed; a no-op on today's prefix-namespaced
+assets, hardening the #192/#639 multi-file + CDN path). `RawNotificationData.textFields()` (#666) is
+the SSOT enumeration of the 5 flat notif text fields (title/text/bigText/tickerText/subText) —
+`toFullString`/`contentHash`, `CompiledNotifRedact`, and `CustomerTextMarkers`'s notif path all
+iterate it instead of hand-listing the fields, so a field added to the model can't silently miss a
+scrub site; the UNKNOWN-notification `SensitiveTextMarkers` scan and the `CustomerTextMarkers`
+backstop both also scan `actionLabels` now (#666) — a push action button label is serialized into
+the envelope the same as the text fields and was previously excluded from every scrub layer.
 UNKNOWN frames and UNKNOWN clicks remain the documented
 debug-only exception (behind the release `NoOpCaptureBus` #346 + the `SensitiveTextMarkers`
 backstop); the id-less building-name line residual is still tracked. `PipelineV2.events` is a HOT `shareIn` stream — one upstream pass feeds

--- a/app/src/test/java/cloud/trotter/dashbuddy/test/util/SnapshotRedactor.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/test/util/SnapshotRedactor.kt
@@ -1,5 +1,6 @@
 package cloud.trotter.dashbuddy.test.util
 
+import cloud.trotter.dashbuddy.domain.model.notification.NotifTextField
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
@@ -120,10 +121,13 @@ object SnapshotRedactor {
     private fun collectNotif(o: JsonObject, repl: MutableMap<String, String>) {
         val isChat = (o["channelId"]?.jsonPrimitive?.content?.contains("inapp-chat") == true) ||
             (o["title"]?.jsonPrimitive?.content?.startsWith("Message from") == true)
-        for (k in listOf("title", "text", "bigText", "tickerText", "subText")) {
+        // #666: iterate the production RawNotificationData.textFields() wire-name
+        // SSOT instead of hand-listing title/text/bigText/tickerText/subText.
+        for (field in NotifTextField.entries) {
+            val k = field.wire
             val v = o[k] as? JsonPrimitive ?: continue
             if (!v.isString) continue
-            val red = if (isChat && k != "title") MASK else scrub(v.content, false)
+            val red = if (isChat && field != NotifTextField.TITLE) MASK else scrub(v.content, false)
             record(v.content, red, repl)
         }
     }

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CaptureWriter.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CaptureWriter.kt
@@ -181,9 +181,14 @@ class CaptureWriter @Inject constructor(
         raw: RawNotificationData,
     ): Observation.Notification {
         // Same fail-closed backstop as captureScreen (#432) for UNKNOWN
-        // notification bodies.
+        // notification bodies. Scans the flat text fields AND actionLabels
+        // (#666 item 2c — a push action button label is serialized into the
+        // envelope same as the text fields and was previously excluded from
+        // this scan, so an UNKNOWN notification with a sensitive marker ONLY in
+        // an action label would have shipped uncaught).
         if (obs.target == UNKNOWN_TARGET) {
             val marker = SensitiveTextMarkers.findMarker(raw.toFullString())
+                ?: raw.actionLabels.firstNotNullOfOrNull { SensitiveTextMarkers.findMarker(it) }
             if (marker != null) {
                 stats.onScrubbedUnknownCapture()
                 Timber.w("Capture scrubbed: UNKNOWN notification hit sensitive marker '%s'", marker)

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CustomerTextMarkers.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CustomerTextMarkers.kt
@@ -101,32 +101,38 @@ object CustomerTextMarkers {
     // Notification captures are FLAT fields, not a UiNode tree — so a hit scrubs
     // the WHOLE offending field (there are no children to isolate). Same
     // already-redacted skip (VET V1) and same marker SSOT as the screen path.
+    // Text fields iterate the #666 RawNotificationData.textFields() SSOT rather
+    // than hand-listing title/text/bigText/tickerText/subText.
 
     /**
      * The first un-redacted customer marker across [raw]'s flat text fields
-     * (title/text/bigText/tickerText/subText), or null when clean. Cheap scan run
-     * on every recognized notification capture; the [scrubNotif] copy is built
-     * only on a hit.
+     * (title/text/bigText/tickerText/subText, via [RawNotificationData.textFields])
+     * OR its `actionLabels` (#666 item 2 — a push action button label is
+     * serialized into the envelope same as the text fields and was previously
+     * excluded from this scan), or null when clean. Cheap scan run on every
+     * recognized notification capture; the [scrubNotif] copy is built only on
+     * a hit.
      */
     fun firstUnredactedMarkerInNotif(raw: RawNotificationData): String? =
-        notifFields(raw).firstNotNullOfOrNull { unredactedMarker(it) }
+        raw.textFields().firstNotNullOfOrNull { (_, value) -> unredactedMarker(value) }
+            ?: raw.actionLabels.firstNotNullOfOrNull { unredactedMarker(it) }
 
     /**
-     * A copy of [raw] with every flat field carrying an un-redacted customer
-     * marker scrubbed WHOLE to [CompiledRedact.REDACTED]. Call only after
-     * [firstUnredactedMarkerInNotif] returned non-null.
+     * A copy of [raw] with every flat text field AND every action label carrying
+     * an un-redacted customer marker scrubbed WHOLE to [CompiledRedact.REDACTED].
+     * Call only after [firstUnredactedMarkerInNotif] returned non-null.
+     * `actionLabels` is intentionally scrubbed here (not folded into
+     * [RawNotificationData.textFields]) since it isn't part of
+     * [RawNotificationData.toFullString]/`contentHash` — the dedup identity must
+     * stay stable regardless of action-label scrubbing.
      */
-    fun scrubNotif(raw: RawNotificationData): RawNotificationData = raw.copy(
-        title = scrubField(raw.title),
-        text = scrubField(raw.text),
-        bigText = scrubField(raw.bigText),
-        tickerText = scrubField(raw.tickerText),
-        subText = scrubField(raw.subText),
-    )
-
-    private fun notifFields(raw: RawNotificationData): List<String?> =
-        listOf(raw.title, raw.text, raw.bigText, raw.tickerText, raw.subText)
+    fun scrubNotif(raw: RawNotificationData): RawNotificationData = raw
+        .withTextFields(raw.textFields().associate { (field, value) -> field to scrubField(value) })
+        .copy(actionLabels = raw.actionLabels.map { scrubActionLabel(it) })
 
     private fun scrubField(field: String?): String? =
         if (unredactedMarker(field) != null) CompiledRedact.REDACTED else field
+
+    private fun scrubActionLabel(label: String): String =
+        if (unredactedMarker(label) != null) CompiledRedact.REDACTED else label
 }

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/CompiledRules.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/CompiledRules.kt
@@ -1,6 +1,7 @@
 package cloud.trotter.dashbuddy.core.pipeline.rules
 
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import cloud.trotter.dashbuddy.domain.model.notification.NotifTextField
 import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData
 import cloud.trotter.dashbuddy.domain.pipeline.RequestedEffect
 import cloud.trotter.dashbuddy.domain.pipeline.TransitionTrigger
@@ -90,23 +91,10 @@ data class CompiledRule<TInput>(
     val notifRedact: CompiledNotifRedact = CompiledNotifRedact.EMPTY,
 )
 
-/** The notification fields a [CompiledNotifRedact] can mask (#620). */
-enum class NotifField(val wire: String) {
-    TITLE("title"),
-    TEXT("text"),
-    BIG_TEXT("bigText"),
-    TICKER_TEXT("tickerText"),
-    SUB_TEXT("subText"),
-    ;
-
-    companion object {
-        fun fromWire(wire: String): NotifField? = entries.firstOrNull { it.wire == wire }
-    }
-}
-
 /**
  * A per-field notification redact masker (#620). Notifications are flat strings
- * (no tree), so masking is keyed by field name rather than a node predicate.
+ * (no tree), so masking is keyed by field name ([NotifTextField], the #666 SSOT
+ * on [RawNotificationData]) rather than a node predicate.
  */
 sealed interface NotifFieldMask {
     /** Mask the whole field value, preserving an optional leading [keepPrefix]. */
@@ -129,24 +117,21 @@ sealed interface NotifFieldMask {
  * `[redacted:<4hex>]` distinctness + fail-closed contract as screen redaction.
  */
 data class CompiledNotifRedact(
-    val fields: Map<NotifField, NotifFieldMask>,
+    val fields: Map<NotifTextField, NotifFieldMask>,
 ) {
     fun isEmpty(): Boolean = fields.isEmpty()
 
     /**
      * Return a masked COPY of [raw] for envelope serialization. The original is
      * never mutated; callers must read the dedup `contentHash` off the ORIGINAL
-     * (a masked copy recomputes a different hash).
+     * (a masked copy recomputes a different hash). Iterates the #666
+     * [RawNotificationData.textFields] SSOT rather than hand-listing the 5 fields.
      */
-    fun apply(raw: RawNotificationData): RawNotificationData = raw.copy(
-        title = maskField(NotifField.TITLE, raw.title),
-        text = maskField(NotifField.TEXT, raw.text),
-        bigText = maskField(NotifField.BIG_TEXT, raw.bigText),
-        tickerText = maskField(NotifField.TICKER_TEXT, raw.tickerText),
-        subText = maskField(NotifField.SUB_TEXT, raw.subText),
+    fun apply(raw: RawNotificationData): RawNotificationData = raw.withTextFields(
+        raw.textFields().associate { (field, value) -> field to maskField(field, value) },
     )
 
-    private fun maskField(field: NotifField, value: String?): String? {
+    private fun maskField(field: NotifTextField, value: String?): String? {
         if (value == null) return null
         return when (val m = fields[field]) {
             null -> value

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompiler.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompiler.kt
@@ -1,6 +1,7 @@
 package cloud.trotter.dashbuddy.core.pipeline.rules
 
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import cloud.trotter.dashbuddy.domain.model.notification.NotifTextField
 import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData
 import cloud.trotter.dashbuddy.domain.state.Flow
 import cloud.trotter.dashbuddy.domain.state.Mode
@@ -202,10 +203,10 @@ object RuleCompiler {
      */
     private fun compileNotifRedactBlock(obj: JsonObject): CompiledNotifRedact {
         val fields = obj.entries.associate { (fieldName, spec) ->
-            val field = NotifField.fromWire(fieldName)
+            val field = NotifTextField.fromWire(fieldName)
                 ?: throw RuleCompileException(
                     "notification redact: unknown field '$fieldName' " +
-                        "(expected one of ${NotifField.entries.map { it.wire }})",
+                        "(expected one of ${NotifTextField.entries.map { it.wire }})",
                 )
             val specObj = spec as? JsonObject
                 ?: throw RuleCompileException(

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureScrubTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureScrubTest.kt
@@ -6,6 +6,7 @@ import cloud.trotter.dashbuddy.core.pipeline.rules.NoRedaction
 import cloud.trotter.dashbuddy.domain.capture.CaptureBus
 import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
 import cloud.trotter.dashbuddy.domain.pipeline.UNKNOWN_TARGET
 import cloud.trotter.dashbuddy.domain.state.ParsedFields
@@ -116,6 +117,47 @@ class CaptureScrubTest {
             PipelineEvent.Click(timestamp = 1_000L, node = benign, packageName = "com.doordash.driverapp"),
             screenTarget = null,
         )
+
+        verify(captureBus, times(1)).offer(any(), any(), anyOrNull(), any(), any(), anyOrNull())
+        assertEquals(0L, stats.scrubbedUnknownCaptureCount)
+    }
+
+    // #666 item 2c: the UNKNOWN-notification backstop must scan actionLabels too —
+    // previously only the flat text fields (title/text/bigText/tickerText/subText)
+    // were scanned, so a sensitive marker living ONLY in a push action button label
+    // (e.g. a future "Cash out" quick-action) would have shipped uncaught.
+
+    private fun unknownNotifObs() = Observation.Notification(
+        timestamp = 1_000L,
+        captureId = null,
+        ruleId = null,
+        metadata = ReplayMetadata.EMPTY,
+        flow = null,
+        modeHint = null,
+        parsed = ParsedFields.None,
+        target = UNKNOWN_TARGET,
+    )
+
+    private fun rawNotif(title: String? = null, actionLabels: List<String> = emptyList()) =
+        RawNotificationData(
+            title = title, text = null, tickerText = null, bigText = null,
+            packageName = "com.doordash.driverapp", postTime = 0L, isClearable = true,
+            actionLabels = actionLabels,
+        )
+
+    @Test
+    fun `UNKNOWN notification with a sensitive marker ONLY in an action label is scrubbed`() {
+        val toxic = rawNotif(title = "New promo", actionLabels = listOf("Cash out"))
+        writer.captureNotification(unknownNotifObs(), toxic)
+
+        verify(captureBus, never()).offer(any(), any(), anyOrNull(), any(), any(), anyOrNull())
+        assertEquals(1L, stats.scrubbedUnknownCaptureCount)
+    }
+
+    @Test
+    fun `benign UNKNOWN notification with clean action labels still captures for triage`() {
+        val benign = rawNotif(title = "New promo", actionLabels = listOf("Accept", "Decline"))
+        writer.captureNotification(unknownNotifObs(), benign)
 
         verify(captureBus, times(1)).offer(any(), any(), anyOrNull(), any(), any(), anyOrNull())
         assertEquals(0L, stats.scrubbedUnknownCaptureCount)

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CustomerTextMarkersTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CustomerTextMarkersTest.kt
@@ -124,6 +124,39 @@ class CustomerTextMarkersTest {
         assertNull(CustomerTextMarkers.firstUnredactedMarkerInNotif(notif(text = "Your delivery from H-E-B")))
     }
 
+    // --- actionLabels (#666 item 2) -------------------------------------------
+
+    @Test
+    fun `a customer-marker action label is detected and scrubbed, a clean label is untouched`() {
+        val raw = notif(title = "New order").copy(
+            actionLabels = listOf("Message from Jane", "Dismiss"),
+        )
+        assertEquals("Message from ", CustomerTextMarkers.firstUnredactedMarkerInNotif(raw))
+
+        val scrubbed = CustomerTextMarkers.scrubNotif(raw)
+        assertEquals("[redacted]", scrubbed.actionLabels[0])
+        assertEquals("Dismiss", scrubbed.actionLabels[1])
+        // Text fields untouched (marker was only in the action label).
+        assertEquals("New order", scrubbed.title)
+        // Clean after scrub.
+        assertNull(CustomerTextMarkers.firstUnredactedMarkerInNotif(scrubbed))
+    }
+
+    @Test
+    fun `action labels with no marker are left untouched`() {
+        val raw = notif(title = "New order").copy(actionLabels = listOf("Accept", "Decline"))
+        assertNull(CustomerTextMarkers.firstUnredactedMarkerInNotif(raw))
+        val scrubbed = CustomerTextMarkers.scrubNotif(raw)
+        assertEquals(listOf("Accept", "Decline"), scrubbed.actionLabels)
+    }
+
+    @Test
+    fun `firstUnredactedMarkerInNotif checks text fields before action labels`() {
+        val raw = notif(title = "Deliver to Jane").copy(actionLabels = listOf("Message from Bob"))
+        // Text-field marker found first (order doesn't affect correctness, but pins behavior).
+        assertEquals("Deliver to ", CustomerTextMarkers.firstUnredactedMarkerInNotif(raw))
+    }
+
     @Test
     fun `no-lead-in customer shapes are the documented residual the rule redact owns`() {
         // Uber trip_en_route_dropoff title is a WHOLE address with NO lead-in marker —

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/NotificationRedactionTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/NotificationRedactionTest.kt
@@ -52,10 +52,11 @@ class NotificationRedactionTest {
         bigText: String? = null,
         tickerText: String? = null,
         channelId: String? = null,
+        actionLabels: List<String> = emptyList(),
     ) = RawNotificationData(
         title = title, text = text, bigText = bigText, tickerText = tickerText,
         packageName = "com.doordash.driverapp", postTime = 0L, isClearable = true,
-        channelId = channelId,
+        channelId = channelId, actionLabels = actionLabels,
     )
 
     private fun obs(ruleId: String?, target: String?) = Observation.Notification(
@@ -257,6 +258,53 @@ class NotificationRedactionTest {
         // Honest residual: the prefix backstop does NOT fire here; the rule's
         // `redact { title {} }` is the primary control for this shape.
         assertEquals(0L, stats.notifRedactBackstopScrubCount)
+    }
+
+    // --- actionLabels (#666 item 2b) -------------------------------------------
+    // actionLabels was serialized into every notif envelope but excluded from the
+    // #632 backstop scan entirely. A recognized notification whose rule forgot to
+    // redact a customer-PII marker living in an action label must still be caught.
+
+    @Test
+    fun `#632 backstop scrubs a marker-bearing action label`() {
+        whenever(captureBus.offer(any(), any(), anyOrNull(), any(), any(), anyOrNull())).thenReturn("cap-1")
+        val leak = raw(title = "New message", actionLabels = listOf("Message from Jennifer", "Dismiss"))
+        writer(noRedactSource)
+            .captureNotification(obs("doordash.notification.customer_message", "customer_message"), leak)
+
+        val json = capturedEnvelope()
+        assertFalse("leaked name gone", json.contains("Jennifer"))
+        assertTrue("action label scrubbed whole", json.contains("[redacted]"))
+        assertTrue("clean sibling label kept", json.contains("Dismiss"))
+        assertEquals(1L, stats.notifRedactBackstopScrubCount)
+    }
+
+    @Test
+    fun `#632 backstop leaves clean action labels untouched`() {
+        whenever(captureBus.offer(any(), any(), anyOrNull(), any(), any(), anyOrNull())).thenReturn("cap-1")
+        val benign = raw(title = "You have a new order!", actionLabels = listOf("Accept", "Decline"))
+        writer(noRedactSource)
+            .captureNotification(obs("doordash.notification.new_order", "new_order"), benign)
+
+        val json = capturedEnvelope()
+        assertTrue(json.contains("Accept"))
+        assertTrue(json.contains("Decline"))
+        assertEquals(0L, stats.notifRedactBackstopScrubCount)
+    }
+
+    @Test
+    fun `#632 backstop action-label scrub preserves the ORIGINAL contentHash`() {
+        whenever(captureBus.offer(any(), any(), anyOrNull(), any(), any(), anyOrNull())).thenReturn("cap-1")
+        val leak = raw(title = "New message", actionLabels = listOf("Message from Jennifer"))
+        val originalHash = leak.contentHash
+        writer(noRedactSource)
+            .captureNotification(obs("doordash.notification.customer_message", "customer_message"), leak)
+
+        val hashCap = argumentCaptor<Int?>()
+        org.mockito.kotlin.verify(captureBus).offer(any(), any(), anyOrNull(), any(), any(), hashCap.capture())
+        // actionLabels are NOT part of toFullString()/contentHash — scrubbing one
+        // must not perturb the dedup identity.
+        assertEquals("dedup identity stays the ORIGINAL raw hash", originalHash, hashCap.lastValue)
     }
 
     @Test

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/notification/RawNotificationData.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/notification/RawNotificationData.kt
@@ -19,9 +19,65 @@ data class RawNotificationData(
     val channelId: String? = null,
     val actionLabels: List<String> = emptyList(),
 ) {
+    /**
+     * SSOT enumeration of the notification's 5 flat text fields (#666/F3). Every
+     * scrub/redact/serialize site that needs "all the text fields" iterates THIS
+     * instead of hand-listing title/text/bigText/tickerText/subText — a field
+     * added here is covered by every reader automatically, and one missed by a
+     * caller is a compile-visible gap rather than a silent leak channel.
+     *
+     * Order is significant: [toFullString] joins in this exact order, and that
+     * join is the input to [contentHash] (CaptureBus dedup identity) — changing
+     * the order or membership here changes historical dedup behavior.
+     */
+    fun textFields(): List<Pair<NotifTextField, String?>> = listOf(
+        NotifTextField.TITLE to title,
+        NotifTextField.TEXT to text,
+        NotifTextField.BIG_TEXT to bigText,
+        NotifTextField.TICKER_TEXT to tickerText,
+        NotifTextField.SUB_TEXT to subText,
+    )
+
+    /**
+     * Return a copy with every text field replaced per [fields] (must supply a
+     * value — possibly unchanged — for every [NotifTextField]; typically built
+     * from a transform over [textFields]). This `copy(...)` call is the ONE
+     * place that enumerates the 5 fields for writing; [textFields] is the one
+     * place that enumerates them for reading.
+     */
+    fun withTextFields(fields: Map<NotifTextField, String?>): RawNotificationData = copy(
+        title = fields.getValue(NotifTextField.TITLE),
+        text = fields.getValue(NotifTextField.TEXT),
+        bigText = fields.getValue(NotifTextField.BIG_TEXT),
+        tickerText = fields.getValue(NotifTextField.TICKER_TEXT),
+        subText = fields.getValue(NotifTextField.SUB_TEXT),
+    )
+
     fun toFullString(): String =
-        listOfNotNull(title, text, bigText, tickerText, subText).joinToString(" | ")
+        textFields().mapNotNull { it.second }.joinToString(" | ")
 
     /** Content hash for CaptureBus dedup — identical text content deduplicates per session. */
     val contentHash: Int get() = toFullString().hashCode()
+}
+
+/**
+ * The 5 flat text fields [RawNotificationData] carries (#666) — the wire-string
+ * vocabulary shared by the notification `redact` rule DSL (`RuleCompiler`/
+ * `CompiledNotifRedact` in `:core:pipeline`) and every text-field scrub backstop
+ * (`CustomerTextMarkers`, [RawNotificationData.textFields]/[RawNotificationData.withTextFields]).
+ * `actionLabels` is a separate list field, deliberately NOT a member here — it
+ * is not part of [RawNotificationData.toFullString]/`contentHash` (dedup
+ * identity must stay stable) and is scrubbed by its own path (#666 item 2).
+ */
+enum class NotifTextField(val wire: String) {
+    TITLE("title"),
+    TEXT("text"),
+    BIG_TEXT("bigText"),
+    TICKER_TEXT("tickerText"),
+    SUB_TEXT("subText"),
+    ;
+
+    companion object {
+        fun fromWire(wire: String): NotifTextField? = entries.firstOrNull { it.wire == wire }
+    }
 }

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/model/notification/RawNotificationDataTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/model/notification/RawNotificationDataTest.kt
@@ -1,0 +1,148 @@
+package cloud.trotter.dashbuddy.domain.model.notification
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import kotlin.reflect.full.memberProperties
+import kotlin.reflect.typeOf
+
+/**
+ * #666 (F3) — pins the [RawNotificationData.textFields] SSOT anchor:
+ *
+ * 1. [textFields] must enumerate EVERY nullable `String?` property declared on
+ *    [RawNotificationData] (reflection-checked, so a future field added to the
+ *    model without a matching [NotifTextField] member fails this test loudly
+ *    instead of silently skipping a scrub/serialize site).
+ * 2. [RawNotificationData.toFullString] must stay BYTE-IDENTICAL to the
+ *    pre-#666 hand-written `listOfNotNull(title, text, bigText, tickerText,
+ *    subText).joinToString(" | ")` implementation — this is the CaptureBus
+ *    dedup identity ([RawNotificationData.contentHash]); a join-order or
+ *    membership change would silently break historical dedup.
+ */
+class RawNotificationDataTest {
+
+    private fun fullFixture() = RawNotificationData(
+        title = "Order ready",
+        text = "Deliver to Jane Q Doe",
+        tickerText = "New message",
+        bigText = "Your order is ready for pickup",
+        subText = "DoorDash",
+        packageName = "com.dd.doordash",
+        postTime = 1_000L,
+        isClearable = true,
+        isOngoing = false,
+        category = "msg",
+        channelId = "chat",
+        actionLabels = listOf("Reply", "Dismiss"),
+    )
+
+    private fun partialFixture() = RawNotificationData(
+        title = "Order ready",
+        text = null,
+        tickerText = null,
+        bigText = null,
+        subText = null,
+        packageName = "com.dd.doordash",
+        postTime = 1_000L,
+        isClearable = true,
+    )
+
+    /**
+     * `category`/`channelId` are also nullable `String?` fields but are notification
+     * METADATA (a channel/category identifier), not display TEXT that could carry
+     * customer PII or belongs in [RawNotificationData.toFullString] — they are
+     * deliberately excluded from the [NotifTextField] anchor. This is the ONE place
+     * that documents the exclusion; every OTHER nullable `String?` field must appear
+     * in [NotifTextField], so a newly added display-text field either gets added here
+     * (a conscious exclusion, reviewed) or fails this test until it's added to the anchor.
+     */
+    private val nonTextNullableStringFields = setOf("category", "channelId")
+
+    @Test
+    fun `every nullable String text field is covered by NotifTextField`() {
+        val stringOptionalType = typeOf<String?>()
+        val nullableStringProps: Set<String> = RawNotificationData::class.memberProperties
+            .filter { it.returnType == stringOptionalType }
+            .map { it.name }
+            .filterNot { it in nonTextNullableStringFields }
+            .toSortedSet()
+
+        val enumeratedByAnchor: Set<String> = NotifTextField.entries.map { it.wire }.toSortedSet()
+
+        assertEquals(
+            "RawNotificationData gained/lost a String? text field that isn't reflected in NotifTextField " +
+                "(the #666 textFields() SSOT anchor) — every String? text field must have a matching member " +
+                "(or be added to nonTextNullableStringFields above with a documented reason).",
+            nullableStringProps,
+            enumeratedByAnchor,
+        )
+    }
+
+    @Test
+    fun `textFields returns every field keyed by its NotifTextField in toFullString order`() {
+        val raw = fullFixture()
+        assertEquals(
+            listOf(
+                NotifTextField.TITLE to raw.title,
+                NotifTextField.TEXT to raw.text,
+                NotifTextField.BIG_TEXT to raw.bigText,
+                NotifTextField.TICKER_TEXT to raw.tickerText,
+                NotifTextField.SUB_TEXT to raw.subText,
+            ),
+            raw.textFields(),
+        )
+    }
+
+    @Test
+    fun `withTextFields replaces exactly the supplied fields`() {
+        val raw = fullFixture()
+        val updated = raw.withTextFields(
+            raw.textFields().associate { (field, value) ->
+                field to if (field == NotifTextField.TITLE) "[redacted]" else value
+            },
+        )
+        assertEquals("[redacted]", updated.title)
+        assertEquals(raw.text, updated.text)
+        assertEquals(raw.bigText, updated.bigText)
+        assertEquals(raw.tickerText, updated.tickerText)
+        assertEquals(raw.subText, updated.subText)
+        // Non-text fields untouched.
+        assertEquals(raw.actionLabels, updated.actionLabels)
+        assertEquals(raw.packageName, updated.packageName)
+    }
+
+    @Test
+    fun `toFullString is byte-identical to the pre-666 hand-written implementation - full fixture`() {
+        val raw = fullFixture()
+        val legacy = legacyToFullString(raw)
+        assertEquals(legacy, raw.toFullString())
+        // Pin the literal too, so a future refactor can't silently drift both sides together.
+        assertEquals(
+            "Order ready | Deliver to Jane Q Doe | Your order is ready for pickup | New message | DoorDash",
+            raw.toFullString(),
+        )
+    }
+
+    @Test
+    fun `toFullString is byte-identical to the pre-666 hand-written implementation - partial fixture`() {
+        val raw = partialFixture()
+        val legacy = legacyToFullString(raw)
+        assertEquals(legacy, raw.toFullString())
+        assertEquals("Order ready", raw.toFullString())
+    }
+
+    @Test
+    fun `contentHash is unaffected by non-text fields`() {
+        val raw = fullFixture()
+        val sameTextDifferentMeta = raw.copy(
+            packageName = "com.uber.driver",
+            postTime = 2_000L,
+            channelId = "other",
+            actionLabels = emptyList(),
+        )
+        assertEquals(raw.contentHash, sameTextDifferentMeta.contentHash)
+    }
+
+    /** The EXACT pre-#666 implementation, kept only as a regression oracle. */
+    private fun legacyToFullString(raw: RawNotificationData): String =
+        listOfNotNull(raw.title, raw.text, raw.bigText, raw.tickerText, raw.subText).joinToString(" | ")
+}


### PR DESCRIPTION
Closes #666. Two LOW hardening items from the #665 fable security review of #632.

## Item 1 — `textFields()` SSOT anchor

Added `RawNotificationData.textFields(): List<Pair<NotifTextField, String?>>` and
`RawNotificationData.withTextFields(Map<NotifTextField, String?>)` in `:domain`
(`domain/.../model/notification/RawNotificationData.kt`) as the ONE enumeration
of the 5 flat notif text fields (title/text/bigText/tickerText/subText). Grounded
the hand-maintained sites first (grepped all 5 field names together) and refactored
every one onto the anchor:

- `RawNotificationData.toFullString()` — now `textFields().mapNotNull { it.second }.joinToString(" | ")`.
- `CompiledNotifRedact.apply()` (`:core:pipeline/rules/CompiledRules.kt`) — now iterates
  `raw.textFields()` and rebuilds via `withTextFields(...)` instead of hand-listing 5 `copy(...)` args.
  Also **deleted the duplicate `NotifField` enum** that lived in `:core:pipeline` and pointed
  `RuleCompiler.compileNotifRedactBlock` at the new domain `NotifTextField` (same wire strings,
  same `fromWire`) — one enum instead of two near-identical ones.
- `CustomerTextMarkers.firstUnredactedMarkerInNotif`/`scrubNotif` (`:core:pipeline/CustomerTextMarkers.kt`)
  — now iterate `textFields()`/`withTextFields()` instead of a private hand-listed `notifFields()` helper.
- `SnapshotRedactor` (`app/src/test/.../test/util/SnapshotRedactor.kt`, test-only corpus fixture tool) —
  iterates `NotifTextField.entries` instead of a hardcoded `listOf("title", "text", ...)`.

**Not touched** (grounded, judged out of scope): `RawNotificationSchema`'s `RawNotificationDto`
(`:domain/capture/schema/`) enumerates ALL 13 `RawNotificationData` fields (not just the 5 text
ones) because `kotlinx.serialization` `@Serializable` data classes need literal named parameters —
it isn't a "scrub list," it's a 1:1 passthrough serializer, so folding it onto the anchor would be
partial and not actually reduce risk. `NotificationMapper` (Android extras → `RawNotificationData`)
also wasn't touched — each field pulls from a distinct Android API (`android.title`, `android.bigText`,
`tickerText` from `Notification` itself, ...) so there's no list to iterate, only distinct extraction
expressions. `RuleCompiler.readNotificationField` (the `from:` parse-expression field reader, a
`when(field)` string switch used for a different purpose — reading a value for `parse`, not
scrubbing) also includes a `"fullString"` pseudo-field that doesn't fit the enum shape; left as-is,
noted here as a candidate for a future pass if it starts drifting from `NotifTextField`.

**`toFullString()`/`contentHash` byte-compat**: pinned by
`RawNotificationDataTest` (`:domain`) — a literal-string assertion plus a diff against the exact
pre-#666 `listOfNotNull(title, text, bigText, tickerText, subText).joinToString(" | ")`
implementation, for both a fully-populated and a partial fixture. Order/membership/join format
are unchanged, so CaptureBus dedup identity for existing captures is preserved.

## Item 2 — `actionLabels` scrubbing

`actionLabels` is serialized into every notif envelope (`RawNotificationDto.actionLabels`) but was
excluded from every scrub layer. Fail-closed fix, scope kept tight per the issue:

- **(a) Rule-declared `notifRedact` vocabulary — deliberately NOT added.** No rule surfaces
  customer PII in an action label today; adding a vocabulary field with no consumer is premature.
  Deferred until a rule actually needs it.
- **(b) The #632 `CustomerTextMarkers` backstop** — `firstUnredactedMarkerInNotif` now also scans
  `raw.actionLabels`, and `scrubNotif` scrubs any label carrying an un-redacted marker to
  `[redacted]` (whole-label scrub, same as a flat field — action labels have no structure to
  partially mask). Wired through the existing `CaptureWriter.captureNotification` backstop path, so
  it shares the same `stats.notifRedactBackstopScrubCount` counter and `Timber.w` log line as the
  text-field backstop (#632's existing WARN semantics — marker + ruleId logged, never the leaked value).
- **(c) UNKNOWN-notification path** — grounded that UNKNOWN notification envelopes are scrubbed by
  `SensitiveTextMarkers.findMarker(raw.toFullString())` in `CaptureWriter.captureNotification`, which
  also did not scan `actionLabels`. Extended it: `SensitiveTextMarkers.findMarker(raw.toFullString())
  ?: raw.actionLabels.firstNotNullOfOrNull { SensitiveTextMarkers.findMarker(it) }` — same
  drop-the-whole-capture behavior as the existing UNKNOWN backstop, same `scrubbedUnknownCaptureCount` counter.
- **contentHash stays the ORIGINAL raw hash** — verified `actionLabels` is not (and remains not) part
  of `textFields()`/`toFullString()`, so scrubbing an action label never perturbs the CaptureBus dedup
  identity (pinned by a new test asserting `contentHash` is unchanged after an action-label scrub).

## Tests

- `RawNotificationDataTest` (`:domain`, new): `textFields()` covers every `String?` TEXT field via
  reflection (with a documented, explicit exclusion list for `category`/`channelId` — nullable
  `String?` metadata fields that are NOT display text and were never part of the old
  `toFullString`), `toFullString()` byte-identical to the pre-#666 implementation for a full +
  partial fixture (both a diff-against-legacy-impl assertion and a pinned literal), `contentHash`
  unaffected by non-text field changes.
- `CustomerTextMarkersTest` (`:core:pipeline`, extended): a marker-bearing action label is detected
  + scrubbed to `[redacted]` while a clean sibling label and the text fields are untouched; a
  clean-labels-only notif is unchanged; text-field markers are found ahead of action-label markers.
- `NotificationRedactionTest` (`:core:pipeline`, extended): the #632 backstop scrubs a
  Message-from-style marker living in an action label via the full `CaptureWriter` path, leaves clean
  labels untouched, and preserves the original `contentHash` — consistent with the existing
  text-field backstop test shapes in the same file.
- `CaptureScrubTest` (`:core:pipeline`, extended): a new UNKNOWN-notification pair of tests — a
  sensitive marker living ONLY in an action label drops the whole capture
  (`scrubbedUnknownCaptureCount` +1, bus never offered), a benign notif with clean action labels
  still captures for triage.

Full suites GREEN (JAVA_HOME=java-25-openjdk):
- `:domain:test` — 270 tests, 0 failures.
- `:core:pipeline:testDebugUnitTest` — 249 tests, 0 failures.
- `:app:testDebugUnitTest` (incl. `AllMatchersSuite`'s member suites — `GoldenSnapshotRegressionTest`,
  `InboxProcessorTest`, etc.) — 903 tests, 0 failures.

### Design-goal review

- **Principle 5 (SSOT)** — this PR's whole point: one enumeration (`NotifTextField`/`textFields()`)
  replaces 3 hand-maintained field lists in production code (`toFullString`, `CompiledNotifRedact`,
  `CustomerTextMarkers`) plus one in test fixtures (`SnapshotRedactor`), and deletes a duplicate
  enum (`NotifField` in `:core:pipeline` folded into the domain `NotifTextField`).
- **Principle 6 (Security & privacy)** — closes two theoretical leak channels: a future rule/field
  that misses a scrub list (item 1, now structurally harder — the anchor lives on the model and
  every scrub site derives from it) and `actionLabels` bypassing all scrub layers (item 2, now
  covered by both the recognized-frame backstop and the UNKNOWN fail-closed scan). Both fixes are
  fail-closed (whole-field/whole-label scrub on any doubt, never a partial leak) and neither touches
  the dedup `contentHash` (verified unaffected — item 1 preserves byte-identical `toFullString`
  output, item 2's `actionLabels` was never part of it and stays that way).
- **Principle 7 (Logging)** — no new log sites; the existing `Timber.w` "Capture backstop: ... 
  scrubbing field from envelope" line at `CaptureWriter.captureNotification` now also fires for an
  action-label hit (still logs marker + ruleId only, never the leaked text — unchanged contract).
- **Principle 8 (Platform-agnostic core)** — no platform literals added; the marker set consulted is
  the existing cross-platform `CustomerTextMarkers.MARKERS` data (#585), unchanged by this PR — only
  the surfaces scanned (now including `actionLabels`) changed, not the vocabulary.

No field-test checklist item: this is a capture-internal (debug-only, `NoOpCaptureBus` release
binding) hardening fix with no on-dash-observable behavior — there's no screen, HUD, or dasher
interaction to watch for; the whole surface area is exercised by the unit tests above.

Orchestrator gates the adversarial `/code-review` + `/security-review` pass and merge at fable tier.
