### PR TITLE
feat(#551): P7 phase 2 — PII-safe shareable log sink (fail-closed scrub at the sink)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -406,7 +406,13 @@ Every new feature or refactor holds to these — they are forefront design input
    tested** (reuse `SensitiveTextMarkers`): a raw merchant/customer string in an INFO+ line is a
    privacy defect of the same class as leaking it to disk — gate the shareable-export sink behind that
    test, do not trust call-site discipline. When a change adds or moves a log site, state its level and
-   (for INFO+) confirm it carries no raw PII. (Implementation tracked in #551.)
+   (for INFO+) confirm it carries no raw PII. Shipped as two sinks in `LogRepository` (#551): the
+   verbatim DEBUG firehose (`app.log`, on-device only) and the PII-safe INFO+ `shareable.log` a user
+   exports as a bug report (Settings → Data & Privacy → Export Data), where every INFO+ line passes a
+   **fail-closed scrub at the sink** — an injected `LogScrubber` bound to `SensitiveTextMarkers` (one
+   marker SSOT, no `:core:data`→`:core:pipeline` edge), a hit/throw/unbound scrubber redacting to a
+   `[scrubbed:<marker>]` placeholder rather than trusting call sites (the #590 replay gate patrols
+   upstream; the sink is the last line).
 8. **Platform-agnostic core.** The recognition→state→effects spine never encodes a specific gig
    platform. Recognition is data (per-platform rulesets), not code; platform identity resolves
    only through the `Platform` registry (`fromRuleId`/`fromPackage`/`fromWire`) — never a literal

--- a/app/src/main/java/cloud/trotter/dashbuddy/di/AppModule.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/di/AppModule.kt
@@ -4,6 +4,8 @@ import android.app.NotificationManager
 import android.content.Context
 import cloud.trotter.dashbuddy.BuildConfig
 import cloud.trotter.dashbuddy.DashBuddyApplication
+import cloud.trotter.dashbuddy.core.data.log.LogScrubber
+import cloud.trotter.dashbuddy.core.pipeline.SensitiveTextMarkers
 import cloud.trotter.dashbuddy.core.state.EffectExecutor
 import cloud.trotter.dashbuddy.core.state.MetadataProvider
 import cloud.trotter.dashbuddy.state.effects.SideEffectEngine
@@ -42,5 +44,17 @@ object AppModule {
     fun provideNotificationManager(@ApplicationContext context: Context): NotificationManager {
         return context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
     }
+
+    /**
+     * The fail-closed PII scrub for the shareable log sink (#551, Principle 7). `:app` is the only
+     * module that sees both `:core:data` (where [LogScrubber]/`LogRepository` live) and
+     * `:core:pipeline` (the [SensitiveTextMarkers] SSOT), so the binding is wired here — keeping ONE
+     * marker definition with no new module edge. `findMarker` is itself fail-closed (a normalization
+     * throw returns a sentinel, not null), and `LogRepository` additionally guards throws + unbound.
+     */
+    @Provides
+    @Singleton
+    fun provideLogScrubber(): LogScrubber =
+        LogScrubber { line -> SensitiveTextMarkers.findMarker(line) }
 
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/log/StateAwareTree.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/log/StateAwareTree.kt
@@ -63,8 +63,10 @@ class StateAwareTree(
         }
         logLine.append("\n")
 
-        // Send to the Repo to be written to disk
-        logRepository.appendLog(logLine.toString())
+        // Send to the Repo to be written to disk. The priority routes the line to the two sinks
+        // (#551): every line hits the firehose; INFO+ additionally flows through the fail-closed
+        // scrub into the shareable/export sink.
+        logRepository.appendLog(logLine.toString(), priority)
     }
 
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/DataExportScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/DataExportScreen.kt
@@ -3,6 +3,8 @@ package cloud.trotter.dashbuddy.ui.main.settings
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -38,11 +40,18 @@ fun DataExportScreen(
     viewModel: DataExportViewModel = hiltViewModel(),
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
+    val logState by viewModel.logState.collectAsStateWithLifecycle()
 
     val pickFolder = rememberLauncherForActivityResult(
         ActivityResultContracts.OpenDocumentTree()
     ) { uri ->
         if (uri != null) viewModel.export(uri)
+    }
+
+    val pickLogFolder = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenDocumentTree()
+    ) { uri ->
+        if (uri != null) viewModel.exportLog(uri)
     }
 
     Scaffold(
@@ -57,7 +66,12 @@ fun DataExportScreen(
             )
         }
     ) { padding ->
-        Column(Modifier.padding(padding).padding(horizontal = 16.dp)) {
+        Column(
+            Modifier
+                .padding(padding)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp)
+        ) {
             Spacer(Modifier.height(8.dp))
             Text(
                 "Export your mileage & earnings to CSV",
@@ -108,6 +122,59 @@ fun DataExportScreen(
                 }
                 DataExportViewModel.ExportState.Idle -> Unit
             }
+
+            Spacer(Modifier.height(32.dp))
+
+            // --- Bug-report (shareable log) export (#551) ---
+            Text(
+                "Export a bug report",
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Spacer(Modifier.height(8.dp))
+            Text(
+                "Pick a folder and DashBuddy writes dashbuddy-log.txt into it — the log the " +
+                    "developer needs to diagnose an issue.\n\n" +
+                    "INFO+ milestones only — no raw store, customer, or address text. Every line is " +
+                    "auto-scrubbed at the sink before it's written, so a leaked name can't reach the " +
+                    "file. On-device, nothing is uploaded.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(16.dp))
+
+            Button(
+                onClick = { viewModel.resetLog(); pickLogFolder.launch(null) },
+                enabled = logState !is DataExportViewModel.LogExportState.InProgress,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Icon(Icons.Default.FileDownload, contentDescription = null)
+                Text("  Choose folder & export log")
+            }
+
+            Spacer(Modifier.height(16.dp))
+
+            when (val s = logState) {
+                is DataExportViewModel.LogExportState.InProgress -> {
+                    CircularProgressIndicator()
+                }
+                is DataExportViewModel.LogExportState.Success -> {
+                    Text(
+                        "Exported dashbuddy-log.txt — ${s.scrubbedLines} line(s) were auto-scrubbed.",
+                        color = MaterialTheme.colorScheme.primary,
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
+                is DataExportViewModel.LogExportState.Error -> {
+                    Text(
+                        "Log export failed: ${s.message}",
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
+                DataExportViewModel.LogExportState.Idle -> Unit
+            }
+
+            Spacer(Modifier.height(16.dp))
         }
     }
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/DataExportViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/DataExportViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import cloud.trotter.dashbuddy.core.data.analytics.AnalyticsRepository
 import cloud.trotter.dashbuddy.core.data.analytics.CsvExporter
+import cloud.trotter.dashbuddy.core.data.log.LogRepository
 import cloud.trotter.dashbuddy.domain.di.IoDispatcher
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -31,6 +32,7 @@ import javax.inject.Inject
 @HiltViewModel
 class DataExportViewModel @Inject constructor(
     private val analyticsRepository: AnalyticsRepository,
+    private val logRepository: LogRepository,
     @param:ApplicationContext private val context: Context,
     @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
@@ -42,8 +44,20 @@ class DataExportViewModel @Inject constructor(
         data class Error(val message: String) : ExportState
     }
 
+    /** Bug-report (shareable log) export state (#551), separate from the CSV export state. */
+    sealed interface LogExportState {
+        data object Idle : LogExportState
+        data object InProgress : LogExportState
+        /** [scrubbedLines] = INFO+ lines the sink-gate redacted (surfaced for honesty). */
+        data class Success(val scrubbedLines: Int) : LogExportState
+        data class Error(val message: String) : LogExportState
+    }
+
     private val _state = MutableStateFlow<ExportState>(ExportState.Idle)
     val state = _state.asStateFlow()
+
+    private val _logState = MutableStateFlow<LogExportState>(LogExportState.Idle)
+    val logState = _logState.asStateFlow()
 
     /** Export all-time analytics into the SAF directory [treeUri] as three CSV files. */
     fun export(treeUri: Uri) {
@@ -80,6 +94,65 @@ class DataExportViewModel @Inject constructor(
 
     fun reset() {
         _state.value = ExportState.Idle
+    }
+
+    /**
+     * Export the PII-safe shareable log (#551) as a single `dashbuddy-log.txt` bug report into the
+     * SAF directory [treeUri]. The content is the shareable sink's current contents — INFO+
+     * milestones only, already scrubbed at the sink — with a header comment. Never the firehose.
+     */
+    fun exportLog(treeUri: Uri) {
+        if (_logState.value == LogExportState.InProgress) return
+        _logState.value = LogExportState.InProgress
+        viewModelScope.launch {
+            val scrubbed = logRepository.autoScrubbedLineCount
+            val result = runCatching {
+                withContext(ioDispatcher) {
+                    val body = logRepository.shareableLogContents()
+                    val content = buildLogFile(body, scrubbed)
+                    writeSingleFile(treeUri, LOG_FILENAME, "text/plain", content)
+                }
+            }
+            _logState.value = result.fold(
+                onSuccess = {
+                    // P7: counts only — never the log body. Non-zero scrub count is itself signal.
+                    Timber.tag("Export").i("Bug-report log exported (auto-scrubbed=%d)", scrubbed)
+                    LogExportState.Success(scrubbed)
+                },
+                onFailure = { e ->
+                    // P7: log the exception CLASS only — messages can embed the SAF folder URI.
+                    Timber.tag("Export").e("Log export failed: %s", e.javaClass.simpleName)
+                    LogExportState.Error(e.message ?: "Export failed")
+                },
+            )
+        }
+    }
+
+    fun resetLog() {
+        _logState.value = LogExportState.Idle
+    }
+
+    /** Header comment + shareable body. Header-only file when the log is empty (CSV parity). */
+    internal fun buildLogFile(body: String, scrubbedLines: Int): String = buildString {
+        append("# DashBuddy bug report — INFO+ milestones only (no raw store/customer text).\n")
+        append("# $scrubbedLines line(s) were auto-scrubbed by the fail-closed sink gate.\n")
+        append("# Generated ")
+        append(java.time.Instant.ofEpochMilli(System.currentTimeMillis()))
+        append("\n\n")
+        append(body)
+    }
+
+    /** Writes one text file into the tree, overwriting any same-named prior export. */
+    private fun writeSingleFile(treeUri: Uri, name: String, mime: String, content: String) {
+        val resolver = context.contentResolver
+        val treeDocId = DocumentsContract.getTreeDocumentId(treeUri)
+        val dirUri = DocumentsContract.buildDocumentUriUsingTree(treeUri, treeDocId)
+        deleteIfExists(treeUri, treeDocId, name)
+        val fileUri = DocumentsContract.createDocument(resolver, dirUri, mime, name)
+            ?: error("Could not create $name in the chosen folder")
+        resolver.openOutputStream(fileUri)?.use { out ->
+            out.write(content.toByteArray(Charsets.UTF_8))
+        } ?: error("Could not open $name for writing")
     }
 
     /** Writes the three CSVs into the tree, overwriting same-named files. Returns files written. */
@@ -126,5 +199,9 @@ class DataExportViewModel @Inject constructor(
                 }
             }
         }
+    }
+
+    private companion object {
+        const val LOG_FILENAME = "dashbuddy-log.txt"
     }
 }

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/data/log/LogRepositoryTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/data/log/LogRepositoryTest.kt
@@ -1,10 +1,14 @@
 package cloud.trotter.dashbuddy.core.data.log
 
+import android.util.Log
+import cloud.trotter.dashbuddy.core.pipeline.SensitiveTextMarkers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -12,26 +16,128 @@ import org.robolectric.RuntimeEnvironment
 import java.io.File
 
 /**
- * #364 — log lines must land in submission order. The old per-line
- * fire-and-forget launches could interleave on the IO pool and race the
- * rotation check; appends now drain through one single-writer channel.
+ * #364 — log lines must land in submission order (single-writer channel).
+ * #551 — two-sink split: the DEBUG firehose vs a PII-safe INFO+ shareable sink, with a
+ * FAIL-CLOSED scrub AT the sink (not call-site trust). These tests are the "tested" half of
+ * Principle 7's "fail-closed and tested" gate.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
 class LogRepositoryTest {
 
+    private fun logDir() =
+        RuntimeEnvironment.getApplication().let { it.getExternalFilesDir(null) ?: it.filesDir }
+
+    private fun firehose() = File(logDir(), "app.log")
+    private fun shareable() = File(logDir(), "shareable.log")
+
+    /** Real production scrubber — one marker SSOT, exactly what `:app` DI binds. */
+    private val realScrubber = LogScrubber { SensitiveTextMarkers.findMarker(it) }
+
     @Test
     fun `lines land in exact submission order`() = runTest {
-        val context = RuntimeEnvironment.getApplication()
         val dispatcher = StandardTestDispatcher(testScheduler)
-        val repo = LogRepository(context, dispatcher)
+        val repo = LogRepository(RuntimeEnvironment.getApplication(), dispatcher, realScrubber)
 
         val n = 200
         repeat(n) { i -> repo.appendLog("line-$i\n") }
         advanceUntilIdle()
 
-        val logFile = File(context.getExternalFilesDir(null) ?: context.filesDir, "app.log")
-        val lines = logFile.readLines()
-        assertEquals((0 until n).map { "line-$it" }, lines)
+        assertEquals((0 until n).map { "line-$it" }, firehose().readLines())
+    }
+
+    @Test
+    fun `DEBUG line goes to firehose only, not the shareable sink`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val repo = LogRepository(RuntimeEnvironment.getApplication(), dispatcher, realScrubber)
+
+        repo.appendLog("debug-only\n", Log.DEBUG)
+        advanceUntilIdle()
+
+        assertTrue(firehose().readText().contains("debug-only"))
+        // Shareable sink saw nothing (below INFO) — file never created, contents empty.
+        assertEquals("", repo.shareableLogContents())
+    }
+
+    @Test
+    fun `INFO line goes to BOTH sinks when clean`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val repo = LogRepository(RuntimeEnvironment.getApplication(), dispatcher, realScrubber)
+
+        repo.appendLog("2026-01-01 00:00:00.000 [Idle] INFO/Milestone: offer received\n", Log.INFO)
+        advanceUntilIdle()
+
+        assertTrue(firehose().readText().contains("offer received"))
+        assertTrue(repo.shareableLogContents().contains("offer received"))
+        assertEquals(0, repo.autoScrubbedLineCount)
+    }
+
+    @Test
+    fun `INFO line containing a marker is scrubbed at the sink, verbatim in firehose`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val repo = LogRepository(RuntimeEnvironment.getApplication(), dispatcher, realScrubber)
+
+        // Distinctive non-marker token = the "leaked" text; "Bank Account" is a real sensitive marker.
+        val leaked = "2026-01-01 00:00:00.000 [Idle] INFO/Chat: SECRETSTORE Bank Account\n"
+        repo.appendLog(leaked, Log.INFO)
+        advanceUntilIdle()
+
+        // Firehose keeps the DEBUG-product line verbatim.
+        assertTrue(firehose().readText().contains("SECRETSTORE"))
+
+        // Shareable sink: ONLY the redacted placeholder; the leaked token is absent from its bytes.
+        val share = repo.shareableLogContents()
+        assertFalse("raw leaked token must not reach the shareable file", share.contains("SECRETSTORE"))
+        assertTrue(share.contains("[scrubbed:Bank Account]"))
+        // Timestamp prefix survives for ordering context.
+        assertTrue(share.contains("2026-01-01 00:00:00.000"))
+        assertEquals(1, repo.autoScrubbedLineCount)
+    }
+
+    @Test
+    fun `evasion form (NBSP inside the marker) is still scrubbed`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val repo = LogRepository(RuntimeEnvironment.getApplication(), dispatcher, realScrubber)
+
+        // NBSP (U+00A0) between the two words — a plain `contains` would miss it; normalize folds it.
+        val evasion = "2026-01-01 00:00:00.000 [Idle] INFO/Chat: LEAKSTORE Bank Account\n"
+        repo.appendLog(evasion, Log.INFO)
+        advanceUntilIdle()
+
+        val share = repo.shareableLogContents()
+        assertFalse(share.contains("LEAKSTORE"))
+        assertTrue(share.contains("[scrubbed:"))
+        assertEquals(1, repo.autoScrubbedLineCount)
+    }
+
+    @Test
+    fun `a throwing scrubber is treated as a hit, never verbatim`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val throwing = LogScrubber { error("boom") }
+        val repo = LogRepository(RuntimeEnvironment.getApplication(), dispatcher, throwing)
+
+        repo.appendLog("2026-01-01 00:00:00.000 [Idle] INFO/X: LEAKY payload\n", Log.INFO)
+        advanceUntilIdle()
+
+        val share = repo.shareableLogContents()
+        assertFalse("throwing scrubber must not fall through to verbatim", share.contains("LEAKY"))
+        assertTrue(share.contains("[scrubbed:scrubber-error]"))
+        assertEquals(1, repo.autoScrubbedLineCount)
+    }
+
+    @Test
+    fun `an unbound (null) scrubber writes NOTHING to the shareable sink`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        // Default ctor arg is null — unbound.
+        val repo = LogRepository(RuntimeEnvironment.getApplication(), dispatcher)
+
+        repo.appendLog("2026-01-01 00:00:00.000 [Idle] INFO/X: milestone\n", Log.INFO)
+        advanceUntilIdle()
+
+        // Firehose still receives it (firehose never depends on the scrubber).
+        assertTrue(firehose().readText().contains("milestone"))
+        // Fail closed: no shareable output at all.
+        assertEquals("", repo.shareableLogContents())
+        assertFalse(shareable().exists())
     }
 }

