### PR TITLE
fix(#689): per-year IRS mileage rates (2026 = $0.725) — per-row CSV, per-year summaries, honest unknown-year fallback

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsScreen.kt
@@ -114,7 +114,7 @@ fun AnalyticsScreen(
                         onSelectPeriod = viewModel::setPeriod,
                     )
                     Spacer(Modifier.height(16.dp))
-                    TimeTab(time = uiState.time)
+                    TimeTab(time = uiState.time, period = uiState.selectedPeriod)
                 }
 
                 AnalyticsTab.Patterns -> ComingSoonCard(uiState.selectedTab)

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/TimeTab.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/TimeTab.kt
@@ -19,12 +19,14 @@ import cloud.trotter.dashbuddy.core.designsystem.component.AppSegment
 import cloud.trotter.dashbuddy.core.designsystem.component.AppStackBar
 import cloud.trotter.dashbuddy.core.designsystem.component.AppStatTile
 import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
+import cloud.trotter.dashbuddy.core.data.analytics.PeriodBounds
 import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
 import cloud.trotter.dashbuddy.domain.analytics.TimeEconomics
 import cloud.trotter.dashbuddy.domain.export.IrsMileage
 import cloud.trotter.dashbuddy.domain.format.Formats
 import cloud.trotter.dashbuddy.domain.format.formatDuration
-import java.time.LocalDate
+import java.time.Instant
+import java.time.ZoneId
 import kotlin.math.roundToInt
 import kotlin.math.roundToLong
 
@@ -199,8 +201,13 @@ private fun MileageTaxCard(time: TimeEconomics, period: AnalyticsPeriod) {
             return@AppCard
         }
 
-        // Current year from the device clock at render (a review surface — no ticker needed).
-        val labels = MileageTaxModel.from(time.miles, LocalDate.now().year, period)
+        // Device clock at render (a review surface — no ticker needed).
+        val labels = MileageTaxModel.from(
+            miles = time.miles,
+            nowMillis = System.currentTimeMillis(),
+            zone = ZoneId.systemDefault(),
+            period = period,
+        )
 
         Text(text = "${Formats.decimal(time.miles, 1)} mi", style = AppTheme.num.heroNum, color = c.text)
         Spacer(Modifier.height(6.dp))
