### PR TITLE
feat(#315): H6 — earnings-by-day chart + hub CSV export action

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/MainActivity.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/MainActivity.kt
@@ -78,7 +78,8 @@ class MainActivity : ComponentActivity() {
                         // --- ANALYTICS HUB (#315 H1 — Money tab v1) ---
                         composable(Screen.Analytics.route) {
                             AnalyticsScreen(
-                                onBack = { navController.popBackStack() }
+                                onBack = { navController.popBackStack() },
+                                onExportCsv = { navController.navigate(Screen.DataExport.route) }
                             )
                         }
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.FileDownload
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -34,11 +35,15 @@ import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
  * shows a "coming soon" card. A **review** surface: UDF state in, `setTab`/`setPeriod` intents out
  * (Principle 1); reactive-fresh via the read-model Flows, no `rememberNow()` tick (a historical
  * period's figures are fixed).
+ *
+ * The header's CSV action routes to the existing Data & Privacy export (#319) — the hub-header entry
+ * point deferred from #671 (#315 H6); no new export logic, navigation only.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AnalyticsScreen(
     onBack: () -> Unit,
+    onExportCsv: () -> Unit,
     viewModel: AnalyticsViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -50,6 +55,11 @@ fun AnalyticsScreen(
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    IconButton(onClick = onExportCsv) {
+                        Icon(Icons.Default.FileDownload, contentDescription = "Export data (CSV)")
                     }
                 },
             )
@@ -83,6 +93,7 @@ fun AnalyticsScreen(
                         economics = uiState.economics,
                         topStores = uiState.topStores,
                         recentSessions = uiState.recentSessions,
+                        dailyEarnings = uiState.dailyEarnings,
                     )
                 }
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsUiState.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsUiState.kt
@@ -1,6 +1,7 @@
 package cloud.trotter.dashbuddy.ui.main.analytics
 
 import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
+import cloud.trotter.dashbuddy.domain.analytics.DailyEarnings
 import cloud.trotter.dashbuddy.domain.analytics.DecisionEconomics
 import cloud.trotter.dashbuddy.domain.analytics.PeriodEconomics
 import cloud.trotter.dashbuddy.domain.analytics.SessionRecord
@@ -38,6 +39,11 @@ data class AnalyticsUiState(
     val economics: PeriodEconomics = PeriodEconomics.EMPTY,
     /** Top-earning stores for [selectedPeriod] (already capped to the display count). */
     val topStores: List<StoreEconomics> = emptyList(),
+    /**
+     * Per-day earnings for [selectedPeriod] — the Money-tab earnings-by-day chart (#315 H6). Empty for
+     * Today/Lifetime (one bar / unbounded), so the Money tab hides the chart card on an empty list.
+     */
+    val dailyEarnings: List<DailyEarnings> = emptyList(),
     /** Most recent dash sessions, newest first (not tappable until #650). */
     val recentSessions: List<SessionRecord> = emptyList(),
     /** Offer-decision economics for [selectedPeriod] — the Decisions tab (#315 H3, frozen est.). */

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import cloud.trotter.dashbuddy.core.data.analytics.AnalyticsRepository
 import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
+import cloud.trotter.dashbuddy.domain.analytics.DailyEarnings
 import cloud.trotter.dashbuddy.domain.analytics.DecisionEconomics
 import cloud.trotter.dashbuddy.domain.analytics.PeriodEconomics
 import cloud.trotter.dashbuddy.domain.analytics.StoreEconomics
@@ -59,7 +60,10 @@ class AnalyticsViewModel @Inject constructor(
                 analyticsRepository.perStoreEconomics(period),
                 analyticsRepository.decisionEconomics(period),
                 analyticsRepository.timeEconomics(period),
-            ) { economics, stores, decisions, time -> PeriodData(period, economics, stores, decisions, time) }
+                analyticsRepository.dailyEarnings(period),
+            ) { economics, stores, decisions, time, daily ->
+                PeriodData(period, economics, stores, decisions, time, daily)
+            }
         },
         analyticsRepository.recentSessions(RECENT_SESSIONS_LIMIT),
     ) { tab, data, sessions ->
@@ -71,6 +75,7 @@ class AnalyticsViewModel @Inject constructor(
             recentSessions = sessions,
             decisions = data.decisions,
             time = data.time,
+            dailyEarnings = data.dailyEarnings,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), AnalyticsUiState())
 
