### PR TITLE
fix(#653): stop identity-less phantom drop double-counting period pay/tips

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
@@ -1228,7 +1228,8 @@ class EffectMapTest {
     fun `leaving PostTask emits DELIVERY_COMPLETED`() {
         val (platform, _) = stateWithPlatform()
         val session = Session("sess-1", startedAt = 100L)
-        val completedTask = Task(taskId = "task-1", jobId = "job-1", phase = TaskPhase.DROPOFF, storeName = "Chipotle", startedAt = 900L, completedAt = 950L)
+        // #653: identity-bearing (a real delivered drop) so the PostTask-exit firewall admits it.
+        val completedTask = Task(taskId = "task-1", jobId = "job-1", phase = TaskPhase.DROPOFF, storeName = "Chipotle", customerNameHash = "cust-1", startedAt = 900L, completedAt = 950L)
         // #596: a real receipt exit has the job still ACTIVE going in (it closes on this same step),
         // so completedJobId is non-null → the SCOPED fallback finds the task. The unscoped (job-less)
         // fallback is now gated when there's genuinely nothing to complete (job already closed, no
@@ -1307,7 +1308,8 @@ class EffectMapTest {
         // must name the still-active task, stamped at the receipt's appearance.
         val (platform, _) = stateWithPlatform()
         val session = Session("sess-1", startedAt = 100L)
-        val active = Task(taskId = "task-9", jobId = "job-1", phase = TaskPhase.DROPOFF, storeName = "Chipotle", startedAt = 900L)
+        // #653: identity-bearing (a real delivered drop) so the PostTask-exit firewall admits it.
+        val active = Task(taskId = "task-9", jobId = "job-1", phase = TaskPhase.DROPOFF, storeName = "Chipotle", customerNameHash = "cust-9", startedAt = 900L)
         val pend = PendingDestructive(
             kind = DestructiveKind.TASK_RETIRE, since = 950L, deadline = 3_450L, authoritative = true,
         )

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjector.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjector.kt
@@ -396,7 +396,10 @@ class AnalyticsProjector @Inject constructor(
          * v2 (#659): frozen fuel/non-fuel per-mile split on delivery_records + estFuel/NonFuelPerMile
          * on offer_records + startSource on session_records — all populated from the immutable log on
          * the refold this bump triggers.
+         * v3 (#653): the fold now drops a full-receipt stamp on an already-delivered multi-delivery
+         * job as SUSPECT (`PayBasis.SUSPECT_FULL_RECEIPT`, no realizedPay/tip/base) instead of
+         * double-counting the period SUM — the refold applies the guard to history.
          */
-        private const val PROJECTOR_VERSION = 2
+        private const val PROJECTOR_VERSION = 3
     }
 }

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -400,7 +400,16 @@ class EffectMap @Inject constructor() {
                     // customer-less "completion" of a store that was never delivered (06-21 seq98:
                     // Smoky Mo's pickup …32 completed at the moment the Burger King add-on was
                     // accepted). Only a task that actually reached the dropoff phase may complete.
-                    if (completedTask != null && completedTask.phase == TaskPhase.DROPOFF) {
+                    // #653 firewall parity: mirror the #596 close-out path's #498 identity firewall
+                    // (below, `customerNameHash == null && customerAddressHash == null`) here too —
+                    // an identity-less phantom drop must not mint a full-receipt completion from the
+                    // PostTask-exit path either, or it would land the whole receipt on a phantom while
+                    // its siblings' apportioned shares already sum to it (the read-model double-count,
+                    // #653/#630). An identity-BEARING single drop is the normal path, unaffected.
+                    val identityLess = completedTask != null &&
+                        completedTask.customerNameHash == null &&
+                        completedTask.customerAddressHash == null
+                    if (completedTask != null && completedTask.phase == TaskPhase.DROPOFF && !identityLess) {
                         val retireSince = p.pendingDestructive
                             ?.takeIf { it.kind == DestructiveKind.TASK_RETIRE }?.since
                         // #528: attribute this drop's share of the combined receipt. Read the

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapPayloadTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapPayloadTest.kt
@@ -444,7 +444,7 @@ class EffectMapPayloadTest {
             jobId = "J6",
             phase = TaskPhase.DROPOFF,
             arrivedAt = 2500L,
-        )
+        ).copy(customerNameHash = "cust-t6") // #653: identity-bearing so the PostTask-exit firewall admits it
         val regionPrev = PlatformRegion(
             platform = Platform.DoorDash,
             mode = Mode.Online,
@@ -479,6 +479,49 @@ class EffectMapPayloadTest {
         // #518: idempotency scoped to the completed task (not obs.timestamp) so a re-entered
         // PostTask receipt can't re-fire the same delivery via effects_fired.
         assertEquals("log:DELIVERY_COMPLETED:T6", logs[0].effectKey)
+    }
+
+    @Test
+    fun `PostTask-exit does NOT mint a completion for an identity-less phantom drop (#653 firewall parity)`() {
+        // Same receipted PostTask exit as above, but the completing DROPOFF task carries NO customer
+        // identity (name AND address hash both null) — the #498/#517/#518 phantom shape. The #596
+        // close-out path already refuses such a task; #653 adds the parity firewall to this
+        // PostTask-exit mint so a phantom can't land a full-receipt completion here either (which the
+        // read-model fold would then double-count against the siblings' apportioned shares).
+        val postFields = ParsedFields.PostTaskFields(
+            totalPay = 7.50,
+            parsedPay = ParsedPay(
+                appPayComponents = listOf(ParsedPayItem("Base Pay", 4.50)),
+                customerTips = listOf(ParsedPayItem("Wendy's", 3.00)),
+            ),
+            sessionEarnings = 47.50,
+        )
+        val phantom = task(
+            taskId = "T7",
+            jobId = "J7",
+            phase = TaskPhase.DROPOFF,
+            arrivedAt = 2500L,
+        ) // identity-less: customerNameHash + customerAddressHash both null (helper default)
+        val regionPrev = PlatformRegion(
+            platform = Platform.DoorDash,
+            mode = Mode.Online,
+            session = Session("s1", startedAt = 500L, runningEarnings = 47.50),
+            activeJob = Job("J7", offerStoreHint = emptyList(), parentOfferHash = null, startedAt = 400L),
+            recentTasks = listOf(phantom),
+            lastPostTaskFields = postFields,
+        )
+        val prev = appState(
+            flow = FlowRegion(flow = Flow.PostTask),
+            platforms = mapOf(Platform.DoorDash to regionPrev),
+        )
+        val next = appState(
+            flow = FlowRegion(flow = Flow.Idle),
+            platforms = mapOf(Platform.DoorDash to regionPrev.copy()),
+        )
+        val obs = screenObs(flow = Flow.Idle, timestamp = 3000L)
+
+        val logs = logEvents(prev, next, obs, AppEventType.DELIVERY_COMPLETED)
+        assertEquals("identity-less phantom does not mint a completion", 0, logs.size)
     }
 
     // =========================================================================

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -73,6 +73,18 @@ card's **mechanical** half, #577 (re-confirmed, 24/24, ~0.55 s — with a new po
 that entry's Bug #1), the #457 path, and #554 ShadowProjector (2/2). The #462/#460 dropoff item
 was found **broken-in-part** (raw PII in capture envelopes) and moved to that entry's Bug #7.)_
 
+- **🆕 NEW — identity-less completions now firewalled at PostTask exit (#653 / PR #673): watch a
+  no-name drop for a MISSING completion.** The PostTask-exit `DELIVERY_COMPLETED` mint now mirrors
+  the close-out path's #498 identity firewall: a dropoff task that never acquired a customer
+  name/address hash mints no completion. Field history says identity-less dropoff tasks are
+  phantoms, but the known residual is a REAL delivery whose only name-bearing screen is still
+  unruled — e.g. a GoPuff last drop via the multi-order-confirm surface (#501 deferred). On any
+  GoPuff batch (or other drop where the customer name never appeared on a recognized screen),
+  check afterwards that the delivery still shows in the session's deliveries/earnings. How to tell
+  it's broken: a real, physically-delivered drop is absent from the completion list / Money tab
+  while its siblings are present.
+  - Confirmed: 0/2
+
 - **🆕 NEW — driving/glance-mode HUD font-scale toggle (#318).** Flip "Driving glance mode" on in
   Settings → General while a dash is running (or the bubble is up). The bubble HUD's text — the
   hero $/hr, task timers, captions, everything — should visibly grow (~12%) immediately, with no

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/RecordFolds.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/RecordFolds.kt
@@ -15,6 +15,15 @@ object PayBasis {
     const val DROP_SHARE = "DROP_SHARE"
     /** The whole receipt total, stamped on this drop (single-drop / collapsed-receipt shape). */
     const val RECEIPT_TOTAL = "RECEIPT_TOTAL"
+    /**
+     * A full-receipt stamp on a drop of an ALREADY-delivered (multi-delivery) job — dropped as
+     * suspect (#653). An identity-less phantom drop in a receipted stack arrives with the whole
+     * `parsedPay` and NO apportioned `dropRealizedPay` share, while its sibling drops' shares
+     * already sum to that receipt; stamping the full receipt here would double-count the period
+     * SUM. Fold-side defense-in-depth behind the #498/#653 upstream identity firewall — no
+     * realizedPay/tip/base is recorded for such a row.
+     */
+    const val SUSPECT_FULL_RECEIPT = "SUSPECT_FULL_RECEIPT"
     /** No pay signal on the completion (receipt-skipped #596). */
     const val NONE = "NONE"
 }
@@ -295,10 +304,24 @@ object RecordFolds {
         val odo = event.metadata?.odometer
         val completedAt = p.completedAt ?: e.occurredAt
 
+        // #653: a full-receipt stamp on a drop of an ALREADY-delivered (multi-delivery) job is
+        // SUSPECT. The signal the fold can see: this jobId already delivered ≥1 drop this session
+        // (it is in the accumulated/hydrated `deliveredJobIds`), yet this completion carries the
+        // whole `parsedPay` receipt with NO apportioned `dropRealizedPay` share — the identity-less
+        // phantom shape (#498/#517/#518), excluded from the apportion denominator upstream. Its
+        // sibling drops' shares already sum to that receipt, so stamping the full receipt here would
+        // double-count the period SUM. Drop the pay/tip/base rather than inflating. A single-delivery
+        // job (this jobId's first/only drop) is NOT flagged — a bare totalPay on the sole drop is
+        // correct and keeps RECEIPT_TOTAL. Defense-in-depth behind the EffectMap identity firewall.
+        val priorDeliveryForThisJob = ctx != null && p.jobId in ctx.deliveredJobIds
+        val suspectFullReceipt =
+            priorDeliveryForThisJob && p.parsedPay != null && p.dropRealizedPay == null
+
         // Pay + basis. dropRealizedPay is a per-drop share (possibly of a multi-drop receipt);
         // its absence with a bare totalPay means the whole receipt landed on this one drop.
-        val realizedPay = p.dropRealizedPay ?: p.totalPay
+        val realizedPay = if (suspectFullReceipt) null else p.dropRealizedPay ?: p.totalPay
         val payBasis = when {
+            suspectFullReceipt -> PayBasis.SUSPECT_FULL_RECEIPT
             p.dropRealizedPay != null -> PayBasis.DROP_SHARE
             p.totalPay != null -> PayBasis.RECEIPT_TOTAL
             else -> PayBasis.NONE
@@ -306,9 +329,10 @@ object RecordFolds {
         // tip/basePay only when this drop IS the job's sole drop — i.e. it carries the WHOLE receipt.
         // The apportioner stamps `dropRealizedPay` even on a single drop (its share == the total), so
         // a null-drop bare receipt OR a share equal to the receipt total is the sole-drop signal; a
-        // smaller share is a stacked drop, which has no per-drop tip split yet (→ null).
+        // smaller share is a stacked drop, which has no per-drop tip split yet (→ null). A suspect
+        // full-receipt drop (#653) is never the sole drop — its siblings already carry the receipt.
         val receipt = p.parsedPay
-        val soleDrop = receipt != null &&
+        val soleDrop = !suspectFullReceipt && receipt != null &&
             (p.dropRealizedPay == null || kotlin.math.abs(p.dropRealizedPay - receipt.total) < 0.005)
         val tip = if (soleDrop) receipt?.totalTip else null
         val basePay = if (soleDrop) receipt?.totalBasePay else null

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/RecordFolds.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/RecordFolds.kt
@@ -16,12 +16,18 @@ object PayBasis {
     /** The whole receipt total, stamped on this drop (single-drop / collapsed-receipt shape). */
     const val RECEIPT_TOTAL = "RECEIPT_TOTAL"
     /**
-     * A full-receipt stamp on a drop of an ALREADY-delivered (multi-delivery) job — dropped as
-     * suspect (#653). An identity-less phantom drop in a receipted stack arrives with the whole
-     * `parsedPay` and NO apportioned `dropRealizedPay` share, while its sibling drops' shares
-     * already sum to that receipt; stamping the full receipt here would double-count the period
-     * SUM. Fold-side defense-in-depth behind the #498/#653 upstream identity firewall — no
-     * realizedPay/tip/base is recorded for such a row.
+     * A full-receipt stamp on an IDENTITY-LESS drop of an ALREADY-delivered (multi-delivery)
+     * job — dropped as suspect (#653). An identity-less phantom drop (customer AND address hash
+     * both null — the #498 class, by construction: the payload copies the task's null hashes) in
+     * a receipted stack arrives with the whole `parsedPay` and NO apportioned `dropRealizedPay`
+     * share, while its sibling drops' shares already sum to that receipt; stamping the full
+     * receipt here would double-count the period SUM. Fold-side defense-in-depth behind the
+     * #498/#653 upstream identity firewall — no realizedPay/tip/base is recorded for such a row.
+     * The identity check is load-bearing: an identity-BEARING full-receipt row on a multi-drop
+     * job is the LEGITIMATE pre-#528 historical mint shape (N−1 null-pay rows + one announced
+     * drop carrying the whole receipt — the job's only money) and must keep [RECEIPT_TOTAL].
+     * A SUSPECT row is kept for auditability (this provenance names why its money is null) and
+     * still counts as a delivery / advances the partition anchors — only its money is nulled.
      */
     const val SUSPECT_FULL_RECEIPT = "SUSPECT_FULL_RECEIPT"
     /** No pay signal on the completion (receipt-skipped #596). */
@@ -304,18 +310,25 @@ object RecordFolds {
         val odo = event.metadata?.odometer
         val completedAt = p.completedAt ?: e.occurredAt
 
-        // #653: a full-receipt stamp on a drop of an ALREADY-delivered (multi-delivery) job is
-        // SUSPECT. The signal the fold can see: this jobId already delivered ≥1 drop this session
-        // (it is in the accumulated/hydrated `deliveredJobIds`), yet this completion carries the
-        // whole `parsedPay` receipt with NO apportioned `dropRealizedPay` share — the identity-less
-        // phantom shape (#498/#517/#518), excluded from the apportion denominator upstream. Its
-        // sibling drops' shares already sum to that receipt, so stamping the full receipt here would
-        // double-count the period SUM. Drop the pay/tip/base rather than inflating. A single-delivery
-        // job (this jobId's first/only drop) is NOT flagged — a bare totalPay on the sole drop is
-        // correct and keeps RECEIPT_TOTAL. Defense-in-depth behind the EffectMap identity firewall.
+        // #653: a full-receipt stamp on an IDENTITY-LESS drop of an ALREADY-delivered
+        // (multi-delivery) job is SUSPECT. The signal the fold can see: this jobId already
+        // delivered ≥1 drop this session (it is in the accumulated/hydrated `deliveredJobIds`),
+        // this completion carries the whole `parsedPay` receipt with NO apportioned
+        // `dropRealizedPay` share, AND it has no customer identity (both hashes null — the
+        // #498/#517/#518 phantom class by construction; the payload copies the task's null hashes,
+        // and identity-less drops are excluded from the apportion denominator upstream). Its
+        // sibling drops' shares already sum to that receipt, so stamping the full receipt here
+        // would double-count the period SUM. Drop the pay/tip/base rather than inflating.
+        // The identity discriminator is LOAD-BEARING for history: the pre-#528 mint shape for a
+        // legitimate receipted multi-drop stack was N−1 null-pay rows + ONE identity-BEARING row
+        // carrying the whole receipt (the job's only money, usually folding LAST) — that row must
+        // keep RECEIPT_TOTAL on the v3 refold, not be nulled. A single-delivery job (this jobId's
+        // first/only drop) is likewise NOT flagged — a bare totalPay on the sole drop is correct.
+        // Defense-in-depth behind the EffectMap identity firewall (which blocks new phantoms).
         val priorDeliveryForThisJob = ctx != null && p.jobId in ctx.deliveredJobIds
         val suspectFullReceipt =
-            priorDeliveryForThisJob && p.parsedPay != null && p.dropRealizedPay == null
+            priorDeliveryForThisJob && p.parsedPay != null && p.dropRealizedPay == null &&
+                p.customerHash == null && p.addressHash == null
 
         // Pay + basis. dropRealizedPay is a per-drop share (possibly of a multi-drop receipt);
         // its absence with a bare totalPay means the whole receipt landed on this one drop.

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/RecordFoldsTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/RecordFoldsTest.kt
@@ -105,11 +105,15 @@ class RecordFoldsTest {
         parsedPay: ParsedPay? = null,
         odo: Double? = null,
         phaseStartedAt: Long = at - 600_000,
+        // Identity-bearing by default (a real delivered drop). A #498/#653 phantom payload has
+        // BOTH hashes null (the payload copies the task's null hashes) — pass true to model it.
+        identityLess: Boolean = false,
     ) = ev(
         AppEventType.DELIVERY_COMPLETED, sid, at,
         DeliveryPayload(
             jobId = jobId, taskId = taskId, storeName = "StoreX",
-            customerHash = "cust-$taskId", addressHash = "addr-$taskId",
+            customerHash = if (identityLess) null else "cust-$taskId",
+            addressHash = if (identityLess) null else "addr-$taskId",
             phaseStartedAt = phaseStartedAt, arrivedAt = at - 120_000, completedAt = at,
             totalPay = totalPay, parsedPay = parsedPay, dropRealizedPay = dropRealizedPay,
         ),
@@ -397,8 +401,9 @@ class RecordFoldsTest {
                 offerAccepted(s, 1_500, "h", eval(net = 15.0, dist = 5.0, opCpm = 0.20)),
                 delivery(s, 3_000, "J1", "T1", dropRealizedPay = 11.34, parsedPay = parsedPay(8.0, 12.0), odo = 5.0),
                 delivery(s, 4_000, "J1", "T2", dropRealizedPay = 8.66, parsedPay = parsedPay(8.0, 12.0), odo = 8.0),
-                // Phantom: full receipt, NO apportioned share, and this job already delivered ≥1 drop.
-                delivery(s, 5_000, "J1", "T3", totalPay = 20.0, dropRealizedPay = null, parsedPay = parsedPay(8.0, 12.0), odo = 9.0),
+                // Phantom: IDENTITY-LESS (both hashes null — the real #498 class), full receipt,
+                // NO apportioned share, and this job already delivered ≥1 drop.
+                delivery(s, 5_000, "J1", "T3", totalPay = 20.0, dropRealizedPay = null, parsedPay = parsedPay(8.0, 12.0), odo = 9.0, identityLess = true),
             ),
         )
         val a = outcomes[2].delivery!!
@@ -432,6 +437,41 @@ class RecordFoldsTest {
         assertEquals(PayBasis.RECEIPT_TOTAL, d.payBasis)
         assertEquals(12.0, d.realizedPay!!, 1e-9)
         assertEquals("sole drop carries the receipt tip", 3.0, d.tip!!, 1e-9)
+    }
+
+    @Test
+    fun `pre-#528 receipted stack — the identity-BEARING full-receipt last drop keeps RECEIPT_TOTAL (#653 F1)`() {
+        val s = "S4d"
+        // The HISTORICAL (05-17 → 07-03, pre-#528) mint shape for a legitimate receipted 2-drop
+        // stack: N−1 null-pay rows + ONE identity-bearing row carrying the whole receipt — no
+        // dropRealizedPay anywhere (the field didn't exist yet). That receipted drop is the job's
+        // ONLY money and normally folds LAST (jobId already in deliveredJobIds). The v3 refold
+        // must keep it RECEIPT_TOTAL with full pay — NOT flag it SUSPECT (which would zero the
+        // entire pre-#528 field campaign's stack pay). The identity discriminator is what saves it.
+        val (outcomes, _) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 0.0),
+                offerAccepted(s, 1_500, "h", eval(net = 15.0, dist = 5.0, opCpm = 0.20)),
+                // Drop A: identity-bearing, NO pay signal at all (the pre-#528 non-announced drop).
+                delivery(s, 3_000, "J1", "TA", odo = 5.0),
+                // Drop B: identity-BEARING, whole receipt (parsedPay + totalPay), no share field.
+                delivery(s, 4_000, "J1", "TB", totalPay = 20.0, dropRealizedPay = null, parsedPay = parsedPay(8.0, 12.0), odo = 8.0),
+            ),
+        )
+        val a = outcomes[2].delivery!!
+        val b = outcomes[3].delivery!!
+
+        assertEquals("non-announced sibling has no pay signal", PayBasis.NONE, a.payBasis)
+        assertNull(a.realizedPay)
+
+        assertEquals("identity-bearing full-receipt drop is LEGITIMATE, not suspect", PayBasis.RECEIPT_TOTAL, b.payBasis)
+        assertEquals(20.0, b.realizedPay!!, 1e-9)
+        assertEquals("it carries the receipt tip (sole money row)", 12.0, b.tip!!, 1e-9)
+        assertEquals(8.0, b.basePay!!, 1e-9)
+
+        // Period SUM == receipt: the stack's money is counted exactly once.
+        val periodSum = outcomes.mapNotNull { it.delivery?.realizedPay }.sum()
+        assertEquals("Σ realizedPay == receipt (counted once, not zeroed)", 20.0, periodSum, 1e-9)
     }
 
     @Test

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/RecordFoldsTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/RecordFoldsTest.kt
@@ -385,6 +385,56 @@ class RecordFoldsTest {
     }
 
     @Test
+    fun `a full-receipt phantom drop in a receipted multi-delivery job is SUSPECT, no period double-count (#653)`() {
+        val s = "S4b"
+        // A receipted stack: two identity-bearing drops (A, B) split the $20 receipt via the
+        // apportioner (their dropRealizedPay shares sum to it). A third, identity-less phantom drop
+        // (C) of the SAME job slips through carrying the WHOLE receipt (parsedPay) with NO share —
+        // the #498/#517/#518 shape. Stamping the full receipt on C would double-count the period SUM.
+        val (outcomes, ctx) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 0.0),
+                offerAccepted(s, 1_500, "h", eval(net = 15.0, dist = 5.0, opCpm = 0.20)),
+                delivery(s, 3_000, "J1", "T1", dropRealizedPay = 11.34, parsedPay = parsedPay(8.0, 12.0), odo = 5.0),
+                delivery(s, 4_000, "J1", "T2", dropRealizedPay = 8.66, parsedPay = parsedPay(8.0, 12.0), odo = 8.0),
+                // Phantom: full receipt, NO apportioned share, and this job already delivered ≥1 drop.
+                delivery(s, 5_000, "J1", "T3", totalPay = 20.0, dropRealizedPay = null, parsedPay = parsedPay(8.0, 12.0), odo = 9.0),
+            ),
+        )
+        val a = outcomes[2].delivery!!
+        val b = outcomes[3].delivery!!
+        val phantom = outcomes[4].delivery!!
+
+        assertEquals(PayBasis.SUSPECT_FULL_RECEIPT, phantom.payBasis)
+        assertNull("suspect drop records no realized pay", phantom.realizedPay)
+        assertNull("suspect drop records no tip", phantom.tip)
+        assertNull("suspect drop records no base pay", phantom.basePay)
+        assertNull("no realized pay ⇒ no net", phantom.netProfit)
+
+        // The no-double-count invariant: the period SUM over the job's drops equals the receipt.
+        val periodSum = outcomes.mapNotNull { it.delivery?.realizedPay }.sum()
+        assertEquals("Σ realizedPay == receipt (phantom adds nothing)", 20.0, periodSum, 1e-9)
+        assertEquals("siblings still carry their apportioned shares", 20.0, a.realizedPay!! + b.realizedPay!!, 1e-9)
+    }
+
+    @Test
+    fun `a single-delivery job with a bare receipt keeps RECEIPT_TOTAL, not SUSPECT (#653 control)`() {
+        val s = "S4c"
+        // First (and only) drop of its job: parsedPay present, no dropRealizedPay share. This is the
+        // legitimate sole-drop shape — the whole receipt IS this drop's pay. Must NOT be flagged.
+        val (outcomes, _) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 0.0),
+                delivery(s, 3_000, "J9", "T9", totalPay = 12.0, dropRealizedPay = null, parsedPay = parsedPay(9.0, 3.0), odo = 5.0),
+            ),
+        )
+        val d = outcomes[1].delivery!!
+        assertEquals(PayBasis.RECEIPT_TOTAL, d.payBasis)
+        assertEquals(12.0, d.realizedPay!!, 1e-9)
+        assertEquals("sole drop carries the receipt tip", 3.0, d.tip!!, 1e-9)
+    }
+
+    @Test
     fun `partition miles sum to the session odometer delta`() {
         val s = "S5"
         val (outcomes, _) = foldSession(


### PR DESCRIPTION
Closes #653. Relates #630 (mid-stack attribution), #498 (identity firewall), follow-up to #314 (analytics read-model).

## The bug
An **identity-less** drop completing in a **receipted multi-delivery** job could add the whole receipt on top of its siblings' apportioned `dropRealizedPay` shares — which already sum to the receipt. The PostTask-exit `DELIVERY_COMPLETED` mint (`EffectMap.kt`) lacked the #498 identity firewall the #596 close-out path has, while `jobDropoffTasks` excludes identity-less drops from the apportion denominator — so the phantom got `dropRealizedPay = null` + the full `parsedPay`, and the fold stamped `realizedPay = totalPay` (the whole receipt) on it. Period-SUM double-count (the #517/#518 class, now in the #314 read-model).

## Two fixes (defense in depth)

### Direction 1 — fold-side hardening (`domain/.../analytics/RecordFolds.kt`)
In `foldDeliveryCompleted`, a full-receipt stamp on an **identity-less** drop of a job that has **already delivered ≥1 drop this session** is treated as SUSPECT. The predicate (all four conditions):
- `p.jobId in ctx.deliveredJobIds` — the fold's accumulated set (hydrated from `delivery_records` on a mid-session restart via `deliveredJobIdsInSession`). Present ⇒ this jobId already delivered at least once.
- `p.parsedPay != null && p.dropRealizedPay == null` — the whole receipt with no apportioned share.
- **`p.customerHash == null && p.addressHash == null`** — the identity-less discriminator (added per the adversarial review's F1): the #498 phantom class is identity-less *by construction*, and this is what separates it from the **legitimate pre-#528 historical mint shape** — a receipted multi-drop stack logged 05-17→07-03 as N−1 null-pay rows + ONE identity-**bearing** row carrying the whole receipt (the job's only money, normally folding last). Without the discriminator the v3 refold would have zeroed that entire field campaign's stack pay; with it, identity-bearing historical receipts keep `RECEIPT_TOTAL`.

Result for a SUSPECT row: `realizedPay = null`, `payBasis = PayBasis.SUSPECT_FULL_RECEIPT` (new constant), `tip`/`basePay` null, `netProfit` null. The row itself is kept (auditability — the provenance names why its money is null) and still counts as a delivery / advances the partition anchors. Single-delivery jobs (this jobId's first/only drop) are **not** flagged — a bare `totalPay` on the sole drop is correct and keeps `RECEIPT_TOTAL`.

### Direction 2 — upstream firewall parity (`core/state/.../EffectMap.kt`)
The PostTask-exit mint now mirrors the close-out path's #498 predicate **exactly** (`customerNameHash == null && customerAddressHash == null`): an identity-less task does not mint a `DELIVERY_COMPLETED` from the PostTask-exit path either. An identity-**bearing** single drop is the normal path, unaffected.

**Stated behavior extension (adversarial review, PLAUSIBLE residual):** a REAL delivery whose dropoff task never acquired either hash — e.g. a GoPuff last drop whose only name-bearing screen is the still-unruled multi-order-confirm surface (#501 deferred) — now loses its `DELIVERY_COMPLETED` at PostTask exit entirely (previously it minted with pay). This is coherent with the close-out path and the apportion denominator, which already treat identity-less as phantom (and #498 field history shows in-the-wild identity-less dropoff tasks were phantoms), but it is an explicit extension of that posture to the last mint site — a field-test checklist item now watches for a missing completion on a no-name drop.

`PROJECTOR_VERSION` 2 → 3 so the refold applies the fold guard to history.

## Period-SUM invariant evidence
`RecordFoldsTest`:
- **Phantom case:** a receipted job with two identity-bearing drops (shares 11.34 + 8.66 = 20.0 receipt) plus an **identity-less** full-receipt phantom of the same job → phantom `realizedPay`/`tip`/`basePay`/`netProfit` all null, `payBasis == SUSPECT_FULL_RECEIPT`, and `Σ realizedPay == 20.0` (the phantom adds nothing).
- **Pre-#528 legit-history regression (F1):** the old mint shape — null-pay identity-bearing sibling folds first, then an identity-**bearing** full-receipt drop of the same job — keeps `RECEIPT_TOTAL` with full pay + tip + base; `Σ realizedPay == 20.0` (counted once, not zeroed).
- **Control:** a single-delivery job with a bare receipt keeps `RECEIPT_TOTAL` with the full pay + tip.

`EffectMapPayloadTest`: an identity-less DROPOFF task reaching PostTask-exit mints **0** completions (firewall parity), mirroring the close-out firewall.

## Replay-suite confirmation
The #565/#498 replay tests + `EffectMapPayloadTest` / `SingleDeliveryReplayTest` / `ReceiptSkipReplayTest` stay green — the normal identity-bearing single/stacked delivery path is unchanged; only the identity-less mint is blocked.

**Test resolution note:** two existing PostTask-exit *mint-mechanism* fixtures used a bare "Chipotle" dropoff task with no customer hash (`EffectMapTest` — `leaving PostTask emits DELIVERY_COMPLETED`, the #431 retire-grace variant — and `EffectMapPayloadTest`'s pay-plumbing test). Neither asserts identity-less-mint *behavior*; they were under-specified fixtures (their sibling tests already set a hash — the adversarial review independently blamed all three as INCIDENTAL). Given a customer hash to match real delivered drops, preserving each test's intent. The `RecordFoldsTest` `delivery()` helper now takes an `identityLess` flag so the phantom fixtures model the real class (both hashes null).

## Test counts (JAVA_HOME=java-25-openjdk, post-F1, `--rerun-tasks` for :domain/:core:state)
- `:domain:test` — 278, 0 failures (+1: the pre-#528 legit-history regression)
- `:core:state:testDebugUnitTest` — 104, 0 failures
- `:app:testDebugUnitTest` (incl. replay tests + AllMatchersSuite) — 911, 0 failures

## Field-test item
Added to `docs/field-testing/README.md` (per the adversarial review): watch a no-name drop (GoPuff multi-order-confirm residual, #501) for a **missing** completion — the one real-world shape the PostTask-exit firewall could newly suppress. The fold-side change needs no field item (pure, refold-deterministic from the immutable log, replay/unit-tested).

### Design-goal review
- **1 UDF** — the fold and `EffectMap` stay pure (driven by event/obs data, no wall clock/side effects); the guard is a read of the already-threaded `deliveredJobIds` + the payload's own hashes.
- **5 SSOT** — `PayBasis.SUSPECT_FULL_RECEIPT` is the one new provenance constant, owned in `RecordFolds` alongside its siblings and consumed by the DB column; no duplicated logic. The identity predicate is now the SAME discriminator at both layers (fold: `customerHash`/`addressHash`; EffectMap: the task hashes the payload copies) — the F1 fix closed the drift between them.
- **6 Security/privacy** — no PII surface change: the fold still records only hashes/economics; the firewall makes phantom rows carry *less* data. `SUSPECT_FULL_RECEIPT` is a state-name constant (INFO-safe).
- **8 Platform-agnostic** — no platform literals added; the fold and firewall are keyed on generic payload/task fields (`jobId`, `deliveredJobIds`, customer hashes), not any platform. Touches `:domain` + `:core:state` — checked: no `== Platform.X`, no magic-string `when`.

### Adversarial review
Fable-tier review returned REQUEST CHANGES with one BLOCKING finding (F1 — the SUSPECT predicate lacked the identity-less discriminator and would have nulled legitimate pre-#528 historical stack money on the v3 refold). **Fixed in `6f57a39a`**: predicate gains `customerHash == null && addressHash == null`, the S4b phantom fixture is now truly identity-less, and the pre-#528 legit-history regression test the review specified is added (passes). The review's PLAUSIBLE residual (identity-less real delivery loses its completion) is now stated above + field-watched (`30f2cba8`). All other surfaces (EffectMap parity, fixture-edit rulings, projector bump, fold semantics) were confirmed sound by the review. Awaiting re-review / merge gate by the orchestrator.