### PR TITLE
test(#590): property tests phase 1 — compile recursion, ReDoS budget, notification totality (red-first + fixes)

### DIFF
--- a/core/pipeline/build.gradle.kts
+++ b/core/pipeline/build.gradle.kts
@@ -55,6 +55,10 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.mockito.kotlin)
+    // #590 — standalone kotest-property (Arb/checkAll/forAll), runner-agnostic:
+    // it runs inside plain JUnit-4 @Test bodies via runTest/runBlocking. NOT the
+    // Kotest runner, NOT jqwik/Jazzer (both JUnit-Platform-only; this repo is JUnit 4).
+    testImplementation(libs.kotest.property)
 }
 
 // ===========================================================================

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/notification/mapper/NotificationMapper.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/notification/mapper/NotificationMapper.kt
@@ -2,10 +2,25 @@ package cloud.trotter.dashbuddy.core.pipeline.notification.mapper
 
 import android.service.notification.StatusBarNotification
 import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData
+import timber.log.Timber
 
-fun StatusBarNotification.toDomain(): RawNotificationData {
+/**
+ * Map a [StatusBarNotification] to the domain [RawNotificationData], or null if
+ * reading it throws.
+ *
+ * The mapping reads `notification.extras` and unwraps `getCharSequence(...)`
+ * (#590). Those extras are attacker-influenced untrusted input: a malformed or
+ * custom-Parcelable extra unparcels LAZILY on first read and can throw
+ * (`BadParcelableException`) — the textbook notification-listener crash class. A
+ * throw here propagates up the notification pipeline flow and kills the listener
+ * (the same crash class #430's supervision closed on the accessibility side). So
+ * this is made TOTAL: any failure drops that one notification (return null; the
+ * pipeline's `mapNotNull` skips it) and the flow keeps emitting. One WARN fires —
+ * a defended invariant, no raw notification text (Principle 7).
+ */
+fun StatusBarNotification.toDomain(): RawNotificationData? = try {
     val extras = this.notification.extras
-    return RawNotificationData(
+    RawNotificationData(
         packageName = this.packageName,
         title = extras.getCharSequence("android.title")?.toString(),
         text = extras.getCharSequence("android.text")?.toString(),
@@ -20,4 +35,9 @@ fun StatusBarNotification.toDomain(): RawNotificationData {
         actionLabels = this.notification.actions
             ?.mapNotNull { it.title?.toString() } ?: emptyList(),
     )
+} catch (e: Exception) {
+    // Untrusted extras threw (e.g. BadParcelableException on lazy unparcel).
+    // Drop this notification; keep the listener flow alive (parity with #430).
+    Timber.tag("Pipeline").w("Dropped a notification: reading its extras threw ${e.javaClass.simpleName} (#590)")
+    null
 }

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/BoundedRegex.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/BoundedRegex.kt
@@ -1,0 +1,118 @@
+package cloud.trotter.dashbuddy.core.pipeline.rules
+
+import timber.log.Timber
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+import java.util.regex.Pattern
+
+/**
+ * A rule-authored [Regex] with a **runtime match-time budget** (#590).
+ *
+ * [RegexSafety] rejects the nested-unbounded ReDoS family at COMPILE time, but
+ * its own KDoc admits Kotlin/Java [Regex] has **no match timeout**, and the
+ * structural heuristic cannot catch every catastrophic shape — ambiguous
+ * alternation (`(a|aa)+$`), optional-inside-star (`(a?)*b`), bounded-outer over
+ * unbounded-inner (`(.*a){20}`), and backreference blowups (`(\w+)\1+`) all slip
+ * through and then backtrack unbounded on the per-event classification thread.
+ * A single such pattern (careless author today; hostile CDN rule once #192
+ * opens) hangs recognition. This makes "accepted ⇒ bounded match time" true by
+ * construction: the compile heuristic no longer has to be sound on its own.
+ *
+ * Catastrophic patterns fail two ways, and both are closed here:
+ *  - **Exponential hang** (ambiguous alternation on a moderate input): the match
+ *    runs on the calling thread against an [InterruptibleCharSequence]; a shared
+ *    daemon watchdog interrupts that thread after [BUDGET_MS]. `Matcher` reads
+ *    the input via `charAt` on every backtracking step, so the guarded sequence
+ *    throws [RegexBudgetExceeded] the moment the interrupt lands.
+ *  - **Stack overflow** (deep quantifier recursion on a long input): Java's
+ *    regex engine recurses per repetition, so a long input overflows the stack
+ *    with a [StackOverflowError] — an [Error] that would otherwise escape every
+ *    `Exception`-only catch downstream. Caught here on the match thread.
+ *
+ * Either way the match **fails closed** — no-match (`false`/`null`), so the frame
+ * simply doesn't recognize (→ UNKNOWN → scrubbed) rather than hanging or crashing
+ * the thread — and one WARN fires (a defended invariant, no rule/PII text —
+ * Principle 7). Well-formed matches finish in microseconds and cancel the
+ * watchdog before it fires, so there is **zero behavior change** for the linear
+ * patterns the production rules use.
+ *
+ * Only rule-authored regexes (everything from [RegexSafety.compileRegex]) are
+ * wrapped; app-authored constant patterns keep the plain hot path.
+ */
+class BoundedRegex internal constructor(private val regex: Regex) {
+
+    fun containsMatchIn(input: CharSequence): Boolean =
+        runBounded(default = false, input) { regex.containsMatchIn(it) }
+
+    fun find(input: CharSequence): MatchResult? =
+        runBounded(default = null, input) { regex.find(it) }
+
+    /** The underlying [Pattern] — compile-time introspection only (no match). */
+    fun toPattern(): Pattern = regex.toPattern()
+
+    /** The raw pattern string, for logging/debugging. */
+    override fun toString(): String = regex.pattern
+
+    private inline fun <T> runBounded(default: T, input: CharSequence, block: (CharSequence) -> T): T {
+        val guarded = InterruptibleCharSequence(input)
+        val self = Thread.currentThread()
+        val watchdog = WATCHDOG.schedule({ self.interrupt() }, BUDGET_MS, TimeUnit.MILLISECONDS)
+        return try {
+            block(guarded)
+        } catch (e: RegexBudgetExceeded) {
+            Timber.tag("Pipeline").w(
+                "Rule regex match aborted: exceeded %dms budget (ReDoS runtime guard, #590)",
+                BUDGET_MS,
+            )
+            default
+        } catch (e: StackOverflowError) {
+            // Deep quantifier recursion on a long input (#590). An Error, so it
+            // would escape every downstream Exception-only catch = fail open.
+            // Treat as no-match — the match is a self-contained operation and the
+            // stack has already unwound to here.
+            Timber.tag("Pipeline").w("Rule regex match overflowed the stack (ReDoS runtime guard, #590)")
+            default
+        } finally {
+            watchdog.cancel(false)
+            // Clear any interrupt the watchdog set. The classification pipeline
+            // is coroutine-based (cooperative cancellation, not thread-interrupt),
+            // so nothing else on this thread relies on the interrupt flag.
+            Thread.interrupted()
+        }
+    }
+
+    private class RegexBudgetExceeded : RuntimeException() {
+        override fun fillInStackTrace(): Throwable = this // cheap: control-flow only
+    }
+
+    /**
+     * Wraps a [CharSequence] so `charAt` throws [RegexBudgetExceeded] once the
+     * current thread is interrupted — the hook the watchdog uses to abort a
+     * runaway backtracking match. `get` maps to `CharSequence.charAt` on the JVM.
+     */
+    private inner class InterruptibleCharSequence(private val inner: CharSequence) : CharSequence {
+        override val length: Int get() = inner.length
+        override fun get(index: Int): Char {
+            if (Thread.currentThread().isInterrupted) throw RegexBudgetExceeded()
+            return inner[index]
+        }
+        override fun subSequence(startIndex: Int, endIndex: Int): CharSequence =
+            InterruptibleCharSequence(inner.subSequence(startIndex, endIndex))
+        override fun toString(): String = inner.toString()
+    }
+
+    companion object {
+        /**
+         * Wall-clock budget for a single rule-authored match. Generous next to a
+         * well-formed match (microseconds); small enough that a catastrophic
+         * pattern can't stall the classification thread for a user-visible beat.
+         */
+        const val BUDGET_MS = 200L
+
+        private val WATCHDOG: ScheduledExecutorService =
+            Executors.newSingleThreadScheduledExecutor { r ->
+                Thread(r, "regex-redos-watchdog").apply { isDaemon = true }
+            }
+    }
+}

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/BoundedRegex.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/BoundedRegex.kt
@@ -57,7 +57,19 @@ class BoundedRegex internal constructor(private val regex: Regex) {
     private inline fun <T> runBounded(default: T, input: CharSequence, block: (CharSequence) -> T): T {
         val guarded = InterruptibleCharSequence(input)
         val self = Thread.currentThread()
-        val watchdog = WATCHDOG.schedule({ self.interrupt() }, BUDGET_MS, TimeUnit.MILLISECONDS)
+        // The gate closes a race (#590 review F1): without it, a watchdog firing
+        // concurrently with match completion could interrupt AFTER the finally
+        // block's Thread.interrupted() clear — leaving a stray interrupt flag on
+        // a dispatcher thread for some later, unrelated blocking call to trip
+        // over. The task interrupts only while `done` is false under the gate;
+        // finally flips `done` under the same gate BEFORE clearing, so no
+        // interrupt can land after the clear.
+        val gate = Any()
+        var done = false
+        val watchdog = WATCHDOG.schedule(
+            { synchronized(gate) { if (!done) self.interrupt() } },
+            BUDGET_MS, TimeUnit.MILLISECONDS,
+        )
         return try {
             block(guarded)
         } catch (e: RegexBudgetExceeded) {
@@ -75,9 +87,12 @@ class BoundedRegex internal constructor(private val regex: Regex) {
             default
         } finally {
             watchdog.cancel(false)
-            // Clear any interrupt the watchdog set. The classification pipeline
-            // is coroutine-based (cooperative cancellation, not thread-interrupt),
-            // so nothing else on this thread relies on the interrupt flag.
+            synchronized(gate) { done = true }
+            // Clear any interrupt the watchdog set — safe AFTER the gate flip
+            // above, which guarantees no further interrupt can land. The
+            // classification pipeline is coroutine-based (cooperative
+            // cancellation, not thread-interrupt), so nothing else on this
+            // thread relies on the interrupt flag.
             Thread.interrupted()
         }
     }
@@ -111,8 +126,13 @@ class BoundedRegex internal constructor(private val regex: Regex) {
         const val BUDGET_MS = 200L
 
         private val WATCHDOG: ScheduledExecutorService =
-            Executors.newSingleThreadScheduledExecutor { r ->
+            java.util.concurrent.ScheduledThreadPoolExecutor(1) { r ->
                 Thread(r, "regex-redos-watchdog").apply { isDaemon = true }
+            }.apply {
+                // Cancelled watchdogs (the overwhelming majority — every healthy
+                // match cancels its own) leave the queue immediately instead of
+                // lingering until their 200 ms deadline (#590 review L1).
+                removeOnCancelPolicy = true
             }
     }
 }

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/CompiledRules.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/CompiledRules.kt
@@ -105,7 +105,7 @@ sealed interface NotifFieldMask {
      * rest — e.g. the STORE in "<name>'s order is ready for pickup at <store>"
      * (merchants are not PII).
      */
-    data class RegexGroup(val regex: Regex, val group: Int) : NotifFieldMask
+    data class RegexGroup(val regex: BoundedRegex, val group: Int) : NotifFieldMask
 }
 
 /**
@@ -140,7 +140,7 @@ data class CompiledNotifRedact(
         }
     }
 
-    private fun maskGroup(value: String, regex: Regex, group: Int): String {
+    private fun maskGroup(value: String, regex: BoundedRegex, group: Int): String {
         // FAIL CLOSED (#620 review F2b): if the capture regex drifts from the
         // require gate (the rule matched but this pattern doesn't, or the group is
         // absent), masking the group would ship the RAW field. A recognized frame

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/JsonRuleInterpreter.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/JsonRuleInterpreter.kt
@@ -8,7 +8,6 @@ import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CancellationException
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.int
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
@@ -195,7 +194,12 @@ class JsonRuleInterpreter @Inject constructor(
         }
 
         return try {
-            val root = Json.parseToJsonElement(jsonString).jsonObject
+            // #590: bounded parse — a depth pre-scan rejects pathologically
+            // nested JSON as a typed RuleCompileException BEFORE the recursive
+            // parser can StackOverflowError (an Error escaping this catch = fail
+            // open). The RuleCompileException lands in the catch below and skips
+            // the file per the malformed-file policy.
+            val root = RuleCompiler.parseBoundedJson(jsonString).jsonObject
 
             // ADR-0003 seven-step compatibility check
             val rejection = RulesetLoader.validate(root, source)

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RegexSafety.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RegexSafety.kt
@@ -18,11 +18,18 @@ package cloud.trotter.dashbuddy.core.pipeline.rules
 internal object RegexSafety {
 
     /**
-     * Compile a rule-supplied pattern into a case-insensitive [Regex], enforcing
-     * the length cap and the catastrophic-backtracking guard first. Throws
-     * [RuleCompileException] on an over-long, ReDoS-prone, or invalid pattern.
+     * Compile a rule-supplied pattern into a case-insensitive [BoundedRegex],
+     * enforcing the length cap and the catastrophic-backtracking guard first.
+     * Throws [RuleCompileException] on an over-long, ReDoS-prone, or invalid
+     * pattern.
+     *
+     * The result is a [BoundedRegex] (#590): the compile-time heuristic below is
+     * a first line of defense, but it is not sound on every catastrophic shape,
+     * and Kotlin [Regex] has no match timeout — so the returned matcher carries a
+     * runtime match-time budget, making "accepted ⇒ bounded" true by
+     * construction. Every rule-authored match runs through this one entry point.
      */
-    fun compileRegex(pattern: String): Regex {
+    fun compileRegex(pattern: String): BoundedRegex {
         if (pattern.length > RuleCompiler.MAX_REGEX_LENGTH)
             throw RuleCompileException(
                 "Regex pattern length ${pattern.length} exceeds " +
@@ -30,7 +37,7 @@ internal object RegexSafety {
             )
         assertNoCatastrophicBacktracking(pattern)
         return try {
-            Regex(pattern, RegexOption.IGNORE_CASE)
+            BoundedRegex(Regex(pattern, RegexOption.IGNORE_CASE))
         } catch (e: Exception) {
             throw RuleCompileException("Invalid regex pattern: '$pattern'", e)
         }

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompiler.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompiler.kt
@@ -1457,5 +1457,5 @@ object RuleCompiler {
      * + ReDoS rejection, #418). Kept here as the compiler's call site / public
      * entry point; the security logic lives in [RegexSafety] (audit #11).
      */
-    internal fun compileRegex(pattern: String): Regex = RegexSafety.compileRegex(pattern)
+    internal fun compileRegex(pattern: String): BoundedRegex = RegexSafety.compileRegex(pattern)
 }

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompiler.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompiler.kt
@@ -38,6 +38,74 @@ object RuleCompiler {
     const val MAX_REGEX_LENGTH = 200
     private const val MAX_EACH_SIZE = 50
 
+    /**
+     * Maximum nesting depth of a parse expression (#590). The `each`/`extract`,
+     * `join`, and `coalesce` compilers recurse into [compileParseExpression]
+     * with NO structural bound of their own — a pathologically nested parse
+     * block would overflow the JVM stack at COMPILE time. A [StackOverflowError]
+     * is an [Error], not an [Exception], so it ESCAPES the `Exception`-only
+     * catch in [JsonRuleInterpreter.loadSingle] (a fail-OPEN crash of the rule
+     * load / classification path). This guard rejects over-deep parse
+     * expressions as a typed [RuleCompileException] instead — fail closed.
+     * Generous: real rules nest < 10.
+     */
+    const val MAX_PARSE_DEPTH = 64
+
+    /**
+     * Maximum nesting depth of raw rule JSON accepted before it reaches
+     * kotlinx-serialization's recursive-descent parser (#590). The parser
+     * overflows the stack on pathological nesting; the resulting
+     * [StackOverflowError] escapes the `Exception`-only loader catch (fail
+     * open). [parseBoundedJson] pre-scans depth and rejects past this bound as
+     * a typed [RuleCompileException] before the recursive parser runs. Generous
+     * (real rule files nest < 10); matches [MAX_PARSE_DEPTH].
+     */
+    const val MAX_JSON_DEPTH = 64
+
+    /**
+     * Parse rule JSON with a fail-CLOSED nesting bound (#590). A cheap linear
+     * pre-scan counts `{`/`[` nesting (skipping string literals + escapes) and
+     * throws [RuleCompileException] past [MAX_JSON_DEPTH] BEFORE
+     * [Json.parseToJsonElement] — whose recursive descent would otherwise
+     * [StackOverflowError] (an [Error] that escapes the loader's
+     * `Exception`-only catch, a fail-open crash). The only place the rule
+     * loader turns a raw string into JSON.
+     */
+    fun parseBoundedJson(jsonString: String): JsonElement {
+        assertJsonDepthWithinBound(jsonString)
+        return kotlinx.serialization.json.Json.parseToJsonElement(jsonString)
+    }
+
+    /** Linear depth pre-scan for [parseBoundedJson]; string-literal aware. */
+    private fun assertJsonDepthWithinBound(json: String) {
+        var depth = 0
+        var maxDepth = 0
+        var inString = false
+        var i = 0
+        while (i < json.length) {
+            val c = json[i]
+            if (inString) {
+                if (c == '\\') { i += 2; continue }
+                if (c == '"') inString = false
+            } else {
+                when (c) {
+                    '"' -> inString = true
+                    '{', '[' -> {
+                        depth++
+                        if (depth > maxDepth) maxDepth = depth
+                        if (depth > MAX_JSON_DEPTH) {
+                            throw RuleCompileException(
+                                "Rule JSON nesting depth exceeds MAX_JSON_DEPTH=$MAX_JSON_DEPTH",
+                            )
+                        }
+                    }
+                    '}', ']' -> if (depth > 0) depth--
+                }
+            }
+            i++
+        }
+    }
+
     // ==========================================================================
     //  Permission introspection
     // ==========================================================================
@@ -263,11 +331,23 @@ object RuleCompiler {
         return CompiledRedact(entries)
     }
 
-    /** Recursively scan raw rule JSON for a `"sha256"` transform value (#598). */
-    private fun jsonUsesSha256(element: JsonElement): Boolean = when (element) {
-        is JsonPrimitive -> element.isString && element.content == "sha256"
-        is JsonObject -> element.values.any { jsonUsesSha256(it) }
-        is JsonArray -> element.any { jsonUsesSha256(it) }
+    /**
+     * Recursively scan raw rule JSON for a `"sha256"` transform value (#598).
+     * Depth-bounded at [MAX_JSON_DEPTH] (#590): this walks the WHOLE raw rule
+     * object, so a pathologically nested rule would overflow the stack here
+     * before the parse-expression compiler's own [MAX_PARSE_DEPTH] guard runs.
+     * Production JSON is already depth-bounded by [parseBoundedJson], so this
+     * guard never trips for real rules; it makes [compileRules] fail-closed for
+     * a JSON tree handed in directly.
+     */
+    private fun jsonUsesSha256(element: JsonElement, depth: Int = 0): Boolean {
+        if (depth > MAX_JSON_DEPTH)
+            throw RuleCompileException("Rule JSON nesting exceeds MAX_JSON_DEPTH=$MAX_JSON_DEPTH")
+        return when (element) {
+            is JsonPrimitive -> element.isString && element.content == "sha256"
+            is JsonObject -> element.values.any { jsonUsesSha256(it, depth + 1) }
+            is JsonArray -> element.any { jsonUsesSha256(it, depth + 1) }
+        }
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -557,9 +637,17 @@ object RuleCompiler {
     // ==========================================================================
 
     /**
-     * Compile a single parse expression for screen rules.
+     * Compile a single parse expression for screen rules. [depth] bounds the
+     * `each`/`join`/`coalesce` recursion at [MAX_PARSE_DEPTH] (#590) — a fail-
+     * closed [RuleCompileException] in place of a stack-overflowing crash.
      */
-    private fun compileParseExpression(spec: JsonElement): (UiNode, Bindings) -> Any? {
+    private fun compileParseExpression(
+        spec: JsonElement,
+        depth: Int = 0,
+    ): (UiNode, Bindings) -> Any? {
+        if (depth > MAX_PARSE_DEPTH)
+            throw RuleCompileException("Parse expression nesting exceeds MAX_PARSE_DEPTH=$MAX_PARSE_DEPTH")
+
         if (spec is JsonPrimitive) {
             val value = spec.content
             return { _, _ -> value }
@@ -580,9 +668,9 @@ object RuleCompiler {
             "textAfterLabel" in obj -> compileTextAfterLabel(obj, fromName)
             "presence" in obj -> compilePresence(obj, fromName)
             "conditionalEnum" in obj -> compileConditionalEnum(obj, fromName)
-            "each" in obj -> compileEach(obj, fromName)
-            "join" in obj -> compileJoin(obj)
-            "coalesce" in obj -> compileCoalesce(obj)
+            "each" in obj -> compileEach(obj, fromName, depth)
+            "join" in obj -> compileJoin(obj, depth)
+            "coalesce" in obj -> compileCoalesce(obj, depth)
             "siblingOf" in obj -> compileSiblingOf(obj, fromName)
             "read" in obj && fromName != null -> compileReadFromBinding(obj, fromName)
             else -> throw RuleCompileException("Unknown parse expression keys: ${obj.keys}")
@@ -739,7 +827,7 @@ object RuleCompiler {
         }
     }
 
-    private fun compileEach(obj: JsonObject, fromName: String?): (UiNode, Bindings) -> Any? {
+    private fun compileEach(obj: JsonObject, fromName: String?, depth: Int = 0): (UiNode, Bindings) -> Any? {
         val findPred = compileNodePred(obj["each"]!!)
         val scopeSpec = obj["scope"]
         val excludeSpec = obj["exclude"]?.let { compileNodePred(it) }
@@ -748,7 +836,7 @@ object RuleCompiler {
 
         val compiledExtract: List<Pair<String, (UiNode, Bindings) -> Any?>> =
             extractObj.entries.map { (name, spec) ->
-                name to compileParseExpression(spec)
+                name to compileParseExpression(spec, depth + 1)
             }
 
         return { tree, bindings ->
@@ -775,13 +863,13 @@ object RuleCompiler {
         }
     }
 
-    private fun compileJoin(obj: JsonObject): (UiNode, Bindings) -> Any? {
+    private fun compileJoin(obj: JsonObject, depth: Int = 0): (UiNode, Bindings) -> Any? {
         val partsArray = obj["join"]!!.jsonArray
         val separator = obj["separator"]?.jsonPrimitive?.content ?: ""
         val skipNulls = obj["skipNulls"]?.jsonPrimitive?.booleanOrNull ?: true
         val transformSpec = obj["transform"]
 
-        val compiledParts = partsArray.map { compileParseExpression(it) }
+        val compiledParts = partsArray.map { compileParseExpression(it, depth + 1) }
 
         return { tree, bindings ->
             val values = compiledParts.map { it(tree, bindings)?.toString() }
@@ -797,7 +885,7 @@ object RuleCompiler {
         }
     }
 
-    private fun compileCoalesce(obj: JsonObject): (UiNode, Bindings) -> Any? {
+    private fun compileCoalesce(obj: JsonObject, depth: Int = 0): (UiNode, Bindings) -> Any? {
         // #549 hardening: coalesce returns the first non-null branch verbatim — it does NOT apply a
         // top-level transform. Silently dropping one would be a privacy footgun: a PII coalesce whose
         // sha256 sat at the top level (instead of inside each branch) would emit the RAW value. Reject
@@ -809,7 +897,7 @@ object RuleCompiler {
                     "would leak the raw value)",
             )
         }
-        val exprs = obj["coalesce"]!!.jsonArray.map { compileParseExpression(it) }
+        val exprs = obj["coalesce"]!!.jsonArray.map { compileParseExpression(it, depth + 1) }
 
         return { tree, bindings ->
             exprs.firstNotNullOfOrNull { it(tree, bindings) }

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/TransformRegistry.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/TransformRegistry.kt
@@ -32,7 +32,7 @@ object TransformRegistry {
 
     /** Compiled-regex cache for the `regex` transform (#362) — the spec is
      *  re-dispatched per value, so without this every value recompiled. */
-    private val regexCache = java.util.concurrent.ConcurrentHashMap<String, Regex>()
+    private val regexCache = java.util.concurrent.ConcurrentHashMap<String, BoundedRegex>()
 
     /**
      * Reference clock for time transforms (#343): the OBSERVATION's instant + zone,

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/notification/NotificationMapperTotalityTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/notification/NotificationMapperTotalityTest.kt
@@ -1,0 +1,99 @@
+package cloud.trotter.dashbuddy.core.pipeline.notification
+
+import android.app.Notification
+import android.os.Bundle
+import android.service.notification.StatusBarNotification
+import cloud.trotter.dashbuddy.core.pipeline.notification.mapper.toDomain
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.element
+import io.kotest.property.checkAll
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.mock
+
+/**
+ * #590 🔴 Invariant 3 — notification mapping is TOTAL.
+ *
+ * `StatusBarNotification.toDomain()` reads `notification.extras` and unwraps
+ * `getCharSequence(...)`. Notification extras are attacker-influenced untrusted
+ * input that unparcels lazily on first read; a malformed/custom-Parcelable extra
+ * can throw (`BadParcelableException`) — the textbook listener-crash class. Such
+ * a throw propagates up the notification pipeline flow and kills the listener
+ * (the crash class #430's supervision closed on the accessibility side).
+ *
+ * Red-first observation: pre-fix, `toDomain()` returned a non-null
+ * `RawNotificationData` and had no catch, so a throwing `getCharSequence`
+ * propagated straight out of the mapper (verified by this test throwing before
+ * the catch was added). Fix: the mapping is wrapped to return null on any
+ * exception (the pipeline's `mapNotNull` drops it) + one PII-free WARN — so one
+ * bad notification is dropped and the flow keeps emitting.
+ */
+class NotificationMapperTotalityTest {
+
+    /** A [StatusBarNotification] whose `notification` and `packageName` are stubbed. */
+    private fun sbn(notification: Notification, pkg: String = "com.doordash.driverapp"): StatusBarNotification =
+        mock {
+            on { this.notification } doReturn notification
+            on { packageName } doReturn pkg
+        }
+
+    /** A [Notification] whose `extras` bundle throws on any `getCharSequence`. */
+    private fun throwingNotification(): Notification {
+        val bundle: Bundle = mock {
+            on { getCharSequence(any()) } doThrow RuntimeException("simulated BadParcelableException")
+        }
+        return mock<Notification>().apply { extras = bundle }
+    }
+
+    /** A well-formed [Notification] carrying a title. */
+    private fun goodNotification(title: String): Notification {
+        val bundle: Bundle = mock {
+            on { getCharSequence("android.title") } doReturn title
+        }
+        return mock<Notification>().apply { extras = bundle }
+    }
+
+    @Test
+    fun `a throwing-extras notification is dropped, not propagated`() {
+        assertNull(sbn(throwingNotification()).toDomain())
+    }
+
+    @Test
+    fun `a well-formed notification still maps`() {
+        val mapped = sbn(goodNotification("Order ready")).toDomain()
+        assertNotNull(mapped)
+        assertEquals("Order ready", mapped!!.title)
+    }
+
+    @Test
+    fun `after a bad notification the flow keeps emitting`() = runTest {
+        val bad = sbn(throwingNotification())
+        val good = sbn(goodNotification("Order ready"))
+        val out = flowOf(bad, good)
+            .mapNotNull { it.toDomain() } // the exact pipeline operator
+            .toList()
+        assertEquals(1, out.size)
+        assertEquals("Order ready", out.single().title)
+    }
+
+    @Test
+    fun `property - a throw on any single extras key never escapes`() = runTest {
+        checkAll(50, Arb.element("android.title", "android.text", "android.bigText", "android.subText")) { key ->
+            val bundle: Bundle = mock {
+                on { getCharSequence(key) } doThrow RuntimeException("boom on $key")
+            }
+            val notif = mock<Notification>().apply { extras = bundle }
+            // Must not throw; a throwing key means the whole notification is dropped.
+            assertNull(sbn(notif).toDomain())
+        }
+    }
+}

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RegexBudgetPropertyTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RegexBudgetPropertyTest.kt
@@ -1,0 +1,118 @@
+package cloud.trotter.dashbuddy.core.pipeline.rules
+
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.element
+import io.kotest.property.arbitrary.list
+import io.kotest.property.checkAll
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+/**
+ * #590 🔴 Invariant 2 — an ACCEPTED rule regex has BOUNDED match time.
+ *
+ * [RegexSafety] rejects the nested-unbounded ReDoS family at COMPILE time, but
+ * its own KDoc admits Kotlin [Regex] has no match timeout and the structural
+ * heuristic is not sound on every catastrophic shape. Any pattern that evades it
+ * runs unbounded on the per-event classification thread.
+ *
+ * Red-first observation (pre-[BoundedRegex] probe): the compile heuristic
+ * ACCEPTS all four soundness-catalog patterns — `(a|aa)+$`, `(\w+)\1+`,
+ * `(a?)*b`, `(.*a){20}` — yet running the RAW `Regex` of `(a|aa)+$` and `(a?)*b`
+ * against a ~3 000-char pumping input threw `java.lang.StackOverflowError` (Java
+ * regex recurses per repetition) — an Error escaping every downstream
+ * Exception-only catch = a fail-OPEN crash of the classification thread. The fix
+ * routes every rule-authored match through [BoundedRegex] (interrupt watchdog +
+ * StackOverflowError catch, fail-closed no-match); the same patterns then return
+ * in single-digit ms.
+ *
+ * A failing property prints its seed; pin it with `PropTestConfig(seed = ...)`.
+ */
+class RegexBudgetPropertyTest {
+
+    private val catalog = listOf("(a|aa)+$", "(\\w+)\\1+", "(a?)*b", "(.*a){20}")
+
+    /** A pumping amplifier: a long run of the class + a non-matching tail. */
+    private fun pumpingInput(): String = "a".repeat(4_000) + "!"
+
+    /**
+     * Run [regex] against [input] on a watchdog thread; true iff it finished
+     * within [budgetMs]. [BoundedRegex]'s own 200 ms budget should always beat
+     * this 1 s outer net — a timeout here means the runtime guard failed.
+     */
+    private fun matchWithinBudget(regex: BoundedRegex, input: CharSequence, budgetMs: Long = 1_000): Boolean {
+        val exec = Executors.newSingleThreadExecutor()
+        return try {
+            val f = exec.submit<Boolean> { regex.containsMatchIn(input) }
+            try {
+                f.get(budgetMs, TimeUnit.MILLISECONDS)
+                true
+            } catch (e: TimeoutException) {
+                f.cancel(true)
+                false
+            }
+        } finally {
+            exec.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `soundness catalog - each pattern is rejected or provably bounded`() {
+        for (pattern in catalog) {
+            val bounded = try {
+                RegexSafety.compileRegex(pattern)
+            } catch (e: RuleCompileException) {
+                continue // rejected at compile — the other acceptable arm
+            }
+            // Accepted by the heuristic ⇒ the runtime budget must bound it.
+            assertTrue(
+                "accepted catalog pattern <$pattern> did not bound its match",
+                matchWithinBudget(bounded, pumpingInput()),
+            )
+        }
+    }
+
+    // --- Pattern grammar: well-formed regexes biased toward catastrophic shapes
+    //     (ambiguous alternation + outer quantifier, optional-inside-star). Most
+    //     nested-unbounded shapes are rejected by RegexSafety; the survivors are
+    //     what the property must prove bounded. --------------------------------
+
+    private val atom = Arb.element("a", "b", "\\w", "\\d", ".")
+    private val quant = Arb.element("", "*", "+", "?", "{2}", "{2,}")
+    private val unit = Arb.bindPair(atom, quant) { a, q -> "$a$q" }
+
+    private val group = Arb.bind3(unit, unit, quant) { u1, u2, q -> "($u1|$u2)$q" }
+
+    @Test
+    fun `property - every accepted generated pattern bounds its match`() = runTest {
+        val piece = Arb.element(0, 1) // 0 = unit, 1 = group
+        checkAll(
+            200,
+            Arb.list(piece, 1..3),
+            unit, group, Arb.element("", "$"),
+        ) { shape, u, g, anchor ->
+            val body = shape.joinToString("") { if (it == 0) u else g }
+            val pat = body + anchor
+            val bounded = try {
+                RegexSafety.compileRegex(pat)
+            } catch (e: RuleCompileException) {
+                return@checkAll // rejected/invalid — nothing to bound
+            }
+            assertTrue(
+                "accepted pattern <$pat> did not bound its match within the watchdog",
+                matchWithinBudget(bounded, pumpingInput()),
+            )
+        }
+    }
+}
+
+// --- Tiny Arb combinators (kept local; kotest-property has no 2/3-arg map) ---
+
+private fun <A, B> Arb.Companion.bindPair(a: Arb<A>, b: Arb<B>, f: (A, B) -> String): Arb<String> =
+    io.kotest.property.arbitrary.arbitrary { rs -> f(a.sample(rs).value, b.sample(rs).value) }
+
+private fun <A, B, C> Arb.Companion.bind3(a: Arb<A>, b: Arb<B>, c: Arb<C>, f: (A, B, C) -> String): Arb<String> =
+    io.kotest.property.arbitrary.arbitrary { rs -> f(a.sample(rs).value, b.sample(rs).value, c.sample(rs).value) }

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompileRecursionPropertyTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompileRecursionPropertyTest.kt
@@ -1,0 +1,121 @@
+package cloud.trotter.dashbuddy.core.pipeline.rules
+
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.element
+import io.kotest.property.arbitrary.int
+import io.kotest.property.checkAll
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #590 🔴 Invariant 1 — rule-compile recursion is FAIL-CLOSED.
+ *
+ * Nested parse expressions (`each`/`extract`, `join`, `coalesce`) and raw
+ * nested rule JSON must compile to success OR fail with the typed
+ * [RuleCompileException] — NEVER a [StackOverflowError]/OOM/other [Throwable].
+ * The loader ([JsonRuleInterpreter.loadSingle]) catches only [Exception]; a
+ * [StackOverflowError] is an [Error] and would escape it = a fail-OPEN crash of
+ * the rule-load / classification path.
+ *
+ * Red-first observation (pre-fix, kotest smoke reproduction): both
+ * `RuleCompiler.compileRules` over a depth-100 000 nested `coalesce` and
+ * `Json.parseToJsonElement` over depth-100 000 nested arrays threw
+ * `java.lang.StackOverflowError` (both compiled fine at depth 1 000). The fix is
+ * [RuleCompiler.MAX_PARSE_DEPTH] (parse-expression recursion) +
+ * [RuleCompiler.parseBoundedJson]/[RuleCompiler.MAX_JSON_DEPTH] (raw-JSON depth
+ * pre-scan before the recursive parser).
+ *
+ * A failing property prints its seed; pin it with `PropTestConfig(seed = ...)`
+ * to reproduce.
+ */
+class RuleCompileRecursionPropertyTest {
+
+    /** parse.fields.x = <verb> -> <verb> -> ... -> "lit", [depth] levels deep. */
+    private fun nestedParseRule(depth: Int, verb: String): JsonArray {
+        var expr: JsonElement = JsonPrimitive("lit")
+        repeat(depth) {
+            expr = when (verb) {
+                "coalesce" -> buildJsonObject { put("coalesce", buildJsonArray { add(expr) }) }
+                "join" -> buildJsonObject { put("join", buildJsonArray { add(expr) }) }
+                else -> buildJsonObject {
+                    put("each", buildJsonObject { put("hasNoId", JsonPrimitive(true)) })
+                    put("extract", buildJsonObject { put("v", expr) })
+                }
+            }
+        }
+        val rule = buildJsonObject {
+            put("id", JsonPrimitive("doordash.screen.probe"))
+            put("priority", JsonPrimitive(1))
+            put("parse", buildJsonObject { put("fields", buildJsonObject { put("x", expr) }) })
+        }
+        return JsonArray(listOf(rule))
+    }
+
+    /** Compile; return true iff only success or [RuleCompileException] resulted. */
+    private fun compileIsFailClosed(array: JsonArray): Boolean = try {
+        RuleCompiler.compileRules<Any>(array, RuleContext.SCREEN)
+        true
+    } catch (e: RuleCompileException) {
+        true
+    } catch (t: Throwable) {
+        System.err.println("parse-expr compile leaked ${t.javaClass.name}: ${t.message}")
+        false
+    }
+
+    /** Parse via the bounded parser; true iff only success or RuleCompileException. */
+    private fun parseIsFailClosed(json: String): Boolean = try {
+        RuleCompiler.parseBoundedJson(json)
+        true
+    } catch (e: RuleCompileException) {
+        true
+    } catch (t: Throwable) {
+        System.err.println("raw-JSON parse leaked ${t.javaClass.name}: ${t.message}")
+        false
+    }
+
+    @Test
+    fun `nested parse expressions at extreme depth never escape a raw Throwable`() {
+        for (verb in listOf("coalesce", "join", "each")) {
+            for (depth in listOf(21, 1_000, 100_000)) {
+                assertTrue(
+                    "verb=$verb depth=$depth must compile or throw RuleCompileException",
+                    compileIsFailClosed(nestedParseRule(depth, verb)),
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `raw nested JSON at extreme depth never escapes a raw Throwable`() {
+        for (depth in listOf(21, 1_000, 100_000)) {
+            val arrays = "[".repeat(depth) + "]".repeat(depth)
+            val objects = "{\"a\":".repeat(depth) + "1" + "}".repeat(depth)
+            assertTrue("nested arrays depth=$depth", parseIsFailClosed(arrays))
+            assertTrue("nested objects depth=$depth", parseIsFailClosed(objects))
+        }
+    }
+
+    @Test
+    fun `property - arbitrary parse-expression depth is always fail-closed`() = runTest {
+        val verbs = Arb.element("coalesce", "join", "each")
+        // Straddle MAX_PARSE_DEPTH (64) and go far past it into stack-overflow
+        // territory pre-fix.
+        checkAll(200, Arb.int(1, 5_000), verbs) { depth, verb ->
+            assertTrue(compileIsFailClosed(nestedParseRule(depth, verb)))
+        }
+    }
+
+    @Test
+    fun `property - arbitrary raw-JSON depth is always fail-closed`() = runTest {
+        checkAll(200, Arb.int(1, 5_000)) { depth ->
+            val json = "[".repeat(depth) + "]".repeat(depth)
+            assertTrue(parseIsFailClosed(json))
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ hilt = "2.59.2"
 hiltNavigationCompose = "1.3.0"
 junit = "4.13.2"
 junitVersion = "1.3.0"
+kotest = "5.9.1"
 kotlin = "2.3.20"
 kotlinSerialization = "1.10.0"
 kotlinxCoroutines = "1.10.2"
@@ -78,6 +79,7 @@ kotlinx-coroutines-play-services = { group = "org.jetbrains.kotlinx", name = "ko
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinSerialization" }
+kotest-property = { module = "io.kotest:kotest-property", version.ref = "kotest" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 mockito-core = { group = "org.mockito", name = "mockito-core", version.ref = "mockito" }
 mockito-kotlin = { group = "org.mockito.kotlin", name = "mockito-kotlin", version.ref = "mockitoKotlin" }


### PR DESCRIPTION
**PR 1 of #590** — adds the `kotest-property` framework and lands the three 🔴 confirmed fail-open gaps as **red-first property tests, each paired with its minimal fix in the same commit**. PR 2 of #590 (marker evasion, INFO+ replay gate, the Phase-1 fill-ins) remains open; Phase 2 fuzzing stays deferred.

## Framework choice

`io.kotest:kotest-property` **5.9.1 — the standalone property lib**, not the Kotest runner, not jqwik/Jazzer (both JUnit-Platform-only; this repo is JUnit 4 + Robolectric + the `AllMatchersSuite` `@Suite`). `Arb`/`checkAll`/`forAll` run inside plain JUnit-4 `@Test` bodies via `kotlinx.coroutines.test.runTest`; a trivial smoke property confirms it. Properties are bounded (~50–200 iterations); a failing run prints its seed, pinnable with `PropTestConfig(seed = …)`.

The issue's **CI-gap** checklist item is already resolved on `master` (`pr-check.yml:43` runs `./gradlew testDebugUnitTest :domain:test`; `CLAUDE.md:63` matches) — no workflow change needed.

## 🔴 Invariant 1 — rule-compile recursion is fail-closed

- **Red observed:** `RuleCompiler.compileRules` over a depth-100 000 nested `coalesce`/`join`/`each` parse expression **and** `Json.parseToJsonElement` over depth-100 000 nested JSON both threw `java.lang.StackOverflowError` (both fine at depth 1 000). A `StackOverflowError` is an `Error`, not an `Exception`, so it escapes the `Exception`-only catch in `JsonRuleInterpreter.loadSingle` = a fail-**open** crash of the rule-load / classify path. Three unbounded recursions were involved: the raw-JSON recursive-descent parser, the `each/extract/join/coalesce` parse-expression compiler, and `jsonUsesSha256` (walks the whole raw rule object).
- **Fix (fail closed, typed `RuleCompileException`):** `MAX_PARSE_DEPTH = 64` threaded through `compileParseExpression` + `compileEach/compileJoin/compileCoalesce`; `RuleCompiler.parseBoundedJson` + `MAX_JSON_DEPTH = 64` (a cheap linear, string-literal-aware depth pre-scan that rejects over-deep JSON before the recursive parser runs, now used by `loadSingle`); `jsonUsesSha256` depth-bounded. Constants are generous (real rules nest < 10).

## 🔴 Invariant 2 — accepted regex ⇒ bounded match time

- **Red observed:** `RegexSafety`'s compile-time heuristic **accepts all four** soundness-catalog patterns — `(a|aa)+$`, `(\w+)\1+`, `(a?)*b`, `(.*a){20}` — and running the RAW `Regex` of `(a|aa)+$` and `(a?)*b` against a ~3–4k-char pumping input threw `java.lang.StackOverflowError` (Java's regex recurses per repetition) — an `Error` escaping every downstream `Exception`-only catch. The other failure mode is an unbounded exponential hang on the same classification thread. `RegexSafety`'s own KDoc admits Kotlin `Regex` has no match timeout and the heuristic is not sound.
- **Fix (runtime match budget at the one rule-authored choke point):** `RegexSafety.compileRegex` now returns `BoundedRegex`, which runs each match on the calling thread against an `InterruptibleCharSequence` under a shared daemon watchdog (200 ms) **and** catches `StackOverflowError` — both modes fail closed to no-match (`false`/`null` → frame goes UNKNOWN → scrubbed) with one PII-free WARN. Only rule-authored regexes are wrapped; app-authored constant patterns keep the plain hot path. The four catalog evaders now return in single-digit ms.

## 🔴 Invariant 3 — notification mapping is total

- **Red observed:** a throwaway probe replicating the pre-fix `StatusBarNotification.toDomain()` body (a Mockito `Notification` whose `extras.getCharSequence` throws) propagated the exception straight out of the mapping — no catch existed. Notification extras unparcel lazily on first read; a malformed/custom-Parcelable extra throws `BadParcelableException`, the textbook listener-crash class, killing the pipeline flow.
- **Fix (parity with #430 accessibility-side supervision):** `toDomain()` now returns `RawNotificationData?`, wrapping the mapping in a catch that returns null on any `Exception` + one PII-free WARN. The pipeline's existing `.mapNotNull { sbn -> sbn.toDomain() }` drops the null — one bad notification is dropped as a single event and the flow keeps emitting. Tests use Mockito only (no Robolectric).

## Security posture

Untrusted-input boundaries hardened, all **fail closed**, **zero behavior change for well-formed rules**:
- Rule-JSON ingest + parse-expression compile: bounded nesting, only typed `RuleCompileException` escapes.
- Rule-authored regex execution: bounded match time (watchdog + `StackOverflowError` catch), no-match on exceed.
- Notification mapping: total; a malformed extra drops one event instead of crashing the listener.

`AllMatchersSuite` + parse-output goldens stay green — the production rules compile and recognize byte-identically.

## Runtime impact

The three new property/totality test classes add **10 tests, ~5.15 s** to the `:core:pipeline` test task. Local full gate (`testDebugUnitTest :domain:test`, warm) ≈ 26 s; `AllMatchersSuite` green. The ~6-min PR job stays flat.

## Design-goal review

- **6 (security & privacy — the governing principle):** this PR *is* the hardening. Three untrusted-input boundaries move from fail-open (crash/hang) to fail-closed (typed reject / bounded no-match / dropped event), each backed by a generative test. WARNs are Principle-7 compliant (defended-invariant level, tag `Pipeline`, no raw rule/notification/PII text).
- **4 (idiomatic Kotlin/Android):** property tests are idiomatic kotest-property inside JUnit-4 bodies; `BoundedRegex` is a small focused wrapper; constants carry KDoc.
- **7 (semantic, PII-safe logging):** the three new WARN sites are defended invariants firing (correct level), carry no raw PII.
- **8 (platform-agnostic core):** nothing platform-specific — no new platform literals, no rule↔state vocabulary; the guards are structural (depth/regex/exception) and apply to every ruleset. Touches `:core:pipeline` only.

## Adversarial review

Pending — to be run at fable tier (`/code-review` + `/security-review`) before merge, per the #589/#591 loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