--- a/app/src/test/java/cloud/trotter/dashbuddy/log/StateAwareTreeTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/log/StateAwareTreeTest.kt
@@ -1,0 +1,43 @@
+package cloud.trotter.dashbuddy.log
+
+import android.util.Log
+import cloud.trotter.dashbuddy.core.data.log.LogRepository
+import cloud.trotter.dashbuddy.core.data.settings.DevSettingsRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import javax.inject.Provider
+
+/**
+ * #551 — the priority must thread through [StateAwareTree] into [LogRepository.appendLog] so the
+ * two-sink split can route INFO+ lines to the shareable sink. Without it every line would default to
+ * DEBUG and the export would be empty.
+ */
+class StateAwareTreeTest {
+
+    private fun tree(logRepo: LogRepository): StateAwareTree {
+        val dev = mock<DevSettingsRepository> {
+            // Pass the level gate for everything so routing is what's under test.
+            whenever(it.minLogLevel).thenReturn(MutableStateFlow(Log.VERBOSE))
+        }
+        return StateAwareTree(logRepo, dev, Provider { "TestState" })
+    }
+
+    @Test
+    fun `INFO priority threads through to appendLog`() {
+        val repo = mock<LogRepository>()
+        tree(repo).log(Log.INFO, "Milestone", "offer received", null)
+        verify(repo).appendLog(any(), eq(Log.INFO))
+    }
+
+    @Test
+    fun `DEBUG priority threads through to appendLog`() {
+        val repo = mock<LogRepository>()
+        tree(repo).log(Log.DEBUG, "Reducer", "PROCESSING Event", null)
+        verify(repo).appendLog(any(), eq(Log.DEBUG))
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/main/settings/DataExportViewModelTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/main/settings/DataExportViewModelTest.kt
@@ -1,0 +1,47 @@
+package cloud.trotter.dashbuddy.ui.main.settings
+
+import cloud.trotter.dashbuddy.core.data.analytics.AnalyticsRepository
+import cloud.trotter.dashbuddy.core.data.log.LogRepository
+import kotlinx.coroutines.Dispatchers
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.mock
+
+/**
+ * #551 — the bug-report (shareable log) export assembles a header stating the auto-scrub count over
+ * the shareable-sink body, and writes a header-only file when the log is empty (CSV empty-parity).
+ * The SAF directory-write edge is untestable here (as with the CSV export), so this covers the pure
+ * content assembly — the P7-relevant piece: the header is honest about scrubbing, the body is the
+ * INFO+ shareable stream only.
+ */
+class DataExportViewModelTest {
+
+    private fun viewModel() = DataExportViewModel(
+        analyticsRepository = mock<AnalyticsRepository>(),
+        logRepository = mock<LogRepository>(),
+        context = mock(),
+        ioDispatcher = Dispatchers.Unconfined,
+    )
+
+    @Test
+    fun `buildLogFile states the scrub count and appends the body`() {
+        val out = viewModel().buildLogFile(
+            body = "2026-01-01 00:00:00.000 [Idle] INFO/Milestone: offer received\n",
+            scrubbedLines = 3,
+        )
+        assertTrue(out.contains("INFO+ milestones only"))
+        assertTrue("header must state the scrub count", out.contains("3 line(s) were auto-scrubbed"))
+        assertTrue(out.contains("offer received"))
+    }
+
+    @Test
+    fun `buildLogFile emits a header-only file when the log is empty`() {
+        val out = viewModel().buildLogFile(body = "", scrubbedLines = 0)
+        assertTrue(out.contains("INFO+ milestones only"))
+        assertTrue(out.contains("0 line(s) were auto-scrubbed"))
+        // No log body — header lines only, all commented.
+        val nonCommentLines = out.lines().filter { it.isNotBlank() && !it.startsWith("#") }
+        assertEquals(emptyList<String>(), nonCommentLines)
+    }
+}

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/log/LogRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/log/LogRepository.kt
@@ -1,6 +1,7 @@
 package cloud.trotter.dashbuddy.core.data.log
 
 import android.content.Context
+import android.util.Log
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
@@ -10,37 +11,122 @@ import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.Locale
+import java.util.concurrent.atomic.AtomicInteger
 import javax.inject.Inject
 import javax.inject.Singleton
 import cloud.trotter.dashbuddy.domain.di.IoDispatcher
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.channels.Channel
 
+/**
+ * Two-sink log store (#551, CLAUDE.md Principle 7 — "the log is two products"):
+ *
+ *  - **[appLogFile] — the DEBUG firehose.** Every line, verbatim, at every level. On-device only,
+ *    never exported. Large rotation budget.
+ *  - **[shareableLogFile] — the PII-safe INFO+ slice.** Only lines whose priority ≥ [Log.INFO],
+ *    each passed through the fail-closed [scrubber] sink-gate before it lands. This is the stream a
+ *    user can export as a bug report ([shareableLogContents]).
+ *
+ * Both files are fed from the SAME single-writer channel (#364) so ordering and rotation stay
+ * race-free — one queued item routes to one or both files inside one worker; there is no second
+ * channel to interleave with.
+ *
+ * **The sink-gate is the load-bearing privacy control.** A raw merchant/customer/address string
+ * reaching an INFO+ line is a privacy defect of the same class as leaking it to disk (Principle 6/7);
+ * the #590 replay gate patrols the upstream path, but this sink must NOT trust call-site discipline —
+ * every INFO+ line is scanned here, last. It fails closed three ways: the [scrubber] itself fails
+ * closed internally, any throw out of the scrubber call is treated as a hit, and an entirely
+ * **unbound (`null`) scrubber writes NOTHING to the shareable file** — a bug report with no lines is
+ * safe; one with un-scrubbed lines is not.
+ */
 @Singleton
 class LogRepository @Inject constructor(
     @param:ApplicationContext private val context: Context,
     @IoDispatcher ioDispatcher: CoroutineDispatcher,
+    /**
+     * Fail-closed PII scrub for the shareable sink. `null` means unbound → the shareable file is
+     * never written (fail closed). Bound in `:app` DI to `SensitiveTextMarkers::findMarker` so the
+     * marker SSOT stays in `:core:pipeline` without a module edge (see [LogScrubber]).
+     */
+    private val scrubber: LogScrubber? = null,
 ) {
     // Run file operations on IO thread to never block the main thread
     private val scope = CoroutineScope(ioDispatcher + SupervisorJob())
 
+    private data class LogLine(val text: String, val priority: Int)
+
     // Single-writer queue (#364): per-line fire-and-forget launches could land
-    // out of order and race the rotation check. One worker drains in order.
-    private val lines = Channel<String>(Channel.UNLIMITED)
+    // out of order and race the rotation check. One worker drains in order,
+    // routing each line to the firehose and (if INFO+) the shareable sink.
+    private val lines = Channel<LogLine>(Channel.UNLIMITED)
+
+    /**
+     * Count of INFO+ lines the sink-gate redacted before they reached [shareableLogFile]. Surfaced
+     * in the export UI ("N lines were auto-scrubbed") — a non-zero value means an upstream call site
+     * leaked raw text that the sink caught. Counter only; never the scrubbed content (Principle 7).
+     */
+    private val scrubbedCounter = AtomicInteger(0)
+    val autoScrubbedLineCount: Int get() = scrubbedCounter.get()
 
     init {
         scope.launch {
-            for (line in lines) {
-                try {
-                    if (appLogFile.exists() && appLogFile.length() > maxLogFileSizeBytes) {
-                        rotateLogFile()
-                    }
-                    appLogFile.appendText(line)
-                } catch (_: Exception) {
-                    // Fail silently to avoid crash loops
-                }
+            for (item in lines) {
+                writeFirehose(item.text)
+                if (item.priority >= Log.INFO) writeShareable(item.text)
             }
         }
+    }
+
+    /** Firehose: verbatim, every line. The DEBUG product; on-device only, never exported. */
+    private fun writeFirehose(line: String) {
+        try {
+            if (appLogFile.exists() && appLogFile.length() > maxLogFileSizeBytes) {
+                rotateLogFile()
+            }
+            appLogFile.appendText(line)
+        } catch (_: Exception) {
+            // Fail silently to avoid crash loops
+        }
+    }
+
+    /**
+     * Shareable sink: fail-closed scrub, then append. Unbound scrubber → write nothing. A scrubber
+     * hit (or any throw out of it) → append a redacted placeholder that carries only the safe marker
+     * name plus the line's own timestamp prefix (never the original message), and bump the counter.
+     */
+    private fun writeShareable(line: String) {
+        val scrub = scrubber ?: return // unbound → fail closed: no shareable output at all
+        val marker: String? = try {
+            scrub.findMarker(line)
+        } catch (_: Throwable) {
+            // A throwing scrubber is treated exactly as a hit — never fall through to verbatim.
+            SCRUBBER_THREW
+        }
+        val outLine = if (marker != null) {
+            scrubbedCounter.incrementAndGet()
+            redactedPlaceholder(line, marker)
+        } else {
+            line
+        }
+        try {
+            if (shareableLogFile.exists() && shareableLogFile.length() > maxShareableLogBytes) {
+                rotateShareableLog()
+            }
+            shareableLogFile.appendText(outLine)
+        } catch (_: Exception) {
+            // Fail silently to avoid crash loops
+        }
+    }
+
+    /**
+     * Build the redacted stand-in for a scrubbed line. Keeps the leading timestamp (cheaply
+     * available: everything before the ` [state]` bracket the [StateAwareTree] format inserts) so
+     * ordering context survives, and appends only the safe [marker] constant. FAIL-SAFE: if the line
+     * has no such delimiter the prefix is empty rather than the whole (un-scrubbed) line.
+     */
+    private fun redactedPlaceholder(line: String, marker: String): String {
+        val prefix = line.substringBefore(" [", missingDelimiterValue = "")
+        return if (prefix.isEmpty()) "[scrubbed:$marker]\n" else "$prefix [scrubbed:$marker]\n"
     }
 
     // --- Config ---
@@ -49,7 +135,12 @@ class LogRepository @Inject constructor(
 
     private val appLogFile by lazy { File(logDir, "app.log") }
 
+    /** INFO+ export sink. Smaller budget (INFO+ only) with a single rotated backup. */
+    private val shareableLogFile by lazy { File(logDir, "shareable.log") }
+    private val shareableRotatedFile by lazy { File(logDir, "shareable.log.1") }
+
     private val maxLogFileSizeBytes = 2.3 * 1024 * 1024 // 2.3 MB
+    private val maxShareableLogBytes = 2.0 * 1024 * 1024 // 2.0 MB (INFO+ only)
     private val maxRotatedLogs = 50
     private val rotationPrefix = "app_log_rotated_"
 
@@ -60,15 +151,24 @@ class LogRepository @Inject constructor(
         .withZone(ZoneId.systemDefault())
 
     /**
-     * Appends a pre-formatted line to the main log file.
-     * Handles rotation if file gets too big.
+     * Appends a pre-formatted line to the log. Always written to the firehose; also written to the
+     * PII-safe shareable sink (after the fail-closed scrub) when [priority] ≥ [Log.INFO].
      */
-    fun appendLog(line: String) {
-        lines.trySend(line)
+    fun appendLog(line: String, priority: Int = Log.DEBUG) {
+        lines.trySend(LogLine(line, priority))
     }
 
     /**
-     * Renames the current log file and starts a new one.
+     * Current contents of the PII-safe shareable log (INFO+, scrubbed) for the bug-report export
+     * (#551). Best-effort snapshot — empty string when nothing has been written yet, so the export
+     * can still emit a header-only file (consistent with the CSV empty behavior).
+     */
+    fun shareableLogContents(): String =
+        runCatching { if (shareableLogFile.exists()) shareableLogFile.readText() else "" }
+            .getOrDefault("")
+
+    /**
+     * Renames the current firehose file and starts a new one.
      */
     private fun rotateLogFile() {
         try {
@@ -81,6 +181,19 @@ class LogRepository @Inject constructor(
                 appLogFile.appendText("--- Log Rotated from ${rotatedFile.name} ---\n")
                 pruneOldLogs()
             }
+        } catch (_: Exception) {
+            // If rotation fails, just keep appending
+        }
+    }
+
+    /**
+     * Shareable-sink rotation: keep exactly one backup (INFO+ is low-volume). Overwrite any prior
+     * backup, rename current → backup, start fresh.
+     */
+    private fun rotateShareableLog() {
+        try {
+            shareableRotatedFile.delete()
+            shareableLogFile.renameTo(shareableRotatedFile)
         } catch (_: Exception) {
             // If rotation fails, just keep appending
         }
@@ -102,5 +215,10 @@ class LogRepository @Inject constructor(
             // Delete the oldest N files
             sortedFiles.take(deleteCount).forEach { it.delete() }
         }
+    }
+
+    private companion object {
+        /** Marker used when the scrubber itself throws (never the scanned text). */
+        const val SCRUBBER_THREW = "scrubber-error"
     }
 }

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/log/LogScrubber.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/log/LogScrubber.kt
@@ -1,0 +1,22 @@
+package cloud.trotter.dashbuddy.core.data.log
+
+/**
+ * The fail-closed PII scrub applied at the shareable-log sink (#551, CLAUDE.md Principle 7 —
+ * "the log is two products": an on-device DEBUG firehose and a PII-safe INFO+ slice a user can
+ * export as a bug report).
+ *
+ * Placement rationale: the marker SSOT (`SensitiveTextMarkers`) lives in `:core:pipeline`, which
+ * `:core:data` does NOT depend on (see CLAUDE.md § Module Structure). Rather than add a module edge
+ * or mirror the marker list, [LogRepository] depends on this thin function type; `:app` (which sees
+ * both modules) binds it to `SensitiveTextMarkers::findMarker`, keeping ONE marker definition.
+ *
+ * Contract: return a non-null **marker name** (a safe constant — a keyword name, a shape id, or the
+ * `normalize-error` sentinel; never the scanned text) when [line] contains a sensitive/PII token,
+ * else `null` when the line is clean. Implementations are expected to fail closed internally (a
+ * normalization throw returns a sentinel, not `null`), and [LogRepository] additionally treats any
+ * throw out of this call — and an entirely unbound scrubber — as a hit, so the shareable sink can
+ * never emit un-scrubbed text.
+ */
+fun interface LogScrubber {
+    fun findMarker(line: String): String?
+}

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -73,6 +73,17 @@ card's **mechanical** half, #577 (re-confirmed, 24/24, ~0.55 s — with a new po
 that entry's Bug #1), the #457 path, and #554 ShadowProjector (2/2). The #462/#460 dropoff item
 was found **broken-in-part** (raw PII in capture envelopes) and moved to that entry's Bug #7.)_
 
+- **🆕 NEW — PII-safe bug-report log export (#551 P2): Data & Privacy → Export Data → Export log.**
+  After a real dash (with at least one recognized offer/delivery so INFO milestones exist), go to
+  Settings → Data & Privacy → Export Data, scroll to "Export a bug report", pick a folder, export.
+  How to tell it's working: (1) open `dashbuddy-log.txt` and **grep your shop's merchant name — ZERO
+  hits** (it's INFO+ milestones only, scrubbed at the sink); any `[scrubbed:<marker>]` lines are the
+  gate catching a leak. (2) The success line's auto-scrub count is sane (usually 0, non-zero means an
+  upstream site leaked and the sink caught it — worth reporting). (3) The firehose (`app.log` in the
+  app's files dir) is still **full fidelity** — raw store names present there, as expected (on-device
+  only, never exported). (PR #551-P2)
+  - Confirmed: 0/2
+
 - **🆕 NEW — per-dash drill-down (#650 PR A): tap a recent dash on the Money tab.** Analytics → Money
   tab → scroll to RECENT DASHES → tap any dash row. It should open a read-only "Dash detail" screen.
   How to tell it's working: the header figures (date, start–end clock times, duration, gross, miles,


### PR DESCRIPTION
Closes #551 when merged. Phase 2 of Principle 7 ("the log is two products"); Phase 1 (#679, semantic levels + tags) already merged.

## The two-products model
`LogRepository` now has two sinks fed from the SAME single-writer channel (#364 ordering/rotation stay race-free):

- **`app.log` — the DEBUG firehose.** Every line, verbatim, every level. On-device only, never exported. Unchanged 2.3 MB / 50-file rotation.
- **`shareable.log` — the PII-safe INFO+ slice.** Only lines with priority ≥ `Log.INFO`, each passed through a fail-closed scrub before it lands. This is the stream a user exports as a bug report (Settings → Data & Privacy → Export Data → "Export a bug report" → `dashbuddy-log.txt`). Smaller 2 MB / keep-one-backup rotation.

`StateAwareTree` (the only caller) threads `priority` through `appendLog(line, priority)` so the split can route.

## The sink-gate + placement rationale
The load-bearing control is a **fail-closed scrub AT the sink**, never call-site trust (the 06-19 receipt: raw `Pickup: H-E-B` already leaked into INFO). The #590 replay gate patrols the upstream path; this sink is the last line.

**Placement:** `:core:data` (where `LogRepository` lives) does NOT depend on `:core:pipeline` (where the `SensitiveTextMarkers` SSOT lives) — see CLAUDE.md § Module Structure. Rather than add a module edge or mirror the marker list, `LogRepository` takes an injected `LogScrubber` (a `(String)->String?` fun interface in `:core:data`); `:app` — the one module that sees both — binds it to `SensitiveTextMarkers::findMarker`. One marker definition, zero new module edges.

**Fail-closed three ways** (all tested):
1. **Hit** → the whole INFO+ line is replaced with a `<timestamp-prefix> [scrubbed:<marker>]` placeholder (marker is a safe constant; the timestamp prefix is `substringBefore(" [", "")` so a format without the delimiter yields an *empty* prefix, never the un-scrubbed line). Counter bumps.
2. **Scrubber throws** → treated exactly as a hit (`[scrubbed:scrubber-error]`), never falls through to verbatim.
3. **Scrubber unbound (`null`)** → the shareable file is **never written** at all (a bug report with no lines is safe; one with un-scrubbed lines is not).

The firehose copy is always verbatim (it's the DEBUG product).

## Scrub-counter honesty
`autoScrubbedLineCount` (AtomicInteger) counts sink redactions and is surfaced in the export success line and the file header ("N lines were auto-scrubbed"). A non-zero value is itself signal: an upstream site leaked and the sink caught it — worth reporting.

## Test coverage
- `LogRepositoryTest` (Robolectric): DEBUG → firehose only; INFO clean → both; INFO with a real marker (`Bank Account`) → firehose verbatim + shareable gets ONLY the placeholder (raw `SECRETSTORE` token asserted **absent** from shareable bytes) + counter=1; **evasion form** (NBSP U+00A0 inside the marker) → still scrubbed; throwing scrubber → hit, never verbatim; unbound scrubber → shareable file never created; ordering preserved.
- `StateAwareTreeTest`: INFO/DEBUG priority thread through to `appendLog(any(), eq(priority))`.
- `DataExportViewModelTest`: pure `buildLogFile` assembly — header states scrub count, body is the shareable stream, header-only file when empty (CSV empty-parity). (SAF write edge untestable here, as with the CSV export.)
- Full gate green: `JAVA_HOME=/usr/lib/jvm/java-25-openjdk ./gradlew testDebugUnitTest :domain:test`.

## Security/privacy posture
Trusted: nothing at the sink — it re-scans every INFO+ line regardless of call-site claims. Gated: shareable output behind the fail-closed scrub (hit/throw/unbound all closed). Scrubbed: full INFO+ export stream via the `SensitiveTextMarkers` SSOT (evasion-hardened `normalize`, #685). No network. Marker names in placeholders are safe constants; the scrub counter and export logs are counts only.

### Design-goal review
- **7 (Semantic, PII-safe logging) — the implementation itself.** This IS Principle 7's shareable-sink gate. New log sites, all INFO, PII-safe by construction (counts / exception-class only): `Export/"Bug-report log exported (auto-scrubbed=%d)"` and `Export/"Log export failed: <class>"` in `DataExportViewModel`. The sink placeholder line carries only a safe marker constant + timestamp. The DEBUG firehose is unchanged.
- **6 (Security & privacy first) — fail-closed chain.** Upstream #590 replay gate + the sink scrub (hit/throw/unbound → closed) + the hardened markers (#685). The sink does not trust call-site discipline; the shareable file is the export/upload surface and is scrubbed at the boundary.
- **5 (SSOT).** Marker list untouched — one `SensitiveTextMarkers` definition, reached via one `LogScrubber` binding in `:app` DI. No mirrored keyword copy, no second scrubber.
- **1 (UDF) — export UI.** `DataExportScreen` observes immutable `LogExportState` via `collectAsStateWithLifecycle` and dispatches `exportLog(uri)`/`resetLog()`; the ViewModel owns the SAF IO off-main; no repository writes from the composable.
- **8 (platform-agnostic).** No `:core:state`/`:domain`/rule-JSON logic touched; no platform literals introduced.

### Adversarial review
Pending — to be run pre-merge per the Git Workflow (fable-tier `/code-review` + `/security-review` on the untrusted-input/PII boundary), outcome recorded here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
