### PR TITLE
feat(#319): CSV export of mileage & earnings (free-tier data-out)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -272,7 +272,13 @@ immutable) serves period economics (`SUM(netProfit)` frozen + `unattributedPay`;
 reported-total authoritative + the unattributed review flag; per-store; Monday-week boundaries via
 `PeriodBounds`, midnight-reactive) as Room-invalidation Flows to the home glance + the future Analytics hub
 (#315). Period totals are **read-side only** — they never re-enter the pure state machine (the dead
-`CrossPlatformRegion.PeriodTotals` fields were deleted). Follow-ups: #650 (drill-down + user corrections as
+`CrossPlatformRegion.PeriodTotals` fields were deleted). The free-tier **CSV export** (#319) is a second
+read-side consumer: `AnalyticsRepository.buildCsvExport` reads raw `deliveriesBetween`/`sessionsBetween`
+rows (row-level, bucketing-free — the driver's own records dumped, not session-anchored periods) and the
+pure `CsvExporter` (`:core:data`, RFC-4180 + machine `Csv`/`IrsMileage` primitives in `:domain`) formats
+deliveries/sessions/summary CSVs; the SAF directory-write edge is a `:app` ViewModel (Settings → Data &
+Privacy → Export Data). Merchant/store names are exported (driver-owned); customer/address hashes are
+excluded; no network. Follow-ups: #650 (drill-down + user corrections as
 `MANUAL_DELIVERY`/`PAY_ADJUSTMENT` events the projector folds — non-destructive, auditable), #653/#655.
 
 ## Development Principles

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/MainActivity.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/MainActivity.kt
@@ -28,6 +28,7 @@ import cloud.trotter.dashbuddy.ui.main.navigation.Screen
 import cloud.trotter.dashbuddy.ui.main.ratings.RatingsScreen
 import cloud.trotter.dashbuddy.ui.main.settings.AboutScreen
 import cloud.trotter.dashbuddy.ui.main.settings.EconomySettingsScreen
+import cloud.trotter.dashbuddy.ui.main.settings.DataExportScreen
 import cloud.trotter.dashbuddy.ui.main.settings.EvidenceSettingsScreen
 import cloud.trotter.dashbuddy.ui.main.settings.GeneralSettingsScreen
 import cloud.trotter.dashbuddy.ui.main.settings.PlatformSettingsScreen
@@ -117,6 +118,13 @@ class MainActivity : ComponentActivity() {
                         // 3. Evidence Locker
                         composable(Screen.EvidenceSettings.route) {
                             EvidenceSettingsScreen(
+                                onBack = { navController.popBackStack() }
+                            )
+                        }
+
+                        // 3a. Export Data (CSV, #319)
+                        composable(Screen.DataExport.route) {
+                            DataExportScreen(
                                 onBack = { navController.popBackStack() }
                             )
                         }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/navigation/DashBuddyRoutes.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/navigation/DashBuddyRoutes.kt
@@ -18,6 +18,7 @@ sealed class Screen(val route: String) {
     data object AboutSettings : Screen("settings/about")
     data object StrategySettings : Screen("settings/strategy")
     data object EvidenceSettings : Screen("settings/evidence")
+    data object DataExport : Screen("settings/data-export")
     data object EconomySettings : Screen("settings/economy")
     data object GeneralSettings : Screen("settings/general")
     data object DeveloperSettings : Screen("settings/developer")

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/DataExportScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/DataExportScreen.kt
@@ -1,0 +1,113 @@
+package cloud.trotter.dashbuddy.ui.main.settings
+
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.FileDownload
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+
+/**
+ * Free-tier CSV data export (#319). One folder pick → three CSVs (deliveries, sessions, summary)
+ * written into it. All-time export (v1); a date-range picker is a follow-up. Driver-owned data out,
+ * no network, no storage permission (Storage Access Framework grants the chosen folder only).
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DataExportScreen(
+    onBack: () -> Unit,
+    viewModel: DataExportViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    val pickFolder = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenDocumentTree()
+    ) { uri ->
+        if (uri != null) viewModel.export(uri)
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Export Data") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Column(Modifier.padding(padding).padding(horizontal = 16.dp)) {
+            Spacer(Modifier.height(8.dp))
+            Text(
+                "Export your mileage & earnings to CSV",
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Spacer(Modifier.height(8.dp))
+            Text(
+                "Pick a folder and DashBuddy writes three spreadsheet files into it:\n" +
+                    "• deliveries.csv — one row per delivery\n" +
+                    "• sessions.csv — one row per dash\n" +
+                    "• summary.csv — totals + estimated IRS mileage deduction\n\n" +
+                    "This is your own data, on-device — nothing is uploaded. Exports all history " +
+                    "(a date-range picker is coming later).",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(24.dp))
+
+            Button(
+                onClick = { viewModel.reset(); pickFolder.launch(null) },
+                enabled = state !is DataExportViewModel.ExportState.InProgress,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Icon(Icons.Default.FileDownload, contentDescription = null)
+                Spacer(Modifier.height(0.dp))
+                Text("  Choose folder & export")
+            }
+
+            Spacer(Modifier.height(16.dp))
+
+            when (val s = state) {
+                is DataExportViewModel.ExportState.InProgress -> {
+                    CircularProgressIndicator()
+                }
+                is DataExportViewModel.ExportState.Success -> {
+                    Text(
+                        "Exported ${s.filesWritten} files to the chosen folder.",
+                        color = MaterialTheme.colorScheme.primary,
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
+                is DataExportViewModel.ExportState.Error -> {
+                    Text(
+                        "Export failed: ${s.message}",
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
+                DataExportViewModel.ExportState.Idle -> Unit
+            }
+        }
+    }
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/DataExportViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/DataExportViewModel.kt
@@ -51,11 +51,14 @@ class DataExportViewModel @Inject constructor(
         _state.value = ExportState.InProgress
         viewModelScope.launch {
             val result = runCatching {
-                val bundle = analyticsRepository.buildCsvExport(
-                    zone = ZoneId.systemDefault(),
-                    generatedAtMillis = System.currentTimeMillis(),
-                )
-                withContext(ioDispatcher) { writeBundle(treeUri, bundle) }
+                // Whole build (DB reads + string assembly) AND write off the main thread.
+                withContext(ioDispatcher) {
+                    val bundle = analyticsRepository.buildCsvExport(
+                        zone = ZoneId.systemDefault(),
+                        generatedAtMillis = System.currentTimeMillis(),
+                    )
+                    writeBundle(treeUri, bundle)
+                }
             }
             _state.value = result.fold(
                 onSuccess = { count ->
@@ -63,7 +66,12 @@ class DataExportViewModel @Inject constructor(
                     ExportState.Success(count)
                 },
                 onFailure = { e ->
-                    Timber.tag("Export").e(e, "CSV export failed")
+                    // P7: ERROR ships in exported bug reports. Platform exception messages can
+                    // embed the SAF folder URI (a user-path), so log only the exception CLASS —
+                    // never the raw message/stack-message.
+                    Timber.tag("Export").e(
+                        "CSV export failed: %s", e.javaClass.simpleName
+                    )
                     ExportState.Error(e.message ?: "Export failed")
                 },
             )

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/DataExportViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/DataExportViewModel.kt
@@ -1,0 +1,122 @@
+package cloud.trotter.dashbuddy.ui.main.settings
+
+import android.content.Context
+import android.net.Uri
+import android.provider.DocumentsContract
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import cloud.trotter.dashbuddy.core.data.analytics.AnalyticsRepository
+import cloud.trotter.dashbuddy.core.data.analytics.CsvExporter
+import cloud.trotter.dashbuddy.domain.di.IoDispatcher
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+import java.time.ZoneId
+import javax.inject.Inject
+
+/**
+ * Drives the free-tier CSV export (#319). Reads the analytics read-model via [AnalyticsRepository],
+ * formats it with the pure [CsvExporter], and writes three files into a user-chosen directory
+ * (Storage Access Framework tree — no storage permission, no network). The formatting is pure and
+ * lives in the data/domain layers; only the SAF write IO is here at the edge.
+ *
+ * P7 logging: counts only — number of files written and byte totals are counters, never row
+ * contents; store/merchant names and any economics stay out of the log.
+ */
+@HiltViewModel
+class DataExportViewModel @Inject constructor(
+    private val analyticsRepository: AnalyticsRepository,
+    @param:ApplicationContext private val context: Context,
+    @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+) : ViewModel() {
+
+    sealed interface ExportState {
+        data object Idle : ExportState
+        data object InProgress : ExportState
+        data class Success(val filesWritten: Int) : ExportState
+        data class Error(val message: String) : ExportState
+    }
+
+    private val _state = MutableStateFlow<ExportState>(ExportState.Idle)
+    val state = _state.asStateFlow()
+
+    /** Export all-time analytics into the SAF directory [treeUri] as three CSV files. */
+    fun export(treeUri: Uri) {
+        if (_state.value == ExportState.InProgress) return
+        _state.value = ExportState.InProgress
+        viewModelScope.launch {
+            val result = runCatching {
+                val bundle = analyticsRepository.buildCsvExport(
+                    zone = ZoneId.systemDefault(),
+                    generatedAtMillis = System.currentTimeMillis(),
+                )
+                withContext(ioDispatcher) { writeBundle(treeUri, bundle) }
+            }
+            _state.value = result.fold(
+                onSuccess = { count ->
+                    Timber.tag("Export").i("CSV export wrote %d files", count)
+                    ExportState.Success(count)
+                },
+                onFailure = { e ->
+                    Timber.tag("Export").e(e, "CSV export failed")
+                    ExportState.Error(e.message ?: "Export failed")
+                },
+            )
+        }
+    }
+
+    fun reset() {
+        _state.value = ExportState.Idle
+    }
+
+    /** Writes the three CSVs into the tree, overwriting same-named files. Returns files written. */
+    private fun writeBundle(treeUri: Uri, bundle: CsvExporter.Bundle): Int {
+        val resolver = context.contentResolver
+        val treeDocId = DocumentsContract.getTreeDocumentId(treeUri)
+        val dirUri = DocumentsContract.buildDocumentUriUsingTree(treeUri, treeDocId)
+        var written = 0
+        listOf(
+            CsvExporter.DELIVERIES_FILENAME to bundle.deliveriesCsv,
+            CsvExporter.SESSIONS_FILENAME to bundle.sessionsCsv,
+            CsvExporter.SUMMARY_FILENAME to bundle.summaryCsv,
+        ).forEach { (name, content) ->
+            // Replace any prior export of the same name so re-exporting isn't cumulative clutter.
+            deleteIfExists(treeUri, treeDocId, name)
+            val fileUri = DocumentsContract.createDocument(resolver, dirUri, "text/csv", name)
+                ?: error("Could not create $name in the chosen folder")
+            resolver.openOutputStream(fileUri)?.use { out ->
+                out.write(content.toByteArray(Charsets.UTF_8))
+            } ?: error("Could not open $name for writing")
+            written++
+        }
+        return written
+    }
+
+    /** Best-effort delete of a prior same-named file in the tree so we overwrite, not duplicate. */
+    private fun deleteIfExists(treeUri: Uri, treeDocId: String, displayName: String) {
+        val resolver = context.contentResolver
+        val childrenUri = DocumentsContract.buildChildDocumentsUriUsingTree(treeUri, treeDocId)
+        runCatching {
+            resolver.query(
+                childrenUri,
+                arrayOf(
+                    DocumentsContract.Document.COLUMN_DOCUMENT_ID,
+                    DocumentsContract.Document.COLUMN_DISPLAY_NAME,
+                ),
+                null, null, null,
+            )?.use { cursor ->
+                while (cursor.moveToNext()) {
+                    if (cursor.getString(1) == displayName) {
+                        val childUri = DocumentsContract.buildDocumentUriUsingTree(treeUri, cursor.getString(0))
+                        DocumentsContract.deleteDocument(resolver, childUri)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/SettingsHomeScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/SettingsHomeScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.icons.filled.Apps
 import androidx.compose.material.icons.filled.AttachMoney
 import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material.icons.filled.FileDownload
 import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.RocketLaunch
@@ -124,6 +125,12 @@ fun SettingsHomeScreen(
                     title = "Evidence Locker",
                     subtitle = "Manage screenshots and logs",
                     onClick = { onNavigate(Screen.EvidenceSettings.route) }
+                )
+                SettingsNavItem(
+                    icon = Icons.Default.FileDownload,
+                    title = "Export Data (CSV)",
+                    subtitle = "Mileage & earnings for a spreadsheet or tax prep",
+                    onClick = { onNavigate(Screen.DataExport.route) }
                 )
             }
 

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
@@ -9,6 +9,7 @@ import cloud.trotter.dashbuddy.domain.analytics.SessionRecord
 import cloud.trotter.dashbuddy.domain.analytics.StoreEconomics
 import cloud.trotter.dashbuddy.domain.evaluation.NetProfit
 import cloud.trotter.dashbuddy.domain.state.Platform
+import java.time.ZoneId
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
@@ -102,6 +103,25 @@ class AnalyticsRepository @Inject constructor(
     /** Every delivery in a session, completion order (future #650 drill-down). */
     fun deliveriesForSession(sessionId: String): Flow<List<DeliveryRecord>> =
         analyticsDao.deliveriesForSession(sessionId).map { rows -> rows.map { it.toDomain() } }
+
+    /**
+     * Build the free-tier CSV export (#319) — deliveries / sessions / summary — for the raw rows in
+     * `[start, end)` (delivery `completedAt` / session `startedAt`). v1 exports all-time (the default
+     * full range). Pure formatting is delegated to [CsvExporter]; this only supplies the rows, the
+     * device [zone], and the export timestamp. Suspend, one-shot (not a Flow) — an export is a
+     * snapshot the driver takes, not a live surface. No PII: customer/address hashes are excluded by
+     * the exporter; store/merchant names are driver-owned and included.
+     */
+    suspend fun buildCsvExport(
+        zone: ZoneId,
+        generatedAtMillis: Long,
+        start: Long = Long.MIN_VALUE,
+        end: Long = Long.MAX_VALUE,
+    ): CsvExporter.Bundle {
+        val deliveries = analyticsDao.deliveriesBetween(start, end)
+        val sessions = analyticsDao.sessionsBetween(start, end)
+        return CsvExporter.export(deliveries, sessions, zone, generatedAtMillis)
+    }
 
     /**
      * Fold the DAO period rows into [PeriodEconomics]. Net is frozen (Σ delivery net +

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/CsvExporter.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/CsvExporter.kt
@@ -23,6 +23,13 @@ import java.time.ZoneId
  * ship them at all. No customer name/address ever existed in these rows (hashed at the edge), and
  * even the hashes stay home. No network path; SAF needs no permission.
  *
+ * **Untrusted-text posture:** store names (and the `?: wire` platform fallback) originate in
+ * third-party UI, so every text-typed cell routes through [Csv.textField], which neutralizes
+ * spreadsheet formula injection (a leading `=`/`+`/`-`/`@`/TAB/CR gets a `'` force-text prefix)
+ * on top of RFC-4180 quoting. Numeric/timestamp cells come from the [Csv] numeric emitters —
+ * program-generated `[-0-9.T:]` strings, safe by construction, left bare so `-2.50` stays
+ * machine-parseable.
+ *
  * Platform is registry-resolved to its display name via [Platform.fromWire] — never a raw wire
  * literal compared in logic (Principle 8).
  */
@@ -76,15 +83,15 @@ object CsvExporter {
 
     private fun deliveriesCsv(rows: List<DeliveryRecordEntity>, zone: ZoneId): String {
         val sb = StringBuilder()
-        sb.append(Csv.row(DELIVERY_HEADER)).append('\n')
+        sb.append(Csv.row(DELIVERY_HEADER.map { Csv.textField(it) })).append('\n')
         for (r in rows) {
             sb.append(
                 Csv.row(
                     listOf(
                         Csv.isoDate(r.completedAt, zone),
                         Csv.isoTime(r.completedAt, zone),
-                        platformName(r.platform),
-                        r.storeName,
+                        Csv.textField(platformName(r.platform)),
+                        Csv.textField(r.storeName),
                         Csv.money(r.realizedPay),
                         Csv.money(r.tip),
                         Csv.money(r.basePay),
@@ -92,8 +99,8 @@ object CsvExporter {
                         Csv.decimal(r.realizedMinutes),
                         Csv.money(r.frozenCostPerMile, digits = 3),
                         Csv.money(r.netProfit),
-                        r.payBasis,
-                        r.costBasis,
+                        Csv.textField(r.payBasis),
+                        Csv.textField(r.costBasis),
                     )
                 )
             ).append('\n')
@@ -103,7 +110,7 @@ object CsvExporter {
 
     private fun sessionsCsv(rows: List<SessionRecordEntity>, zone: ZoneId): String {
         val sb = StringBuilder()
-        sb.append(Csv.row(SESSION_HEADER)).append('\n')
+        sb.append(Csv.row(SESSION_HEADER.map { Csv.textField(it) })).append('\n')
         for (s in rows) {
             // Online duration: to the close if known, else the last event seen (still-live / orphaned).
             val durationMillis = (s.endedAt ?: s.lastEventAt) - s.startedAt
@@ -112,7 +119,7 @@ object CsvExporter {
                     listOf(
                         Csv.isoDateTime(s.startedAt, zone),
                         Csv.isoDateTime(s.endedAt, zone),
-                        platformName(s.platform),
+                        Csv.textField(platformName(s.platform)),
                         Csv.millisToMinutes(durationMillis),
                         Csv.money(s.reportedEarnings),
                         Csv.int(s.deliveries),
@@ -147,12 +154,14 @@ object CsvExporter {
         val totalRealized = deliveries.mapNotNull { it.realizedPay }.sum()
 
         val sb = StringBuilder()
-        sb.append(Csv.row(listOf("metric", "value"))).append('\n')
-        fun line(metric: String, value: String) {
-            sb.append(Csv.row(listOf(metric, value))).append('\n')
+        sb.append(Csv.row(listOf(Csv.textField("metric"), Csv.textField("value")))).append('\n')
+        // Metric names are program constants; values below are pre-encoded numeric/timestamp
+        // cells except date_range's literal, which goes through textField like any text cell.
+        fun line(metric: String, encodedValue: String) {
+            sb.append(Csv.row(listOf(Csv.textField(metric), encodedValue))).append('\n')
         }
         line("export_generated_at", Csv.isoDateTime(generatedAtMillis, zone))
-        line("date_range", "all_time")
+        line("date_range", Csv.textField("all_time"))
         line("tax_year", IrsMileage.TAX_YEAR.toString())
         line("irs_business_rate_per_mile", Csv.money(IrsMileage.RATE_PER_MILE, digits = 3))
         line("total_deductible_miles", Csv.decimal(totalMiles))

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/CsvExporter.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/CsvExporter.kt
@@ -1,0 +1,166 @@
+package cloud.trotter.dashbuddy.core.data.analytics
+
+import cloud.trotter.dashbuddy.core.database.analytics.DeliveryRecordEntity
+import cloud.trotter.dashbuddy.core.database.analytics.SessionRecordEntity
+import cloud.trotter.dashbuddy.domain.export.Csv
+import cloud.trotter.dashbuddy.domain.export.IrsMileage
+import cloud.trotter.dashbuddy.domain.state.Platform
+import java.time.ZoneId
+
+/**
+ * Formats the durable analytics read-model into the free-tier CSV export (#319) — three files a
+ * driver can hand to a spreadsheet or a tax preparer. Pure: entity lists in, CSV strings out. No
+ * Android, no IO, no network — the SAF write edge lives in `:app`. Unit-tested directly.
+ *
+ * **Row-level RAW export, bucketing-free.** Unlike the period read-model (session-anchored buckets,
+ * #655), this ships the underlying rows as-is: a delivery row keys off its own `completedAt`, a
+ * session row off its own `startedAt`. There is no period math to disagree with — it's the driver's
+ * own records, dumped. Callers filter by a `completedAt` / `startedAt` range (v1 exports all-time).
+ *
+ * **Privacy posture (Pledges / Principle 6).** Store names are *merchant* names — driver-owned,
+ * exportable. `customerHash`/`addressHash` are deliberately **excluded**: they are edge-hashed
+ * customer PII with no purpose in a tax/earnings spreadsheet, so the privacy-lean default is to not
+ * ship them at all. No customer name/address ever existed in these rows (hashed at the edge), and
+ * even the hashes stay home. No network path; SAF needs no permission.
+ *
+ * Platform is registry-resolved to its display name via [Platform.fromWire] — never a raw wire
+ * literal compared in logic (Principle 8).
+ */
+object CsvExporter {
+
+    /** The three CSV documents written side-by-side into the chosen directory. */
+    data class Bundle(
+        val deliveriesCsv: String,
+        val sessionsCsv: String,
+        val summaryCsv: String,
+    )
+
+    const val DELIVERIES_FILENAME = "deliveries.csv"
+    const val SESSIONS_FILENAME = "sessions.csv"
+    const val SUMMARY_FILENAME = "summary.csv"
+
+    private val DELIVERY_HEADER = listOf(
+        "date", "time", "platform", "store", "gross_pay", "tip", "base_pay",
+        "miles", "minutes", "frozen_cost_per_mile", "net_profit", "pay_basis", "cost_basis",
+    )
+
+    private val SESSION_HEADER = listOf(
+        "start", "end", "platform", "duration_minutes", "reported_earnings", "deliveries",
+        "offers_received", "offers_accepted", "offers_declined", "offers_timeout",
+        "odometer_start", "odometer_end", "miles",
+    )
+
+    /**
+     * Build all three CSVs. [deliveries]/[sessions] are the raw rows (any order; sorted here for a
+     * stable, chronological export). [zone] is the device's local zone (passed in so this stays
+     * pure/testable); [generatedAtMillis] stamps the summary's export time.
+     */
+    fun export(
+        deliveries: List<DeliveryRecordEntity>,
+        sessions: List<SessionRecordEntity>,
+        zone: ZoneId,
+        generatedAtMillis: Long,
+    ): Bundle = Bundle(
+        deliveriesCsv = deliveriesCsv(deliveries.sortedBy { it.completedAt }, zone),
+        sessionsCsv = sessionsCsv(sessions.sortedBy { it.startedAt }, zone),
+        summaryCsv = summaryCsv(deliveries, sessions, zone, generatedAtMillis),
+    )
+
+    private fun platformName(wire: String): String = Platform.fromWire(wire)?.displayName ?: wire
+
+    private fun sessionMiles(s: SessionRecordEntity): Double? {
+        val start = s.startOdometer ?: return null
+        val last = s.lastOdometer ?: return null
+        return (last - start).coerceAtLeast(0.0)
+    }
+
+    private fun deliveriesCsv(rows: List<DeliveryRecordEntity>, zone: ZoneId): String {
+        val sb = StringBuilder()
+        sb.append(Csv.row(DELIVERY_HEADER)).append('\n')
+        for (r in rows) {
+            sb.append(
+                Csv.row(
+                    listOf(
+                        Csv.isoDate(r.completedAt, zone),
+                        Csv.isoTime(r.completedAt, zone),
+                        platformName(r.platform),
+                        r.storeName,
+                        Csv.money(r.realizedPay),
+                        Csv.money(r.tip),
+                        Csv.money(r.basePay),
+                        Csv.decimal(r.realizedMiles),
+                        Csv.decimal(r.realizedMinutes),
+                        Csv.money(r.frozenCostPerMile, digits = 3),
+                        Csv.money(r.netProfit),
+                        r.payBasis,
+                        r.costBasis,
+                    )
+                )
+            ).append('\n')
+        }
+        return sb.toString()
+    }
+
+    private fun sessionsCsv(rows: List<SessionRecordEntity>, zone: ZoneId): String {
+        val sb = StringBuilder()
+        sb.append(Csv.row(SESSION_HEADER)).append('\n')
+        for (s in rows) {
+            // Online duration: to the close if known, else the last event seen (still-live / orphaned).
+            val durationMillis = (s.endedAt ?: s.lastEventAt) - s.startedAt
+            sb.append(
+                Csv.row(
+                    listOf(
+                        Csv.isoDateTime(s.startedAt, zone),
+                        Csv.isoDateTime(s.endedAt, zone),
+                        platformName(s.platform),
+                        Csv.millisToMinutes(durationMillis),
+                        Csv.money(s.reportedEarnings),
+                        Csv.int(s.deliveries),
+                        Csv.int(s.offersReceived),
+                        Csv.int(s.offersAccepted),
+                        Csv.int(s.offersDeclined),
+                        Csv.int(s.offersTimeout),
+                        Csv.decimal(s.startOdometer),
+                        Csv.decimal(s.lastOdometer),
+                        Csv.decimal(sessionMiles(s)),
+                    )
+                )
+            ).append('\n')
+        }
+        return sb.toString()
+    }
+
+    /**
+     * A `metric,value` summary — the tax-preparer line the issue calls for: total odometer-derived
+     * business miles × the IRS standard business rate, with the tax year and rate stated explicitly
+     * so the deduction number is never ambiguous about which year produced it.
+     */
+    private fun summaryCsv(
+        deliveries: List<DeliveryRecordEntity>,
+        sessions: List<SessionRecordEntity>,
+        zone: ZoneId,
+        generatedAtMillis: Long,
+    ): String {
+        val totalMiles = sessions.sumOf { sessionMiles(it) ?: 0.0 }
+        val deduction = IrsMileage.deduction(totalMiles)
+        val totalReported = sessions.mapNotNull { it.reportedEarnings }.sum()
+        val totalRealized = deliveries.mapNotNull { it.realizedPay }.sum()
+
+        val sb = StringBuilder()
+        sb.append(Csv.row(listOf("metric", "value"))).append('\n')
+        fun line(metric: String, value: String) {
+            sb.append(Csv.row(listOf(metric, value))).append('\n')
+        }
+        line("export_generated_at", Csv.isoDateTime(generatedAtMillis, zone))
+        line("date_range", "all_time")
+        line("tax_year", IrsMileage.TAX_YEAR.toString())
+        line("irs_business_rate_per_mile", Csv.money(IrsMileage.RATE_PER_MILE, digits = 3))
+        line("total_deductible_miles", Csv.decimal(totalMiles))
+        line("estimated_mileage_deduction", Csv.money(deduction))
+        line("total_sessions", Csv.int(sessions.size))
+        line("total_deliveries", Csv.int(deliveries.size))
+        line("total_reported_earnings", Csv.money(totalReported))
+        line("total_realized_delivery_pay", Csv.money(totalRealized))
+        return sb.toString()
+    }
+}

--- a/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/CsvExporterTest.kt
+++ b/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/CsvExporterTest.kt
@@ -88,6 +88,24 @@ class CsvExporterTest {
         assertTrue(out.deliveriesCsv.contains("\"Chili's, Cedar Park\""))
     }
 
+    @Test fun formulaInjection_storeName_isNeutralizedEndToEnd() {
+        // Store names are third-party UI (untrusted). A formula payload must land in the written
+        // file carrying the force-text prefix so a spreadsheet renders it as literal text.
+        val out = CsvExporter.export(
+            listOf(delivery(1, "=cmd(\"/c calc\")!A1")),
+            emptyList(), utc, generatedAt,
+        )
+        val row = out.deliveriesCsv.trim().lines()[1]
+        // The neutralized cell: '-prefixed, and RFC-4180 quoted (payload contains quotes).
+        assertTrue("neutralized cell missing in: $row", row.contains("\"'=cmd("))
+        // No cell in the row may still BEGIN with the raw formula (quoted or bare).
+        assertFalse("raw formula cell leaked in: $row", row.contains(",=cmd") || row.startsWith("=cmd"))
+        assertFalse("raw quoted formula cell leaked in: $row", row.contains(",\"=cmd"))
+        // Program-generated negatives stay bare and machine-parseable (strict-numeric exemption).
+        val negOut = CsvExporter.export(listOf(delivery(2, "S", pay = -2.50)), emptyList(), utc, generatedAt)
+        assertEquals("-2.50", negOut.deliveriesCsv.trim().lines()[1].split(",")[4])
+    }
+
     @Test fun hashes_areNeverExported() {
         val out = CsvExporter.export(
             listOf(delivery(1, "H-E-B")),

--- a/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/CsvExporterTest.kt
+++ b/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/CsvExporterTest.kt
@@ -1,0 +1,155 @@
+package cloud.trotter.dashbuddy.core.data.analytics
+
+import cloud.trotter.dashbuddy.core.database.analytics.DeliveryRecordEntity
+import cloud.trotter.dashbuddy.core.database.analytics.SessionRecordEntity
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.ZoneId
+
+/** Entity → CSV assembly, hash exclusion, header shape, and the summary deduction (#319). */
+class CsvExporterTest {
+
+    private val utc = ZoneId.of("UTC")
+    private val generatedAt = 1_783_260_207_000L // 2026-07-05T14:03:27Z
+
+    private fun delivery(
+        seq: Long,
+        store: String?,
+        completedAt: Long = generatedAt,
+        pay: Double? = 8.50,
+    ) = DeliveryRecordEntity(
+        eventSequenceId = seq,
+        sessionId = "s1",
+        platform = "doordash",
+        jobId = "j$seq",
+        taskId = "t$seq",
+        storeName = store,
+        customerHash = "CUSTOMER_HASH_SHOULD_NOT_APPEAR",
+        addressHash = "ADDRESS_HASH_SHOULD_NOT_APPEAR",
+        phaseStartedAt = completedAt - 600_000,
+        arrivedAt = completedAt - 300_000,
+        completedAt = completedAt,
+        deadlineMillis = null,
+        realizedPay = pay,
+        payBasis = "DROP_SHARE",
+        tip = 3.25,
+        basePay = 5.25,
+        odometerAtCompletion = 1000.0,
+        realizedMiles = 4.2,
+        realizedMinutes = 12.5,
+        frozenCostPerMile = 0.165,
+        netProfit = 7.81,
+        costBasis = "OFFER_FROZEN",
+    )
+
+    private fun session(
+        id: String = "s1",
+        startedAt: Long = generatedAt - 3_600_000,
+        endedAt: Long? = generatedAt,
+        startOdo: Double? = 1000.0,
+        lastOdo: Double? = 1042.0,
+        reported: Double? = 55.00,
+    ) = SessionRecordEntity(
+        sessionId = id,
+        platform = "doordash",
+        startedAt = startedAt,
+        endedAt = endedAt,
+        lastEventAt = endedAt ?: startedAt,
+        endSource = "summary_screen",
+        startOdometer = startOdo,
+        lastOdometer = lastOdo,
+        reportedEarnings = reported,
+        reportedDurationMillis = 3_600_000,
+        offersReceived = 5,
+        offersAccepted = 3,
+        offersDeclined = 1,
+        offersTimeout = 1,
+        deliveries = 3,
+        jobsCompleted = 3,
+    )
+
+    @Test fun deliveries_headerAndRow_withPlatformDisplayName() {
+        val out = CsvExporter.export(listOf(delivery(1, "H-E-B")), emptyList(), utc, generatedAt)
+        val lines = out.deliveriesCsv.trim().lines()
+        assertEquals(
+            "date,time,platform,store,gross_pay,tip,base_pay,miles,minutes,frozen_cost_per_mile,net_profit,pay_basis,cost_basis",
+            lines[0],
+        )
+        assertEquals(
+            "2026-07-05,14:03:27,DoorDash,H-E-B,8.50,3.25,5.25,4.20,12.50,0.165,7.81,DROP_SHARE,OFFER_FROZEN",
+            lines[1],
+        )
+    }
+
+    @Test fun deliveries_storeWithComma_isQuoted() {
+        val out = CsvExporter.export(listOf(delivery(1, "Chili's, Cedar Park")), emptyList(), utc, generatedAt)
+        assertTrue(out.deliveriesCsv.contains("\"Chili's, Cedar Park\""))
+    }
+
+    @Test fun hashes_areNeverExported() {
+        val out = CsvExporter.export(
+            listOf(delivery(1, "H-E-B")),
+            listOf(session()),
+            utc,
+            generatedAt,
+        )
+        val all = out.deliveriesCsv + out.sessionsCsv + out.summaryCsv
+        assertFalse(all.contains("CUSTOMER_HASH_SHOULD_NOT_APPEAR"))
+        assertFalse(all.contains("ADDRESS_HASH_SHOULD_NOT_APPEAR"))
+    }
+
+    @Test fun deliveries_sortedByCompletedAt() {
+        val out = CsvExporter.export(
+            listOf(
+                delivery(2, "Late", completedAt = generatedAt + 1000),
+                delivery(1, "Early", completedAt = generatedAt),
+            ),
+            emptyList(), utc, generatedAt,
+        )
+        val lines = out.deliveriesCsv.trim().lines()
+        assertTrue(lines[1].contains("Early"))
+        assertTrue(lines[2].contains("Late"))
+    }
+
+    @Test fun nullPay_becomesEmptyField_notZero() {
+        val out = CsvExporter.export(listOf(delivery(1, "S", pay = null)), emptyList(), utc, generatedAt)
+        val row = out.deliveriesCsv.trim().lines()[1]
+        // gross_pay is the 5th column (index 4) and must be empty, not "0.00".
+        assertEquals("", row.split(",")[4])
+    }
+
+    @Test fun sessions_headerAndDerivedMiles() {
+        val out = CsvExporter.export(emptyList(), listOf(session()), utc, generatedAt)
+        val lines = out.sessionsCsv.trim().lines()
+        assertEquals(
+            "start,end,platform,duration_minutes,reported_earnings,deliveries,offers_received," +
+                "offers_accepted,offers_declined,offers_timeout,odometer_start,odometer_end,miles",
+            lines[0],
+        )
+        val cols = lines[1].split(",")
+        assertEquals("DoorDash", cols[2])
+        assertEquals("60.00", cols[3])        // 1h duration
+        assertEquals("42.00", cols.last())    // 1042 - 1000 miles
+    }
+
+    @Test fun sessionMiles_missingOdometer_isEmpty() {
+        val out = CsvExporter.export(emptyList(), listOf(session(startOdo = null, lastOdo = null)), utc, generatedAt)
+        assertEquals("", out.sessionsCsv.trim().lines()[1].split(",").last())
+    }
+
+    @Test fun summary_deductionMath() {
+        val out = CsvExporter.export(
+            listOf(delivery(1, "S")),
+            listOf(session(startOdo = 1000.0, lastOdo = 1100.0)), // 100 mi
+            utc, generatedAt,
+        )
+        val summary = out.summaryCsv
+        assertTrue(summary.contains("tax_year,2025"))
+        assertTrue(summary.contains("total_deductible_miles,100.00"))
+        assertTrue(summary.contains("estimated_mileage_deduction,70.00")) // 100 * 0.70
+        assertTrue(summary.contains("total_sessions,1"))
+        assertTrue(summary.contains("total_deliveries,1"))
+    }
+}

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
@@ -201,6 +201,21 @@ interface AnalyticsDao {
     @Query("SELECT * FROM delivery_records WHERE sessionId = :sessionId ORDER BY completedAt ASC")
     fun deliveriesForSession(sessionId: String): Flow<List<DeliveryRecordEntity>>
 
+    // ── Raw row reads for CSV export (#319) ──────────────────────────────
+
+    /**
+     * Every delivery whose own `completedAt` is in `[start, end)`, chronological. Row-level RAW
+     * export (bucketing-free, #319) — this keys on the delivery's own completion time, NOT the
+     * session-anchored period join the read-model uses (#655); an export is the driver's underlying
+     * records dumped as-is. v1 passes `[Long.MIN, Long.MAX)` for all-time.
+     */
+    @Query("SELECT * FROM delivery_records WHERE completedAt >= :start AND completedAt < :end ORDER BY completedAt ASC")
+    suspend fun deliveriesBetween(start: Long, end: Long): List<DeliveryRecordEntity>
+
+    /** Every session whose own `startedAt` is in `[start, end)`, chronological. Raw export (#319). */
+    @Query("SELECT * FROM session_records WHERE startedAt >= :start AND startedAt < :end ORDER BY startedAt ASC")
+    suspend fun sessionsBetween(start: Long, end: Long): List<SessionRecordEntity>
+
     // ── Projector support: restart-correct context hydration (PR2) ───────
 
     @Query("SELECT * FROM session_records WHERE sessionId = :id")

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -73,6 +73,18 @@ card's **mechanical** half, #577 (re-confirmed, 24/24, ~0.55 s — with a new po
 that entry's Bug #1), the #457 path, and #554 ShadowProjector (2/2). The #462/#460 dropoff item
 was found **broken-in-part** (raw PII in capture envelopes) and moved to that entry's Bug #7.)_
 
+- **🆕 NEW — CSV data export (#319).** Settings → Data & Privacy → "Export Data (CSV)" → tap
+  "Choose folder & export" and pick a folder (e.g. Downloads). Three files should appear:
+  `deliveries.csv`, `sessions.csv`, `summary.csv`. Open each in a spreadsheet app: deliveries should
+  have one row per completed drop (date/time, platform, store, pay, tip, miles, minutes, net…),
+  sessions one row per dash (start/end, duration, odometer start/end, miles, offer counts), and
+  summary a totals block ending in `estimated_mileage_deduction` (= total miles × 0.70, the IRS 2025
+  business rate). **How to tell it's working:** values are sane (money looks like `8.50` not `0.00`
+  everywhere; store names with commas like "Chili's, Cedar Park" stay in one cell, not split), and
+  NO customer names/addresses or hashes appear anywhere. All-time export (v1 has no date-range
+  picker). Screens with no dashes yet just yield header-only files — that's fine.
+  - Confirmed: 0/2
+
 - **🆕 NEW — driving/glance-mode HUD font-scale toggle (#318).** Flip "Driving glance mode" on in
   Settings → General while a dash is running (or the bubble is up). The bubble HUD's text — the
   hero $/hr, task timers, captions, everything — should visibly grow (~12%) immediately, with no

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/export/Csv.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/export/Csv.kt
@@ -1,0 +1,70 @@
+package cloud.trotter.dashbuddy.domain.export
+
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+/**
+ * Pure, machine-readable CSV primitives for the free-tier data export (#319).
+ *
+ * This is deliberately NOT the human-facing [cloud.trotter.dashbuddy.domain.format.Formats]
+ * locale policy: an export is a **machine string** (a spreadsheet / a tax preparer's tool
+ * parses it back), so everything here pins [Locale.ROOT] and emits ungrouped decimals — no
+ * thousands separators, no `$`, no locale decimal comma. A German-locale device must still
+ * write `1234.50`, not `1.234,50`, or the CSV is unparseable. Timestamps are ISO-8601 in the
+ * device's local zone (passed in — pure, no `ZoneId.systemDefault()` call baked here so it is
+ * unit-testable).
+ *
+ * Quoting is RFC-4180: a field containing a comma, a double-quote, or a newline is wrapped in
+ * double-quotes and its own quotes are doubled. Store/merchant names routinely contain commas
+ * ("Chili's Grill & Bar, Cedar Park"), so this is load-bearing, not decorative.
+ *
+ * Lives in `:domain` (pure Kotlin, no Android) so the `:core:data` exporter and its unit tests
+ * both route through one definition (Principle 5).
+ */
+object Csv {
+
+    private val DATE: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.ROOT)
+    private val TIME: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss", Locale.ROOT)
+    private val DATE_TIME: DateTimeFormatter =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss", Locale.ROOT)
+
+    /** RFC-4180 quote a single field. `null` ⇒ empty field (distinguishes missing from `0`). */
+    fun field(value: String?): String {
+        if (value == null) return ""
+        val needsQuoting = value.any { it == ',' || it == '"' || it == '\n' || it == '\r' }
+        if (!needsQuoting) return value
+        return "\"" + value.replace("\"", "\"\"") + "\""
+    }
+
+    /** Assemble one CSV record from raw (unquoted) fields; each is RFC-4180 quoted. */
+    fun row(values: List<String?>): String = values.joinToString(",") { field(it) }
+
+    /** Ungrouped, Locale.ROOT decimal money. `null` ⇒ empty field (missing ≠ `0.00`). */
+    fun money(value: Double?, digits: Int = 2): String =
+        if (value == null) "" else String.format(Locale.ROOT, "%.${digits}f", value)
+
+    /** Ungrouped, Locale.ROOT decimal. `null` ⇒ empty field. */
+    fun decimal(value: Double?, digits: Int = 2): String =
+        if (value == null) "" else String.format(Locale.ROOT, "%.${digits}f", value)
+
+    /** Plain integer, no grouping. `null` ⇒ empty field. */
+    fun int(value: Int?): String = value?.toString() ?: ""
+
+    /** ISO-8601 local date (`2026-07-05`) in [zone]. `null` ⇒ empty field. */
+    fun isoDate(epochMillis: Long?, zone: ZoneId): String =
+        if (epochMillis == null) "" else DATE.format(Instant.ofEpochMilli(epochMillis).atZone(zone))
+
+    /** ISO-8601 local time (`14:03:27`) in [zone]. `null` ⇒ empty field. */
+    fun isoTime(epochMillis: Long?, zone: ZoneId): String =
+        if (epochMillis == null) "" else TIME.format(Instant.ofEpochMilli(epochMillis).atZone(zone))
+
+    /** ISO-8601 local date-time (`2026-07-05T14:03:27`) in [zone]. `null` ⇒ empty field. */
+    fun isoDateTime(epochMillis: Long?, zone: ZoneId): String =
+        if (epochMillis == null) "" else DATE_TIME.format(Instant.ofEpochMilli(epochMillis).atZone(zone))
+
+    /** Milliseconds → decimal minutes (2 dp). `null` ⇒ empty field. */
+    fun millisToMinutes(millis: Long?, digits: Int = 2): String =
+        if (millis == null) "" else String.format(Locale.ROOT, "%.${digits}f", millis / 60_000.0)
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/export/Csv.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/export/Csv.kt
@@ -16,6 +16,24 @@ import java.util.Locale
  * device's local zone (passed in — pure, no `ZoneId.systemDefault()` call baked here so it is
  * unit-testable).
  *
+ * **Cell typing is the injection defense.** The API splits cells into two kinds so the call
+ * site's type choice enforces the guard:
+ *
+ *  - [textField] — for **text** cells, above all untrusted third-party strings (store/merchant
+ *    names come from another app's UI tree). Applies RFC-4180 quoting AND **formula-injection
+ *    neutralization**: spreadsheets strip the RFC-4180 quotes on import and then interpret a
+ *    cell starting with `=`, `+`, `-`, `@`, TAB, or CR as a *formula* (CSV injection), so a
+ *    leading dangerous character is prefixed with `'` (the standard force-text marker). A store
+ *    named `=cmd(...)` lands in the sheet as literal text, never executes.
+ *  - The **numeric/timestamp emitters** ([money], [decimal], [int], [isoDate], [isoTime],
+ *    [isoDateTime], [millisToMinutes]) — safe **by construction**: they only ever format
+ *    program-generated numbers/instants into `[-0-9.T:]` strings (no comma/quote/newline, never
+ *    a formula payload), so they are NOT `'`-prefixed — a negative amount stays a bare,
+ *    machine-parseable `-2.50`. Never route free text through these.
+ *
+ * [row] joins **already-encoded** cells — every cell must come from [textField] or a numeric
+ * emitter; it applies no escaping of its own (re-escaping would corrupt quoted cells).
+ *
  * Quoting is RFC-4180: a field containing a comma, a double-quote, or a newline is wrapped in
  * double-quotes and its own quotes are doubled. Store/merchant names routinely contain commas
  * ("Chili's Grill & Bar, Cedar Park"), so this is load-bearing, not decorative.
@@ -30,41 +48,58 @@ object Csv {
     private val DATE_TIME: DateTimeFormatter =
         DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss", Locale.ROOT)
 
-    /** RFC-4180 quote a single field. `null` ⇒ empty field (distinguishes missing from `0`). */
-    fun field(value: String?): String {
+    /** Leading characters a spreadsheet interprets as the start of a formula (CSV injection). */
+    private val FORMULA_LEADERS = charArrayOf('=', '+', '-', '@', '\t', '\r')
+
+    /**
+     * Encode one **text** cell: neutralize a leading formula character (`'` prefix), then
+     * RFC-4180 quote. Use for every human/text column — REQUIRED for anything untrusted
+     * (third-party UI strings). `null` ⇒ empty cell (distinguishes missing from empty content).
+     */
+    fun textField(value: String?): String {
         if (value == null) return ""
+        val neutralized =
+            if (value.isNotEmpty() && value[0] in FORMULA_LEADERS) "'$value" else value
+        return quote(neutralized)
+    }
+
+    /** RFC-4180 quote a cell's content ([textField] is the public text entry point). */
+    private fun quote(value: String): String {
         val needsQuoting = value.any { it == ',' || it == '"' || it == '\n' || it == '\r' }
         if (!needsQuoting) return value
         return "\"" + value.replace("\"", "\"\"") + "\""
     }
 
-    /** Assemble one CSV record from raw (unquoted) fields; each is RFC-4180 quoted. */
-    fun row(values: List<String?>): String = values.joinToString(",") { field(it) }
+    /**
+     * Assemble one CSV record from **already-encoded** cells (each from [textField] or a
+     * numeric/timestamp emitter). Applies no escaping of its own.
+     */
+    fun row(cells: List<String>): String = cells.joinToString(",")
 
-    /** Ungrouped, Locale.ROOT decimal money. `null` ⇒ empty field (missing ≠ `0.00`). */
+    /** Ungrouped, Locale.ROOT decimal money. `null` ⇒ empty cell (missing ≠ `0.00`). */
     fun money(value: Double?, digits: Int = 2): String =
         if (value == null) "" else String.format(Locale.ROOT, "%.${digits}f", value)
 
-    /** Ungrouped, Locale.ROOT decimal. `null` ⇒ empty field. */
+    /** Ungrouped, Locale.ROOT decimal. `null` ⇒ empty cell. */
     fun decimal(value: Double?, digits: Int = 2): String =
         if (value == null) "" else String.format(Locale.ROOT, "%.${digits}f", value)
 
-    /** Plain integer, no grouping. `null` ⇒ empty field. */
+    /** Plain integer, no grouping. `null` ⇒ empty cell. */
     fun int(value: Int?): String = value?.toString() ?: ""
 
-    /** ISO-8601 local date (`2026-07-05`) in [zone]. `null` ⇒ empty field. */
+    /** ISO-8601 local date (`2026-07-05`) in [zone]. `null` ⇒ empty cell. */
     fun isoDate(epochMillis: Long?, zone: ZoneId): String =
         if (epochMillis == null) "" else DATE.format(Instant.ofEpochMilli(epochMillis).atZone(zone))
 
-    /** ISO-8601 local time (`14:03:27`) in [zone]. `null` ⇒ empty field. */
+    /** ISO-8601 local time (`14:03:27`) in [zone]. `null` ⇒ empty cell. */
     fun isoTime(epochMillis: Long?, zone: ZoneId): String =
         if (epochMillis == null) "" else TIME.format(Instant.ofEpochMilli(epochMillis).atZone(zone))
 
-    /** ISO-8601 local date-time (`2026-07-05T14:03:27`) in [zone]. `null` ⇒ empty field. */
+    /** ISO-8601 local date-time (`2026-07-05T14:03:27`) in [zone]. `null` ⇒ empty cell. */
     fun isoDateTime(epochMillis: Long?, zone: ZoneId): String =
         if (epochMillis == null) "" else DATE_TIME.format(Instant.ofEpochMilli(epochMillis).atZone(zone))
 
-    /** Milliseconds → decimal minutes (2 dp). `null` ⇒ empty field. */
+    /** Milliseconds → decimal minutes (2 dp). `null` ⇒ empty cell. */
     fun millisToMinutes(millis: Long?, digits: Int = 2): String =
         if (millis == null) "" else String.format(Locale.ROOT, "%.${digits}f", millis / 60_000.0)
 }

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/export/IrsMileage.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/export/IrsMileage.kt
@@ -1,0 +1,31 @@
+package cloud.trotter.dashbuddy.domain.export
+
+/**
+ * IRS standard mileage deduction constant for the CSV export's tax summary (#319).
+ *
+ * The free-tier pledge is "the driver can hand this to a tax preparer": the export ships the
+ * driver's own odometer-derived business miles times the IRS standard business mileage rate as an
+ * *estimated* deduction line. This is intentionally the standard-mileage method, not actual-expense
+ * (which the app's operating-cost model separately estimates for net-profit) — a tax preparer
+ * expects the IRS rate.
+ *
+ * **The rate is year-specific and the constant is named with its tax year on purpose.** The IRS
+ * publishes each year's rate in mid-December; [RATE_PER_MILE] is the tax-year-2025 business rate
+ * ($0.70/mi, confirmed). The export labels the tax year explicitly so a downstream reader never
+ * mistakes which year's rate produced the number.
+ *
+ * TODO(#319): confirm the IRS 2026 business standard mileage rate once published and add a
+ * per-year lookup (the export can then pick the rate matching each row's date). Until then the
+ * export honestly reports [TAX_YEAR] = 2025 in the summary rather than inventing 2026 precision.
+ */
+object IrsMileage {
+
+    /** Tax year the [RATE_PER_MILE] applies to — surfaced in the export summary so it's unambiguous. */
+    const val TAX_YEAR: Int = 2025
+
+    /** IRS standard business mileage rate for [TAX_YEAR] 2025 = $0.70/mi (confirmed). */
+    const val RATE_PER_MILE: Double = 0.70
+
+    /** Estimated standard-mileage deduction for [miles] business miles at [RATE_PER_MILE]. */
+    fun deduction(miles: Double): Double = miles * RATE_PER_MILE
+}

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/export/CsvTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/export/CsvTest.kt
@@ -1,0 +1,121 @@
+package cloud.trotter.dashbuddy.domain.export
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.time.ZoneId
+
+/** RFC-4180 quoting, machine number formatting, ISO timestamps, and the IRS deduction math (#319). */
+class CsvTest {
+
+    private val utc = ZoneId.of("UTC")
+
+    // ── RFC-4180 quoting ────────────────────────────────────────────────
+
+    @Test fun plainField_isUnquoted() {
+        assertEquals("H-E-B", Csv.field("H-E-B"))
+    }
+
+    @Test fun fieldWithComma_isQuoted() {
+        assertEquals("\"Chili's, Cedar Park\"", Csv.field("Chili's, Cedar Park"))
+    }
+
+    @Test fun fieldWithQuote_doublesTheQuote() {
+        assertEquals("\"Joe \"\"The Rock\"\" Bar\"", Csv.field("Joe \"The Rock\" Bar"))
+    }
+
+    @Test fun fieldWithNewline_isQuoted() {
+        assertEquals("\"line1\nline2\"", Csv.field("line1\nline2"))
+    }
+
+    @Test fun fieldWithCarriageReturn_isQuoted() {
+        assertEquals("\"a\rb\"", Csv.field("a\rb"))
+    }
+
+    @Test fun nullField_isEmpty() {
+        assertEquals("", Csv.field(null))
+    }
+
+    @Test fun row_quotesEachField() {
+        assertEquals(
+            "a,\"b,c\",\"d\"\"e\"",
+            Csv.row(listOf("a", "b,c", "d\"e")),
+        )
+    }
+
+    @Test fun row_nullBecomesEmptyField() {
+        assertEquals("a,,c", Csv.row(listOf("a", null, "c")))
+    }
+
+    // ── Money / decimal (machine, Locale.ROOT, ungrouped) ───────────────
+
+    @Test fun money_twoDecimals_noGrouping() {
+        assertEquals("1234.50", Csv.money(1234.5))
+    }
+
+    @Test fun money_null_isEmpty_notZero() {
+        assertEquals("", Csv.money(null))
+    }
+
+    @Test fun money_zero_isFormatted() {
+        assertEquals("0.00", Csv.money(0.0))
+    }
+
+    @Test fun money_threeDecimals_forCostPerMile() {
+        assertEquals("0.165", Csv.money(0.165, digits = 3))
+    }
+
+    @Test fun decimal_null_isEmpty() {
+        assertEquals("", Csv.decimal(null))
+    }
+
+    @Test fun intFormatting_andNull() {
+        assertEquals("7", Csv.int(7))
+        assertEquals("", Csv.int(null))
+    }
+
+    @Test fun millisToMinutes() {
+        assertEquals("30.00", Csv.millisToMinutes(1_800_000L))
+        assertEquals("", Csv.millisToMinutes(null))
+    }
+
+    // ── ISO-8601 timestamps ─────────────────────────────────────────────
+
+    @Test fun isoDate_utc() {
+        // 2026-07-05T14:03:27Z
+        val ms = 1_783_260_207_000L
+        assertEquals("2026-07-05", Csv.isoDate(ms, utc))
+    }
+
+    @Test fun isoTime_utc() {
+        val ms = 1_783_260_207_000L
+        assertEquals("14:03:27", Csv.isoTime(ms, utc))
+    }
+
+    @Test fun isoDateTime_utc() {
+        val ms = 1_783_260_207_000L
+        assertEquals("2026-07-05T14:03:27", Csv.isoDateTime(ms, utc))
+    }
+
+    @Test fun isoDateTime_respectsZone() {
+        val ms = 1_783_260_207_000L // 14:03:27 UTC → EDT (UTC-4) in July
+        assertEquals("2026-07-05T10:03:27", Csv.isoDateTime(ms, ZoneId.of("America/New_York")))
+    }
+
+    @Test fun isoTimestamps_null_areEmpty() {
+        assertEquals("", Csv.isoDate(null, utc))
+        assertEquals("", Csv.isoTime(null, utc))
+        assertEquals("", Csv.isoDateTime(null, utc))
+    }
+
+    // ── IRS deduction ───────────────────────────────────────────────────
+
+    @Test fun irsRate_isTaxYear2025Business() {
+        assertEquals(2025, IrsMileage.TAX_YEAR)
+        assertEquals(0.70, IrsMileage.RATE_PER_MILE, 0.0)
+    }
+
+    @Test fun irsDeduction_math() {
+        assertEquals(70.0, IrsMileage.deduction(100.0), 1e-9)
+        assertEquals(0.0, IrsMileage.deduction(0.0), 0.0)
+    }
+}

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/export/CsvTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/export/CsvTest.kt
@@ -4,46 +4,90 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.time.ZoneId
 
-/** RFC-4180 quoting, machine number formatting, ISO timestamps, and the IRS deduction math (#319). */
+/**
+ * RFC-4180 quoting, formula-injection neutralization, machine number formatting, ISO timestamps,
+ * and the IRS deduction math (#319).
+ */
 class CsvTest {
 
     private val utc = ZoneId.of("UTC")
 
-    // ── RFC-4180 quoting ────────────────────────────────────────────────
+    // ── RFC-4180 quoting (textField) ────────────────────────────────────
 
     @Test fun plainField_isUnquoted() {
-        assertEquals("H-E-B", Csv.field("H-E-B"))
+        assertEquals("H-E-B", Csv.textField("H-E-B"))
     }
 
     @Test fun fieldWithComma_isQuoted() {
-        assertEquals("\"Chili's, Cedar Park\"", Csv.field("Chili's, Cedar Park"))
+        assertEquals("\"Chili's, Cedar Park\"", Csv.textField("Chili's, Cedar Park"))
     }
 
     @Test fun fieldWithQuote_doublesTheQuote() {
-        assertEquals("\"Joe \"\"The Rock\"\" Bar\"", Csv.field("Joe \"The Rock\" Bar"))
+        assertEquals("\"Joe \"\"The Rock\"\" Bar\"", Csv.textField("Joe \"The Rock\" Bar"))
     }
 
     @Test fun fieldWithNewline_isQuoted() {
-        assertEquals("\"line1\nline2\"", Csv.field("line1\nline2"))
-    }
-
-    @Test fun fieldWithCarriageReturn_isQuoted() {
-        assertEquals("\"a\rb\"", Csv.field("a\rb"))
+        assertEquals("\"line1\nline2\"", Csv.textField("line1\nline2"))
     }
 
     @Test fun nullField_isEmpty() {
-        assertEquals("", Csv.field(null))
+        assertEquals("", Csv.textField(null))
     }
 
-    @Test fun row_quotesEachField() {
+    // ── Formula-injection neutralization (textField only) ───────────────
+
+    @Test fun leadingEquals_isNeutralized() {
+        assertEquals("'=cmd()", Csv.textField("=cmd()"))
+    }
+
+    @Test fun leadingPlus_isNeutralized() {
+        assertEquals("'+1+1", Csv.textField("+1+1"))
+    }
+
+    @Test fun leadingMinus_isNeutralized() {
+        assertEquals("'-2+3", Csv.textField("-2+3"))
+    }
+
+    @Test fun leadingAt_isNeutralized() {
+        assertEquals("'@SUM(A1)", Csv.textField("@SUM(A1)"))
+    }
+
+    @Test fun leadingTab_isNeutralized() {
+        assertEquals("'\tX", Csv.textField("\tX"))
+    }
+
+    @Test fun leadingCarriageReturn_isNeutralizedAndQuoted() {
+        // CR is both a formula leader AND an RFC-4180 quote trigger: '-prefixed, then quoted.
+        assertEquals("\"'\ra\"", Csv.textField("\ra"))
+    }
+
+    @Test fun neutralizedFieldWithComma_isAlsoQuoted() {
+        assertEquals("\"'=a,b\"", Csv.textField("=a,b"))
+    }
+
+    @Test fun interiorFormulaChars_areNotNeutralized() {
+        // Only a LEADING dangerous char triggers the guard.
+        assertEquals("H-E-B Plus=1", Csv.textField("H-E-B Plus=1"))
+    }
+
+    @Test fun numericEmitters_stayBare_negativeMoneyNotNeutralized() {
+        // Program-generated numbers are safe by construction and must stay machine-parseable.
+        assertEquals("-2.50", Csv.money(-2.5))
+        assertEquals("-4.20", Csv.decimal(-4.2))
+        assertEquals("-3", Csv.int(-3))
+    }
+
+    // ── Row assembly (pre-encoded cells) ────────────────────────────────
+
+    @Test fun row_joinsEncodedCells() {
         assertEquals(
             "a,\"b,c\",\"d\"\"e\"",
-            Csv.row(listOf("a", "b,c", "d\"e")),
+            Csv.row(listOf(Csv.textField("a"), Csv.textField("b,c"), Csv.textField("d\"e"))),
         )
     }
 
-    @Test fun row_nullBecomesEmptyField() {
-        assertEquals("a,,c", Csv.row(listOf("a", null, "c")))
+    @Test fun row_nullTextBecomesEmptyCell() {
+        assertEquals("a,,c", Csv.row(listOf(Csv.textField("a"), Csv.textField(null), Csv.textField("c"))))
     }
 
     // ── Money / decimal (machine, Locale.ROOT, ungrouped) ───────────────


### PR DESCRIPTION
Closes #319.

Free-tier pillar item — **driver-owned data out, no network.** Settings → Data & Privacy →
**Export Data (CSV)** launches a Storage Access Framework directory pick and writes three CSVs into
the chosen folder. This is the first user-facing export of the #314 analytics read-model.

## What ships

- **`:domain` `export/Csv.kt`** — pure, machine-readable CSV primitives: RFC-4180 quoting
  (commas/quotes/newlines in store names), `Locale.ROOT` ungrouped decimals (a German-locale phone
  still writes `1234.50`, not `1.234,50`), ISO-8601 **local** timestamps (zone passed in → pure &
  testable). `null` → empty field (distinguishes missing from `0.00`).
- **`:domain` `export/IrsMileage.kt`** — the IRS standard-mileage constant, **named with its tax
  year** (see below).
- **`:core:data` `analytics/CsvExporter.kt`** — pure entity→CSV assembly (no Android/IO). Emits the
  three CSV strings.
- **`:core:data` `AnalyticsRepository.buildCsvExport(...)`** + **`AnalyticsDao.deliveriesBetween` /
  `sessionsBetween`** raw-row queries (all-time v1 passes the full range).
- **`:app` `DataExportViewModel`** — the SAF write edge (`DocumentsContract`, no extra dep), P7
  counts-only logging; **`DataExportScreen`** + a **Settings → Data & Privacy** nav row + route wiring.

## File shapes

**deliveries.csv** (one row per completed drop, sorted by `completedAt`):
`date,time,platform,store,gross_pay,tip,base_pay,miles,minutes,frozen_cost_per_mile,net_profit,pay_basis,cost_basis`

**sessions.csv** (one row per dash, sorted by `startedAt`):
`start,end,platform,duration_minutes,reported_earnings,deliveries,offers_received,offers_accepted,offers_declined,offers_timeout,odometer_start,odometer_end,miles`

**summary.csv** (`metric,value` block): `export_generated_at`, `date_range=all_time`, `tax_year`,
`irs_business_rate_per_mile`, `total_deductible_miles`, **`estimated_mileage_deduction`** (miles ×
rate — the tax-preparer line), `total_sessions`, `total_deliveries`, `total_reported_earnings`,
`total_realized_delivery_pay`.

## SAF choice (justification)

**`ACTION_OPEN_DOCUMENT_TREE` (directory pick) writing three files** — one interaction, clean
separate files, no extra dependency (`DocumentsContract` is framework-native, unlike
`androidx.documentfile`). Rejected: two/three sequential `CreateDocument` launches (clunky — a pick
per file); a single CSV with a `record_type` column (loses the tax-preparer-friendly file
separation and forces heterogeneous columns); a ZIP (needless friction for a spreadsheet user). SAF
needs **no storage permission**. Re-export overwrites same-named files (delete-then-create) so it's
not cumulative clutter.

## Privacy posture (Pledges / Principle 6)

- **Store/merchant names ARE exported** — driver-owned, not customer PII.
- **`customerHash`/`addressHash` are EXCLUDED** — edge-hashed customer PII has no purpose in a
  tax/earnings spreadsheet, so the privacy-lean default is to not ship them at all (test asserts
  neither hash appears in any of the three files). No raw customer name/address ever existed in
  these rows (hashed at the edge upstream).
- **No network, no new permission.** Logging is counts-only (files written), never row contents.

## IRS-rate handling

`IrsMileage.RATE_PER_MILE = 0.70` is labeled **`TAX_YEAR = 2025`** (the confirmed 2025 business
rate) and the summary emits both the year and the rate so the deduction is never ambiguous about
which year produced it. A `TODO(#319)` flags confirming the 2026 rate + a per-year lookup once the
IRS publishes it — no silently-invented 2026 precision.

## Deferred / follow-ups

- **All-time export only (v1)** — a date-range picker is a follow-up (the DAO queries are already
  range-based, so it's additive).
- **The Analytics hub-header export action is DEFERRED** to the parallel PR that owns
  `AnalyticsScreen`; the orchestrator wires it later. This PR only adds the Settings entry point.

## Tests

`:domain:test` 286 (incl. **CsvTest 22**), `:core:data:testDebugUnitTest` 13 (incl.
**CsvExporterTest 8**), `:app:testDebugUnitTest` 903. **0 failures.** Covered: RFC-4180 quoting
edges (comma/quote/newline/CR), null vs zero, machine number/timestamp formatting + zone offset,
entity→CSV rows, platform display-name resolution, hash exclusion, session-miles derivation, and
the deduction math. New DAO queries are trivial `SELECT … WHERE … ORDER BY` validated at compile
time by Room/KSP (no instrumented DAO test added — those need a device).

### Design-goal review

- **P1 (UDF):** reducers untouched; export is a read-side one-shot off the repository, UI dispatches
  an intent (folder Uri) → ViewModel, never writes repos directly.
- **P2 (MAD):** Kotlin/Compose, Hilt VM, coroutines + IO dispatcher, SAF via framework APIs.
- **P3 (SRP):** pure formatting split (`:domain` primitives / `:core:data` assembly) from the `:app`
  IO edge; small files.
- **P4 (Kotlin/Android):** `Locale.ROOT` for machine strings (the whole point of `Csv`);
  `runCatching` + sealed `ExportState`; structured `viewModelScope`.
- **P5 (SSOT):** RFC-4180 + number/timestamp formatting has one owner (`Csv`); the IRS rate is one
  constant. Export is deliberately **not** routed through the human-facing `Formats` (that pins
  `Locale.getDefault()` + `$` — wrong for a machine CSV); the divergence is intentional and
  documented.
- **P6 (security/privacy):** hashes excluded, merchants included, no network, no new permission,
  counts-only logging — stated above.
- **P7 (logging):** one `Export` tag, INFO logs a file count only (a counter, PII-safe); errors at
  ERROR.
- **P8 (platform-agnostic):** platform rendered via `Platform.fromWire(...).displayName`, never a
  literal compared in logic; no new `:core:state`/`:core:pipeline` vocabulary.
- **Reactive UI:** export result is a `StateFlow` the screen collects; nothing time-derived to tick.

### Adversarial review

Not yet run — the orchestrator gates this PR with a fable-tier `/code-review` + `/security-review`
(untrusted-input boundary is minimal here: no rule ingest, but the SAF write + PII-exclusion is
worth a security pass) before merge. **Do not merge until that pass is clean.**