### PR TITLE
refactor(#551): Principle-7 logging phase 1 — PII-safe INFO+, semantic levels, stable tags

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
@@ -307,13 +307,19 @@ class SideEffectEngine @Inject constructor(
             is AppEffect.ResumeOdometer -> odometerEffectHandler.resume()
 
             is AppEffect.RecordShopRate -> {
-                // #556: learn the dasher's shopping pace. PII-safe (store name is a merchant name).
+                // #556: learn the dasher's shopping pace.
                 val minutes = effect.shopDurationMs / 60_000.0
                 strategyRepository.recordShopRate(effect.itemsShopped, minutes)
+                val perMin = if (minutes > 0) effect.itemsShopped / minutes else 0.0
+                // #551 P7: rate math is a shareable INFO milestone, but the merchant name
+                // (raw third-party UI text) stays on the DEBUG firehose only.
                 Timber.tag("ShopRate").i(
+                    "recorded %d items / %.1f min = %.2f/min",
+                    effect.itemsShopped, minutes, perMin,
+                )
+                Timber.tag("ShopRate").d(
                     "recorded %d items / %.1f min = %.2f/min (store=%s)",
-                    effect.itemsShopped, minutes,
-                    if (minutes > 0) effect.itemsShopped / minutes else 0.0, effect.storeName ?: "?",
+                    effect.itemsShopped, minutes, perMin, effect.storeName ?: "?",
                 )
             }
 
@@ -509,7 +515,10 @@ class SideEffectEngine @Inject constructor(
     private fun logFromArgs(args: Map<String, String>) {
         val type = args["type"] ?: "RULE_EFFECT"
         val payload = args["payload"]
-        Timber.i("Rule LOG [%s]: %s", type, payload ?: "(no payload)")
+        // #551 P7: a rule LOG payload is a rule-authored diagnostic that can template raw
+        // third-party UI text ({rawText}, {storeName} — e.g. "TIP_RECEIVED: {rawText}"), so it is
+        // a DEBUG firehose step, never the shareable INFO stream.
+        Timber.tag("Effects").d("Rule LOG [%s]: %s", type, payload ?: "(no payload)")
     }
 
     private fun sessionStartFromArgs(args: Map<String, String>) {

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/TipEffectHandler.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/TipEffectHandler.kt
@@ -19,13 +19,18 @@ class TipEffectHandler @Inject constructor(
     fun process(scope: CoroutineScope, effect: AppEffect.ProcessTipNotification) {
         scope.launch(Dispatchers.IO) {
             try {
-                Timber.i("Tip received: ${Formats.money(effect.amount)} from ${effect.storeName}")
+                // #551 P7: the tip amount is the dasher's own economics (INFO-safe); the store name
+                // is raw third-party UI text, so it stays on the DEBUG firehose.
+                Timber.tag("Effects").i("Tip received: %s", Formats.money(effect.amount))
+                Timber.tag("Effects").d(
+                    "Tip received: %s from %s", Formats.money(effect.amount), effect.storeName,
+                )
                 bubbleManager.postMessage(
                     text = "Nice! ${Formats.money(effect.amount)} tip from ${effect.storeName}",
                     persona = ChatPersona.Dispatcher
                 )
             } catch (e: Exception) {
-                Timber.e(e, "Error processing tip notification")
+                Timber.tag("Effects").e(e, "Error processing tip notification")
             }
         }
     }

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/TtsEffectHandler.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/TtsEffectHandler.kt
@@ -11,6 +11,7 @@ import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
 import dagger.hilt.android.qualifiers.ApplicationContext
 import timber.log.Timber
 import java.util.Locale
+import java.util.concurrent.atomic.AtomicLong
 import javax.inject.Inject
 import javax.inject.Singleton
 import cloud.trotter.dashbuddy.domain.format.Formats
@@ -20,6 +21,10 @@ class TtsEffectHandler @Inject constructor(
     @param:ApplicationContext private val context: Context,
 ) {
     private var tts: TextToSpeech? = null
+
+    /** Monotonic utterance ids (#551 P7): the id is logged by the WARN error callback, so it
+     *  must never embed the merchant name — a counter correlates callbacks just as well. */
+    private val utteranceSeq = AtomicLong(0)
 
     @Volatile
     private var isReady = false
@@ -75,7 +80,7 @@ class TtsEffectHandler @Inject constructor(
         Timber.tag("Tts").d("speaking: %s", text)
 
         audioManager.requestAudioFocus(audioFocusRequest)
-        val result = tts?.speak(text, TextToSpeech.QUEUE_FLUSH, null, "offer_${eval.merchantName}")
+        val result = tts?.speak(text, TextToSpeech.QUEUE_FLUSH, null, "offer_${utteranceSeq.incrementAndGet()}")
         if (result != TextToSpeech.SUCCESS) {
             // A failed speak() never fires an utterance callback — release focus here or
             // other apps stay ducked (#341).

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/TtsEffectHandler.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/TtsEffectHandler.kt
@@ -49,14 +49,14 @@ class TtsEffectHandler @Inject constructor(
                         // No-op: errorCode overload handles this
                     }
                     override fun onError(utteranceId: String?, errorCode: Int) {
-                        Timber.w("TTS error %d for utterance %s", errorCode, utteranceId)
+                        Timber.tag("Tts").w("error %d for utterance %s", errorCode, utteranceId)
                         audioManager.abandonAudioFocusRequest(audioFocusRequest)
                     }
                 })
                 isReady = true
-                Timber.i("TTS engine initialized")
+                Timber.tag("Tts").i("engine initialized")
             } else {
-                Timber.w("TTS init failed with status %d", status)
+                Timber.tag("Tts").w("init failed with status %d", status)
             }
         }
     }
@@ -64,18 +64,22 @@ class TtsEffectHandler @Inject constructor(
     /** Speak the offer's evaluation aloud — the verdict, then the card's headline economics. */
     fun speakOffer(eval: OfferEvaluation) {
         if (!isReady) {
-            Timber.w("TTS not ready, skipping offer speech")
+            Timber.tag("Tts").w("not ready, skipping offer speech")
             return
         }
         val text = formatEvaluation(eval)
-        Timber.i("TTS speaking: %s", text)
+        // #551 P7: the spoken text names merchants ("Accept. Target & Maple Street …"),
+        // so the shareable INFO stream carries counts only; the raw utterance stays on the
+        // DEBUG firehose.
+        Timber.tag("Tts").i("speaking (%d chars)", text.length)
+        Timber.tag("Tts").d("speaking: %s", text)
 
         audioManager.requestAudioFocus(audioFocusRequest)
         val result = tts?.speak(text, TextToSpeech.QUEUE_FLUSH, null, "offer_${eval.merchantName}")
         if (result != TextToSpeech.SUCCESS) {
             // A failed speak() never fires an utterance callback — release focus here or
             // other apps stay ducked (#341).
-            Timber.w("TTS speak returned %s — abandoning audio focus", result)
+            Timber.tag("Tts").w("speak returned %s — abandoning audio focus", result)
             audioManager.abandonAudioFocusRequest(audioFocusRequest)
         }
     }

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/shadow/ShadowStoreChainLogger.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/shadow/ShadowStoreChainLogger.kt
@@ -20,8 +20,10 @@ import javax.inject.Singleton
  *
  * Runs off the hot path: a passive collector on [StateManagerV2.state] that captures the active job
  * (with its resolved task stores) and the PostTask payout while a job is live, and emits one chain
- * line when the job clears. Debug-build only (a diagnostic, like captures). PII-safe by construction
- * — store names are merchant names, customers are logged as `sha256` prefixes only (no raw PII).
+ * line when the job clears. Debug-build only (a diagnostic, like captures). The full store-chain body
+ * names merchants (raw third-party UI text), so it logs at **DEBUG** (firehose only, #551 P7); the
+ * shareable **INFO** milestone carries only the job id + link count (customers are always `sha256`
+ * prefixes, never raw PII).
  */
 @Singleton
 class ShadowStoreChainLogger @Inject constructor(
@@ -51,7 +53,9 @@ class ShadowStoreChainLogger @Inject constructor(
         }
     }
 
-    private fun logChain(job: Job, payout: ParsedPay?) {
+    // internal (not private) so the #551 P7 PII-safety test can drive the exact log site directly
+    // without a full AppState/StateFlow fixture.
+    internal fun logChain(job: Job, payout: ParsedPay?) {
         val chain = StoreChainProjector.project(job, payout)
         if (chain.links.isEmpty()) return
         val body = chain.links.joinToString("; ") { l ->
@@ -65,6 +69,9 @@ class ShadowStoreChainLogger @Inject constructor(
                 append(" custs=").append(l.customerHashes.map { it.take(6) })
             }
         }
-        Timber.tag("ShadowProjector").i("job %s store-chain (%d): %s", chain.jobId, chain.links.size, body)
+        // #551 P7: milestone (job id + link count) is PII-safe INFO; the merchant-bearing body
+        // is raw third-party UI text, so it stays on the DEBUG firehose.
+        Timber.tag("Shadow").i("job %s store-chain resolved (%d links)", chain.jobId, chain.links.size)
+        Timber.tag("Shadow").d("job %s store-chain (%d): %s", chain.jobId, chain.links.size, body)
     }
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManager.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManager.kt
@@ -144,8 +144,10 @@ class BubbleManager @Inject constructor(
         persona: ChatPersona = ChatPersona.Dispatcher,
         expand: Boolean = false
     ) {
-        // Updated to use displayName
-        Timber.tag("Chat").i("[${persona.displayName}]: $text")
+        // #551 P7: chat text can carry raw merchant/store text ("Pickup: <store>"), so the
+        // shareable INFO stream logs a counts-only milestone; the raw body stays on DEBUG.
+        Timber.tag("Chat").i("message posted [%s] (%d chars)", persona.displayName, text.length)
+        Timber.tag("Chat").d("[%s]: %s", persona.displayName, text)
 
         // 2. UPDATED: Launched in a coroutine because the Repository is pure suspend now!
         scope.launch {
@@ -279,7 +281,10 @@ class BubbleManager @Inject constructor(
     fun postOfferNotification(offer: FlowCardSnapshot.Offer, evaluation: OfferEvaluation) {
         val summary = evaluation.toNotificationSummary()
         val persona = evaluation.notificationPersona()
-        Timber.tag("Chat").i("[${persona.displayName}]: $summary")
+        // #551 P7: the offer summary ends with the merchant name (raw third-party UI text), so
+        // INFO carries a PII-safe milestone and the raw summary stays on the DEBUG firehose.
+        Timber.tag("Chat").i("offer posted [%s] (%d chars)", persona.displayName, summary.length)
+        Timber.tag("Chat").d("[%s]: %s", persona.displayName, summary)
         scope.launch { chatRepository.saveMessage(activeSessionId.value, summary.toString(), persona) }
         showOfferHeadsUp(offer, summary, persona)
     }

--- a/app/src/test/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngineTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngineTest.kt
@@ -1,5 +1,6 @@
 package cloud.trotter.dashbuddy.state.effects
 
+import android.util.Log
 import cloud.trotter.dashbuddy.core.data.event.AppEventRepo
 import cloud.trotter.dashbuddy.core.data.strategy.StrategyRepository
 import cloud.trotter.dashbuddy.core.database.effects.EffectsFiredDao
@@ -25,7 +26,9 @@ import cloud.trotter.dashbuddy.domain.pipeline.RequestedEffect
 import cloud.trotter.dashbuddy.domain.pipeline.TimeoutType
 import cloud.trotter.dashbuddy.domain.model.accessibility.BoundingBox
 import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.test.util.RecordingTree
 import cloud.trotter.dashbuddy.ui.bubble.BubbleManager
+import timber.log.Timber
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -666,5 +669,36 @@ class SideEffectEngineTest {
         advanceTimeBy(11)
         runCurrent()
         assertEquals(1, fired.size)
+    }
+
+    // =========================================================================
+    // #551 P7 — RecordShopRate: rate math is INFO-safe, the store name stays on DEBUG
+    // =========================================================================
+
+    @Test
+    fun `RecordShopRate keeps the store name out of INFO+ but on the DEBUG firehose`() = runTest {
+        val engine = buildEngine(StandardTestDispatcher(testScheduler))
+        val tree = RecordingTree()
+        Timber.plant(tree)
+        try {
+            engine.process(
+                AppEffect.RecordShopRate(
+                    itemsShopped = 24,
+                    shopDurationMs = 18 * 60_000L,
+                    storeName = "H-E-B",
+                    jobId = "job-1",
+                    taskId = "task-1",
+                ),
+            )
+            runCurrent()
+
+            // The shareable INFO stream carries the pace math but never the merchant name.
+            tree.assertNoInfoPlusContains("H-E-B")
+            tree.assertLevelContains(Log.INFO, "24 items")
+            // The DEBUG firehose still names the store.
+            tree.assertLevelContains(Log.DEBUG, "H-E-B")
+        } finally {
+            Timber.uproot(tree)
+        }
     }
 }

--- a/app/src/test/java/cloud/trotter/dashbuddy/state/shadow/ShadowStoreChainLoggerPiiLogTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/state/shadow/ShadowStoreChainLoggerPiiLogTest.kt
@@ -1,0 +1,72 @@
+package cloud.trotter.dashbuddy.state.shadow
+
+import android.util.Log
+import cloud.trotter.dashbuddy.core.state.StateManagerV2
+import cloud.trotter.dashbuddy.domain.model.pay.ParsedPay
+import cloud.trotter.dashbuddy.domain.model.pay.ParsedPayItem
+import cloud.trotter.dashbuddy.domain.state.Job
+import cloud.trotter.dashbuddy.domain.state.Task
+import cloud.trotter.dashbuddy.domain.state.TaskPhase
+import cloud.trotter.dashbuddy.test.util.RecordingTree
+import org.junit.Test
+import org.mockito.kotlin.mock
+import timber.log.Timber
+
+/**
+ * #551 Phase 1 — Principle 7 fail-closed guard for [ShadowStoreChainLogger]. The store-chain body
+ * names raw merchants (the 06-21 receipt: 9 INFO lines naming stores). The shareable INFO milestone
+ * now carries only the job id + link count; the merchant-bearing body stays on the DEBUG firehose.
+ * The fixture is the real 2026-06-19 Target + Maple Street stack.
+ */
+class ShadowStoreChainLoggerPiiLogTest {
+
+    private fun pickup(id: String, store: String) = Task(
+        taskId = id, jobId = "job-1", phase = TaskPhase.PICKUP,
+        storeName = store, startedAt = 100L, completedAt = 200L,
+    )
+
+    private fun dropoff(id: String, store: String, cust: String) = Task(
+        taskId = id, jobId = "job-1", phase = TaskPhase.DROPOFF, storeName = store,
+        customerNameHash = cust, startedAt = 300L, completedAt = 400L,
+    )
+
+    @Test
+    fun `logChain keeps merchants out of INFO+ but on the DEBUG firehose`() {
+        val logger = ShadowStoreChainLogger(mock<StateManagerV2>())
+        val job = Job(
+            jobId = "job-1",
+            offerStoreHint = listOf("Target", "Maple Street Biscuit Company"),
+            parentOfferHash = null,
+            startedAt = 50L,
+            tasks = listOf(
+                pickup("p-target", "Target"),
+                pickup("p-maple", "Maple Street Biscuit Company"),
+                dropoff("d-target", "Target", "cust-A"),
+                dropoff("d-maple", "Maple Street Biscuit Company", "cust-B"),
+            ),
+        )
+        val payout = ParsedPay(
+            appPayComponents = listOf(ParsedPayItem("Base Pay", 6.40)),
+            customerTips = listOf(
+                ParsedPayItem("Maple Street Biscuit - Alamo Ranch", 6.50),
+                ParsedPayItem("Target (02426)", 2.25),
+            ),
+        )
+
+        val tree = RecordingTree()
+        Timber.plant(tree)
+        try {
+            logger.logChain(job, payout)
+
+            // The shareable INFO milestone carries only the job id + link count.
+            tree.assertNoInfoPlusContains("Target")
+            tree.assertNoInfoPlusContains("Maple Street")
+            tree.assertLevelContains(Log.INFO, "store-chain resolved (2 links)")
+            // The DEBUG firehose still names the merchants.
+            tree.assertLevelContains(Log.DEBUG, "Target")
+            tree.assertLevelContains(Log.DEBUG, "Maple Street")
+        } finally {
+            Timber.uproot(tree)
+        }
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/test/util/RecordingTree.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/test/util/RecordingTree.kt
@@ -1,0 +1,70 @@
+package cloud.trotter.dashbuddy.test.util
+
+import android.util.Log
+import timber.log.Timber
+
+/**
+ * A Timber [Timber.Tree] that records every log call as a [Record] so tests can assert on the
+ * level, tag, and (already arg-formatted) message of each line.
+ *
+ * This is the **seed of the #551 Phase-2 shareable-export sink guard**. Development Principle 7
+ * requires INFO+ to be **PII-safe by construction** — a raw merchant/customer/address string in an
+ * INFO-or-higher line is a privacy defect of the same class as leaking it to disk. Tests plant this
+ * tree, drive a component, and assert that no INFO+ line carries raw third-party UI text while the
+ * DEBUG firehose keeps full fidelity. Phase 2 will reuse it to gate the real export sink behind a
+ * [cloud.trotter.dashbuddy.core.pipeline.SensitiveTextMarkers]-based fail-closed scan.
+ *
+ * Usage:
+ * ```
+ * val tree = RecordingTree()
+ * Timber.plant(tree)
+ * try { /* drive component */ } finally { Timber.uproot(tree) }
+ * tree.assertNoInfoPlusContains("H-E-B")   // shareable stream is clean
+ * tree.assertLevelContains(Log.DEBUG, "H-E-B") // firehose kept it
+ * ```
+ */
+class RecordingTree : Timber.Tree() {
+
+    /** One recorded log line. [message] is already formatted (Timber applies args before [log]). */
+    data class Record(val priority: Int, val tag: String?, val message: String)
+
+    private val _records = mutableListOf<Record>()
+
+    val records: List<Record> get() = synchronized(_records) { _records.toList() }
+
+    override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
+        synchronized(_records) { _records += Record(priority, tag, message) }
+    }
+
+    /** Records at INFO or higher — the shareable-export candidate stream. */
+    fun infoPlus(): List<Record> = records.filter { it.priority >= Log.INFO }
+
+    /**
+     * Fail if any INFO+ message contains [needle] — a raw-PII leak into the shareable stream.
+     * The fail-closed assertion Principle 7 demands (call-site discipline is not trusted).
+     */
+    fun assertNoInfoPlusContains(needle: String) {
+        val hit = infoPlus().firstOrNull { it.message.contains(needle) }
+        check(hit == null) {
+            "INFO+ log leaked '$needle': [${levelName(hit!!.priority)}/${hit.tag}] ${hit.message}"
+        }
+    }
+
+    /** Assert at least one record at exactly [priority] contains [needle] (firehose fidelity kept). */
+    fun assertLevelContains(priority: Int, needle: String) {
+        val ok = records.any { it.priority == priority && it.message.contains(needle) }
+        check(ok) {
+            "No ${levelName(priority)} log contained '$needle'. Records: " +
+                records.joinToString("\n") { "[${levelName(it.priority)}/${it.tag}] ${it.message}" }
+        }
+    }
+
+    private fun levelName(priority: Int) = when (priority) {
+        Log.VERBOSE -> "VERBOSE"
+        Log.DEBUG -> "DEBUG"
+        Log.INFO -> "INFO"
+        Log.WARN -> "WARN"
+        Log.ERROR -> "ERROR"
+        else -> "P$priority"
+    }
+}

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/ObservationClassifier.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/ObservationClassifier.kt
@@ -90,19 +90,21 @@ class ObservationClassifier @Inject constructor(
     ): Observation.Screen {
         val ruleset = interpreter.screenRuleset
         if (ruleset == null) {
-            Timber.w("ObservationClassifier: no screen ruleset loaded")
+            // Fail-closed invariant fired (rulesets not loaded) — a real WARN (#551 P7).
+            Timber.tag("Classifier").w("no screen ruleset loaded")
             return makeScreenObservation(now, UNKNOWN_TARGET, null, null, ParsedFields.None, null)
         }
 
         val result = ruleset.matchFirst(event.tree, platformWire)
         if (result == null) {
-            Timber.i("SCREEN: UNKNOWN")
+            // #551 P7: per-frame trace → VERBOSE (firehose only), never the shareable INFO stream.
+            Timber.tag("Classifier").v("SCREEN: UNKNOWN")
             return makeScreenObservation(now, UNKNOWN_TARGET, null, null, ParsedFields.None, null)
         }
 
-        Timber.i("SCREEN: ${result.intent}")
+        Timber.tag("Classifier").v("SCREEN: ${result.intent}")
         if (result.effects.isNotEmpty()) {
-            Timber.d("SCREEN: ${result.intent} has ${result.effects.size} effect(s)")
+            Timber.tag("Classifier").d("SCREEN: ${result.intent} has ${result.effects.size} effect(s)")
         }
 
         val parsed = ParsedFieldsFactory.create(result.shape, result.fields)
@@ -188,7 +190,7 @@ class ObservationClassifier @Inject constructor(
         val nodeId = event.node.viewIdResourceName
             ?.takeIf { it.isNotBlank() && it != NO_ID_FALLBACK }
         val nodeText = event.node.text?.takeIf { it.isNotBlank() }
-        Timber.d("ObservationClassifier: UNKNOWN click — id=$nodeId text=$nodeText")
+        Timber.tag("Classifier").d("UNKNOWN click — id=$nodeId text=$nodeText")
         return Observation.Click(
             timestamp = now,
             captureId = null,
@@ -234,7 +236,7 @@ class ObservationClassifier @Inject constructor(
 
         // Unknown notification — preserve raw text for future analysis
         val rawText = event.raw.toFullString()
-        Timber.d("ObservationClassifier: UNKNOWN notification — $rawText")
+        Timber.tag("Classifier").d("UNKNOWN notification — $rawText")
         return Observation.Notification(
             timestamp = event.raw.postTime,
             captureId = null,

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/mapper/AccessibilityNodeMapper.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/mapper/AccessibilityNodeMapper.kt
@@ -82,9 +82,11 @@ private fun convert(
         }
     }
 
-    // In debug builds, log when children are reported but inaccessible
+    // In debug builds, log when children are reported but inaccessible. #551 P7: this is benign,
+    // frequent per-frame tree noise — VERBOSE (firehose only), not WARN. WARN must mean a defended
+    // invariant fired, and this noise was drowning the real WARNs (grace commits, gate denials).
     if (BuildConfig.DEBUG && nullChildren > 0) {
-        Timber.w(
+        Timber.tag("Mapper").v(
             "👻 NULL CHILDREN: %d/%d null at depth=%d class=%s id=%s",
             nullChildren, childCount, depth,
             node.className, node.viewIdResourceName,

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -117,6 +117,20 @@ was found **broken-in-part** (raw PII in capture envelopes) and moved to that en
   picker). Screens with no dashes yet just yield header-only files — that's fine.
   - Confirmed: 0/2
 
+- **🆕 NEW — Principle-7 logging phase 1: INFO+ log is PII-safe, `SCREEN:` spam gone, real WARNs
+  visible (#551 PR #551-P1).** After a dash (ideally one with a **grocery shop**, so the TTS/ShopRate
+  paths fire), export/inspect the log (Settings → the log/bug-report export, or pull the on-device
+  file). How to tell it's working: **(a)** grep the log for your shop's merchant name (e.g. `H-E-B`,
+  `Target`) — it must appear ONLY on `DEBUG` lines, NEVER on `INFO`/`WARN`/`ERROR` (the shareable
+  stream). The INFO milestones should read counts-only, e.g. `INFO/Tts: speaking (NN chars)`,
+  `INFO/ShopRate: recorded NN items / M.M min = R.RR/min`, `INFO/Chat: offer posted [Persona] (NN
+  chars)`. **(b)** The per-frame `SCREEN: <intent>` lines are gone from INFO (now `VERBOSE/Classifier`)
+  and the `👻 NULL CHILDREN` noise is gone from WARN (now `VERBOSE/Mapper`). **(c)** The real WARNs —
+  `GRACE_COMMIT`/grace-timer wakes, fail-closed gate denials — are now legible in the INFO+ slice
+  instead of drowned. How to tell it's broken: any raw store/customer/address text on an INFO+ line,
+  `SCREEN:` still at INFO, or WARN still buried under ghost-child noise. (PR #551-P1)
+  - Confirmed: 0/2
+
 - **🆕 NEW — driving/glance-mode HUD font-scale toggle (#318).** Flip "Driving glance mode" on in
   Settings → General while a dash is running (or the bubble is up). The bubble HUD's text — the
   hero $/hr, task timers, captions, everything — should visibly grow (~12%) immediately, with no


### PR DESCRIPTION
Implements **Phase 1 of #551** — fix the confirmed raw-merchant INFO+ log leaks and apply the Principle-7 level/tag taxonomy to the worst-offender sites. **Phase 2 (the shareable INFO+ export sink + the `SensitiveTextMarkers` fail-closed export guard) is NOT in this PR and remains open on #551.**

Principle 7: **INFO+ is the shareable stream and must be PII-safe by construction — no raw store/customer/address text.** Raw third-party UI text lives at DEBUG/VERBOSE only. The dasher's own first-name+last-initial is fine.

## Site-by-site change table

| File:line | Site | Before | After |
|---|---|---|---|
| `TtsEffectHandler.kt:71` | spoken utterance names merchants | `INFO` `TTS speaking: <text>` | `INFO/Tts speaking (%d chars)` (counts) + `DEBUG/Tts speaking: <text>` |
| `TtsEffectHandler.kt` 52/57/59/67/78 | init/ready/error | untagged `INFO`/`WARN` | same level, `Tts` tag |
| `SideEffectEngine.kt:313` (ShopRate) | `store=%s` in rate line | `INFO/ShopRate ... (store=%s)` | `INFO/ShopRate` rate math only + `DEBUG/ShopRate ... (store=%s)` |
| `SideEffectEngine.kt:512` (rule LOG) | payload templates `{rawText}`/`{storeName}` | `INFO` `Rule LOG [%s]: %s` | `DEBUG/Effects Rule LOG [%s]: %s` |
| `ShadowStoreChainLogger.kt:68` | merchant-bearing chain body | `INFO/ShadowProjector job … <body>` | `INFO/Shadow store-chain resolved (%d links)` (milestone) + `DEBUG/Shadow … <body>` |
| `BubbleManager.kt:148` (postMessage) | chat text "Pickup: `<store>`" | `INFO/Chat [persona]: <text>` | `INFO/Chat message posted [persona] (%d chars)` + `DEBUG/Chat [persona]: <text>` |
| `BubbleManager.kt:282` (offer) | summary ends with merchant | `INFO/Chat [persona]: <summary>` | `INFO/Chat offer posted [persona] (%d chars)` + `DEBUG/Chat [persona]: <summary>` |
| `TipEffectHandler.kt:22` | `from <store>` | `INFO Tip received … from <store>` | `INFO/Effects Tip received: <amount>` + `DEBUG/Effects … from <store>` |
| `ObservationClassifier.kt:99,103` | per-frame `SCREEN:` spam | `INFO SCREEN: …` | `VERBOSE/Classifier SCREEN: …` |
| `ObservationClassifier.kt:93` | no-ruleset fail-closed | untagged `WARN` | `WARN/Classifier` (real defended invariant) |
| `ObservationClassifier.kt:105,191,237` | effect/unknown-click/unknown-notif | untagged `DEBUG` | `DEBUG/Classifier` (unchanged level; raw text stays DEBUG) |
| `AccessibilityNodeMapper.kt:87` | `👻 NULL CHILDREN` benign per-frame noise | `WARN` (drowning real WARNs) | `VERBOSE/Mapper` |

Sweep note: the `Rule LOG` INFO line was found during the item-6 sweep — rule-authored payloads in `matchers/rules/uber.json5:827` (`TIP_RECEIVED: {rawText}`) and `doordash/notifications.json5:39` (`TIP_ADDED: ${amount} {storeName}`) template raw third-party text into that line, so it was a live merchant/customer leak into INFO. A rule-effect diagnostic is a DEBUG-tier step anyway, so demoting both fixes taxonomy and the leak.

## Privacy posture (per CLAUDE.md requirement)

- **Scrubbed from INFO+ (the shareable stream):** merchant/store names (Tts, ShopRate, Shadow, Bubble chat + offer, Tip, rule LOG), and any rule-templated `{rawText}`/`{storeName}`. INFO now carries only counts, economics (dasher's own money), state names, hashes, job ids + link counts — PII-safe by construction.
- **Stays at DEBUG (the on-device firehose):** the full utterance, the store name, the store-chain body, the raw chat/offer text, the rule LOG payload — full replay fidelity kept, firehose only. Unknown-click `nodeText` / unknown-notification `rawText` were already DEBUG and stay DEBUG.
- **Moved to VERBOSE:** per-frame `SCREEN:` trace and `NULL CHILDREN` tree noise — firehose-only, and this un-drowns the real WARNs (grace commits, fail-closed gate denials).
- **Trust boundary unchanged:** no recognition/capture/effect behavior changed — logs only, no UI rendering touched.

## Test coverage

- New `RecordingTree` test util (`app/.../test/util/RecordingTree.kt`) — plants a recording Timber tree, records `(priority, tag, message)`, exposes `assertNoInfoPlusContains` (fail-closed: any INFO+ line containing the needle fails) and `assertLevelContains` (firehose fidelity kept). Named so **Phase 2 can reuse it** to gate the real export sink.
- `SideEffectEngineTest`: new `RecordShopRate` test — drives the real engine, asserts no INFO+ line names `H-E-B`, INFO carries the rate math, DEBUG names the store.
- `ShadowStoreChainLoggerPiiLogTest`: drives `logChain` (made `internal`) with the real 06-19 Target + Maple Street stack — asserts merchants absent from INFO+, present at DEBUG, INFO milestone reads `store-chain resolved (2 links)`.
- No existing test asserted on the changed log strings/levels (the `"Pickup: <store>"` test references are `AppEffect.UpdateBubble` payloads / `postMessage` verifications — UI content, not log output — untouched).
- `JAVA_HOME=/usr/lib/jvm/java-25-openjdk ./gradlew :app:testDebugUnitTest :domain:test :core:pipeline:testDebugUnitTest` — all green.

## Design-goal review

- **5 SSOT** — reused the existing tag vocabulary rather than inventing synonyms: kept `Chat` (both uses live in BubbleManager) and `ShopRate`; the sole prior `ShadowProjector` use *was* the edited line, retagged to the task-specified `Shadow`; `Tts`/`Effects`/`Classifier`/`Mapper` are the component names. Every fixed site follows the same INFO-milestone-plus-DEBUG-fidelity shape — one pattern, not per-site divergence.
- **6 Security & privacy** — this is the point: INFO+ is now PII-safe at every confirmed site, and that property is **fail-closed-tested** (`RecordingTree.assertNoInfoPlusContains`), not left to call-site discipline (which is exactly what drifted per the 06-19/06-21 receipts). No raw customer/merchant/address text can reach the shareable stream at the fixed sites; the DEBUG firehose keeps replay fidelity.
- **7 Semantic logging** — the implementation: levels now carry meaning (VERBOSE = per-frame firehose; DEBUG = effect/reducer steps + raw third-party text; INFO = PII-safe milestones; WARN = a defended invariant fired, no longer drowned by ghost-child noise), and each touched site logs under a stable component tag instead of the catch-all `App`.
- **8 Platform-agnostic core** — the two `:core:pipeline` edits (`ObservationClassifier`, `AccessibilityNodeMapper`) are level/tag changes only; no platform literals introduced, no `when` on platform, no new rule↔state vocabulary.
- Untouched principles (UDF, MAD, Reactive UI) — no state/flow/UI-rendering changes; logs only.

Phase 2 (the INFO+ shareable export sink + the `SensitiveTextMarkers`-based fail-closed export test) remains open on #551.
