### PR TITLE
arch(#438): multiplatform pack A — per-platform timers/screen-target, post-merge uniqueness, Unknown-region filter

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
@@ -69,8 +69,16 @@ class SideEffectEngine @Inject constructor(
     )
     override val events: SharedFlow<StateEvent> = _events.asSharedFlow()
 
-    // Internal tracker for Timers (Replaces TimeoutHandler)
-    private val activeTimers = ConcurrentHashMap<Any, Job>()
+    /**
+     * Composite timer key (#438 item 1): the registry is keyed by (type, platform), not
+     * type alone. Two paused platforms each hold their own SESSION_PAUSED_SAFETY timer,
+     * and platform A's resume-cancel no longer untracks/kills platform B's timer of the
+     * same type. Null platform = a non-platform-scoped timer of this type.
+     */
+    private data class TimerKey(val type: TimeoutType, val platform: Platform?)
+
+    // Internal tracker for Timers (Replaces TimeoutHandler), keyed by (type, platform).
+    private val activeTimers = ConcurrentHashMap<TimerKey, Job>()
 
     // Action throttle tracker: effectKey → last fired timestamp
     private val actionLastFiredAt = ConcurrentHashMap<String, Long>()
@@ -392,7 +400,8 @@ class SideEffectEngine @Inject constructor(
 
             is AppEffect.CancelTimeout -> {
                 // Untracking happens via the job's self-removing completion handler.
-                activeTimers[effect.type]?.cancel()
+                // Keyed by (type, platform) so a resume cancels only THIS platform's timer.
+                activeTimers[TimerKey(effect.type, effect.platform)]?.cancel()
             }
         }
 
@@ -449,7 +458,10 @@ class SideEffectEngine @Inject constructor(
                 e.args,
                 Platform.fromRuleId(e.ruleId).takeIf { it != Platform.Unknown },
             )
-            EffectVerb.CANCEL_TIMEOUT -> cancelTimeoutFromArgs(e.args)
+            EffectVerb.CANCEL_TIMEOUT -> cancelTimeoutFromArgs(
+                e.args,
+                Platform.fromRuleId(e.ruleId).takeIf { it != Platform.Unknown },
+            )
         }
         return true
     }
