### PR TITLE
docs: ROADMAP refresh — 07-05 evening wave

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,40 +1,34 @@
 # DashBuddy Roadmap (living doc)
 
-**Updated:** 2026-07-05 (full 72-issue sweep + triage; analytics hub build day). Buckets reflect
-the board reality — when an issue's state changes, move it here or this doc rots. Companion:
-`docs/design/analytics-roadmap.md` (the analytics-specific phases).
+**Updated:** 2026-07-05 evening (post analytics-hub completion — H4/H6/#650 merged). Buckets
+reflect the board reality — when an issue's state changes, move it here or this doc rots.
+Companion: `docs/design/analytics-roadmap.md` (the analytics-specific phases).
 
-## Now / in flight (2026-07-05)
+## Now / in flight (2026-07-05 evening)
 
-- **Analytics hub (#315, epic)** — Money tab v1 MERGED (#662); Decisions tab (H3) + the frozen
-  fuel/non-fuel waterfall lift (#659, incl. the `startSource` hydration fix) in build. Remaining
-  phases: H4 Time tab, H5 Patterns (needs #159 chains; zone capture doesn't exist), H6 per-day
-  earnings chart. All new aggregations MUST use the #655 session-anchored WHERE shape.
-- **#653** — identity-less-drop double-count guard (fold-side + upstream firewall parity). Next
-  after #659 merges (same fold files).
-- **#319 CSV export** — after H3 merges (shares `AnalyticsScreen`). The free-tier pillar item.
-- **#650** — per-dash drill-down + corrections-as-events (`MANUAL_DELIVERY`/`PAY_ADJUSTMENT`).
-  Consumes `recentSessions`/`deliveriesForSession` + the unattributed callout. Carries two review
-  notes: the dangling-sessionId LEFT-JOIN belt, and the correction folds must upsert session rows
-  atomically.
+- **#551** — semantic log levels + PII-safe shareable sink (Principle 7 implementation; the
+  export is a privacy surface; reuses `SensitiveTextMarkers` fail-closed). Phase 1 (leak fixes +
+  level/tag taxonomy) first, then the INFO+ export sink with the fail-closed scrub test. *opus*
+- **Analytics hub (#315, epic)** — Money (H1/H2/H6 incl. earnings-by-day chart + header CSV
+  action), Decisions (H3), and Time (H4) tabs are ALL LIVE. The only remaining phase is
+  **H5 Patterns**, blocked on #159 (chains; zone capture doesn't exist). All new aggregations
+  MUST use the #655 session-anchored WHERE shape.
 
 ## Next up (unblocked, ranked by value × boundedness)
 
-1. **#551** — semantic log levels + PII-safe shareable sink (Principle 7 implementation; the
-   export is a privacy surface; reuses `SensitiveTextMarkers` fail-closed). *opus*
-2. **#590** — generative property tests over the untrusted-input boundaries (already found live
+1. **#590** — generative property tests over the untrusted-input boundaries (already found live
    fail-open gaps + a CI blind spot historically). *opus*
-3. **#419** — rule-count caps + sensitive-rule survival across a ruleset replace (pledge;
+2. **#419** — rule-count caps + sensitive-rule survival across a ruleset replace (pledge;
    in-app, no repo dependency; #192 prereq). *opus*
-4. **#438** — multiplatform correctness pack (per-platform timer keys etc.; unblocks #588;
+3. **#438** — multiplatform correctness pack (per-platform timer keys etc.; unblocks #588;
    advances #585). *opus*
-5. **#647** — canonicalizer merge hardening (unknown section keys; flat/dir collision). *opus/sonnet*
-6. **#293** — RuleCompiler robustness hardening (complements #647/#590). *opus*
-7. **#666** — notification envelope: actionLabels scrub + `textFields()` SSOT anchor. *sonnet*
-8. **#660** — null-session gross seam (net > gross possible; decide fix direction when observed).
-9. Mechanical batch: **#439** dead-vocabulary cull, **#57** strings.xml extraction (→ #428 i18n),
+4. **#647** — canonicalizer merge hardening (unknown section keys; flat/dir collision). *opus/sonnet*
+5. **#293** — RuleCompiler robustness hardening (complements #647/#590). *opus*
+6. **#660** — null-session gross seam (net > gross possible; decide fix direction when observed).
+   The #675 per-day chart is a consumer of the same seam (noted on the issue).
+7. Mechanical batch: **#439** dead-vocabulary cull, **#57** strings.xml extraction (→ #428 i18n),
    **#240/#239/#238** file splits (#237 family), **#244** test relocation. *sonnet*
-10. **#105** — Layer-2 OfferPipelineTest. *sonnet*
+8. **#105** — Layer-2 OfferPipelineTest. *sonnet*
 
 ## Needs design / field data first (actionable-soon)
 
@@ -66,7 +60,14 @@ the board reality — when an issue's state changes, move it here or this doc ro
 
 ## Recently resolved in the 2026-07-05 sweep
 
-Closed as superseded: #202 (→ #314 plan §7), #106 (→ SessionReplay `reduceMixed`), #338
-(→ #461/#531), PR #547 (annotations already 2/2 in the README). Merged: PR #496 (running-$/hr
-design doc, reconciled with the frozen-record model). Shipped: #655, #632, #318, retro-findings
-fix (#664), Money tab v1 (#662). Filed: #659, #660, #666.
+**Evening wave:** #653 (phantom double-count guard, #673); #315 H4 Time tab (#674); #315 H6
+earnings-by-day chart + hub-header CSV action (#675); **#650 CLOSED** — per-dash drill-down
+(#676) + corrections-as-events `MANUAL_DELIVERY`/`PAY_ADJUSTMENT` (#677; fable review caught an
+uncosted-MANUAL net-drop HIGH + a liveness-inflation MED pre-merge). Deferred from #650:
+session-scoped "categorize a bonus" (needs a v11 display-only table).
+
+**Day wave:** Closed as superseded: #202 (→ #314 plan §7), #106 (→ SessionReplay `reduceMixed`),
+#338 (→ #461/#531), PR #547 (annotations already 2/2 in the README). Merged: PR #496
+(running-$/hr design doc, reconciled with the frozen-record model). Shipped: #655, #632, #318,
+retro-findings fix (#664), Money tab v1 (#662), Decisions tab (#669), #666 NotifTextField SSOT
+(#670), #659 4-step waterfall (#668/#672), #319 CSV export (#671). Filed: #659, #660, #666.


### PR DESCRIPTION
[skip ci]

Docs-only. Moves the 07-05 evening merges into the resolved bucket (#673/#674/#675/#676/#677 — hub H4+H6, #650 both PRs, #653), promotes #551 to Now/in-flight, drops the closed #666/#653/#319/#650 entries from the queue, and notes the #660 seam's new consumer.

No code; no design-goal review needed (no principle-bearing surface touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)