### PR TITLE
refactor(#293): RuleCompiler robustness — typed rejects, per-rule isolation (sensitive-exempt), value-honoring predicates

### DIFF
--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/JsonRuleInterpreter.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/JsonRuleInterpreter.kt
@@ -227,14 +227,18 @@ class JsonRuleInterpreter @Inject constructor(
                 )
             }
 
+            // #293 item 8: the file's platform_id (validated present by
+            // RulesetLoader.validate) pins each rule id's required platform prefix.
+            val platformId = root["platform_id"]?.jsonPrimitive?.content
+
             val screens = root["screens"]?.jsonArray
-                ?.let { RuleCompiler.compileRules<UiNode>(it, RuleContext.SCREEN) }
+                ?.let { RuleCompiler.compileRules<UiNode>(it, RuleContext.SCREEN, platformId) }
                 ?: emptyList()
             val clicks = root["clicks"]?.jsonArray
-                ?.let { RuleCompiler.compileRules<UiNode>(it, RuleContext.CLICK) }
+                ?.let { RuleCompiler.compileRules<UiNode>(it, RuleContext.CLICK, platformId) }
                 ?: emptyList()
             val notifications = root["notifications"]?.jsonArray
-                ?.let { RuleCompiler.compileRules<RawNotificationData>(it, RuleContext.NOTIFICATION) }
+                ?.let { RuleCompiler.compileRules<RawNotificationData>(it, RuleContext.NOTIFICATION, platformId) }
                 ?: emptyList()
 
             val formatVersion = root["format_version"]?.jsonPrimitive?.int

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/ParsedFieldsFactory.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/ParsedFieldsFactory.kt
@@ -55,6 +55,7 @@ object ParsedFieldsFactory {
                 throw RuleCompileException(
                     "Rule '$ruleId' declares shape '$shape' but parse block is missing required " +
                         "fields: ${missing.joinToString(", ") { "'$it'" }}",
+                    isolable = true, // authoring-level shape violation — the rule isolates (#293 item 4)
                 )
             }
         }
@@ -65,6 +66,7 @@ object ParsedFieldsFactory {
                     throw RuleCompileException(
                         "Rule '$ruleId' declares shape '$shape' but parse block must include " +
                             "at least one of: ${group.joinToString(", ") { "'$it'" }}",
+                        isolable = true, // authoring-level shape violation — the rule isolates (#293 item 4)
                     )
                 }
             }

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompileException.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompileException.kt
@@ -3,20 +3,23 @@ package cloud.trotter.dashbuddy.core.pipeline.rules
 /**
  * Thrown when a rule JSON cannot be compiled into a valid lambda.
  *
- * [failClosed] marks a rejection that must reject the WHOLE file rather than be
- * isolated to the single offending rule by the per-rule fault-isolation loop
- * (#293 item 4). Set it for **security / Pledge / DoS** controls — an anti-DoS
- * cap (#419), a customer-PII / capture-redaction guard (#598/#620/#624), an
- * actuation reject (#425), or a compile-recursion/depth bound (#590) — where a
- * silent per-rule skip would weaken a documented fail-closed control. The
- * default (`false`) is a genuine *authoring* malformation (a bad predicate, an
- * unknown key, a mistyped field, a bad platform prefix): those degrade one
- * recognition surface to UNKNOWN (→ scrubbed — safe) and so isolate to a
- * skip+WARN. Sensitive-layer rules ALSO always reject whole-file, decided
- * separately from the rule id (see `RuleCompiler.rawRuleIsSensitive`).
+ * [isolable] — per-rule fault isolation (#293 item 4) is **OPT-IN**. The
+ * default (`false`) is the conservative WHOLE-FILE reject (the pre-#293
+ * status quo), so a FUTURE security-relevant compile check that forgets to
+ * think about isolation can never be silently downgraded to a per-rule skip —
+ * the failure mode of a forgotten tag is a loud over-reject, not a quiet
+ * pledge weakening (Principle 6: do not trust call-site discipline). Tag
+ * `isolable = true` ONLY on rule-authoring-level validations (a bad predicate,
+ * an unknown key, a mistyped field, a bad platform prefix, a bad parse shape)
+ * whose worst case is ONE recognition surface degrading to UNKNOWN (→ capture
+ * scrub — safe). Security / Pledge / DoS controls (#419 caps, #598/#620/#624
+ * capture-PII guards, #425 actuation rejects, #590 depth bounds) stay
+ * untagged and reject the whole file by default. Even an isolable error still
+ * rejects the whole file when the offending rule is sensitive-layer (see
+ * `RuleCompiler.rawRuleIsSensitive` — the belt on top of this default).
  */
 class RuleCompileException(
     message: String,
     cause: Throwable? = null,
-    val failClosed: Boolean = false,
+    val isolable: Boolean = false,
 ) : Exception(message, cause)

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompileException.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompileException.kt
@@ -1,5 +1,22 @@
 package cloud.trotter.dashbuddy.core.pipeline.rules
 
-/** Thrown when a rule JSON cannot be compiled into a valid lambda. */
-class RuleCompileException(message: String, cause: Throwable? = null) :
-    Exception(message, cause)
+/**
+ * Thrown when a rule JSON cannot be compiled into a valid lambda.
+ *
+ * [failClosed] marks a rejection that must reject the WHOLE file rather than be
+ * isolated to the single offending rule by the per-rule fault-isolation loop
+ * (#293 item 4). Set it for **security / Pledge / DoS** controls — an anti-DoS
+ * cap (#419), a customer-PII / capture-redaction guard (#598/#620/#624), an
+ * actuation reject (#425), or a compile-recursion/depth bound (#590) — where a
+ * silent per-rule skip would weaken a documented fail-closed control. The
+ * default (`false`) is a genuine *authoring* malformation (a bad predicate, an
+ * unknown key, a mistyped field, a bad platform prefix): those degrade one
+ * recognition surface to UNKNOWN (→ scrubbed — safe) and so isolate to a
+ * skip+WARN. Sensitive-layer rules ALSO always reject whole-file, decided
+ * separately from the rule id (see `RuleCompiler.rawRuleIsSensitive`).
+ */
+class RuleCompileException(
+    message: String,
+    cause: Throwable? = null,
+    val failClosed: Boolean = false,
+) : Exception(message, cause)

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompiler.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompiler.kt
@@ -17,6 +17,8 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.longOrNull
+import timber.log.Timber
+import java.util.Locale
 
 /**
  * Compiles a parsed `rules.json` [JsonElement] tree into typed lambda rulesets.
@@ -145,6 +147,7 @@ object RuleCompiler {
                         if (depth > MAX_JSON_DEPTH) {
                             throw RuleCompileException(
                                 "Rule JSON nesting depth exceeds MAX_JSON_DEPTH=$MAX_JSON_DEPTH",
+                                failClosed = true,
                             )
                         }
                     }
@@ -213,15 +216,47 @@ object RuleCompiler {
      * Compile a JSON array of rule objects into typed [CompiledRule] instances.
      * The [context] determines predicate vocabulary and parse input source.
      */
