### PR TITLE
feat(#659): Money tab 4-step true-net waterfall with F2 coverage guard

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/MoneyTab.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/MoneyTab.kt
@@ -110,7 +110,12 @@ private fun EarningsHero(economics: PeriodEconomics) {
  */
 object WaterfallModel {
 
-    /** One row of the rendered waterfall. [amount] is non-negative for [Role.COST] by construction. */
+    /**
+     * One row of the rendered waterfall. [amount] is non-negative for [Role.COST] on the 4-step
+     * path by construction (frozen per-mile rates × floored miles); the 3-step fallback's derived
+     * cost (`gross − net`) CAN go negative in the reported<delivered shape (#662-F1) — the bar
+     * renders zero-width and the signed amount displays honestly.
+     */
     data class Step(val role: Role, val label: String, val amount: Double)
 
     enum class Role { GROSS, COST, NET }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/MoneyTab.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/MoneyTab.kt
@@ -41,9 +41,9 @@ private const val UNATTRIBUTED_EPSILON = 0.005
 
 /**
  * Money tab v1 (#315 H1): the frozen-net earnings review for the selected period, top→bottom —
- * earnings hero, 3-step true-net waterfall, stat tiles, the unattributed-pay review flag, top
- * stores, and recent dashes. Pure data in / [PeriodEconomics] + record lists, no side effects.
- * Every string routes through the [Formats]/[formatShortDate] SSOT.
+ * earnings hero, true-net waterfall (3- or 4-step per [WaterfallModel], #659), stat tiles, the
+ * unattributed-pay review flag, top stores, and recent dashes. Pure data in / [PeriodEconomics] +
+ * record lists, no side effects. Every string routes through the [Formats]/[formatShortDate] SSOT.
  */
 @Composable
 fun MoneyTab(
@@ -96,28 +96,86 @@ private fun EarningsHero(economics: PeriodEconomics) {
 }
 
 /**
- * The 3-step true-net waterfall (#659 pending 4-step lift): gross → −operating cost → net.
- * Operating cost is the gap (gross − net); unattributed pay is net-additive, so it flows through
- * consistently. Each row is a proportional bar against gross — the honest visual of "what stayed".
+ * Pure decision logic for the true-net waterfall's step count (#659) — kept Compose-free so it's
+ * unit-testable in isolation from rendering.
+ *
+ * The waterfall renders **4-step** (Gross → −Fuel → −Non-fuel → Net) only when the frozen
+ * fuel/non-fuel split is trustworthy for the whole period: both sums are non-null AND they
+ * reconcile against the period's derived operating cost (`gross − net`) within a tolerance. A
+ * period that mixes `OFFER_FROZEN` rows with pre-split fallback rows has fuel+non-fuel covering
+ * only the frozen subset, so the sums fall short of `gross − net` — that shortfall IS the coverage
+ * signal, no separate flag needed. When the guard fails, this silently returns the exact **3-step**
+ * (Gross → −Operating cost → Net) shape instead — no partial-coverage note is shown; the fallback
+ * keeps the surface honest without cluttering it with a caveat (see PR for the tradeoff).
+ */
+object WaterfallModel {
+
+    /** One row of the rendered waterfall. [amount] is non-negative for [Role.COST] by construction. */
+    data class Step(val role: Role, val label: String, val amount: Double)
+
+    enum class Role { GROSS, COST, NET }
+
+    /** Whichever is larger wins: a flat cent floor for small periods, 1% for large ones. */
+    private const val RELATIVE_TOLERANCE = 0.01
+    private const val ABSOLUTE_TOLERANCE_DOLLARS = 0.50
+
+    fun from(economics: PeriodEconomics): List<Step> {
+        val gross = economics.grossEarnings
+        val net = economics.netProfit
+        val cost = gross - net
+        val fuel = economics.fuelCost
+        val nonFuel = economics.nonFuelCost
+
+        if (fuel != null && nonFuel != null) {
+            val tolerance = maxOf(cost * RELATIVE_TOLERANCE, ABSOLUTE_TOLERANCE_DOLLARS)
+            if (kotlin.math.abs((fuel + nonFuel) - cost) <= tolerance) {
+                return listOf(
+                    Step(Role.GROSS, "Gross", gross),
+                    Step(Role.COST, "Fuel", fuel),
+                    Step(Role.COST, "Non-fuel (wear, depreciation, fixed)", nonFuel),
+                    Step(Role.NET, "Net", net),
+                )
+            }
+        }
+
+        return listOf(
+            Step(Role.GROSS, "Gross", gross),
+            Step(Role.COST, "Operating cost", cost),
+            Step(Role.NET, "Net", net),
+        )
+    }
+}
+
+/**
+ * The true-net waterfall: gross → −cost step(s) → net, 3- or 4-step per [WaterfallModel.from]
+ * (#659). Unattributed pay is net-additive, so it flows through consistently regardless of step
+ * count. Each row is a proportional bar against the period's largest magnitude — the honest
+ * visual of "what stayed".
  */
 @Composable
 private fun TrueNetWaterfall(economics: PeriodEconomics) {
     val c = AppTheme.colors
-    val gross = economics.grossEarnings
-    val net = economics.netProfit
-    val cost = gross - net
+    val steps = WaterfallModel.from(economics)
     // Bars scale against the largest magnitude so a net > gross (net-additive unattributed) still
     // renders sanely and a zero period draws empty bars instead of dividing by zero.
-    val scale = maxOf(gross, cost, net, 0.0).takeIf { it > 0.0 } ?: 1.0
+    val scale = (listOf(0.0) + steps.map { it.amount }).max().takeIf { it > 0.0 } ?: 1.0
 
     AppCard(modifier = Modifier.fillMaxWidth()) {
         Text(text = "TRUE NET", style = MaterialTheme.typography.labelMedium, color = c.text3)
         Spacer(Modifier.height(10.dp))
-        WaterfallRow("Gross", Formats.money(gross), (gross / scale).toFloat(), c.accent, c.text)
-        Spacer(Modifier.height(8.dp))
-        WaterfallRow("Operating cost", "−${Formats.money(cost)}", (cost / scale).toFloat(), c.bad, c.text2)
-        Spacer(Modifier.height(8.dp))
-        WaterfallRow("Net", Formats.money(net), (net / scale).toFloat(), c.good, if (net >= 0.0) c.good else c.bad)
+        steps.forEachIndexed { index, step ->
+            if (index > 0) Spacer(Modifier.height(8.dp))
+            val (amountText, barColor, amountColor) = when (step.role) {
+                WaterfallModel.Role.GROSS -> Triple(Formats.money(step.amount), c.accent, c.text)
+                WaterfallModel.Role.COST -> Triple("−${Formats.money(step.amount)}", c.bad, c.text2)
+                WaterfallModel.Role.NET -> Triple(
+                    Formats.money(step.amount),
+                    c.good,
+                    if (step.amount >= 0.0) c.good else c.bad,
+                )
+            }
+            WaterfallRow(step.label, amountText, (step.amount / scale).toFloat(), barColor, amountColor)
+        }
     }
 }
 

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/WaterfallModelTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/WaterfallModelTest.kt
@@ -1,0 +1,101 @@
+package cloud.trotter.dashbuddy.ui.main.analytics
+
+import cloud.trotter.dashbuddy.domain.analytics.PeriodEconomics
+import cloud.trotter.dashbuddy.domain.analytics.PeriodTotals
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * #659 — the true-net waterfall's step-count decision (Gross → −Fuel → −Non-fuel → Net vs the
+ * 3-step Gross → −Operating cost → Net fallback). Pure logic, no Compose: [WaterfallModel.from]
+ * is exercised directly against [PeriodEconomics] shapes.
+ */
+class WaterfallModelTest {
+
+    private fun economics(
+        gross: Double,
+        net: Double,
+        fuel: Double? = null,
+        nonFuel: Double? = null,
+    ): PeriodEconomics = PeriodEconomics(
+        totals = PeriodTotals(earnings = net, miles = 20.0, deliveries = 3, jobs = 2, onlineDuration = 3_600_000L),
+        grossEarnings = gross,
+        netProfit = net,
+        unattributedPay = 0.0,
+        netPerHour = null,
+        netPerMile = null,
+        fuelCost = fuel,
+        nonFuelCost = nonFuel,
+    )
+
+    @Test
+    fun `full frozen coverage renders 4 steps that sum to net`() {
+        val steps = WaterfallModel.from(economics(gross = 20.0, net = 10.0, fuel = 6.0, nonFuel = 4.0))
+
+        assertEquals(4, steps.size)
+        assertEquals(
+            listOf("Gross", "Fuel", "Non-fuel (wear, depreciation, fixed)", "Net"),
+            steps.map { it.label },
+        )
+        assertEquals(
+            listOf(WaterfallModel.Role.GROSS, WaterfallModel.Role.COST, WaterfallModel.Role.COST, WaterfallModel.Role.NET),
+            steps.map { it.role },
+        )
+        // Gross - Fuel - NonFuel == Net (the waterfall must actually reconcile visually).
+        val gross = steps[0].amount
+        val fuel = steps[1].amount
+        val nonFuel = steps[2].amount
+        val net = steps[3].amount
+        assertEquals(net, gross - fuel - nonFuel, 1e-9)
+    }
+
+    @Test
+    fun `coverage within tolerance still renders 4 steps`() {
+        // cost = 10.0, split sums to 9.7 -> within the 0.50 absolute tolerance floor.
+        val steps = WaterfallModel.from(economics(gross = 20.0, net = 10.0, fuel = 5.8, nonFuel = 3.9))
+        assertEquals(4, steps.size)
+    }
+
+    @Test
+    fun `null fuel falls back to 3 steps`() {
+        val steps = WaterfallModel.from(economics(gross = 20.0, net = 10.0, fuel = null, nonFuel = 4.0))
+
+        assertEquals(3, steps.size)
+        assertEquals(listOf("Gross", "Operating cost", "Net"), steps.map { it.label })
+        assertEquals(10.0, steps[1].amount, 1e-9) // gross - net
+    }
+
+    @Test
+    fun `null nonFuel falls back to 3 steps`() {
+        val steps = WaterfallModel.from(economics(gross = 20.0, net = 10.0, fuel = 6.0, nonFuel = null))
+        assertEquals(3, steps.size)
+    }
+
+    @Test
+    fun `partial coverage below tolerance falls back to 3 steps`() {
+        // cost = 10.0, split sums to only 5.0 -> a mixed frozen+fallback period (#659 F2 guard).
+        val steps = WaterfallModel.from(economics(gross = 20.0, net = 10.0, fuel = 3.0, nonFuel = 2.0))
+
+        assertEquals(3, steps.size)
+        assertEquals(listOf("Gross", "Operating cost", "Net"), steps.map { it.label })
+        assertEquals(10.0, steps[1].amount, 1e-9)
+    }
+
+    @Test
+    fun `zero period falls back to 3 steps of zeros`() {
+        val steps = WaterfallModel.from(PeriodEconomics.EMPTY)
+
+        assertEquals(3, steps.size)
+        assertEquals(listOf("Gross", "Operating cost", "Net"), steps.map { it.label })
+        steps.forEach { assertEquals(0.0, it.amount, 1e-9) }
+    }
+
+    @Test
+    fun `zero period with full zero split still reconciles to 4 steps`() {
+        // Degenerate but honest: 0 == 0 within tolerance, so the split is still "trustworthy".
+        val steps = WaterfallModel.from(economics(gross = 0.0, net = 0.0, fuel = 0.0, nonFuel = 0.0))
+
+        assertEquals(4, steps.size)
+        steps.forEach { assertEquals(0.0, it.amount, 1e-9) }
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/WaterfallModelTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/WaterfallModelTest.kt
@@ -98,4 +98,16 @@ class WaterfallModelTest {
         assertEquals(4, steps.size)
         steps.forEach { assertEquals(0.0, it.amount, 1e-9) }
     }
+
+    @Test
+    fun `negative derived cost (reported under delivered) falls back to 3 steps with the signed cost`() {
+        // The #662-F1 shape: gross < net → derived cost is negative. The 1% tolerance term goes
+        // negative but the $0.50 floor rescues max(); any real (non-negative) split then fails the
+        // guard, so the fallback renders — with the honest signed cost, never a fabricated split.
+        val steps = WaterfallModel.from(economics(gross = 20.0, net = 25.0, fuel = 1.0, nonFuel = 2.0))
+
+        assertEquals(3, steps.size)
+        assertEquals(listOf("Gross", "Operating cost", "Net"), steps.map { it.label })
+        assertEquals(-5.0, steps[1].amount, 1e-9)
+    }
 }

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -87,13 +87,25 @@ was found **broken-in-part** (raw PII in capture envelopes) and moved to that en
   From the home screen tap the **Analytics** tile: it should open a real hub (back arrow) with a
   **Money / Patterns / Decisions / Time** tab bar (the last three show a "coming soon" card). On
   **Money**, pick **Today / Week / Month / Lifetime** and confirm the figures re-anchor: the earnings
-  hero (gross + True-Net / Net-hr chips), the 3-step **gross → −operating cost → net** waterfall, the
+  hero (gross + True-Net / Net-hr chips), the **gross → −cost step(s) → net** waterfall (3- or 4-step
+  per #659 — see the dedicated item below), the
   2×2 tiles ($/hr · $/mi · Miles · Deliveries), top stores, and recent dashes. Cross-check: for the
   **same period** the Money numbers should match the dashboard's tiles (both read the same frozen
   read-model). An **unattributed-pay callout** appears only when that period has bonuses/adjustments.
   How to tell it's broken: the old "Construction Area 🚧" placeholder still shows, figures don't change
   with the period, Money ≠ dashboard for the same window, a crash on an empty period, or a "$0.00"
   unattributed callout on a period with none.
+  - Confirmed: 0/2
+- **🆕 NEW — Money tab 4-step waterfall: Fuel vs Non-fuel, with a clean fallback on mixed periods
+  (#659).** After the v10 refold, open **Analytics → Money** on a period whose deliveries all carry
+  the frozen fuel/non-fuel split (a period entirely dashed after the #668 data-side merge should
+  qualify): the waterfall should show **4 rows** — Gross → −Fuel → −Non-fuel → Net — and Fuel +
+  Non-fuel should visually sum to the old "Operating cost" gap. Then check a period that **mixes**
+  pre-split (fallback) deliveries with frozen ones (e.g. Lifetime, or a week straddling the merge):
+  the waterfall should **silently fall back to the 3-step** Gross → −Operating cost → Net shape — no
+  broken numbers, no partial-coverage row, no crash. How to tell it's broken: a 4-step render on a
+  mixed period (Fuel+Non-fuel not summing to Gross−Net), a 3-step render on an all-frozen period
+  (coverage guard too strict), or Fuel/Non-fuel bars rendering negative/nonsensical.
   - Confirmed: 0/2
 - **🆕 NEW — Analytics Decisions tab: offer funnel + value-of-saying-no + score-vs-outcome (#315 H3).**
   In the Analytics hub tap the **Decisions** tab and pick a period (Today / Week / Month / Lifetime).


### PR DESCRIPTION
## Summary

Completes #659 (data side merged in #668): the Money tab's true-net waterfall now
renders **4-step** (Gross → −Fuel → −Non-fuel → Net) when the frozen fuel/non-fuel
split is trustworthy for the whole period, and falls back to the existing **3-step**
(Gross → −Operating cost → Net) otherwise.

## Guard semantics (F2 coverage guard)

The decision is extracted into a pure, Compose-free function, `WaterfallModel.from(economics)`
(`app/.../ui/main/analytics/MoneyTab.kt`):

- Requires `economics.fuelCost != null && economics.nonFuelCost != null`.
- Requires `|fuel + nonFuel − (gross − net)| <= max(cost * 1%, $0.50)` — the split must
  reconcile against the period's derived operating cost within tolerance (whichever bound
  is larger, so small periods get a cent floor and large periods get a proportional
  band).
- A period that mixes `OFFER_FROZEN` deliveries with pre-split fallback rows has
  `fuel + nonFuel` cover only the frozen subset, so the sums fall short of `gross − net` —
  that shortfall **is** the coverage signal; no separate flag/column is needed.
- On failure, returns the **exact** existing 3-step shape (same labels, same math) — no UI
  regression for periods that don't yet have a covering split (e.g. Lifetime, or any
  period straddling the #668 merge).

## Silent-fallback choice

Per the issue spec, a guard failure falls back **silently** — no "partial coverage" note or
caveat UI. Rationale: the surface should never show numbers that don't reconcile, and a
permanent "some data missing" callout would be clutter for what's expected to be a
transient condition (mixed pre/post-split periods age out as older deliveries roll off
Today/Week/Month; only Lifetime stays permanently mixed). If field use reveals dashers
want to know Lifetime specifically doesn't have Fuel/Non-fuel yet, a coverage note can be
added later — kept out of scope here to match the bounded task.

## Design-goal review

- **UDF / Reactive UI (1, Reactive UI rules)** — `WaterfallModel.from` is pure data-in/data-out,
  no side effects; `TrueNetWaterfall` stays a stateless composable driven entirely by the
  `PeriodEconomics` passed in. No new time-derived values, so the ticker rules don't apply.
- **Single responsibility (3)** — the step-count *decision* is now a separate, named, unit-testable
  function instead of being inlined in the composable; the composable's job shrinks to
  "render whatever steps I'm given."
- **Kotlin/Android practices (4)** — `Role` enum instead of a stringly-typed row kind; the guard
  reads as one early-return branch rather than a boolean flag threaded through smart-casts
  (an earlier draft using a `splitCovers: Boolean` val tripped a real compiler warning —
  "Condition is always true" — because Kotlin couldn't smart-cast `fuel`/`nonFuel` through
  the boolean; restructured to a direct `if (fuel != null && nonFuel != null)` branch).
- **SSOT (5)** — reuses the existing `Formats.money` SSOT for every amount string; no new
  formatting logic. The guard consumes `PeriodEconomics.fuelCost`/`nonFuelCost`, which are
  already the SSOT sums from the projector (#668) — no re-derivation.
- **Security & privacy (6)** — no PII surface touched; this is aggregate dollar figures only.
- **Platform-agnostic core (8)** — N/A, this diff touches only `:app` UI, not `:core:state`/
  `:core:pipeline`/`:domain`/rule JSON.

## Test plan

- New `WaterfallModelTest` (`app/src/test/.../ui/main/analytics/WaterfallModelTest.kt`), 7 cases:
  full coverage → 4 steps summing to net; in-tolerance coverage → 4 steps; null fuel → 3 steps;
  null non-fuel → 3 steps; out-of-tolerance partial coverage → 3 steps; zero period
  (`PeriodEconomics.EMPTY`) → 3 steps of zeros; zero period with an explicit zero split → 4 steps
  of zeros (degenerate-but-honest case).
- Full suite green: `:app:testDebugUnitTest` 918 tests / `:domain:test` 275 tests, 0
  failures/errors (JAVA_HOME=java-25-openjdk).
- `AllMatchersSuite` green (no recognition/rule changes in this diff, but ran per the
  pre-PR checklist).

## Field testing

Added a checklist item to `docs/field-testing/README.md` (`## Next field test`) for the
4-step render + silent-fallback behavior on-device, `Confirmed: 0/2`. Also touched up the
now-stale "3-step" wording in the existing #315 H1 Money-tab checklist item to point at
this one instead of asserting a fixed step count.

## Deviations from spec

None. Implements exactly what's described in the #659 issue thread: 4-step render gated
by the F2 coverage guard, silent 3-step fallback, "Fuel" / "Non-fuel (wear, depreciation,
fixed)" labels, zero-safe proportional bars.

**Do not merge** — orchestrator gates per the 3-phase pipeline (adversarial review at
fable tier still needs to run).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>