### PR TITLE
feat(#650): per-dash drill-down (read-only session detail)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/MainActivity.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/MainActivity.kt
@@ -19,10 +19,13 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
 import cloud.trotter.dashbuddy.ui.main.analytics.AnalyticsScreen
+import cloud.trotter.dashbuddy.ui.main.analytics.SessionDetailScreen
 import cloud.trotter.dashbuddy.ui.main.dashboard.DashboardScreen
 import cloud.trotter.dashbuddy.ui.main.navigation.Screen
 import cloud.trotter.dashbuddy.ui.main.ratings.RatingsScreen
@@ -79,7 +82,24 @@ class MainActivity : ComponentActivity() {
                         composable(Screen.Analytics.route) {
                             AnalyticsScreen(
                                 onBack = { navController.popBackStack() },
-                                onExportCsv = { navController.navigate(Screen.DataExport.route) }
+                                onExportCsv = { navController.navigate(Screen.DataExport.route) },
+                                onOpenSession = { sessionId ->
+                                    navController.navigate(Screen.SessionDetail.route(sessionId))
+                                }
+                            )
+                        }
+
+                        // --- PER-DASH DRILL-DOWN (#650 — read-only session detail) ---
+                        composable(
+                            Screen.SessionDetail.route,
+                            arguments = listOf(
+                                navArgument(Screen.SessionDetail.ARG_SESSION_ID) {
+                                    type = NavType.StringType
+                                }
+                            )
+                        ) {
+                            SessionDetailScreen(
+                                onBack = { navController.popBackStack() }
                             )
                         }
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsScreen.kt
@@ -44,6 +44,7 @@ import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
 fun AnalyticsScreen(
     onBack: () -> Unit,
     onExportCsv: () -> Unit,
+    onOpenSession: (String) -> Unit,
     viewModel: AnalyticsViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -94,6 +95,7 @@ fun AnalyticsScreen(
                         topStores = uiState.topStores,
                         recentSessions = uiState.recentSessions,
                         dailyEarnings = uiState.dailyEarnings,
+                        onOpenSession = onOpenSession,
                     )
                 }
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsUiState.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsUiState.kt
@@ -44,7 +44,7 @@ data class AnalyticsUiState(
      * Today/Lifetime (one bar / unbounded), so the Money tab hides the chart card on an empty list.
      */
     val dailyEarnings: List<DailyEarnings> = emptyList(),
-    /** Most recent dash sessions, newest first (not tappable until #650). */
+    /** Most recent dash sessions, newest first — each row taps through to the per-dash drill-down (#650). */
     val recentSessions: List<SessionRecord> = emptyList(),
     /** Offer-decision economics for [selectedPeriod] — the Decisions tab (#315 H3, frozen est.). */
     val decisions: DecisionEconomics = DecisionEconomics.EMPTY,

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/MoneyTab.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/MoneyTab.kt
@@ -1,6 +1,7 @@
 package cloud.trotter.dashbuddy.ui.main.analytics
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -56,6 +57,7 @@ fun MoneyTab(
     topStores: List<StoreEconomics>,
     recentSessions: List<SessionRecord>,
     dailyEarnings: List<DailyEarnings>,
+    onOpenSession: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(16.dp)) {
@@ -73,7 +75,7 @@ fun MoneyTab(
             )
         }
         TopStoresCard(topStores)
-        RecentDashesCard(recentSessions)
+        RecentDashesCard(recentSessions, onOpenSession)
     }
 }
 
@@ -341,11 +343,11 @@ private fun TopStoresCard(stores: List<StoreEconomics>) {
 
 /**
  * Recent dashes, newest first. Sessions don't carry a frozen net, so the money column shows the
- * platform-reported earnings (an em dash until a summary is seen). Not tappable yet — the per-dash
- * drill-down is #650.
+ * platform-reported earnings (an em dash until a summary is seen). Each row is tappable → the
+ * read-only per-dash drill-down ([onOpenSession], #650).
  */
 @Composable
-private fun RecentDashesCard(sessions: List<SessionRecord>) {
+private fun RecentDashesCard(sessions: List<SessionRecord>, onOpenSession: (String) -> Unit) {
     val c = AppTheme.colors
     AppCard(modifier = Modifier.fillMaxWidth()) {
         Text(text = "RECENT DASHES", style = MaterialTheme.typography.labelMedium, color = c.text3)
@@ -355,8 +357,12 @@ private fun RecentDashesCard(sessions: List<SessionRecord>) {
         } else {
             sessions.forEachIndexed { index, session ->
                 if (index > 0) Spacer(Modifier.height(10.dp))
-                // TODO(#650): make each dash row tappable → per-dash delivery breakdown.
-                Row(verticalAlignment = Alignment.CenterVertically) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { onOpenSession(session.sessionId) },
+                ) {
                     Column(Modifier.weight(1f)) {
                         Text(
                             text = formatShortDate(session.startedAt),

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/SessionDetailScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/SessionDetailScreen.kt
@@ -1,0 +1,265 @@
+package cloud.trotter.dashbuddy.ui.main.analytics
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import cloud.trotter.dashbuddy.core.designsystem.component.AppCallout
+import cloud.trotter.dashbuddy.core.designsystem.component.AppCard
+import cloud.trotter.dashbuddy.core.designsystem.component.AppChip
+import cloud.trotter.dashbuddy.core.designsystem.component.AppStatTile
+import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
+import cloud.trotter.dashbuddy.domain.analytics.DeliveryRecord
+import cloud.trotter.dashbuddy.domain.analytics.SessionDetail
+import cloud.trotter.dashbuddy.domain.format.Formats
+import cloud.trotter.dashbuddy.domain.format.formatClockTime
+import cloud.trotter.dashbuddy.domain.format.formatDuration
+import cloud.trotter.dashbuddy.domain.format.formatShortDate
+import kotlin.math.roundToInt
+
+/** Below this the unattributed pay is effectively zero — no callout (avoids a "$0.00" flag). */
+private const val UNATTRIBUTED_EPSILON = 0.005
+
+/** Placeholder shown for a figure that has no measurable value yet (dashboard parity). */
+private const val EMPTY_VALUE = "—"
+
+/**
+ * The read-only per-dash drill-down (#650 PR A): one dash expanded top→bottom — a header card
+ * (date/time span, platform, duration, gross/miles/deliveries), the per-dash unattributed-pay flag,
+ * and the per-delivery breakdown in completion order. A **review** surface (Principle 1 — UDF, state
+ * in; no intents, corrections are PR B): reactive-fresh via the read-model Flow, no `rememberNow()`
+ * tick (a historical dash's figures are fixed; the #657 reframe). Every number routes through the
+ * [Formats]/[formatShortDate]/[formatClockTime]/[formatDuration] SSOTs. Store names are merchants —
+ * fine to render (Principle 7 governs logs, not this UI); no customer hashes are surfaced.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SessionDetailScreen(
+    onBack: () -> Unit,
+    viewModel: SessionDetailViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Dash detail") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        val detail = uiState.detail
+        when {
+            detail != null -> DashDetailContent(
+                detail = detail,
+                modifier = Modifier
+                    .padding(padding)
+                    .verticalScroll(rememberScrollState())
+                    .padding(16.dp)
+                    .fillMaxSize(),
+            )
+            // Post-load, a null detail means no session row exists for this id.
+            !uiState.loading -> CenteredMessage("Dash not found.", Modifier.padding(padding))
+            // Pre-first-emission: keep the frame empty (the read-model emits promptly).
+            else -> Box(Modifier.padding(padding).fillMaxSize())
+        }
+    }
+}
+
+@Composable
+private fun DashDetailContent(detail: SessionDetail, modifier: Modifier) {
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        HeaderCard(detail)
+        if (detail.unattributedPay > UNATTRIBUTED_EPSILON) {
+            AppCallout(
+                text = "${Formats.money(detail.unattributedPay)} unaccounted on this dash — the " +
+                    "platform reported more than the captured deliveries. Corrections land in the " +
+                    "next phase (#650).",
+                container = AppTheme.colors.warnBg,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+        DeliveriesCard(detail.deliveries)
+    }
+}
+
+@Composable
+private fun HeaderCard(detail: SessionDetail) {
+    val c = AppTheme.colors
+    val session = detail.session
+    val hasReported = session.reportedEarnings != null
+    val gross = session.reportedEarnings ?: detail.deliveredPay
+    AppCard(modifier = Modifier.fillMaxWidth()) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Column(Modifier.weight(1f)) {
+                Text(
+                    text = formatShortDate(session.startedAt),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = c.text,
+                )
+                Spacer(Modifier.height(2.dp))
+                val endText = session.endedAt?.let { formatClockTime(it) } ?: EMPTY_VALUE
+                Text(
+                    text = "${formatClockTime(session.startedAt)}–$endText",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = c.text3,
+                )
+            }
+            // Platform label is registry-resolved (never a literal) — Principle 8.
+            AppChip(text = session.platform.shortName.ifEmpty { session.platform.displayName })
+        }
+        Spacer(Modifier.height(4.dp))
+        Text(
+            text = "Duration ${dashDuration(session.startedAt, session.endedAt, session.reportedDurationMillis)}",
+            style = MaterialTheme.typography.bodySmall,
+            color = c.text3,
+        )
+        Spacer(Modifier.height(12.dp))
+        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            AppStatTile(
+                label = if (hasReported) "Gross (reported)" else "Gross (captured)",
+                value = Formats.money(gross),
+                modifier = Modifier.weight(1f),
+            )
+            AppStatTile(
+                label = "Miles",
+                value = session.miles?.let { Formats.decimal(it) } ?: EMPTY_VALUE,
+                modifier = Modifier.weight(1f),
+            )
+            AppStatTile(
+                label = "Deliveries",
+                value = Formats.commaInt(session.deliveries),
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}
+
+/**
+ * The dash's wall-clock duration: measured `endedAt − startedAt` when the dash closed, else the
+ * platform-reported duration, else an em dash. All through the [formatDuration] SSOT.
+ */
+private fun dashDuration(startedAt: Long, endedAt: Long?, reportedDurationMillis: Long?): String =
+    when {
+        endedAt != null -> formatDuration(endedAt - startedAt)
+        reportedDurationMillis != null -> formatDuration(reportedDurationMillis)
+        else -> EMPTY_VALUE
+    }
+
+@Composable
+private fun DeliveriesCard(deliveries: List<DeliveryRecord>) {
+    val c = AppTheme.colors
+    AppCard(modifier = Modifier.fillMaxWidth()) {
+        Text(text = "DELIVERIES", style = MaterialTheme.typography.labelMedium, color = c.text3)
+        Spacer(Modifier.height(10.dp))
+        if (deliveries.isEmpty()) {
+            EmptyRow("No deliveries captured for this dash.")
+        } else {
+            deliveries.forEachIndexed { index, delivery ->
+                if (index > 0) Spacer(Modifier.height(14.dp))
+                DeliveryRow(delivery)
+            }
+        }
+    }
+}
+
+@Composable
+private fun DeliveryRow(delivery: DeliveryRecord) {
+    val c = AppTheme.colors
+    Row(verticalAlignment = Alignment.Top) {
+        Column(Modifier.weight(1f)) {
+            Text(
+                text = delivery.storeName ?: "Unknown store",
+                style = MaterialTheme.typography.bodyMedium,
+                color = c.text,
+            )
+            Text(
+                text = formatClockTime(delivery.completedAt),
+                style = MaterialTheme.typography.bodySmall,
+                color = c.text3,
+            )
+            travelLine(delivery)?.let {
+                Text(text = it, style = MaterialTheme.typography.bodySmall, color = c.text3)
+            }
+        }
+        Column(horizontalAlignment = Alignment.End) {
+            Text(
+                text = delivery.realizedPay?.let { Formats.money(it) } ?: EMPTY_VALUE,
+                style = AppTheme.num.smNum,
+                color = c.text,
+            )
+            delivery.tip?.let {
+                Text(
+                    text = "incl. ${Formats.money(it)} tip",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = c.text3,
+                )
+            }
+            val net = delivery.netProfit
+            Text(
+                text = "net ${net?.let { Formats.money(it) } ?: EMPTY_VALUE}",
+                style = MaterialTheme.typography.bodySmall,
+                color = when {
+                    net == null -> c.text3
+                    net >= 0.0 -> c.good
+                    else -> c.bad
+                },
+                textAlign = TextAlign.End,
+            )
+        }
+    }
+}
+
+/** "3.2 mi · 14 min" — only the parts actually measured; null when neither is present. */
+private fun travelLine(delivery: DeliveryRecord): String? {
+    val parts = buildList {
+        delivery.realizedMiles?.let { add("${Formats.decimal(it)} mi") }
+        delivery.realizedMinutes?.let { add("${it.roundToInt()} min") }
+    }
+    return parts.takeIf { it.isNotEmpty() }?.joinToString(" · ")
+}
+
+@Composable
+private fun EmptyRow(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.bodyMedium,
+        color = AppTheme.colors.text3,
+        modifier = Modifier.padding(vertical = 4.dp),
+    )
+}
+
+@Composable
+private fun CenteredMessage(text: String, modifier: Modifier = Modifier) {
+    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Text(text = text, style = MaterialTheme.typography.bodyMedium, color = AppTheme.colors.text3)
+    }
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/SessionDetailViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/SessionDetailViewModel.kt
@@ -1,0 +1,54 @@
+package cloud.trotter.dashbuddy.ui.main.analytics
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import cloud.trotter.dashbuddy.core.data.analytics.AnalyticsRepository
+import cloud.trotter.dashbuddy.domain.analytics.SessionDetail
+import cloud.trotter.dashbuddy.ui.main.navigation.Screen
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+
+/**
+ * State holder for the read-only per-dash drill-down (#650 PR A) — one immutable
+ * [SessionDetailUiState] assembled reactively from [AnalyticsRepository.sessionDetail]
+ * (Principle 1 — UDF, state out; no intents yet, PR A only reads). The sessionId is read from
+ * [SavedStateHandle] (the nav argument), so this VM needs no explicit initializer.
+ *
+ * Reactive by construction: the source is a Room-invalidation `Flow`, so the header + rows re-emit
+ * as the projector folds each delivery — a **review** surface, not a per-second tick (no
+ * `rememberNow()` clock; same reframe as the hub #657). Read-model only, no economy dependency, no
+ * new PII surface (store names are driver-owned; no customer hashes are exposed).
+ */
+@HiltViewModel
+class SessionDetailViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    analyticsRepository: AnalyticsRepository,
+) : ViewModel() {
+
+    private val sessionId: String =
+        savedStateHandle[Screen.SessionDetail.ARG_SESSION_ID] ?: ""
+
+    val uiState: StateFlow<SessionDetailUiState> =
+        analyticsRepository.sessionDetail(sessionId)
+            .map { SessionDetailUiState(detail = it, loading = false) }
+            .stateIn(
+                viewModelScope,
+                SharingStarted.WhileSubscribed(5000),
+                SessionDetailUiState(),
+            )
+}
+
+/**
+ * Immutable state for the per-dash drill-down (#650 PR A). [loading] is the pre-first-emission
+ * state; once the read-model emits, a `null` [detail] means the session row is absent (dash not
+ * found / projector rebuild) and a present one is the full [SessionDetail].
+ */
+data class SessionDetailUiState(
+    val detail: SessionDetail? = null,
+    val loading: Boolean = true,
+)

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/navigation/DashBuddyRoutes.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/navigation/DashBuddyRoutes.kt
@@ -1,5 +1,7 @@
 package cloud.trotter.dashbuddy.ui.main.navigation
 
+import android.net.Uri
+
 sealed class Screen(val route: String) {
     // Top Level
     data object Dashboard : Screen("dashboard")
@@ -9,6 +11,16 @@ sealed class Screen(val route: String) {
     data object Ratings : Screen("ratings")
     // Analytics hub (#315 H1) — Money tab v1; Patterns/Decisions/Time tabs stubbed.
     data object Analytics : Screen("analytics")
+
+    /**
+     * Per-dash drill-down (#650) — the read-only session detail for one dash. The [route] template
+     * carries the sessionId; [route] (the fun) URL-encodes it since a session id can hold arbitrary
+     * characters. The screen reads the id back from `SavedStateHandle`.
+     */
+    data object SessionDetail : Screen("analytics/session/{sessionId}") {
+        const val ARG_SESSION_ID = "sessionId"
+        fun route(sessionId: String): String = "analytics/session/${Uri.encode(sessionId)}"
+    }
 
     // Settings Hierarchy
     // Note: We use "settings/home" as the landing page for settings

--- a/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsSessionDetailTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsSessionDetailTest.kt
@@ -1,0 +1,150 @@
+package cloud.trotter.dashbuddy.analytics
+
+import androidx.room.Room
+import cloud.trotter.dashbuddy.core.data.analytics.AnalyticsRepository
+import cloud.trotter.dashbuddy.core.database.DashBuddyDatabase
+import cloud.trotter.dashbuddy.core.database.analytics.AnalyticsDao
+import cloud.trotter.dashbuddy.core.database.analytics.DeliveryRecordEntity
+import cloud.trotter.dashbuddy.core.database.analytics.SessionRecordEntity
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+/**
+ * #650 PR A — the read-only per-dash drill-down over an in-memory database. Proves:
+ *  - `sessionDetail` emits `null` for an unknown session id;
+ *  - it assembles the session header + its deliveries in **completion order** (the DAO `ORDER BY
+ *    completedAt ASC`, even when inserted out of order);
+ *  - `SessionDetail.unattributedPay` mirrors the `grossAndUnattributed` SQL definition — reported
+ *    over delivered ⇒ the delta, reported null ⇒ 0, reported under delivered ⇒ 0 (never negative).
+ */
+@RunWith(RobolectricTestRunner::class)
+class AnalyticsSessionDetailTest {
+
+    private lateinit var db: DashBuddyDatabase
+    private lateinit var dao: AnalyticsDao
+    private lateinit var repo: AnalyticsRepository
+
+    private val base = 1_600_000_000_000L
+    private val hour = 3_600_000L
+
+    @Before
+    fun setUp() {
+        val context = RuntimeEnvironment.getApplication()
+        db = Room.inMemoryDatabaseBuilder(context, DashBuddyDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = db.analyticsDao()
+        repo = AnalyticsRepository(dao)
+    }
+
+    @After
+    fun tearDown() = db.close()
+
+    private fun session(
+        id: String,
+        reportedEarnings: Double? = null,
+    ) = SessionRecordEntity(
+        sessionId = id,
+        platform = "doordash",
+        startedAt = base,
+        endedAt = base + hour,
+        lastEventAt = base + hour,
+        endSource = "summary_screen",
+        startOdometer = 0.0,
+        lastOdometer = 12.0,
+        reportedEarnings = reportedEarnings,
+        reportedDurationMillis = hour,
+        offersReceived = 0,
+        offersAccepted = 0,
+        offersDeclined = 0,
+        offersTimeout = 0,
+        deliveries = 2,
+        jobsCompleted = 2,
+    )
+
+    private fun delivery(
+        seq: Long,
+        sessionId: String?,
+        completedAt: Long,
+        realizedPay: Double? = 8.0,
+        storeName: String? = "Wendys",
+    ) = DeliveryRecordEntity(
+        eventSequenceId = seq,
+        sessionId = sessionId,
+        platform = "doordash",
+        jobId = "job-$seq",
+        taskId = "task-$seq",
+        storeName = storeName,
+        customerHash = null,
+        addressHash = null,
+        phaseStartedAt = completedAt - 600_000,
+        arrivedAt = null,
+        completedAt = completedAt,
+        deadlineMillis = null,
+        realizedPay = realizedPay,
+        payBasis = "DROP_SHARE",
+        tip = null,
+        basePay = null,
+        odometerAtCompletion = null,
+        realizedMiles = 3.0,
+        realizedMinutes = 10.0,
+        frozenCostPerMile = null,
+        netProfit = null,
+        costBasis = "NONE",
+    )
+
+    @Test
+    fun `unknown session id emits null`() = runBlocking {
+        assertNull(repo.sessionDetail("nope").first())
+    }
+
+    @Test
+    fun `assembles session header and deliveries in completion order`() = runBlocking {
+        dao.upsertSession(session("S"))
+        // Inserted out of completion order; the DAO orders by completedAt ASC.
+        dao.upsertDelivery(delivery(2, "S", completedAt = base + 2 * hour, storeName = "Chili's"))
+        dao.upsertDelivery(delivery(1, "S", completedAt = base + hour, storeName = "Wendys"))
+
+        val detail = repo.sessionDetail("S").first()!!
+        assertEquals("S", detail.session.sessionId)
+        assertEquals(2, detail.deliveries.size)
+        assertEquals("Wendys", detail.deliveries[0].storeName)   // earlier completedAt first
+        assertEquals("Chili's", detail.deliveries[1].storeName)
+        assertEquals(16.0, detail.deliveredPay, 1e-9)            // 8 + 8
+    }
+
+    @Test
+    fun `unattributedPay is reported minus delivered when reported exceeds delivered`() = runBlocking {
+        dao.upsertSession(session("S", reportedEarnings = 25.0))
+        dao.upsertDelivery(delivery(1, "S", completedAt = base + hour, realizedPay = 8.0))
+        dao.upsertDelivery(delivery(2, "S", completedAt = base + 2 * hour, realizedPay = 10.0))
+
+        val detail = repo.sessionDetail("S").first()!!
+        assertEquals(18.0, detail.deliveredPay, 1e-9)
+        assertEquals(7.0, detail.unattributedPay, 1e-9)          // 25 − 18
+    }
+
+    @Test
+    fun `unattributedPay is zero when reported is null`() = runBlocking {
+        dao.upsertSession(session("S", reportedEarnings = null))
+        dao.upsertDelivery(delivery(1, "S", completedAt = base + hour, realizedPay = 8.0))
+
+        assertEquals(0.0, repo.sessionDetail("S").first()!!.unattributedPay, 1e-9)
+    }
+
+    @Test
+    fun `unattributedPay never goes negative when delivered exceeds reported`() = runBlocking {
+        dao.upsertSession(session("S", reportedEarnings = 5.0))
+        dao.upsertDelivery(delivery(1, "S", completedAt = base + hour, realizedPay = 8.0))
+
+        assertEquals(0.0, repo.sessionDetail("S").first()!!.unattributedPay, 1e-9)
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/SessionDetailViewModelTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/SessionDetailViewModelTest.kt
@@ -1,0 +1,96 @@
+package cloud.trotter.dashbuddy.ui.main.analytics
+
+import androidx.lifecycle.SavedStateHandle
+import cloud.trotter.dashbuddy.core.data.analytics.AnalyticsRepository
+import cloud.trotter.dashbuddy.domain.analytics.DeliveryRecord
+import cloud.trotter.dashbuddy.domain.analytics.SessionDetail
+import cloud.trotter.dashbuddy.domain.analytics.SessionRecord
+import cloud.trotter.dashbuddy.ui.main.navigation.Screen
+import cloud.trotter.dashbuddy.domain.state.Platform
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+/**
+ * #650 PR A — the per-dash drill-down ViewModel pulls its sessionId from [SavedStateHandle] and maps
+ * [AnalyticsRepository.sessionDetail] into an immutable [SessionDetailUiState], loading → loaded.
+ * Same stub-flow pattern as [AnalyticsViewModelTest].
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SessionDetailViewModelTest {
+
+    private val analyticsRepository: AnalyticsRepository = mock()
+
+    private fun session(id: String) = SessionRecord(
+        sessionId = id, platform = Platform.DoorDash, startedAt = 1_700_000_000_000L,
+        endedAt = 1_700_003_600_000L, reportedEarnings = 30.0, reportedDurationMillis = 3_600_000L,
+        miles = 12.0, deliveries = 1, jobsCompleted = 1, offersReceived = 2, offersAccepted = 1,
+        offersDeclined = 1, offersTimeout = 0,
+    )
+
+    private fun delivery(id: String) = DeliveryRecord(
+        eventSequenceId = 1L, sessionId = id, platform = Platform.DoorDash, jobId = "job-1",
+        taskId = "task-1", storeName = "Wendys", completedAt = 1_700_001_000_000L,
+        realizedPay = 8.0, netProfit = 3.0, realizedMiles = 3.0, realizedMinutes = 10.0,
+        tip = 2.0, basePay = 6.0,
+    )
+
+    private fun buildViewModel(sessionId: String) = SessionDetailViewModel(
+        SavedStateHandle(mapOf(Screen.SessionDetail.ARG_SESSION_ID to sessionId)),
+        analyticsRepository,
+    )
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    @Test
+    fun `loads the detail for the SavedStateHandle sessionId, loading to loaded`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val detail = SessionDetail(session("s1"), listOf(delivery("s1")))
+        whenever(analyticsRepository.sessionDetail(eq("s1"))).thenReturn(flowOf(detail))
+
+        val viewModel = buildViewModel("s1")
+
+        // Initial stateIn value is the loading placeholder before the first emission.
+        assertTrue(viewModel.uiState.value.loading)
+        assertNull(viewModel.uiState.value.detail)
+
+        val job = launch { viewModel.uiState.collect {} }
+        testScheduler.advanceUntilIdle()
+
+        val loaded = viewModel.uiState.value
+        assertTrue(!loaded.loading)
+        val detailOut = loaded.detail!!
+        assertEquals("s1", detailOut.session.sessionId)
+        assertEquals(1, detailOut.deliveries.size)
+        job.cancel()
+    }
+
+    @Test
+    fun `an unknown session id resolves to a loaded null detail`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        whenever(analyticsRepository.sessionDetail(eq("gone"))).thenReturn(flowOf(null))
+
+        val viewModel = buildViewModel("gone")
+        val job = launch { viewModel.uiState.collect {} }
+        testScheduler.advanceUntilIdle()
+
+        val ui = viewModel.uiState.value
+        assertTrue(!ui.loading)
+        assertNull(ui.detail)
+        job.cancel()
+    }
+}

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
@@ -11,6 +11,7 @@ import cloud.trotter.dashbuddy.domain.analytics.DecisionEconomics
 import cloud.trotter.dashbuddy.domain.analytics.DeliveryRecord
 import cloud.trotter.dashbuddy.domain.analytics.PeriodEconomics
 import cloud.trotter.dashbuddy.domain.analytics.PeriodTotals
+import cloud.trotter.dashbuddy.domain.analytics.SessionDetail
 import cloud.trotter.dashbuddy.domain.analytics.SessionRecord
 import cloud.trotter.dashbuddy.domain.analytics.StoreEconomics
 import cloud.trotter.dashbuddy.domain.analytics.TimeEconomics
@@ -203,6 +204,22 @@ class AnalyticsRepository @Inject constructor(
     /** Every delivery in a session, completion order (future #650 drill-down). */
     fun deliveriesForSession(sessionId: String): Flow<List<DeliveryRecord>> =
         analyticsDao.deliveriesForSession(sessionId).map { rows -> rows.map { it.toDomain() } }
+
+    /**
+     * One dash fully expanded (#650 PR A drill-down): the session header + its deliveries in
+     * completion order, as a [SessionDetail], or `null` when no session row exists for [sessionId]
+     * (the dash was never recorded, or the projector wiped/rebuilt). Read-model only, reactive by
+     * construction (both sources are Room-invalidation Flows, so the detail re-emits as the projector
+     * folds each delivery), no economy dependency (the per-delivery net is frozen), no new PII surface
+     * (store names are driver-owned; no customer hashes are exposed on [DeliveryRecord]).
+     */
+    fun sessionDetail(sessionId: String): Flow<SessionDetail?> =
+        combine(
+            analyticsDao.sessionRecordFlow(sessionId),
+            analyticsDao.deliveriesForSession(sessionId),
+        ) { session, deliveries ->
+            session?.let { SessionDetail(it.toDomain(), deliveries.map { row -> row.toDomain() }) }
+        }
 
     /**
      * Build the free-tier CSV export (#319) — deliveries / sessions / summary — for the raw rows in

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
@@ -300,6 +300,10 @@ interface AnalyticsDao {
     @Query("SELECT * FROM delivery_records WHERE sessionId = :sessionId ORDER BY completedAt ASC")
     fun deliveriesForSession(sessionId: String): Flow<List<DeliveryRecordEntity>>
 
+    /** One session row as a Flow — the #650 drill-down header (re-emits on projector commits). */
+    @Query("SELECT * FROM session_records WHERE sessionId = :id")
+    fun sessionRecordFlow(id: String): Flow<SessionRecordEntity?>
+
     // ── Raw row reads for CSV export (#319) ──────────────────────────────
 
     /**

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -73,6 +73,14 @@ card's **mechanical** half, #577 (re-confirmed, 24/24, ~0.55 s — with a new po
 that entry's Bug #1), the #457 path, and #554 ShadowProjector (2/2). The #462/#460 dropoff item
 was found **broken-in-part** (raw PII in capture envelopes) and moved to that entry's Bug #7.)_
 
+- **🆕 NEW — per-dash drill-down (#650 PR A): tap a recent dash on the Money tab.** Analytics → Money
+  tab → scroll to RECENT DASHES → tap any dash row. It should open a read-only "Dash detail" screen.
+  How to tell it's working: the header figures (date, start–end clock times, duration, gross, miles,
+  deliveries) match that dash's summary, and the per-delivery rows list each drop (store, completion
+  time, pay, tip, net, miles/min) matching what you actually delivered. When the platform-reported
+  total exceeded the captured delivery pay, an "unaccounted on this dash" callout appears. (PR #650-A)
+  - Confirmed: 0/2
+
 - **🆕 NEW — identity-less completions now firewalled at PostTask exit (#653 / PR #673): watch a
   no-name drop for a MISSING completion.** The PostTask-exit `DELIVERY_COMPLETED` mint now mirrors
   the close-out path's #498 identity firewall: a dropoff task that never acquired a customer

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/SessionDetail.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/SessionDetail.kt
@@ -1,0 +1,33 @@
+package cloud.trotter.dashbuddy.domain.analytics
+
+/**
+ * One dash, fully expanded — the read-only per-dash drill-down (#650 PR A): the [session] header
+ * plus every [DeliveryRecord] captured under it, in completion order. Read-model only, assembled at
+ * the repository boundary from the durable records; no economy dependency (the per-delivery net is
+ * the frozen stored value, never re-costed), no new PII surface (store names are driver-owned;
+ * customer/address hashes are not exposed on [DeliveryRecord] at all).
+ *
+ * Corrections/edits are #650 PR B — this DTO is the surface those correction entry points hang off,
+ * but here it is strictly a read projection.
+ */
+data class SessionDetail(
+    val session: SessionRecord,
+    val deliveries: List<DeliveryRecord>,   // completion order
+) {
+    /** Σ captured delivery pay for THIS session (null pays counted as 0). */
+    val deliveredPay: Double get() = deliveries.sumOf { it.realizedPay ?: 0.0 }
+
+    /**
+     * `reported − delivered` when the platform-reported total exceeds captured delivery pay, else
+     * `0` (never negative) — the per-dash review flag. This deliberately mirrors the SQL `CASE` in
+     * [cloud.trotter.dashbuddy.domain.analytics] `AnalyticsDao.grossAndUnattributed` (that query is
+     * the definition owner: reported-authoritative, non-negative); this is the same number the
+     * period-level unattributed callout sums, scoped to one dash. It is the entry point the #650 PR B
+     * corrections attach to.
+     */
+    val unattributedPay: Double
+        get() {
+            val reported = session.reportedEarnings ?: return 0.0
+            return (reported - deliveredPay).coerceAtLeast(0.0)
+        }
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/format/TimeFormats.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/format/TimeFormats.kt
@@ -62,3 +62,18 @@ fun formatShortDate(
     DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)
         .withLocale(locale)
         .format(Instant.ofEpochMilli(millis).atZone(zone))
+
+/**
+ * "5:42 PM" / "17:42" — a localized clock time for a review surface (the per-delivery rows of the
+ * #650 drill-down). Same display policy as [formatShortDate]: the localized SHORT time in [locale],
+ * resolved against the device [zone] — display copy the dasher reads in their own locale, not a
+ * machine string. One owner for a rendered clock time (Principle 5).
+ */
+fun formatClockTime(
+    millis: Long,
+    zone: ZoneId = ZoneId.systemDefault(),
+    locale: Locale = Locale.getDefault(),
+): String =
+    DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT)
+        .withLocale(locale)
+        .format(Instant.ofEpochMilli(millis).atZone(zone))

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/format/TimeFormatsTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/format/TimeFormatsTest.kt
@@ -4,6 +4,7 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
+import java.time.ZoneId
 import java.util.Locale
 
 /**
@@ -47,5 +48,21 @@ class TimeFormatsTest {
         Locale.setDefault(Locale.forLanguageTag("ar-EG"))
         assertEquals("3m 12s", formatDuration(192_000))
         assertEquals("1:05", formatCountdown(65_000))
+    }
+
+    @Test
+    fun `formatClockTime renders localized SHORT time at a fixed zone and locale`() {
+        // 2021-09-13 21:42:07 UTC → 5:42 PM in America/New_York (EDT, UTC−4), US locale.
+        // CLDR separates the time from the day-period with a NARROW NO-BREAK SPACE (U+202F).
+        val millis = 1_631_569_327_000L
+        assertEquals(
+            "5:42 PM",
+            formatClockTime(millis, ZoneId.of("America/New_York"), Locale.US).replace('\u202F', ' '),
+        )
+        // Same instant is 21:42 in UTC under a 24-hour locale (UK).
+        assertEquals(
+            "21:42",
+            formatClockTime(millis, ZoneId.of("UTC"), Locale.UK),
+        )
     }
 }


### PR DESCRIPTION
## What / why

PR A of **#650** — the read-only per-dash drill-down. Tapping a dash row in the Money tab's RECENT DASHES list now opens a **Dash detail** screen: a header card (date, start–end clock span, duration, gross/miles/deliveries) and a per-delivery breakdown in completion order (store, completion time, pay, tip, net, miles/min). This is the surface the driver uses to see what one dash actually contained.

**Scope guard:** this PR **only reads**. Corrections/editing (`MANUAL_DELIVERY` / `PAY_ADJUSTMENT` events the projector folds) are **PR B of #650** — not in scope here.

## Changes

- **Domain** — new `SessionDetail(session, deliveries)` DTO with `deliveredPay` / `unattributedPay`; `TimeFormats.formatClockTime` (localized SHORT time, mirrors `formatShortDate`'s signature).
- **Data** — `AnalyticsDao.sessionRecordFlow(id)` (Flow beside the existing suspend `sessionRecord`); `AnalyticsRepository.sessionDetail(sessionId): Flow<SessionDetail?>` combining the session-row Flow + `deliveriesForSession` (null when the row is absent).
- **UI** — `Screen.SessionDetail` route (`analytics/session/{sessionId}`, Uri-encoded id, read back from `SavedStateHandle`); `SessionDetailViewModel` + `SessionDetailUiState`; `SessionDetailScreen`. Money-tab recent-dashes rows are now `clickable` → `onOpenSession`, threaded `MainActivity → AnalyticsScreen → MoneyTab`. Removed the "not tappable until #650" notes.

## Data semantics

- **Read-model only, reactive by construction.** Both sources are Room-invalidation Flows, so the detail re-emits as the projector folds each delivery. **No economy dependency** — the per-delivery net is the frozen stored value, never re-costed.
- **Per-dash unattributed mirrors the period definition.** `SessionDetail.unattributedPay` = `reported − delivered` when reported exceeds delivered, else `0` (never negative) — deliberately the same `CASE` as `AnalyticsDao.grossAndUnattributed` (cited in the KDoc as the definition owner). It is the same number the period callout sums, scoped to one dash — the entry point PR B's corrections attach to.

## Test coverage

- `AnalyticsSessionDetailTest` (Robolectric + in-memory DB, modeled on `AnalyticsTimeTest`): `sessionDetail` null for unknown id; assembles header + deliveries in completion order; `unattributedPay` — reported>delivered → delta, reported null → 0, reported<delivered → 0.
- `SessionDetailViewModelTest` (mock repo, modeled on `AnalyticsViewModelTest`): loading → loaded, sessionId pulled from `SavedStateHandle`, unknown id → loaded-null.
- `TimeFormatsTest`: `formatClockTime` at fixed zone/locale ("5:42 PM" US, "21:42" UK; NNBSP normalized).

`JAVA_HOME=…/java-25-openjdk ./gradlew :app:testDebugUnitTest :domain:test` green.

### Design-goal review

1. **UDF** — state out (`StateFlow<SessionDetailUiState>`), no intents (read-only); the screen observes immutable state, derives display strings. No reducer/repository writes.
3. **Single responsibility** — new small files per concern (DTO / VM+UiState / screen); the drill-down is not bolted onto MoneyTab.
4. **Kotlin/Android idioms** — matched the neighboring analytics ViewModel/screen/DAO/repo idioms; standard compose-navigation `navArgument` route (no existing arg-carrying route to copy).
5. **SSOT** — clock-time formatter added to `TimeFormats` (not hand-rolled); `unattributedPay` cites its SQL definition owner (`grossAndUnattributed`); all numbers route through `Formats`/`TimeFormats`.
6. **Security & privacy** — store names are driver-owned and rendered (never logged); no customer/address hashes are exposed on `DeliveryRecord`, so none can surface. No new capture/network/PII surface.
8. **Platform-agnostic** — the platform chip resolves its label through the `Platform` registry (`shortName`/`displayName`), never a literal.
- **Reactive UI** — a **review** surface: Room-invalidation reactive, no `rememberNow()` ticker (a historical dash's figures are fixed; the #657 reframe).
