### PR TITLE
feat(#650): user corrections as events (MANUAL_DELIVERY / PAY_ADJUSTMENT)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -291,8 +291,13 @@ rows (row-level, bucketing-free — the driver's own records dumped, not session
 pure `CsvExporter` (`:core:data`, RFC-4180 + machine `Csv`/`IrsMileage` primitives in `:domain`) formats
 deliveries/sessions/summary CSVs; the SAF directory-write edge is a `:app` ViewModel (Settings → Data &
 Privacy → Export Data). Merchant/store names are exported (driver-owned); customer/address hashes are
-excluded; no network. Follow-ups: #650 (drill-down + user corrections as
-`MANUAL_DELIVERY`/`PAY_ADJUSTMENT` events the projector folds — non-destructive, auditable), #653/#655.
+excluded; no network. #650 corrections are now IN: the per-dash drill-down (`SessionDetailScreen`) appends
+`MANUAL_DELIVERY` (a driver-entered missed drop → `MANUAL`-basis delivery_record) and `PAY_ADJUSTMENT` (a
+re-price of an existing row → `USER_CORRECTED`, net recomputed against that row's OWN frozen cpm) via the
+write-side `CorrectionRepository`; the projector folds them non-destructively (the original event/row is never
+deleted) and rebuild-faithfully (a from-zero refold replays a correction after its target and reproduces
+identical rows — no PROJECTOR_VERSION bump needed, the new event types can't exist in already-folded history).
+Session-categorize of an unattributed remainder is deferred (#650 follow-up). Related: #653/#655.
 
 ## Development Principles
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/SessionDetailScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/SessionDetailScreen.kt
@@ -13,17 +13,26 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -80,6 +89,8 @@ fun SessionDetailScreen(
         when {
             detail != null -> DashDetailContent(
                 detail = detail,
+                onAddManualDelivery = viewModel::addManualDelivery,
+                onAdjustPay = viewModel::adjustPay,
                 modifier = Modifier
                     .padding(padding)
                     .verticalScroll(rememberScrollState())
@@ -95,19 +106,59 @@ fun SessionDetailScreen(
 }
 
 @Composable
-private fun DashDetailContent(detail: SessionDetail, modifier: Modifier) {
+private fun DashDetailContent(
+    detail: SessionDetail,
+    onAddManualDelivery: (pay: Double, tip: Double?, storeName: String?, note: String?) -> Unit,
+    onAdjustPay: (targetEventSequenceId: Long, newPay: Double, note: String?) -> Unit,
+    modifier: Modifier,
+) {
+    // Correction dialog state — hoisted here, stateless children below (Principle 1 / 3).
+    var showAddDialog by remember { mutableStateOf(false) }
+    var adjustTarget by remember { mutableStateOf<DeliveryRecord?>(null) }
+
+    val hasCallout = detail.unattributedPay > UNATTRIBUTED_EPSILON
+
     Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(16.dp)) {
         HeaderCard(detail)
-        if (detail.unattributedPay > UNATTRIBUTED_EPSILON) {
-            AppCallout(
-                text = "${Formats.money(detail.unattributedPay)} unaccounted on this dash — the " +
-                    "platform reported more than the captured deliveries. Corrections land in the " +
-                    "next phase (#650).",
-                container = AppTheme.colors.warnBg,
-                modifier = Modifier.fillMaxWidth(),
-            )
+        if (hasCallout) {
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                AppCallout(
+                    text = "${Formats.money(detail.unattributedPay)} unaccounted on this dash — the " +
+                        "platform reported more than the captured deliveries.",
+                    container = AppTheme.colors.warnBg,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                TextButton(onClick = { showAddDialog = true }) { Text("Add missed delivery") }
+            }
         }
-        DeliveriesCard(detail.deliveries)
+        // With no callout, the add entry point lives at the bottom of the deliveries card — a missed
+        // delivery can exist without a reported excess.
+        DeliveriesCard(
+            deliveries = detail.deliveries,
+            showAddButton = !hasCallout,
+            onAddMissed = { showAddDialog = true },
+            onAdjust = { adjustTarget = it },
+        )
+    }
+
+    if (showAddDialog) {
+        AddMissedDeliveryDialog(
+            onDismiss = { showAddDialog = false },
+            onConfirm = { pay, tip, store, note ->
+                onAddManualDelivery(pay, tip, store, note)
+                showAddDialog = false
+            },
+        )
+    }
+    adjustTarget?.let { target ->
+        AdjustPayDialog(
+            currentPay = target.realizedPay,
+            onDismiss = { adjustTarget = null },
+            onConfirm = { newPay, note ->
+                onAdjustPay(target.eventSequenceId, newPay, note)
+                adjustTarget = null
+            },
+        )
     }
 }
 
@@ -175,7 +226,12 @@ private fun dashDuration(startedAt: Long, endedAt: Long?, reportedDurationMillis
     }
 
 @Composable
-private fun DeliveriesCard(deliveries: List<DeliveryRecord>) {
+private fun DeliveriesCard(
+    deliveries: List<DeliveryRecord>,
+    showAddButton: Boolean,
+    onAddMissed: () -> Unit,
+    onAdjust: (DeliveryRecord) -> Unit,
+) {
     val c = AppTheme.colors
     AppCard(modifier = Modifier.fillMaxWidth()) {
         Text(text = "DELIVERIES", style = MaterialTheme.typography.labelMedium, color = c.text3)
@@ -185,14 +241,18 @@ private fun DeliveriesCard(deliveries: List<DeliveryRecord>) {
         } else {
             deliveries.forEachIndexed { index, delivery ->
                 if (index > 0) Spacer(Modifier.height(14.dp))
-                DeliveryRow(delivery)
+                DeliveryRow(delivery, onAdjust = { onAdjust(delivery) })
             }
+        }
+        if (showAddButton) {
+            Spacer(Modifier.height(6.dp))
+            TextButton(onClick = onAddMissed) { Text("Add missed delivery") }
         }
     }
 }
 
 @Composable
-private fun DeliveryRow(delivery: DeliveryRecord) {
+private fun DeliveryRow(delivery: DeliveryRecord, onAdjust: () -> Unit) {
     val c = AppTheme.colors
     Row(verticalAlignment = Alignment.Top) {
         Column(Modifier.weight(1f)) {
@@ -235,6 +295,13 @@ private fun DeliveryRow(delivery: DeliveryRecord) {
                 textAlign = TextAlign.End,
             )
         }
+        IconButton(onClick = onAdjust) {
+            Icon(
+                Icons.Default.Edit,
+                contentDescription = "Adjust pay",
+                tint = AppTheme.colors.text3,
+            )
+        }
     }
 }
 
@@ -262,4 +329,100 @@ private fun CenteredMessage(text: String, modifier: Modifier = Modifier) {
     Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Text(text = text, style = MaterialTheme.typography.bodyMedium, color = AppTheme.colors.text3)
     }
+}
+
+/** A blank or non-blank-but-positive number parses; a non-blank invalid one does not. */
+private fun optionalMoney(text: String): Double? = text.takeIf { it.isNotBlank() }?.toDoubleOrNull()
+private fun String.isBlankOrValidMoney(): Boolean = isBlank() || (toDoubleOrNull()?.let { it > 0.0 } == true)
+private fun String.isValidMoney(): Boolean = toDoubleOrNull()?.let { it > 0.0 } == true
+
+/**
+ * Add-a-missed-delivery dialog (#650) — store (optional), pay (required, > 0), tip (optional, > 0
+ * when present), note (optional). Confirm stays disabled until pay is valid and any entered tip is
+ * valid. Stateless w/ hoisted local field state per the codebase idiom.
+ */
+@Composable
+private fun AddMissedDeliveryDialog(
+    onDismiss: () -> Unit,
+    onConfirm: (pay: Double, tip: Double?, storeName: String?, note: String?) -> Unit,
+) {
+    var store by remember { mutableStateOf("") }
+    var pay by remember { mutableStateOf("") }
+    var tip by remember { mutableStateOf("") }
+    var note by remember { mutableStateOf("") }
+    val valid = pay.isValidMoney() && tip.isBlankOrValidMoney()
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Add missed delivery") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                MoneyField(store, { store = it }, "Store (optional)", numeric = false)
+                MoneyField(pay, { pay = it }, "Pay")
+                MoneyField(tip, { tip = it }, "Tip (optional)")
+                MoneyField(note, { note = it }, "Note (optional)", numeric = false)
+            }
+        },
+        confirmButton = {
+            TextButton(
+                enabled = valid,
+                onClick = {
+                    onConfirm(
+                        pay.toDouble(),
+                        optionalMoney(tip),
+                        store.trim().takeIf { it.isNotBlank() },
+                        note.trim().takeIf { it.isNotBlank() },
+                    )
+                },
+            ) { Text("Add") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
+}
+
+/**
+ * Adjust-pay dialog (#650) — prefilled with the delivery's current pay, note optional. Confirm stays
+ * disabled until the new pay is a positive number.
+ */
+@Composable
+private fun AdjustPayDialog(
+    currentPay: Double?,
+    onDismiss: () -> Unit,
+    onConfirm: (newPay: Double, note: String?) -> Unit,
+) {
+    // Prefill with a parse-faithful value (NOT Formats.decimal, which rounds to 1 digit and would
+    // silently drop cents from the round-trip).
+    var pay by remember { mutableStateOf(currentPay?.toString() ?: "") }
+    var note by remember { mutableStateOf("") }
+    val valid = pay.isValidMoney()
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Adjust pay") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                MoneyField(pay, { pay = it }, "Pay")
+                MoneyField(note, { note = it }, "Note (optional)", numeric = false)
+            }
+        },
+        confirmButton = {
+            TextButton(
+                enabled = valid,
+                onClick = { onConfirm(pay.toDouble(), note.trim().takeIf { it.isNotBlank() }) },
+            ) { Text("Save") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
+}
+
+@Composable
+private fun MoneyField(value: String, onValueChange: (String) -> Unit, label: String, numeric: Boolean = true) {
+    OutlinedTextField(
+        value = value,
+        onValueChange = onValueChange,
+        label = { Text(label) },
+        singleLine = true,
+        keyboardOptions = if (numeric) KeyboardOptions(keyboardType = KeyboardType.Decimal) else KeyboardOptions.Default,
+        modifier = Modifier.fillMaxWidth(),
+    )
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/SessionDetailViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/SessionDetailViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import cloud.trotter.dashbuddy.core.data.analytics.AnalyticsRepository
+import cloud.trotter.dashbuddy.core.data.analytics.CorrectionRepository
 import cloud.trotter.dashbuddy.domain.analytics.SessionDetail
 import cloud.trotter.dashbuddy.ui.main.navigation.Screen
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -11,23 +12,28 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 /**
- * State holder for the read-only per-dash drill-down (#650 PR A) — one immutable
- * [SessionDetailUiState] assembled reactively from [AnalyticsRepository.sessionDetail]
- * (Principle 1 — UDF, state out; no intents yet, PR A only reads). The sessionId is read from
+ * State holder for the per-dash drill-down (#650) — one immutable [SessionDetailUiState] assembled
+ * reactively from [AnalyticsRepository.sessionDetail] (Principle 1 — UDF, state out), plus the two
+ * correction intents ([addManualDelivery] / [adjustPay], events up). The sessionId is read from
  * [SavedStateHandle] (the nav argument), so this VM needs no explicit initializer.
  *
  * Reactive by construction: the source is a Room-invalidation `Flow`, so the header + rows re-emit
  * as the projector folds each delivery — a **review** surface, not a per-second tick (no
- * `rememberNow()` clock; same reframe as the hub #657). Read-model only, no economy dependency, no
- * new PII surface (store names are driver-owned; no customer hashes are exposed).
+ * `rememberNow()` clock; same reframe as the hub #657). The corrections are **events, never
+ * destructive edits**: an intent appends a `MANUAL_DELIVERY`/`PAY_ADJUSTMENT` to the log via
+ * [CorrectionRepository]; the projector folds it and Room invalidation refreshes this screen — there
+ * is NO optimistic local mutation. Read-model only, no economy dependency, no new PII surface (store
+ * names are driver-owned; no customer hashes are exposed).
  */
 @HiltViewModel
 class SessionDetailViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     analyticsRepository: AnalyticsRepository,
+    private val correctionRepository: CorrectionRepository,
 ) : ViewModel() {
 
     private val sessionId: String =
@@ -41,6 +47,44 @@ class SessionDetailViewModel @Inject constructor(
                 SharingStarted.WhileSubscribed(5000),
                 SessionDetailUiState(),
             )
+
+    /**
+     * Append a driver-entered missed delivery for this dash (#650). `completedAt` defaults to the
+     * loaded session's `endedAt ?: startedAt` — the simplest honest v1 default for when the drop
+     * happened; miles are v1-null (not asked for). The projector folds it (payBasis `MANUAL`) and the
+     * read-model Flow refreshes the screen.
+     */
+    fun addManualDelivery(pay: Double, tip: Double?, storeName: String?, note: String?) {
+        val session = uiState.value.detail?.session
+        val completedAt = session?.endedAt ?: session?.startedAt ?: System.currentTimeMillis()
+        viewModelScope.launch {
+            correctionRepository.addManualDelivery(
+                sessionId = sessionId,
+                storeName = storeName,
+                pay = pay,
+                tip = tip,
+                completedAt = completedAt,
+                miles = null,
+                note = note,
+            )
+        }
+    }
+
+    /**
+     * Append a driver re-price of a recorded delivery (#650). The projector rewrites the target row
+     * (payBasis `USER_CORRECTED`, net recomputed against its own frozen cpm) and the read-model Flow
+     * refreshes the screen.
+     */
+    fun adjustPay(targetEventSequenceId: Long, newPay: Double, note: String?) {
+        viewModelScope.launch {
+            correctionRepository.adjustDeliveryPay(
+                targetEventSequenceId = targetEventSequenceId,
+                sessionId = sessionId,
+                newPay = newPay,
+                note = note,
+            )
+        }
+    }
 }
 
 /**

--- a/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsProjectorTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsProjectorTest.kt
@@ -535,6 +535,33 @@ class AnalyticsProjectorTest {
     }
 
     @Test
+    fun `re-pricing a MANUAL row keeps the MANUAL basis and the net-additive policy (review F1)`() = runBlocking {
+        // The v1 UI shape: a manual delivery with no miles. Its net must equal its pay (missing cost
+        // terms count as 0 — net-additive), and a later driver re-price must keep BOTH the MANUAL
+        // provenance and that policy: the generic machine recompute would null the net and silently
+        // drop the dollars from the period SUM.
+        insert(
+            AppEventType.MANUAL_DELIVERY, "MISSED", 5_000,
+            ManualDeliveryPayload(sessionId = "MISSED", pay = 9.0, completedAt = 5_000),
+        )
+        projector().catchUp()
+        val seq = analyticsDao.lastDeliveryInSession("MISSED")!!.eventSequenceId
+        val folded = analyticsDao.deliveryRecord(seq)!!
+        assertEquals("uncosted manual net = pay (net-additive)", 9.0, folded.netProfit!!, 1e-9)
+
+        insert(
+            AppEventType.PAY_ADJUSTMENT, "MISSED", 6_000,
+            PayAdjustmentPayload(targetEventSequenceId = seq, sessionId = "MISSED", newPay = 12.0),
+        )
+        projector().catchUp()
+
+        val d = analyticsDao.deliveryRecord(seq)!!
+        assertEquals("a driver statement stays a driver statement", "MANUAL", d.payBasis)
+        assertEquals(12.0, d.realizedPay!!, 1e-9)
+        assertEquals("net keeps the MANUAL missing-terms-as-0 policy", 12.0, d.netProfit!!, 1e-9)
+    }
+
+    @Test
     fun `a PAY_ADJUSTMENT re-prices its target to USER_CORRECTED and shrinks the session unattributed pay`() = runBlocking {
         val deliverySeq = seedCorrectableSession(deliveryPay = 10.0, reportedEarnings = 20.0)
         projector().catchUp()

--- a/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsProjectorTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsProjectorTest.kt
@@ -2,6 +2,7 @@ package cloud.trotter.dashbuddy.analytics
 
 import androidx.room.Room
 import cloud.trotter.dashbuddy.core.data.analytics.AnalyticsProjector
+import cloud.trotter.dashbuddy.core.data.analytics.AnalyticsRepository
 import cloud.trotter.dashbuddy.core.data.event.AppEventRepo
 import cloud.trotter.dashbuddy.core.data.settings.AppPreferencesRepository
 import cloud.trotter.dashbuddy.core.database.DashBuddyDatabase
@@ -18,7 +19,9 @@ import cloud.trotter.dashbuddy.domain.model.event.AppEventCodec
 import cloud.trotter.dashbuddy.domain.model.event.AppEventType
 import cloud.trotter.dashbuddy.domain.model.event.payload.AppEventPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.ManualDeliveryPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.OfferPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.PayAdjustmentPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionEndSource
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStartPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStartSource
@@ -461,6 +464,147 @@ class AnalyticsProjectorTest {
         assertEquals("the real DASH_START upgraded startedAt (not stuck at the stop time)", 1_000L, s.startedAt)
         assertEquals("interaction", s.startSource)
         assertEquals(10.0, s.startOdometer!!, 1e-9)
+    }
+
+    // ── User corrections (#650) ─────────────────────────────────────────
+
+    /** A session with a real DASH_START, one accepted offer (frozen cpm 0.25), one delivery, a stop. */
+    private suspend fun seedCorrectableSession(
+        sid: String = "S1",
+        deliveryPay: Double = 10.0,
+        reportedEarnings: Double = 20.0,
+    ): Long {
+        insert(
+            AppEventType.DASH_START, sid, 1_000,
+            SessionStartPayload(sid, Platform.DoorDash.name, 1_000, SessionStartSource.INTERACTION, "x"),
+            odometer = 100.0,
+        )
+        insert(
+            AppEventType.OFFER_ACCEPTED, sid, 2_000,
+            OfferPayload(
+                offerHash = "h1",
+                parsedOffer = ParsedOffer(offerHash = "h1", payAmount = 12.0, distanceMiles = 3.0),
+                evaluation = eval(0.25), outcome = AppEventType.OFFER_ACCEPTED,
+                presentedAt = 1_970, decidedAt = 2_000, returnFlow = Flow.Idle,
+            ),
+        )
+        val deliverySeq = insert(
+            AppEventType.DELIVERY_COMPLETED, sid, 3_000,
+            DeliveryPayload(
+                jobId = "J1", taskId = "T1", storeName = "StoreX", customerHash = "c",
+                phaseStartedAt = 2_400, arrivedAt = 2_880, completedAt = 3_000, totalPay = deliveryPay,
+            ),
+            odometer = 105.0, // 5 miles from the DASH_START reading
+        )
+        insert(
+            AppEventType.DASH_STOP, sid, 4_000,
+            SessionStopPayload(sid, endedAt = 4_000, source = SessionEndSource.SUMMARY_SCREEN, totalEarnings = reportedEarnings),
+            odometer = 110.0,
+        )
+        return deliverySeq
+    }
+
+    @Test
+    fun `a MANUAL_DELIVERY for a session with no prior rows lands its delivery AND a session row in one drain (the #661 invariant)`() = runBlocking {
+        // No DASH_START at all — the correction is the only event for session "MISSED".
+        insert(
+            AppEventType.MANUAL_DELIVERY, "MISSED", 5_000,
+            ManualDeliveryPayload(
+                sessionId = "MISSED", storeName = "Chipotle", pay = 9.0, tip = 2.0,
+                completedAt = 5_000, miles = 3.0, note = "app crashed before capture",
+            ),
+        )
+
+        projector().catchUp()
+
+        val totals = analyticsDao.deliveryTotals(0, Long.MAX_VALUE).first()
+        assertEquals("the manual delivery is recorded", 1, totals.deliveries)
+        assertEquals(9.0, totals.pay, 1e-9)
+
+        // #661: a correction can never create a dangling-sessionId delivery row — the projector
+        // synthesized + upserted the session context in the SAME transaction.
+        val s = analyticsDao.sessionRecord("MISSED")
+        assertNotNull("the synthesized session row landed in the same drain", s)
+        assertEquals(1, s!!.deliveries)
+
+        val d = analyticsDao.lastDeliveryInSession("MISSED")!!
+        assertEquals("MANUAL", d.payBasis)
+        assertEquals("Chipotle", d.storeName)
+        assertEquals(3.0, d.realizedMiles!!, 1e-9)
+        assertNull("a manual row has no captured customer identity", d.customerHash)
+    }
+
+    @Test
+    fun `a PAY_ADJUSTMENT re-prices its target to USER_CORRECTED and shrinks the session unattributed pay`() = runBlocking {
+        val deliverySeq = seedCorrectableSession(deliveryPay = 10.0, reportedEarnings = 20.0)
+        projector().catchUp()
+
+        val repo = AnalyticsRepository(analyticsDao)
+        assertEquals("before: reported 20 − captured 10", 10.0, repo.sessionDetail("S1").first()!!.unattributedPay, 1e-9)
+
+        // The driver re-prices the captured delivery up to $15 (a mis-captured tip).
+        insert(
+            AppEventType.PAY_ADJUSTMENT, "S1", 6_000,
+            PayAdjustmentPayload(targetEventSequenceId = deliverySeq, sessionId = "S1", newPay = 15.0, note = "missed tip"),
+        )
+        projector().catchUp()
+
+        val d = analyticsDao.deliveryRecord(deliverySeq)!!
+        assertEquals("USER_CORRECTED", d.payBasis)
+        assertEquals(15.0, d.realizedPay!!, 1e-9)
+        // Net recomputed against the row's OWN frozen cpm (0.25) over its 5 realized miles.
+        assertEquals(15.0 - 5.0 * 0.25, d.netProfit!!, 1e-9)
+        assertEquals("frozen cpm is untouched by the re-price", 0.25, d.frozenCostPerMile!!, 1e-9)
+
+        assertEquals("after: reported 20 − captured 15", 5.0, repo.sessionDetail("S1").first()!!.unattributedPay, 1e-9)
+    }
+
+    @Test
+    fun `a PAY_ADJUSTMENT whose target row is missing is skipped without crashing and the watermark still advances`() = runBlocking {
+        seedCorrectableSession()
+        projector().catchUp()
+        val before = analyticsDao.lastDeliveryInSession("S1")!!
+
+        // Target a sequenceId that no delivery_record has.
+        insert(
+            AppEventType.PAY_ADJUSTMENT, "S1", 6_000,
+            PayAdjustmentPayload(targetEventSequenceId = 9_999, sessionId = "S1", newPay = 99.0, note = "typo"),
+        )
+        projector().catchUp() // must not throw
+
+        assertEquals("the target delivery is unchanged", before, analyticsDao.lastDeliveryInSession("S1"))
+        assertEquals("the watermark advanced past the skipped correction", 5L, analyticsDao.getWatermark()!!.watermarkSequenceId)
+    }
+
+    @Test
+    fun `wiping and refolding from 0 reproduces byte-identical corrected rows (rebuild-faithful)`() = runBlocking {
+        val deliverySeq = seedCorrectableSession(deliveryPay = 10.0, reportedEarnings = 20.0)
+        // A manual delivery AND a re-price of the captured one.
+        insert(
+            AppEventType.MANUAL_DELIVERY, "S1", 5_000,
+            ManualDeliveryPayload(
+                sessionId = "S1", storeName = "Panera", pay = 7.5, tip = 1.5,
+                completedAt = 5_000, miles = 2.0, note = "took an offer off-app",
+            ),
+        )
+        insert(
+            AppEventType.PAY_ADJUSTMENT, "S1", 6_000,
+            PayAdjustmentPayload(targetEventSequenceId = deliverySeq, sessionId = "S1", newPay = 15.0, note = "missed tip"),
+        )
+        projector().catchUp()
+
+        val deliveriesBefore = analyticsDao.deliveriesBetween(Long.MIN_VALUE, Long.MAX_VALUE)
+        val sessionsBefore = analyticsDao.sessionsBetween(Long.MIN_VALUE, Long.MAX_VALUE)
+
+        // Force a version-mismatch wipe + refold from watermark 0.
+        analyticsDao.setWatermark(AnalyticsProjectionStateEntity(watermarkSequenceId = 6, projectorVersion = 99))
+        projector().catchUp()
+
+        assertEquals(
+            "the corrected delivery rows rebuild byte-identically from the log",
+            deliveriesBefore, analyticsDao.deliveriesBetween(Long.MIN_VALUE, Long.MAX_VALUE),
+        )
+        assertEquals(sessionsBefore, analyticsDao.sessionsBetween(Long.MIN_VALUE, Long.MAX_VALUE))
     }
 
     @Test(expected = CancellationException::class)

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/SessionDetailViewModelTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/SessionDetailViewModelTest.kt
@@ -2,6 +2,7 @@ package cloud.trotter.dashbuddy.ui.main.analytics
 
 import androidx.lifecycle.SavedStateHandle
 import cloud.trotter.dashbuddy.core.data.analytics.AnalyticsRepository
+import cloud.trotter.dashbuddy.core.data.analytics.CorrectionRepository
 import cloud.trotter.dashbuddy.domain.analytics.DeliveryRecord
 import cloud.trotter.dashbuddy.domain.analytics.SessionDetail
 import cloud.trotter.dashbuddy.domain.analytics.SessionRecord
@@ -21,7 +22,9 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 /**
@@ -33,6 +36,7 @@ import org.mockito.kotlin.whenever
 class SessionDetailViewModelTest {
 
     private val analyticsRepository: AnalyticsRepository = mock()
+    private val correctionRepository: CorrectionRepository = mock()
 
     private fun session(id: String) = SessionRecord(
         sessionId = id, platform = Platform.DoorDash, startedAt = 1_700_000_000_000L,
@@ -51,6 +55,7 @@ class SessionDetailViewModelTest {
     private fun buildViewModel(sessionId: String) = SessionDetailViewModel(
         SavedStateHandle(mapOf(Screen.SessionDetail.ARG_SESSION_ID to sessionId)),
         analyticsRepository,
+        correctionRepository,
     )
 
     @After
@@ -91,6 +96,41 @@ class SessionDetailViewModelTest {
         val ui = viewModel.uiState.value
         assertTrue(!ui.loading)
         assertNull(ui.detail)
+        job.cancel()
+    }
+
+    @Test
+    fun `addManualDelivery intent appends via the repository, defaulting completedAt to the session's end`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val detail = SessionDetail(session("s1"), listOf(delivery("s1")))
+        whenever(analyticsRepository.sessionDetail(eq("s1"))).thenReturn(flowOf(detail))
+        val viewModel = buildViewModel("s1")
+        val job = launch { viewModel.uiState.collect {} }
+        testScheduler.advanceUntilIdle()
+
+        viewModel.addManualDelivery(pay = 9.5, tip = 2.0, storeName = "Chipotle", note = "missed")
+        testScheduler.advanceUntilIdle()
+
+        // completedAt defaults to the loaded session's endedAt; miles is v1-null.
+        verify(correctionRepository).addManualDelivery(
+            eq("s1"), eq("Chipotle"), eq(9.5), eq(2.0), eq(1_700_003_600_000L), isNull(), eq("missed"),
+        )
+        job.cancel()
+    }
+
+    @Test
+    fun `adjustPay intent appends via the repository with the target seq and the VM sessionId`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val detail = SessionDetail(session("s1"), listOf(delivery("s1")))
+        whenever(analyticsRepository.sessionDetail(eq("s1"))).thenReturn(flowOf(detail))
+        val viewModel = buildViewModel("s1")
+        val job = launch { viewModel.uiState.collect {} }
+        testScheduler.advanceUntilIdle()
+
+        viewModel.adjustPay(targetEventSequenceId = 42L, newPay = 15.0, note = "tip")
+        testScheduler.advanceUntilIdle()
+
+        verify(correctionRepository).adjustDeliveryPay(eq(42L), eq("s1"), eq(15.0), eq("tip"))
         job.cancel()
     }
 }

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjector.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjector.kt
@@ -195,13 +195,26 @@ class AnalyticsProjector @Inject constructor(
                     // P7: counts only, no payload text.
                     Timber.tag(TAG).w("PAY_ADJUSTMENT: target row %d not found", adj.targetEventSequenceId)
                 } else {
-                    val net = if (row.frozenCostPerMile != null && row.realizedMiles != null) {
-                        NetProfit.net(adj.newPay, row.realizedMiles!!, row.frozenCostPerMile!!)
-                    } else {
-                        null
+                    // A MANUAL row stays MANUAL (#650 review F1): a driver correcting their own
+                    // statement leaves it a driver statement (the audit trail lives in the log), and
+                    // its net keeps the MANUAL missing-terms-as-0 policy (net-additive) — the generic
+                    // machine recompute would null the net and drop the dollars from period SUM.
+                    // Machine rows flip to USER_CORRECTED with the machine recompute (null when not
+                    // computable — the pre-existing #660-family seam, not widened). Deterministic on
+                    // refold: the row's basis reads the same at apply time in live and refold order.
+                    val manual = row.payBasis == PayBasis.MANUAL
+                    val net = when {
+                        manual -> NetProfit.net(adj.newPay, row.realizedMiles ?: 0.0, row.frozenCostPerMile ?: 0.0)
+                        row.frozenCostPerMile != null && row.realizedMiles != null ->
+                            NetProfit.net(adj.newPay, row.realizedMiles!!, row.frozenCostPerMile!!)
+                        else -> null
                     }
                     analyticsDao.upsertDelivery(
-                        row.copy(realizedPay = adj.newPay, payBasis = PayBasis.USER_CORRECTED, netProfit = net),
+                        row.copy(
+                            realizedPay = adj.newPay,
+                            payBasis = if (manual) PayBasis.MANUAL else PayBasis.USER_CORRECTED,
+                            netProfit = net,
+                        ),
                     )
                 }
             }

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjector.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjector.kt
@@ -12,8 +12,11 @@ import cloud.trotter.dashbuddy.core.database.analytics.SessionRecordEntity
 import cloud.trotter.dashbuddy.core.database.event.AppEventDao
 import cloud.trotter.dashbuddy.domain.analytics.DeliveryFold
 import cloud.trotter.dashbuddy.domain.analytics.OfferFold
+import cloud.trotter.dashbuddy.domain.analytics.PayAdjustmentFold
+import cloud.trotter.dashbuddy.domain.analytics.PayBasis
 import cloud.trotter.dashbuddy.domain.analytics.RecordFolds
 import cloud.trotter.dashbuddy.domain.analytics.SessionFoldContext
+import cloud.trotter.dashbuddy.domain.evaluation.NetProfit
 import cloud.trotter.dashbuddy.domain.state.Platform
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -149,6 +152,7 @@ class AnalyticsProjector @Inject constructor(
         val touched = LinkedHashSet<String>()
         val deliveries = ArrayList<DeliveryFold>()
         val offers = ArrayList<OfferFold>()
+        val payAdjustments = ArrayList<PayAdjustmentFold>()
         var skips = 0
 
         for (ev in events) {
@@ -159,6 +163,7 @@ class AnalyticsProjector @Inject constructor(
             if (outcome.skip != null) skips++
             outcome.delivery?.let { deliveries += it }
             outcome.offer?.let { offers += it }
+            outcome.payAdjustment?.let { payAdjustments += it }
             outcome.context?.let { ctx ->
                 contexts[ctx.sessionId] = ctx
                 touched += ctx.sessionId
@@ -172,18 +177,43 @@ class AnalyticsProjector @Inject constructor(
         }
 
         val lastSeq = events.last().sequenceId
+        var adjustmentSkips = 0
         db.withTransaction {
             deliveries.forEach { analyticsDao.upsertDelivery(it.toEntity()) }
             offers.forEach { analyticsDao.upsertOffer(it.toEntity()) }
             touched.forEach { sid -> contexts[sid]?.let { analyticsDao.upsertSession(it.toEntity()) } }
+            // Apply driver PAY_ADJUSTMENT re-prices AFTER the batch's own delivery upserts (so a
+            // same-batch target is already written) and before the watermark. Determinism: a
+            // correction always sequences after its target's DELIVERY_COMPLETED, so a from-zero refold
+            // replays them in this same order and reproduces identical rows. The re-price recomputes
+            // net against the row's OWN frozen cpm (never today's economy — an immutable historical
+            // fact); tip/basePay are left untouched.
+            payAdjustments.forEach { adj ->
+                val row = analyticsDao.deliveryRecord(adj.targetEventSequenceId)
+                if (row == null) {
+                    adjustmentSkips++
+                    // P7: counts only, no payload text.
+                    Timber.tag(TAG).w("PAY_ADJUSTMENT: target row %d not found", adj.targetEventSequenceId)
+                } else {
+                    val net = if (row.frozenCostPerMile != null && row.realizedMiles != null) {
+                        NetProfit.net(adj.newPay, row.realizedMiles!!, row.frozenCostPerMile!!)
+                    } else {
+                        null
+                    }
+                    analyticsDao.upsertDelivery(
+                        row.copy(realizedPay = adj.newPay, payBasis = PayBasis.USER_CORRECTED, netProfit = net),
+                    )
+                }
+            }
             analyticsDao.setWatermark(
                 AnalyticsProjectionStateEntity(watermarkSequenceId = lastSeq, projectorVersion = PROJECTOR_VERSION),
             )
         }
 
         Timber.tag(TAG).d(
-            "batch: %d events (→seq %d) → %d deliveries, %d offers, %d sessions, %d skipped",
-            events.size, lastSeq, deliveries.size, offers.size, touched.size, skips,
+            "batch: %d events (→seq %d) → %d deliveries, %d offers, %d sessions, %d re-priced, %d skipped",
+            events.size, lastSeq, deliveries.size, offers.size, touched.size,
+            payAdjustments.size - adjustmentSkips, skips,
         )
         if (skips > 0) {
             Timber.tag(TAG).w("batch skipped %d event(s) with a missing/malformed payload", skips)
@@ -399,6 +429,8 @@ class AnalyticsProjector @Inject constructor(
          * v3 (#653): the fold now drops a full-receipt stamp on an already-delivered multi-delivery
          * job as SUSPECT (`PayBasis.SUSPECT_FULL_RECEIPT`, no realizedPay/tip/base) instead of
          * double-counting the period SUM — the refold applies the guard to history.
+         * (#650 does NOT bump this: `MANUAL_DELIVERY`/`PAY_ADJUSTMENT` are new event types that cannot
+         * exist in already-folded history, so there is nothing to refold — a fresh drain folds them.)
          */
         private const val PROJECTOR_VERSION = 3
     }

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/CorrectionRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/CorrectionRepository.kt
@@ -1,0 +1,96 @@
+package cloud.trotter.dashbuddy.core.data.analytics
+
+import cloud.trotter.dashbuddy.core.data.event.AppEventRepo
+import cloud.trotter.dashbuddy.domain.model.event.AppEvent
+import cloud.trotter.dashbuddy.domain.model.event.AppEventType
+import cloud.trotter.dashbuddy.domain.model.event.payload.ManualDeliveryPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.PayAdjustmentPayload
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Write-side entry point for driver corrections (#650) — appends `MANUAL_DELIVERY` / `PAY_ADJUSTMENT`
+ * events to the durable `app_events` log. Deliberately SEPARATE from the read-side [AnalyticsRepository]
+ * (Principle 3 — single responsibility: one repository reads the projected records, another writes the
+ * correction events; they never share a code path). Corrections are **events, never destructive edits**:
+ * the original capture and its provenance stay in the log; the projector folds the correction on its
+ * next `maxSequenceId()` drain and Room invalidation refreshes any reactive UI — there is no manual
+ * projector nudge, and no optimistic local mutation.
+ *
+ * Privacy (P7): the INFO milestones log counts / sequence ids / a `sha256`-free session id only — never
+ * the driver-authored note or store text (those are driver-owned local data).
+ */
+@Singleton
+class CorrectionRepository @Inject constructor(
+    private val appEventRepo: AppEventRepo,
+) {
+
+    /**
+     * Append a driver-entered missed delivery (#650). [pay] is required; [tip]/[storeName]/[miles]/[note]
+     * are optional driver knowledge. [completedAt] is when the delivery happened (the caller picks an
+     * honest default, e.g. the session's end/start). The projector folds it into a `delivery_record`
+     * (payBasis `MANUAL`) on its next drain.
+     */
+    suspend fun addManualDelivery(
+        sessionId: String,
+        storeName: String?,
+        pay: Double,
+        tip: Double?,
+        completedAt: Long,
+        miles: Double?,
+        note: String?,
+    ) {
+        appEventRepo.appendUserEvent(
+            AppEvent(
+                type = AppEventType.MANUAL_DELIVERY,
+                occurredAt = System.currentTimeMillis(),
+                sessionId = sessionId,
+                payload = ManualDeliveryPayload(
+                    sessionId = sessionId,
+                    storeName = storeName,
+                    pay = pay,
+                    tip = tip,
+                    completedAt = completedAt,
+                    miles = miles,
+                    note = note,
+                ),
+            ),
+        )
+        // P7: no note/store text — counts/ids only.
+        Timber.tag(TAG).i("MANUAL_DELIVERY appended for session %s", sessionId)
+    }
+
+    /**
+     * Append a driver re-price of an already-recorded delivery (#650). [targetEventSequenceId] is the
+     * PK of the `delivery_record` to re-price; [sessionId] is for attribution/liveness only. The
+     * projector rewrites the target row's realizedPay to [newPay] (payBasis → `USER_CORRECTED`, net
+     * recomputed against the row's own frozen cost basis) on its next drain — the original event stays.
+     */
+    suspend fun adjustDeliveryPay(
+        targetEventSequenceId: Long,
+        sessionId: String?,
+        newPay: Double,
+        note: String?,
+    ) {
+        appEventRepo.appendUserEvent(
+            AppEvent(
+                type = AppEventType.PAY_ADJUSTMENT,
+                occurredAt = System.currentTimeMillis(),
+                sessionId = sessionId,
+                payload = PayAdjustmentPayload(
+                    targetEventSequenceId = targetEventSequenceId,
+                    sessionId = sessionId,
+                    newPay = newPay,
+                    note = note,
+                ),
+            ),
+        )
+        // P7: no note text — counts/ids only.
+        Timber.tag(TAG).i("PAY_ADJUSTMENT appended for delivery seq %d", targetEventSequenceId)
+    }
+
+    private companion object {
+        private const val TAG = "Corrections"
+    }
+}

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/event/AppEventRepo.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/event/AppEventRepo.kt
@@ -54,6 +54,18 @@ class AppEventRepo @Inject constructor(
         }
     }
 
+    /**
+     * Append a user-initiated event (a #650 correction — `MANUAL_DELIVERY` / `PAY_ADJUSTMENT`) with a
+     * plain insert and NO `effects_fired` idempotency mark. The mark exists only for state-machine
+     * effect idempotency (crash-recovery double-run protection of effect-driven `LogEvent`s keyed by an
+     * effect key); a user-initiated correction has no effect key and is never replayed by the effect
+     * engine, so a bare insert is the correct — and complete — write. The analytics projector's
+     * `maxSequenceId()` drain picks it up automatically.
+     */
+    suspend fun appendUserEvent(event: AppEvent, metadataJson: String? = null) {
+        dao.insert(event.toEntity(metadataJson))
+    }
+
     fun getAllEvents(): Flow<List<AppEvent>> =
         dao.getAllEvents().map { rows -> rows.map { it.toDomain() } }
 

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
@@ -328,6 +328,15 @@ interface AnalyticsDao {
     @Query("SELECT * FROM delivery_records WHERE sessionId = :id ORDER BY eventSequenceId DESC LIMIT 1")
     suspend fun lastDeliveryInSession(id: String): DeliveryRecordEntity?
 
+    /**
+     * One delivery row by its source-event PK — the target of a driver PAY_ADJUSTMENT re-price (#650).
+     * The projector reads it inside the batch transaction (after the batch's own delivery upserts) to
+     * rewrite realizedPay + recompute net against the row's own frozen cost basis; null ⇒ the target
+     * does not exist (a skip, never a crash).
+     */
+    @Query("SELECT * FROM delivery_records WHERE eventSequenceId = :eventSequenceId")
+    suspend fun deliveryRecord(eventSequenceId: Long): DeliveryRecordEntity?
+
     /** Still-live sessions for a platform — the next DASH_START infers their close. */
     @Query("SELECT * FROM session_records WHERE platform = :platform AND endedAt IS NULL")
     suspend fun openSessions(platform: String): List<SessionRecordEntity>

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -81,6 +81,19 @@ was found **broken-in-part** (raw PII in capture envelopes) and moved to that en
   total exceeded the captured delivery pay, an "unaccounted on this dash" callout appears. (PR #650-A)
   - Confirmed: 0/2
 
+- **🆕 NEW — user corrections as events (#650 PR B): add a missed delivery, adjust a pay.** On a dash
+  that has an **"unaccounted on this dash"** callout (Analytics → Money → tap the dash), tap **Add
+  missed delivery**, enter a pay (optionally store/tip/note), confirm. How to tell it's working: within
+  a moment the callout **shrinks or disappears** and a new delivery row appears (store you typed, the
+  pay, marked as a manual/driver entry). Then tap the **edit (pencil) icon** on any delivery row,
+  change the pay, save: the row **re-prices** and the header gross / period totals follow. On a dash
+  with **no** callout, the **Add missed delivery** button still appears at the bottom of the deliveries
+  card. Cross-check nothing was destroyed: the original captured rows are still present (a correction is
+  an added event, not an overwrite). How to tell it's broken: the callout doesn't move after adding, the
+  new row never appears, the re-price doesn't stick (or reverts on the next screen refresh), or a
+  previously captured delivery vanishes. (PR #650-B)
+  - Confirmed: 0/2
+
 - **🆕 NEW — identity-less completions now firewalled at PostTask exit (#653 / PR #673): watch a
   no-name drop for a MISSING completion.** The PostTask-exit `DELIVERY_COMPLETED` mint now mirrors
   the close-out path's #498 identity firewall: a dropoff task that never acquired a customer

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/RecordFolds.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/RecordFolds.kt
@@ -457,8 +457,9 @@ object RecordFolds {
      * A driver-entered missed delivery (#650) → one `DeliveryFold` (payBasis [PayBasis.MANUAL]),
      * folded into the session accumulator exactly as a captured completion, but from the driver's own
      * statement. The frozen economy is inherited exactly like [foldDeliveryCompleted] (the session's
-     * offer basis, else the current fallback, else NONE), so a manual delivery's net is costed the same
-     * way as its captured siblings and is likewise immutable.
+     * offer basis, else the current fallback, else NONE) and is likewise immutable — but the NET uses
+     * the MANUAL missing-terms-as-0 policy (net-additive; see the inline comment): an uncosted driver
+     * statement must not lose its dollars from period net just for being recorded.
      */
     private fun foldManualDelivery(
         event: SequencedAppEvent,
@@ -483,12 +484,14 @@ object RecordFolds {
         }
         val frozenFuelPerMile = if (costBasis == CostBasis.OFFER_FROZEN) ctx.lastEvaluatedFuelPerMile else null
         val frozenNonFuelPerMile = if (costBasis == CostBasis.OFFER_FROZEN) ctx.lastEvaluatedNonFuelPerMile else null
-        // Net only when pay + the driver's stated miles + a cpm are all present (else undefined).
-        val netProfit = if (frozenCpm != null && p.miles != null) {
-            NetProfit.net(p.pay, p.miles, frozenCpm)
-        } else {
-            null
-        }
+        // MANUAL-basis net policy (#650 review F1): missing cost terms count as 0, so an uncosted
+        // driver statement stays NET-ADDITIVE — exactly as its dollars were while still inside
+        // `unattributedPay` (the documented net-additive estimate, PeriodEconomics). Without this,
+        // recording the missed delivery the callout asks for would DROP period net by the row's pay:
+        // the money leaves the net-additive unattributed bucket and lands in a null-net row that
+        // SUM(netProfit) discards. Machine rows keep machine semantics (the null-net machine seam is
+        // #660-family and deliberately not widened here).
+        val netProfit = NetProfit.net(p.pay, p.miles ?: 0.0, frozenCpm ?: 0.0)
 
         val delivery = DeliveryFold(
             eventSequenceId = event.sequenceId,
@@ -522,28 +525,33 @@ object RecordFolds {
         // do not pass the event's odometer into them: a manual delivery carries no odometer reading and
         // must not perturb the surrounding machine rows' partition (miles/time) deltas on a refold —
         // that would make the rebuild non-faithful. This non-perturbation is load-bearing.
+        // Liveness advances with the DELIVERY's stated time, never the correction's wall-clock
+        // `occurredAt` (#650 review F2): a correction recorded days later must not stretch a
+        // crash-orphaned (endedAt-null) session's online span to "now".
         val newCtx = ctx.copy(
             deliveries = ctx.deliveries + 1,
             deliveredJobIds = ctx.deliveredJobIds + jobId,
-            lastEventAt = maxOf(ctx.lastEventAt, e.occurredAt),
+            lastEventAt = maxOf(ctx.lastEventAt, p.completedAt),
         )
         return FoldOutcome(context = newCtx, delivery = delivery)
     }
 
     /**
      * A driver PAY_ADJUSTMENT (#650) — the pure fold emits the [PayAdjustmentFold] decision (which row,
-     * what new pay) and advances the resolved session's liveness when the correction names a session;
-     * it CANNOT read the target `delivery_record` here (that is not the session accumulator), so the
-     * orchestrator applies the re-price inside the batch transaction.
+     * what new pay); it CANNOT read the target `delivery_record` here (that is not the session
+     * accumulator), so the orchestrator applies the re-price inside the batch transaction. The session
+     * context passes through UNTOUCHED (#650 review F2): a re-price is bookkeeping about a past row,
+     * not session activity — advancing liveness with the CORRECTION's wall-clock `occurredAt` would
+     * stretch a crash-orphaned (endedAt-null) session's online span to "now", and synthesizing a
+     * context here could mint a session row stamped with correction time (the target's session row
+     * already exists via the #661 invariant, or its delivery row could not).
      */
     private fun foldPayAdjustment(event: SequencedAppEvent, context: SessionFoldContext?): FoldOutcome {
         val e = event.event
         val p = e.payload as? PayAdjustmentPayload
             ?: return FoldOutcome(context = context, skip = "PAY_ADJUSTMENT: missing/malformed payload")
-        val sid = e.sessionId ?: p.sessionId
-        val ctx = sid?.let { resolveContext(context, it, e.occurredAt).advance(e.occurredAt, event.metadata?.odometer) }
         return FoldOutcome(
-            context = ctx ?: context,
+            context = context,
             payAdjustment = PayAdjustmentFold(p.targetEventSequenceId, p.newPay),
         )
     }

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/RecordFolds.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/RecordFolds.kt
@@ -4,7 +4,9 @@ import cloud.trotter.dashbuddy.domain.evaluation.NetProfit
 import cloud.trotter.dashbuddy.domain.model.event.AppEventType
 import cloud.trotter.dashbuddy.domain.model.event.SequencedAppEvent
 import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.ManualDeliveryPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.OfferPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.PayAdjustmentPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStartPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStopPayload
 import cloud.trotter.dashbuddy.domain.state.Platform
@@ -32,6 +34,18 @@ object PayBasis {
     const val SUSPECT_FULL_RECEIPT = "SUSPECT_FULL_RECEIPT"
     /** No pay signal on the completion (receipt-skipped #596). */
     const val NONE = "NONE"
+
+    /**
+     * A driver-entered missed delivery (#650); pay/tip/miles are the driver's own statement, not a
+     * capture. Keeps a manual correction distinguishable from a machine-captured row forever.
+     */
+    const val MANUAL = "MANUAL"
+
+    /**
+     * A machine-captured row whose pay was re-priced by a driver PAY_ADJUSTMENT (#650); the original
+     * event remains in the log — the re-price is a later event, never a destructive edit.
+     */
+    const val USER_CORRECTED = "USER_CORRECTED"
 }
 
 /**
@@ -134,6 +148,24 @@ data class FoldOutcome(
     val offer: OfferFold? = null,
     val freshSession: Boolean = false,
     val skip: String? = null,
+    /**
+     * A driver PAY_ADJUSTMENT decision (#650): the pure fold decides WHICH row to re-price and to
+     * what, but cannot read the target `delivery_record` (it is not the session accumulator) — the
+     * orchestrator applies it inside the batch transaction after the delivery/offer upserts.
+     */
+    val payAdjustment: PayAdjustmentFold? = null,
+)
+
+/**
+ * A driver's re-price decision (#650) — the pure fold's output for a PAY_ADJUSTMENT. The orchestrator
+ * looks up [targetEventSequenceId] in `delivery_records` and rewrites its realizedPay to [newPay]
+ * (payBasis → `USER_CORRECTED`, net recomputed against the row's OWN frozen cost basis). Because a
+ * PAY_ADJUSTMENT always sequences after its target's DELIVERY_COMPLETED, a from-zero refold replays
+ * them in order and reproduces identical rows.
+ */
+data class PayAdjustmentFold(
+    val targetEventSequenceId: Long,
+    val newPay: Double,
 )
 
 /**
@@ -169,6 +201,8 @@ object RecordFolds {
             AppEventType.OFFER_DECLINED,
             AppEventType.OFFER_TIMEOUT -> foldOffer(event, context)
             AppEventType.DELIVERY_COMPLETED -> foldDeliveryCompleted(event, context, currentCostPerMile)
+            AppEventType.MANUAL_DELIVERY -> foldManualDelivery(event, context, currentCostPerMile)
+            AppEventType.PAY_ADJUSTMENT -> foldPayAdjustment(event, context)
             AppEventType.DASH_STOP -> foldDashStop(event, context)
             // Every other session-attributed event just advances the liveness/odometer anchors so
             // the open-session duration and lastOdometer stay honest; the watermark still moves past
@@ -417,6 +451,101 @@ object RecordFolds {
             lastOdometer = odo ?: ctx.lastOdometer,
         )
         return FoldOutcome(context = newCtx, delivery = delivery)
+    }
+
+    /**
+     * A driver-entered missed delivery (#650) → one `DeliveryFold` (payBasis [PayBasis.MANUAL]),
+     * folded into the session accumulator exactly as a captured completion, but from the driver's own
+     * statement. The frozen economy is inherited exactly like [foldDeliveryCompleted] (the session's
+     * offer basis, else the current fallback, else NONE), so a manual delivery's net is costed the same
+     * way as its captured siblings and is likewise immutable.
+     */
+    private fun foldManualDelivery(
+        event: SequencedAppEvent,
+        context: SessionFoldContext?,
+        currentCostPerMile: Double?,
+    ): FoldOutcome {
+        val e = event.event
+        val p = e.payload as? ManualDeliveryPayload
+            ?: return FoldOutcome(context = context, skip = "MANUAL_DELIVERY: missing/malformed payload")
+        val sid = e.sessionId ?: p.sessionId
+        // resolveContext synthesizes an `_unknown` context if the session isn't known — and the
+        // projector upserts every touched context in the same batch transaction, so a manual delivery
+        // can never create a dangling-sessionId delivery row (the #661 invariant).
+        val ctx = resolveContext(context, sid, e.occurredAt)
+        val jobId = "manual:" + event.sequenceId
+
+        // Frozen economy — the same waterfall as a captured completion (immutable historical fact).
+        val (frozenCpm, costBasis) = when {
+            ctx.lastEvaluatedCostPerMile != null -> ctx.lastEvaluatedCostPerMile to CostBasis.OFFER_FROZEN
+            currentCostPerMile != null -> currentCostPerMile to CostBasis.CURRENT_FALLBACK
+            else -> null to CostBasis.NONE
+        }
+        val frozenFuelPerMile = if (costBasis == CostBasis.OFFER_FROZEN) ctx.lastEvaluatedFuelPerMile else null
+        val frozenNonFuelPerMile = if (costBasis == CostBasis.OFFER_FROZEN) ctx.lastEvaluatedNonFuelPerMile else null
+        // Net only when pay + the driver's stated miles + a cpm are all present (else undefined).
+        val netProfit = if (frozenCpm != null && p.miles != null) {
+            NetProfit.net(p.pay, p.miles, frozenCpm)
+        } else {
+            null
+        }
+
+        val delivery = DeliveryFold(
+            eventSequenceId = event.sequenceId,
+            sessionId = sid,
+            platform = ctx.platform.wire,
+            jobId = jobId,
+            taskId = jobId,
+            storeName = p.storeName,
+            customerHash = null,
+            addressHash = null,
+            phaseStartedAt = p.completedAt,
+            arrivedAt = null,
+            completedAt = p.completedAt,
+            deadlineMillis = null,
+            realizedPay = p.pay,
+            payBasis = PayBasis.MANUAL,
+            tip = p.tip,
+            basePay = null,
+            odometerAtCompletion = null,
+            // The driver's own stated miles — NOT a partition delta off the odometer.
+            realizedMiles = p.miles,
+            realizedMinutes = null,
+            frozenCostPerMile = frozenCpm,
+            frozenFuelPerMile = frozenFuelPerMile,
+            frozenNonFuelPerMile = frozenNonFuelPerMile,
+            netProfit = netProfit,
+            costBasis = costBasis,
+        )
+
+        // Advance the delivery counters + liveness, but DO NOT touch prevDropOdometer/prevDropAt and
+        // do not pass the event's odometer into them: a manual delivery carries no odometer reading and
+        // must not perturb the surrounding machine rows' partition (miles/time) deltas on a refold —
+        // that would make the rebuild non-faithful. This non-perturbation is load-bearing.
+        val newCtx = ctx.copy(
+            deliveries = ctx.deliveries + 1,
+            deliveredJobIds = ctx.deliveredJobIds + jobId,
+            lastEventAt = maxOf(ctx.lastEventAt, e.occurredAt),
+        )
+        return FoldOutcome(context = newCtx, delivery = delivery)
+    }
+
+    /**
+     * A driver PAY_ADJUSTMENT (#650) — the pure fold emits the [PayAdjustmentFold] decision (which row,
+     * what new pay) and advances the resolved session's liveness when the correction names a session;
+     * it CANNOT read the target `delivery_record` here (that is not the session accumulator), so the
+     * orchestrator applies the re-price inside the batch transaction.
+     */
+    private fun foldPayAdjustment(event: SequencedAppEvent, context: SessionFoldContext?): FoldOutcome {
+        val e = event.event
+        val p = e.payload as? PayAdjustmentPayload
+            ?: return FoldOutcome(context = context, skip = "PAY_ADJUSTMENT: missing/malformed payload")
+        val sid = e.sessionId ?: p.sessionId
+        val ctx = sid?.let { resolveContext(context, it, e.occurredAt).advance(e.occurredAt, event.metadata?.odometer) }
+        return FoldOutcome(
+            context = ctx ?: context,
+            payAdjustment = PayAdjustmentFold(p.targetEventSequenceId, p.newPay),
+        )
     }
 
     private fun foldDashStop(event: SequencedAppEvent, context: SessionFoldContext?): FoldOutcome {

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/AppEventCodec.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/AppEventCodec.kt
@@ -2,7 +2,9 @@ package cloud.trotter.dashbuddy.domain.model.event
 
 import cloud.trotter.dashbuddy.domain.model.event.payload.AppEventPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.ManualDeliveryPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.OfferPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.PayAdjustmentPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.OfferReceivedPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.PickupPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionPausedPayload
@@ -34,6 +36,8 @@ object AppEventCodec {
         is SessionStartPayload -> json.encodeToString(payload)
         is SessionPausedPayload -> json.encodeToString(payload)
         is SessionStopPayload -> json.encodeToString(payload)
+        is ManualDeliveryPayload -> json.encodeToString(payload)
+        is PayAdjustmentPayload -> json.encodeToString(payload)
     }
 
     /**
@@ -72,6 +76,12 @@ object AppEventCodec {
 
             AppEventType.DASH_STOP ->
                 json.decodeFromString<SessionStopPayload>(payloadJson)
+
+            AppEventType.MANUAL_DELIVERY ->
+                json.decodeFromString<ManualDeliveryPayload>(payloadJson)
+
+            AppEventType.PAY_ADJUSTMENT ->
+                json.decodeFromString<PayAdjustmentPayload>(payloadJson)
 
             AppEventType.ZONE_SWITCH,
             AppEventType.NOTIFICATION_RECEIVED,

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/AppEventType.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/AppEventType.kt
@@ -25,6 +25,10 @@ enum class AppEventType {
     DELIVERY_CONFIRMED, // Dasher finished the drop-off (handoff or POD photo done); analogue of PICKUP_CONFIRMED
     DELIVERY_COMPLETED, // PostTask exit (receipt dismissed); carries pay breakdown
 
+    // --- User corrections (#650) ---
+    MANUAL_DELIVERY, // A driver-entered missed delivery (durable correction event, never destructive)
+    PAY_ADJUSTMENT,  // A driver re-price of an already-recorded delivery (the original event stays)
+
     // --- System / Generic ---
     SCREEN_VIEWED, // For generic screen transitions like "Earnings Screen"
     ERROR_OCCURRED

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/payload/AppEventPayloads.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/payload/AppEventPayloads.kt
@@ -131,6 +131,56 @@ data class DeliveryPayload(
     val sessionEarningsAtCompletion: Double? = null,
 ) : AppEventPayload
 
+/**
+ * Payload for `MANUAL_DELIVERY` (#650) — a driver-entered missed delivery: a real drop the capture
+ * pipeline never saw (an unrecognized screen, a crash, an offer taken outside the app). It is an
+ * **event, never a destructive edit**: the projector folds it into a `delivery_record` (payBasis
+ * `MANUAL`) exactly as it folds a captured completion, so the correction is durable, rebuild-faithful
+ * (a from-zero refold reproduces it), and auditable — the `MANUAL` provenance keeps a driver's own
+ * statement distinguishable from a machine capture forever.
+ *
+ * [pay] is the only required money field ([tip]/[miles] are optional driver knowledge); [miles] is
+ * the driver's own statement of the drop's distance, NOT a partition delta off the odometer — a
+ * manual delivery must not perturb the surrounding machine rows' mileage anchors on a refold.
+ * [note] is driver-authored free text (driver-owned local data; never emitted in INFO+ logs, P7).
+ */
+@Serializable
+data class ManualDeliveryPayload(
+    /** The dash session this correction belongs to. */
+    val sessionId: String,
+    /** Driver-entered merchant name, optional. */
+    val storeName: String? = null,
+    /** Required — the driver's stated pay for this delivery. */
+    val pay: Double,
+    val tip: Double? = null,
+    /** When the delivery happened; v1 the caller defaults it (e.g. the session's end/start). */
+    val completedAt: Long,
+    /** Driver-known miles, optional — the driver's statement, not an odometer partition delta. */
+    val miles: Double? = null,
+    /** Driver-authored free text — driver-owned local data, never in INFO+ logs (P7). */
+    val note: String? = null,
+) : AppEventPayload
+
+/**
+ * Payload for `PAY_ADJUSTMENT` (#650) — a driver re-price of an already-recorded delivery (a
+ * mis-captured tip, a late-arriving adjustment). It is an **event, never a destructive edit**: the
+ * original `DELIVERY_COMPLETED` event and its provenance stay in the log untouched; the projector
+ * re-prices the target `delivery_record` in place (payBasis flips to `USER_CORRECTED`, net recomputed
+ * against the row's OWN frozen cost basis — never re-costed by today's economy). Because a correction
+ * always sequences AFTER its target's completion, a from-zero refold replays them in order and
+ * reproduces identical rows; the `USER_CORRECTED` provenance keeps machine-vs-user distinguishable.
+ */
+@Serializable
+data class PayAdjustmentPayload(
+    /** PK (source `sequenceId`) of the `delivery_record` being re-priced. */
+    val targetEventSequenceId: Long,
+    /** For session attribution / liveness only — the fold never reads the target row through it. */
+    val sessionId: String? = null,
+    val newPay: Double,
+    /** Driver-authored free text — driver-owned local data, never in INFO+ logs (P7). */
+    val note: String? = null,
+) : AppEventPayload
+
 /** Wire values for [SessionStartPayload.source] (#366) — mirrors [SessionEndSource]. */
 object SessionStartSource {
     /** Normal user-initiated start. */

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/RecordFoldsTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/RecordFoldsTest.kt
@@ -9,7 +9,9 @@ import cloud.trotter.dashbuddy.domain.model.event.EventMetadata
 import cloud.trotter.dashbuddy.domain.model.event.SequencedAppEvent
 import cloud.trotter.dashbuddy.domain.model.event.payload.AppEventPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.ManualDeliveryPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.OfferPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.PayAdjustmentPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionEndSource
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStartPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStartSource
@@ -591,5 +593,174 @@ class RecordFoldsTest {
         )
         assertEquals("real platform from DASH_START is preserved", Platform.DoorDash, outcomes.last().context!!.platform)
         assertEquals(Platform.DoorDash, ctx!!.platform)
+    }
+
+    // ── User corrections (#650) ─────────────────────────────────────────
+
+    private fun manualDelivery(
+        sid: String?,
+        at: Long,
+        pay: Double,
+        tip: Double? = null,
+        miles: Double? = null,
+        store: String? = "ManualStore",
+        completedAt: Long = at,
+    ) = ev(
+        AppEventType.MANUAL_DELIVERY, sid, at,
+        ManualDeliveryPayload(
+            sessionId = sid ?: "S",
+            storeName = store,
+            pay = pay,
+            tip = tip,
+            completedAt = completedAt,
+            miles = miles,
+            note = "driver note",
+        ),
+    )
+
+    private fun payAdjustment(sid: String?, at: Long, target: Long, newPay: Double) = ev(
+        AppEventType.PAY_ADJUSTMENT, sid, at,
+        PayAdjustmentPayload(targetEventSequenceId = target, sessionId = sid, newPay = newPay, note = "fix"),
+    )
+
+    @Test
+    fun `a manual delivery folds to a MANUAL-basis row carrying the driver's stated pay-tip-miles`() {
+        val s = "M1"
+        val (outcomes, ctx) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 100.0),
+                manualDelivery(s, 2_000, pay = 12.0, tip = 3.0, miles = 4.0),
+            ),
+            currentCpm = null,
+        )
+        val d = outcomes[1].delivery!!
+        assertEquals(PayBasis.MANUAL, d.payBasis)
+        assertEquals(12.0, d.realizedPay!!, 1e-9)
+        assertEquals(3.0, d.tip!!, 1e-9)
+        assertEquals("driver's stated miles, not a partition delta", 4.0, d.realizedMiles!!, 1e-9)
+        assertNull("a manual delivery has no measured elapsed time", d.realizedMinutes)
+        assertNull(d.basePay)
+        assertNull("no customer identity on a driver-entered row", d.customerHash)
+        assertNull(d.addressHash)
+        assertNull("no odometer on a manual row", d.odometerAtCompletion)
+        assertEquals("ManualStore", d.storeName)
+        assertEquals("manual:${d.eventSequenceId}", d.jobId)
+        assertEquals(d.jobId, d.taskId)
+        assertEquals(2_000L, d.completedAt)
+        assertEquals("no offer + no current economy ⇒ NONE cpm, null net", CostBasis.NONE, d.costBasis)
+        assertNull(d.netProfit)
+
+        assertEquals("the manual delivery counts", 1, ctx!!.deliveries)
+        assertEquals(1, ctx.jobsCompleted)
+    }
+
+    @Test
+    fun `a manual delivery inherits the frozen economy exactly like a captured completion (all three bases)`() {
+        val s = "M2"
+        // OFFER_FROZEN — a preceding accepted offer supplies the session cpm.
+        val (withOffer, _) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 0.0),
+                offerAccepted(s, 1_500, "h", eval(net = 8.0, dist = 4.0, opCpm = 0.40)),
+                manualDelivery(s, 2_000, pay = 10.0, miles = 4.0),
+            ),
+            currentCpm = 0.99,
+        )
+        val d1 = withOffer[2].delivery!!
+        assertEquals(CostBasis.OFFER_FROZEN, d1.costBasis)
+        assertEquals(0.40, d1.frozenCostPerMile!!, 1e-9)
+        assertEquals(10.0 - 4.0 * 0.40, d1.netProfit!!, 1e-9)
+
+        // CURRENT_FALLBACK — no offer, but a live economy cpm.
+        val (fallback, _) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 0.0),
+                manualDelivery(s, 2_000, pay = 10.0, miles = 4.0),
+            ),
+            currentCpm = 0.50,
+        )
+        val d2 = fallback[1].delivery!!
+        assertEquals(CostBasis.CURRENT_FALLBACK, d2.costBasis)
+        assertEquals(10.0 - 4.0 * 0.50, d2.netProfit!!, 1e-9)
+
+        // NONE — no offer, no economy → null cpm, null net (even though miles are known).
+        val (none, _) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 0.0),
+                manualDelivery(s, 2_000, pay = 10.0, miles = 4.0),
+            ),
+            currentCpm = null,
+        )
+        val d3 = none[1].delivery!!
+        assertEquals(CostBasis.NONE, d3.costBasis)
+        assertNull(d3.frozenCostPerMile)
+        assertNull(d3.netProfit)
+    }
+
+    @Test
+    fun `a manual delivery does not perturb a later machine delivery's partition anchors (rebuild-stable)`() {
+        val s = "M3"
+        // Control: DASH_START then a machine completion — no manual event between them.
+        val (control, _) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 100.0),
+                delivery(s, 3_000, "J1", "T1", totalPay = 8.0, odo = 105.0),
+            ),
+        )
+        val controlMachine = control[1].delivery!!
+
+        // With a manual delivery folded BEFORE the machine completion: it must not move
+        // prevDropOdometer/prevDropAt, so the machine row's realized miles/minutes are unchanged.
+        val (withManual, _) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 100.0),
+                manualDelivery(s, 2_000, pay = 5.0, miles = 2.0),
+                delivery(s, 3_000, "J1", "T1", totalPay = 8.0, odo = 105.0),
+            ),
+        )
+        val perturbedMachine = withManual[2].delivery!!
+
+        assertEquals(
+            "machine realizedMiles unchanged by the interposed manual delivery",
+            controlMachine.realizedMiles!!, perturbedMachine.realizedMiles!!, 1e-9,
+        )
+        assertEquals(
+            "machine realizedMinutes unchanged by the interposed manual delivery",
+            controlMachine.realizedMinutes!!, perturbedMachine.realizedMinutes!!, 1e-9,
+        )
+    }
+
+    @Test
+    fun `PAY_ADJUSTMENT emits the re-price decision, no record, and advances liveness`() {
+        val s = "M4"
+        val ctx = RecordFolds.foldEvent(dashStart(s, 1_000, odo = 0.0), null, null).context
+        val out = RecordFolds.foldEvent(payAdjustment(s, 5_000, target = 42L, newPay = 15.5), ctx, null)
+
+        assertNull("a re-price produces no delivery record in the pure fold", out.delivery)
+        assertNull(out.offer)
+        val adj = out.payAdjustment!!
+        assertEquals(42L, adj.targetEventSequenceId)
+        assertEquals(15.5, adj.newPay, 1e-9)
+        assertEquals("liveness advanced to the correction's timestamp", 5_000L, out.context!!.lastEventAt)
+    }
+
+    @Test
+    fun `malformed MANUAL_DELIVERY and PAY_ADJUSTMENT payloads are skipped, not folded`() {
+        val s = "M5"
+        val badManual = SequencedAppEvent(
+            sequenceId = ++seq,
+            event = AppEvent(AppEventType.MANUAL_DELIVERY, occurredAt = 2_000, sessionId = s, payload = null),
+        )
+        val manualOut = RecordFolds.foldEvent(badManual, null, null)
+        assertNull(manualOut.delivery)
+        assertNotNull(manualOut.skip)
+
+        val badAdjust = SequencedAppEvent(
+            sequenceId = ++seq,
+            event = AppEvent(AppEventType.PAY_ADJUSTMENT, occurredAt = 2_000, sessionId = s, payload = null),
+        )
+        val adjustOut = RecordFolds.foldEvent(badAdjust, null, null)
+        assertNull(adjustOut.payAdjustment)
+        assertNotNull(adjustOut.skip)
     }
 }

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/RecordFoldsTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/RecordFoldsTest.kt
@@ -647,8 +647,11 @@ class RecordFoldsTest {
         assertEquals("manual:${d.eventSequenceId}", d.jobId)
         assertEquals(d.jobId, d.taskId)
         assertEquals(2_000L, d.completedAt)
-        assertEquals("no offer + no current economy ⇒ NONE cpm, null net", CostBasis.NONE, d.costBasis)
-        assertNull(d.netProfit)
+        assertEquals("no offer + no current economy ⇒ NONE cpm", CostBasis.NONE, d.costBasis)
+        assertEquals(
+            "MANUAL net policy: missing cost terms count as 0 ⇒ net = pay (net-additive, review F1)",
+            12.0, d.netProfit!!, 1e-9,
+        )
 
         assertEquals("the manual delivery counts", 1, ctx!!.deliveries)
         assertEquals(1, ctx.jobsCompleted)
@@ -683,7 +686,8 @@ class RecordFoldsTest {
         assertEquals(CostBasis.CURRENT_FALLBACK, d2.costBasis)
         assertEquals(10.0 - 4.0 * 0.50, d2.netProfit!!, 1e-9)
 
-        // NONE — no offer, no economy → null cpm, null net (even though miles are known).
+        // NONE — no offer, no economy → null cpm; MANUAL net policy keeps the dollars net-additive
+        // (miles are known but uncostable ⇒ cost term 0 ⇒ net = pay, review F1).
         val (none, _) = foldSession(
             listOf(
                 dashStart(s, 1_000, odo = 0.0),
@@ -694,7 +698,40 @@ class RecordFoldsTest {
         val d3 = none[1].delivery!!
         assertEquals(CostBasis.NONE, d3.costBasis)
         assertNull(d3.frozenCostPerMile)
-        assertNull(d3.netProfit)
+        assertEquals(10.0, d3.netProfit!!, 1e-9)
+    }
+
+    @Test
+    fun `an uncosted manual delivery stays net-additive - net equals pay minus what IS costable (review F1)`() {
+        val s = "M6"
+        // The v1 UI path: miles = null. With an offer cpm present, the miles term is 0 ⇒ net = pay —
+        // the dollars must NOT vanish from period SUM(netProfit) after leaving unattributedPay.
+        val (outcomes, _) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 0.0),
+                offerAccepted(s, 1_500, "h", eval(net = 8.0, dist = 4.0, opCpm = 0.40)),
+                manualDelivery(s, 2_000, pay = 12.0, miles = null),
+            ),
+            currentCpm = null,
+        )
+        val d = outcomes[2].delivery!!
+        assertEquals(CostBasis.OFFER_FROZEN, d.costBasis)
+        assertEquals("null miles ⇒ 0-mile cost term ⇒ net = pay", 12.0, d.netProfit!!, 1e-9)
+    }
+
+    @Test
+    fun `manual-delivery liveness advances with the DELIVERY's stated time, not the correction's wall clock (review F2)`() {
+        val s = "M7"
+        // Correction recorded much later (occurredAt = 999_999) about a drop at completedAt = 2_000:
+        // an endedAt-null session's lastEventAt must NOT stretch to the correction time.
+        val (_, ctx) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 0.0),
+                manualDelivery(s, 999_999, pay = 5.0, completedAt = 2_000),
+            ),
+            currentCpm = null,
+        )
+        assertEquals(2_000L, ctx!!.lastEventAt)
     }
 
     @Test
