### PR TITLE
test(#590): property tests phase 2 — marker evasion, INFO+ replay gate, ingestion fill-ins

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -166,6 +166,11 @@ dependencies {
     testImplementation(libs.mockito.core)
     testImplementation(libs.mockito.kotlin)
     testImplementation(libs.kotlinx.coroutines.test)
+    // #590 — standalone kotest-property (Arb/checkAll/forAll) for the phase-2
+    // ingestion property tests that live in the app test tree (they need
+    // TestRulesetFactory + SessionReplay, which resolve here). Same runner-agnostic
+    // JUnit-4 usage as :core:pipeline; NOT the Kotest runner, NOT jqwik/Jazzer.
+    testImplementation(libs.kotest.property)
     // #314 — Robolectric DAO round-trip tests build an in-memory DashBuddyDatabase;
     // Room's builder API is only transitively runtime-visible via :core:database
     // (implementation), so surface it on the test compile classpath. room-ktx (the

--- a/app/src/test/java/cloud/trotter/dashbuddy/replay/ClassifyGateCaptureFuzzTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/replay/ClassifyGateCaptureFuzzTest.kt
@@ -1,0 +1,152 @@
+package cloud.trotter.dashbuddy.replay
+
+import cloud.trotter.dashbuddy.core.pipeline.ObservationClassifier
+import cloud.trotter.dashbuddy.core.pipeline.PipelineEvent
+import cloud.trotter.dashbuddy.core.pipeline.PipelineStats
+import cloud.trotter.dashbuddy.core.pipeline.SensitiveTextMarkers
+import cloud.trotter.dashbuddy.core.pipeline.CaptureWriter
+import cloud.trotter.dashbuddy.core.pipeline.accessibility.TreeSnapshot
+import cloud.trotter.dashbuddy.core.pipeline.rules.CompiledRedact
+import cloud.trotter.dashbuddy.core.pipeline.rules.JsonRuleInterpreter
+import cloud.trotter.dashbuddy.core.pipeline.rules.ScreenRedactionSource
+import cloud.trotter.dashbuddy.domain.capture.CaptureBus
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadataProvider
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import cloud.trotter.dashbuddy.domain.pipeline.UNKNOWN_TARGET
+import cloud.trotter.dashbuddy.test.util.TestRulesetFactory
+import io.kotest.property.Arb
+import io.kotest.property.RandomSource
+import io.kotest.property.arbitrary.arbitrary
+import io.kotest.property.checkAll
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+/**
+ * #590 fill-in — end-to-end `classify → gate → capture` on adversarial trees.
+ *
+ * Drives kotest-generated adversarial [UiNode] trees (bounded depth/width within the
+ * tree-budget caps, with hostile text: sensitive markers, homoglyph-mutated markers,
+ * SSN/PAN shapes, very long strings, unicode, blanks) through the REAL
+ * [ObservationClassifier] wired to the PRODUCTION rules ([TestRulesetFactory]) and then
+ * the real [CaptureWriter] fail-closed backstop. Asserts:
+ *  - classify + capture never throw (no crash on hostile input);
+ *  - each frame classifies + captures within a wall-clock budget (bounded time);
+ *  - the fail-closed invariant: an UNKNOWN frame that reaches the capture bus NEVER
+ *    carried a [SensitiveTextMarkers] hit — a toxic UNKNOWN is always dropped
+ *    (post the #590 evasion hardening, homoglyph markers are caught too).
+ *
+ * Pipeline-service stages (the accessibility gate/dedup) need Android services and are
+ * out of scope; this exercises the classify + capture-scrub path directly, mirroring
+ * `CaptureScrubTest`'s wiring.
+ *
+ * A failing property prints its seed; pin it with `PropTestConfig(seed = ...)`.
+ */
+class ClassifyGateCaptureFuzzTest {
+
+    private val pkg = "com.doordash.driverapp"
+
+    /** No-op redaction source (UNKNOWN frames have no ruleId, so this is never consulted). */
+    private val noRedaction = object : ScreenRedactionSource {
+        override fun redactFor(ruleId: String): CompiledRedact? = null
+    }
+
+    private val classifier = ObservationClassifier(
+        mock<JsonRuleInterpreter> {
+            on { screenRuleset } doReturn TestRulesetFactory.screenRuleset
+        },
+        mock<ReplayMetadataProvider> { on { current() } doReturn ReplayMetadata.EMPTY },
+    )
+
+    /** A capture bus that records whether it was offered a write this frame. */
+    private class RecordingBus : CaptureBus {
+        var offered = false
+        override fun offer(
+            captureId: String,
+            source: String,
+            classification: String?,
+            platform: String,
+            envelopeJson: String,
+            contentHash: Int?,
+        ): String? {
+            offered = true
+            return captureId
+        }
+    }
+
+    // --- Adversarial text pool ---------------------------------------------------
+
+    private val toxicTexts = listOf(
+        "Available Balance: \$152.10",
+        "Routing Number 021000021",
+        "123-45-6789",
+        "4111 1111 1111 1111",
+        "DasherDirect",
+        "Available Balance", // NBSP homoglyph — must still be caught post-#590
+        "R​outing Number",   // zero-width injected
+        "Ａvailable Balance", // fullwidth 'A'
+    )
+    private val benignTexts = listOf(
+        "Dash Now", "Accept", "Decline", "Pickup from Chipotle", "\$7.50", "3.2 mi",
+        "Deliver by 7:45 PM", "", "   ", "\uD800 lone-surrogate",
+    )
+
+    private fun textArb(rs: RandomSource): String = when (rs.random.nextInt(10)) {
+        0, 1 -> toxicTexts[rs.random.nextInt(toxicTexts.size)]
+        2 -> "x".repeat(3_000 + rs.random.nextInt(2_000)) // very long
+        else -> benignTexts[rs.random.nextInt(benignTexts.size)]
+    }
+
+    /** Build a bounded adversarial tree: depth <= [maxDepth], total nodes <= [maxNodes]. */
+    private fun buildTree(rs: RandomSource, maxDepth: Int, budget: IntArray): UiNode {
+        budget[0]--
+        val withId = rs.random.nextInt(4) == 0
+        val childCount = if (maxDepth <= 0 || budget[0] <= 0) 0 else rs.random.nextInt(4)
+        val children = (0 until childCount).mapNotNull {
+            if (budget[0] <= 0) null else buildTree(rs, maxDepth - 1, budget)
+        }
+        return UiNode(
+            text = textArb(rs),
+            viewIdResourceName = if (withId) "$pkg:id/n${rs.random.nextInt(50)}" else null,
+            children = children,
+        )
+    }
+
+    private val treeArb: Arb<UiNode> = arbitrary { rs ->
+        buildTree(rs, maxDepth = 6, budget = intArrayOf(200))
+    }
+
+    private fun event(tree: UiNode) = PipelineEvent.Screen(
+        timestamp = 1_000L,
+        tree = tree,
+        snapshot = TreeSnapshot(tree, packageName = pkg, source = TreeSnapshot.Source.STATE_CHANGED),
+        packageName = pkg,
+    )
+
+    @Test
+    fun `property - adversarial trees never crash classify or capture, stay time-bounded, and never leak an UNKNOWN sensitive frame`() = runTest {
+        checkAll(200, treeArb) { tree ->
+            val bus = RecordingBus()
+            val writer = CaptureWriter(bus, PipelineStats(), noRedaction)
+
+            val start = System.nanoTime()
+            val obs = classifier.classify(event(tree)) // must not throw
+            writer.captureScreen(obs, event(tree))      // must not throw
+            val elapsedMs = (System.nanoTime() - start) / 1_000_000
+
+            assertTrue("classify+capture took ${elapsedMs}ms — not time-bounded", elapsedMs < 2_000)
+
+            // Fail-closed invariant: a toxic UNKNOWN frame is always dropped before the bus.
+            if (obs.target == UNKNOWN_TARGET && bus.offered) {
+                assertNull(
+                    "an UNKNOWN frame with a sensitive marker reached the capture bus — backstop leaked",
+                    SensitiveTextMarkers.findMarker(tree),
+                )
+            }
+        }
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/replay/InfoLogPiiGateReplayTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/replay/InfoLogPiiGateReplayTest.kt
@@ -1,0 +1,100 @@
+package cloud.trotter.dashbuddy.replay
+
+import android.util.Log
+import cloud.trotter.dashbuddy.core.pipeline.SensitiveTextMarkers
+import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import cloud.trotter.dashbuddy.test.util.RecordingTree
+import cloud.trotter.dashbuddy.test.util.SessionReplay
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import timber.log.Timber
+
+/**
+ * #590 / #551 — the **INFO+ PII-safe-by-construction regression gate**.
+ *
+ * Development Principle 7 makes INFO+ the *shareable* log stream (a user can export it as a bug
+ * report), so a raw merchant/customer/address string in an INFO-or-higher line is a privacy defect
+ * of the same class as leaking it to disk. #551 Phase 1 (PR #679) fixed the known INFO leak sites
+ * (`TipEffectHandler`/`ShadowStoreChainLogger`/`SideEffectEngine`) and shipped the [RecordingTree]
+ * test tree; this test is the **Phase-2 gate** that patrols the property so the future export sink
+ * can trust INFO+ *by construction*, not by call-site discipline.
+ *
+ * It plants a [RecordingTree], drives the real single-delivery capture session end-to-end through
+ * the production recognition + the REAL `StateMachine` ([SessionReplay.reduceMixed] — the same
+ * fixture + wiring as [SingleDeliveryReplayTest]), then asserts that **no** recorded INFO/WARN/ERROR
+ * line either:
+ *  (a) contains a raw store/address string harvested from the session's OWN parsed fields
+ *      (the deny-list is derived from the fixture data itself — never hardcoded), or
+ *  (b) trips the hardened [SensitiveTextMarkers.findMarker] scan (banking markers + SSN/PAN shapes,
+ *      post the #590 evasion hardening).
+ *
+ * Post-#679 the reduceMixed path (classifier + steppers + `EffectMap`) is expected to be clean, so
+ * this stays green; it goes red the moment a PII-bearing INFO+ log is (re)introduced into that path.
+ * Customer name/address in this fixture are already `sha256`-redacted (a hash in INFO is Principle-7
+ * safe), so the meaningful deny-list is the raw merchant `storeName`/`storeAddress` values — exactly
+ * the class the #679 sweep demoted to DEBUG.
+ */
+class InfoLogPiiGateReplayTest {
+
+    private val session = "snapshots/sessions/single_delivery_2026_06_16"
+
+    /** Raw store/address strings the session's own parse produced — the deny-list, from the data. */
+    private fun harvestStoreStrings(steps: List<SessionReplay.ReplayStep>): Set<String> {
+        val out = mutableSetOf<String>()
+        for (step in steps) {
+            val parsed = (step.observation as? Observation.FlowObservation)?.parsed ?: continue
+            when (val p = parsed) {
+                is ParsedFields.TaskFields -> {
+                    p.storeName?.let { out += it }
+                    p.storeAddress?.let { out += it }
+                }
+                is ParsedFields.NotificationFields -> p.storeName?.let { out += it }
+                is ParsedFields.OfferFields -> p.parsedOffer.orders.forEach { out += it.storeName }
+                else -> {}
+            }
+        }
+        // Only non-trivial tokens can meaningfully leak; drop blanks/very short values that would
+        // false-match on unrelated log text (a 1-2 char store token is not a realistic leak anchor).
+        return out.map { it.trim() }.filter { it.length >= 3 }.toSet()
+    }
+
+    @Test
+    fun `no INFO-plus log line in a reduceMixed replay leaks a raw store string or a sensitive marker`() {
+        val recording = RecordingTree()
+        Timber.plant(recording)
+        val steps = try {
+            val screens = SessionReplay.loadSession(session).map { SessionReplay.ScreenInput(it) }
+            val click = SessionReplay.loadClickFrame("$session/02_accept_offer_click.json")
+            SessionReplay.reduceMixed(screens + click)
+        } finally {
+            Timber.uproot(recording)
+        }
+
+        // Sanity: the harness actually ran (drove the machine and produced parsed store data), so a
+        // green result is a real patrol, not a vacuous pass on an empty trace.
+        assertTrue("replay produced no steps — fixture/wiring broken", steps.isNotEmpty())
+        val denyList = harvestStoreStrings(steps)
+        assertTrue("harvested no store strings from the parse — deny-list would be vacuous", denyList.isNotEmpty())
+
+        val infoPlus = recording.records.filter { it.priority >= Log.INFO }
+
+        // (a) No INFO+ line carries a raw store/address value the parse itself produced.
+        for (record in infoPlus) {
+            val leak = denyList.firstOrNull { record.message.contains(it, ignoreCase = true) }
+            assertNull(
+                "INFO+ leaked raw store string '$leak': [${record.priority}/${record.tag}] ${record.message}",
+                leak,
+            )
+        }
+
+        // (b) No INFO+ line trips the hardened sensitive-marker scan (banking markers + PAN/SSN).
+        for (record in infoPlus) {
+            assertNull(
+                "INFO+ line hit a sensitive marker: [${record.priority}/${record.tag}] ${record.message}",
+                SensitiveTextMarkers.findMarker(record.message),
+            )
+        }
+    }
+}

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/SensitiveTextMarkers.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/SensitiveTextMarkers.kt
@@ -1,6 +1,8 @@
 package cloud.trotter.dashbuddy.core.pipeline
 
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import java.text.Normalizer
+import java.util.Locale
 
 /**
  * App-owned fail-closed backstop for the sensitive-screen pledge (#432).
@@ -78,24 +80,86 @@ object SensitiveTextMarkers {
     )
 
     /**
-     * Scan the tree's text for a sensitive marker. Returns the first
-     * matched marker (for logging) or null when clean.
+     * Sentinel returned when [normalize] throws — the scan is FAIL-CLOSED (#590):
+     * a text we cannot normalize is treated as toxic, never silently reported
+     * clean. Losing a real banking screen to disk because a homoglyph tripped the
+     * normalizer would defeat the whole backstop, so an unexpected throw drops the
+     * capture exactly as a real marker would.
      */
-    fun findMarker(tree: UiNode): String? {
-        for (text in tree.allText) {
-            val keyword = KEYWORDS.firstOrNull { text.contains(it, ignoreCase = true) }
-            if (keyword != null) return keyword
-            val shape = SHAPE_PATTERNS.firstOrNull { it.containsMatchIn(text) }
-            if (shape != null) return "shape:${shape.pattern}"
-        }
-        return null
+    private const val NORMALIZE_FAILED = "normalize-error"
+
+    /**
+     * Markers pre-normalized once (evasion resistance, #590). The scan compares
+     * NORMALIZED text against NORMALIZED markers so the two sides agree — a marker
+     * with an ASCII space matches text whose space arrived as an NBSP after
+     * folding. Paired with the original marker so [findMarker] still returns the
+     * human-readable form for the WARN log.
+     */
+    private val normalizedKeywords: List<Pair<String, String>> by lazy {
+        KEYWORDS.map { normalize(it) to it }
     }
 
-    /** Scan a flat text blob (notification body) for a sensitive marker. */
-    fun findMarker(text: String): String? {
-        val keyword = KEYWORDS.firstOrNull { text.contains(it, ignoreCase = true) }
-        if (keyword != null) return keyword
-        return SHAPE_PATTERNS.firstOrNull { it.containsMatchIn(text) }
+    /**
+     * Single-pass homoglyph/whitespace normalizer (#590) shared by both scan
+     * overloads and applied to BOTH sides (markers + scanned text). Closes the
+     * evasion classes a plain `contains` substring test misses:
+     *  - NFKC folds NBSP (U+00A0) / narrow-NBSP (U+202F) → space and fullwidth
+     *    digits/letters (U+FF10+) / ideographic space (U+3000) → ASCII;
+     *  - zero-width & other format chars (U+200B/200C/200D/FEFF, `Character.FORMAT`)
+     *    are stripped, so a marker split by an invisible char rejoins;
+     *  - unicode dashes (U+2010–U+2015, U+2212 minus) fold to ASCII `-` so the
+     *    SSN/PAN shapes match homoglyph hyphens;
+     *  - all remaining whitespace (incl. the `` unit separator used to join
+     *    sibling text) collapses to a single ASCII space;
+     *  - `Locale.ROOT` lowercase gives locale-safe case-insensitivity in one place
+     *    (so the scan can use a plain, allocation-light `contains`).
+     * Single allocation pass over the NFKC output; NFKC itself is O(n).
+     */
+    internal fun normalize(s: String): String {
+        val nfkc = Normalizer.normalize(s, Normalizer.Form.NFKC)
+        val sb = StringBuilder(nfkc.length)
+        for (ch in nfkc) {
+            when {
+                Character.getType(ch) == Character.FORMAT.toInt() -> {} // strip zero-width / format
+                ch in '‐'..'―' || ch == '−' -> sb.append('-') // unicode dashes → hyphen
+                ch == '' || ch.isWhitespace() -> sb.append(' ') // canonicalize whitespace
+                else -> sb.append(ch)
+            }
+        }
+        return sb.toString().lowercase(Locale.ROOT)
+    }
+
+    private fun scan(normalizedText: String): String? {
+        val keyword = normalizedKeywords.firstOrNull { (norm, _) -> normalizedText.contains(norm) }
+        if (keyword != null) return keyword.second
+        return SHAPE_PATTERNS.firstOrNull { it.containsMatchIn(normalizedText) }
             ?.let { "shape:${it.pattern}" }
+    }
+
+    /**
+     * Scan the tree's text for a sensitive marker. Returns the first
+     * matched marker (for logging) or null when clean.
+     *
+     * The whole `allText` is joined on a space and scanned as ONE normalized blob
+     * (#590): a keyword within a single node stays intact, AND a keyword split
+     * across adjacent sibling nodes ("Bank" | "Account") rejoins across the space.
+     * Uses the existing `allText` walk — no new tree traversal. FAIL-CLOSED: any
+     * throw in normalization returns the toxic sentinel (drop the capture), never
+     * null.
+     */
+    fun findMarker(tree: UiNode): String? = try {
+        scan(normalize(tree.allText.joinToString(" ")))
+    } catch (_: Throwable) {
+        NORMALIZE_FAILED
+    }
+
+    /**
+     * Scan a flat text blob (notification body) for a sensitive marker.
+     * FAIL-CLOSED: a normalization throw returns the toxic sentinel, never null.
+     */
+    fun findMarker(text: String): String? = try {
+        scan(normalize(text))
+    } catch (_: Throwable) {
+        NORMALIZE_FAILED
     }
 }

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/SensitiveMarkerEvasionTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/SensitiveMarkerEvasionTest.kt
@@ -1,0 +1,234 @@
+package cloud.trotter.dashbuddy.core.pipeline
+
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.element
+import io.kotest.property.checkAll
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+/**
+ * #590 — MARKER EVASION RESISTANCE for the sensitive-screen pledge backstop.
+ *
+ * [SensitiveTextMarkers] is the fail-closed guard the matcher-layer block leans on:
+ * an unrecognized banking/identity screen classifies UNKNOWN and is scrubbed from
+ * the capture ONLY if [SensitiveTextMarkers.findMarker] hits. Before this suite the
+ * scan was a plain case-insensitive substring test, so any homoglyph/whitespace
+ * mutation of a toxic seed marker evaded it and the raw screen shipped to disk.
+ *
+ * Red-first observation (pre-hardening, current `contains(..., ignoreCase = true)`):
+ * every non-case mutation class below EVADED the substring scan and returned
+ * `null` (clean) on a genuinely toxic screen —
+ *  - NBSP (U+00A0) / narrow-NBSP (U+202F) substituted for the ASCII space,
+ *  - zero-width chars (U+200B/200C/200D/FEFF) injected between letters,
+ *  - unicode dashes (U+2010–U+2015) substituted for the ASCII hyphen in the SSN/PAN shapes,
+ *  - fullwidth digits/letters (U+FF10+),
+ *  - the marker split across two adjacent sibling text nodes.
+ * Only the plain case-variant mutation was already caught (`ignoreCase = true`).
+ *
+ * The fix normalizes BOTH the scanned text and the markers through one single-pass
+ * [SensitiveTextMarkers] normalizer (NFKC + zero-width/format strip + unicode-dash
+ * fold + whitespace canonicalization + `Locale.ROOT` lowercase) before the substring
+ * scan, and — for the sibling-split class — scans the space-joined `allText` form
+ * (the existing tree walk, no new traversal). The normalization is fail-CLOSED: any
+ * throw is treated as a hit, never as "clean".
+ *
+ * Documented out-of-scope residuals (see the bottom of this file) are asserted as
+ * residuals, not detections, so a future hardening that closes them is a visible
+ * behaviour change.
+ */
+class SensitiveMarkerEvasionTest {
+
+    // ---- Seed toxic markers to mutate (a representative spread) -----------------
+    // Multi-word (space-bearing) keywords, a single-word keyword, and the two shapes.
+    private val keywordSeeds = listOf(
+        "Routing Number",
+        "Bank Account",
+        "Available Balance",
+        "DasherDirect",
+        "CVV",
+    )
+    private val ssnSeed = "123-45-6789"
+    private val panSeed = "4111 1111 1111 1111"
+
+    private fun tree(vararg texts: String) = UiNode(children = texts.map { UiNode(text = it) })
+
+    // ---- Mutations --------------------------------------------------------------
+
+    private fun nbsp(s: String) = s.replace(' ', ' ')
+    private fun narrowNbsp(s: String) = s.replace(' ', ' ')
+    private fun zeroWidth(s: String) = s.toCharArray().joinToString("​")
+    private fun unicodeDash(s: String) = s.replace('-', '‐')
+    private fun fullwidth(s: String) = s.map { c ->
+        val code = when (c) {
+            in '0'..'9' -> '０'.code + (c - '0')
+            in 'a'..'z' -> 'ａ'.code + (c - 'a')
+            in 'A'..'Z' -> 'Ａ'.code + (c - 'A')
+            ' ' -> '　'.code // ideographic space — NFKC-folds to a normal space
+            else -> c.code
+        }
+        code.toChar()
+    }.joinToString("")
+    private fun altCase(s: String) = s.mapIndexed { i, c ->
+        if (i % 2 == 0) c.uppercaseChar() else c.lowercaseChar()
+    }.joinToString("")
+
+    /** Split [s] at its first space into two adjacent sibling text nodes. */
+    private fun splitSiblings(s: String): UiNode {
+        val idx = s.indexOf(' ')
+        return if (idx < 0) tree(s) else tree(s.substring(0, idx), s.substring(idx + 1))
+    }
+
+    private fun assertDetected(mutation: String, seed: String, tree: UiNode) {
+        assertNotNull(
+            "EVASION: mutation '$mutation' of toxic marker <$seed> was NOT detected — " +
+                "a genuinely sensitive screen would ship to disk",
+            SensitiveTextMarkers.findMarker(tree),
+        )
+    }
+
+    private fun assertDetected(mutation: String, seed: String, text: String) {
+        assertNotNull(
+            "EVASION: mutation '$mutation' of toxic marker <$seed> was NOT detected (flat overload)",
+            SensitiveTextMarkers.findMarker(text),
+        )
+    }
+
+    // ---- Keyword mutations ------------------------------------------------------
+
+    @Test
+    fun `NBSP-substituted keyword markers are still detected`() {
+        for (seed in keywordSeeds) {
+            assertDetected("NBSP tree", seed, tree(nbsp(seed)))
+            assertDetected("NBSP flat", seed, nbsp(seed))
+        }
+    }
+
+    @Test
+    fun `narrow-NBSP-substituted keyword markers are still detected`() {
+        for (seed in keywordSeeds) {
+            assertDetected("narrow-NBSP tree", seed, tree(narrowNbsp(seed)))
+            assertDetected("narrow-NBSP flat", seed, narrowNbsp(seed))
+        }
+    }
+
+    @Test
+    fun `zero-width-injected keyword markers are still detected`() {
+        for (seed in keywordSeeds) {
+            assertDetected("ZW tree", seed, tree(zeroWidth(seed)))
+            assertDetected("ZW flat", seed, zeroWidth(seed))
+        }
+    }
+
+    @Test
+    fun `fullwidth keyword markers are still detected`() {
+        for (seed in keywordSeeds) {
+            assertDetected("fullwidth tree", seed, tree(fullwidth(seed)))
+            assertDetected("fullwidth flat", seed, fullwidth(seed))
+        }
+    }
+
+    @Test
+    fun `case-variant keyword markers are still detected (already covered pre-fix)`() {
+        for (seed in keywordSeeds) {
+            assertDetected("altCase tree", seed, tree(altCase(seed)))
+            assertDetected("altCase flat", seed, altCase(seed))
+        }
+    }
+
+    @Test
+    fun `keyword markers split across adjacent sibling nodes are still detected`() {
+        // Only the space-bearing multi-word keywords can split; single-word keywords
+        // can't and are covered by the per-node path above.
+        for (seed in keywordSeeds.filter { it.contains(' ') }) {
+            assertDetected("sibling-split", seed, splitSiblings(seed))
+        }
+    }
+
+    // ---- Shape mutations (SSN / card PAN) --------------------------------------
+
+    @Test
+    fun `unicode-dash SSN shape is still detected`() {
+        assertDetected("unicode-dash SSN tree", ssnSeed, tree(unicodeDash(ssnSeed)))
+        assertDetected("unicode-dash SSN flat", ssnSeed, unicodeDash(ssnSeed))
+    }
+
+    @Test
+    fun `fullwidth-digit SSN shape is still detected`() {
+        assertDetected("fullwidth SSN tree", ssnSeed, tree(fullwidth(ssnSeed)))
+        assertDetected("fullwidth SSN flat", ssnSeed, fullwidth(ssnSeed))
+    }
+
+    @Test
+    fun `NBSP-separated card PAN shape is still detected`() {
+        assertDetected("NBSP PAN tree", panSeed, tree(nbsp(panSeed)))
+        assertDetected("NBSP PAN flat", panSeed, nbsp(panSeed))
+    }
+
+    @Test
+    fun `fullwidth-digit card PAN shape is still detected`() {
+        assertDetected("fullwidth PAN tree", panSeed, tree(fullwidth(panSeed)))
+        assertDetected("fullwidth PAN flat", panSeed, fullwidth(panSeed))
+    }
+
+    // ---- Property: random composition of the keyword mutations still detected ---
+
+    @Test
+    fun `property - any composition of homoglyph-whitespace mutations still detects a keyword`() = runTest {
+        val seed = Arb.element(keywordSeeds)
+        val mut = Arb.element<(String) -> String>(
+            ::nbsp, ::narrowNbsp, ::zeroWidth, ::fullwidth, ::altCase,
+        )
+        checkAll(200, seed, mut, mut) { s, m1, m2 ->
+            val mutated = m2(m1(s))
+            assertDetected("composed", s, tree(mutated))
+        }
+    }
+
+    // ---- Fail-closed: normalization never returns "clean" on a throw -----------
+    // (Covered structurally: the normalizer catches all Throwable and returns a
+    // toxic sentinel. A deliberately malformed lone-surrogate string exercises the
+    // path without crashing.) A lone surrogate is not valid for NFKC on some JDKs.
+
+    @Test
+    fun `lone-surrogate text never crashes the scan`() {
+        // Must not throw; result may be null (no marker) or non-null (fail-closed).
+        SensitiveTextMarkers.findMarker(tree("\uD800 balance"))
+        SensitiveTextMarkers.findMarker("\uD800 balance")
+    }
+
+    // ---- Documented out-of-scope RESIDUALS -------------------------------------
+    // A plain single-token shape (SSN) split across two sibling nodes as
+    // "123-45" / "6789" IS caught (the space-joined form re-assembles it), but a
+    // PAN split so that no 4-4-4-4 run survives the join is a residual — the shape
+    // needs the digit groups contiguous. The rule-declared sensitive rules remain
+    // the primary control for shaped values; these markers are the backstop.
+    @Test
+    fun `RESIDUAL - a fully fragmented PAN (one digit per node) is NOT caught by the shape backstop`() {
+        // Documented residual: 16 single-digit sibling nodes never form a 4-4-4-4
+        // run in the joined text, so the PAN shape can't match. Recognized banking
+        // screens (the primary control) still block this; the marker backstop does not.
+        val digits = panSeed.filter { it.isDigit() }.map { it.toString() }
+        val fragmented = UiNode(children = digits.map { UiNode(text = it) })
+        // Assert the residual explicitly so closing it later is a visible change.
+        org.junit.Assert.assertNull(
+            "if this becomes non-null, the residual was closed — update the doc",
+            SensitiveTextMarkers.findMarker(fragmented),
+        )
+    }
+
+    // Sanity: the normalizer must not turn CLEAN screens toxic (Principle: zero
+    // behaviour change on the clean corpus).
+    @Test
+    fun `ordinary screens stay clean after normalization`() {
+        org.junit.Assert.assertNull(
+            SensitiveTextMarkers.findMarker(
+                tree("Pickup from Chipotle", "Deliver by 7:45 PM", "\$7.50", "3.2 mi", "Accept"),
+            ),
+        )
+        org.junit.Assert.assertNull(
+            SensitiveTextMarkers.findMarker(tree("Total: \$1,234.56", "ETA 12-45")),
+        )
+    }
+}

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/EachAmplificationBoundedTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/EachAmplificationBoundedTest.kt
@@ -1,0 +1,128 @@
+package cloud.trotter.dashbuddy.core.pipeline.rules
+
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.int
+import io.kotest.property.checkAll
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #590 fill-in — `each`/`extract` MATCH-TIME amplification is BOUNDED (not 50^K).
+ *
+ * `each` caps its own node harvest at `RuleCompiler.MAX_EACH_SIZE` (50) via
+ * `findNodes(...).take(MAX_EACH_SIZE)`. But `extract` fields are themselves parse
+ * expressions, so a NESTED `each`-inside-`extract` multiplies per level. The worry
+ * is a rule that turns a wide accessibility tree into a `tree_width ^ depth`
+ * extraction on the classification thread. This proves each nesting level is capped
+ * at 50 independently, so the output is bounded by `50 ^ depth` (and, on any real
+ * bounded tree, by the tree itself) — never `tree_width ^ depth` — and completes
+ * well within a wall-clock budget.
+ *
+ * A failing property prints its seed; pin it with `PropTestConfig(seed = ...)`.
+ */
+class EachAmplificationBoundedTest {
+
+    /** Mirror of the private RuleCompiler.MAX_EACH_SIZE, referenced in the bound. */
+    private val maxEach = 50
+
+    /** A bushy tree: [width] children, each with [width] grandchildren, all id-less. */
+    private fun bushyTree(width: Int): UiNode = UiNode(
+        text = "root",
+        children = (0 until width).map { i ->
+            UiNode(
+                text = "n$i",
+                children = (0 until width).map { j -> UiNode(text = "n$i-$j") },
+            )
+        },
+    )
+
+    /** parse.fields.items = a [depth]-deep nested `each`/`extract` over all id-less nodes. */
+    private fun nestedEachRule(depth: Int): JsonArray {
+        // innermost extract is a leaf text read
+        var expr: JsonElement = JsonPrimitive("text")
+        repeat(depth) {
+            expr = buildJsonObject {
+                put("each", buildJsonObject { put("hasNoId", JsonPrimitive(true)) })
+                put("extract", buildJsonObject { put("v", expr) })
+            }
+        }
+        val rule = buildJsonObject {
+            put("id", JsonPrimitive("doordash.screen.probe"))
+            put("priority", JsonPrimitive(1))
+            // require: matches any tree (root has no id)
+            put("require", buildJsonObject { put("exists", buildJsonObject { put("hasNoId", JsonPrimitive(true)) }) })
+            put("parse", buildJsonObject {
+                put("as", JsonPrimitive("idle"))
+                put("fields", buildJsonObject { put("items", expr) })
+            })
+        }
+        return JsonArray(listOf(rule))
+    }
+
+    /** Count every extracted leaf across the nested List<Map<...>> `each` output. */
+    private fun countLeaves(value: Any?): Int = when (value) {
+        is List<*> -> value.sumOf { countLeaves(it) }
+        is Map<*, *> -> value.values.sumOf { countLeaves(it) }
+        null -> 0
+        else -> 1 // a terminal extracted value (String, etc.)
+    }
+
+    /** The theoretical cap on total extractions for a [depth]-nested each: sum_{k=1..depth} 50^k. */
+    private fun theoreticalBound(depth: Int): Long {
+        var total = 0L
+        var level = 1L
+        repeat(depth) {
+            level *= maxEach
+            total += level
+        }
+        return total
+    }
+
+    @Test
+    fun `property - nested each on a wide tree stays within the MAX_EACH_SIZE-derived bound and time budget`() = runTest {
+        // width up to 40 → up to ~1600 id-less nodes; depth 1..3. Naive tree_width^depth
+        // would be up to 40^3 = 64 000 *per outer node*; the cap must hold it far below.
+        checkAll(120, Arb.int(2, 40), Arb.int(1, 3)) { width, depth ->
+            val ruleset = Ruleset(RuleCompiler.compileRules<UiNode>(nestedEachRule(depth), RuleContext.SCREEN))
+            val tree = bushyTree(width)
+
+            val start = System.nanoTime()
+            val result = ruleset.matchFirst(tree, "doordash")
+            val elapsedMs = (System.nanoTime() - start) / 1_000_000
+
+            requireNotNull(result) { "probe rule must match the id-less tree" }
+            val leaves = countLeaves(result.fields["items"])
+
+            assertTrue(
+                "leaf count $leaves exceeded the 50^depth bound ${theoreticalBound(depth)} " +
+                    "(width=$width depth=$depth) — amplification is NOT capped per level",
+                leaves <= theoreticalBound(depth),
+            )
+            assertTrue(
+                "nested-each match took ${elapsedMs}ms (width=$width depth=$depth) — not time-bounded",
+                elapsedMs < 2_000,
+            )
+        }
+    }
+
+    @Test
+    fun `a very wide tree does not amplify past 50 outer x 50 inner for depth 2`() = runTest {
+        // 200x200 = ~40 000 id-less nodes. Depth-2 naive would extract 40 000 * 40 000;
+        // the cap holds the leaf count at <= 50 (outer) * 50 (inner) + 50 (the outer maps).
+        val ruleset = Ruleset(RuleCompiler.compileRules<UiNode>(nestedEachRule(2), RuleContext.SCREEN))
+        val tree = bushyTree(200)
+        val start = System.nanoTime()
+        val result = requireNotNull(ruleset.matchFirst(tree, "doordash"))
+        val elapsedMs = (System.nanoTime() - start) / 1_000_000
+        val leaves = countLeaves(result.fields["items"])
+        assertTrue("leaf count $leaves must be <= 50*50", leaves <= maxEach.toLong() * maxEach)
+        assertTrue("depth-2 match on a 40k-node tree took ${elapsedMs}ms", elapsedMs < 2_000)
+    }
+}

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/LoadAtomicityTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/LoadAtomicityTest.kt
@@ -1,0 +1,145 @@
+package cloud.trotter.dashbuddy.core.pipeline.rules
+
+import android.content.Context
+import cloud.trotter.dashbuddy.domain.action.RuleAction
+import cloud.trotter.dashbuddy.domain.capability.RuleCapability
+import cloud.trotter.dashbuddy.domain.capability.RuleCapabilityGrants
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.mock
+
+/**
+ * #590 fill-in — [JsonRuleInterpreter] load is ATOMIC: a file that fails mid-load
+ * leaves NO partial state — no rules from it are matchable AND no capability grants
+ * are reconciled from it.
+ *
+ * The consent reconcile (#417) grants ACTUATION capabilities; it must happen only for
+ * a bundle that fully passed compile + the sensitive-coverage gate. If reconcile ran
+ * BEFORE a later reject (a dup-id whole-file reject, or a sensitive-coverage reject),
+ * a rejected bundle's taps would be auto-granted while its rules never went live — a
+ * fail-open grant leak. This pins the ordering.
+ *
+ * Result (green — not red-first): the ordering already holds. `loadSingle` is itself
+ * atomic (it returns a complete [JsonRuleInterpreter.CompiledRuleBundle] or null,
+ * never a partial), the dup-id reject returns null from `loadSingle` BEFORE `load`
+ * ever reaches reconcile, and the sensitive-coverage reject in `load` returns BEFORE
+ * reconcile too. This test locks that in against a future refactor moving reconcile
+ * earlier.
+ */
+class LoadAtomicityTest {
+
+    /** Records every reconcile call so a leaked grant is observable. */
+    private class RecordingGrants : RuleCapabilityGrants {
+        val reconcileCalls = mutableListOf<List<RuleCapability>>()
+        override val grantedKeys: StateFlow<Set<String>> = MutableStateFlow(emptySet())
+        override suspend fun reconcile(capabilities: List<RuleCapability>) {
+            reconcileCalls += capabilities
+        }
+        override suspend fun isActionGranted(ruleId: String?, action: RuleAction): Boolean = false
+    }
+
+    private fun interpreter(grants: RuleCapabilityGrants) =
+        JsonRuleInterpreter(context = mock<Context>(), capabilityGrants = grants)
+
+    // --- Rule-file builders (minimal valid doordash bundles) ---------------------
+
+    private val sensitiveRule = """
+        {
+          "id": "doordash.screen.sensitive",
+          "priority": 0,
+          "overrideable": false,
+          "parse": { "as": "sensitive" },
+          "branches": [
+            { "intent": "sensitive.balance", "require": { "exists": { "hasText": "Available Balance" } } }
+          ]
+        }
+    """.trimIndent()
+
+    private fun screenRule(id: String, priority: Int) = """
+        {
+          "id": "$id",
+          "priority": $priority,
+          "require": { "exists": { "hasText": "Dash Now" } }
+        }
+    """.trimIndent()
+
+    private fun file(vararg screens: String) = """
+        {
+          "format_version": 2,
+          "platform_id": "doordash.driver",
+          "screens": [ ${screens.joinToString(",")} ]
+        }
+    """.trimIndent()
+
+    private val validFile = file(sensitiveRule)
+
+    // Earlier rules compile fine, then a duplicate id triggers a WHOLE-FILE reject.
+    private val dupIdFile = file(
+        sensitiveRule,
+        screenRule("doordash.screen.dup", 10),
+        screenRule("doordash.screen.dup", 11),
+    )
+
+    // Compiles, but ships NO sensitive rule → sensitive-coverage reject in load().
+    private val noSensitiveFile = file(screenRule("doordash.screen.idle", 10))
+
+    @Test
+    fun `a dup-id whole-file reject reconciles NO capabilities and loads no rules`() = runTest {
+        val grants = RecordingGrants()
+        val interp = interpreter(grants)
+        interp.load(dupIdFile, source = "asset:rules/doordash.json")
+
+        assertFalse("a rejected file must not go live", interp.isLoaded)
+        assertTrue(
+            "reconcile ran for a rejected file — a fail-open grant leak (calls=${grants.reconcileCalls.size})",
+            grants.reconcileCalls.isEmpty(),
+        )
+    }
+
+    @Test
+    fun `a sensitive-coverage reject reconciles NO capabilities and loads no rules`() = runTest {
+        val grants = RecordingGrants()
+        val interp = interpreter(grants)
+        interp.load(noSensitiveFile, source = "asset:rules/doordash.json")
+
+        assertFalse("a coverage-rejected file must not go live", interp.isLoaded)
+        assertTrue(
+            "reconcile ran despite the sensitive-coverage reject (calls=${grants.reconcileCalls.size})",
+            grants.reconcileCalls.isEmpty(),
+        )
+    }
+
+    @Test
+    fun `a valid file goes live and reconciles exactly once (positive control)`() = runTest {
+        val grants = RecordingGrants()
+        val interp = interpreter(grants)
+        interp.load(validFile, source = "asset:rules/doordash.json")
+
+        assertTrue("a valid bundle must go live", interp.isLoaded)
+        assertNotNull(interp.screenRuleset)
+        assertEquals("valid load reconciles exactly once", 1, grants.reconcileCalls.size)
+    }
+
+    @Test
+    fun `a bad load after a good one keeps the previous bundle and does not re-reconcile`() = runTest {
+        val grants = RecordingGrants()
+        val interp = interpreter(grants)
+
+        interp.load(validFile, source = "asset:rules/doordash.json")
+        val goodRuleset = interp.screenRuleset
+        assertEquals(1, grants.reconcileCalls.size)
+
+        // The failing load must be a no-op on the live state.
+        interp.load(dupIdFile, source = "asset:rules/doordash.json")
+
+        assertTrue("previous good bundle must remain live", interp.isLoaded)
+        assertEquals("live ruleset must be unchanged by the rejected load", goodRuleset, interp.screenRuleset)
+        assertEquals("no extra reconcile from the rejected load", 1, grants.reconcileCalls.size)
+    }
+}

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/TransformFuzzFailClosedTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/TransformFuzzFailClosedTest.kt
@@ -1,0 +1,162 @@
+package cloud.trotter.dashbuddy.core.pipeline.rules
+
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.arbitrary
+import io.kotest.property.arbitrary.element
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.string
+import io.kotest.property.checkAll
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import org.junit.Assert.fail
+import org.junit.Test
+
+/**
+ * #590 fill-in — [TransformRegistry] is FAIL-CLOSED under fuzzed transform specs.
+ *
+ * The engine contract (ADR-0001 v2) is: every transform spec is validated at COMPILE
+ * time ([TransformRegistry.validateTransformSpec], typed [RuleCompileException] on any
+ * malformed shape), so match-time [TransformRegistry.applyAny] can assume a
+ * well-formed spec and MUST never throw a raw (non-[RuleCompileException]) [Throwable]
+ * — a raw NPE/ClassCast escaping `apply` on the classification thread is a fail-OPEN
+ * crash.
+ *
+ * This fuzzes arbitrary/malformed specs — unknown ops, wrong arg types, 0/2-key
+ * objects, absurd `split` indices, empty `replace` patterns — and asserts:
+ *  1. `validateTransformSpec` only ever throws the typed [RuleCompileException]
+ *     (never a raw Throwable);
+ *  2. a spec that PASSES validation then applies without a raw throw (RuleCompileException
+ *     is tolerated — it's still typed/fail-closed — but a raw Throwable is a defect);
+ *  3. a validated string output never exceeds the input by more than a DOCUMENTED
+ *     factor (the only amplifier is `replace` with an empty pattern, which inserts the
+ *     replacement between every char — bounded by the rule-authored, compile-bounded
+ *     replacement length).
+ *
+ * A failing property prints its seed; pin it with `PropTestConfig(seed = ...)`.
+ */
+class TransformFuzzFailClosedTest {
+
+    private val input = "Deliver to 123-45-6789 at 4111 1111 1111 1111 by 8:52 PM"
+
+    // Documented amplification factor (assertion 3). `replace` with an empty pattern is
+    // the only growth path: output <= (input.length + 1) * replacementLen. The generator
+    // caps replacement length at 6, so the worst-case bound is generous headroom.
+    private val maxReplacementLen = 6
+    private fun lengthBound(): Int = (input.length + 1) * maxReplacementLen + 64
+
+    // --- Arb of transform specs, half well-formed and half deliberately broken --------
+
+    private val plainName = Arb.element(
+        // known plain transforms
+        "trim", "lower", "upper", "sha256", "parseCurrency", "parseDistance",
+        // unknown / typo'd names (must compile-reject)
+        "explode", "eval", "toBytes", "", "  ", "REPLACE",
+    )
+
+    private val shortStr = Arb.string(0, maxReplacementLen)
+
+    private fun paramSpec(rs: io.kotest.property.RandomSource): JsonElement {
+        val key = Arb.element(
+            "stripPrefix", "stripSuffix", "extractBefore", "extractAfter",
+            "stripPrefixes", "replace", "split", "regex",
+            "unknownOp", // must reject
+        ).sample(rs).value
+        val param: JsonElement = when (Arb.int(0, 6).sample(rs).value) {
+            0 -> JsonPrimitive(shortStr.sample(rs).value) // string param
+            1 -> JsonPrimitive(Arb.int(-5, Int.MAX_VALUE).sample(rs).value) // absurd int
+            2 -> buildJsonObject { // replace-ish (maybe missing keys)
+                if (Arb.int(0, 1).sample(rs).value == 0) put("pattern", JsonPrimitive(shortStr.sample(rs).value))
+                put("replacement", JsonPrimitive(shortStr.sample(rs).value))
+            }
+            3 -> buildJsonObject { // split-ish (maybe missing index)
+                put("separator", JsonPrimitive(shortStr.sample(rs).value))
+                if (Arb.int(0, 1).sample(rs).value == 0) put("index", JsonPrimitive(Arb.int(-3, 999999).sample(rs).value))
+            }
+            4 -> buildJsonObject { // regex-ish
+                put("pattern", JsonPrimitive(Arb.element("\\d+", "(a+)+", "[", "").sample(rs).value))
+                put("group", JsonPrimitive(Arb.int(-1, 9).sample(rs).value))
+            }
+            5 -> buildJsonArray { } // wrong type for a string param
+            else -> JsonPrimitive(true) // wrong type entirely
+        }
+        return buildJsonObject { put(key, param) }
+    }
+
+    private val specArb: Arb<JsonElement> = arbitrary { rs ->
+        when (Arb.int(0, 4).sample(rs).value) {
+            0 -> JsonPrimitive(plainName.sample(rs).value)
+            1, 2 -> paramSpec(rs)
+            3 -> buildJsonArray { // chain of 1-3 specs
+                repeat(Arb.int(1, 3).sample(rs).value) {
+                    add(if (Arb.int(0, 1).sample(rs).value == 0) JsonPrimitive(plainName.sample(rs).value) else paramSpec(rs))
+                }
+            }
+            else -> buildJsonObject { // pathological 0-key or 2-key object
+                if (Arb.int(0, 1).sample(rs).value == 0) {
+                    put("split", JsonPrimitive(1)); put("trim", JsonPrimitive(2))
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `property - validate is typed-reject-or-ok and a validated spec never raw-throws at apply`() = runTest {
+        checkAll(400, specArb) { spec ->
+            val validated = try {
+                TransformRegistry.validateTransformSpec(spec)
+                true
+            } catch (e: RuleCompileException) {
+                false // the acceptable typed-reject arm
+            } catch (t: Throwable) {
+                fail("validateTransformSpec leaked a raw ${t.javaClass.name}: ${t.message} for spec=$spec")
+                false
+            }
+
+            if (validated) {
+                val out = try {
+                    TransformRegistry.applyAny(spec, input)
+                } catch (e: RuleCompileException) {
+                    null // still typed/fail-closed — tolerated
+                } catch (t: Throwable) {
+                    fail("applyAny leaked a raw ${t.javaClass.name}: ${t.message} for a VALIDATED spec=$spec")
+                    null
+                }
+                if (out is String) {
+                    assertOutputBounded(out, spec)
+                }
+            }
+        }
+    }
+
+    private fun assertOutputBounded(out: String, spec: JsonElement) {
+        if (out.length > lengthBound()) {
+            fail("validated transform output length ${out.length} exceeded documented bound ${lengthBound()} for spec=$spec")
+        }
+    }
+
+    @Test
+    fun `applyAny on an unvalidated malformed spec still only throws the typed RuleCompileException`() {
+        // The runtime contract when apply IS reached on a broken spec (e.g. a 2-key
+        // object, an unknown op): a typed reject, never a raw crash. (Missing required
+        // sub-keys are a compile-time reject, so this asserts the shapes apply() itself
+        // guards — single-key + known-op dispatch.)
+        val broken = listOf(
+            buildJsonObject { put("nope", JsonPrimitive("x")) },
+            buildJsonObject { put("a", JsonPrimitive(1)); put("b", JsonPrimitive(2)) },
+            JsonPrimitive("definitelyNotATransform"),
+        )
+        for (spec in broken) {
+            try {
+                TransformRegistry.applyAny(spec, input)
+                // succeeding is fine (no-op)
+            } catch (e: RuleCompileException) {
+                // typed reject — acceptable
+            } catch (t: Throwable) {
+                fail("applyAny leaked a raw ${t.javaClass.name} for broken spec=$spec")
+            }
+        }
+    }
+}


### PR DESCRIPTION
Phase 2 of #590 — the **privacy-side** property/generative tests, building on PR #680 (kotest-property + compile/ReDoS/notification invariants) and #679 (#551 Phase 1 INFO fixes + `RecordingTree`). Scope: the *Marker evasion resistance* item, the *INFO+ logs PII-safe by construction* item, and the four *Phase 1 fill-in* bullets. Phase 2 coverage-guided fuzzing stays deferred; the #551 Phase-2 export-sink UI is not in scope.

## Deliverable 1 — marker evasion resistance (pledge surface)
`SensitiveMarkerEvasionTest` mutates each toxic seed marker and asserts it's still caught.

**Red-first: 10 of 14 mutation classes EVADED** the plain `contains(..., ignoreCase=true)` scan and returned `null` (clean) on a genuinely toxic screen — every non-case class:
- NBSP (U+00A0) / narrow-NBSP (U+202F) substituted for the ASCII space
- zero-width chars (U+200B/200C/200D/FEFF) injected between letters
- unicode dashes (U+2010–U+2015) for the ASCII hyphen in the SSN/PAN shapes
- fullwidth digits/letters (U+FF10+)
- the marker split across two adjacent sibling text nodes

Only the plain case-variant class was already caught.

**Fix lives in the SSOT** (`SensitiveTextMarkers.normalize`) so every consumer (UNKNOWN screen/click/notification capture-scrub) inherits it: a single-pass NFKC + `Character.FORMAT` strip (zero-width) + unicode-dash fold + whitespace canonicalization + `Locale.ROOT` lowercase, applied to **both** the scanned text and the markers. The tree scan joins `allText` on a space and scans one normalized blob — reuses the existing walk, no new traversal — closing the sibling-split class. **Fail-CLOSED:** any normalization throw returns a toxic sentinel, never "clean" (KDoc'd; exercised by a lone-surrogate case).

**Documented residual (this matters, per the #624 precedent):** a fully fragmented PAN (one digit per sibling node) can't form a 4-4-4-4 run in the joined text and is not caught by the shape backstop — the *recognized* sensitive rules remain the primary control for shaped values; the markers are the backstop. Asserted explicitly as a residual so closing it later is a visible change.

Zero behaviour change on the clean corpus — `AllMatchersSuite`, `CaptureScrubTest`, `SensitiveTextMarkersTest`, `CaptureBackstopCorpusTest`, and the golden/`SnapshotSecurityScanner` guards all stay green.

## Deliverable 2 — INFO+ replay PII gate
`InfoLogPiiGateReplayTest` plants a `RecordingTree`, drives the real single-delivery session through production recognition + the real `StateMachine` (`SessionReplay.reduceMixed`, same fixture/wiring as `SingleDeliveryReplayTest`), and asserts no INFO/WARN/ERROR line (a) contains a raw store/address string harvested from the session's **own** parsed fields (deny-list derived from the data, not hardcoded) or (b) trips the hardened `SensitiveTextMarkers.findMarker` scan.

**No live leak found** in the reduceMixed path (classifier + steppers + `EffectMap`) post-#679 — the gate is green and now patrols the path so the future shareable-export sink can trust INFO+ by construction. (Customer PII in the fixture is already `sha256`-redacted, so the meaningful deny-list is the raw merchant `storeName`/`storeAddress` values — the class #679 demoted to DEBUG.)

## Deliverable 3 — Phase-1 fill-ins (one focused test each)
- **`ClassifyGateCaptureFuzzTest`** (:app): adversarial `UiNode` trees (bounded depth/width, hostile text incl. homoglyph markers + SSN/PAN shapes + 3–5k-char strings + lone surrogate) through the real `ObservationClassifier` (production `TestRulesetFactory` rules) + `CaptureWriter` — no crash, time-bounded, and an UNKNOWN frame reaching the bus never carried a `SensitiveTextMarkers` hit (fail-closed).
- **`EachAmplificationBoundedTest`**: nested `each`/`extract` on wide trees stays within the `50^depth` `MAX_EACH_SIZE`-derived bound (not `tree_width^depth`) and is time-bounded; a 40k-node tree at depth 2 caps at 50×50.
- **`TransformFuzzFailClosedTest`**: fuzzed/malformed transform specs — `validateTransformSpec` is typed-reject-or-ok (never a raw `Throwable`) and a **validated** spec never raw-throws at `applyAny`; validated string output within a documented factor (only amplifier is `replace` with an empty pattern, bounded by the compile-bounded replacement length).
- **`LoadAtomicityTest`**: a dup-id whole-file reject and a sensitive-coverage reject each reconcile **NO** capabilities and load **no** rules; a bad load after a good one keeps the previous bundle. **Green, not red-first** — `reconcile` already runs *after* full compile + the coverage gate (`loadSingle` is itself atomic: complete bundle or null), so no live defect; the test locks that ordering against a future refactor moving reconcile earlier.

## Security posture
- The hardened scan now catches homoglyph/whitespace/zero-width/fullwidth/unicode-dash evasions and the sibling-split of every seed marker; normalization is **fail-closed** (a throw ⇒ toxic).
- No new PII surface: the normalizer only masks/detects; nothing new is persisted or logged. The INFO+ gate is a *read-only* patrol. The load-atomicity test confirms no fail-open grant leak.

## Verification
`testDebugUnitTest :domain:test` green + `*AllMatchersSuite*` + the capture/scrub/security suites green. New tests add **~0.72s** total wall time (heaviest: `ClassifyGateCaptureFuzzTest` ≈ 0.56s); the PR job stays well under ~7 min. All property tests bound iterations (120–400) and print the failing seed for reproduction.

### Design-goal review
- **6 (security & privacy first):** the pledge-surface change — the sensitive-marker backstop is hardened against homoglyph/whitespace evasion in the SSOT (every consumer inherits), and normalization is fail-closed (a throw is treated as toxic, never "clean"). The documented PAN-fragmentation residual is stated, not silent (the #624 residual precedent). No new PII surface.
- **7 (semantic, PII-safe logging):** `InfoLogPiiGateReplayTest` is the enforcement test for the INFO-must-be-PII-safe rule — it gates the shareable stream on the hardened `SensitiveTextMarkers` scan + a data-derived store deny-list rather than call-site discipline, exactly as Principle 7 demands.
- **5 (SSOT):** the normalization logic lives in one place (`SensitiveTextMarkers.normalize`) and is applied consistently to both the scanned text and the markers — no second copy; the test scanner (`SnapshotSecurityScanner`) still reads the same `KEYWORDS` SSOT (its shape-parity item is a separate #590 bullet, out of scope here).
- **8 (platform-agnostic core):** no new platform literals — the marker/normalize logic is cross-platform data/text handling; the load-atomicity test uses `doordash`-prefixed fixtures only as ruleset DATA, not `:core` logic. No `:core:state`/`:domain` behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)