@@ -224,42 +231,39 @@ private fun MileageTaxCard(time: TimeEconomics, period: AnalyticsPeriod) {
 
 /**
  * Pure copy logic for the MILEAGE & TAX card (#689) — Compose-free so it's unit-testable in
- * isolation from rendering (the [WaterfallModel] precedent). The card covers a selected *period*,
- * which is single-year by construction for Today/Week/Month; only Lifetime can span years.
+ * isolation from rendering (the [WaterfallModel] precedent). Today and This-Month are single-year
+ * by construction, but the Monday-anchored week straddles Jan 1 whenever New Year's Day falls
+ * Tue–Sun, and Lifetime can span any boundary — so the spans-years check derives from the period's
+ * actual [PeriodBounds] window (the bounds SSOT), not from the enum.
  *
  * Locked policy: label the deduction with the **current** year's rate via the [IrsMileage] lookup
- * (never a literal year/rate). When the current year has no published IRS rate yet
- * (`!IrsMileage.isKnown`), append an explicit disclaimer — the deduction still computes off the
- * latest known rate ([IrsMileage.deduction]'s fallback) but the substitution is stated. For
- * Lifetime, add a note that the period may span tax years and point at the CSV export (which owns
- * the per-year precision) — cheap honesty over re-costing every row here.
+ * (never a literal year/rate); the fallback policy and disclaimer copy are [IrsMileage.effectiveRate]
+ * / [IrsMileage.fallbackNote] (one owner — the CSV renders the identical note). A period that spans
+ * tax years gets a note pointing at the CSV export (which owns the per-year precision) — cheap
+ * honesty over re-costing every row here.
  */
 object MileageTaxModel {
 
     data class Labels(
         /** "$X.XX est. IRS <year> standard-mileage deduction ($0.725/mi)". */
         val deductionLine: String,
-        /** Non-null only when the current year's rate isn't published — the honest-fallback note. */
+        /** Non-null only when the current year has no rate in the table — [IrsMileage.fallbackNote]. */
         val disclaimer: String?,
-        /** Non-null only for Lifetime, which can straddle a year boundary. */
+        /** Non-null when the period's window spans (Lifetime: may span) a tax-year boundary. */
         val spansYearsNote: String?,
     )
 
-    fun from(miles: Double, currentYear: Int, period: AnalyticsPeriod): Labels {
-        val rate = IrsMileage.rateFor(currentYear) ?: IrsMileage.latestKnown().second
-        val deductionLine = "${Formats.money(IrsMileage.deduction(miles, currentYear))} " +
-            "est. IRS $currentYear standard-mileage deduction (${Formats.money3(rate)}/mi)"
-        val disclaimer = if (IrsMileage.isKnown(currentYear)) {
-            null
-        } else {
-            "$currentYear rate not yet published — estimated at the ${IrsMileage.latestKnown().first} rate"
+    fun from(miles: Double, nowMillis: Long, zone: ZoneId, period: AnalyticsPeriod): Labels {
+        val year = Instant.ofEpochMilli(nowMillis).atZone(zone).year
+        val deductionLine = "${Formats.money(IrsMileage.deduction(miles, year))} " +
+            "est. IRS $year standard-mileage deduction (${Formats.money3(IrsMileage.effectiveRate(year))}/mi)"
+        val spansYearsNote = when {
+            period == AnalyticsPeriod.LIFETIME -> "may span tax years — see the CSV export for per-year figures"
+            Instant.ofEpochMilli(PeriodBounds.of(period, nowMillis, zone).start).atZone(zone).year != year ->
+                "spans tax years — see the CSV export for per-year figures"
+            else -> null
         }
-        val spansYearsNote = if (period == AnalyticsPeriod.LIFETIME) {
-            "spans tax years — see the CSV export for per-year figures"
-        } else {
-            null
-        }
-        return Labels(deductionLine, disclaimer, spansYearsNote)
+        return Labels(deductionLine, IrsMileage.fallbackNote(year), spansYearsNote)
     }
 }
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/TimeTab.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/TimeTab.kt
@@ -19,10 +19,12 @@ import cloud.trotter.dashbuddy.core.designsystem.component.AppSegment
 import cloud.trotter.dashbuddy.core.designsystem.component.AppStackBar
 import cloud.trotter.dashbuddy.core.designsystem.component.AppStatTile
 import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
+import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
 import cloud.trotter.dashbuddy.domain.analytics.TimeEconomics
 import cloud.trotter.dashbuddy.domain.export.IrsMileage
 import cloud.trotter.dashbuddy.domain.format.Formats
 import cloud.trotter.dashbuddy.domain.format.formatDuration
+import java.time.LocalDate
 import kotlin.math.roundToInt
 import kotlin.math.roundToLong
 
@@ -45,13 +47,14 @@ private const val EMPTY_VALUE = "—"
 @Composable
 fun TimeTab(
     time: TimeEconomics,
+    period: AnalyticsPeriod,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(16.dp)) {
         TimeSplitCard(time)
         DeadheadCard(time)
         OnTimeCard(time)
-        MileageTaxCard(time)
+        MileageTaxCard(time, period)
     }
 }
 
@@ -186,7 +189,7 @@ private fun OnTimeCard(time: TimeEconomics) {
 
 /** Mileage & tax: the period's session odometer miles + the estimated IRS standard-mileage deduction. */
 @Composable
-private fun MileageTaxCard(time: TimeEconomics) {
+private fun MileageTaxCard(time: TimeEconomics, period: AnalyticsPeriod) {
     val c = AppTheme.colors
     AppCard(modifier = Modifier.fillMaxWidth()) {
         Text(text = "MILEAGE & TAX", style = MaterialTheme.typography.labelMedium, color = c.text3)
@@ -196,21 +199,67 @@ private fun MileageTaxCard(time: TimeEconomics) {
             return@AppCard
         }
 
+        // Current year from the device clock at render (a review surface — no ticker needed).
+        val labels = MileageTaxModel.from(time.miles, LocalDate.now().year, period)
+
         Text(text = "${Formats.decimal(time.miles, 1)} mi", style = AppTheme.num.heroNum, color = c.text)
         Spacer(Modifier.height(6.dp))
-        Text(
-            text = "${Formats.money(IrsMileage.deduction(time.miles))} " +
-                "est. IRS ${IrsMileage.TAX_YEAR} standard-mileage deduction " +
-                "(${Formats.money(IrsMileage.RATE_PER_MILE)}/mi)",
-            style = MaterialTheme.typography.bodyMedium,
-            color = c.text,
-        )
+        Text(text = labels.deductionLine, style = MaterialTheme.typography.bodyMedium, color = c.text)
+        labels.disclaimer?.let {
+            Spacer(Modifier.height(4.dp))
+            Text(text = it, style = MaterialTheme.typography.bodySmall, color = c.text3)
+        }
+        labels.spansYearsNote?.let {
+            Spacer(Modifier.height(4.dp))
+            Text(text = it, style = MaterialTheme.typography.bodySmall, color = c.text3)
+        }
         Spacer(Modifier.height(6.dp))
         Text(
             text = "standard-mileage method — not the app's operating-cost model; confirm with a tax preparer.",
             style = MaterialTheme.typography.bodySmall,
             color = c.text3,
         )
+    }
+}
+
+/**
+ * Pure copy logic for the MILEAGE & TAX card (#689) — Compose-free so it's unit-testable in
+ * isolation from rendering (the [WaterfallModel] precedent). The card covers a selected *period*,
+ * which is single-year by construction for Today/Week/Month; only Lifetime can span years.
+ *
+ * Locked policy: label the deduction with the **current** year's rate via the [IrsMileage] lookup
+ * (never a literal year/rate). When the current year has no published IRS rate yet
+ * (`!IrsMileage.isKnown`), append an explicit disclaimer — the deduction still computes off the
+ * latest known rate ([IrsMileage.deduction]'s fallback) but the substitution is stated. For
+ * Lifetime, add a note that the period may span tax years and point at the CSV export (which owns
+ * the per-year precision) — cheap honesty over re-costing every row here.
+ */
+object MileageTaxModel {
+
+    data class Labels(
+        /** "$X.XX est. IRS <year> standard-mileage deduction ($0.725/mi)". */
+        val deductionLine: String,
+        /** Non-null only when the current year's rate isn't published — the honest-fallback note. */
+        val disclaimer: String?,
+        /** Non-null only for Lifetime, which can straddle a year boundary. */
+        val spansYearsNote: String?,
+    )
+
+    fun from(miles: Double, currentYear: Int, period: AnalyticsPeriod): Labels {
+        val rate = IrsMileage.rateFor(currentYear) ?: IrsMileage.latestKnown().second
+        val deductionLine = "${Formats.money(IrsMileage.deduction(miles, currentYear))} " +
+            "est. IRS $currentYear standard-mileage deduction (${Formats.money3(rate)}/mi)"
+        val disclaimer = if (IrsMileage.isKnown(currentYear)) {
+            null
+        } else {
+            "$currentYear rate not yet published — estimated at the ${IrsMileage.latestKnown().first} rate"
+        }
+        val spansYearsNote = if (period == AnalyticsPeriod.LIFETIME) {
+            "spans tax years — see the CSV export for per-year figures"
+        } else {
+            null
+        }
+        return Labels(deductionLine, disclaimer, spansYearsNote)
     }
 }
 

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/MileageTaxModelTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/MileageTaxModelTest.kt
@@ -1,0 +1,62 @@
+package cloud.trotter.dashbuddy.ui.main.analytics
+
+import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.Locale
+
+/**
+ * #689 — the MILEAGE & TAX card's pure copy logic: the year-labelled deduction line, the
+ * unknown-year honest-fallback disclaimer, and the Lifetime spans-years note. Compose-free, per the
+ * [WaterfallModel] / `WaterfallModelTest` precedent (test the logic, not the rendering).
+ */
+class MileageTaxModelTest {
+
+    // Formats.money* pins Locale.getDefault(); fix it so the "$0.725/mi" assertions are deterministic.
+    @Before fun enUsLocale() = Locale.setDefault(Locale.US)
+
+    @Test fun knownYear_labelsThatYearsRate_noDisclaimer() {
+        val labels = MileageTaxModel.from(miles = 100.0, currentYear = 2026, period = AnalyticsPeriod.THIS_WEEK)
+        assertTrue(labels.deductionLine.contains("IRS 2026"))
+        assertTrue(labels.deductionLine.contains("$0.725/mi"))
+        assertTrue(labels.deductionLine.contains("$72.50")) // 100 * 0.725
+        assertNull(labels.disclaimer)
+        assertNull(labels.spansYearsNote)
+    }
+
+    @Test fun year2025_usesItsOwnRate() {
+        val labels = MileageTaxModel.from(100.0, 2025, AnalyticsPeriod.TODAY)
+        assertTrue(labels.deductionLine.contains("IRS 2025"))
+        assertTrue(labels.deductionLine.contains("$0.700/mi"))
+        assertTrue(labels.deductionLine.contains("$70.00"))
+    }
+
+    @Test fun unknownYear_fallsBackToLatestRate_withDisclaimer() {
+        val labels = MileageTaxModel.from(100.0, 2027, AnalyticsPeriod.THIS_MONTH)
+        // 2027 unpublished → latest known rate (2026 = $0.725/mi), labelled honestly.
+        assertTrue(labels.deductionLine.contains("IRS 2027"))
+        assertTrue(labels.deductionLine.contains("$0.725/mi"))
+        assertTrue(labels.deductionLine.contains("$72.50"))
+        assertNull(labels.spansYearsNote)
+        org.junit.Assert.assertEquals(
+            "2027 rate not yet published — estimated at the 2026 rate",
+            labels.disclaimer,
+        )
+    }
+
+    @Test fun lifetime_addsSpansYearsNote() {
+        val labels = MileageTaxModel.from(100.0, 2026, AnalyticsPeriod.LIFETIME)
+        org.junit.Assert.assertEquals(
+            "spans tax years — see the CSV export for per-year figures",
+            labels.spansYearsNote,
+        )
+    }
+
+    @Test fun nonLifetime_hasNoSpansYearsNote() {
+        assertNull(MileageTaxModel.from(100.0, 2026, AnalyticsPeriod.TODAY).spansYearsNote)
+        assertNull(MileageTaxModel.from(100.0, 2026, AnalyticsPeriod.THIS_WEEK).spansYearsNote)
+        assertNull(MileageTaxModel.from(100.0, 2026, AnalyticsPeriod.THIS_MONTH).spansYearsNote)
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/MileageTaxModelTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/MileageTaxModelTest.kt
@@ -1,24 +1,45 @@
 package cloud.trotter.dashbuddy.ui.main.analytics
 
 import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
+import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import java.time.ZoneId
+import java.time.ZonedDateTime
 import java.util.Locale
 
 /**
  * #689 — the MILEAGE & TAX card's pure copy logic: the year-labelled deduction line, the
- * unknown-year honest-fallback disclaimer, and the Lifetime spans-years note. Compose-free, per the
- * [WaterfallModel] / `WaterfallModelTest` precedent (test the logic, not the rendering).
+ * unknown-year honest-fallback disclaimer (copy owned by `IrsMileage.fallbackNote`), and the
+ * spans-years note derived from the period's real `PeriodBounds` window (so the Jan-straddling
+ * Monday week is covered, not just Lifetime). Compose-free, per the [WaterfallModel] /
+ * `WaterfallModelTest` precedent (test the logic, not the rendering).
  */
 class MileageTaxModelTest {
 
-    // Formats.money* pins Locale.getDefault(); fix it so the "$0.725/mi" assertions are deterministic.
-    @Before fun enUsLocale() = Locale.setDefault(Locale.US)
+    private val utc: ZoneId = ZoneId.of("UTC")
+
+    /** Epoch millis for noon on the given date in [utc] — pins the "device clock" per test. */
+    private fun noonUtc(year: Int, month: Int, day: Int): Long =
+        ZonedDateTime.of(year, month, day, 12, 0, 0, 0, utc).toInstant().toEpochMilli()
+
+    // Formats.money* pins Locale.getDefault(); fix it (and restore — repo convention, see
+    // FormatsTest) so the "$0.725/mi" assertions are deterministic without leaking Locale.US
+    // into later test classes in the shared test JVM.
+    private lateinit var originalLocale: Locale
+
+    @Before fun pinLocale() {
+        originalLocale = Locale.getDefault()
+        Locale.setDefault(Locale.US)
+    }
+
+    @After fun restoreLocale() = Locale.setDefault(originalLocale)
 
     @Test fun knownYear_labelsThatYearsRate_noDisclaimer() {
-        val labels = MileageTaxModel.from(miles = 100.0, currentYear = 2026, period = AnalyticsPeriod.THIS_WEEK)
+        val labels = MileageTaxModel.from(100.0, noonUtc(2026, 7, 15), utc, AnalyticsPeriod.THIS_WEEK)
         assertTrue(labels.deductionLine.contains("IRS 2026"))
         assertTrue(labels.deductionLine.contains("$0.725/mi"))
         assertTrue(labels.deductionLine.contains("$72.50")) // 100 * 0.725
@@ -27,36 +48,53 @@ class MileageTaxModelTest {
     }
 
     @Test fun year2025_usesItsOwnRate() {
-        val labels = MileageTaxModel.from(100.0, 2025, AnalyticsPeriod.TODAY)
+        val labels = MileageTaxModel.from(100.0, noonUtc(2025, 6, 15), utc, AnalyticsPeriod.TODAY)
         assertTrue(labels.deductionLine.contains("IRS 2025"))
         assertTrue(labels.deductionLine.contains("$0.700/mi"))
         assertTrue(labels.deductionLine.contains("$70.00"))
     }
 
     @Test fun unknownYear_fallsBackToLatestRate_withDisclaimer() {
-        val labels = MileageTaxModel.from(100.0, 2027, AnalyticsPeriod.THIS_MONTH)
+        val labels = MileageTaxModel.from(100.0, noonUtc(2027, 6, 15), utc, AnalyticsPeriod.THIS_MONTH)
         // 2027 unpublished → latest known rate (2026 = $0.725/mi), labelled honestly.
         assertTrue(labels.deductionLine.contains("IRS 2027"))
         assertTrue(labels.deductionLine.contains("$0.725/mi"))
         assertTrue(labels.deductionLine.contains("$72.50"))
         assertNull(labels.spansYearsNote)
-        org.junit.Assert.assertEquals(
+        assertEquals(
             "2027 rate not yet published — estimated at the 2026 rate",
             labels.disclaimer,
         )
     }
 
-    @Test fun lifetime_addsSpansYearsNote() {
-        val labels = MileageTaxModel.from(100.0, 2026, AnalyticsPeriod.LIFETIME)
-        org.junit.Assert.assertEquals(
-            "spans tax years — see the CSV export for per-year figures",
+    @Test fun lifetime_addsMaySpanYearsNote() {
+        val labels = MileageTaxModel.from(100.0, noonUtc(2026, 7, 15), utc, AnalyticsPeriod.LIFETIME)
+        assertEquals(
+            "may span tax years — see the CSV export for per-year figures",
             labels.spansYearsNote,
         )
     }
 
-    @Test fun nonLifetime_hasNoSpansYearsNote() {
-        assertNull(MileageTaxModel.from(100.0, 2026, AnalyticsPeriod.TODAY).spansYearsNote)
-        assertNull(MileageTaxModel.from(100.0, 2026, AnalyticsPeriod.THIS_WEEK).spansYearsNote)
-        assertNull(MileageTaxModel.from(100.0, 2026, AnalyticsPeriod.THIS_MONTH).spansYearsNote)
+    @Test fun weekStraddlingNewYear_addsSpansYearsNote() {
+        // Thu 2026-01-01 → the Monday-anchored week starts Mon 2025-12-29: the window spans tax
+        // years, so the note fires even though the period isn't Lifetime.
+        val labels = MileageTaxModel.from(100.0, noonUtc(2026, 1, 1), utc, AnalyticsPeriod.THIS_WEEK)
+        assertEquals(
+            "spans tax years — see the CSV export for per-year figures",
+            labels.spansYearsNote,
+        )
+        // The deduction itself is still labelled (and priced) at the current year's rate.
+        assertTrue(labels.deductionLine.contains("IRS 2026"))
+    }
+
+    @Test fun singleYearWindows_haveNoSpansYearsNote() {
+        val midYear = noonUtc(2026, 7, 15)
+        assertNull(MileageTaxModel.from(100.0, midYear, utc, AnalyticsPeriod.TODAY).spansYearsNote)
+        assertNull(MileageTaxModel.from(100.0, midYear, utc, AnalyticsPeriod.THIS_WEEK).spansYearsNote)
+        assertNull(MileageTaxModel.from(100.0, midYear, utc, AnalyticsPeriod.THIS_MONTH).spansYearsNote)
+        // Jan 1 itself: Today and This-Month start at Jan 1 00:00 — same year, no note.
+        val newYearsDay = noonUtc(2026, 1, 1)
+        assertNull(MileageTaxModel.from(100.0, newYearsDay, utc, AnalyticsPeriod.TODAY).spansYearsNote)
+        assertNull(MileageTaxModel.from(100.0, newYearsDay, utc, AnalyticsPeriod.THIS_MONTH).spansYearsNote)
     }
 }

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/CsvExporter.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/CsvExporter.kt
@@ -5,6 +5,7 @@ import cloud.trotter.dashbuddy.core.database.analytics.SessionRecordEntity
 import cloud.trotter.dashbuddy.domain.export.Csv
 import cloud.trotter.dashbuddy.domain.export.IrsMileage
 import cloud.trotter.dashbuddy.domain.state.Platform
+import java.time.Instant
 import java.time.ZoneId
 
 /**
@@ -137,10 +138,21 @@ object CsvExporter {
         return sb.toString()
     }
 
+    /** The local tax year a record falls in, derived from its epoch millis in the export [zone]. */
+    private fun taxYearOf(epochMillis: Long, zone: ZoneId): Int =
+        Instant.ofEpochMilli(epochMillis).atZone(zone).year
+
     /**
-     * A `metric,value` summary — the tax-preparer line the issue calls for: total odometer-derived
-     * business miles × the IRS standard business rate, with the tax year and rate stated explicitly
-     * so the deduction number is never ambiguous about which year produced it.
+     * A `metric,value` summary — the tax-preparer lines the issue calls for: odometer-derived
+     * business miles × the IRS standard business rate. The rate is **year-specific** (#689), so the
+     * deduction is computed per row's own tax year — a session's `startedAt` resolved in the export
+     * [zone] (one owner: the same zone the row timestamps use). Sessions are grouped by tax year and
+     * **one `tax_year`/`irs_business_rate_per_mile`/`total_deductible_miles`/`estimated_mileage_deduction`
+     * group is emitted per year present**, ascending, so a year-boundary-spanning export applies the
+     * right rate to each year's miles instead of one (wrong) global label. A year with no published
+     * IRS rate falls back to the latest known rate ([IrsMileage.latestKnown]) and appends a
+     * clearly-labelled `rate_note` disclaimer (routed through [Csv.textField] — formula-injection
+     * rules still apply) so the substitution is never silent.
      */
     private fun summaryCsv(
         deliveries: List<DeliveryRecordEntity>,
@@ -148,24 +160,37 @@ object CsvExporter {
         zone: ZoneId,
         generatedAtMillis: Long,
     ): String {
-        val totalMiles = sessions.sumOf { sessionMiles(it) ?: 0.0 }
-        val deduction = IrsMileage.deduction(totalMiles)
+        // Deductible miles grouped by the session's own local tax year (ascending).
+        val milesByYear: Map<Int, Double> = sessions
+            .groupBy { taxYearOf(it.startedAt, zone) }
+            .mapValues { (_, group) -> group.sumOf { sessionMiles(it) ?: 0.0 } }
+            .toSortedMap()
         val totalReported = sessions.mapNotNull { it.reportedEarnings }.sum()
         val totalRealized = deliveries.mapNotNull { it.realizedPay }.sum()
 
         val sb = StringBuilder()
         sb.append(Csv.row(listOf(Csv.textField("metric"), Csv.textField("value")))).append('\n')
         // Metric names are program constants; values below are pre-encoded numeric/timestamp
-        // cells except date_range's literal, which goes through textField like any text cell.
+        // cells except the text literals (date_range, rate_note), which go through textField.
         fun line(metric: String, encodedValue: String) {
             sb.append(Csv.row(listOf(Csv.textField(metric), encodedValue))).append('\n')
         }
         line("export_generated_at", Csv.isoDateTime(generatedAtMillis, zone))
         line("date_range", Csv.textField("all_time"))
-        line("tax_year", IrsMileage.TAX_YEAR.toString())
-        line("irs_business_rate_per_mile", Csv.money(IrsMileage.RATE_PER_MILE, digits = 3))
-        line("total_deductible_miles", Csv.decimal(totalMiles))
-        line("estimated_mileage_deduction", Csv.money(deduction))
+        for ((year, miles) in milesByYear) {
+            val rate = IrsMileage.rateFor(year) ?: IrsMileage.latestKnown().second
+            line("tax_year", year.toString())
+            line("irs_business_rate_per_mile", Csv.money(rate, digits = 3))
+            line("total_deductible_miles", Csv.decimal(miles))
+            line("estimated_mileage_deduction", Csv.money(IrsMileage.deduction(miles, year)))
+            if (!IrsMileage.isKnown(year)) {
+                val latestYear = IrsMileage.latestKnown().first
+                line(
+                    "rate_note",
+                    Csv.textField("$year rate not yet published — estimated at the $latestYear rate"),
+                )
+            }
+        }
         line("total_sessions", Csv.int(sessions.size))
         line("total_deliveries", Csv.int(deliveries.size))
         line("total_reported_earnings", Csv.money(totalReported))

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/CsvExporter.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/CsvExporter.kt
@@ -149,10 +149,10 @@ object CsvExporter {
      * [zone] (one owner: the same zone the row timestamps use). Sessions are grouped by tax year and
      * **one `tax_year`/`irs_business_rate_per_mile`/`total_deductible_miles`/`estimated_mileage_deduction`
      * group is emitted per year present**, ascending, so a year-boundary-spanning export applies the
-     * right rate to each year's miles instead of one (wrong) global label. A year with no published
-     * IRS rate falls back to the latest known rate ([IrsMileage.latestKnown]) and appends a
-     * clearly-labelled `rate_note` disclaimer (routed through [Csv.textField] — formula-injection
-     * rules still apply) so the substitution is never silent.
+     * right rate to each year's miles instead of one (wrong) global label. A year with no rate in
+     * the table applies [IrsMileage.effectiveRate]'s fallback and appends [IrsMileage.fallbackNote]
+     * as a `rate_note` line (routed through [Csv.textField] — formula-injection rules still apply)
+     * so the substitution is never silent.
      */
     private fun summaryCsv(
         deliveries: List<DeliveryRecordEntity>,
@@ -178,18 +178,11 @@ object CsvExporter {
         line("export_generated_at", Csv.isoDateTime(generatedAtMillis, zone))
         line("date_range", Csv.textField("all_time"))
         for ((year, miles) in milesByYear) {
-            val rate = IrsMileage.rateFor(year) ?: IrsMileage.latestKnown().second
             line("tax_year", year.toString())
-            line("irs_business_rate_per_mile", Csv.money(rate, digits = 3))
+            line("irs_business_rate_per_mile", Csv.money(IrsMileage.effectiveRate(year), digits = 3))
             line("total_deductible_miles", Csv.decimal(miles))
             line("estimated_mileage_deduction", Csv.money(IrsMileage.deduction(miles, year)))
-            if (!IrsMileage.isKnown(year)) {
-                val latestYear = IrsMileage.latestKnown().first
-                line(
-                    "rate_note",
-                    Csv.textField("$year rate not yet published — estimated at the $latestYear rate"),
-                )
-            }
+            IrsMileage.fallbackNote(year)?.let { line("rate_note", Csv.textField(it)) }
         }
         line("total_sessions", Csv.int(sessions.size))
         line("total_deliveries", Csv.int(deliveries.size))

--- a/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/CsvExporterTest.kt
+++ b/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/CsvExporterTest.kt
@@ -7,12 +7,17 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.time.ZoneId
+import java.time.ZonedDateTime
 
 /** Entity → CSV assembly, hash exclusion, header shape, and the summary deduction (#319). */
 class CsvExporterTest {
 
     private val utc = ZoneId.of("UTC")
     private val generatedAt = 1_783_260_207_000L // 2026-07-05T14:03:27Z
+
+    /** Noon-UTC on a fixed day of [year] — pins a session into a specific local tax year. */
+    private fun millisIn(year: Int): Long =
+        ZonedDateTime.of(year, 6, 15, 12, 0, 0, 0, utc).toInstant().toEpochMilli()
 
     private fun delivery(
         seq: Long,
@@ -158,16 +163,62 @@ class CsvExporterTest {
     }
 
     @Test fun summary_deductionMath() {
+        // Default session starts 2026-07-05 (an hour before generatedAt) → 2026 rate ($0.725/mi).
         val out = CsvExporter.export(
             listOf(delivery(1, "S")),
             listOf(session(startOdo = 1000.0, lastOdo = 1100.0)), // 100 mi
             utc, generatedAt,
         )
         val summary = out.summaryCsv
-        assertTrue(summary.contains("tax_year,2025"))
+        assertTrue(summary.contains("tax_year,2026"))
+        assertTrue(summary.contains("irs_business_rate_per_mile,0.725"))
         assertTrue(summary.contains("total_deductible_miles,100.00"))
-        assertTrue(summary.contains("estimated_mileage_deduction,70.00")) // 100 * 0.70
+        assertTrue(summary.contains("estimated_mileage_deduction,72.50")) // 100 * 0.725
         assertTrue(summary.contains("total_sessions,1"))
         assertTrue(summary.contains("total_deliveries,1"))
+    }
+
+    @Test fun summary_yearBoundarySpan_emitsOneGroupPerYear_withEachYearsRate() {
+        val out = CsvExporter.export(
+            emptyList(),
+            listOf(
+                session(id = "a", startedAt = millisIn(2025), endedAt = millisIn(2025), startOdo = 1000.0, lastOdo = 1100.0), // 100 mi @2025
+                session(id = "b", startedAt = millisIn(2026), endedAt = millisIn(2026), startOdo = 2000.0, lastOdo = 2200.0), // 200 mi @2026
+            ),
+            utc, generatedAt,
+        )
+        val summary = out.summaryCsv
+        // Two tax-year groups, each with its own rate + deduction.
+        assertTrue(summary.contains("tax_year,2025"))
+        assertTrue(summary.contains("tax_year,2026"))
+        assertTrue(summary.contains("irs_business_rate_per_mile,0.700"))
+        assertTrue(summary.contains("irs_business_rate_per_mile,0.725"))
+        assertTrue(summary.contains("estimated_mileage_deduction,70.00"))  // 100 * 0.70
+        assertTrue(summary.contains("estimated_mileage_deduction,145.00")) // 200 * 0.725
+        // Ascending order: the 2025 group precedes the 2026 group.
+        assertTrue(summary.indexOf("tax_year,2025") < summary.indexOf("tax_year,2026"))
+        // No stray disclaimer for years with a published rate.
+        assertFalse(summary.contains("rate_note"))
+    }
+
+    @Test fun summary_unknownYear_usesLatestRate_withFormulaSafeDisclaimer() {
+        val out = CsvExporter.export(
+            emptyList(),
+            listOf(session(startedAt = millisIn(2027), endedAt = millisIn(2027), startOdo = 1000.0, lastOdo = 1100.0)), // 100 mi @2027 (unpublished)
+            utc, generatedAt,
+        )
+        val summary = out.summaryCsv
+        assertTrue(summary.contains("tax_year,2027"))
+        // Falls back to the latest known rate (2026 = $0.725/mi) → 100 * 0.725 = 72.50.
+        assertTrue(summary.contains("irs_business_rate_per_mile,0.725"))
+        assertTrue(summary.contains("estimated_mileage_deduction,72.50"))
+        // Explicit, clearly-labelled disclaimer line (routed through Csv.textField — formula-safe).
+        assertTrue(
+            summary.contains("rate_note,2027 rate not yet published — estimated at the 2026 rate"),
+        )
+        // Disclaimer starts with a digit, so no cell in the summary begins with a formula leader.
+        summary.trim().lines().forEach { row ->
+            assertFalse("formula-leading cell leaked: $row", row.startsWith("=") || row.startsWith("@"))
+        }
     }
 }

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -121,8 +121,9 @@ was found **broken-in-part** (raw PII in capture envelopes) and moved to that en
   `deliveries.csv`, `sessions.csv`, `summary.csv`. Open each in a spreadsheet app: deliveries should
   have one row per completed drop (date/time, platform, store, pay, tip, miles, minutes, net…),
   sessions one row per dash (start/end, duration, odometer start/end, miles, offer counts), and
-  summary a totals block ending in `estimated_mileage_deduction` (= total miles × 0.70, the IRS 2025
-  business rate). **How to tell it's working:** values are sane (money looks like `8.50` not `0.00`
+  summary a totals block with **one `tax_year` group per year present** (miles × the IRS standard
+  business rate for that year via the per-year lookup — 2025 = $0.70, 2026 = $0.725; a future year
+  with no published rate falls back to the latest rate + a `rate_note` disclaimer). **How to tell it's working:** values are sane (money looks like `8.50` not `0.00`
   everywhere; store names with commas like "Chili's, Cedar Park" stay in one cell, not split), and
   NO customer names/addresses or hashes appear anywhere. All-time export (v1 has no date-range
   picker). Screens with no dashes yet just yield header-only files — that's fine.
@@ -196,7 +197,8 @@ was found **broken-in-part** (raw PII in capture envelopes) and moved to that en
   card (a % headline + an On-delivery / Deadhead miles bar — deadhead = miles not attached to any
   delivery), an **on-time** gauge ("NN% on time" over the deliveries that carried a deadline, "N of M
   … with a deadline", plus a "typically Xm early/late" margin line), and a **mileage & tax** card
-  (period miles + the est. IRS 2025 standard-mileage deduction at $0.70/mi). How to tell it's working:
+  (period miles + the est. IRS standard-mileage deduction at the current year's rate via the per-year
+  lookup — 2026 = $0.725/mi; Lifetime adds a "spans tax years — see the CSV export" note). How to tell it's working:
   the online split ≈ the time you spent online vs on drops for the dash, deadhead miles look sane
   (small on a busy dash, larger if you drove a lot between/after drops), the on-time % and margin match
   how you did against the app's deadlines, and the mileage matches the odometer miles for the period.

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -198,7 +198,8 @@ was found **broken-in-part** (raw PII in capture envelopes) and moved to that en
   delivery), an **on-time** gauge ("NN% on time" over the deliveries that carried a deadline, "N of M
   … with a deadline", plus a "typically Xm early/late" margin line), and a **mileage & tax** card
   (period miles + the est. IRS standard-mileage deduction at the current year's rate via the per-year
-  lookup — 2026 = $0.725/mi; Lifetime adds a "spans tax years — see the CSV export" note). How to tell it's working:
+  lookup — 2026 = $0.725/mi; Lifetime adds a "may span tax years — see the CSV export" note, and a
+  Monday-anchored week straddling Jan 1 gets a "spans tax years" note). How to tell it's working:
   the online split ≈ the time you spent online vs on drops for the dash, deadhead miles look sane
   (small on a busy dash, larger if you drove a lot between/after drops), the on-time % and margin match
   how you did against the app's deadlines, and the mileage matches the odometer miles for the period.

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/export/IrsMileage.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/export/IrsMileage.kt
@@ -15,10 +15,13 @@ package cloud.trotter.dashbuddy.domain.export
  * each record's own tax year: the CSV export applies the right rate per row (emitting one summary
  * group per tax year present), and the Time tab labels the current year's rate.
  *
- * **Unknown (unpublished) year → the latest known rate, always disclaimed** (dev decision, #689):
- * a future year with no published rate falls back to [latestKnown] rather than silently applying a
- * stale year's number; every consumer surfaces an explicit "rate not yet published" note driven by
- * [isKnown]. Honest-fallback beats a fabricated year label.
+ * **Unknown year → the latest known rate, always disclaimed** (dev decision, #689): a year with no
+ * entry in [RATES] falls back to [latestKnown] rather than silently applying a stale year's number,
+ * and every consumer surfaces the disclaimer. [effectiveRate] owns the fallback policy and
+ * [fallbackNote] owns the disclaimer copy — consumers derive both from here (Principle 5), never
+ * re-implement them. The note is direction-aware: a year *after* the latest known is "not yet
+ * published"; a year *before* the table (device clock skew, backfilled history) has a published IRS
+ * rate that simply isn't shipped in this table, so the copy must not claim non-publication.
  *
  * **RELEASE CHECKLIST (each December):** when the IRS publishes the next year's notice, add the new
  * `year to rate` entry to [RATES] (plus a corpus/UI test bump). That annual edit is the whole
@@ -46,8 +49,8 @@ object IrsMileage {
     fun isKnown(year: Int): Boolean = RATES.containsKey(year)
 
     /**
-     * The most recently published `(year, rate)` — the honest fallback rate for an unknown future
-     * year (used by [deduction] and surfaced with a disclaimer by every consumer).
+     * The most recently published `(year, rate)` — the honest fallback for an unknown year (applied
+     * by [effectiveRate] and disclaimed by [fallbackNote]).
      */
     fun latestKnown(): Pair<Int, Double> {
         val year = RATES.keys.max()
@@ -55,10 +58,30 @@ object IrsMileage {
     }
 
     /**
-     * Estimated standard-mileage deduction for [miles] business miles driven in [year]. An unknown
-     * (unpublished) year falls back to the latest known year's rate ([latestKnown]) — callers must
-     * surface the disclaimer via [isKnown] so the substitution is never silent.
+     * The rate actually applied for [year]: the published rate, or the latest known rate as the
+     * fallback. The single owner of the fallback policy — [deduction] and every consumer's "/mi"
+     * label derive from this, so a printed rate and its deduction can never disagree.
      */
-    fun deduction(miles: Double, year: Int): Double =
-        miles * (rateFor(year) ?: latestKnown().second)
+    fun effectiveRate(year: Int): Double = rateFor(year) ?: latestKnown().second
+
+    /**
+     * The one disclaimer copy for a fallback-rate substitution — the CSV `rate_note` and the
+     * Time-tab card render exactly this string (SSOT) — or `null` when [year] has a published rate
+     * in [RATES]. Direction-aware so it never states a falsehood: a past year's rate exists, it
+     * just isn't in this table.
+     */
+    fun fallbackNote(year: Int): String? {
+        val latestYear = latestKnown().first
+        return when {
+            isKnown(year) -> null
+            year > latestYear -> "$year rate not yet published — estimated at the $latestYear rate"
+            else -> "no $year rate in the app's rate table — estimated at the $latestYear rate"
+        }
+    }
+
+    /**
+     * Estimated standard-mileage deduction for [miles] business miles driven in [year], at
+     * [effectiveRate] — callers must surface [fallbackNote] so a substitution is never silent.
+     */
+    fun deduction(miles: Double, year: Int): Double = miles * effectiveRate(year)
 }

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/export/IrsMileage.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/export/IrsMileage.kt
@@ -1,31 +1,64 @@
 package cloud.trotter.dashbuddy.domain.export
 
 /**
- * IRS standard mileage deduction constant for the CSV export's tax summary (#319).
+ * IRS standard business mileage rates, keyed by tax year, for the analytics tax lines (#319, #689).
  *
- * The free-tier pledge is "the driver can hand this to a tax preparer": the export ships the
+ * The free-tier pledge is "the driver can hand this to a tax preparer": the export/Time-tab ship the
  * driver's own odometer-derived business miles times the IRS standard business mileage rate as an
- * *estimated* deduction line. This is intentionally the standard-mileage method, not actual-expense
+ * *estimated* deduction. This is intentionally the standard-mileage method, not actual-expense
  * (which the app's operating-cost model separately estimates for net-profit) — a tax preparer
  * expects the IRS rate.
  *
- * **The rate is year-specific and the constant is named with its tax year on purpose.** The IRS
- * publishes each year's rate in mid-December; [RATE_PER_MILE] is the tax-year-2025 business rate
- * ($0.70/mi, confirmed). The export labels the tax year explicitly so a downstream reader never
- * mistakes which year's rate produced the number.
+ * **The rate is year-specific — recognition is DATA, not a hardcoded constant (Principle 5/8).**
+ * The IRS publishes each year's rate in mid-December as a newsroom page + notice PDF; there is no
+ * open API, so the rate ships as data in an annual app release. Consumers pick the rate matching
+ * each record's own tax year: the CSV export applies the right rate per row (emitting one summary
+ * group per tax year present), and the Time tab labels the current year's rate.
  *
- * TODO(#319): confirm the IRS 2026 business standard mileage rate once published and add a
- * per-year lookup (the export can then pick the rate matching each row's date). Until then the
- * export honestly reports [TAX_YEAR] = 2025 in the summary rather than inventing 2026 precision.
+ * **Unknown (unpublished) year → the latest known rate, always disclaimed** (dev decision, #689):
+ * a future year with no published rate falls back to [latestKnown] rather than silently applying a
+ * stale year's number; every consumer surfaces an explicit "rate not yet published" note driven by
+ * [isKnown]. Honest-fallback beats a fabricated year label.
+ *
+ * **RELEASE CHECKLIST (each December):** when the IRS publishes the next year's notice, add the new
+ * `year to rate` entry to [RATES] (plus a corpus/UI test bump). That annual edit is the whole
+ * maintenance hook. A future OTA delivery path (so the rate could ride the signed matchers/CDN
+ * config channel instead of an app update) is tracked separately as #695 — it is gated on the
+ * #416 signature-verification infra and is NOT this object's job.
  */
 object IrsMileage {
 
-    /** Tax year the [RATE_PER_MILE] applies to — surfaced in the export summary so it's unambiguous. */
-    const val TAX_YEAR: Int = 2025
+    /**
+     * IRS standard business mileage rate (dollars per mile) by tax year.
+     *  - 2025 = $0.70/mi (confirmed).
+     *  - 2026 = $0.725/mi — up 2.5¢, effective 2026-01-01 (IRS Notice 2026-10). See
+     *    https://www.irs.gov/newsroom/irs-sets-2026-business-standard-mileage-rate-at-725-cents-per-mile-up-25-cents
+     */
+    val RATES: Map<Int, Double> = mapOf(
+        2025 to 0.70,
+        2026 to 0.725,
+    )
 
-    /** IRS standard business mileage rate for [TAX_YEAR] 2025 = $0.70/mi (confirmed). */
-    const val RATE_PER_MILE: Double = 0.70
+    /** The exact published rate for [year], or `null` when that year has no published rate yet. */
+    fun rateFor(year: Int): Double? = RATES[year]
 
-    /** Estimated standard-mileage deduction for [miles] business miles at [RATE_PER_MILE]. */
-    fun deduction(miles: Double): Double = miles * RATE_PER_MILE
+    /** Whether [year] has a published IRS rate — the unknown-year disclaimer trigger. */
+    fun isKnown(year: Int): Boolean = RATES.containsKey(year)
+
+    /**
+     * The most recently published `(year, rate)` — the honest fallback rate for an unknown future
+     * year (used by [deduction] and surfaced with a disclaimer by every consumer).
+     */
+    fun latestKnown(): Pair<Int, Double> {
+        val year = RATES.keys.max()
+        return year to RATES.getValue(year)
+    }
+
+    /**
+     * Estimated standard-mileage deduction for [miles] business miles driven in [year]. An unknown
+     * (unpublished) year falls back to the latest known year's rate ([latestKnown]) — callers must
+     * surface the disclaimer via [isKnown] so the substitution is never silent.
+     */
+    fun deduction(miles: Double, year: Int): Double =
+        miles * (rateFor(year) ?: latestKnown().second)
 }

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/export/CsvTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/export/CsvTest.kt
@@ -1,6 +1,9 @@
 package cloud.trotter.dashbuddy.domain.export
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.time.ZoneId
 
@@ -151,15 +154,36 @@ class CsvTest {
         assertEquals("", Csv.isoDateTime(null, utc))
     }
 
-    // ── IRS deduction ───────────────────────────────────────────────────
+    // ── IRS per-year mileage rates (#689) ───────────────────────────────
 
-    @Test fun irsRate_isTaxYear2025Business() {
-        assertEquals(2025, IrsMileage.TAX_YEAR)
-        assertEquals(0.70, IrsMileage.RATE_PER_MILE, 0.0)
+    @Test fun irsRate_knownYears() {
+        assertEquals(0.70, IrsMileage.rateFor(2025)!!, 0.0)
+        assertEquals(0.725, IrsMileage.rateFor(2026)!!, 0.0)
     }
 
-    @Test fun irsDeduction_math() {
-        assertEquals(70.0, IrsMileage.deduction(100.0), 1e-9)
-        assertEquals(0.0, IrsMileage.deduction(0.0), 0.0)
+    @Test fun irsRate_unknownYear_isNull() {
+        assertNull(IrsMileage.rateFor(2027))
+        assertNull(IrsMileage.rateFor(2024))
+    }
+
+    @Test fun irsIsKnown_tracksThePublishedTable() {
+        assertTrue(IrsMileage.isKnown(2025))
+        assertTrue(IrsMileage.isKnown(2026))
+        assertFalse(IrsMileage.isKnown(2027))
+    }
+
+    @Test fun irsLatestKnown_isTheMaxYearsRate() {
+        assertEquals(2026 to 0.725, IrsMileage.latestKnown())
+    }
+
+    @Test fun irsDeduction_perYearRate() {
+        assertEquals(70.0, IrsMileage.deduction(100.0, 2025), 1e-9)
+        assertEquals(72.5, IrsMileage.deduction(100.0, 2026), 1e-9)
+        assertEquals(0.0, IrsMileage.deduction(0.0, 2025), 0.0)
+    }
+
+    @Test fun irsDeduction_unknownYear_fallsBackToLatestKnownRate() {
+        // 2027 has no published rate → latest known (2026 = $0.725/mi).
+        assertEquals(72.5, IrsMileage.deduction(100.0, 2027), 1e-9)
     }
 }

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/export/CsvTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/export/CsvTest.kt
@@ -186,4 +186,26 @@ class CsvTest {
         // 2027 has no published rate → latest known (2026 = $0.725/mi).
         assertEquals(72.5, IrsMileage.deduction(100.0, 2027), 1e-9)
     }
+
+    @Test fun irsEffectiveRate_publishedRate_orLatestKnownFallback() {
+        assertEquals(0.70, IrsMileage.effectiveRate(2025), 0.0)
+        assertEquals(0.725, IrsMileage.effectiveRate(2026), 0.0)
+        assertEquals(0.725, IrsMileage.effectiveRate(2027), 0.0) // future unknown → latest
+        assertEquals(0.725, IrsMileage.effectiveRate(2024), 0.0) // pre-table → latest (disclaimed below)
+    }
+
+    @Test fun irsFallbackNote_isDirectionAware_andNullForPublishedYears() {
+        assertNull(IrsMileage.fallbackNote(2025))
+        assertNull(IrsMileage.fallbackNote(2026))
+        // Future year: genuinely not yet published.
+        assertEquals(
+            "2027 rate not yet published — estimated at the 2026 rate",
+            IrsMileage.fallbackNote(2027),
+        )
+        // Past year: its rate IS published (just not shipped) — the copy must not claim otherwise.
+        assertEquals(
+            "no 2024 rate in the app's rate table — estimated at the 2026 rate",
+            IrsMileage.fallbackNote(2024),
+        )
+    }
 }


### PR DESCRIPTION
## What & why

`IrsMileage` hardcoded `TAX_YEAR = 2025` / `RATE_PER_MILE = 0.70`, so any 2026 CSV export (#319) or Analytics Time-tab MILEAGE & TAX card (#674) labelled its estimated standard-mileage deduction as **tax year 2025 at $0.70/mi**. The 2026 rate is now published — **72.5¢/mi**, up 2.5¢, effective 2026-01-01 ([IRS Notice 2026-10](https://www.irs.gov/newsroom/irs-sets-2026-business-standard-mileage-rate-at-725-cents-per-mile-up-25-cents)) — so the honest-2025 stopgap is stale. This makes the rate a **per-year lookup** and has both consumers pick the rate by each record's own tax year.

There is no open API for the IRS rate (researched on the issue), so the rate ships as **data in the annual app release** (December release-checklist note in the KDoc). A future OTA delivery path is #695, gated on the #416 signature infra — not a prerequisite here.

## The two consumers (all `IrsMileage` call sites swept)

1. **CSV export (`CsvExporter` summary)** — deduction is now computed **per row's own tax year** (a session's `startedAt` resolved in the export zone — the same zone the row timestamps already use, one owner). Sessions are grouped by tax year and **one `tax_year` / `irs_business_rate_per_mile` / `total_deductible_miles` / `estimated_mileage_deduction` group is emitted per year present**, ascending. `date_range` and the global totals are unchanged.
2. **Time tab MILEAGE & TAX card (`TimeTab`)** — a period is single-year by construction for Today/Week/Month; only Lifetime can span years. The card labels the **current** year's rate via the lookup (year + rate from `IrsMileage`, never a literal), computed from the device clock per composition. Lifetime adds a "spans tax years — see the CSV export for per-year figures" note (the CSV owns per-year precision). Copy logic is extracted to a pure, Compose-free `MileageTaxModel` (the `WaterfallModel` precedent) and unit-tested.

## Locked decisions (dev, #689)

- **Two consumers**, both derive from one rate table.
- **Unknown (unpublished) year → the latest known rate, always disclaimed** — CSV appends a `rate_note` line ("`<year>` rate not yet published — estimated at the `<latest>` rate"); the card appends the same disclaimer. Never a silent stale-year substitution.
- **Rate-as-data, no network** — an annual data edit, OTA is #695.

## Tests

- `IrsMileage`: exact years, unknown-year null/fallback, `latestKnown`, per-year deduction.
- `CsvExporterTest`: a 2025+2026 span → two summary groups with the right rates; a 2027 (unpublished) row → latest-known rate + a formula-safe disclaimer line; `summary_deductionMath` regenerated to the 2026 rate (the fixture session is a 2026 session).
- `MileageTaxModelTest`: year-labelled line, unknown-year disclaimer, Lifetime span note.

Full gate green: `testDebugUnitTest :domain:test`.

### Design-goal review

- **5 (SSOT):** one rate table (`IrsMileage.RATES`) is the sole owner; both consumers and every label/disclaimer derive from `rateFor`/`latestKnown`/`isKnown`/`deduction` — no second copy of a rate or year, no literal year/rate in either consumer.
- **4 (Kotlin/data-not-code):** the rates are data in an annual release, not a hardcoded constant; adding a year is a one-line map edit + a test bump (the December checklist hook).
- **6 (security/privacy):** no network surface added (rate ships as data, pledge-consistent); the unknown-year disclaimer routes through `Csv.textField` so formula-injection neutralization still applies, and the summary stays aggregate-only (no PII).
- **1 (UDF) / Reactive UI:** the card stays a pure function of state + the device clock at render (no ticker needed — a review surface); copy logic is a pure model, side-effect-free.

Closes #689