@@ -731,7 +768,7 @@ class RecordFoldsTest {
     }
 
     @Test
-    fun `PAY_ADJUSTMENT emits the re-price decision, no record, and advances liveness`() {
+    fun `PAY_ADJUSTMENT emits the re-price decision, no record, and passes the context through untouched (review F2)`() {
         val s = "M4"
         val ctx = RecordFolds.foldEvent(dashStart(s, 1_000, odo = 0.0), null, null).context
         val out = RecordFolds.foldEvent(payAdjustment(s, 5_000, target = 42L, newPay = 15.5), ctx, null)
@@ -741,7 +778,10 @@ class RecordFoldsTest {
         val adj = out.payAdjustment!!
         assertEquals(42L, adj.targetEventSequenceId)
         assertEquals(15.5, adj.newPay, 1e-9)
-        assertEquals("liveness advanced to the correction's timestamp", 5_000L, out.context!!.lastEventAt)
+        // Bookkeeping about a past row, not session activity: liveness must NOT advance to the
+        // correction's wall-clock time (it would stretch an endedAt-null session's online span).
+        assertEquals(ctx, out.context)
+        assertEquals(1_000L, out.context!!.lastEventAt)
     }
 
     @Test


### PR DESCRIPTION
## What

PR B of #650 — user corrections as durable, folded events. Two new event types are appended to the `app_events` log and folded by the analytics projector:

- **`MANUAL_DELIVERY`** — a driver-entered missed drop (a real delivery the capture pipeline never saw). Folds into a `delivery_record` with payBasis **`MANUAL`**, frozen economy inherited exactly like a captured completion (session offer basis → CURRENT_FALLBACK → NONE), pay/tip/miles taken as the driver's own statement.
- **`PAY_ADJUSTMENT`** — a re-price of an already-recorded delivery. The projector rewrites the target row's `realizedPay`, flips payBasis to **`USER_CORRECTED`**, and recomputes net against **that row's own frozen cpm** (never today's economy). The original event/row is never deleted.

Write path is the new `CorrectionRepository` (`:core:data`), append-only via `AppEventRepo.appendUserEvent` (a bare insert — no `effects_fired` mark, since a user correction has no effect key and is never replayed by the effect engine). The UI is the per-dash drill-down (`SessionDetailScreen`): an "Add missed delivery" button (below the unattributed callout, or at the bottom of the deliveries card when there's none) and a per-row edit (pencil) → adjust-pay dialog. No optimistic mutation — the projector folds on its `maxSequenceId()` drain and Room invalidation refreshes the screen.

## Why

#650 PR A shipped the read-only drill-down and left corrections as the follow-up. This makes the "unaccounted on this dash" flag actionable and lets the driver repair a mis-captured pay — without ever destroying the machine-captured history.

## Event-sourced properties

- **Durable** — corrections are events in the append-only log, folded like any other.
- **Rebuild-faithful** — a correction always sequences *after* its target's `DELIVERY_COMPLETED`, so a from-zero refold replays them in order and reproduces byte-identical rows. `MANUAL_DELIVERY` also does **not** touch the surrounding machine rows' partition (miles/time) anchors, so a refold with a manual drop interposed leaves the machine rows unchanged (tested).
- **Auditable** — `payBasis` (`MANUAL` / `USER_CORRECTED`) keeps a driver's own statement distinguishable from a machine capture forever.
- **Non-destructive** — a re-price is a *later event*; the original `DELIVERY_COMPLETED` and its provenance stay in the log.

## The #661 invariant

A correction can never create a dangling-sessionId delivery row: the fold resolves (and if absent, synthesizes an `_unknown`) session context, and the projector upserts every touched context **in the same batch transaction** as the delivery row. Structurally, a `MANUAL_DELIVERY` for a session with no prior rows lands its delivery *and* a session row in one drain (tested).

## Why `PROJECTOR_VERSION` is not bumped

`MANUAL_DELIVERY` / `PAY_ADJUSTMENT` are new event types that cannot exist in already-folded history — there is nothing to refold, so a fresh incremental drain folds them. A version bump would only cost a pointless full-log rebuild.

## Privacy posture (P7)

Driver-authored `note` and `storeName` are driver-owned local data — persisted at rest, **never** emitted in INFO+ logs. `CorrectionRepository` and the projector's re-price/skip paths log counts / sequence ids / session ids only. No new capture, no network, no customer-PII surface (manual rows carry null customer/address hashes).

## Test coverage

- `RecordFoldsTest` (`:domain`) — MANUAL row shape + `MANUAL` basis + cpm inheritance across all three bases; **anchor non-perturbation** (a manual drop doesn't move a later machine row's realized miles/minutes); PAY_ADJUSTMENT emits the decision + advances liveness; malformed payloads skip.
- `AnalyticsProjectorTest` (`:app`, in-memory Room) — (a) MANUAL for a session with no prior rows → delivery + synthesized session in one drain; (b) PAY_ADJUSTMENT re-prices to `USER_CORRECTED`, net from the row's own frozen cpm, and `sessionDetail.unattributedPay` shrinks; (c) missing target → skip, no crash, watermark still advances; (d) wipe + refold from 0 reproduces byte-identical corrected rows.
- `SessionDetailViewModelTest` — the two intents call `CorrectionRepository` with the right arguments (incl. `completedAt` defaulting to the session's end).

`JAVA_HOME=…/java-25-openjdk ./gradlew :app:testDebugUnitTest :domain:test` → green.

### Design-goal review

- **1 (UDF)** — intents flow down (`addManualDelivery`/`adjustPay`), state is reactive out (the read-model `Flow`); no optimistic local mutation, the projector + Room invalidation drive the refresh.
- **3 (SRP)** — write-side `CorrectionRepository` is a separate class from the read-side `AnalyticsRepository`; they never share a code path.
- **5 (SSOT)** — net reuses the `NetProfit` SSOT for the re-price; `PayBasis` vocabulary is owned in `RecordFolds`; the frozen-economy waterfall is the same one `foldDeliveryCompleted` uses.
- **6/7 (privacy)** — driver note/store are local-only, never in INFO+ logs; manual rows carry null customer hashes; no new capture/network.
- **8 (platform-agnostic)** — platform resolves through the session context's `Platform` registry (`ctx.platform.wire`), never a literal; no new platform vocabulary.

### Adversarial review

Pending — to be run pre-merge (fable-tier `/code-review` + `/security-review` per the workflow). Do not merge until clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)