### PR TITLE
chore(#647): canonicalizer fail-loud guards — unknown section keys + flat/dir collision

### DIFF
--- a/matchers/build.gradle.kts
+++ b/matchers/build.gradle.kts
@@ -456,3 +456,8 @@ artifacts {
 }
 
 tasks.named("assemble") { dependsOn(canonicalizeRules) }
+
+// The hardening proof task runs with every canonicalize (#647 review): the guards
+// themselves fire inline during canonicalization, but this keeps their bad-input
+// proofs live in CI instead of rotting as a never-invoked standalone task.
+tasks.named("canonicalizeRules") { dependsOn("verifyMatchersHardening") }

--- a/matchers/build.gradle.kts
+++ b/matchers/build.gradle.kts
@@ -78,8 +78,86 @@ fun canonicalizeElement(element: JsonElement): String =
 fun canonicalizeJson5(src: String): String =
     canonicalizeElement(canonicalParser().parseToJsonElement(src))
 
+/** Unknown top-level key reject for a flat `<platform>.json5` source (#647).
+ * Kept out of `canonicalizeJson5` so that path stays a pure serializer (it is
+ * also re-fed a merged canonical element during the idempotency proof). */
+fun rejectUnknownFlatKeys(src: String, sourceLabel: String) {
+    val obj = canonicalParser().parseToJsonElement(src).jsonObject
+    val errs = unknownTopLevelKeyErrors(obj, FLAT_TOP_LEVEL_KEYS, sourceLabel)
+    if (errs.isNotEmpty()) throw GradleException(errs.joinToString("; "))
+}
+
 /** Rule sections, in the fixed canonical key order that follows the metadata. */
 val RULE_SECTIONS: List<String> = listOf("screens", "clicks", "notifications")
+
+// ---------------------------------------------------------------------------
+// Build-time fail-loud guards on the rule-source ingestion boundary (#647).
+//
+// These make two silent-drop failure modes LOUD at canonicalize time, in the
+// spirit of the #639 dup-id reject. Neither is reachable on today's sources;
+// both harden the multi-platform / untrusted-CDN-rules path (#192/M2).
+//
+// SSOT: the allowed top-level key set is derived once here from the metadata +
+// section vocabulary (`RULE_SECTIONS` above), then composed per file-kind — no
+// hand-maintained second copy per path.
+// ---------------------------------------------------------------------------
+/** Metadata keys carried by a flat file / a directory's `_manifest.json5`. */
+val METADATA_KEYS: List<String> = listOf("format_version", "platform_id")
+
+/** The editor `$schema` pointer is authoring metadata, allowed on every kind. */
+val SCHEMA_KEY: String = "\$schema"
+
+/** A flat `<platform>.json5` carries metadata + all sections (e.g. uber.json5). */
+val FLAT_TOP_LEVEL_KEYS: List<String> = listOf(SCHEMA_KEY) + METADATA_KEYS + RULE_SECTIONS
+
+/** A directory `_manifest.json5` is metadata ONLY — rules live in the surface
+ * sub-files; any section array here would be silently ignored by the merge. */
+val MANIFEST_TOP_LEVEL_KEYS: List<String> = listOf(SCHEMA_KEY) + METADATA_KEYS
+
+/** A surface sub-file carries only sections — metadata is read from the
+ * manifest, so a stray metadata key here would be silently ignored. */
+val SURFACE_TOP_LEVEL_KEYS: List<String> = listOf(SCHEMA_KEY) + RULE_SECTIONS
+
+/**
+ * Unknown top-level key reject (#647, deliverable 1). Any key on a rule-source
+ * object that is NOT in the allowed set for its file-kind is an author error —
+ * most importantly a typo'd section key (`"screen":` for `"screens":`, or a
+ * mis-named array), which today silently drops those rules from the merge (only
+ * corpus-covered rules would surface via the goldens). Returns human-readable
+ * error strings (empty when clean), naming the source and the offending key.
+ */
+fun unknownTopLevelKeyErrors(
+    obj: JsonObject,
+    allowed: List<String>,
+    sourceLabel: String,
+): List<String> =
+    obj.keys.filter { it !in allowed }.map {
+        "unknown top-level key '$it' in $sourceLabel (allowed: $allowed)"
+    }
+
+/**
+ * Platform file/dir collision reject (#647, deliverable 2). If both a flat
+ * `<platform>.json5` and a `<platform>/` directory exist for one platform, both
+ * emit `<platform>.json` and the later-processed one silently clobbers the
+ * other. Impossible today (each platform is one or the other). Takes
+ * (platform, sourceLabel) pairs so it is pure/testable independent of the
+ * filesystem; returns error strings (empty when clean).
+ */
+fun platformCollisionErrors(sources: List<Pair<String, String>>): List<String> {
+    val byPlatform = LinkedHashMap<String, MutableList<String>>()
+    sources.forEach { (platform, label) -> byPlatform.getOrPut(platform) { mutableListOf() } += label }
+    return byPlatform.filterValues { it.size > 1 }.map { (platform, labels) ->
+        "platform '$platform' has colliding sources (${labels.joinToString(", ")}): a platform must be " +
+            "EITHER a flat <platform>.json5 file OR a <platform>/ directory, not both"
+    }
+}
+
+/** Map the canonicalize entries (flat files + platform dirs) to (platform,
+ * sourceLabel) pairs for the collision check. */
+fun platformSources(entries: List<File>): List<Pair<String, String>> =
+    entries.map { e ->
+        if (e.isDirectory) e.name to "${e.name}/" else e.nameWithoutExtension to e.name
+    }
 
 /**
  * Directory path (#639): merge a platform DIRECTORY of surface sub-files into ONE
@@ -109,6 +187,11 @@ fun mergeRuleDirectory(dir: File): Pair<JsonElement, List<String>> {
         )
     }
     val manifest = parser.parseToJsonElement(manifestFile.readText(Charsets.UTF_8)).jsonObject
+    // Unknown-key reject (#647): the manifest is metadata ONLY — a section array
+    // here would be silently ignored by the merge below.
+    val keyErrors = unknownTopLevelKeyErrors(
+        manifest, MANIFEST_TOP_LEVEL_KEYS, "${dir.name}/_manifest.json5",
+    ).toMutableList()
     val metadata = linkedMapOf<String, JsonElement>(
         "format_version" to (manifest["format_version"]
             ?: throw GradleException("${dir.name}/_manifest.json5 missing format_version")),
@@ -126,6 +209,9 @@ fun mergeRuleDirectory(dir: File): Pair<JsonElement, List<String>> {
 
     subFiles.forEach { f ->
         val obj = parser.parseToJsonElement(f.readText(Charsets.UTF_8)).jsonObject
+        // Unknown-key reject (#647): a surface sub-file carries only sections
+        // (`$schema` aside) — a typo'd section key silently drops its rules.
+        keyErrors += unknownTopLevelKeyErrors(obj, SURFACE_TOP_LEVEL_KEYS, "${dir.name}/${f.name}")
         RULE_SECTIONS.forEach { section ->
             val arr = obj[section] as? JsonArray ?: return@forEach
             arr.forEach { rule ->
@@ -142,6 +228,10 @@ fun mergeRuleDirectory(dir: File): Pair<JsonElement, List<String>> {
             }
         }
     }
+
+    // Unknown top-level keys are structural author errors (like a missing
+    // manifest) — fail loud immediately, listing every offending file+key.
+    if (keyErrors.isNotEmpty()) throw GradleException(keyErrors.joinToString("; "))
 
     // metadata (format_version, platform_id) first, then the three sections in
     // fixed order — LinkedHashMap `plus` preserves insertion order.
@@ -199,6 +289,11 @@ val canonicalizeRules = tasks.register("canonicalizeRules") {
         if (entries.isEmpty()) {
             throw GradleException("no rules sources (rules/*.json5 files or rules/<platform>/ directories) found")
         }
+        // Platform file/dir collision reject (#647): fail before any output is
+        // written, so a colliding flat file can't silently clobber a merged dir.
+        platformCollisionErrors(platformSources(entries)).let {
+            if (it.isNotEmpty()) throw GradleException(it.joinToString("; "))
+        }
         entries.forEach { entry ->
             val platform: String
             val canon: String
@@ -209,7 +304,9 @@ val canonicalizeRules = tasks.register("canonicalizeRules") {
                 canon = canonicalizeElement(merged)
             } else {
                 platform = entry.nameWithoutExtension
-                canon = canonicalizeJson5(entry.readText(Charsets.UTF_8))
+                val text = entry.readText(Charsets.UTF_8)
+                rejectUnknownFlatKeys(text, entry.name) // #647: parity with the dir path
+                canon = canonicalizeJson5(text)
             }
             File(out, "$platform.json").writeText(canon, Charsets.UTF_8)
             logger.lifecycle("canonicalized ${entry.name} -> $platform.json (${canon.toByteArray().size} bytes)")
@@ -234,6 +331,10 @@ tasks.register("verifyMatchersCanonical") {
         val entries = srcDir.asFile.listFiles { f -> f.isDirectory || f.extension == "json5" }
             ?.sortedBy { it.name } ?: emptyList()
         if (entries.isEmpty()) throw GradleException("no rules sources found to verify")
+        // Platform file/dir collision reject (#647).
+        platformCollisionErrors(platformSources(entries)).let {
+            if (it.isNotEmpty()) throw GradleException(it.joinToString("; "))
+        }
         entries.forEach { entry ->
             val platform: String
             // `once` is the canonical output for this platform (merged for a
@@ -248,7 +349,9 @@ tasks.register("verifyMatchersCanonical") {
                 once = canonicalizeElement(merged)
             } else {
                 platform = entry.nameWithoutExtension
-                once = canonicalizeJson5(entry.readText(Charsets.UTF_8))
+                val text = entry.readText(Charsets.UTF_8)
+                rejectUnknownFlatKeys(text, entry.name) // #647
+                once = canonicalizeJson5(text)
             }
             // Idempotency on the (possibly merged) canonical output: feeding it
             // back through the single-file canonicalizer must reproduce it exactly.
@@ -264,6 +367,77 @@ tasks.register("verifyMatchersCanonical") {
             }
             logger.lifecycle("PROOF OK: ${entry.name} canonicalizes idempotently to schema-valid, dup-id-free JSON (${once.toByteArray().size} bytes).")
         }
+    }
+}
+
+// ---- Hardening-guard PROOF (#647). The two fail-loud guards are unreachable on
+// today's clean sources, so `canonicalizeRules`/`verifyMatchersCanonical` only
+// prove they DON'T false-positive. This task drives the pure guard functions
+// with SYNTHETIC bad + clean inputs to prove they actually FIRE — the honest
+// negative test the build-script has no unit-test source set to host otherwise.
+tasks.register("verifyMatchersHardening") {
+    group = "matchers"
+    description = "PROOF (#647): the unknown-top-level-key and platform file/dir collision guards fire on bad inputs and pass clean inputs."
+    doLast {
+        val parser = canonicalParser()
+        fun require(cond: Boolean, msg: String) {
+            if (!cond) throw GradleException("verifyMatchersHardening FAILED: $msg")
+        }
+        fun obj(json: String): JsonObject = parser.parseToJsonElement(json).jsonObject
+
+        // Deliverable 1 — unknown top-level key.
+        val typo = unknownTopLevelKeyErrors(
+            obj("""{ "${SCHEMA_KEY}": "x", "screen": [] }"""), SURFACE_TOP_LEVEL_KEYS, "doordash/offer.json5",
+        )
+        require(
+            typo.size == 1 && typo.single().contains("'screen'") && typo.single().contains("offer.json5"),
+            "typo'd surface section key not rejected: $typo",
+        )
+        require(
+            unknownTopLevelKeyErrors(
+                obj("""{ "${SCHEMA_KEY}": "x", "screens": [], "clicks": [], "notifications": [] }"""),
+                SURFACE_TOP_LEVEL_KEYS, "doordash/offer.json5",
+            ).isEmpty(),
+            "clean surface sub-file wrongly flagged",
+        )
+        val manifestBad = unknownTopLevelKeyErrors(
+            obj("""{ "format_version": 2, "platform_id": "p", "screens": [] }"""),
+            MANIFEST_TOP_LEVEL_KEYS, "doordash/_manifest.json5",
+        )
+        require(
+            manifestBad.size == 1 && manifestBad.single().contains("'screens'"),
+            "manifest section key (silently ignored by merge) not rejected: $manifestBad",
+        )
+        require(
+            unknownTopLevelKeyErrors(
+                obj("""{ "${SCHEMA_KEY}": "x", "format_version": 2, "platform_id": "p" }"""),
+                MANIFEST_TOP_LEVEL_KEYS, "doordash/_manifest.json5",
+            ).isEmpty(),
+            "clean manifest wrongly flagged",
+        )
+        require(
+            unknownTopLevelKeyErrors(
+                obj("""{ "${SCHEMA_KEY}": "x", "format_version": 2, "platform_id": "p", "screens": [], "clicks": [], "notifications": [] }"""),
+                FLAT_TOP_LEVEL_KEYS, "uber.json5",
+            ).isEmpty(),
+            "clean flat file wrongly flagged",
+        )
+
+        // Deliverable 2 — platform file/dir collision.
+        val collide = platformCollisionErrors(
+            listOf("uber" to "uber.json5", "uber" to "uber/", "doordash" to "doordash/"),
+        )
+        require(
+            collide.size == 1 && collide.single().contains("'uber'") &&
+                collide.single().contains("uber.json5") && collide.single().contains("uber/"),
+            "flat/dir collision for one platform not detected: $collide",
+        )
+        require(
+            platformCollisionErrors(listOf("uber" to "uber.json5", "doordash" to "doordash/")).isEmpty(),
+            "distinct platforms wrongly flagged as colliding",
+        )
+
+        logger.lifecycle("PROOF OK (#647): unknown-key + collision guards fire on bad inputs and pass clean inputs.")
     }
 }
 


### PR DESCRIPTION
Closes #647.

## What / why

Two build-time fail-loud guards on the matchers rule-source ingestion boundary (`matchers/build.gradle.kts`), the two LOW hardening items from the #639 (PR #646) adversarial review. Neither is reachable on today's clean sources; both harden the multi-platform / untrusted-CDN-rules path (#192/M2) by turning **silent-drop** failure modes **loud** at canonicalize time — the same spirit as the #639 dup-id reject.

**1. Unknown top-level key reject (both paths).** A rule-source object carrying any key outside the allowed set for its file-kind now fails the build, naming the file + offending key. This catches a typo'd section key (`"screen":` for `"screens":`, or a mis-named array) that previously **silently dropped** those rules from the merge — only corpus-covered rules would ever surface the loss via the goldens. Enforced **per file-kind** (the real sources imply distinct legitimate sets):
  - **flat** `<platform>.json5` (uber): `$schema` + `format_version`/`platform_id` + `screens`/`clicks`/`notifications`
  - **manifest** `_manifest.json5`: `$schema` + metadata **only** — a section array here is silently ignored by the merge, so it's now rejected
  - **surface sub-file** (offer.json5, …): `$schema` + sections **only** — metadata is read from the manifest, so a stray metadata key is rejected

**2. Platform file/dir collision reject.** If both `<platform>.json5` and `<platform>/` ever exist for one platform, both emit `<platform>.json` and the later-processed (flat) output silently clobbers the merged one. Now fails loud naming the platform + both sources, before any output is written. Impossible on today's sources (each platform is one or the other).

## Byte-identical proof (today's sources)

Ran `:core:pipeline:importMatchersRules --rerun-tasks` before and after the change and diffed the generated assets:

```
diff baseline/doordash.json  generated/doordash.json  -> IDENTICAL (118873 bytes)
diff baseline/uber.json      generated/uber.json      -> IDENTICAL ( 20447 bytes)
```

The guards only add validation ahead of the unchanged serializer/merge; they cannot alter output. Confirmed inert.

## Test approach

The matchers included build has **no unit-test source set** (the #639 dup-id check likewise lives only as build-script logic, proven via the `verifyMatchers*` proof tasks + the app's goldens). So the guard predicates were factored into **pure, filesystem-independent functions** (`unknownTopLevelKeyErrors`, `platformCollisionErrors` over `(platform, sourceLabel)` pairs) and a new **`verifyMatchersHardening`** proof task drives them with synthetic **bad + clean** inputs — asserting each guard *fires* on the bad case (a typo'd `"screen"`, a section in a manifest, a `uber.json5`/`uber/` collision) and *passes* the clean case. Both `verifyMatchersHardening` and the existing `verifyMatchersCanonical` are green.

Additionally verified **live**: temporarily renamed `screens`→`screen` in a real `doordash/offer.json5` and confirmed `canonicalizeRules` fails with `unknown top-level key 'screen' in doordash/offer.json5 (allowed: [$schema, screens, clicks, notifications])`, then restored the source.

`JAVA_HOME=/usr/lib/jvm/java-25-openjdk ./gradlew :core:pipeline:importMatchersRules testDebugUnitTest :domain:test` — **BUILD SUCCESSFUL**.

No field-test item (build-time only).

### Design-goal review

- **Principle 6 (Security & privacy — fail-closed at the untrusted-input boundary).** Both guards make the rule-source ingestion boundary fail **loud/closed**: a typo that would silently drop rules, and a filename collision that would silently clobber a canonical asset, now fail the build instead of shipping a degraded ruleset behind the #432 fail-closed load gate. Directly hardens the #192/M2 CDN-rules path where rule sources become untrusted input.
- **Principle 5 (SSOT).** The allowed-key vocabulary is defined **once** (`METADATA_KEYS` + the existing `RULE_SECTIONS` + `SCHEMA_KEY`) and composed into the three per-file-kind sets; the flat and directory paths both route their unknown-key check through the single `unknownTopLevelKeyErrors` helper — no hand-maintained second copy per path.
- **Principle 3 (single responsibility).** Guard logic factored into small pure functions rather than inlined into the task bodies, which also makes them testable without a test source set.
- Principle 8 (platform-agnostic): no new platform literals — the checks are keyed off file structure/vocabulary, not any specific platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)