@@ -91,6 +96,7 @@ class AnalyticsViewModel @Inject constructor(
         val stores: List<StoreEconomics>,
         val decisions: DecisionEconomics,
         val time: TimeEconomics,
+        val dailyEarnings: List<DailyEarnings>,
     )
 
     private companion object {

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/MoneyTab.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/MoneyTab.kt
@@ -22,16 +22,21 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import cloud.trotter.dashbuddy.core.designsystem.component.AppBar
+import cloud.trotter.dashbuddy.core.designsystem.component.AppBarChart
 import cloud.trotter.dashbuddy.core.designsystem.component.AppCallout
 import cloud.trotter.dashbuddy.core.designsystem.component.AppCard
 import cloud.trotter.dashbuddy.core.designsystem.component.AppChip
 import cloud.trotter.dashbuddy.core.designsystem.component.AppStatTile
 import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
+import cloud.trotter.dashbuddy.domain.analytics.DailyEarnings
 import cloud.trotter.dashbuddy.domain.analytics.PeriodEconomics
 import cloud.trotter.dashbuddy.domain.analytics.SessionRecord
 import cloud.trotter.dashbuddy.domain.analytics.StoreEconomics
 import cloud.trotter.dashbuddy.domain.format.Formats
 import cloud.trotter.dashbuddy.domain.format.formatShortDate
+import java.time.format.TextStyle
+import java.util.Locale
 
 /** Placeholder shown for a rate figure that has no measurable denominator yet (dashboard parity). */
 private const val EMPTY_VALUE = "—"
@@ -50,10 +55,13 @@ fun MoneyTab(
     economics: PeriodEconomics,
     topStores: List<StoreEconomics>,
     recentSessions: List<SessionRecord>,
+    dailyEarnings: List<DailyEarnings>,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(16.dp)) {
         EarningsHero(economics)
+        // Hidden for Today/Lifetime (one bar / unbounded window) — the repository returns an empty list.
+        if (dailyEarnings.isNotEmpty()) EarningsByDayCard(dailyEarnings)
         TrueNetWaterfall(economics)
         StatTiles(economics)
         if (economics.unattributedPay > UNATTRIBUTED_EPSILON) {
@@ -94,6 +102,54 @@ private fun EarningsHero(economics: PeriodEconomics) {
         }
     }
 }
+
+/**
+ * Earnings-by-day bar chart (#315 H6): one bar per local calendar day of the period, gap days at
+ * zero, the best day highlighted. Session-anchored (#655) — a dash's whole gross sits on its start
+ * day. Only rendered when [days] is non-empty (Today/Lifetime pass an empty list; see [MoneyTab]).
+ */
+@Composable
+private fun EarningsByDayCard(days: List<DailyEarnings>) {
+    val c = AppTheme.colors
+    AppCard(modifier = Modifier.fillMaxWidth()) {
+        Text(text = "EARNINGS BY DAY", style = MaterialTheme.typography.labelMedium, color = c.text3)
+        Spacer(Modifier.height(10.dp))
+        if (days.all { it.gross <= 0.0 }) {
+            EmptyRow("No earnings in this period yet.")
+        } else {
+            // Highlight the first day that hit the period's peak gross (only when someone earned).
+            val bestDay = days.maxByOrNull { it.gross }?.takeIf { it.gross > 0.0 }?.date
+            val isWeek = days.size == 7
+            val bars = days.map { day ->
+                AppBar(
+                    label = dayLabel(day, isWeek),
+                    value = day.gross.toFloat(),
+                    highlight = day.date == bestDay,
+                )
+            }
+            AppBarChart(bars = bars, modifier = Modifier.fillMaxWidth())
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = "gross per day · dashes count on their start day",
+                style = MaterialTheme.typography.bodySmall,
+                color = c.text3,
+            )
+        }
+    }
+}
+
+/**
+ * Bar label: for a 7-day week the locale's narrow day-of-week name; for a month-length list only the
+ * milestone days (1, 5, 10, 15, 20, 25, 30) carry their day-of-month number — 31 labels won't fit.
+ */
+private val MONTH_LABEL_DAYS = setOf(1, 5, 10, 15, 20, 25, 30)
+
+private fun dayLabel(day: DailyEarnings, isWeek: Boolean): String =
+    if (isWeek) {
+        day.date.dayOfWeek.getDisplayName(TextStyle.NARROW, Locale.getDefault())
+    } else {
+        day.date.dayOfMonth.let { if (it in MONTH_LABEL_DAYS) it.toString() else "" }
+    }
 
 /**
  * Pure decision logic for the true-net waterfall's step count (#659) — kept Compose-free so it's

--- a/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsDailyEarningsTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsDailyEarningsTest.kt
@@ -1,0 +1,194 @@
+package cloud.trotter.dashbuddy.analytics
+
+import androidx.room.Room
+import cloud.trotter.dashbuddy.core.data.analytics.AnalyticsRepository
+import cloud.trotter.dashbuddy.core.data.analytics.PeriodBounds
+import cloud.trotter.dashbuddy.core.database.DashBuddyDatabase
+import cloud.trotter.dashbuddy.core.database.analytics.AnalyticsDao
+import cloud.trotter.dashbuddy.core.database.analytics.DeliveryRecordEntity
+import cloud.trotter.dashbuddy.core.database.analytics.SessionRecordEntity
+import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import java.time.DayOfWeek
+import java.time.Instant
+import java.time.ZoneId
+
+/**
+ * #315 H6 — the per-day earnings chart input. Proves:
+ *  - `sessionGrossRows` is **reported-authoritative** per session (summary total wins; a null falls
+ *    back to Σ delivered pay; a no-delivery session yields 0), and windows by `startedAt`;
+ *  - the repository's `dailyEarnings` groups those rows into a **complete, gap-filled** day axis in a
+ *    fixed zone — a midnight-spanning session lands wholly on its start day (#655), THIS_WEEK yields
+ *    exactly 7 Monday-first entries, and TODAY/LIFETIME return empty by design.
+ *
+ * Timestamps are derived FROM [PeriodBounds.of] against the real clock so the assertions are stable
+ * regardless of when the test runs (the repository period flow reads the wall clock).
+ */
+@RunWith(RobolectricTestRunner::class)
+class AnalyticsDailyEarningsTest {
+
+    private lateinit var db: DashBuddyDatabase
+    private lateinit var dao: AnalyticsDao
+    private lateinit var repo: AnalyticsRepository
+
+    private val zone: ZoneId = ZoneId.of("America/Chicago")
+    private val hour = 3_600_000L
+
+    @Before
+    fun setUp() {
+        val context = RuntimeEnvironment.getApplication()
+        db = Room.inMemoryDatabaseBuilder(context, DashBuddyDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = db.analyticsDao()
+        repo = AnalyticsRepository(dao)
+    }
+
+    @After
+    fun tearDown() = db.close()
+
+    private fun session(
+        id: String,
+        startedAt: Long,
+        reportedEarnings: Double?,
+        platform: String = "doordash",
+    ) = SessionRecordEntity(
+        sessionId = id,
+        platform = platform,
+        startedAt = startedAt,
+        endedAt = startedAt + hour,
+        lastEventAt = startedAt + hour,
+        endSource = "summary_screen",
+        startOdometer = 0.0,
+        lastOdometer = 5.0,
+        reportedEarnings = reportedEarnings,
+        reportedDurationMillis = hour,
+        offersReceived = 0,
+        offersAccepted = 0,
+        offersDeclined = 0,
+        offersTimeout = 0,
+        deliveries = 1,
+        jobsCompleted = 1,
+    )
+
+    private fun delivery(
+        seq: Long,
+        sessionId: String?,
+        completedAt: Long,
+        pay: Double?,
+    ) = DeliveryRecordEntity(
+        eventSequenceId = seq,
+        sessionId = sessionId,
+        platform = "doordash",
+        jobId = "job-$seq",
+        taskId = "task-$seq",
+        storeName = "Wendys",
+        customerHash = null,
+        addressHash = null,
+        phaseStartedAt = completedAt - 600_000,
+        arrivedAt = null,
+        completedAt = completedAt,
+        deadlineMillis = null,
+        realizedPay = pay,
+        payBasis = "DROP_SHARE",
+        tip = null,
+        basePay = null,
+        odometerAtCompletion = null,
+        realizedMiles = null,
+        realizedMinutes = null,
+        frozenCostPerMile = null,
+        netProfit = null,
+        costBasis = "NONE",
+    )
+
+    /** The Monday-00:00 (Chicago) start of the current pay week — the anchor every fixture derives from. */
+    private fun weekStart(): Long = PeriodBounds.of(AnalyticsPeriod.THIS_WEEK, System.currentTimeMillis(), zone).start
+
+    /** sessionGrossRows: reported wins, null → Σ delivered pay, no-delivery → 0; windowed by startedAt. */
+    @Test
+    fun `sessionGrossRows is reported-authoritative and windows by startedAt`() = runBlocking {
+        val base = weekStart()
+        // S1: reported 50 present, but delivered only 40 → reported wins.
+        dao.upsertSession(session("S1", base, reportedEarnings = 50.0))
+        dao.upsertDelivery(delivery(1, "S1", completedAt = base + hour, pay = 25.0))
+        dao.upsertDelivery(delivery(2, "S1", completedAt = base + hour, pay = 15.0))
+        // S2: no reported → falls back to Σ delivered = 20.
+        dao.upsertSession(session("S2", base + hour, reportedEarnings = null))
+        dao.upsertDelivery(delivery(3, "S2", completedAt = base + hour, pay = 20.0))
+        // S3: no reported, no delivery → 0.
+        dao.upsertSession(session("S3", base + 2 * hour, reportedEarnings = null))
+
+        // Window [base, base + 90min) excludes S3 (started at +2h).
+        val rows = dao.sessionGrossRows(base, base + 90 * 60_000L).first()
+        assertEquals(2, rows.size)
+        assertEquals(base, rows[0].startedAt)             // ORDER BY startedAt ASC
+        assertEquals(50.0, rows[0].gross, 1e-9)           // reported-authoritative
+        assertEquals(20.0, rows[1].gross, 1e-9)           // Σ delivered fallback
+
+        // A wider window catches S3 at 0 gross.
+        val all = dao.sessionGrossRows(base, base + 3 * hour).first()
+        assertEquals(3, all.size)
+        assertEquals(0.0, all[2].gross, 1e-9)
+    }
+
+    /** THIS_WEEK ⇒ a complete 7-day, Monday-first axis with gap days at 0.0. */
+    @Test
+    fun `dailyEarnings for the week is a complete Monday-first axis with zero-filled gaps`() = runBlocking {
+        val base = weekStart()
+        // One dash on Wednesday (day index 2) of the week, reported 42.
+        val wednesday = Instant.ofEpochMilli(base).atZone(zone).toLocalDate().plusDays(2)
+        val wednesdayNoon = wednesday.atTime(12, 0).atZone(zone).toInstant().toEpochMilli()
+        dao.upsertSession(session("W", wednesdayNoon, reportedEarnings = 42.0))
+
+        val days = repo.dailyEarnings(AnalyticsPeriod.THIS_WEEK, zone).first()
+        assertEquals(7, days.size)
+        assertEquals(DayOfWeek.MONDAY, days.first().date.dayOfWeek)
+        assertEquals(42.0, days[2].gross, 1e-9)                 // Wednesday carries the dash
+        assertEquals(0.0, days[0].gross, 1e-9)                  // Monday is a gap day, present at 0
+        assertEquals(0.0, days.filterIndexed { i, _ -> i != 2 }.sumOf { it.gross }, 1e-9)
+    }
+
+    /** A session started 23:50 Monday lands wholly on Monday, never split into Tuesday (#655). */
+    @Test
+    fun `midnight-spanning session lands wholly on its start day`() = runBlocking {
+        val base = weekStart()
+        val mondayDate = Instant.ofEpochMilli(base).atZone(zone).toLocalDate()
+        val tuesdayMidnight = mondayDate.plusDays(1).atStartOfDay(zone).toInstant().toEpochMilli()
+        val mondayLateNight = tuesdayMidnight - 600_000              // 23:50 Monday
+        dao.upsertSession(session("M", mondayLateNight, reportedEarnings = 30.0))
+        // Its delivery even completes after midnight — irrelevant, gross is session-anchored.
+        dao.upsertDelivery(delivery(1, "M", completedAt = tuesdayMidnight + 600_000, pay = 30.0))
+
+        val days = repo.dailyEarnings(AnalyticsPeriod.THIS_WEEK, zone).first()
+        assertEquals(30.0, days[0].gross, 1e-9)   // Monday, whole gross
+        assertEquals(0.0, days[1].gross, 1e-9)    // Tuesday, nothing
+    }
+
+    /** THIS_MONTH ⇒ 28–31 entries, first day is the 1st. */
+    @Test
+    fun `dailyEarnings for the month is a full-month axis starting on the 1st`() = runBlocking {
+        val monthStart = PeriodBounds.of(AnalyticsPeriod.THIS_MONTH, System.currentTimeMillis(), zone).start
+        dao.upsertSession(session("X", monthStart + hour, reportedEarnings = 15.0))
+
+        val days = repo.dailyEarnings(AnalyticsPeriod.THIS_MONTH, zone).first()
+        assertTrue("month should have 28..31 entries", days.size in 28..31)
+        assertEquals(1, days.first().date.dayOfMonth)
+        assertEquals(15.0, days.first().gross, 1e-9)
+    }
+
+    /** TODAY and LIFETIME are excluded by design (one bar / unbounded) ⇒ empty list. */
+    @Test
+    fun `dailyEarnings is empty for TODAY and LIFETIME`() = runBlocking {
+        assertTrue(repo.dailyEarnings(AnalyticsPeriod.TODAY, zone).first().isEmpty())
+        assertTrue(repo.dailyEarnings(AnalyticsPeriod.LIFETIME, zone).first().isEmpty())
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsViewModelTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsViewModelTest.kt
@@ -2,6 +2,7 @@ package cloud.trotter.dashbuddy.ui.main.analytics
 
 import cloud.trotter.dashbuddy.core.data.analytics.AnalyticsRepository
 import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
+import cloud.trotter.dashbuddy.domain.analytics.DailyEarnings
 import cloud.trotter.dashbuddy.domain.analytics.DecisionEconomics
 import cloud.trotter.dashbuddy.domain.analytics.PeriodEconomics
 import cloud.trotter.dashbuddy.domain.analytics.PeriodTotals
@@ -44,13 +45,15 @@ class AnalyticsViewModelTest {
         stores: List<StoreEconomics> = emptyList(),
         decisions: DecisionEconomics = DecisionEconomics.EMPTY,
         time: TimeEconomics = TimeEconomics.EMPTY,
+        dailyEarnings: List<DailyEarnings> = emptyList(),
     ) {
         whenever(analyticsRepository.periodEconomics(eq(period), anyOrNull())).thenReturn(flowOf(economics))
         whenever(analyticsRepository.perStoreEconomics(eq(period))).thenReturn(flowOf(stores))
-        // The VM collects decisions + time unconditionally (see AnalyticsViewModel), so every period
-        // stub must supply both flows or the combine would fold a null.
+        // The VM collects decisions + time + dailyEarnings unconditionally (see AnalyticsViewModel), so
+        // every period stub must supply all three flows or the combine would fold a null.
         whenever(analyticsRepository.decisionEconomics(eq(period))).thenReturn(flowOf(decisions))
         whenever(analyticsRepository.timeEconomics(eq(period))).thenReturn(flowOf(time))
+        whenever(analyticsRepository.dailyEarnings(eq(period), anyOrNull())).thenReturn(flowOf(dailyEarnings))
     }
 
     private fun decisions(accepted: Int, declined: Int, timedOut: Int, acceptanceRate: Double?) =

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
@@ -6,6 +6,7 @@ import cloud.trotter.dashbuddy.core.database.analytics.OutcomeCountRow
 import cloud.trotter.dashbuddy.core.database.analytics.ScoreOutcomeRow
 import cloud.trotter.dashbuddy.core.database.analytics.SessionTotalsRow
 import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
+import cloud.trotter.dashbuddy.domain.analytics.DailyEarnings
 import cloud.trotter.dashbuddy.domain.analytics.DecisionEconomics
 import cloud.trotter.dashbuddy.domain.analytics.DeliveryRecord
 import cloud.trotter.dashbuddy.domain.analytics.PeriodEconomics
@@ -16,11 +17,13 @@ import cloud.trotter.dashbuddy.domain.analytics.TimeEconomics
 import cloud.trotter.dashbuddy.domain.evaluation.NetProfit
 import cloud.trotter.dashbuddy.domain.model.event.AppEventType
 import cloud.trotter.dashbuddy.domain.state.Platform
+import java.time.Instant
 import java.time.ZoneId
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -155,6 +158,43 @@ class AnalyticsRepository @Inject constructor(
                 analyticsDao.deliveryTimeTotals(start, end),
             ) { s, d -> assembleTime(s, d) }
         }
+
+    /**
+     * Per-day earnings for [period] (#315 H6, Money-tab chart) — a **complete day axis**: one
+     * [DailyEarnings] per local calendar day of the window, in order, with gap days present at `0.0`
+     * gross (a driver who skipped Tuesday still gets a Tuesday bar). Gross per day = Σ of the
+     * reported-authoritative per-session gross ([AnalyticsDao.sessionGrossRows], the same definition as
+     * [grossAndUnattributed]) for the sessions that *started* that day.
+     *
+     * **Session-anchored (#655):** a session's whole gross lands on its start instant's local day, so a
+     * midnight-spanning dash counts entirely on its start day — never split across two bars. [zone] is
+     * injectable so a fixed-zone test can pin the day boundaries; production uses the device zone.
+     *
+     * [TODAY][AnalyticsPeriod.TODAY] and [LIFETIME][AnalyticsPeriod.LIFETIME] return an empty list: a
+     * one-bar chart adds nothing, and LIFETIME's window is unbounded (its days can't be enumerated). The
+     * UI hides the card on an empty list.
+     *
+     * Re-emits on new session records (Room invalidation) and at week/month rollover (the boundary flow).
+     */
+    fun dailyEarnings(period: AnalyticsPeriod, zone: ZoneId = ZoneId.systemDefault()): Flow<List<DailyEarnings>> {
+        if (period == AnalyticsPeriod.TODAY || period == AnalyticsPeriod.LIFETIME) return flowOf(emptyList())
+        return periodBoundariesFlow(period, zone).flatMapLatest { (start, end) ->
+            analyticsDao.sessionGrossRows(start, end).map { rows ->
+                // The end bound is exactly the next period's local midnight (PeriodBounds), so iterate
+                // day-by-day up to (but excluding) the end instant's date — a complete, gap-filled axis.
+                val startDate = Instant.ofEpochMilli(start).atZone(zone).toLocalDate()
+                val endDate = Instant.ofEpochMilli(end).atZone(zone).toLocalDate()
+                val byDay = rows.groupBy { Instant.ofEpochMilli(it.startedAt).atZone(zone).toLocalDate() }
+                buildList {
+                    var date = startDate
+                    while (date < endDate) {
+                        add(DailyEarnings(date, byDay[date]?.sumOf { it.gross } ?: 0.0))
+                        date = date.plusDays(1)
+                    }
+                }
+            }
+        }
+    }
 
     /** Recent dashes, newest first (future hub / #650). */
     fun recentSessions(limit: Int = 20): Flow<List<SessionRecord>> =

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
@@ -197,6 +197,26 @@ interface AnalyticsDao {
     )
     fun grossAndUnattributedByPlatform(start: Long, end: Long): Flow<List<PlatformGrossTotalsRow>>
 
+    /**
+     * Per-session start + reported-authoritative gross for the sessions started in `[start, end)` — the
+     * per-day earnings chart input (#315 H6). Gross per session = `reportedEarnings` when present else
+     * that session's Σ delivered pay (same definition as [grossAndUnattributed]; the LEFT JOIN is onto a
+     * GROUP BY sessionId subquery, one row per session, no fan-out). Session-anchored by construction
+     * (#655): a session's whole gross lands on its start instant's day.
+     */
+    @Query(
+        """SELECT s.startedAt AS startedAt,
+                  COALESCE(s.reportedEarnings, d.deliveredPay, 0) AS gross
+           FROM session_records s
+           LEFT JOIN (
+             SELECT sessionId, SUM(realizedPay) AS deliveredPay
+             FROM delivery_records GROUP BY sessionId
+           ) d ON d.sessionId = s.sessionId
+           WHERE s.startedAt >= :start AND s.startedAt < :end
+           ORDER BY s.startedAt ASC"""
+    )
+    fun sessionGrossRows(start: Long, end: Long): Flow<List<SessionGrossRow>>
+
     // ── Decisions-tab aggregates (#315 H3) ──────────────────────────────
 
     /**

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsTotals.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsTotals.kt
@@ -68,6 +68,17 @@ data class PlatformGrossTotalsRow(
     val unattributed: Double,
 )
 
+/**
+ * One session's start instant + reported-authoritative gross (#315 H6) — the per-day earnings-chart
+ * input, one row per session started in the window. [gross] = the summary-screen `reportedEarnings`
+ * when present, else that session's Σ delivered pay (the same per-session definition as
+ * [GrossTotalsRow]); the repository buckets it onto [startedAt]'s local day (session-anchored, #655).
+ */
+data class SessionGrossRow(
+    val startedAt: Long,
+    val gross: Double,
+)
+
 /** Cross-platform session totals for a period: miles = Σ odo delta, onlineMillis = Σ duration, sessions = COUNT. */
 data class SessionTotalsRow(
     val miles: Double,

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -158,6 +158,20 @@ was found **broken-in-part** (raw PII in capture envelopes) and moved to that en
   switch, a negative deadhead/unattributed value, an on-time gauge counting deliveries that had no
   deadline, or a crash opening the tab with no dashes yet.
   - Confirmed: 0/2
+- **🆕 NEW — Analytics Money tab: earnings-by-day chart + header CSV export icon (#315 H6).**
+  Open **Analytics → Money** and pick **Week** or **Month**: a new **"EARNINGS BY DAY"** card should
+  appear as the **second** card (right under the gross hero), a bar per day of the period — 7 bars for
+  Week (labelled M/T/W…), ~28–31 for Month (only the 1/5/10/15/20/25/30 labelled). The **best-earning
+  day** should be highlighted in the accent color, gap days you didn't dash show as empty/zero bars,
+  and a "gross per day · dashes count on their start day" caption sits below. Cross-check: each bar's
+  height should track that day's take, and the sum across the week/month should roughly match the gross
+  hero. Then switch to **Today** and **Lifetime** — the chart card should be **absent** on both (one bar
+  adds nothing; Lifetime is unbounded). Separately, tap the **download icon in the hub's top bar** — it
+  should open the same **Data & Privacy → Export Data (CSV)** screen the Settings row reaches. How to
+  tell it's broken: the chart shows on Today/Lifetime, a day's bar doesn't match its earnings, no day
+  highlighted on a period where you did earn, missing gap days (a squished <7 bar week), or the header
+  icon doesn't open the CSV export screen. (PR #315-H6.)
+  - Confirmed: 0/2
 - **🆕 NEW — the main dashboard is now a REVIEW surface, not a live bubble mirror (#657 / PR #658).**
   Open the app **after a dash** (not while on a task): the **Today** tiles (True Net / Net $/hr /
   Miles) should already reflect the just-completed dash with no manual refresh (the read-model folds

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/DailyEarnings.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/DailyEarnings.kt
@@ -1,0 +1,19 @@
+package cloud.trotter.dashbuddy.domain.analytics
+
+import java.time.LocalDate
+
+/**
+ * One local calendar day of a bounded period's earnings (#315 H6) — the per-day earnings-chart input.
+ *
+ * A [dailyEarnings][cloud.trotter.dashbuddy.core.data.analytics] list is a **complete axis**, not a
+ * sparse one: every day of the window is present, in order, with gap days carrying `0.0` [gross] (a
+ * driver who didn't dash Tuesday still gets a Tuesday bar). [gross] is the reported-authoritative
+ * per-session gross (summary total when present, else that session's Σ delivered pay — the same
+ * definition as the read-model's gross), attributed **wholly to the session's start day**
+ * (session-anchored periods, #655): a dash begun 11:50pm counts entirely on that evening, never split
+ * across midnight.
+ */
+data class DailyEarnings(
+    val date: LocalDate,
+    val gross: Double,
+)


### PR DESCRIPTION
## What / why

Phase **H6** of the Analytics hub (#315), Money tab:

**(a) Per-day earnings chart.** A new **"EARNINGS BY DAY"** card, rendered second on the Money tab (right under the gross hero), for the **Week** and **Month** periods. One `AppBar` per local calendar day of the period — 7 bars for a week (narrow day-of-week labels), 28–31 for a month (only days 1/5/10/15/20/25/30 labelled, 31 labels won't fit), the best-earning day highlighted in the accent color, gap days present as zero bars, with a "gross per day · dashes count on their start day" caption. An all-zero period falls back to the existing `EmptyRow` idiom. **Today** and **Lifetime** get no chart (a one-bar chart adds nothing; Lifetime's window is unbounded).

**(b) Hub-header CSV action.** A download icon in the Analytics `TopAppBar` (the same `Icons.Default.FileDownload` the Settings "Export Data" row uses) routes to the existing Data & Privacy CSV export screen — the hub-header entry point deferred from #671. Navigation only, no new export logic.

## Data semantics

- **Session-anchored (#655):** a session's whole gross lands on its start instant's local day — a midnight-spanning dash counts entirely on its start day, never split across two bars.
- **Reported-authoritative gross** per session (summary total when present, else that session's Σ delivered pay) — the **same definition** as the DAO's `grossAndUnattributed` (new `sessionGrossRows` reuses the identical LEFT JOIN onto a `GROUP BY sessionId` subquery, one row per session, no fan-out).
- **Complete day axis with zero-fill:** the repository builds every day from `start` to `end` (exclusive) via `PeriodBounds`' local-midnight boundaries (zone-injectable for tests), summing each session row's gross into its start day — 7 entries for a week, 28–31 for a month.
- **TODAY / LIFETIME excluded by design** (empty list → UI hides the card).

## Test coverage

- `AnalyticsDailyEarningsTest` (new, Robolectric + in-memory DB): `sessionGrossRows` reported-authoritative (reported wins / null → Σ delivered / no-delivery → 0) + `startedAt` window filter; repository `dailyEarnings` in a fixed `America/Chicago` zone with fixtures derived **from** `PeriodBounds.of(...)` so assertions are clock-stable — complete Monday-first 7-day week axis with zero-filled gaps, midnight-spanning session lands wholly on its start day, full-month axis starting on the 1st, and TODAY/LIFETIME empty.
- `AnalyticsViewModelTest`: the period stub now supplies the new `dailyEarnings` flow (same unconditional-collect pattern as the decisions/time stubs).
- `JAVA_HOME=/usr/lib/jvm/java-25-openjdk ./gradlew :app:testDebugUnitTest :domain:test` — green.

## Field validation

Added a checklist item to `docs/field-testing/README.md` (`Confirmed: 0/2`).

### Design-goal review

- **1 (UDF):** state flows down (`AnalyticsUiState.dailyEarnings`), intents up; the new source is a pure Room-invalidation `Flow` folded into the one immutable UiState under `flatMapLatest` alongside the other period sources — no side effects in the reduce. The CSV action is a hoisted `onExportCsv: () -> Unit` lambda; navigation happens at the `MainActivity` edge.
- **3 (SRP):** DAO query + row DTO + domain DTO + repository grouping + UI card are each small and single-purpose; the day-label helper is extracted and the chart reuses the existing `AppBarChart`/`AppBar` design-system components rather than a bespoke chart.
- **4 (Kotlin/Android idioms):** matched surrounding style — `buildList`/`groupBy`/`sumOf`, `java.time` in pure `:domain`, `Locale.getDefault()` for the user-facing day labels, the 5-flow `combine` overload.
- **5 (SSOT):** the per-session gross definition is **reused, not re-derived** — `sessionGrossRows` mirrors `grossAndUnattributed`'s exact per-session `COALESCE(reportedEarnings, Σ deliveredPay, 0)`; day bucketing and the `[start,end)` window are owned by `PeriodBounds` (zone injected, never a second copy of the boundary math).
- **6 (privacy):** no new PII surface — economics/counts only; store/customer text never enters this path. The CSV action reuses the already-hardened export (customer/address hashes excluded there).
- **8 (platform-agnostic):** no platform literals; the aggregate is cross-platform, no `:core:state`/`:core:pipeline`/`:domain` state-machine vocabulary added (the new `:domain` type is a read-model DTO, not rule/state vocabulary).
- **Reactive UI:** a review surface — freshness comes from Room invalidation + the boundary flow's week/month rollover, not a `rememberNow()` ticker (a historical period's per-day figures are fixed), consistent with the rest of the hub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)