-    fun <TInput> compileRules(array: JsonArray, context: RuleContext): List<CompiledRule<TInput>> {
-        val rules = array.map { compileRule<TInput>(it.jsonObject, context) }
+    fun <TInput> compileRules(
+        array: JsonArray,
+        context: RuleContext,
+        platformId: String? = null,
+    ): List<CompiledRule<TInput>> {
+        // #293 item 4: per-rule fault isolation. One malformed rule SKIPS (WARN
+        // with id + reason, no rule-body text — P7) instead of failing the whole
+        // file — EXCEPT it still rejects the WHOLE file when EITHER:
+        //   • the rule is part of the sensitive LAYER (id carries `.sensitive.`,
+        //     `overrideable == false`, or an unreadable id) — never silently thin
+        //     the sensitive block, whose coverage the #432 check only guarantees
+        //     as ≥1-survives, not all-survive; OR
+        //   • the rejection is a fail-closed SECURITY / PLEDGE / DoS control
+        //     ([RuleCompileException.failClosed]: an #419 cap, a #598/#620/#624
+        //     capture-PII guard, a #425 actuation reject, a #590 depth bound) —
+        //     downgrading one of THOSE to a silent per-rule skip would weaken a
+        //     documented fail-closed control (Principle 6 > the spec's narrower
+        //     "sensitive-only" exemption; this is a strict strengthening).
+        // A genuine AUTHORING malformation (bad predicate, unknown key, mistyped
+        // field, bad platform prefix) degrades one recognition surface to UNKNOWN
+        // (→ scrubbed — safe), so it isolates to a skip.
+        val rules = mutableListOf<CompiledRule<TInput>>()
+        for (element in array) {
+            val obj = element.jsonObject
+            try {
+                rules += compileRule<TInput>(obj, context, platformId)
+            } catch (e: RuleCompileException) {
+                if (e.failClosed || rawRuleIsSensitive(obj)) throw e
+                Timber.tag("Rules").w(
+                    "Skipping malformed %s rule '%s' (non-sensitive; frame → UNKNOWN → scrubbed): %s",
+                    context.name.lowercase(Locale.ROOT), rawRuleId(obj), e.message,
+                )
+            }
+        }
         // Enforce unique priorities within the same rule type
         val seen = mutableMapOf<Int, String>()
         for (rule in rules) {
             val existing = seen.put(rule.priority, rule.id)
             if (existing != null) {
                 throw RuleCompileException(
-                    "Duplicate priority ${rule.priority} in ${context.name.lowercase()} rules: " +
+                    "Duplicate priority ${rule.priority} in ${context.name.lowercase(Locale.ROOT)} rules: " +
                         "'$existing' and '${rule.id}'. Priorities must be unique per rule type.",
                 )
             }
@@ -230,9 +265,35 @@ object RuleCompiler {
     }
 
     @Suppress("UNCHECKED_CAST")
-    private fun <TInput> compileRule(obj: JsonObject, context: RuleContext): CompiledRule<TInput> {
-        val id = obj["id"]!!.jsonPrimitive.content
-        val priority = obj["priority"]!!.jsonPrimitive.int
+    private fun <TInput> compileRule(
+        obj: JsonObject,
+        context: RuleContext,
+        platformId: String? = null,
+    ): CompiledRule<TInput> {
+        // #293 item 3: typed id/priority — a missing/mistyped field is a
+        // RuleCompileException naming the field, never a raw NPE/CCE from `!!`.
+        val id = requireStringField(obj, "id", ruleId = null)
+        val priority = requireIntField(obj, "priority", ruleId = id)
+
+        // #293 item 5: unknown top-level rule keys (the `"overridable"` typo,
+        // `"if_"`) are a typed reject naming them, not a silent default.
+        validateKnownKeys(obj, knownRuleKeys(context), scope = "rule", ruleId = id)
+
+        // #293 item 8: each rule id must carry the file's platform prefix. A
+        // mis-prefixed id silently never matches today (Platform.fromRuleId reads
+        // the leading segment) — make it loud. Platform-agnostic: the prefix is
+        // whatever the file's platform_id declares, never a hardcoded platform.
+        if (platformId != null) {
+            val platformRoot = platformId.substringBefore('.')
+            if (!id.startsWith("$platformRoot.")) {
+                throw ruleError(
+                    id,
+                    "id must start with the file's platform prefix '$platformRoot.' " +
+                        "(platform_id='$platformId')",
+                )
+            }
+        }
+
         val overrideable = obj["overrideable"]?.jsonPrimitive?.booleanOrNull ?: true
 
         // Rule-level bindings (screen rules only)
@@ -266,6 +327,7 @@ object RuleCompiler {
             throw RuleCompileException(
                 "Rule '$id': `redact` is not supported on CLICK rules — a click envelope carries " +
                     "app-vocabulary button labels, not customer PII. Remove the redact block.",
+                failClosed = true,
             )
         }
 
@@ -280,6 +342,7 @@ object RuleCompiler {
                     "(#598): a rule that hashes customer PII in its parse must redact the same raw " +
                     "nodes from the capture envelope, or the plaintext ships to disk. Add a " +
                     "top-level \"redact\": [ { \"find\": <nodePred>, \"keepPrefix\": [ ... ] } ].",
+                failClosed = true,
             )
         }
 
@@ -291,6 +354,7 @@ object RuleCompiler {
             throw RuleCompileException(
                 "Rule '$id' declares $rawBranchCount branches, exceeding " +
                     "MAX_BRANCHES_PER_RULE=$MAX_BRANCHES_PER_RULE",
+                failClosed = true,
             )
         }
 
@@ -308,8 +372,11 @@ object RuleCompiler {
                         "Rule '$id': a `redact` block inside a branches[] entry is not supported — " +
                             "redact masks capture-envelope nodes for the ENTIRE recognized frame, " +
                             "not per-branch. Move it to the rule's top level.",
+                        failClosed = true,
                     )
                 }
+                // #293 item 5: unknown branch keys are a typed reject naming them.
+                validateKnownKeys(branchObj, knownBranchKeys(context), scope = "branch", ruleId = id)
                 compileBranch(branchObj, context, ruleState.flow, ruleState.modeHint,
                     ruleOutcomes = ruleState.outcomes, ruleId = id,
                     ruleParseBlock = ruleParseObj, ruleParseAs = ruleParseAs, ruleBindObj = ruleBindObj)
@@ -329,6 +396,7 @@ object RuleCompiler {
             throw RuleCompileException(
                 "Rule '$id' declares $effectCount effects, exceeding " +
                     "MAX_EFFECTS_PER_RULE=$MAX_EFFECTS_PER_RULE",
+                failClosed = true,
             )
         }
 
@@ -348,11 +416,13 @@ object RuleCompiler {
                 ?: throw RuleCompileException(
                     "notification redact: unknown field '$fieldName' " +
                         "(expected one of ${NotifTextField.entries.map { it.wire }})",
+                    failClosed = true,
                 )
             val specObj = spec as? JsonObject
                 ?: throw RuleCompileException(
                     "notification redact: field '$fieldName' must be an object " +
                         "({ \"keepPrefix\": [...] } or { \"match\": <regex>, \"maskGroup\": <int> })",
+                    failClosed = true,
                 )
             val matchPattern = specObj["match"]?.jsonPrimitive?.content
             val masker: NotifFieldMask = if (matchPattern != null) {
@@ -367,6 +437,7 @@ object RuleCompiler {
                     throw RuleCompileException(
                         "notification redact: field '$fieldName' maskGroup $group is out of range " +
                             "(pattern '$matchPattern' has $groupCount capturing group(s); valid 0..$groupCount)",
+                        failClosed = true,
                     )
                 }
                 NotifFieldMask.RegexGroup(regex, group)
@@ -393,9 +464,9 @@ object RuleCompiler {
     private fun compileRedactBlock(array: JsonArray): CompiledRedact {
         val entries = array.map { element ->
             val obj = element as? JsonObject
-                ?: throw RuleCompileException("redact entry must be an object with a 'find' predicate")
+                ?: throw RuleCompileException("redact entry must be an object with a 'find' predicate", failClosed = true)
             val findSpec = obj["find"]
-                ?: throw RuleCompileException("redact entry has no 'find' predicate")
+                ?: throw RuleCompileException("redact entry has no 'find' predicate", failClosed = true)
             val find = compileNodePred(findSpec)
             val keepPrefix = obj["keepPrefix"]?.jsonArray?.map { it.jsonPrimitive.content }
                 ?: emptyList()
@@ -415,7 +486,7 @@ object RuleCompiler {
      */
     private fun jsonUsesSha256(element: JsonElement, depth: Int = 0): Boolean {
         if (depth > MAX_JSON_DEPTH)
-            throw RuleCompileException("Rule JSON nesting exceeds MAX_JSON_DEPTH=$MAX_JSON_DEPTH")
+            throw RuleCompileException("Rule JSON nesting exceeds MAX_JSON_DEPTH=$MAX_JSON_DEPTH", failClosed = true)
         return when (element) {
             is JsonPrimitive -> element.isString && element.content == "sha256"
             is JsonObject -> element.values.any { jsonUsesSha256(it, depth + 1) }
@@ -719,7 +790,7 @@ object RuleCompiler {
         depth: Int = 0,
     ): (UiNode, Bindings) -> Any? {
         if (depth > MAX_PARSE_DEPTH)
-            throw RuleCompileException("Parse expression nesting exceeds MAX_PARSE_DEPTH=$MAX_PARSE_DEPTH")
+            throw RuleCompileException("Parse expression nesting exceeds MAX_PARSE_DEPTH=$MAX_PARSE_DEPTH", failClosed = true)
 
         if (spec is JsonPrimitive) {
             val value = spec.content
@@ -858,9 +929,9 @@ object RuleCompiler {
                 fn
             }
             "allTextContains" in presenceSpec -> {
-                val text = presenceSpec["allTextContains"]!!.jsonPrimitive.content.lowercase()
+                val text = presenceSpec["allTextContains"]!!.jsonPrimitive.content.lowercase(Locale.ROOT)
                 val fn: (UiNode) -> Boolean = { tree ->
-                    tree.allText.joinToString("\u001F").lowercase().contains(text)
+                    tree.allTextLowerJoined.contains(text)
                 }
                 fn
             }
@@ -968,6 +1039,7 @@ object RuleCompiler {
                 "coalesce does not apply a top-level 'transform' — put the transform inside each " +
                     "branch (a top-level transform would be silently dropped, which for a PII field " +
                     "would leak the raw value)",
+                failClosed = true,
             )
         }
         val exprs = obj["coalesce"]!!.jsonArray.map { compileParseExpression(it, depth + 1) }
@@ -1057,6 +1129,7 @@ object RuleCompiler {
                     "bindings (e.g. bind: { \"declineButton\": { \"find\": ... } }) and the " +
                     "app-owned RuleAction registry performs taps. " +
                     "See docs/design/rule-capability-consent.md.",
+                failClosed = true,
             )
         }
         val verb = cloud.trotter.dashbuddy.domain.pipeline.EffectVerb.fromWire(wireVerb)
@@ -1138,18 +1211,169 @@ object RuleCompiler {
     }
 
     // ==========================================================================
+    //  #293 robustness helpers — typed casts, value-honoring flags, known keys
+    // ==========================================================================
+
+    /**
+     * The scalar of a single-key predicate, or a typed [RuleCompileException]
+     * (#293 item 3). Replaces the bare `value as JsonPrimitive` casts scattered
+     * through the predicate compilers so a mistyped rule (a nested object where a
+     * string is expected) fails rule LOAD with a clear message instead of throwing
+     * a raw [ClassCastException] out of the compiler.
+     */
+    private fun primOf(value: JsonElement, key: String): JsonPrimitive =
+        value as? JsonPrimitive
+            ?: throw RuleCompileException("Predicate '$key' requires a scalar value, got: $value")
+
+    /**
+     * A boolean-flag predicate's declared value (#293 item 2), typed (#293 item 3).
+     * `{"isClickable": false}` now matches NON-clickable nodes instead of silently
+     * ignoring the value. A non-boolean value is a typed compile error, not a
+     * silent default.
+     */
+    private fun boolFlag(value: JsonElement, key: String): Boolean =
+        primOf(value, key).booleanOrNull
+            ?: throw RuleCompileException(
+                "Predicate '$key' requires a boolean value (true/false), got: $value",
+            )
+
+    /**
+     * Enforce that a predicate object carries EXACTLY ONE key (#293 item 1). The
+     * predicate vocabularies (tree/node/notification) are single-key by design
+     * (see docs/rules.schema.json: "Object with exactly one key"); a second key
+     * — `{"hasIdSuffix":"x","hasText":"y"}` — used to compile with only the first
+     * key firing and the rest silently dropped. There are no auxiliary keys on
+     * these predicates (case-insensitivity is intrinsic, not a `ignoreCase` flag),
+     * so exactly-one is the correct contract. [what] names the vocabulary for the
+     * error; the empty-object case keeps its own message.
+     */
+    private fun requireSinglePredicateKey(obj: JsonObject, what: String) {
+        if (obj.size > 1) {
+            throw RuleCompileException(
+                "$what must have exactly one key, got ${obj.keys.toList()}",
+            )
+        }
+    }
+
+    /** A required string field on a rule object, typed (#293 item 3). */
+    private fun requireStringField(obj: JsonObject, field: String, ruleId: String?): String {
+        val el = obj[field]
+            ?: throw ruleError(ruleId, "missing required '$field'")
+        val prim = el as? JsonPrimitive
+        if (prim == null || !prim.isString) {
+            throw ruleError(ruleId, "'$field' must be a string, got: $el")
+        }
+        return prim.content
+    }
+
+    /** A required integer field on a rule object, typed (#293 item 3). */
+    private fun requireIntField(obj: JsonObject, field: String, ruleId: String?): Int {
+        val el = obj[field]
+            ?: throw ruleError(ruleId, "missing required '$field'")
+        return (el as? JsonPrimitive)?.intOrNull
+            ?: throw ruleError(ruleId, "'$field' must be an integer, got: $el")
+    }
+
+    private fun ruleError(ruleId: String?, msg: String): RuleCompileException =
+        RuleCompileException(if (ruleId != null) "Rule '$ruleId': $msg" else "Rule: $msg")
+
+    // -- Known-key validation (#293 item 5) --------------------------------------
+    //
+    // Single owner for the rule/branch key vocabulary the compiler consumes. Built
+    // from what compileRule/compileBranch actually read PLUS docs/rules.schema.json
+    // (the compiler-ignored `comment`/`description` metadata keys are permitted).
+    // An unknown key — the `"overridable"` typo, `"if_"` — is a typed reject naming
+    // it, instead of silently defaulting. Production goldens are the proof this set
+    // is right (a legitimate key that tripped it would fail DefaultRulesIntegrationTest).
+
+    /** Metadata keys any rule/branch object may carry; ignored by the compiler. */
+    private val META_KEYS = setOf("comment", "description")
+
+    private fun knownRuleKeys(context: RuleContext): Set<String> = when (context) {
+        RuleContext.SCREEN -> setOf(
+            "id", "priority", "overrideable", "state", "bind", "redact", "reject",
+            "require", "parse", "validate", "effects", "transitionOverrides",
+            "branches", "intent",
+        )
+        RuleContext.CLICK -> setOf(
+            "id", "priority", "overrideable", "state", "bind", "redact", "reject",
+            "require", "parse", "validate", "effects", "transitionOverrides",
+            "branches", "intent", "screenIs",
+        )
+        RuleContext.NOTIFICATION -> setOf(
+            "id", "priority", "overrideable", "state", "redact", "reject",
+            "require", "parse", "validate", "effects", "transitionOverrides",
+            "branches", "intent",
+        )
+    } + META_KEYS
+
+    private fun knownBranchKeys(context: RuleContext): Set<String> = when (context) {
+        RuleContext.SCREEN -> setOf(
+            "state", "bind", "reject", "require", "parse", "validate", "effects",
+            "transitionOverrides", "intent",
+        )
+        RuleContext.CLICK -> setOf(
+            "state", "bind", "reject", "require", "parse", "validate", "effects",
+            "transitionOverrides", "intent", "screenIs",
+        )
+        RuleContext.NOTIFICATION -> setOf(
+            "state", "reject", "require", "parse", "validate", "effects",
+            "transitionOverrides", "intent",
+        )
+    } + META_KEYS
+
+    private fun validateKnownKeys(
+        obj: JsonObject,
+        allowed: Set<String>,
+        scope: String,
+        ruleId: String?,
+    ) {
+        val unknown = obj.keys.filterNot { it in allowed }
+        if (unknown.isNotEmpty()) {
+            throw ruleError(ruleId, "unknown $scope key(s) $unknown (allowed: ${allowed.sorted()})")
+        }
+    }
+
+    // -- Per-rule fault isolation, sensitive-exempt (#293 item 4) -----------------
+
+    /**
+     * True when a rule that FAILED to compile must still reject the WHOLE file
+     * rather than be skipped (#293 item 4). Per-rule isolation must never silently
+     * thin the sensitive block: the #432 coverage check only guarantees ≥1
+     * sensitive rule per platform survives, not that ALL did. A skipped
+     * non-sensitive rule degrades one recognition surface (its frames → UNKNOWN →
+     * scrubbed — safe); a skipped sensitive rule degrades the Pledge. Read from RAW
+     * JSON because the rule didn't compile: sensitive iff the readable `id` carries
+     * the `.sensitive.` segment, OR `overrideable == false`, OR the `id` is
+     * UNREADABLE (can't tell what it is → fail closed).
+     */
+    private fun rawRuleIsSensitive(obj: JsonObject): Boolean {
+        val idPrim = obj["id"] as? JsonPrimitive
+        val id = idPrim?.takeIf { it.isString }?.content
+            ?: return true // unreadable id → fail closed
+        if (".sensitive." in id) return true
+        val overrideable = (obj["overrideable"] as? JsonPrimitive)?.booleanOrNull ?: true
+        return !overrideable
+    }
+
+    /** Readable rule id for a WARN line, or a placeholder — never rule-body text (P7). */
+    private fun rawRuleId(obj: JsonObject): String =
+        (obj["id"] as? JsonPrimitive)?.takeIf { it.isString }?.content ?: "<unreadable-id>"
+
+    // ==========================================================================
     //  Tree predicate compiler (operates on full UiNode tree)
     // ==========================================================================
 
     fun compileTreePred(json: JsonElement, depth: Int = 0): (UiNode) -> Boolean {
         if (depth > MAX_DEPTH)
-            throw RuleCompileException("Predicate nesting exceeds MAX_DEPTH=$MAX_DEPTH")
+            throw RuleCompileException("Predicate nesting exceeds MAX_DEPTH=$MAX_DEPTH", failClosed = true)
 
         val obj = json as? JsonObject
             ?: throw RuleCompileException("Tree predicate must be a JSON object, got: $json")
         val key = obj.keys.firstOrNull()
             ?: throw RuleCompileException("Empty tree predicate object")
-        val value = obj[key]!!
+        requireSinglePredicateKey(obj, "Tree predicate")
+        val value = obj.getValue(key)
 
         return when (key) {
             "exists" -> {
@@ -1161,25 +1385,25 @@ object RuleCompiler {
                 ;{ tree -> tree.findNode(nodePred) == null }
             }
             "allTextContains" -> {
-                val text = (value as? JsonPrimitive)?.content?.lowercase()
+                val text = (value as? JsonPrimitive)?.content?.lowercase(Locale.ROOT)
                     ?: throw RuleCompileException("allTextContains requires a string value")
-                ;{ tree -> tree.allText.joinToString("\u001F").lowercase().contains(text) }
+                ;{ tree -> tree.allTextLowerJoined.contains(text) }
             }
             "allTextContainsAll" -> {
                 val texts = (value as? JsonArray)
-                    ?.map { (it as JsonPrimitive).content.lowercase() }
+                    ?.map { primOf(it, key).content.lowercase(Locale.ROOT) }
                     ?: throw RuleCompileException("allTextContainsAll requires an array")
                 ;{ tree ->
-                    val joined = tree.allText.joinToString("\u001F").lowercase()
+                    val joined = tree.allTextLowerJoined
                     texts.all { joined.contains(it) }
                 }
             }
             "allTextContainsAny" -> {
                 val texts = (value as? JsonArray)
-                    ?.map { (it as JsonPrimitive).content.lowercase() }
+                    ?.map { primOf(it, key).content.lowercase(Locale.ROOT) }
                     ?: throw RuleCompileException("allTextContainsAny requires an array")
                 ;{ tree ->
-                    val joined = tree.allText.joinToString("\u001F").lowercase()
+                    val joined = tree.allTextLowerJoined
                     texts.any { joined.contains(it) }
                 }
             }
@@ -1209,48 +1433,51 @@ object RuleCompiler {
 
     fun compileNodePred(json: JsonElement, depth: Int = 0): (UiNode) -> Boolean {
         if (depth > MAX_DEPTH)
-            throw RuleCompileException("Predicate nesting exceeds MAX_DEPTH=$MAX_DEPTH")
+            throw RuleCompileException("Predicate nesting exceeds MAX_DEPTH=$MAX_DEPTH", failClosed = true)
 
         val obj = json as? JsonObject
             ?: throw RuleCompileException("Node predicate must be a JSON object, got: $json")
         val key = obj.keys.firstOrNull()
             ?: throw RuleCompileException("Empty node predicate object")
-        val value = obj[key]!!
+        requireSinglePredicateKey(obj, "Node predicate")
+        val value = obj.getValue(key)
 
         return when (key) {
             "hasIdSuffix" -> {
-                val s = (value as JsonPrimitive).content
+                val s = primOf(value, key).content
                 ;{ node -> node.viewIdResourceName?.endsWith(s, ignoreCase = true) == true }
             }
             "hasIdExact" -> {
-                val s = (value as JsonPrimitive).content
+                val s = primOf(value, key).content
                 ;{ node -> node.viewIdResourceName == s }
             }
             "hasIdContaining" -> {
-                val s = (value as JsonPrimitive).content
+                val s = primOf(value, key).content
                 ;{ node -> node.viewIdResourceName?.contains(s) == true }
             }
-            "hasNoId" ->
-                { node -> node.viewIdResourceName.isNullOrBlank() }
+            "hasNoId" -> {
+                val want = boolFlag(value, key)
+                ;{ node -> node.viewIdResourceName.isNullOrBlank() == want }
+            }
 
             "hasText" -> {
-                val s = (value as JsonPrimitive).content
+                val s = primOf(value, key).content
                 ;{ node -> node.text?.equals(s, ignoreCase = true) == true }
             }
             "hasTextCaseSensitive" -> {
-                val s = (value as JsonPrimitive).content
+                val s = primOf(value, key).content
                 ;{ node -> node.text == s }
             }
             "hasTextContaining" -> {
-                val s = (value as JsonPrimitive).content
+                val s = primOf(value, key).content
                 ;{ node -> node.text?.contains(s, ignoreCase = true) == true }
             }
             "hasTextStartsWith" -> {
-                val s = (value as JsonPrimitive).content
+                val s = primOf(value, key).content
                 ;{ node -> node.text?.startsWith(s, ignoreCase = true) == true }
             }
             "hasTextMatchesRegex" -> {
-                val regex = compileRegex((value as JsonPrimitive).content)
+                val regex = compileRegex(primOf(value, key).content)
                 ;{ node -> node.text?.let { str -> regex.containsMatchIn(str) } == true }
             }
 
@@ -1261,42 +1488,42 @@ object RuleCompiler {
             // Button has no text on the outer node; the text is in a nested
             // textView_prism_button_title child).
             "hasAnyText" -> {
-                val s = (value as JsonPrimitive).content
+                val s = primOf(value, key).content
                 ;{ node -> node.allText.any { it.equals(s, ignoreCase = true) } }
             }
 
             "hasDesc" -> {
-                val s = (value as JsonPrimitive).content
+                val s = primOf(value, key).content
                 ;{ node -> node.contentDescription?.equals(s, ignoreCase = true) == true }
             }
             "hasDescContaining" -> {
-                val s = (value as JsonPrimitive).content
+                val s = primOf(value, key).content
                 ;{ node -> node.contentDescription?.contains(s, ignoreCase = true) == true }
             }
 
             "hasStateDescription" -> {
-                val s = (value as JsonPrimitive).content
+                val s = primOf(value, key).content
                 ;{ node -> node.stateDescription?.equals(s, ignoreCase = true) == true }
             }
             "hasStateDescriptionContaining" -> {
-                val s = (value as JsonPrimitive).content
+                val s = primOf(value, key).content
                 ;{ node -> node.stateDescription?.contains(s, ignoreCase = true) == true }
             }
 
             "hasClassName" -> {
-                val s = (value as JsonPrimitive).content
+                val s = primOf(value, key).content
                 ;{ node -> node.className == s }
             }
             "hasClassNameEndsWith" -> {
-                val s = (value as JsonPrimitive).content
+                val s = primOf(value, key).content
                 ;{ node -> node.className?.endsWith(s, ignoreCase = true) == true }
             }
 
-            "isClickable" -> { node -> node.isClickable }
-            "isEnabled" -> { node -> node.isEnabled }
-            "isChecked" -> { node -> node.isChecked != 0 }
-            "hasChildren" -> { node -> node.children.isNotEmpty() }
-            "isLeaf" -> { node -> node.children.isEmpty() }
+            "isClickable" -> { val want = boolFlag(value, key); { node -> node.isClickable == want } }
+            "isEnabled" -> { val want = boolFlag(value, key); { node -> node.isEnabled == want } }
+            "isChecked" -> { val want = boolFlag(value, key); { node -> (node.isChecked != 0) == want } }
+            "hasChildren" -> { val want = boolFlag(value, key); { node -> node.children.isNotEmpty() == want } }
+            "isLeaf" -> { val want = boolFlag(value, key); { node -> node.children.isEmpty() == want } }
 
             "all" -> {
                 val preds = (value as? JsonArray)
@@ -1325,82 +1552,87 @@ object RuleCompiler {
 
     fun compileNotifPred(json: JsonElement, depth: Int = 0): (RawNotificationData) -> Boolean {
         if (depth > MAX_DEPTH)
-            throw RuleCompileException("Predicate nesting exceeds MAX_DEPTH=$MAX_DEPTH")
+            throw RuleCompileException("Predicate nesting exceeds MAX_DEPTH=$MAX_DEPTH", failClosed = true)
 
         val obj = json as? JsonObject
             ?: throw RuleCompileException("Notification predicate must be a JSON object")
         val key = obj.keys.firstOrNull()
             ?: throw RuleCompileException("Empty notification predicate object")
-        val value = obj[key]!!
+        requireSinglePredicateKey(obj, "Notification predicate")
+        val value = obj.getValue(key)
 
         return when (key) {
             "titleEquals" -> {
-                val s = (value as JsonPrimitive).content
+                val s = primOf(value, key).content
                 ;{ raw -> raw.title?.equals(s, ignoreCase = true) == true }
             }
             "titleContains" -> {
-                val s = (value as JsonPrimitive).content
+                val s = primOf(value, key).content
                 ;{ raw -> raw.title?.contains(s, ignoreCase = true) == true }
             }
             "titleMatchesRegex" -> {
-                val regex = compileRegex((value as JsonPrimitive).content)
+                val regex = compileRegex(primOf(value, key).content)
                 ;{ raw -> raw.title?.let { str -> regex.containsMatchIn(str) } == true }
             }
             "textEquals" -> {
-                val s = (value as JsonPrimitive).content
+                val s = primOf(value, key).content
                 ;{ raw -> raw.text?.equals(s, ignoreCase = true) == true }
             }
             "textContains" -> {
-                val s = (value as JsonPrimitive).content
+                val s = primOf(value, key).content
                 ;{ raw -> raw.text?.contains(s, ignoreCase = true) == true }
             }
             "textMatchesRegex" -> {
-                val regex = compileRegex((value as JsonPrimitive).content)
+                val regex = compileRegex(primOf(value, key).content)
                 ;{ raw -> raw.text?.let { str -> regex.containsMatchIn(str) } == true }
             }
             "bigTextContains" -> {
-                val s = (value as JsonPrimitive).content
+                val s = primOf(value, key).content
                 ;{ raw -> raw.bigText?.contains(s, ignoreCase = true) == true }
             }
             "bigTextMatchesRegex" -> {
-                val regex = compileRegex((value as JsonPrimitive).content)
+                val regex = compileRegex(primOf(value, key).content)
                 ;{ raw -> raw.bigText?.let { str -> regex.containsMatchIn(str) } == true }
             }
             "tickerTextContains" -> {
-                val s = (value as JsonPrimitive).content
+                val s = primOf(value, key).content
                 ;{ raw -> raw.tickerText?.contains(s, ignoreCase = true) == true }
             }
             "tickerTextMatchesRegex" -> {
-                val regex = compileRegex((value as JsonPrimitive).content)
+                val regex = compileRegex(primOf(value, key).content)
                 ;{ raw -> raw.tickerText?.let { str -> regex.containsMatchIn(str) } == true }
             }
-            "isClearable" ->
-                { raw -> raw.isClearable }
-            "isOngoing" ->
-                { raw -> raw.isOngoing }
+            "isClearable" -> {
+                val want = boolFlag(value, key)
+                ;{ raw -> raw.isClearable == want }
+            }
+            "isOngoing" -> {
+                val want = boolFlag(value, key)
+                ;{ raw -> raw.isOngoing == want }
+            }
             "channelIdEquals" -> {
-                val s = (value as JsonPrimitive).content
+                val s = primOf(value, key).content
                 ;{ raw -> raw.channelId == s }
             }
             "channelIdContains" -> {
-                val s = (value as JsonPrimitive).content
+                val s = primOf(value, key).content
                 ;{ raw -> raw.channelId?.contains(s, ignoreCase = true) == true }
             }
             "categoryEquals" -> {
-                val s = (value as JsonPrimitive).content
+                val s = primOf(value, key).content
                 ;{ raw -> raw.category == s }
             }
             "hasAction" -> {
-                val s = (value as JsonPrimitive).content
+                val s = primOf(value, key).content
                 ;{ raw -> raw.actionLabels.any { it.contains(s, ignoreCase = true) } }
             }
             "anyFieldContains" -> {
-                val s = (value as JsonPrimitive).content
+                val s = primOf(value, key).content
                 ;{ raw -> raw.toFullString().contains(s, ignoreCase = true) }
             }
             "anyFieldContainsAll" -> {
                 val texts = (value as? JsonArray)
-                    ?.map { (it as JsonPrimitive).content }
+                    ?.map { primOf(it, key).content }
                     ?: throw RuleCompileException("anyFieldContainsAll requires an array")
                 ;{ raw ->
                     val full = raw.toFullString()
@@ -1409,7 +1641,7 @@ object RuleCompiler {
             }
             "anyFieldContainsAny" -> {
                 val texts = (value as? JsonArray)
-                    ?.map { (it as JsonPrimitive).content }
+                    ?.map { primOf(it, key).content }
                     ?: throw RuleCompileException("anyFieldContainsAny requires an array")
                 ;{ raw ->
                     val full = raw.toFullString()
@@ -1417,7 +1649,7 @@ object RuleCompiler {
                 }
             }
             "anyFieldMatchesRegex" -> {
-                val regex = compileRegex((value as JsonPrimitive).content)
+                val regex = compileRegex(primOf(value, key).content)
                 ;{ raw -> regex.containsMatchIn(raw.toFullString()) }
             }
             "all" -> {

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompiler.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompiler.kt
@@ -147,7 +147,6 @@ object RuleCompiler {
                         if (depth > MAX_JSON_DEPTH) {
                             throw RuleCompileException(
                                 "Rule JSON nesting depth exceeds MAX_JSON_DEPTH=$MAX_JSON_DEPTH",
-                                failClosed = true,
                             )
                         }
                     }
@@ -221,29 +220,29 @@ object RuleCompiler {
         context: RuleContext,
         platformId: String? = null,
     ): List<CompiledRule<TInput>> {
-        // #293 item 4: per-rule fault isolation. One malformed rule SKIPS (WARN
-        // with id + reason, no rule-body text — P7) instead of failing the whole
-        // file — EXCEPT it still rejects the WHOLE file when EITHER:
-        //   • the rule is part of the sensitive LAYER (id carries `.sensitive.`,
-        //     `overrideable == false`, or an unreadable id) — never silently thin
-        //     the sensitive block, whose coverage the #432 check only guarantees
-        //     as ≥1-survives, not all-survive; OR
-        //   • the rejection is a fail-closed SECURITY / PLEDGE / DoS control
-        //     ([RuleCompileException.failClosed]: an #419 cap, a #598/#620/#624
-        //     capture-PII guard, a #425 actuation reject, a #590 depth bound) —
-        //     downgrading one of THOSE to a silent per-rule skip would weaken a
-        //     documented fail-closed control (Principle 6 > the spec's narrower
-        //     "sensitive-only" exemption; this is a strict strengthening).
-        // A genuine AUTHORING malformation (bad predicate, unknown key, mistyped
-        // field, bad platform prefix) degrades one recognition surface to UNKNOWN
-        // (→ scrubbed — safe), so it isolates to a skip.
+        // #293 item 4: per-rule fault isolation, OPT-IN (review F1). A rule
+        // skips (WARN with id + reason, no rule-body text — P7) instead of
+        // failing the whole file ONLY when BOTH:
+        //   • the rejection is tagged [RuleCompileException.isolable] — a
+        //     rule-authoring-level validation whose worst case is one
+        //     recognition surface degrading to UNKNOWN (→ scrubbed — safe); AND
+        //   • the rule is NOT part of the sensitive LAYER (id carries
+        //     `.sensitive.`, `overrideable == false`, or an unreadable id) —
+        //     never silently thin the sensitive block, whose coverage the #432
+        //     check only guarantees as ≥1-survives, not all-survive.
+        // Everything else — every UNTAGGED throw — rejects the WHOLE file (the
+        // conservative pre-#293 status quo). The default direction is the
+        // point: a future security/Pledge/DoS check (#419 caps, #598/#620/#624
+        // capture-PII guards, #425 actuation, #590 depth bounds) that forgets
+        // to consider isolation fails LOUD (over-reject), never as a silent
+        // per-rule downgrade — Principle 6: do not trust call-site discipline.
         val rules = mutableListOf<CompiledRule<TInput>>()
         for (element in array) {
             val obj = element.jsonObject
             try {
                 rules += compileRule<TInput>(obj, context, platformId)
             } catch (e: RuleCompileException) {
-                if (e.failClosed || rawRuleIsSensitive(obj)) throw e
+                if (!e.isolable || rawRuleIsSensitive(obj)) throw e
                 Timber.tag("Rules").w(
                     "Skipping malformed %s rule '%s' (non-sensitive; frame → UNKNOWN → scrubbed): %s",
                     context.name.lowercase(Locale.ROOT), rawRuleId(obj), e.message,
@@ -327,7 +326,6 @@ object RuleCompiler {
             throw RuleCompileException(
                 "Rule '$id': `redact` is not supported on CLICK rules — a click envelope carries " +
                     "app-vocabulary button labels, not customer PII. Remove the redact block.",
-                failClosed = true,
             )
         }
 
@@ -342,7 +340,6 @@ object RuleCompiler {
                     "(#598): a rule that hashes customer PII in its parse must redact the same raw " +
                     "nodes from the capture envelope, or the plaintext ships to disk. Add a " +
                     "top-level \"redact\": [ { \"find\": <nodePred>, \"keepPrefix\": [ ... ] } ].",
-                failClosed = true,
             )
         }
 
@@ -354,7 +351,6 @@ object RuleCompiler {
             throw RuleCompileException(
                 "Rule '$id' declares $rawBranchCount branches, exceeding " +
                     "MAX_BRANCHES_PER_RULE=$MAX_BRANCHES_PER_RULE",
-                failClosed = true,
             )
         }
 
@@ -372,7 +368,6 @@ object RuleCompiler {
                         "Rule '$id': a `redact` block inside a branches[] entry is not supported — " +
                             "redact masks capture-envelope nodes for the ENTIRE recognized frame, " +
                             "not per-branch. Move it to the rule's top level.",
-                        failClosed = true,
                     )
                 }
                 // #293 item 5: unknown branch keys are a typed reject naming them.
@@ -396,7 +391,6 @@ object RuleCompiler {
             throw RuleCompileException(
                 "Rule '$id' declares $effectCount effects, exceeding " +
                     "MAX_EFFECTS_PER_RULE=$MAX_EFFECTS_PER_RULE",
-                failClosed = true,
             )
         }
 
@@ -416,13 +410,11 @@ object RuleCompiler {
                 ?: throw RuleCompileException(
                     "notification redact: unknown field '$fieldName' " +
                         "(expected one of ${NotifTextField.entries.map { it.wire }})",
-                    failClosed = true,
                 )
             val specObj = spec as? JsonObject
                 ?: throw RuleCompileException(
                     "notification redact: field '$fieldName' must be an object " +
                         "({ \"keepPrefix\": [...] } or { \"match\": <regex>, \"maskGroup\": <int> })",
-                    failClosed = true,
                 )
             val matchPattern = specObj["match"]?.jsonPrimitive?.content
             val masker: NotifFieldMask = if (matchPattern != null) {
@@ -437,7 +429,6 @@ object RuleCompiler {
                     throw RuleCompileException(
                         "notification redact: field '$fieldName' maskGroup $group is out of range " +
                             "(pattern '$matchPattern' has $groupCount capturing group(s); valid 0..$groupCount)",
-                        failClosed = true,
                     )
                 }
                 NotifFieldMask.RegexGroup(regex, group)
@@ -464,9 +455,9 @@ object RuleCompiler {
     private fun compileRedactBlock(array: JsonArray): CompiledRedact {
         val entries = array.map { element ->
             val obj = element as? JsonObject
-                ?: throw RuleCompileException("redact entry must be an object with a 'find' predicate", failClosed = true)
+                ?: throw RuleCompileException("redact entry must be an object with a 'find' predicate")
             val findSpec = obj["find"]
-                ?: throw RuleCompileException("redact entry has no 'find' predicate", failClosed = true)
+                ?: throw RuleCompileException("redact entry has no 'find' predicate")
             val find = compileNodePred(findSpec)
             val keepPrefix = obj["keepPrefix"]?.jsonArray?.map { it.jsonPrimitive.content }
                 ?: emptyList()
@@ -486,7 +477,7 @@ object RuleCompiler {
      */
     private fun jsonUsesSha256(element: JsonElement, depth: Int = 0): Boolean {
         if (depth > MAX_JSON_DEPTH)
-            throw RuleCompileException("Rule JSON nesting exceeds MAX_JSON_DEPTH=$MAX_JSON_DEPTH", failClosed = true)
+            throw RuleCompileException("Rule JSON nesting exceeds MAX_JSON_DEPTH=$MAX_JSON_DEPTH")
         return when (element) {
             is JsonPrimitive -> element.isString && element.content == "sha256"
             is JsonObject -> element.values.any { jsonUsesSha256(it, depth + 1) }
@@ -790,7 +781,7 @@ object RuleCompiler {
         depth: Int = 0,
     ): (UiNode, Bindings) -> Any? {
         if (depth > MAX_PARSE_DEPTH)
-            throw RuleCompileException("Parse expression nesting exceeds MAX_PARSE_DEPTH=$MAX_PARSE_DEPTH", failClosed = true)
+            throw RuleCompileException("Parse expression nesting exceeds MAX_PARSE_DEPTH=$MAX_PARSE_DEPTH")
 
         if (spec is JsonPrimitive) {
             val value = spec.content
@@ -1039,7 +1030,6 @@ object RuleCompiler {
                 "coalesce does not apply a top-level 'transform' — put the transform inside each " +
                     "branch (a top-level transform would be silently dropped, which for a PII field " +
                     "would leak the raw value)",
-                failClosed = true,
             )
         }
         val exprs = obj["coalesce"]!!.jsonArray.map { compileParseExpression(it, depth + 1) }
@@ -1072,7 +1062,10 @@ object RuleCompiler {
         val onFail = obj["onFail"]?.jsonPrimitive?.content ?: "skip"
         // A typo'd onFail used to coerce silently to "skip" (#362).
         if (onFail !in setOf("skip", "dropParsed")) {
-            throw RuleCompileException("Unknown onFail: '$onFail' (expected 'skip' or 'dropParsed')")
+            throw RuleCompileException(
+                "Unknown onFail: '$onFail' (expected 'skip' or 'dropParsed')",
+                isolable = true, // authoring typo — the rule isolates (#293 item 4)
+            )
         }
 
         return { parsed ->
@@ -1129,7 +1122,6 @@ object RuleCompiler {
                     "bindings (e.g. bind: { \"declineButton\": { \"find\": ... } }) and the " +
                     "app-owned RuleAction registry performs taps. " +
                     "See docs/design/rule-capability-consent.md.",
-                failClosed = true,
             )
         }
         val verb = cloud.trotter.dashbuddy.domain.pipeline.EffectVerb.fromWire(wireVerb)
@@ -1223,7 +1215,10 @@ object RuleCompiler {
      */
     private fun primOf(value: JsonElement, key: String): JsonPrimitive =
         value as? JsonPrimitive
-            ?: throw RuleCompileException("Predicate '$key' requires a scalar value, got: $value")
+            ?: throw RuleCompileException(
+                "Predicate '$key' requires a scalar value, got: $value",
+                isolable = true,
+            )
 
     /**
      * A boolean-flag predicate's declared value (#293 item 2), typed (#293 item 3).
@@ -1235,6 +1230,7 @@ object RuleCompiler {
         primOf(value, key).booleanOrNull
             ?: throw RuleCompileException(
                 "Predicate '$key' requires a boolean value (true/false), got: $value",
+                isolable = true,
             )
 
     /**
@@ -1251,6 +1247,7 @@ object RuleCompiler {
         if (obj.size > 1) {
             throw RuleCompileException(
                 "$what must have exactly one key, got ${obj.keys.toList()}",
+                isolable = true,
             )
         }
     }
@@ -1274,8 +1271,18 @@ object RuleCompiler {
             ?: throw ruleError(ruleId, "'$field' must be an integer, got: $el")
     }
 
+    /**
+     * A rule-authoring-level error (missing/mistyped id or priority, unknown
+     * key, bad platform prefix) — tagged isolable: worst case is one surface
+     * degrading to UNKNOWN. The isolation loop's sensitive belt still rejects
+     * the whole file when the offending rule is sensitive-layer or its id is
+     * unreadable (`rawRuleIsSensitive`).
+     */
     private fun ruleError(ruleId: String?, msg: String): RuleCompileException =
-        RuleCompileException(if (ruleId != null) "Rule '$ruleId': $msg" else "Rule: $msg")
+        RuleCompileException(
+            if (ruleId != null) "Rule '$ruleId': $msg" else "Rule: $msg",
+            isolable = true,
+        )
 
     // -- Known-key validation (#293 item 5) --------------------------------------
     //
@@ -1366,7 +1373,7 @@ object RuleCompiler {
 
     fun compileTreePred(json: JsonElement, depth: Int = 0): (UiNode) -> Boolean {
         if (depth > MAX_DEPTH)
-            throw RuleCompileException("Predicate nesting exceeds MAX_DEPTH=$MAX_DEPTH", failClosed = true)
+            throw RuleCompileException("Predicate nesting exceeds MAX_DEPTH=$MAX_DEPTH")
 
         val obj = json as? JsonObject
             ?: throw RuleCompileException("Tree predicate must be a JSON object, got: $json")
@@ -1433,7 +1440,7 @@ object RuleCompiler {
 
     fun compileNodePred(json: JsonElement, depth: Int = 0): (UiNode) -> Boolean {
         if (depth > MAX_DEPTH)
-            throw RuleCompileException("Predicate nesting exceeds MAX_DEPTH=$MAX_DEPTH", failClosed = true)
+            throw RuleCompileException("Predicate nesting exceeds MAX_DEPTH=$MAX_DEPTH")
 
         val obj = json as? JsonObject
             ?: throw RuleCompileException("Node predicate must be a JSON object, got: $json")
@@ -1552,7 +1559,7 @@ object RuleCompiler {
 
     fun compileNotifPred(json: JsonElement, depth: Int = 0): (RawNotificationData) -> Boolean {
         if (depth > MAX_DEPTH)
-            throw RuleCompileException("Predicate nesting exceeds MAX_DEPTH=$MAX_DEPTH", failClosed = true)
+            throw RuleCompileException("Predicate nesting exceeds MAX_DEPTH=$MAX_DEPTH")
 
         val obj = json as? JsonObject
             ?: throw RuleCompileException("Notification predicate must be a JSON object")
@@ -1742,7 +1749,10 @@ object RuleCompiler {
                 val idSuffix = nav.removePrefix("findDescendant(").removeSuffix(")")
                 ;{ node -> node.findDescendantById(idSuffix) }
             }
-            else -> throw RuleCompileException("Unknown navigation: '$nav'")
+            else -> throw RuleCompileException(
+                "Unknown navigation: '$nav'",
+                isolable = true, // authoring typo — the rule isolates (#293 item 4)
+            )
         }
     }
 

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/CapabilityEnumeratorTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/CapabilityEnumeratorTest.kt
@@ -63,11 +63,23 @@ class CapabilityEnumeratorTest {
 
     @Test
     fun `reordering binding keys does NOT change the consent key`() {
+        // canonicalJson recursively sorts object keys, so reordering the bind
+        // ENTRY's keys must not change the consent key. A multi-key PREDICATE is
+        // now rejected by the compiler (#293 item 1), so the reorder is exercised
+        // on the entry's own keys (find + optional).
+        fun rule(entry: String) = """
+        [{
+          "id": "doordash.screen.offer_popup_test",
+          "priority": 10,
+          "require": { "exists": { "hasText": "Decline" } },
+          "bind": { "declineButton": $entry }
+        }]
+        """.trimIndent()
         val one = CapabilityEnumerator.enumerate(
-            compile(declineRule(bindPredicate = """{ "hasText": "Decline", "hasIdSuffix": "btn" }""")), "s",
+            compile(rule("""{ "find": { "hasText": "Decline" }, "optional": false }""")), "s",
         ).single()
         val reordered = CapabilityEnumerator.enumerate(
-            compile(declineRule(bindPredicate = """{ "hasIdSuffix": "btn", "hasText": "Decline" }""")), "s",
+            compile(rule("""{ "optional": false, "find": { "hasText": "Decline" } }""")), "s",
         ).single()
         assertEquals(one.key, reordered.key)
     }

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCapabilityEnumerationTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCapabilityEnumerationTest.kt
@@ -70,11 +70,25 @@ class RuleCapabilityEnumerationTest {
 
     @Test
     fun `reordering binding keys does NOT change the key - no spurious re-consent`() {
+        // The consent key canonicalizes (recursively sorts) the binding
+        // definition JSON, so reordering the bind ENTRY's keys must not change
+        // it. A multi-key PREDICATE is now rejected by the compiler (#293 item 1
+        // — extra predicate keys used to be silently dropped), so the reorder is
+        // exercised on the entry's own keys (find + optional), which is the real
+        // canonicalization surface.
+        fun rule(entry: String) = """
+        [{
+          "id": "doordash.screen.offer_popup_test",
+          "priority": 10,
+          "require": { "exists": { "hasText": "Decline" } },
+          "bind": { "declineButton": $entry }
+        }]
+        """.trimIndent()
         val one = RuleCompiler.enumerateCapabilities(
-            compile(declineTargetRule(bindPredicate = """{ "hasText": "Decline", "hasIdSuffix": "btn" }""")), "s",
+            compile(rule("""{ "find": { "hasText": "Decline" }, "optional": false }""")), "s",
         ).single()
         val reordered = RuleCompiler.enumerateCapabilities(
-            compile(declineTargetRule(bindPredicate = """{ "hasIdSuffix": "btn", "hasText": "Decline" }""")), "s",
+            compile(rule("""{ "optional": false, "find": { "hasText": "Decline" } }""")), "s",
         ).single()
         assertEquals(one.key, reordered.key)
     }

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompilerHardeningTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompilerHardeningTest.kt
@@ -1,0 +1,270 @@
+package cloud.trotter.dashbuddy.core.pipeline.rules
+
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+/**
+ * #293 — the RuleCompiler robustness pack (the Phase-A2 survivors of #211). One
+ * focused test per item: multi-key predicate reject (1), value-honoring boolean
+ * flags (2), typed compile errors (3), per-rule fault isolation with the
+ * sensitive/fail-closed whole-file exemption (4 — BOTH arms), known-key
+ * validation (5), and rule-id platform-prefix validation (8). Locale.ROOT (6)
+ * and the memoized joined text (9) are proven behavior-equivalent by the
+ * existing predicate suites + goldens; item 7 (regex match-time timeout) is
+ * already delivered by #680's BoundedRegex/RegexSafety.
+ */
+class RuleCompilerHardeningTest {
+
+    private fun node(
+        viewId: String? = null,
+        text: String? = null,
+        isClickable: Boolean = false,
+    ) = UiNode(viewIdResourceName = viewId, text = text, isClickable = isClickable)
+
+    private fun arr(s: String) = Json.parseToJsonElement(s).jsonArray
+
+    private fun compile(s: String) =
+        RuleCompiler.compileRules<UiNode>(arr(s), RuleContext.SCREEN)
+
+    private fun compileWithPlatform(s: String, platformId: String) =
+        RuleCompiler.compileRules<UiNode>(arr(s), RuleContext.SCREEN, platformId)
+
+    private fun expectCompileFails(block: () -> Unit, contains: String? = null) {
+        try {
+            block()
+            fail("expected RuleCompileException")
+        } catch (e: RuleCompileException) {
+            contains?.let {
+                assertTrue("message '${e.message}' should contain '$it'", e.message?.contains(it) == true)
+            }
+        }
+    }
+
+    // ── Item 1: multi-key predicate objects reject ──────────────────────────
+
+    @Test
+    fun `a node predicate with two keys is rejected (was silently first-key-only)`() {
+        expectCompileFails(
+            { RuleCompiler.compileNodePred(Json.parseToJsonElement("""{ "hasText": "x", "hasIdSuffix": "y" }""")) },
+            contains = "exactly one key",
+        )
+    }
+
+    @Test
+    fun `a tree predicate with two keys is rejected`() {
+        expectCompileFails(
+            { RuleCompiler.compileTreePred(Json.parseToJsonElement("""{ "exists": { "hasText": "x" }, "not": { "hasText": "y" } }""")) },
+            contains = "exactly one key",
+        )
+    }
+
+    @Test
+    fun `a notification predicate with two keys is rejected`() {
+        expectCompileFails(
+            { RuleCompiler.compileNotifPred(Json.parseToJsonElement("""{ "titleEquals": "x", "textEquals": "y" }""")) },
+            contains = "exactly one key",
+        )
+    }
+
+    @Test
+    fun `a single-key predicate still compiles`() {
+        val pred = RuleCompiler.compileNodePred(Json.parseToJsonElement("""{ "hasText": "Accept" }"""))
+        assertTrue(pred(node(text = "Accept")))
+    }
+
+    // ── Item 2: boolean-flag predicates honor their value ───────────────────
+
+    @Test
+    fun `isClickable false matches NON-clickable nodes`() {
+        val wantFalse = RuleCompiler.compileNodePred(Json.parseToJsonElement("""{ "isClickable": false }"""))
+        assertTrue("isClickable:false must match a non-clickable node", wantFalse(node(isClickable = false)))
+        assertFalse("isClickable:false must NOT match a clickable node", wantFalse(node(isClickable = true)))
+
+        val wantTrue = RuleCompiler.compileNodePred(Json.parseToJsonElement("""{ "isClickable": true }"""))
+        assertTrue(wantTrue(node(isClickable = true)))
+        assertFalse(wantTrue(node(isClickable = false)))
+    }
+
+    @Test
+    fun `hasNoId false matches nodes that HAVE an id`() {
+        val wantFalse = RuleCompiler.compileNodePred(Json.parseToJsonElement("""{ "hasNoId": false }"""))
+        assertTrue(wantFalse(node(viewId = "com.x:id/btn")))
+        assertFalse(wantFalse(node(viewId = null)))
+    }
+
+    @Test
+    fun `a non-boolean value for a boolean flag is a typed compile error`() {
+        expectCompileFails(
+            { RuleCompiler.compileNodePred(Json.parseToJsonElement("""{ "isClickable": "yes" }""")) },
+            contains = "boolean",
+        )
+    }
+
+    // ── Item 3: typed compile errors (NPE/CCE never escape as themselves) ────
+
+    @Test
+    fun `a rule missing id fails with a typed RuleCompileException, not an NPE`() {
+        expectCompileFails(
+            { compile("""[{ "priority": 10, "require": { "exists": { "hasText": "x" } } }]""") },
+            contains = "id",
+        )
+    }
+
+    @Test
+    fun `a rule with a non-integer priority fails typed, not a CCE`() {
+        // Routed through a sensitive-layer id so the typed reject propagates out of
+        // the per-rule isolation loop and its message is observable (a non-sensitive
+        // equivalent would isolate to a skip — see the item-4 tests).
+        expectCompileFails(
+            { compile("""[{ "id": "doordash.screen.sensitive.x", "priority": "high", "require": { "exists": { "hasText": "x" } } }]""") },
+            contains = "priority",
+        )
+    }
+
+    @Test
+    fun `a predicate scalar given an object fails typed, not a CCE`() {
+        expectCompileFails(
+            { RuleCompiler.compileNodePred(Json.parseToJsonElement("""{ "hasText": { "nested": true } }""")) },
+            contains = "scalar",
+        )
+    }
+
+    // ── Item 4: per-rule fault isolation — BOTH arms ────────────────────────
+
+    @Test
+    fun `a malformed non-sensitive rule skips while its valid siblings survive`() {
+        val rules = compile(
+            """
+            [
+              { "id": "doordash.screen.good_a", "priority": 10, "require": { "exists": { "hasText": "A" } } },
+              { "id": "doordash.screen.bad", "priority": 11, "require": { "exists": { "hasText": "B" } }, "bogusKey": true },
+              { "id": "doordash.screen.good_b", "priority": 12, "require": { "exists": { "hasText": "C" } } }
+            ]
+            """.trimIndent(),
+        )
+        assertEquals(
+            "the bad rule is skipped; both good siblings survive",
+            listOf("doordash.screen.good_a", "doordash.screen.good_b"),
+            rules.map { it.id },
+        )
+    }
+
+    @Test
+    fun `a malformed SENSITIVE rule rejects the WHOLE file (never thin the pledge block)`() {
+        expectCompileFails(
+            {
+                compile(
+                    """
+                    [
+                      { "id": "doordash.screen.good", "priority": 10, "require": { "exists": { "hasText": "A" } } },
+                      { "id": "doordash.screen.sensitive.banking", "priority": 11, "require": { "exists": { "hasText": "B" } }, "bogusKey": true }
+                    ]
+                    """.trimIndent(),
+                )
+            },
+            contains = "bogusKey",
+        )
+    }
+
+    @Test
+    fun `a rule with an unreadable id rejects the WHOLE file (fail closed)`() {
+        // No readable id → the isolation loop can't tell if it's sensitive → reject whole file.
+        expectCompileFails(
+            { compile("""[{ "priority": 10, "require": { "exists": { "hasText": "x" } } }]""") },
+        )
+    }
+
+    @Test
+    fun `a fail-closed security reject (DoS cap) rejects the WHOLE file even for a non-sensitive rule`() {
+        // MAX_EFFECTS_PER_RULE is an anti-DoS control; item 4 must not downgrade it
+        // to a silent per-rule skip. Build a non-sensitive rule over the effect cap.
+        val effects = (0..RuleCompiler.MAX_EFFECTS_PER_RULE).joinToString(",") {
+            """{ "bubble": { "text": "e$it" } }"""
+        }
+        expectCompileFails(
+            {
+                compile(
+                    """[{ "id": "doordash.screen.dos", "priority": 10, "require": { "exists": { "hasText": "x" } }, "effects": [ $effects ] }]""",
+                )
+            },
+            contains = "MAX_EFFECTS_PER_RULE",
+        )
+    }
+
+    // ── Item 5: known-key validation at rule + branch level ─────────────────
+
+    // (Rule/branch-level rejects are routed through a sensitive-layer id so the
+    // typed message propagates out of the per-rule isolation loop and can be
+    // asserted; the non-sensitive equivalent isolates to a skip — item 4.)
+
+    @Test
+    fun `the overridable typo is rejected at the rule level naming the key`() {
+        expectCompileFails(
+            {
+                compile(
+                    """[{ "id": "doordash.screen.sensitive.x", "priority": 10, "overridable": false, "require": { "exists": { "hasText": "x" } } }]""",
+                )
+            },
+            contains = "overridable",
+        )
+    }
+
+    @Test
+    fun `an unknown branch key is rejected naming it`() {
+        expectCompileFails(
+            {
+                compile(
+                    """
+                    [{
+                      "id": "doordash.screen.sensitive.x", "priority": 10,
+                      "branches": [
+                        { "require": { "exists": { "hasText": "x" } }, "if_": true }
+                      ]
+                    }]
+                    """.trimIndent(),
+                )
+            },
+            contains = "if_",
+        )
+    }
+
+    @Test
+    fun `a legitimate metadata comment key is accepted`() {
+        val rules = compile(
+            """[{ "id": "doordash.screen.x", "priority": 10, "comment": "a note", "require": { "exists": { "hasText": "x" } } }]""",
+        )
+        assertEquals(1, rules.size)
+    }
+
+    // ── Item 8: rule-id platform prefix validated at load ───────────────────
+
+    @Test
+    fun `a rule id not carrying the file platform prefix is rejected`() {
+        // Sensitive id so the reject propagates out of the isolation loop (a
+        // mis-prefixed non-sensitive rule isolates to a skip — item 4).
+        expectCompileFails(
+            {
+                compileWithPlatform(
+                    """[{ "id": "uber.screen.sensitive.x", "priority": 10, "require": { "exists": { "hasText": "x" } } }]""",
+                    platformId = "doordash.driver",
+                )
+            },
+            contains = "platform prefix",
+        )
+    }
+
+    @Test
+    fun `a correctly-prefixed rule id passes the platform check`() {
+        val rules = compileWithPlatform(
+            """[{ "id": "doordash.screen.x", "priority": 10, "require": { "exists": { "hasText": "x" } } }]""",
+            platformId = "doordash.driver",
+        )
+        assertEquals(1, rules.size)
+    }
+}

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompilerHardeningTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompilerHardeningTest.kt
@@ -13,7 +13,8 @@ import org.junit.Test
  * #293 — the RuleCompiler robustness pack (the Phase-A2 survivors of #211). One
  * focused test per item: multi-key predicate reject (1), value-honoring boolean
  * flags (2), typed compile errors (3), per-rule fault isolation with the
- * sensitive/fail-closed whole-file exemption (4 — BOTH arms), known-key
+ * opt-in `isolable` isolation + sensitive/untagged whole-file default (4 —
+ * both arms + the inversion canary), known-key
  * validation (5), and rule-id platform-prefix validation (8). Locale.ROOT (6)
  * and the memoized joined text (9) are proven behavior-equivalent by the
  * existing predicate suites + goldens; item 7 (regex match-time timeout) is
@@ -181,9 +182,10 @@ class RuleCompilerHardeningTest {
     }
 
     @Test
-    fun `a fail-closed security reject (DoS cap) rejects the WHOLE file even for a non-sensitive rule`() {
-        // MAX_EFFECTS_PER_RULE is an anti-DoS control; item 4 must not downgrade it
-        // to a silent per-rule skip. Build a non-sensitive rule over the effect cap.
+    fun `a security reject (DoS cap) rejects the WHOLE file even for a non-sensitive rule`() {
+        // MAX_EFFECTS_PER_RULE is an anti-DoS control. Isolation is opt-in
+        // (review F1): security sites carry NO `isolable` tag, so the default
+        // whole-file reject applies. Build a non-sensitive rule over the cap.
         val effects = (0..RuleCompiler.MAX_EFFECTS_PER_RULE).joinToString(",") {
             """{ "bubble": { "text": "e$it" } }"""
         }
@@ -194,6 +196,32 @@ class RuleCompilerHardeningTest {
                 )
             },
             contains = "MAX_EFFECTS_PER_RULE",
+        )
+    }
+
+    @Test
+    fun `CANARY - an UNTAGGED RuleCompileException rejects the WHOLE file (isolation is opt-in)`() {
+        // The regression test for the review-F1 inversion itself: a bare
+        // RuleCompileException (no `isolable` flag) thrown while compiling a
+        // NON-sensitive rule must reject the whole file — the conservative
+        // default arm. If this fails, either the isolation loop's default was
+        // weakened (a Principle 6 violation — a future untagged security check
+        // would silently downgrade to a per-rule skip), or the chosen untagged
+        // site ("Empty tree predicate object") was tagged isolable — pick
+        // another untagged site consciously, don't loosen the loop. The valid
+        // sibling proves the file rejects WHOLE, not just the bad rule.
+        expectCompileFails(
+            {
+                compile(
+                    """
+                    [
+                      { "id": "doordash.screen.good", "priority": 10, "require": { "exists": { "hasText": "A" } } },
+                      { "id": "doordash.screen.bare_error", "priority": 11, "require": {} }
+                    ]
+                    """.trimIndent(),
+                )
+            },
+            contains = "Empty tree predicate",
         )
     }
 

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompilerTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompilerTest.kt
@@ -826,8 +826,13 @@ class RuleCompilerTest {
         ParsedFieldsFactory.validateShapeFields("future_shape", emptySet(), "test.rule")
     }
 
-    @Test(expected = RuleCompileException::class)
-    fun `compileRules rejects offer shape rule missing payAmount`() {
+    @Test
+    fun `offer shape rule missing payAmount is caught at compile and isolates the rule (item 4 skip)`() {
+        // The shape-contract violation is an authoring malformation, not a
+        // fail-closed security control, so #293 item 4 isolates it to a per-rule
+        // SKIP (WARN'd) rather than failing the whole file — the missing required
+        // field is still caught at compile (the rule never becomes a live offer
+        // matcher; a bad offer never recognizes → surface UNKNOWN → safe).
         val ruleJson = """[{
             "id": "test.screen.bad_offer",
             "priority": 10,
@@ -839,9 +844,10 @@ class RuleCompilerTest {
                 }
             }
         }]"""
-        RuleCompiler.compileRules<UiNode>(
+        val compiled = RuleCompiler.compileRules<UiNode>(
             Json.parseToJsonElement(ruleJson).jsonArray, RuleContext.SCREEN,
         )
+        assertTrue("the malformed offer rule must be skipped, not compiled", compiled.isEmpty())
     }
 
     @Test

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/TransformHardeningTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/TransformHardeningTest.kt
@@ -6,6 +6,7 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Test
@@ -115,10 +116,17 @@ class TransformHardeningTest {
         )
     }
 
-    // ── Item 6: onFail typos fail rule compile ──
+    // ── Item 6: onFail typos are caught at compile (not coerced at match) ──
+    //
+    // #362 made a typo'd onFail a compile-time RuleCompileException instead of a
+    // silent match-time coercion. #293 item 4 isolates a non-sensitive AUTHORING
+    // malformation to a per-rule SKIP (WARN'd) rather than failing the whole
+    // file — the typo is still caught at compile (the rule never becomes a live
+    // matcher), which is the property #362 defends. The whole-file-reject arm
+    // (sensitive rules + fail-closed controls) is covered in RuleCompilerHardeningTest.
 
-    @Test(expected = RuleCompileException::class)
-    fun `unknown onFail fails at compile time, not silently coercing to skip`() {
+    @Test
+    fun `unknown onFail is caught at compile and isolates the rule (item 4 skip)`() {
         val ruleJson = """[{
             "id": "test.screen.onfail_typo",
             "priority": 10,
@@ -133,15 +141,16 @@ class TransformHardeningTest {
                 { "assert": "fieldNotNull", "field": "f", "onFail": "drop" }
             ]
         }]"""
-        RuleCompiler.compileRules<cloud.trotter.dashbuddy.domain.model.accessibility.UiNode>(
+        val compiled = RuleCompiler.compileRules<cloud.trotter.dashbuddy.domain.model.accessibility.UiNode>(
             Json.parseToJsonElement(ruleJson).jsonArray, RuleContext.SCREEN,
         )
+        assertTrue("the malformed rule must be skipped, not compiled to a live matcher", compiled.isEmpty())
     }
 
-    // ── Item 3: unknown navigation fails rule compile ──
+    // ── Item 3: unknown navigation caught at compile, not at first match ──
 
-    @Test(expected = RuleCompileException::class)
-    fun `unknown navigate verb fails at compile time, not at first match`() {
+    @Test
+    fun `unknown navigate verb is caught at compile and isolates the rule (item 4 skip)`() {
         val ruleJson = """[{
             "id": "test.screen.bad_nav",
             "priority": 10,
@@ -153,9 +162,10 @@ class TransformHardeningTest {
                 }
             }
         }]"""
-        RuleCompiler.compileRules<cloud.trotter.dashbuddy.domain.model.accessibility.UiNode>(
+        val compiled = RuleCompiler.compileRules<cloud.trotter.dashbuddy.domain.model.accessibility.UiNode>(
             Json.parseToJsonElement(ruleJson).jsonArray, RuleContext.SCREEN,
         )
+        assertTrue("the malformed rule must be skipped, not compiled to a live matcher", compiled.isEmpty())
     }
 
     // ── Item 1 regression: validated specs can't NPE at match time ──

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/accessibility/UiNode.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/accessibility/UiNode.kt
@@ -1,6 +1,7 @@
 package cloud.trotter.dashbuddy.domain.model.accessibility
 
 import cloud.trotter.dashbuddy.domain.pipeline.NO_ID_FALLBACK
+import java.util.Locale
 
 /**
  * A data class to hold structured information about a single UI element (node).
@@ -255,6 +256,18 @@ data class UiNode(
         if (!node.text.isNullOrBlank()) list.add(node.text)
         if (!node.contentDescription.isNullOrBlank()) list.add(node.contentDescription)
         node.children.forEach { collectText(it, list) }
+    }
+
+    /**
+     * The subtree's [allText] joined on the `\u001F` unit separator and lowercased
+     * once (Locale.ROOT), memoized (#293 item 9). The `allText*` tree predicates
+     * rebuilt this string per rule per event; this node is immutable so a single
+     * `by lazy` is the SSOT the compiler's match closures read. Locale.ROOT keeps
+     * the fold locale-independent (#187/#211), matching the compiler's search-text
+     * side (both lowercase with Locale.ROOT).
+     */
+    val allTextLowerJoined: String by lazy {
+        allText.joinToString("\u001F").lowercase(Locale.ROOT)
     }
 
     val structuralHash: Int by lazy {

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/capture/MapperEnforcementTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/capture/MapperEnforcementTest.kt
@@ -13,6 +13,7 @@ class MapperEnforcementTest {
         val ignoredProperties = setOf(
             "parent",           // transient property
             "allText",          // lazy property
+            "allTextLowerJoined", // lazy property (memoized joined+lowercased tree text, #293)
             "structuralHash",   // lazy property
             "contentHash",      // lazy property
             "stableHash",       // lazy property (identity-based dedup)


### PR DESCRIPTION
Closes #293 — the RuleCompiler robustness pack (the Phase-A2 survivors of #211).

Recognition is untrusted input today (a third-party accessibility tree) and will be more so once rules ship OTA/community-authored (#192). This hardens the compiler so a malformed or hostile rule can't crash recognition, silently mis-match, or leak PII.

## Per-item summary

1. **Multi-key predicate objects reject.** The tree / node / notification predicate dispatchers used `obj.keys.firstOrNull()`, so `{"hasText":"x","hasIdSuffix":"y"}` compiled as `hasText` only and silently dropped the rest. They now reject an object with != 1 key (`requireSinglePredicateKey`). Verified against `docs/rules.schema.json` ("Object with exactly one key") and the real rule sources: these vocabularies carry **no** auxiliary keys (case-insensitivity is intrinsic, not an `ignoreCase` flag), so exactly-one is the correct contract.
2. **Boolean-flag predicates honor their value.** `isClickable/isEnabled/isChecked/hasChildren/isLeaf/hasNoId/isClearable/isOngoing` ignored the JSON value; `"isClickable": false` matched clickable nodes. They now compare against the declared boolean (`boolFlag`, which is also typed). **Byte-inert:** the only one of these used in production is `hasNoId: true` (17×); none is written `false` (grep of `matchers/rules/`).
3. **Typed compile errors.** `obj["id"]!!` / `obj["priority"]!!` non-null asserts and the `value as JsonPrimitive` predicate casts are replaced with `requireStringField` / `requireIntField` / `primOf`, each throwing `RuleCompileException` (naming the field / rule where known). An NPE/CCE can no longer escape the compiler as itself.
4. **Per-rule fault isolation — with the vetted fail-closed constraint (see below).**
5. **Known-key validation at rule + branch level.** `validateKnownKeys` rejects unknown keys naming them — the `"overridable"` typo, `"if_"`. The key sets are a single owner built from what the compiler consumes **+** `docs/rules.schema.json`, and permit the compiler-ignored `comment`/`description` metadata keys that real assets carry. Production goldens prove the sets are right.
6. **`Locale.ROOT` lowercase.** Every bare `.lowercase()` in the compiler match paths → `.lowercase(Locale.ROOT)` (the #187/#211 machine-string rule).
7. **Already done — not touched.** Regex match-time timeout is delivered by #680's `BoundedRegex` / `RegexSafety` (length cap + ReDoS rejection). No change here.
8. **Rule-id platform prefix validated at load.** Each rule `id` must carry the file `platform_id`'s platform segment (`platform_id="doordash.driver"` → ids must start `doordash.`), threaded from `loadSingle`. A mis-prefixed id silently never matched before (`Platform.fromRuleId` reads the leading segment); it now rejects loud. Platform-agnostic — the prefix is whatever the file declares, no literal. **Byte-inert** (every production id already prefix-matches).
9. **Memoize the joined-lowercased tree text.** The `allText*` predicates rebuilt `allText.joinToString(US).lowercase()` per rule per event. New `UiNode.allTextLowerJoined` is a `by lazy` SSOT (UiNode is immutable → sound), folded once with `Locale.ROOT`. Match results are proven unchanged by the existing predicate suites + goldens.

## Item 4 — the fail-closed design, spelled out (rev. after adversarial review F1)

The compile try/catch moved inside the `compileRules` per-rule loop. **Isolation is OPT-IN** (review F1 inverted the original opt-out flag): a malformed rule **skips** (WARN with rule id + reason, no rule-body text — P7) instead of failing the whole file **only when both**:

- the rejection is tagged `RuleCompileException.isolable = true` — a rule-authoring-level validation whose worst case is one recognition surface degrading to UNKNOWN (→ scrubbed — safe). 8 tagged sites: bad predicate scalar (`primOf`), non-boolean flag value (`boolFlag`), multi-key predicate (`requireSinglePredicateKey`), missing/mistyped id + priority / unknown rule- & branch-keys / platform-prefix mismatch (`ruleError`), unknown `onFail`, unknown `navigate`, and both `ParsedFieldsFactory.validateShapeFields` shape rejects; **and**
- the rule is **not** part of the sensitive LAYER — readable id contains `.sensitive.`, or `overrideable == false`, or the id is **unreadable** (can't tell what it is → fail closed). Per-rule isolation must never silently thin the sensitive block; the #432 coverage check only guarantees ≥1 sensitive rule per platform survives, not that **all** did. This belt applies even to isolable errors.

**Everything else — every UNTAGGED throw — rejects the WHOLE file** (the conservative pre-#293 status quo). That default direction is the point (review F1): a future security/Pledge/DoS compile check (#419 caps, #598/#620/#624 capture-PII guards, #425 actuation rejects, #590 depth bounds — all deliberately untagged) that forgets to consider isolation fails **loud** (over-reject), never as a silent per-rule downgrade. Principle 6: do not trust call-site discipline — the cost asymmetry decides the default (forgotten opt-out = annoying-but-safe whole-file reject; forgotten opt-in = silent pledge weakening). A **CANARY test** pins the default arm: a bare untagged `RuleCompileException` from a non-sensitive rule must reject the whole file.

**Deviation from the literal spec, flagged:** the issue named only the sensitive-layer whole-file exemption; the shipped design also keeps whole-file rejection for all untagged (security/Pledge/DoS) rejects, via the opt-in default. This is a strict *strengthening* — Principle 6 overrides the narrower wording — and preserves the intent of every existing security test. Genuine authoring malformations (bad predicate, unknown key, mistyped field, bad prefix, unknown nav/onFail, bad shape) isolate to a skip.

## Byte-inert proof

- `:app:testDebugUnitTest --tests "*AllMatchersSuite*"` green — the golden-corpus positive guard, parse-output golden, ruleset + classifier regressions all pass unchanged against the **production** rules, so items 1/2/5/8 don't trip on real assets and item 9 doesn't change any match result.
- `DefaultRulesIntegrationTest` (compiles the shipped bundles) green.
- Full gate `testDebugUnitTest :domain:test` green.
- Grep receipts: production boolean predicates are `hasNoId: true` only (never `false`); every production rule id already carries its platform prefix.

## Existing tests reconciled to the new contract

- `TransformHardeningTest` (unknown onFail / unknown navigate) and `RuleCompilerTest` (offer-shape missing payAmount): these authoring malformations now assert item-4 isolation (caught at compile, rule skipped — never compiled to a live matcher) instead of a whole-file throw. The #362 property ("detected at compile, not coerced at match") still holds.
- `CapabilityEnumeratorTest` / `RuleCapabilityEnumerationTest` "reordering binding keys": these reordered a two-key **predicate**, which item 1 now correctly rejects. They reorder the bind **entry** keys (`find` + `optional`) instead — the real canonical-JSON key-sort surface the consent key pins.

## Tests

New `RuleCompilerHardeningTest` (19 tests): one focused, red-first-where-feasible test per item — multi-key reject (tree/node/notif); `false`-flag honored + typed non-boolean; typed missing-id / bad-priority / object-for-scalar; **per-rule isolation BOTH arms** (non-sensitive skip keeps valid siblings; sensitive rule + unreadable id + a fail-closed DoS cap each reject the whole file); `overridable`/`if_` known-key rejects + `comment` accepted; platform-prefix reject/accept.

## Security / privacy posture

Untrusted input: rule JSON (third-party once #192 lands). This PR is **fail-closed strengthened, never weakened**: typed rejects replace raw NPE/CCE; the sensitive block and every `failClosed` security/Pledge/DoS control still reject the whole file; the per-rule skip only degrades a non-sensitive recognition surface to UNKNOWN (→ scrubbed). The item-4 WARN carries rule id + the structural reason only (no third-party UI/PII — this is compile-time over our own authored rule JSON, before any device text).

## Design-goal review

- **6 (security & privacy first).** The load-bearing goal. Fail-closed posture is **strengthened, not weakened**: the item-4 exemption covers the sensitive layer **and** all `failClosed` security/Pledge/DoS rejects (the explicit, justified deviation above); a non-sensitive skip is safe by construction (surface → UNKNOWN → scrubbed). Typed rejects remove the NPE/CCE escape. No new plaintext at WARN.
- **4 (Kotlin/Android best practices).** `Locale.ROOT` on every machine-string `.lowercase()` in the match paths (item 6); immutable `by lazy` memo on the immutable `UiNode` (item 9). Idiomatic typed helpers over `!!`/unchecked casts.
- **5 (SSOT).** The rule/branch known-key sets and the `allTextLowerJoined` fold each have exactly one owner; the boolean-flag/predicate-scalar reads route through `boolFlag`/`primOf`. No duplicated key lists.
- **8 (platform-agnostic core).** Nothing platform-specific added. The item-8 prefix check derives the prefix from the file's own `platform_id` (no literal, no `== DoorDash`); the sensitive-layer detection keys off the `.sensitive.` id segment / `overrideable`, both cross-platform. Adding a platform still needs zero `:core:*`/`:domain` edits.
- **1 (UDF), 2 (MAD), 3 (SRP), 7 (logging).** Compiler stays pure; the one new log site is a P7-safe WARN (level = a defended invariant fired: a malformed rule isolated).

No field-test item: no on-dash behavior change (recognition is byte-inert per the goldens).

## Adversarial review

Fable adversarial review round 1 complete: one MED design finding (F1 — the isolation flag's default direction) — **fixed in-PR** (`fix(#293): review F1 — isolation is opt-in (isolable), whole-file reject is the default`): flag inverted to opt-in `isolable`, 18 security tags deleted (default covers them), 8 authoring-level sites tagged, CANARY test added for the default arm. Full gate + AllMatchersSuite re-run green.