@@ -551,8 +563,12 @@ class SideEffectEngine @Inject constructor(
      * THE timer pattern (#406): LAZY start so the map entry exists before the
      * body can run; the completion handler removes only ITSELF (two-arg
      * remove), so an expiring timer can never untrack a replacement of the
-     * same type (#341). Detached onto the engine scope — never blocks the
-     * queue (#351). Previously hand-rolled twice in this file.
+     * same (type, platform) key (#341). Detached onto the engine scope — never
+     * blocks the queue (#351). Previously hand-rolled twice in this file.
+     *
+     * Keyed by (type, platform) (#438 item 1): a schedule replaces only the
+     * same platform's timer of that type, so two platforms' timers of the same
+     * type coexist.
      */
     private fun scheduleTimer(
         type: TimeoutType,
@@ -560,7 +576,8 @@ class SideEffectEngine @Inject constructor(
         platform: Platform?,
         payload: ObservationPayload?,
     ) {
-        activeTimers[type]?.cancel()
+        val key = TimerKey(type, platform)
+        activeTimers[key]?.cancel()
         val job = engineScope.launch(start = CoroutineStart.LAZY) {
             delay(durationMs)
             Timber.w("Timer Expired: %s", type)
@@ -573,12 +590,12 @@ class SideEffectEngine @Inject constructor(
                 )
             )
         }
-        job.invokeOnCompletion { activeTimers.remove(type, job) }
-        activeTimers[type] = job
+        job.invokeOnCompletion { activeTimers.remove(key, job) }
+        activeTimers[key] = job
         job.start()
     }
 
-    private fun cancelTimeoutFromArgs(args: Map<String, String>) {
+    private fun cancelTimeoutFromArgs(args: Map<String, String>, platform: Platform?) {
         val typeWire = args["type"] ?: return
         val type = try {
             TimeoutType.valueOf(typeWire)
@@ -587,7 +604,8 @@ class SideEffectEngine @Inject constructor(
             return
         }
         // Untracking happens via the job's self-removing completion handler.
-        activeTimers[type]?.cancel()
+        // Keyed by (type, platform) to mirror the rule-driven schedule (#438 item 1).
+        activeTimers[TimerKey(type, platform)]?.cancel()
     }
 
     private fun isExternalEffect(effect: AppEffect): Boolean = when (effect) {

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/event/type/view/clicked/ClickClassifierTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/event/type/view/clicked/ClickClassifierTest.kt
@@ -3,6 +3,7 @@ package cloud.trotter.dashbuddy.core.pipeline.accessibility.event.type.view.clic
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
 import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
 import cloud.trotter.dashbuddy.domain.capture.ReplayMetadataProvider
 import cloud.trotter.dashbuddy.core.pipeline.ObservationClassifier
@@ -41,12 +42,21 @@ class ClickClassifierTest {
     )
 
     private fun classifyClick(node: UiNode, screenTarget: String? = null): Observation.Click {
-        // Set screen context so rules with screenIs constraints can match
-        ObservationClassifier::class.java.getDeclaredField("lastScreenTarget").apply {
-            isAccessible = true
-            set(classifier, screenTarget)
-        }
-        return classifier.classify(PipelineEvent.Click(System.currentTimeMillis(), node))
+        // Prime this platform's screen context so rules with screenIs constraints can
+        // match (#438 item 2 — the classifier now keys screen targets per platform wire).
+        // The click carries DoorDash's package so it resolves to the "doordash" wire.
+        @Suppress("UNCHECKED_CAST")
+        val targets = ObservationClassifier::class.java
+            .getDeclaredField("lastScreenTargets").apply { isAccessible = true }
+            .get(classifier) as MutableMap<String, String>
+        targets.clear()
+        if (screenTarget != null) targets[Platform.DoorDash.wire] = screenTarget
+        return classifier.classify(
+            PipelineEvent.Click(
+                System.currentTimeMillis(), node,
+                packageName = Platform.DoorDash.packageName,
+            ),
+        )
     }
 
     private fun Observation.Click.intent(): String =
@@ -153,6 +163,33 @@ class ClickClassifierTest {
         val fields = result.clickFields()
         assertNull(fields.nodeId)
         assertNull(fields.nodeText)
+    }
+
+    // =========================================================================
+    // Per-platform screen context (#438 item 2)
+    // =========================================================================
+
+    @Test
+    fun `another platform's screen target does not gate this platform's click`() {
+        // Prime ONLY Uber's screen context with pickup_arrival, then classify a
+        // DoorDash click whose rule requires screenIs=pickup_arrival. Before item 2
+        // the single global would have leaked Uber's screen and matched; now the
+        // DoorDash click has no primed target of its own and stays Unknown.
+        @Suppress("UNCHECKED_CAST")
+        val targets = ObservationClassifier::class.java
+            .getDeclaredField("lastScreenTargets").apply { isAccessible = true }
+            .get(classifier) as MutableMap<String, String>
+        targets.clear()
+        targets[Platform.Uber.wire] = "pickup_arrival"
+
+        val result = classifier.classify(
+            PipelineEvent.Click(
+                System.currentTimeMillis(),
+                node(viewId = "primary_action_button", text = "Arrived"),
+                packageName = Platform.DoorDash.packageName,
+            ),
+        )
+        assertEquals("unknown", result.intent())
     }
 
     @Test

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/state/StateMachineTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/state/StateMachineTest.kt
@@ -1195,6 +1195,66 @@ class StateMachineTest {
     }
 
     // =========================================================================
+    // #438 item 4 — Platform.Unknown region filter
+    // =========================================================================
+
+    @Test
+    fun `UiInput with null ruleId (Platform_Unknown) mints no platform region`() {
+        // An offer Accept/Decline dispatches Observation.UiInput with ruleId=null →
+        // Platform.fromRuleId(null) == Unknown. It must NOT create an Unknown region.
+        val state = AppState()
+        val next = machine.step(
+            state,
+            Observation.UiInput(timestamp = tick(), action = "accept"),
+        ).newState
+
+        assertTrue(
+            "no platform region may be minted for an Unknown-platform observation",
+            next.regions.platforms.isEmpty(),
+        )
+        assertNull(next.regions.platforms[Platform.Unknown])
+    }
+
+    @Test
+    fun `Unknown-platform observation does not step an existing real platform region`() {
+        // Get DoorDash Online, then feed an Unknown-platform UiInput: DoorDash's region
+        // survives untouched and no Unknown region appears.
+        var state = machine.step(
+            AppState(), screenObs(flow = Flow.OfferPresented, parsed = offerFields()),
+        ).newState
+        val ddBefore = state.regions.platforms[Platform.DoorDash]!!
+
+        state = machine.step(
+            state, Observation.UiInput(timestamp = tick(), action = "decline"),
+        ).newState
+
+        assertNull(state.regions.platforms[Platform.Unknown])
+        assertEquals(Mode.Online, state.regions.platforms[Platform.DoorDash]!!.mode)
+        assertEquals(ddBefore.session?.sessionId, state.regions.platforms[Platform.DoorDash]!!.session?.sessionId)
+    }
+
+    @Test
+    fun `a legacy persisted Unknown region is dropped on the next step (recovery decode-compat)`() {
+        // Simulate a snapshot decoded from before this fix: a stale PlatformRegion(Unknown)
+        // in the map. It must decode without crashing (Platform is a by-name enum — done by
+        // construction here) and be DROPPED on the next step, whatever that step's platform.
+        val legacy = AppState().let {
+            it.copy(
+                regions = it.regions.copy(
+                    platforms = mapOf(Platform.Unknown to PlatformRegion(Platform.Unknown)),
+                ),
+            )
+        }
+
+        val next = machine.step(
+            legacy, screenObs(flow = Flow.OfferPresented, parsed = offerFields()),
+        ).newState
+
+        assertNull("legacy Unknown region must be dropped", next.regions.platforms[Platform.Unknown])
+        assertNotNull(next.regions.platforms[Platform.DoorDash])
+    }
+
+    // =========================================================================
     // PRIVATE HELPERS
     // =========================================================================
 

--- a/app/src/test/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngineTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngineTest.kt
@@ -654,6 +654,78 @@ class SideEffectEngineTest {
     }
 
     @Test
+    fun `two platforms' timers of the same type coexist and each fires`() = runTest {
+        // #438 item 1: the registry is keyed by (type, platform), so two paused
+        // platforms each hold their own SESSION_PAUSED_SAFETY timer — before this,
+        // the second schedule cancelled the first (shared type key).
+        val engine = buildEngine(StandardTestDispatcher(testScheduler))
+        val fired = mutableListOf<TimeoutEvent>()
+        backgroundScope.launch(StandardTestDispatcher(testScheduler)) {
+            engine.events.collect { if (it is TimeoutEvent) fired.add(it) }
+        }
+        runCurrent()
+
+        engine.process(
+            AppEffect.ScheduleTimeout(
+                durationMs = 10, type = TimeoutType.SESSION_PAUSED_SAFETY,
+                platform = Platform.DoorDash,
+            ),
+        )
+        engine.process(
+            AppEffect.ScheduleTimeout(
+                durationMs = 10, type = TimeoutType.SESSION_PAUSED_SAFETY,
+                platform = Platform.Uber,
+            ),
+        )
+        runCurrent()
+        advanceTimeBy(11)
+        runCurrent()
+
+        assertEquals(2, fired.size)
+        assertEquals(
+            setOf(Platform.DoorDash, Platform.Uber),
+            fired.map { it.platform }.toSet(),
+        )
+    }
+
+    @Test
+    fun `cancelling one platform's timer leaves the other platform's timer armed`() = runTest {
+        // #438 item 1: platform A's resume CancelTimeout must not kill platform B's
+        // pause-safety timer of the same type.
+        val engine = buildEngine(StandardTestDispatcher(testScheduler))
+        val fired = mutableListOf<TimeoutEvent>()
+        backgroundScope.launch(StandardTestDispatcher(testScheduler)) {
+            engine.events.collect { if (it is TimeoutEvent) fired.add(it) }
+        }
+        runCurrent()
+
+        engine.process(
+            AppEffect.ScheduleTimeout(
+                durationMs = 100, type = TimeoutType.SESSION_PAUSED_SAFETY,
+                platform = Platform.DoorDash,
+            ),
+        )
+        engine.process(
+            AppEffect.ScheduleTimeout(
+                durationMs = 100, type = TimeoutType.SESSION_PAUSED_SAFETY,
+                platform = Platform.Uber,
+            ),
+        )
+        runCurrent()
+        // Cancel only DoorDash's timer.
+        engine.process(
+            AppEffect.CancelTimeout(TimeoutType.SESSION_PAUSED_SAFETY, Platform.DoorDash),
+        )
+        runCurrent()
+        advanceTimeBy(200)
+        runCurrent()
+
+        // Only Uber's timer survived and fired.
+        assertEquals(1, fired.size)
+        assertEquals(Platform.Uber, fired.single().platform)
+    }
+
+    @Test
     fun `timers still arm during recovery (loopback, not external)`() = runTest {
         val engine = buildEngine(StandardTestDispatcher(testScheduler))
         val fired = mutableListOf<TimeoutEvent>()

--- a/app/src/test/java/cloud/trotter/dashbuddy/test/util/SessionReplay.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/test/util/SessionReplay.kt
@@ -240,8 +240,8 @@ object SessionReplay {
     /**
      * Level B, heterogeneous — fold a timestamp-ordered mix of real screen/click captures and
      * synthetic click/timeout observations through the REAL [StateMachine]. ONE classifier instance
-     * handles both screens and clicks, so a preceding screen primes `lastScreenTarget` for the
-     * following click naturally (no reflection). Every observation is re-stamped with its input
+     * handles both screens and clicks, so a preceding screen primes that platform's last-screen
+     * target for the following click naturally (no reflection). Every observation is re-stamped with its input
      * [ReplayInput.atMs] (the classifier stamps wall-clock `eventNow`), keeping the fold
      * deterministic.
      */
@@ -318,7 +318,7 @@ object SessionReplay {
 
     /**
      * A classifier wired to **both** the production screen and click rulesets — one instance, so a
-     * screen classification updates `lastScreenTarget` for the next click ([reduceMixed]).
+     * screen classification updates that platform's last-screen target for the next click ([reduceMixed]).
      */
     private fun mixedClassifier(): ObservationClassifier = ObservationClassifier(
         mock<JsonRuleInterpreter> {

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/ObservationClassifier.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/ObservationClassifier.kt
@@ -15,6 +15,7 @@ import cloud.trotter.dashbuddy.core.pipeline.rules.JsonRuleInterpreter
 import cloud.trotter.dashbuddy.core.pipeline.rules.ParsedFieldsFactory
 import cloud.trotter.dashbuddy.core.pipeline.rules.TransformRegistry
 import timber.log.Timber
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
 import cloud.trotter.dashbuddy.domain.pipeline.UNKNOWN_TARGET
@@ -24,8 +25,8 @@ import cloud.trotter.dashbuddy.domain.pipeline.NO_ID_FALLBACK
  * Single classification entry point for all pipeline events.
  *
  * Dispatches to the appropriate compiled ruleset (screen, click, notification)
- * based on event type. Caches the last classified screen target so that click
- * observations are enriched with screen context.
+ * based on event type. Caches the last classified screen target PER PLATFORM so
+ * that click observations are enriched with THEIR platform's screen context.
  *
  * Replaces the former `ScreenClassifier`, `ClickClassifier`, and
  * `NotificationClassifier` classes.
@@ -35,10 +36,23 @@ class ObservationClassifier @Inject constructor(
     private val interpreter: JsonRuleInterpreter,
     private val metadataProvider: ReplayMetadataProvider,
 ) {
-    /** Last classified screen target — updated after every non-sensitive Screen classification. */
-    @Volatile
-    var lastScreenTarget: String? = null
-        private set
+    /**
+     * Last classified screen target, keyed by platform wire (#438 item 2). A single
+     * global `lastScreenTarget` let an Uber screen gate a DoorDash click rule's
+     * `screenIs` while both platforms dashed concurrently — latent under the
+     * single-platform alpha, wrong the moment two run at once.
+     *
+     * Honest keying: only a frame whose package resolves to a real platform (a
+     * non-null wire) WRITES here — a null/Unknown-platform frame can't clobber a
+     * real platform's entry. On the read side a click whose platform is Unknown
+     * gets NO screen context (`screenTargetFor` returns null): we won't gate a
+     * click rule with cross-frame screen context we can't attribute to a platform.
+     */
+    private val lastScreenTargets = ConcurrentHashMap<String, String>()
+
+    /** THIS platform's last non-sensitive screen target, or null when unattributable. */
+    private fun screenTargetFor(platformWire: String?): String? =
+        platformWire?.let { lastScreenTargets[it] }
 
     /** True once rulesets are published — pipelines drop frames until then (#432). */
     val isReady: Boolean get() = interpreter.isLoaded
@@ -123,9 +137,11 @@ class ObservationClassifier @Inject constructor(
             expectedOutcomes = result.outcomes,
         )
 
-        // Cache last non-sensitive screen for click enrichment
-        if (obs.parsed !is ParsedFields.SensitiveFields) {
-            lastScreenTarget = obs.target
+        // Cache last non-sensitive screen for click enrichment, keyed by THIS
+        // frame's platform (#438 item 2). An Unknown/null-platform frame (null wire)
+        // is skipped so it can't clobber a real platform's screen context.
+        if (obs.parsed !is ParsedFields.SensitiveFields && platformWire != null) {
+            obs.target?.let { lastScreenTargets[platformWire] = it }
         }
 
         return obs
@@ -164,9 +180,11 @@ class ObservationClassifier @Inject constructor(
         platformWire: String?,
         now: Long,
     ): Observation.Click {
+        // Gate this click against ITS OWN platform's last screen (#438 item 2).
+        val screenTarget = screenTargetFor(platformWire)
         val ruleset = interpreter.clickRuleset
         if (ruleset != null) {
-            val result = ruleset.matchFirst(event.node, platformWire, lastScreenTarget)
+            val result = ruleset.matchFirst(event.node, platformWire, screenTarget)
             if (result != null) {
                 val parsed = ParsedFields.ClickFields(intent = result.intent)
                 return Observation.Click(
@@ -181,7 +199,7 @@ class ObservationClassifier @Inject constructor(
                     effects = DedupeTokens.resolve(result.effects, parsed),
                     transitionOverrides = result.transitionOverrides,
                     expectedOutcomes = result.outcomes,
-                    screenTarget = lastScreenTarget,
+                    screenTarget = screenTarget,
                 )
             }
         }
@@ -204,7 +222,7 @@ class ObservationClassifier @Inject constructor(
                 nodeText = nodeText,
             ),
             target = UNKNOWN_TARGET,
-            screenTarget = lastScreenTarget,
+            screenTarget = screenTarget,
         )
     }
 

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/AccessibilityPipeline.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/AccessibilityPipeline.kt
@@ -140,7 +140,9 @@ class AccessibilityPipeline @Inject constructor(
             val contentHash = when (event) {
                 is PipelineEvent.Screen -> event.tree.stableHash
                 is PipelineEvent.Click ->
-                    clickDedupHash(event.node, classifier.lastScreenTarget)
+                    // #438 item 2: the click's own per-platform screen context (set at
+                    // classify time), not a global — Observation.Click carries it.
+                    clickDedupHash(event.node, (obs as? Observation.Click)?.screenTarget)
                 else -> null
             }
             if (!frameGate.admit(obs, contentHash)) {
@@ -154,7 +156,8 @@ class AccessibilityPipeline @Inject constructor(
                 obs is Observation.Screen && event is PipelineEvent.Screen ->
                     captureWriter.captureScreen(obs, event)
                 obs is Observation.Click && event is PipelineEvent.Click ->
-                    captureWriter.captureClick(obs, event, classifier.lastScreenTarget)
+                    // #438 item 2: capture with the click's own per-platform screen context.
+                    captureWriter.captureClick(obs, event, obs.screenTarget)
                 else -> obs
             }
         }

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/JsonRuleInterpreter.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/JsonRuleInterpreter.kt
@@ -109,15 +109,19 @@ class JsonRuleInterpreter @Inject constructor(
                 perFile += path to result
             }
 
-            // Cross-file rule-id collision policy (C3, #633): drop any LATER file that
-            // re-declares an id an EARLIER file already claimed, BEFORE the merge.
-            // Ruleset.byId is last-wins, so merging the later file would shadow the
+            // Post-merge cross-file collision policy (#633 rule-id + #438 item 3
+            // priority): drop any LATER file that collides with an EARLIER file on a
+            // rule id OR a (platform, section, priority) tuple, BEFORE the merge.
+            // Ruleset.byId is last-wins, so a re-declared id would shadow the
             // capture-redaction lookup (redactFor/notifRedactFor) across files while
             // priority-ordered matchFirst still recognizes with the earlier rule — the
             // wrong rule's redact could resolve and ship an id-keyed customer-PII node
-            // raw. Skips the offending file WHOLE (malformed-file-skip policy),
-            // complementing the within-file dup-id reject (#624). Earlier files keep
-            // every rule; other platforms are unaffected (no outage behind #432).
+            // raw. A duplicate priority within one platform's section makes matchFirst's
+            // tie-break decide recognition by load order silently. Both skip the
+            // offending file WHOLE (malformed-file-skip policy), complementing the
+            // within-file dup-id (#624) and per-file priority (compileRules) rejects.
+            // Earlier files keep every rule; other platforms are unaffected (no outage
+            // behind #432).
             val accepted = acceptNonCollidingFiles(perFile)
 
             val allScreens = mutableListOf<CompiledRule<UiNode>>()
@@ -356,26 +360,54 @@ fun missingSensitivePlatforms(screens: List<CompiledRule<UiNode>>): Set<Platform
 }
 
 /**
- * Cross-file rule-id collision policy (C3, #633). Given per-file compiled bundles in
- * LOAD ORDER, return only the files whose top-level rule ids don't collide with an id
- * an EARLIER-accepted file already claimed; a colliding file is SKIPPED WHOLE and
- * logged at ERROR (lost coverage), never merged.
+ * A merged-rule priority uniqueness key (#438 item 3): a duplicate priority is a
+ * conflict only WITHIN one platform's one rule section. Distinct platforms may reuse
+ * priorities freely (their rulesets never interleave in [Ruleset.matchFirst]), and a
+ * screen and a click may share a priority (separate rulesets).
+ */
+private data class PriorityKey(val platform: Platform, val section: String, val priority: Int)
+
+private fun bundlePriorityKeys(bundle: JsonRuleInterpreter.CompiledRuleBundle): List<PriorityKey> =
+    bundle.screens.map { PriorityKey(Platform.fromRuleId(it.id), "screens", it.priority) } +
+        bundle.clicks.map { PriorityKey(Platform.fromRuleId(it.id), "clicks", it.priority) } +
+        bundle.notifications.map { PriorityKey(Platform.fromRuleId(it.id), "notifications", it.priority) }
+
+/**
+ * Post-merge cross-file collision policy (#633 rule-id + #438 item 3 priority). Given
+ * per-file compiled bundles in LOAD ORDER, return only the files that don't collide with
+ * an EARLIER-accepted file on EITHER:
+ *  - a top-level rule id ([CompiledRule.id]), or
+ *  - a (platform, section, priority) tuple — priority uniqueness enforced POST-MERGE per
+ *    (platform, screens|clicks|notifications), not just per file.
+ * A colliding file is SKIPPED WHOLE and logged at ERROR (lost coverage), never merged.
  *
- * Why skip the LATER file, not the earlier one: [Ruleset]'s `byId` is last-wins, so a
+ * Why per (platform, section) post-merge: [RuleCompiler.compileRules] enforces priority
+ * uniqueness per rule TYPE within a SINGLE file, which is sufficient only because today
+ * each platform lives in exactly one asset file. The moment a platform splits across
+ * files (the #639 subrepo runtime path) or a remote OTA file ships alongside a bundled
+ * one (#192/#416), two files could each declare `doordash.screen` priority 100 and the
+ * per-file check would never see it — [Ruleset.matchFirst]'s stable-sort tie-break would
+ * then decide recognition by load order, silently. This is the post-merge analog of the
+ * canonicalize-time dup check (#639).
+ *
+ * Why skip the LATER file, not the earlier one (both collision kinds): consistent with
+ * the #633 first-file-wins policy. For a rule id, [Ruleset]'s `byId` is last-wins, so a
  * later file re-declaring an id would SHADOW the byId redact lookup
  * ([JsonRuleInterpreter.redactFor] / [JsonRuleInterpreter.notifRedactFor]) the capture
- * stage uses, while priority-ordered [Ruleset.matchFirst] still recognizes with a
+ * stage uses while priority-ordered [Ruleset.matchFirst] still recognizes with a
  * DIFFERENT rule — the wrong rule's `redact` block resolves and an id-keyed customer-PII
  * node (no marker prefix, invisible to the #624 screen backstop) could ship raw. Keeping
- * the earlier file's rules makes byId and matchFirst agree on that id.
+ * the earlier file's rules makes byId and matchFirst agree.
  *
  * ids come from top-level [CompiledRule.id] only — branches share the parent id and are
- * NOT in `byId`, so a branch never triggers a collision. Impossible with the current
- * prefix-namespaced asset bundles (`doordash.` / `uber.`), so this is a no-op today; it
- * hardens the future multi-file subrepo (#639) + untrusted CDN/fork rule path (#192/#416).
+ * NOT in `byId`, so a branch never triggers a collision. Both checks are impossible with
+ * the current prefix-namespaced single-file-per-platform asset bundles (`doordash.` /
+ * `uber.`), so this is a no-op today (byte-inert; [DefaultRulesIntegrationTest] and
+ * [ParseOutputGoldenTest] stay green); it hardens the future multi-file subrepo (#639) +
+ * untrusted CDN/fork rule path (#192/#416).
  *
  * Pure + top-level so it's unit-testable without an Android Context. The ERROR log names
- * the colliding id + both file paths ONLY — no rule text / no PII (Principle 7).
+ * the colliding id/priority + both file paths ONLY — no rule text / no PII (Principle 7).
  *
  * @param files compiled bundles in LOAD ORDER (earlier entries win a collision).
  */
@@ -383,21 +415,34 @@ fun acceptNonCollidingFiles(
     files: List<Pair<String, JsonRuleInterpreter.CompiledRuleBundle>>,
 ): List<Pair<String, JsonRuleInterpreter.CompiledRuleBundle>> {
     val claimedBy = HashMap<String, String>() // ruleId → first-claiming file path
+    val priorityClaimedBy = HashMap<PriorityKey, String>() // (platform, section, priority) → path
     val accepted = mutableListOf<Pair<String, JsonRuleInterpreter.CompiledRuleBundle>>()
     for ((path, bundle) in files) {
         val ids = bundle.screens.map { it.id } +
             bundle.clicks.map { it.id } +
             bundle.notifications.map { it.id }
-        val collision = ids.firstOrNull { it in claimedBy }
-        if (collision != null) {
+        val idCollision = ids.firstOrNull { it in claimedBy }
+        if (idCollision != null) {
             Timber.e(
                 "JsonRuleInterpreter: rule id '%s' in '%s' already claimed by '%s' — skipping the " +
                     "later file (cross-file byId redact-lookup shadow, #633)",
-                collision, path, claimedBy.getValue(collision),
+                idCollision, path, claimedBy.getValue(idCollision),
+            )
+            continue
+        }
+        val priorityKeys = bundlePriorityKeys(bundle)
+        val priorityCollision = priorityKeys.firstOrNull { it in priorityClaimedBy }
+        if (priorityCollision != null) {
+            Timber.e(
+                "JsonRuleInterpreter: %s priority %d for platform '%s' in '%s' already claimed by " +
+                    "'%s' — skipping the later file (post-merge priority uniqueness, #438)",
+                priorityCollision.section, priorityCollision.priority,
+                priorityCollision.platform.wire, path, priorityClaimedBy.getValue(priorityCollision),
             )
             continue
         }
         for (id in ids) claimedBy[id] = path
+        for (key in priorityKeys) priorityClaimedBy[key] = path
         accepted += path to bundle
     }
     return accepted

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/JsonRuleInterpreterCrossFileCollisionTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/JsonRuleInterpreterCrossFileCollisionTest.kt
@@ -112,6 +112,67 @@ class JsonRuleInterpreterCrossFileCollisionTest {
         assertNotNull(screens.ruleById("uber.screen.gamma_only"))
     }
 
+    /** A file with a single screen rule at [priority] with a unique id, for the given platform. */
+    private fun fileWithPriority(platform: String, id: String, priority: Int) = """
+        {
+          "format_version": 2,
+          "platform_id": "$platform",
+          "screens": [
+            { "id": "$id", "priority": $priority, "require": { "exists": { "hasText": "P" } } }
+          ]
+        }
+    """.trimIndent()
+
+    @Test
+    fun `later file colliding on a same-platform section priority is skipped`() {
+        // #438 item 3: two DIFFERENT files for the SAME platform declare the SAME
+        // screen priority with DISTINCT ids. compileRules' per-file check can't see
+        // it (different files); the post-merge gate rejects the later file.
+        val alpha = interpreter.loadSingle(
+            fileWithPriority("doordash.driver", "doordash.screen.a", 7777), "alpha.json",
+        )!!
+        val beta = interpreter.loadSingle(
+            fileWithPriority("doordash.driver", "doordash.screen.b", 7777), "beta.json",
+        )!!
+
+        val accepted = acceptNonCollidingFiles(listOf("alpha.json" to alpha, "beta.json" to beta))
+
+        // Later colliding file dropped whole; earlier survives.
+        assertEquals(listOf("alpha.json"), accepted.map { it.first })
+        val err = logs.entries.singleOrNull { it.priority == Log.ERROR }
+        assertNotNull("a priority collision must log exactly one ERROR", err)
+        assertTrue(err!!.message.contains("7777"))
+        assertTrue(err.message.contains("beta.json"))
+        assertTrue(err.message.contains("alpha.json"))
+
+        val screens = Ruleset(accepted.flatMap { it.second.screens })
+        assertNotNull(screens.ruleById("doordash.screen.a"))
+        assertNull(screens.ruleById("doordash.screen.b"))
+    }
+
+    @Test
+    fun `distinct platforms may reuse the same priority freely`() {
+        // #438 item 3: a DoorDash screen and an Uber screen at the SAME priority is
+        // NOT a collision — distinct platforms never interleave in matchFirst.
+        val dd = interpreter.loadSingle(
+            fileWithPriority("doordash.driver", "doordash.screen.a", 5555), "dd.json",
+        )!!
+        val uber = interpreter.loadSingle(
+            fileWithPriority("uber.driver", "uber.screen.a", 5555), "uber.json",
+        )!!
+
+        val accepted = acceptNonCollidingFiles(listOf("dd.json" to dd, "uber.json" to uber))
+
+        assertEquals(listOf("dd.json", "uber.json"), accepted.map { it.first })
+        assertTrue(
+            "cross-platform priority reuse must not log an ERROR",
+            logs.entries.none { it.priority == Log.ERROR },
+        )
+        val screens = Ruleset(accepted.flatMap { it.second.screens })
+        assertNotNull(screens.ruleById("doordash.screen.a"))
+        assertNotNull(screens.ruleById("uber.screen.a"))
+    }
+
     @Test
     fun `two files with disjoint ids both load fully`() {
         val one = interpreter.loadSingle(disjointFile("doordash.driver", "doordash.screen.one"), "one.json")!!

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/AppEffect.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/AppEffect.kt
@@ -104,7 +104,17 @@ sealed class AppEffect {
          */
         val payload: ObservationPayload? = null,
     ) : AppEffect()
-    data class CancelTimeout(val type: TimeoutType) : AppEffect()
+    data class CancelTimeout(
+        val type: TimeoutType,
+        /**
+         * Platform region whose timer of [type] to cancel (#438 item 1) — MUST match
+         * the [ScheduleTimeout.platform] of the timer being cancelled. The engine keys
+         * its timer registry by (type, platform), so two paused platforms hold their own
+         * SESSION_PAUSED_SAFETY timer and one platform's resume-cancel no longer kills the
+         * other's. Null = the non-platform-scoped timer of this type.
+         */
+        val platform: Platform? = null,
+    ) : AppEffect()
 
     data object StartOdometer : AppEffect()
     data object StopOdometer : AppEffect()

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -628,7 +628,7 @@ class EffectMap @Inject constructor() {
                         if (resumeOverride != null) {
                             addAll(resumeOverride)
                         } else {
-                            add(AppEffect.CancelTimeout(TimeoutType.SESSION_PAUSED_SAFETY))
+                            add(AppEffect.CancelTimeout(TimeoutType.SESSION_PAUSED_SAFETY, next.platform))
                         }
                     }
                 }
@@ -644,7 +644,7 @@ class EffectMap @Inject constructor() {
                         if (resumeOverride != null) {
                             addAll(resumeOverride)
                         } else {
-                            add(AppEffect.CancelTimeout(TimeoutType.SESSION_PAUSED_SAFETY))
+                            add(AppEffect.CancelTimeout(TimeoutType.SESSION_PAUSED_SAFETY, next.platform))
                         }
                     }
                 }
@@ -710,7 +710,7 @@ class EffectMap @Inject constructor() {
                     ),
                 )
             prevPend != null && nextPend == null ->
-                listOf(AppEffect.CancelTimeout(TimeoutType.GRACE_COMMIT))
+                listOf(AppEffect.CancelTimeout(TimeoutType.GRACE_COMMIT, next.platform))
             else -> emptyList()
         }
     }
@@ -719,8 +719,9 @@ class EffectMap @Inject constructor() {
      * Schedule/cancel the wake-up timer for a graced screen-implied resume out of
      * Paused (#605) — the [PlatformRegion.pendingModeResume] mirror of
      * [diffGraceTimer]. A SEPARATE [TimeoutType.MODE_RESUME_COMMIT] (not a shared
-     * GRACE_COMMIT) because SideEffectEngine.activeTimers is keyed by TimeoutType
-     * alone: a resume-grace GRACE_COMMIT would cross-cancel a live destructive grace
+     * GRACE_COMMIT) because both graces belong to the SAME platform region, so even the
+     * (type, platform) timer key (#438 item 1) would not separate them under a shared
+     * GRACE_COMMIT — a resume-grace timer would cross-cancel a live destructive grace
      * timer. Arm (or a re-arm with a new deadline) schedules; a cancel (paused frame
      * within the window, or the resume committing) cancels. A commit lands in the
      * cancel branch too — harmless, the timer has already fired or no-ops.
@@ -742,7 +743,7 @@ class EffectMap @Inject constructor() {
                     ),
                 )
             prevPend != null && nextPend == null ->
-                listOf(AppEffect.CancelTimeout(TimeoutType.MODE_RESUME_COMMIT))
+                listOf(AppEffect.CancelTimeout(TimeoutType.MODE_RESUME_COMMIT, next.platform))
             else -> emptyList()
         }
     }

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/StateMachine.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/StateMachine.kt
@@ -59,8 +59,22 @@ class StateMachine @Inject constructor(
         obs: Observation,
     ): Map<Platform, PlatformRegion> {
         val platform = obs.platform
+        // #438 item 4: an observation whose platform can't be resolved
+        // (Platform.Unknown — e.g. an offer Accept/Decline UiInput/Loopback that
+        // carries ruleId=null) must NOT mint or step a PlatformRegion(Unknown). R0
+        // (FlowRegion) already saw it — it was stepped in step() before this — and
+        // CrossPlatformRegion derives only from real platform regions; only this
+        // per-platform tier is skipped. Before this, the first such observation
+        // planted a permanent Unknown region into state + every snapshot, and it
+        // polluted the CrossPlatform aggregates (anyPlatformOnline / activeSessionCount).
+        //
+        // Decode-compat: an OLD snapshot that persisted an Unknown region before this
+        // fix still decodes fine (Platform is a by-name enum); it is simply DROPPED on
+        // the next step here (the `- Platform.Unknown` below runs on every observation,
+        // whatever its platform), never fed to a stepper — no recovery crash.
+        if (platform == Platform.Unknown) return prev - Platform.Unknown
         val prevRegion = prev[platform] ?: PlatformRegion(platform)
         val nextRegion = platformStepper.step(prevRegion, prevFlow, nextFlow, obs, transitionPolicy)
-        return prev + (platform to nextRegion)
+        return (prev + (platform to nextRegion)) - Platform.Unknown
     }
 }

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/Observation.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/Observation.kt
@@ -169,9 +169,10 @@ enum class TimeoutType {
      * (#605), committing a graced screen-implied resume out of [Mode.Paused].
      * Like [GRACE_COMMIT] it carries no handler logic — the stepper's lazy
      * expiry performs the mode flip. A SEPARATE type (not [GRACE_COMMIT] reuse)
-     * is REQUIRED because `SideEffectEngine.activeTimers` is keyed by
-     * [TimeoutType] alone: sharing [GRACE_COMMIT] would cross-cancel a live
-     * `TASK_RETIRE`/`SESSION_END` grace timer (re-opening #431).
+     * is REQUIRED because both graces belong to the SAME platform region, so even
+     * the (type, platform) timer key (#438 item 1) would not separate them: sharing
+     * [GRACE_COMMIT] would cross-cancel a live `TASK_RETIRE`/`SESSION_END` grace
+     * timer (re-opening #431).
      */
     MODE_RESUME_COMMIT,
 }


### PR DESCRIPTION
Multi-platform correctness pack A for #438 — the bounded, latent-today items from the 2026-06-11 architecture validation. All four are the same class: a **global-per-X resource that must be keyed per-platform**, harmless under the single-platform alpha but wrong the moment two platforms run concurrently (the CrossPlatformRegion / multi-app roadmap). This PR is Principle-8 enforcement work.

Scoping per the issue's 2026-07-05 comment: items **5/7/8/9** (core-stepper reshape, per-platform offer slots, actuation identity, odometer arbitration) and **6** (per-platform grace seam) stay open on #438 for a design session — they are explicit co-design items (with #251 / #245 / ADR-0007) and would bake in a slot shape the ADR is meant to own.

## Item 1 — timer registry keyed `(type, platform)`
`SideEffectEngine.activeTimers` was keyed by `TimeoutType` alone (anchors `SideEffectEngine.kt:68/414/428`). Two paused platforms shared ONE `SESSION_PAUSED_SAFETY` timer, and platform A's resume `CancelTimeout` untracked/killed platform B's timer of the same type.

- Registry keyed by a private `TimerKey(type, platform)` composite. The identity comes from the effect's **own data**, not a literal: `AppEffect.ScheduleTimeout` already threaded `platform` (for #342 fire-routing); `AppEffect.CancelTimeout` now carries it too, and every EffectMap cancel passes `next.platform` — the same value its sibling schedule passes.
- Cancel/replace preserved per `(type, platform)`. Rule-driven schedule/cancel (`SCHEDULE_TIMEOUT`/`CANCEL_TIMEOUT` verbs) both derive the platform from `ruleId` identically.
- The distinct `MODE_RESUME_COMMIT` vs `GRACE_COMMIT` type is still required — both graces belong to the **same** platform region, so the composite key alone wouldn't separate them; two stale comments (EffectMap, Observation) corrected.
- **Why latent today / breaks under concurrency:** one platform never holds two same-type timers at once, so the shared key never collides while a single platform dashes.

## Item 2 — per-platform `lastScreenTarget`
`ObservationClassifier.lastScreenTarget` was one global var (anchor `ObservationClassifier.kt:38-40`) used to gate click rules' `screenIs`. With two platforms dashing, an Uber screen could gate a DoorDash click rule.

- Keyed by the platform wire the classifier already resolves (`ConcurrentHashMap<wire, target>`).
- **Honest keying, KDoc'd:** only a frame whose package resolves to a real platform (non-null wire) WRITES, so a null/Unknown frame can't clobber a real platform's entry; a click whose platform is Unknown reads NO screen context — we won't gate a `screenIs` rule with cross-frame context we can't attribute to a platform.
- The two `AccessibilityPipeline` consumers now read the click observation's own `screenTarget` (set per-platform at classify time) instead of the classifier global — byte-inert, since for a click `obs.screenTarget` equals the value read immediately after classify.
- **Why latent today / breaks under concurrency:** a single platform's frames all resolve to one wire, so one bucket behaves exactly like the old global.

## Item 3 — post-merge priority uniqueness per `(platform, section)` + cross-file dup-ID
`RuleCompiler.compileRules` enforces priority uniqueness per rule TYPE within a **single file** (anchor `RuleCompiler.kt:148-159`) — sufficient only because today each platform is exactly one asset file. Split a platform across files (the #639 subrepo runtime path) or ship a remote OTA file beside a bundled one (#192/#416) and two files could each declare `doordash.screen` priority 100; the per-file check never sees it, and `Ruleset.matchFirst`'s stable-sort tie-break silently decides recognition by load order.

- **Extended** the existing #633 gate `acceptNonCollidingFiles` (rather than duplicate it) to also reject a LATER file colliding with an earlier-accepted file on a `(platform, section, priority)` tuple — skip the file WHOLE + ERROR, consistent with #633 first-file-wins. This is the runtime analog of the #639 canonicalize-time dup check.
- **Cross-file duplicate rule IDs** were already upgraded warn→fail-closed-skip by #633; this layers priority uniqueness onto the same gate. Distinct platforms may reuse priorities freely (their rulesets never interleave in `matchFirst`).
- **Byte-inert argument:** today's assets are single-file-per-platform with prefix-namespaced ids (`doordash.` / `uber.`), so no two files can ever share a platform — the new gate can never fire in production. The per-file `compileRules` check is unchanged. `AllMatchersSuite`, `DefaultRulesIntegrationTest`, and `ParseOutputGoldenTest` stay green with no regen. The ERROR log carries the id/priority + file paths only, no rule text / PII (Principle 7).

## Item 4 — filter `Platform.Unknown` from `stepPlatforms`
The first UiInput/Loopback whose platform couldn't be resolved (`Platform.fromRuleId(null) == Unknown`, e.g. an offer Accept/Decline carrying no `ruleId`) minted a **permanent** `PlatformRegion(Unknown)` into state + every snapshot (anchor `StateMachine.kt:61-64`) and polluted the `CrossPlatformRegion` aggregates (`anyPlatformOnline` / `activeSessionCount` fold over every region including Unknown).

- `stepPlatforms` skips Unknown: an Unknown-platform observation neither mints nor steps a region. R0/FlowRegion still sees it (stepped earlier in `step()`); CrossPlatform derives only from real regions — KDoc'd.
- **Decode-compat decision:** a snapshot persisted before this fix decodes fine (`Platform` is a by-name enum — no schema change), and the legacy Unknown region is actively **dropped on the next step** (`- Platform.Unknown` on both branches, so it clears regardless of the next observation's platform). No recovery crash; recovery tests stay green.
- **Why latent today:** item 8 (the anonymous Accept/Decline contract) is the literal mint source; without concurrent offers the stale Unknown region simply sat inert until now.

## Tests
- New: two platforms' same-type timers coexist + each fires; cancelling one leaves the other (item 1). An Uber screen target no longer gates a DoorDash click (item 2). Same-platform section priority collision → later file skipped + ERROR; distinct platforms reuse a priority freely (item 3). UiInput `ruleId=null` mints/steps no platform region; a live DoorDash region is untouched by an Unknown observation; a legacy persisted Unknown region is dropped on the next step (item 4).
- Full gate green: `testDebugUnitTest :domain:test`; `--tests "*AllMatchersSuite*"` green (item 3 byte-inert).

**No field-test checklist item:** items 1 and 4 do not change single-platform behavior (item 1 keys with the platform each single-platform timer already carried; item 4's Unknown path is only reached by the not-yet-shipped anonymous-actuation source, and R0 is unchanged). Items 2/3 are pipeline/load-time correctness with no on-dash single-platform surface.

### Design-goal review
- **8 (platform-agnostic core) — the whole PR.** Each item removes a global-per-X resource and re-keys it by an identity the data already carries: item 1 keys timers by `(type, platform)` from the effect's own `platform` field (no literal); item 2 keys screen targets by the wire the classifier already resolves; item 3 keys priority uniqueness by `(platform, section)` derived via `Platform.fromRuleId`; item 4 routes Unknown to no region via the `Platform` registry value, never a `== DoorDash` literal. No new platform literals, no magic-string `when`; new vocabulary rides existing enumerated contracts (`Platform`, `TimeoutType`).
- **1 (UDF).** Reducers/steppers stay pure — item 4 is a pure filter in `stepPlatforms` (obs-timestamp driven, no wall clock); item 1's keying lives at the effect edge (`SideEffectEngine`), not in a reducer; `CancelTimeout` gains a data field only.
- **5 (SSOT).** One owner per key: item 1's `TimerKey`, item 2's per-wire map, item 3's single post-merge gate (extended, not duplicated — reuses `acceptNonCollidingFiles`).
- **6 (security/privacy).** Item 3 keeps the fail-closed skip-whole-file policy and the no-PII ERROR log; item 2 preserves the sensitive-screen skip on writes. No change to trust boundaries or scrub layers.

Items 5/6/7/8/9 remain open on #438 for the design session.
