### PR TITLE
feat(#315): H4 — Time tab (time split, deadhead, on-time, mileage & tax)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsScreen.kt
@@ -30,11 +30,10 @@ import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
 import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
 
 /**
- * The Analytics hub (#315). Ships the real Money / Patterns / Decisions / Time tab bar now so
- * the structure is stable; only [AnalyticsTab.Money] has content in H1 (the others show a
- * "coming soon" card — Decisions H3, Time H4, Patterns H5). A **review** surface: UDF state in,
- * `setTab`/`setPeriod` intents out (Principle 1); reactive-fresh via the read-model Flows, no
- * `rememberNow()` tick (a historical period's figures are fixed).
+ * The Analytics hub (#315). Money / Decisions / Time all render real content; Patterns (H5) still
+ * shows a "coming soon" card. A **review** surface: UDF state in, `setTab`/`setPeriod` intents out
+ * (Principle 1); reactive-fresh via the read-model Flows, no `rememberNow()` tick (a historical
+ * period's figures are fixed).
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -96,9 +95,16 @@ fun AnalyticsScreen(
                     DecisionsTab(decisions = uiState.decisions)
                 }
 
-                AnalyticsTab.Patterns,
-                AnalyticsTab.Time,
-                -> ComingSoonCard(uiState.selectedTab)
+                AnalyticsTab.Time -> {
+                    PeriodSelector(
+                        selectedPeriod = uiState.selectedPeriod,
+                        onSelectPeriod = viewModel::setPeriod,
+                    )
+                    Spacer(Modifier.height(16.dp))
+                    TimeTab(time = uiState.time)
+                }
+
+                AnalyticsTab.Patterns -> ComingSoonCard(uiState.selectedTab)
             }
         }
     }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsUiState.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsUiState.kt
@@ -5,11 +5,12 @@ import cloud.trotter.dashbuddy.domain.analytics.DecisionEconomics
 import cloud.trotter.dashbuddy.domain.analytics.PeriodEconomics
 import cloud.trotter.dashbuddy.domain.analytics.SessionRecord
 import cloud.trotter.dashbuddy.domain.analytics.StoreEconomics
+import cloud.trotter.dashbuddy.domain.analytics.TimeEconomics
 
 /**
- * The Analytics hub tabs (#315). Only [Money] has content in H1; the rest ship as the
- * real tab-bar structure with a "coming soon" placeholder so later phases (Decisions H3,
- * Time H4, Patterns H5) slot in without reshaping navigation.
+ * The Analytics hub tabs (#315). [Money], [Decisions] (H3), and [Time] (H4) render real content;
+ * [Patterns] (H5) still ships as the real tab-bar structure with a "coming soon" placeholder so it
+ * slots in without reshaping navigation.
  */
 enum class AnalyticsTab(val label: String) {
     Money("Money"),
@@ -41,4 +42,6 @@ data class AnalyticsUiState(
     val recentSessions: List<SessionRecord> = emptyList(),
     /** Offer-decision economics for [selectedPeriod] — the Decisions tab (#315 H3, frozen est.). */
     val decisions: DecisionEconomics = DecisionEconomics.EMPTY,
+    /** Time / mileage economics for [selectedPeriod] — the Time tab (#315 H4, measured). */
+    val time: TimeEconomics = TimeEconomics.EMPTY,
 )

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsViewModel.kt
@@ -7,6 +7,7 @@ import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
 import cloud.trotter.dashbuddy.domain.analytics.DecisionEconomics
 import cloud.trotter.dashbuddy.domain.analytics.PeriodEconomics
 import cloud.trotter.dashbuddy.domain.analytics.StoreEconomics
+import cloud.trotter.dashbuddy.domain.analytics.TimeEconomics
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -20,10 +21,10 @@ import javax.inject.Inject
 /**
  * State holder for the Analytics hub (#315 H1) — a **review** surface assembled reactively
  * from the durable analytics read-model ([AnalyticsRepository]), exposing one immutable
- * [AnalyticsUiState] (Principle 1 — UDF). Strictly over the EXISTING repository surface:
+ * [AnalyticsUiState] (Principle 1 — UDF). Over the read-model repository surface:
  * `periodEconomics` (frozen-net totals), `perStoreEconomics` (top stores), `recentSessions`
- * (recent dashes) — no new SQL/DAO aggregation (those are later phases; the #655 bucketing
- * work owns the DAO internals).
+ * (recent dashes), `decisionEconomics` (H3 funnel/verdicts), and `timeEconomics` (H4 time/mileage) —
+ * every source session-anchored (#655) via the DAO join, which owns the bucketing.
  *
  * Reactive by construction: every source is a Room-invalidation `Flow`, so the tiles re-emit
  * as the projector folds each delivery and at midnight/week/month rollover (the boundary
@@ -57,7 +58,8 @@ class AnalyticsViewModel @Inject constructor(
                 analyticsRepository.periodEconomics(period),
                 analyticsRepository.perStoreEconomics(period),
                 analyticsRepository.decisionEconomics(period),
-            ) { economics, stores, decisions -> PeriodData(period, economics, stores, decisions) }
+                analyticsRepository.timeEconomics(period),
+            ) { economics, stores, decisions, time -> PeriodData(period, economics, stores, decisions, time) }
         },
         analyticsRepository.recentSessions(RECENT_SESSIONS_LIMIT),
     ) { tab, data, sessions ->
@@ -68,6 +70,7 @@ class AnalyticsViewModel @Inject constructor(
             topStores = data.stores.take(TOP_STORES),
             recentSessions = sessions,
             decisions = data.decisions,
+            time = data.time,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), AnalyticsUiState())
 
@@ -87,6 +90,7 @@ class AnalyticsViewModel @Inject constructor(
         val economics: PeriodEconomics,
         val stores: List<StoreEconomics>,
         val decisions: DecisionEconomics,
+        val time: TimeEconomics,
     )
 
     private companion object {

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/TimeTab.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/TimeTab.kt
@@ -1,0 +1,225 @@
+package cloud.trotter.dashbuddy.ui.main.analytics
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import cloud.trotter.dashbuddy.core.designsystem.component.AppCard
+import cloud.trotter.dashbuddy.core.designsystem.component.AppGaugeRing
+import cloud.trotter.dashbuddy.core.designsystem.component.AppLegend
+import cloud.trotter.dashbuddy.core.designsystem.component.AppSegment
+import cloud.trotter.dashbuddy.core.designsystem.component.AppStackBar
+import cloud.trotter.dashbuddy.core.designsystem.component.AppStatTile
+import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
+import cloud.trotter.dashbuddy.domain.analytics.TimeEconomics
+import cloud.trotter.dashbuddy.domain.export.IrsMileage
+import cloud.trotter.dashbuddy.domain.format.Formats
+import cloud.trotter.dashbuddy.domain.format.formatDuration
+import kotlin.math.roundToInt
+import kotlin.math.roundToLong
+
+/** Placeholder shown for a figure with no measurable input yet (Money/Decisions-tab parity). */
+private const val EMPTY_VALUE = "—"
+
+/**
+ * Time tab (#315 H4): the measured time / mileage review for the selected period, top→bottom — the
+ * online-time split (on-delivery vs unattributed), the deadhead ratio, the on-time gauge, and the
+ * mileage-&-tax card. Pure data in ([TimeEconomics]), no side effects (Principle 1 — UDF).
+ *
+ * **Everything here is MEASURED, not estimated** — session durations, per-delivery partition deltas,
+ * odometer deltas — so there's no "est." qualifier and no economy dependency (this surface reports
+ * time and miles, never a re-costed value). Attribution semantics are stated honestly on each card
+ * (delivery deltas include the approach legs; deadhead is the unattributed remainder; the on-time
+ * rate covers only deadline-carrying deliveries). Aggregate-only: counts + durations + miles, no
+ * merchant/customer text (Principle 6). Every number routes through the [Formats] / [formatDuration]
+ * SSOT; the tax line reads the year + rate from [IrsMileage] (never a literal).
+ */
+@Composable
+fun TimeTab(
+    time: TimeEconomics,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        TimeSplitCard(time)
+        DeadheadCard(time)
+        OnTimeCard(time)
+        MileageTaxCard(time)
+    }
+}
+
+/** Online-time split: hero online duration + an on-delivery / unattributed stack bar + dash tiles. */
+@Composable
+private fun TimeSplitCard(time: TimeEconomics) {
+    val c = AppTheme.colors
+    AppCard(modifier = Modifier.fillMaxWidth()) {
+        Text(text = "TIME SPLIT", style = MaterialTheme.typography.labelMedium, color = c.text3)
+        Spacer(Modifier.height(10.dp))
+        if (time.onlineMillis == 0L) {
+            EmptyRow("No dashes in this period yet.")
+            return@AppCard
+        }
+
+        Text(text = formatDuration(time.onlineMillis), style = AppTheme.num.heroNum, color = c.text)
+        Spacer(Modifier.height(2.dp))
+        Text(
+            text = "online across ${Formats.commaInt(time.sessions)} " +
+                if (time.sessions == 1) "dash" else "dashes",
+            style = MaterialTheme.typography.bodySmall,
+            color = c.text3,
+        )
+        Spacer(Modifier.height(14.dp))
+
+        val onDeliveryMillis = time.deliveryMillis ?: 0L
+        val segments = listOf(
+            AppSegment("On delivery", onDeliveryMillis.toFloat(), c.good, note = formatDuration(onDeliveryMillis)),
+            AppSegment("Unattributed", time.unattributedMillis.toFloat(), c.neutral, note = formatDuration(time.unattributedMillis)),
+        )
+        AppStackBar(segments, height = 14.dp)
+        Spacer(Modifier.height(10.dp))
+        AppLegend(segments)
+        Spacer(Modifier.height(14.dp))
+
+        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            AppStatTile(
+                label = "Dashes",
+                value = Formats.commaInt(time.sessions),
+                modifier = Modifier.weight(1f),
+            )
+            AppStatTile(
+                label = "Avg dash",
+                value = time.avgDashMillis?.let { formatDuration(it) } ?: EMPTY_VALUE,
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}
+
+/**
+ * Deadhead: the share of odometer miles not attributed to any delivery. Delivery miles are odometer
+ * partition deltas anchored on drop completions, so they already include the approach legs between
+ * drops — the deadhead here is the honest remainder (the tail after the last drop, and dashes with
+ * no delivery at all).
+ */
+@Composable
+private fun DeadheadCard(time: TimeEconomics) {
+    val c = AppTheme.colors
+    AppCard(modifier = Modifier.fillMaxWidth()) {
+        Text(text = "DEADHEAD", style = MaterialTheme.typography.labelMedium, color = c.text3)
+        Spacer(Modifier.height(10.dp))
+        if (time.miles <= 0.0) {
+            EmptyRow("No miles measured in this period yet.")
+            return@AppCard
+        }
+
+        val deadheadPct = (time.unattributedMiles / time.miles * 100.0).roundToInt()
+        Text(text = "$deadheadPct%", style = AppTheme.num.heroNum, color = c.text)
+        Spacer(Modifier.height(2.dp))
+        Text(
+            text = "miles with no delivery attached — after the last drop, or dashes with none",
+            style = MaterialTheme.typography.bodySmall,
+            color = c.text3,
+        )
+        Spacer(Modifier.height(14.dp))
+
+        // Attributed portion = total − unattributed (min of delivery-delta and total), so the bar
+        // sums to the period's odometer miles cleanly.
+        val onDeliveryMiles = time.miles - time.unattributedMiles
+        val segments = listOf(
+            AppSegment("On delivery", onDeliveryMiles.toFloat(), c.good, note = "${Formats.decimal(onDeliveryMiles, 1)} mi"),
+            AppSegment("Deadhead", time.unattributedMiles.toFloat(), c.neutral, note = "${Formats.decimal(time.unattributedMiles, 1)} mi"),
+        )
+        AppStackBar(segments, height = 14.dp)
+        Spacer(Modifier.height(10.dp))
+        AppLegend(segments)
+    }
+}
+
+/** On-time: a gauge over deliveries that carried a captured deadline + the average finish margin. */
+@Composable
+private fun OnTimeCard(time: TimeEconomics) {
+    val c = AppTheme.colors
+    AppCard(modifier = Modifier.fillMaxWidth()) {
+        Text(text = "ON TIME", style = MaterialTheme.typography.labelMedium, color = c.text3)
+        Spacer(Modifier.height(10.dp))
+        val rate = time.onTimeRate
+        if (rate == null) {
+            EmptyRow("No deliveries carried a deadline in this period.")
+            return@AppCard
+        }
+
+        AppGaugeRing(
+            progress = rate.toFloat(),
+            value = "${(rate * 100.0).roundToInt()}%",
+            label = "on time",
+            color = c.good,
+        )
+        Spacer(Modifier.height(10.dp))
+        Text(
+            text = "${Formats.commaInt(time.onTimeDeliveries)} of ${Formats.commaInt(time.deliveriesWithDeadline)} " +
+                (if (time.deliveriesWithDeadline == 1) "delivery" else "deliveries") + " with a deadline",
+            style = MaterialTheme.typography.bodySmall,
+            color = c.text3,
+        )
+
+        // Average finish margin (deadline − completedAt): positive ⇒ typically early.
+        time.avgDeadlineMarginMillis?.let { margin ->
+            Spacer(Modifier.height(4.dp))
+            val early = margin >= 0.0
+            val magnitude = kotlin.math.abs(margin).roundToLong()
+            Text(
+                text = if (early) "typically ${formatDuration(magnitude)} early"
+                else "typically ${formatDuration(magnitude)} late",
+                style = MaterialTheme.typography.bodySmall,
+                color = if (early) c.good else c.bad,
+            )
+        }
+    }
+}
+
+/** Mileage & tax: the period's session odometer miles + the estimated IRS standard-mileage deduction. */
+@Composable
+private fun MileageTaxCard(time: TimeEconomics) {
+    val c = AppTheme.colors
+    AppCard(modifier = Modifier.fillMaxWidth()) {
+        Text(text = "MILEAGE & TAX", style = MaterialTheme.typography.labelMedium, color = c.text3)
+        Spacer(Modifier.height(10.dp))
+        if (time.miles <= 0.0) {
+            EmptyRow("No miles measured in this period yet.")
+            return@AppCard
+        }
+
+        Text(text = "${Formats.decimal(time.miles, 1)} mi", style = AppTheme.num.heroNum, color = c.text)
+        Spacer(Modifier.height(6.dp))
+        Text(
+            text = "${Formats.money(IrsMileage.deduction(time.miles))} " +
+                "est. IRS ${IrsMileage.TAX_YEAR} standard-mileage deduction " +
+                "(${Formats.money(IrsMileage.RATE_PER_MILE)}/mi)",
+            style = MaterialTheme.typography.bodyMedium,
+            color = c.text,
+        )
+        Spacer(Modifier.height(6.dp))
+        Text(
+            text = "standard-mileage method — not the app's operating-cost model; confirm with a tax preparer.",
+            style = MaterialTheme.typography.bodySmall,
+            color = c.text3,
+        )
+    }
+}
+
+@Composable
+private fun EmptyRow(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.bodyMedium,
+        color = AppTheme.colors.text3,
+        modifier = Modifier.padding(vertical = 4.dp),
+    )
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsTimeTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsTimeTest.kt
@@ -1,0 +1,237 @@
+package cloud.trotter.dashbuddy.analytics
+
+import androidx.room.Room
+import cloud.trotter.dashbuddy.core.data.analytics.AnalyticsRepository
+import cloud.trotter.dashbuddy.core.database.DashBuddyDatabase
+import cloud.trotter.dashbuddy.core.database.analytics.AnalyticsDao
+import cloud.trotter.dashbuddy.core.database.analytics.DeliveryRecordEntity
+import cloud.trotter.dashbuddy.core.database.analytics.SessionRecordEntity
+import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+/**
+ * #315 H4 — the Time-tab aggregates over an in-memory database. Proves:
+ *  - `deliveryTimeTotals` is **session-anchored** (#655), byte-identical WHERE shape to the delivery
+ *    aggregates — a delivery buckets by its *session's* start day, not its own `completedAt`;
+ *  - the null-session fallback counts by the delivery's own `completedAt`, disjoint from the session
+ *    clause (never double-counted);
+ *  - on-time counting splits deadline-carrying rows on `completedAt <= deadlineMillis`, excludes
+ *    null-deadline rows, and `avgDeadlineMarginMillis` signs early-positive;
+ *  - an empty period returns nullable SUMs as null (no fabricated 0), and the repository folds them
+ *    into a [cloud.trotter.dashbuddy.domain.analytics.TimeEconomics] with null rates and coerced-≥0
+ *    derived values;
+ *  - the `sessions` COUNT lands in `sessionTotals` (+ per-platform), and `avgDashMillis` /
+ *    `unattributedMillis` derive correctly, including the coerce-≥0 edge (delivery time exceeding the
+ *    online span must not yield a negative unattributed).
+ */
+@RunWith(RobolectricTestRunner::class)
+class AnalyticsTimeTest {
+
+    private lateinit var db: DashBuddyDatabase
+    private lateinit var dao: AnalyticsDao
+    private lateinit var repo: AnalyticsRepository
+
+    private val base = 1_600_000_000_000L
+    private val hour = 3_600_000L
+    private val day = 86_400_000L
+
+    @Before
+    fun setUp() {
+        val context = RuntimeEnvironment.getApplication()
+        db = Room.inMemoryDatabaseBuilder(context, DashBuddyDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = db.analyticsDao()
+        repo = AnalyticsRepository(dao)
+    }
+
+    @After
+    fun tearDown() = db.close()
+
+    private fun session(
+        id: String,
+        startedAt: Long,
+        onlineMillis: Long = hour,
+        miles: Double = 5.0,
+        platform: String = "doordash",
+    ) = SessionRecordEntity(
+        sessionId = id,
+        platform = platform,
+        startedAt = startedAt,
+        endedAt = startedAt + onlineMillis,
+        lastEventAt = startedAt + onlineMillis,
+        endSource = "summary_screen",
+        startOdometer = 0.0,
+        lastOdometer = miles,
+        reportedEarnings = null,
+        reportedDurationMillis = onlineMillis,
+        offersReceived = 0,
+        offersAccepted = 0,
+        offersDeclined = 0,
+        offersTimeout = 0,
+        deliveries = 1,
+        jobsCompleted = 1,
+    )
+
+    private fun delivery(
+        seq: Long,
+        sessionId: String?,
+        completedAt: Long,
+        realizedMinutes: Double? = 10.0,
+        realizedMiles: Double? = 3.0,
+        deadlineMillis: Long? = null,
+        platform: String = "doordash",
+    ) = DeliveryRecordEntity(
+        eventSequenceId = seq,
+        sessionId = sessionId,
+        platform = platform,
+        jobId = "job-$seq",
+        taskId = "task-$seq",
+        storeName = "Wendys",
+        customerHash = null,
+        addressHash = null,
+        phaseStartedAt = completedAt - 600_000,
+        arrivedAt = null,
+        completedAt = completedAt,
+        deadlineMillis = deadlineMillis,
+        realizedPay = 8.0,
+        payBasis = "DROP_SHARE",
+        tip = null,
+        basePay = null,
+        odometerAtCompletion = null,
+        realizedMiles = realizedMiles,
+        realizedMinutes = realizedMinutes,
+        frozenCostPerMile = null,
+        netProfit = null,
+        costBasis = "NONE",
+    )
+
+    /** A delivery completed 00:10 today, in a session started 23:50 yesterday, buckets YESTERDAY. */
+    @Test
+    fun `deliveryTimeTotals is session-anchored, not completedAt-anchored`() = runBlocking {
+        val todayStart = base
+        val yesterdayStart = todayStart - day
+        val sessionStart = todayStart - 600_000   // 23:50 yesterday
+        val completed = todayStart + 600_000       // 00:10 today
+
+        dao.upsertSession(session("Y", sessionStart))
+        dao.upsertDelivery(
+            delivery(1, "Y", completedAt = completed, realizedMinutes = 10.0, realizedMiles = 3.0, deadlineMillis = completed + 60_000),
+        )
+
+        // TODAY: the session started yesterday ⇒ nothing lands here (session-anchored).
+        val today = dao.deliveryTimeTotals(todayStart, todayStart + day).first()
+        assertNull(today.deliveryMinutes)
+        assertNull(today.deliveryMiles)
+        assertEquals(0, today.withDeadline)
+        assertEquals(0, today.onTime)
+
+        // YESTERDAY: the whole delivery, though its completedAt is after midnight.
+        val yest = dao.deliveryTimeTotals(yesterdayStart, todayStart).first()
+        assertEquals(10.0, yest.deliveryMinutes!!, 1e-9)
+        assertEquals(3.0, yest.deliveryMiles!!, 1e-9)
+        assertEquals(1, yest.withDeadline)
+        assertEquals(1, yest.onTime)
+    }
+
+    /** A `sessionId IS NULL` delivery counts by its own `completedAt`; disjoint from the session clause. */
+    @Test
+    fun `null-session delivery counts by completedAt, disjoint from session clause`() = runBlocking {
+        val todayStart = base
+        val completedToday = todayStart + 600_000
+
+        dao.upsertOfferlessNullDelivery(completedToday)
+        dao.upsertSession(session("S", todayStart + 100))
+        dao.upsertDelivery(delivery(2, "S", completedAt = todayStart + hour, realizedMinutes = 8.0, realizedMiles = 2.0))
+
+        val today = dao.deliveryTimeTotals(todayStart, todayStart + day).first()
+        assertEquals(20.0, today.deliveryMinutes!!, 1e-9)  // 12 (null-session) + 8 (session) — each once
+        assertEquals(6.0, today.deliveryMiles!!, 1e-9)     // 4 + 2
+
+        // Yesterday window: null-session completedAt is today, session started today ⇒ empty.
+        assertNull(dao.deliveryTimeTotals(todayStart - day, todayStart).first().deliveryMinutes)
+
+        // LIFETIME catches both, still once each.
+        assertEquals(20.0, dao.deliveryTimeTotals(0, Long.MAX_VALUE).first().deliveryMinutes!!, 1e-9)
+    }
+
+    /** On-time splits on `completedAt <= deadline`; null-deadline rows excluded; margin signs early-positive. */
+    @Test
+    fun `on-time math splits on deadline and averages margin`() = runBlocking {
+        dao.upsertSession(session("S1", base))
+        // early by 120s
+        dao.upsertDelivery(delivery(1, "S1", completedAt = base + hour, deadlineMillis = base + hour + 120_000))
+        // late by 60s
+        dao.upsertDelivery(delivery(2, "S1", completedAt = base + 2 * hour, deadlineMillis = base + 2 * hour - 60_000))
+        // no deadline ⇒ excluded from withDeadline/onTime AND the margin average
+        dao.upsertDelivery(delivery(3, "S1", completedAt = base + 3 * hour, deadlineMillis = null))
+
+        val r = dao.deliveryTimeTotals(0, Long.MAX_VALUE).first()
+        assertEquals(2, r.withDeadline)
+        assertEquals(1, r.onTime)
+        // AVG(deadline − completedAt) over the two deadline rows = (120_000 + (−60_000)) / 2 = 30_000, positive = early
+        assertEquals(30_000.0, r.avgDeadlineMarginMillis!!, 1e-6)
+    }
+
+    /** Empty period ⇒ nullable SUMs stay null; repo folds to null rates + coerced-0 derived values. */
+    @Test
+    fun `empty period yields null sums and null-rate TimeEconomics`() = runBlocking {
+        val r = dao.deliveryTimeTotals(0, Long.MAX_VALUE).first()
+        assertNull(r.deliveryMinutes)
+        assertNull(r.deliveryMiles)
+        assertEquals(0, r.withDeadline)
+        assertEquals(0, r.onTime)
+        assertNull(r.avgDeadlineMarginMillis)
+
+        val t = repo.timeEconomics(AnalyticsPeriod.LIFETIME).first()
+        assertEquals(0, t.sessions)
+        assertEquals(0L, t.onlineMillis)
+        assertNull(t.deliveryMinutes)
+        assertNull(t.deliveryMiles)
+        assertNull(t.onTimeRate)
+        assertNull(t.avgDashMillis)
+        assertNull(t.deliveryMillis)
+        assertEquals(0L, t.unattributedMillis)   // coerced ≥ 0, no fabricated figure
+        assertEquals(0.0, t.unattributedMiles, 1e-9)
+    }
+
+    /** `sessions` COUNT lands in the session totals; `avgDashMillis`/`unattributedMillis` derive + coerce ≥ 0. */
+    @Test
+    fun `sessions count and derived splits including coerce edge`() = runBlocking {
+        dao.upsertSession(session("A", base, onlineMillis = hour, miles = 10.0))
+        dao.upsertSession(session("B", base + 10_000, onlineMillis = hour, miles = 6.0))
+        // Delivery time deliberately EXCEEDS the combined online span (200 min = 12_000_000ms > 2h).
+        dao.upsertDelivery(delivery(1, "A", completedAt = base + hour, realizedMinutes = 200.0, realizedMiles = 4.0))
+
+        // Cross-platform session count.
+        val s = dao.sessionTotals(0, Long.MAX_VALUE).first()
+        assertEquals(2, s.sessions)
+        assertEquals(2 * hour, s.onlineMillis)
+        assertEquals(16.0, s.miles, 1e-9)
+
+        // Per-platform variant carries the same count.
+        val sp = dao.sessionTotalsByPlatform(0, Long.MAX_VALUE).first().first { it.platform == "doordash" }
+        assertEquals(2, sp.sessions)
+
+        val t = repo.timeEconomics(AnalyticsPeriod.LIFETIME).first()
+        assertEquals(2, t.sessions)
+        assertEquals(hour, t.avgDashMillis)                    // 2h online / 2 dashes
+        assertEquals(12_000_000L, t.deliveryMillis)            // 200 min × 60_000
+        assertEquals(0L, t.unattributedMillis)                 // 7.2M online − 12M delivery ⇒ coerced to 0, NOT negative
+        assertEquals(12.0, t.unattributedMiles, 1e-9)          // 16 total − 4 delivery
+    }
+
+    /** Helper: a null-session delivery (no session context at all) completed at [completedAt]. */
+    private suspend fun AnalyticsDao.upsertOfferlessNullDelivery(completedAt: Long) =
+        upsertDelivery(delivery(1, sessionId = null, completedAt = completedAt, realizedMinutes = 12.0, realizedMiles = 4.0))
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsViewModelTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsViewModelTest.kt
@@ -7,6 +7,7 @@ import cloud.trotter.dashbuddy.domain.analytics.PeriodEconomics
 import cloud.trotter.dashbuddy.domain.analytics.PeriodTotals
 import cloud.trotter.dashbuddy.domain.analytics.SessionRecord
 import cloud.trotter.dashbuddy.domain.analytics.StoreEconomics
+import cloud.trotter.dashbuddy.domain.analytics.TimeEconomics
 import cloud.trotter.dashbuddy.domain.state.Platform
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -42,12 +43,14 @@ class AnalyticsViewModelTest {
         economics: PeriodEconomics,
         stores: List<StoreEconomics> = emptyList(),
         decisions: DecisionEconomics = DecisionEconomics.EMPTY,
+        time: TimeEconomics = TimeEconomics.EMPTY,
     ) {
         whenever(analyticsRepository.periodEconomics(eq(period), anyOrNull())).thenReturn(flowOf(economics))
         whenever(analyticsRepository.perStoreEconomics(eq(period))).thenReturn(flowOf(stores))
-        // The VM collects decisions unconditionally (see AnalyticsViewModel), so every period stub
-        // must supply a decisions flow or the combine would fold a null.
+        // The VM collects decisions + time unconditionally (see AnalyticsViewModel), so every period
+        // stub must supply both flows or the combine would fold a null.
         whenever(analyticsRepository.decisionEconomics(eq(period))).thenReturn(flowOf(decisions))
+        whenever(analyticsRepository.timeEconomics(eq(period))).thenReturn(flowOf(time))
     }
 
     private fun decisions(accepted: Int, declined: Int, timedOut: Int, acceptanceRate: Double?) =

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
@@ -1,8 +1,10 @@
 package cloud.trotter.dashbuddy.core.data.analytics
 
 import cloud.trotter.dashbuddy.core.database.analytics.AnalyticsDao
+import cloud.trotter.dashbuddy.core.database.analytics.DeliveryTimeTotalsRow
 import cloud.trotter.dashbuddy.core.database.analytics.OutcomeCountRow
 import cloud.trotter.dashbuddy.core.database.analytics.ScoreOutcomeRow
+import cloud.trotter.dashbuddy.core.database.analytics.SessionTotalsRow
 import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
 import cloud.trotter.dashbuddy.domain.analytics.DecisionEconomics
 import cloud.trotter.dashbuddy.domain.analytics.DeliveryRecord
@@ -10,6 +12,7 @@ import cloud.trotter.dashbuddy.domain.analytics.PeriodEconomics
 import cloud.trotter.dashbuddy.domain.analytics.PeriodTotals
 import cloud.trotter.dashbuddy.domain.analytics.SessionRecord
 import cloud.trotter.dashbuddy.domain.analytics.StoreEconomics
+import cloud.trotter.dashbuddy.domain.analytics.TimeEconomics
 import cloud.trotter.dashbuddy.domain.evaluation.NetProfit
 import cloud.trotter.dashbuddy.domain.model.event.AppEventType
 import cloud.trotter.dashbuddy.domain.state.Platform
@@ -125,6 +128,34 @@ class AnalyticsRepository @Inject constructor(
             ) { outcomes, scores -> assembleDecisions(outcomes, scores) }
         }
 
+    /**
+     * Time / mileage economics for [period] (#315 H4, Time tab): the online-time split, the deadhead
+     * (unattributed-miles) ratio, the on-time rate + avg deadline margin, and the session odometer
+     * miles behind the mileage-&-tax card. Combines the session totals ([AnalyticsDao.sessionTotals]
+     * — online time, miles, dash count) with the delivery-time aggregate
+     * ([AnalyticsDao.deliveryTimeTotals] — realized minutes/miles, on-time counts) into one
+     * [TimeEconomics].
+     *
+     * **Session-anchored (#655):** both aggregates derive from the sessions that *started* in the
+     * period (the delivery join has the same WHERE shape as [deliveryTotals], with a null-session
+     * `completedAt` fallback), so the split and its remainder are internally consistent by
+     * construction. Re-emits on new records (Room invalidation) and at midnight/week/month rollover
+     * (the boundary flow).
+     *
+     * **All figures are MEASURED, not estimated** — Σ session durations, Σ per-delivery partition
+     * deltas, Σ odometer deltas — with **no economy dependency** (Principle 5: this surface reports
+     * measured time/miles, never a re-costed value). Deadline coverage is explicit: the on-time rate
+     * covers only deliveries that carried a captured deadline. No new PII surface (counts + measured
+     * time/miles only).
+     */
+    fun timeEconomics(period: AnalyticsPeriod): Flow<TimeEconomics> =
+        periodBoundariesFlow(period).flatMapLatest { (start, end) ->
+            combine(
+                analyticsDao.sessionTotals(start, end),
+                analyticsDao.deliveryTimeTotals(start, end),
+            ) { s, d -> assembleTime(s, d) }
+        }
+
     /** Recent dashes, newest first (future hub / #650). */
     fun recentSessions(limit: Int = 20): Flow<List<SessionRecord>> =
         analyticsDao.recentSessions(limit).map { rows -> rows.map { it.toDomain() } }
@@ -227,4 +258,24 @@ class AnalyticsRepository @Inject constructor(
             avgEstPerHourDeclined = declinedScores?.avgEstPerHour,
         )
     }
+
+    /**
+     * Fold the session + delivery-time DAO rows into [TimeEconomics] (#315 H4). A straight pass-through
+     * of measured aggregates — nullable delivery SUMs stay nullable (no fabricated zero), and every
+     * derived split ([TimeEconomics.unattributedMillis]/[TimeEconomics.unattributedMiles] etc.) is the
+     * DTO's own coerce-≥0 helper, so this repository stores no second copy of that math (Principle 5).
+     */
+    private fun assembleTime(
+        session: SessionTotalsRow,
+        delivery: DeliveryTimeTotalsRow,
+    ): TimeEconomics = TimeEconomics(
+        sessions = session.sessions,
+        onlineMillis = session.onlineMillis,
+        deliveryMinutes = delivery.deliveryMinutes,
+        miles = session.miles,
+        deliveryMiles = delivery.deliveryMiles,
+        deliveriesWithDeadline = delivery.withDeadline,
+        onTimeDeliveries = delivery.onTime,
+        avgDeadlineMarginMillis = delivery.avgDeadlineMarginMillis,
+    )
 }

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
@@ -130,7 +130,8 @@ interface AnalyticsDao {
 
     @Query(
         """SELECT COALESCE(SUM(MAX(lastOdometer - startOdometer, 0)), 0) AS miles,
-                  COALESCE(SUM(COALESCE(endedAt, lastEventAt) - startedAt), 0) AS onlineMillis
+                  COALESCE(SUM(COALESCE(endedAt, lastEventAt) - startedAt), 0) AS onlineMillis,
+                  COUNT(*) AS sessions
            FROM session_records
            WHERE startedAt >= :start AND startedAt < :end"""
     )
@@ -139,7 +140,8 @@ interface AnalyticsDao {
     @Query(
         """SELECT platform,
                   COALESCE(SUM(MAX(lastOdometer - startOdometer, 0)), 0) AS miles,
-                  COALESCE(SUM(COALESCE(endedAt, lastEventAt) - startedAt), 0) AS onlineMillis
+                  COALESCE(SUM(COALESCE(endedAt, lastEventAt) - startedAt), 0) AS onlineMillis,
+                  COUNT(*) AS sessions
            FROM session_records
            WHERE startedAt >= :start AND startedAt < :end
            GROUP BY platform"""
@@ -237,6 +239,36 @@ interface AnalyticsDao {
            GROUP BY outcome"""
     )
     fun offerScoreOutcomes(start: Long, end: Long): Flow<List<ScoreOutcomeRow>>
+
+    // ── Time-tab aggregates (#315 H4) ───────────────────────────────────
+
+    /**
+     * Realized-time / realized-miles / on-time aggregates for the deliveries belonging to the
+     * **sessions that started in `[start, end)`** (session-anchored periods, #655) — the Time-tab
+     * inputs. The WHERE clause is **byte-identical to [deliveryTotals]**: a delivery buckets by the
+     * period of its *session's* `startedAt` (joined via `sessionId`), with the same null-session
+     * `completedAt` fallback for a truly session-less row. `NULL IN (…)` is never true in SQL, so the
+     * two clauses are disjoint (no double count); LIFETIME `(0, MAX)` keeps every row.
+     *
+     * [deliveryMinutes]/[deliveryMiles] are nullable SUMs left un-`COALESCE`d — SQL `SUM` of an empty
+     * set is NULL, the honest "nothing measured" signal (never a fabricated 0). [withDeadline]/[onTime]
+     * count ONLY deadline-carrying rows (a delivery with no captured deadline is excluded from both —
+     * never counted as late), and [avgDeadlineMarginMillis] averages `deadline − completedAt` over just
+     * those rows (positive = typically early; NULL when none carried a deadline — `AVG` skips the null
+     * CASE arms).
+     */
+    @Query(
+        """SELECT SUM(realizedMinutes) AS deliveryMinutes,
+                  SUM(realizedMiles) AS deliveryMiles,
+                  COALESCE(SUM(CASE WHEN deadlineMillis IS NOT NULL THEN 1 ELSE 0 END), 0) AS withDeadline,
+                  COALESCE(SUM(CASE WHEN deadlineMillis IS NOT NULL AND completedAt <= deadlineMillis THEN 1 ELSE 0 END), 0) AS onTime,
+                  AVG(CASE WHEN deadlineMillis IS NOT NULL THEN deadlineMillis - completedAt END) AS avgDeadlineMarginMillis
+           FROM delivery_records
+           WHERE sessionId IN (SELECT sessionId FROM session_records
+                               WHERE startedAt >= :start AND startedAt < :end)
+              OR (sessionId IS NULL AND completedAt >= :start AND completedAt < :end)"""
+    )
+    fun deliveryTimeTotals(start: Long, end: Long): Flow<DeliveryTimeTotalsRow>
 
     // ── Drill-down list reads (future hub / #650) ────────────────────────
 

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsTotals.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsTotals.kt
@@ -68,10 +68,12 @@ data class PlatformGrossTotalsRow(
     val unattributed: Double,
 )
 
-/** Cross-platform session totals for a period: miles = Σ odo delta, onlineMillis = Σ duration. */
+/** Cross-platform session totals for a period: miles = Σ odo delta, onlineMillis = Σ duration, sessions = COUNT. */
 data class SessionTotalsRow(
     val miles: Double,
     val onlineMillis: Long,
+    /** Dashes (sessions) that started in the period — the Time-tab dash count / avg-dash denominator (#315 H4). */
+    val sessions: Int,
 )
 
 /** Per-platform session totals (GROUP BY platform). */
@@ -79,6 +81,26 @@ data class PlatformSessionTotalsRow(
     val platform: String,
     val miles: Double,
     val onlineMillis: Long,
+    /** Dashes for the platform's period rows (#315 H4). */
+    val sessions: Int,
+)
+
+/**
+ * Time-tab delivery aggregates for a period (#315 H4) — session-anchored (#655), same WHERE shape as
+ * [DeliveryTotalsRow]. [deliveryMinutes]/[deliveryMiles] are Σ per-delivery realized **partition
+ * deltas** (nullable and left un-`COALESCE`d: SQL `SUM` of an empty set is NULL — the "nothing
+ * measured" signal, never a fabricated 0 miles/minutes). [withDeadline]/[onTime] cover ONLY
+ * deadline-carrying rows (a delivery with no captured deadline is excluded from both, never counted
+ * as late). [avgDeadlineMarginMillis] = `AVG(deadlineMillis − completedAt)` over deadline-carrying
+ * rows, positive when the driver typically finished early (nullable — null when no row carried a
+ * deadline).
+ */
+data class DeliveryTimeTotalsRow(
+    val deliveryMinutes: Double?,
+    val deliveryMiles: Double?,
+    val withDeadline: Int,
+    val onTime: Int,
+    val avgDeadlineMarginMillis: Double?,
 )
 
 /**

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -143,6 +143,21 @@ was found **broken-in-part** (raw PII in capture envelopes) and moved to that en
   figures don't re-anchor on a period switch, a "$0.00"/blank where an em-dash should be on an empty
   period, or a crash opening the tab with no offers yet.
   - Confirmed: 0/2
+- **🆕 NEW — Analytics Time tab: time split, deadhead, on-time gauge, mileage & tax (#315 H4).**
+  In the Analytics hub tap the **Time** tab and pick a period (Today / Week / Month / Lifetime). Four
+  cards should appear: a **time split** (hero online duration + "online across N dashes", an
+  On-delivery / Unattributed stack bar with durations, and Dashes / Avg-dash tiles), a **deadhead**
+  card (a % headline + an On-delivery / Deadhead miles bar — deadhead = miles not attached to any
+  delivery), an **on-time** gauge ("NN% on time" over the deliveries that carried a deadline, "N of M
+  … with a deadline", plus a "typically Xm early/late" margin line), and a **mileage & tax** card
+  (period miles + the est. IRS 2025 standard-mileage deduction at $0.70/mi). How to tell it's working:
+  the online split ≈ the time you spent online vs on drops for the dash, deadhead miles look sane
+  (small on a busy dash, larger if you drove a lot between/after drops), the on-time % and margin match
+  how you did against the app's deadlines, and the mileage matches the odometer miles for the period.
+  How to tell it's broken: the "coming soon" card still shows, figures don't re-anchor on a period
+  switch, a negative deadhead/unattributed value, an on-time gauge counting deliveries that had no
+  deadline, or a crash opening the tab with no dashes yet.
+  - Confirmed: 0/2
 - **🆕 NEW — the main dashboard is now a REVIEW surface, not a live bubble mirror (#657 / PR #658).**
   Open the app **after a dash** (not while on a task): the **Today** tiles (True Net / Net $/hr /
   Miles) should already reflect the just-completed dash with no manual refresh (the read-model folds

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/TimeEconomics.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/TimeEconomics.kt
@@ -1,0 +1,79 @@
+package cloud.trotter.dashbuddy.domain.analytics
+
+import kotlin.math.roundToLong
+
+/**
+ * Time / mileage economics for an [AnalyticsPeriod] (#315 H4, Time tab) — the read model behind the
+ * time-split, deadhead, on-time, and mileage-&-tax cards. Aggregated over the period's session set
+ * (session-anchored periods, #655): [onlineMillis]/[miles]/[sessions] come from the sessions that
+ * *started* in the window; the delivery-side figures come from the deliveries belonging to those
+ * sessions (joined via `sessionId`, with a null-session `completedAt` fallback).
+ *
+ * **Everything here is MEASURED, not estimated.** [onlineMillis] is Σ session durations,
+ * [deliveryMinutes]/[deliveryMiles] are Σ per-delivery **partition deltas** (the odometer/time gap
+ * since the previous drop, or `DASH_START` for the first), and [miles] is the session odometer
+ * delta. Because delivery miles/minutes are anchored on drop completions, they **include the
+ * approach legs between drops** — so the unattributed remainder ([unattributedMillis] /
+ * [unattributedMiles]) is honestly "not attributed to any delivery": the tail after the last drop
+ * and zero-delivery dashes, never a re-estimate.
+ *
+ * **Deadline coverage is explicit** (Principle 5/6 honesty): [deliveriesWithDeadline] is only the
+ * deliveries that carried a captured deadline; [onTimeDeliveries] and [onTimeRate] cover ONLY that
+ * subset — a delivery without a captured deadline is excluded, never silently counted as late.
+ *
+ * Nullable where a source SUM/AVG had no measurable input (no fabricated zeros): [deliveryMinutes]/
+ * [deliveryMiles] are null on an empty set, [onTimeRate] is null with no deadline-carrying delivery,
+ * [avgDeadlineMarginMillis] is null when no delivery carried a deadline.
+ */
+data class TimeEconomics(
+    /** Dashes (sessions) that started in the period. */
+    val sessions: Int,
+    /** Σ session online duration (ms) — measured wall-clock time online. */
+    val onlineMillis: Long,
+    /** Σ per-delivery realized minutes (partition deltas); null when nothing measured. */
+    val deliveryMinutes: Double?,
+    /** Session odometer miles for the period (Σ per-session odometer delta). */
+    val miles: Double,
+    /** Σ per-delivery realized miles (partition deltas); null when nothing measured. */
+    val deliveryMiles: Double?,
+    /** Deliveries that carried a captured deadline — the on-time denominator. */
+    val deliveriesWithDeadline: Int,
+    /** Deliveries completed at/under their deadline, among [deliveriesWithDeadline]. */
+    val onTimeDeliveries: Int,
+    /** AVG(deadline − completedAt) over deadline-carrying deliveries; positive = typically early. */
+    val avgDeadlineMarginMillis: Double?,
+) {
+    /** On-time fraction over deadline-carrying deliveries, or `null` when none carried a deadline. */
+    val onTimeRate: Double?
+        get() = if (deliveriesWithDeadline == 0) null
+        else onTimeDeliveries.toDouble() / deliveriesWithDeadline
+
+    /** Delivery-attributed online time (ms) = [deliveryMinutes] × 60_000, rounded; null when none measured. */
+    val deliveryMillis: Long?
+        get() = deliveryMinutes?.let { (it * 60_000.0).roundToLong() }
+
+    /** Online time NOT attributed to any delivery (ms), coerced ≥ 0 — the tail + zero-delivery dashes. */
+    val unattributedMillis: Long
+        get() = (onlineMillis - (deliveryMillis ?: 0L)).coerceAtLeast(0L)
+
+    /** Session miles NOT attributed to any delivery, coerced ≥ 0 — deadhead. */
+    val unattributedMiles: Double
+        get() = (miles - (deliveryMiles ?: 0.0)).coerceAtLeast(0.0)
+
+    /** Average online time per dash (ms), or `null` when no dashes in the period. */
+    val avgDashMillis: Long?
+        get() = if (sessions == 0) null else onlineMillis / sessions
+
+    companion object {
+        val EMPTY = TimeEconomics(
+            sessions = 0,
+            onlineMillis = 0L,
+            deliveryMinutes = null,
+            miles = 0.0,
+            deliveryMiles = null,
+            deliveriesWithDeadline = 0,
+            onTimeDeliveries = 0,
+            avgDeadlineMarginMillis = null,
+        )
+    }
+}


### PR DESCRIPTION
## What / why

Phase H4 of the Analytics hub (#315): the **Time tab** — the measured time / mileage review for the selected period. Four cards, top to bottom:

1. **Time split** — hero online duration + "online across N dashes"; an On-delivery / Unattributed stack bar (durations in the legend); Dashes / Avg-dash tiles.
2. **Deadhead** — a % headline (unattributed miles ÷ total miles) + an On-delivery / Deadhead miles bar. Copy is honest about attribution: delivery miles are odometer partition deltas anchored on drop completions (they include the approach legs), so deadhead = miles not attached to any delivery (the tail after the last drop + zero-delivery dashes).
3. **On-time** — `AppGaugeRing` over the deliveries that carried a captured deadline ("NN% on time", "N of M … with a deadline"), plus a "typically Xm early/late" line from the average deadline margin (green/red).
4. **Mileage & tax** — period session odometer miles + the est. IRS standard-mileage deduction, with the tax year + rate read from the `IrsMileage` SSOT (never a literal), and a "confirm with a tax preparer" honesty note.

## Data semantics

- **Session-anchored (#655):** the new `deliveryTimeTotals` DAO query's WHERE clause is **token-identical** to `deliveryTotals` — a delivery buckets by its *session's* `startedAt`, with the same null-session `completedAt` fallback (disjoint clauses, no double count). Session totals gain a `sessions` COUNT.
- **Measured, not estimated:** online time = Σ session durations, delivery time/miles = Σ per-delivery partition deltas, period miles = Σ odometer deltas. **No economy dependency** — this surface reports time/miles, never a re-costed value.
- **Deadline coverage is explicit:** `withDeadline`/`onTime`/`onTimeRate` cover ONLY deliveries that carried a captured deadline; a deadline-less delivery is excluded, never counted as late. Nullable SUMs stay null on an empty set (no fabricated zeros); derived `unattributedMillis`/`unattributedMiles` coerce ≥ 0.

## Test coverage

New `AnalyticsTimeTest` (Robolectric + in-memory DB), 5 tests: session-anchored bucketing (midnight-spanning dash lands on the start day), null-session `completedAt` fallback + disjointness, on-time split on `completedAt <= deadlineMillis` with null-deadline exclusion and signed (early-positive) margin, empty-period null sums → null-rate `TimeEconomics`, and the `sessions` count + derived `avgDashMillis`/`unattributedMillis` incl. the coerce-≥0 edge (delivery time exceeding the online span must not go negative). Fixed `AnalyticsViewModelTest` to stub the new `timeEconomics` flow. Full `:app:testDebugUnitTest :domain:test` green (928 tests).

## Design-goal review

- **1 UDF** — pure `TimeEconomics` in, no side effects; VM folds the read-model Flows into one immutable `AnalyticsUiState`; the tab is a stateless data-in composable.
- **3 single responsibility** — one card = one private composable; the DTO owns its derived math, the repository's `assembleTime` is a straight pass-through (no second copy of the coerce/round logic).
- **4 idiomatic Kotlin** — nullable SUMs modelled as `Double?` (no fabricated 0), derived vals on the DTO, `Locale.ROOT` machine formatting stays inside `Formats`/`formatDuration`.
- **5 SSOT** — every number routes through `Formats` / `formatDuration`; the tax line reads `IrsMileage.TAX_YEAR`/`RATE_PER_MILE`/`deduction`; the coerce/round helpers live once on the DTO. The new DAO WHERE shape is **token-identical to `deliveryTotals`** (the #655 bucketing owner) — no parallel bucketing logic.
- **6 privacy** — counts + measured time/miles only; no new PII, capture, or network surface.
- **8 platform-agnostic** — no platform literals; cross-platform aggregates only (the per-platform `sessions` column is additive, keyed via the existing GROUP BY).
- **Reactive UI** — a **review** surface: reactive-fresh via Room-invalidation Flows (re-emits on projector commits + midnight/week/month rollover), no `rememberNow()` ticker needed (a historical period's figures are fixed — the #657 reframe).

No deviations from the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)