### PR TITLE
fix(#690): retire fallbackToDestructiveMigration — loud-fail + pre-open backup + migration tests

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -42,6 +42,14 @@ jobs:
         # include; without it every :domain test is CI-invisible (#617 review / #590 gap).
         run: ./gradlew testDebugUnitTest :domain:test
 
+      - name: Schemas committed (Room export drift)
+        # With the destructive fallback retired (#690), an uncommitted Room schema export is a
+        # missing upgrade path that only crashes on a device. KSP regenerated the schemas during
+        # the build/test steps above; if that produced a JSON diff (or a new untracked file) the
+        # bump was committed without its schema — fail the job.
+        run: |
+          git diff --exit-code -- core/database/schemas && test -z "$(git status --porcelain core/database/schemas)"
+
       - name: Upload debug APK
         uses: actions/upload-artifact@v4
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,18 +112,25 @@ matchers (included build, not a :core module) ⇒ canonicalizes rules → :core:
   recovery (StateManagerV2). Defines `EffectExecutor` and `MetadataProvider` interfaces.
 - **`:core:database`** — Room entities, DAOs, and database setup. **Data-safety posture (#690):
   no `fallbackToDestructiveMigration`.** `app_events` is the analytics source of truth (the
-  read-model tables are a rebuildable projection of it), so an upgrade Room has no path for must
-  **fail loud** (`IllegalStateException` at open) rather than silently DROP-and-recreate the log —
-  the dev backs up + resolves instead of losing history. `DatabaseModule` also takes a pre-open
-  file snapshot (`DatabaseBackup`, last 2, failure-tolerant) when an upgrade is pending, so even a
-  botched *future* migration is recoverable. Schema version is one SSOT const
-  (`DashBuddyDatabase.VERSION`, consumed by the `@Database` annotation, the backup detector, and the
-  CI-gating `SchemaVersionGuardTest`). **Release checklist when changing the schema: bump
+  read-model tables are a rebuildable projection of it), so an upgrade that Room has no path for must
+  **fail loud** (`IllegalStateException`) rather than silently DROP-and-recreate the log — the dev
+  backs up + resolves instead of losing history. The supported upgrade base is **v8+**: on-disk
+  versions below v8, and downgrades (on-disk newer than the code), are an **intentional loud crash at
+  startup**, each preceded by a fresh pre-crash snapshot. `DatabaseModule` **eagerly opens** the DB
+  at injection time (`openHelper.writableDatabase`) so the failure is a deterministic startup crash,
+  not a lazy first-query one that the projector/recovery supervision would swallow; just before the
+  open it takes a pre-open file snapshot (`DatabaseBackup`, WAL-aware version read, dedup-marked,
+  version-prefixed dirs, last 2, failure-tolerant) whenever the on-disk version ≠ the code version, so
+  even a botched *future* migration is recoverable. Schema version is one SSOT const
+  (`DashBuddyDatabase.VERSION`). **Release checklist when changing the schema: bump
   `DashBuddyDatabase.VERSION` → regenerate the exported schema JSON (`exportSchema`) → add the
   `AutoMigration` (or a manual `Migration`) covering the new edge → add its `MigrationTestHelper`
-  case** (`core/database/src/androidTest`). Migration-correctness tests are instrumented
-  (`connectedAndroidTest`) and do NOT gate the unit-only PR CI; `SchemaVersionGuardTest` (unit) is
-  what gates — it fails if `VERSION` has no matching newest schema JSON.
+  case** (`core/database/src/androidTest`). Two **real gates** enforce this: the CI
+  `Schemas committed (Room export drift)` step fails if the build regenerated an uncommitted schema
+  JSON, and `SchemaVersionGuardTest` (unit) source-scans the `@Database` migration edges (it's BINARY
+  retention) to prove they chain v8 → `VERSION` with no gap — the forgotten-`AutoMigration` class the
+  retired fallback used to mask. Migration-*correctness* tests are instrumented (`connectedAndroidTest`)
+  and do NOT gate the unit-only PR CI.
 - **`:core:data`** — Repository implementations, mappers, data sources. Bridges domain interfaces to
   concrete data layers.
 - **`:core:network`** — Retrofit clients, OkHttp interceptors, EIA gas price API integration.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,20 @@ matchers (included build, not a :core module) ⇒ canonicalizes rules → :core:
   PlatformRegionStepper, CrossPlatformRegionStepper), effect map, `TransitionPolicy` (the
   expected/unexpected classification + commit graces; replaced the old `HealingPolicy`), crash
   recovery (StateManagerV2). Defines `EffectExecutor` and `MetadataProvider` interfaces.
-- **`:core:database`** — Room entities, DAOs, and database setup.
+- **`:core:database`** — Room entities, DAOs, and database setup. **Data-safety posture (#690):
+  no `fallbackToDestructiveMigration`.** `app_events` is the analytics source of truth (the
+  read-model tables are a rebuildable projection of it), so an upgrade Room has no path for must
+  **fail loud** (`IllegalStateException` at open) rather than silently DROP-and-recreate the log —
+  the dev backs up + resolves instead of losing history. `DatabaseModule` also takes a pre-open
+  file snapshot (`DatabaseBackup`, last 2, failure-tolerant) when an upgrade is pending, so even a
+  botched *future* migration is recoverable. Schema version is one SSOT const
+  (`DashBuddyDatabase.VERSION`, consumed by the `@Database` annotation, the backup detector, and the
+  CI-gating `SchemaVersionGuardTest`). **Release checklist when changing the schema: bump
+  `DashBuddyDatabase.VERSION` → regenerate the exported schema JSON (`exportSchema`) → add the
+  `AutoMigration` (or a manual `Migration`) covering the new edge → add its `MigrationTestHelper`
+  case** (`core/database/src/androidTest`). Migration-correctness tests are instrumented
+  (`connectedAndroidTest`) and do NOT gate the unit-only PR CI; `SchemaVersionGuardTest` (unit) is
+  what gates — it fails if `VERSION` has no matching newest schema JSON.
 - **`:core:data`** — Repository implementations, mappers, data sources. Bridges domain interfaces to
   concrete data layers.
 - **`:core:network`** — Retrofit clients, OkHttp interceptors, EIA gas price API integration.

--- a/app/src/main/java/cloud/trotter/dashbuddy/DashBuddyApplication.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/DashBuddyApplication.kt
@@ -85,6 +85,13 @@ class DashBuddyApplication : Application(), Configuration.Provider {
     }
 
     override fun onCreate() {
+        // Planted before super.onCreate() so injection-time code (DatabaseBackup #690, which runs
+        // during Hilt field injection inside super.onCreate()) can log. The plain DebugTree needs no
+        // injected dependencies; the StateAwareTree below does, so it stays planted after super.
+        if (BuildConfig.DEBUG) {
+            Timber.plant(Timber.DebugTree())
+        }
+
         super.onCreate()
         instance = this
 
@@ -99,9 +106,6 @@ class DashBuddyApplication : Application(), Configuration.Provider {
             }
         }
 
-        if (BuildConfig.DEBUG) {
-            Timber.plant(Timber.DebugTree())
-        }
         Timber.plant(
             StateAwareTree(
                 logRepository,

--- a/core/database/build.gradle.kts
+++ b/core/database/build.gradle.kts
@@ -55,6 +55,10 @@ dependencies {
 
     testImplementation(libs.junit)
     testImplementation(libs.kotlin.reflect)
+    // #690 — DatabaseBackupTest needs a real Context (getDatabasePath/filesDir) and a real
+    // SQLiteDatabase to set user_version, so it runs under Robolectric (same dep the app module
+    // uses for its Room round-trip tests). This is a UNIT test — it gates PR CI.
+    testImplementation(libs.robolectric)
 
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/core/database/src/androidTest/java/cloud/trotter/dashbuddy/core/database/MigrationTest.kt
+++ b/core/database/src/androidTest/java/cloud/trotter/dashbuddy/core/database/MigrationTest.kt
@@ -12,8 +12,10 @@ import org.junit.runner.RunWith
 /**
  * #690 — the destructive fallback is retired, so the committed migration chain is the ONLY thing
  * standing between an upgrade and the durable `app_events` log. This proves the **full chained**
- * upgrade path (v8 → v9 → v10) is non-destructive: a populated v8 DB survives the real
- * `AutoMigration`s to v10 with its `app_events` rows intact and legible.
+ * upgrade path (v8 → … → the current [DashBuddyDatabase.VERSION]) is non-destructive: a populated v8
+ * DB survives the real `AutoMigration`s all the way to the current version with its `app_events` rows
+ * intact and legible. The target is [DashBuddyDatabase.VERSION] (not a hardcoded number), so every
+ * future version bump automatically extends the chain this test validates.
  *
  * The per-step tests ([AnalyticsMigration8to9Test], [AnalyticsMigration9to10Test]) cover each edge;
  * this test exercises them *in sequence* the way a real device upgrading across two versions would,
@@ -28,7 +30,7 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class MigrationTest {
 
-    private val dbName = "migration-8-to-10-chained-test"
+    private val dbName = "migration-chained-to-current-test"
 
     @get:Rule
     val helper = MigrationTestHelper(
@@ -39,7 +41,7 @@ class MigrationTest {
     )
 
     @Test
-    fun migrate8To10_chained_preservesAppEventsIntact() {
+    fun migrate8ToCurrent_chained_preservesAppEventsIntact() {
         // Create the schema at v8 and seed app_events rows that MUST survive the whole chain.
         helper.createDatabase(dbName, 8).use { db ->
             db.execSQL(
@@ -52,14 +54,15 @@ class MigrationTest {
             )
         }
 
-        // Run the REAL committed auto-migrations across BOTH edges at once (8 → 9 → 10) and validate
-        // against the exported 10.json schema.
-        val db = helper.runMigrationsAndValidate(dbName, 10, true)
+        // Run every REAL committed auto-migration edge at once (8 → … → VERSION) and validate against
+        // the current exported schema. Using VERSION means the validate step demands the FULL chain,
+        // and a future bump extends it automatically.
+        val db = helper.runMigrationsAndValidate(dbName, DashBuddyDatabase.VERSION, true)
 
         // app_events rows survived the full chain — the source of truth is intact, not wiped.
         db.query("SELECT COUNT(*) FROM app_events").use { c ->
             c.moveToFirst()
-            assertEquals("app_events rows preserved across the chained 8→10 upgrade", 2, c.getInt(0))
+            assertEquals("app_events rows preserved across the chained upgrade to current", 2, c.getInt(0))
         }
         // And the payload/columns are legible, not just present.
         db.query("SELECT eventType, eventPayload, metadata FROM app_events WHERE sequenceId = 2").use { c ->

--- a/core/database/src/androidTest/java/cloud/trotter/dashbuddy/core/database/MigrationTest.kt
+++ b/core/database/src/androidTest/java/cloud/trotter/dashbuddy/core/database/MigrationTest.kt
@@ -1,0 +1,73 @@
+package cloud.trotter.dashbuddy.core.database
+
+import androidx.room.testing.MigrationTestHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * #690 — the destructive fallback is retired, so the committed migration chain is the ONLY thing
+ * standing between an upgrade and the durable `app_events` log. This proves the **full chained**
+ * upgrade path (v8 → v9 → v10) is non-destructive: a populated v8 DB survives the real
+ * `AutoMigration`s to v10 with its `app_events` rows intact and legible.
+ *
+ * The per-step tests ([AnalyticsMigration8to9Test], [AnalyticsMigration9to10Test]) cover each edge;
+ * this test exercises them *in sequence* the way a real device upgrading across two versions would,
+ * which is the scenario the retired fallback used to paper over.
+ *
+ * **Instrumented / androidTest** because [MigrationTestHelper] opens an on-disk SQLite DB via the
+ * framework factory and replays the exported schema JSONs (surfaced to test assets by the
+ * `androidTest` sourceSet in `build.gradle.kts`). Runs under `:core:database:connectedAndroidTest`.
+ * NOTE: the PR CI runs unit tests only, so this does NOT gate PRs — the unit-level
+ * [SchemaVersionGuardTest] is the CI-gating guard. Run this locally / in an instrumented job.
+ */
+@RunWith(AndroidJUnit4::class)
+class MigrationTest {
+
+    private val dbName = "migration-8-to-10-chained-test"
+
+    @get:Rule
+    val helper = MigrationTestHelper(
+        InstrumentationRegistry.getInstrumentation(),
+        DashBuddyDatabase::class.java,
+        emptyList(),
+        FrameworkSQLiteOpenHelperFactory(),
+    )
+
+    @Test
+    fun migrate8To10_chained_preservesAppEventsIntact() {
+        // Create the schema at v8 and seed app_events rows that MUST survive the whole chain.
+        helper.createDatabase(dbName, 8).use { db ->
+            db.execSQL(
+                """INSERT INTO app_events (sequenceId, aggregateId, eventType, eventPayload, occurredAt, metadata)
+                   VALUES (1, 'S1', 'DASH_START', '{}', 1000, NULL)""",
+            )
+            db.execSQL(
+                """INSERT INTO app_events (sequenceId, aggregateId, eventType, eventPayload, occurredAt, metadata)
+                   VALUES (2, 'S1', 'DELIVERY_COMPLETED', '{"dropRealizedPay":8.5}', 2000, '{"odometer":5.0}')""",
+            )
+        }
+
+        // Run the REAL committed auto-migrations across BOTH edges at once (8 → 9 → 10) and validate
+        // against the exported 10.json schema.
+        val db = helper.runMigrationsAndValidate(dbName, 10, true)
+
+        // app_events rows survived the full chain — the source of truth is intact, not wiped.
+        db.query("SELECT COUNT(*) FROM app_events").use { c ->
+            c.moveToFirst()
+            assertEquals("app_events rows preserved across the chained 8→10 upgrade", 2, c.getInt(0))
+        }
+        // And the payload/columns are legible, not just present.
+        db.query("SELECT eventType, eventPayload, metadata FROM app_events WHERE sequenceId = 2").use { c ->
+            c.moveToFirst()
+            assertEquals("DELIVERY_COMPLETED", c.getString(0))
+            assertEquals("""{"dropRealizedPay":8.5}""", c.getString(1))
+            assertEquals("""{"odometer":5.0}""", c.getString(2))
+        }
+        db.close()
+    }
+}

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/DashBuddyDatabase.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/DashBuddyDatabase.kt
@@ -33,7 +33,7 @@ import cloud.trotter.dashbuddy.core.database.snapshot.AppStateSnapshotEntity
         OfferRecordEntity::class,
         AnalyticsProjectionStateEntity::class,
     ],
-    version = 10,
+    version = DashBuddyDatabase.VERSION,
     exportSchema = true,
     // v8→v9 adds only new tables (the analytics read-model). AutoMigration is a
     // no-op for existing tables, so it CANNOT wipe app_events (unlike the
@@ -58,5 +58,22 @@ abstract class DashBuddyDatabase : RoomDatabase() {
     abstract fun effectsFiredDao(): EffectsFiredDao
     abstract fun observationDao(): ObservationDao
     abstract fun analyticsDao(): AnalyticsDao
+
+    companion object {
+        /**
+         * On-disk database file name. SSOT for both the Room builder and the pre-open backup
+         * belt ([cloud.trotter.dashbuddy.core.database.di.DatabaseBackup]).
+         */
+        const val NAME = "dashbuddy-v2.db"
+
+        /**
+         * The schema version this build ships. SSOT: consumed by the `@Database` annotation
+         * above, by the pre-open backup's "is an upgrade pending?" check, and asserted equal to
+         * the newest exported schema JSON by the unit-level `SchemaVersionGuardTest` (#690). Bump
+         * this in lockstep with a new `schemas/**/<N>.json`, an `AutoMigration(N-1 → N)`, and its
+         * `MigrationTestHelper` case — see the release checklist in CLAUDE.md.
+         */
+        const val VERSION = 10
+    }
 
 }

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/di/DatabaseBackup.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/di/DatabaseBackup.kt
@@ -1,0 +1,125 @@
+package cloud.trotter.dashbuddy.core.database.di
+
+import android.content.Context
+import timber.log.Timber
+import java.io.File
+import java.io.RandomAccessFile
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Pre-open safety belt for the durable database (#690, the #314 follow-up).
+ *
+ * Since [cloud.trotter.dashbuddy.core.database.di.DatabaseModule] no longer falls back to a
+ * destructive migration, an upgrade Room has no path for is a **loud crash** rather than a silent
+ * wipe. That is the desired posture — but a botched *future* migration (or a corrupt DB) is still a
+ * data-loss risk, and once Room opens the file it is the only copy. So immediately before Room opens
+ * the database, if an upgrade is pending we snapshot the current DB files to a timestamped subdir
+ * under an app-internal `db-backups/` dir, keeping only the last [KEEP]. A pre-migration snapshot
+ * means even a bad migration is recoverable: the dev can restore the copy and back out.
+ *
+ * The `app_events` log is the analytics **source of truth** (the read-model tables are a rebuildable
+ * projection of it), so protecting these files is protecting the product's history.
+ *
+ * **Detection.** We read SQLite's `user_version` straight from the file header (bytes 60–63, the
+ * value Room stores its schema version in) without opening the DB — an O(1) header read. We snapshot
+ * only when the on-disk version is *older* than the code's [DashBuddyDatabase.VERSION] (an upgrade is
+ * about to run), or when the header can't be read (unknown → snapshot defensively). The common
+ * no-change launch reads 4 bytes and returns, so this is not a copy-every-launch cost.
+ *
+ * **Failure-tolerant by construction.** A backup failure must NEVER stop the app from starting —
+ * every path is wrapped, logs one WARN under a stable tag, and continues. The snapshot copies only
+ * the driver's own on-device DB files; no PII is logged (version numbers + a file count only).
+ */
+internal object DatabaseBackup {
+
+    private const val TAG = "DbBackup"
+
+    /** How many historical snapshots to retain. Bounded so the prune is O(small) every launch. */
+    private const val KEEP = 2
+
+    /** Directory (under `filesDir`) that holds timestamped snapshot subdirs. */
+    private const val BACKUP_DIR = "db-backups"
+
+    /** The Room DB file plus its WAL sidecars. All three must travel together to be restorable. */
+    private val FILE_SUFFIXES = listOf("", "-shm", "-wal")
+
+    /**
+     * Snapshot [dbName] (and its `-shm`/`-wal` sidecars) if the on-disk schema version is older than
+     * [currentVersion]. No-op on first launch (no file yet) and on a same-version launch. Never
+     * throws — a failure logs one WARN and returns so [DatabaseModule] can proceed to open the DB.
+     */
+    fun backupIfUpgradePending(context: Context, dbName: String, currentVersion: Int) {
+        try {
+            val dbFile = context.getDatabasePath(dbName)
+            if (!dbFile.exists()) return // first launch — nothing to protect yet
+
+            val onDiskVersion = readUserVersion(dbFile)
+            // Skip only when we KNOW the on-disk schema already matches (or exceeds) the code. An
+            // unreadable header (null) falls through to a defensive snapshot.
+            if (onDiskVersion != null && onDiskVersion >= currentVersion) return
+
+            val stamp = SimpleDateFormat("yyyyMMdd-HHmmss", Locale.ROOT).format(Date())
+            val backupsRoot = File(context.filesDir, BACKUP_DIR)
+            val dest = File(backupsRoot, stamp)
+            if (!dest.mkdirs() && !dest.isDirectory) {
+                Timber.tag(TAG).w("could not create backup dir %s; skipping snapshot", dest.path)
+                return
+            }
+
+            var copied = 0
+            for (suffix in FILE_SUFFIXES) {
+                val src = File(dbFile.parentFile, dbName + suffix)
+                if (src.exists()) {
+                    src.copyTo(File(dest, dbName + suffix), overwrite = true)
+                    copied++
+                }
+            }
+
+            prune(backupsRoot)
+
+            Timber.tag(TAG).i(
+                "pre-migration DB snapshot taken (onDisk=%s → code=%d): %d file(s) → %s",
+                onDiskVersion?.toString() ?: "unknown",
+                currentVersion,
+                copied,
+                dest.name,
+            )
+        } catch (t: Throwable) {
+            // The belt must never prevent startup. Log and continue to open the DB.
+            Timber.tag(TAG).w(t, "pre-migration DB backup failed; continuing to open DB")
+        }
+    }
+
+    /**
+     * Read SQLite's `user_version` from the file header (big-endian int at byte offset 60) without
+     * opening the DB. Returns null if the file is too short or unreadable.
+     */
+    private fun readUserVersion(dbFile: File): Int? = try {
+        RandomAccessFile(dbFile, "r").use { raf ->
+            if (raf.length() < 64) return null
+            raf.seek(60)
+            val b = ByteArray(4)
+            raf.readFully(b)
+            ((b[0].toInt() and 0xFF) shl 24) or
+                ((b[1].toInt() and 0xFF) shl 16) or
+                ((b[2].toInt() and 0xFF) shl 8) or
+                (b[3].toInt() and 0xFF)
+        }
+    } catch (t: Throwable) {
+        Timber.tag(TAG).w(t, "could not read on-disk DB user_version; will snapshot defensively")
+        null
+    }
+
+    /** Keep only the [KEEP] newest snapshot subdirs (lexical == chronological for the stamp format). */
+    private fun prune(backupsRoot: File) {
+        val dirs = backupsRoot.listFiles { f -> f.isDirectory }
+            ?.sortedBy { it.name }
+            ?: return
+        if (dirs.size <= KEEP) return
+        for (old in dirs.dropLast(KEEP)) {
+            old.deleteRecursively()
+        }
+    }
+}

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/di/DatabaseBackup.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/di/DatabaseBackup.kt
@@ -1,53 +1,83 @@
 package cloud.trotter.dashbuddy.core.database.di
 
 import android.content.Context
+import android.database.sqlite.SQLiteDatabase
 import timber.log.Timber
 import java.io.File
-import java.io.RandomAccessFile
-import java.text.SimpleDateFormat
-import java.util.Date
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import java.util.Locale
 
 /**
  * Pre-open safety belt for the durable database (#690, the #314 follow-up).
  *
  * Since [cloud.trotter.dashbuddy.core.database.di.DatabaseModule] no longer falls back to a
- * destructive migration, an upgrade Room has no path for is a **loud crash** rather than a silent
- * wipe. That is the desired posture — but a botched *future* migration (or a corrupt DB) is still a
- * data-loss risk, and once Room opens the file it is the only copy. So immediately before Room opens
- * the database, if an upgrade is pending we snapshot the current DB files to a timestamped subdir
- * under an app-internal `db-backups/` dir, keeping only the last [KEEP]. A pre-migration snapshot
- * means even a bad migration is recoverable: the dev can restore the copy and back out.
+ * destructive migration, an upgrade that Room has no path for is a **loud crash** rather than a
+ * silent wipe. That is the desired posture — but a botched *future* migration (or a corrupt DB) is
+ * still a data-loss risk, and once Room opens the file it is the only copy. So immediately before
+ * Room opens the database, if the on-disk schema version does not match the code we snapshot the
+ * current DB files to a version-prefixed, timestamped subdir under an app-internal `db-backups/`
+ * dir, keeping only the last [KEEP]. A pre-migration snapshot means even a bad migration is
+ * recoverable: the dev can restore the copy and back out.
  *
  * The `app_events` log is the analytics **source of truth** (the read-model tables are a rebuildable
  * projection of it), so protecting these files is protecting the product's history.
  *
- * **Detection.** We read SQLite's `user_version` straight from the file header (bytes 60–63, the
- * value Room stores its schema version in) without opening the DB — an O(1) header read. We snapshot
- * only when the on-disk version is *older* than the code's [DashBuddyDatabase.VERSION] (an upgrade is
- * about to run), or when the header can't be read (unknown → snapshot defensively). The common
- * no-change launch reads 4 bytes and returns, so this is not a copy-every-launch cost.
+ * **Detection (WAL-aware).** SQLite's `user_version` (the value Room stores its schema version in)
+ * lives on page 1. Under WAL journaling — Room's default — a committed page-1 change lands in the
+ * `-wal` sidecar and is NOT written back to the main file's header until a checkpoint. So reading
+ * byte offset 60 of the main file directly is **stale**: right after a migration commits, the header
+ * still reads the OLD version until the next checkpoint, which would misclassify the very next launch
+ * as "upgrade pending", take a spurious snapshot, and let [prune] rotate out the genuine
+ * pre-migration copy. We therefore read the version the way SQLite resolves it — a single read-only
+ * open, `[SQLiteDatabase.version]`, which reads through the WAL — and never touch the raw header.
+ *
+ * We snapshot whenever the on-disk version does **not equal** the code's [DashBuddyDatabase.VERSION]
+ * (an upgrade OR a downgrade is about to be handled), or when the version can't be read (unknown →
+ * snapshot defensively, since a corrupt DB is exactly what Android's `DefaultDatabaseErrorHandler`
+ * may DELETE at open). The common no-change launch reads the version, sees a match, and returns —
+ * this is not a copy-every-launch cost.
+ *
+ * **Bounded churn (dedup marker).** Each snapshot dir carries a `source.meta` describing the source
+ * it copied (`version`/`length`/`mtime`). Before snapshotting we read the newest existing snapshot's
+ * marker; if it matches the current source exactly we skip. This bounds every unbounded-copy loop a
+ * mismatch-triggered snapshot could otherwise cause: a crash-loop that relaunches with an unchanged
+ * file, a persistently-corrupt/unreadable header copying every launch, a downgrade crash loop.
  *
  * **Failure-tolerant by construction.** A backup failure must NEVER stop the app from starting —
  * every path is wrapped, logs one WARN under a stable tag, and continues. The snapshot copies only
  * the driver's own on-device DB files; no PII is logged (version numbers + a file count only).
+ *
+ * **Logging caveat.** This runs at Hilt injection time (inside `Application.super.onCreate()`),
+ * before the state-aware log tree is planted. In debug builds a plain `DebugTree` is planted before
+ * `super.onCreate()` so these lines surface; in release builds there is no early tree, so
+ * injection-time WARN/INFO here are dropped (accepted — the crash itself is the signal).
  */
 internal object DatabaseBackup {
 
     private const val TAG = "DbBackup"
 
-    /** How many historical snapshots to retain. Bounded so the prune is O(small) every launch. */
+    /** How many historical snapshots to retain (including the one just created). */
     private const val KEEP = 2
 
-    /** Directory (under `filesDir`) that holds timestamped snapshot subdirs. */
+    /** Directory (under `filesDir`) that holds version-prefixed, timestamped snapshot subdirs. */
     private const val BACKUP_DIR = "db-backups"
+
+    /** File written into each snapshot dir describing the source it copied (the dedup marker). */
+    private const val META_FILE = "source.meta"
 
     /** The Room DB file plus its WAL sidecars. All three must travel together to be restorable. */
     private val FILE_SUFFIXES = listOf("", "-shm", "-wal")
 
+    private val stampFormat = DateTimeFormatter
+        .ofPattern("yyyyMMdd-HHmmss", Locale.ROOT)
+        .withZone(ZoneId.systemDefault())
+
     /**
-     * Snapshot [dbName] (and its `-shm`/`-wal` sidecars) if the on-disk schema version is older than
-     * [currentVersion]. No-op on first launch (no file yet) and on a same-version launch. Never
+     * Snapshot [dbName] (and its `-shm`/`-wal` sidecars) if the on-disk schema version does not equal
+     * [currentVersion]. No-op on first launch (no file yet), on a same-version launch, and on a
+     * repeat launch whose source is byte-identical to the newest snapshot (dedup marker). Never
      * throws — a failure logs one WARN and returns so [DatabaseModule] can proceed to open the DB.
      */
     fun backupIfUpgradePending(context: Context, dbName: String, currentVersion: Int) {
@@ -56,17 +86,23 @@ internal object DatabaseBackup {
             if (!dbFile.exists()) return // first launch — nothing to protect yet
 
             val onDiskVersion = readUserVersion(dbFile)
-            // Skip only when we KNOW the on-disk schema already matches (or exceeds) the code. An
-            // unreadable header (null) falls through to a defensive snapshot.
-            if (onDiskVersion != null && onDiskVersion >= currentVersion) return
+            // Skip only when we KNOW the on-disk schema already matches the code. A MISMATCH in
+            // either direction (upgrade or dev-sideloaded downgrade) snapshots before Room reacts;
+            // an unreadable version (null) falls through to a defensive snapshot.
+            if (onDiskVersion != null && onDiskVersion == currentVersion) return
 
-            val stamp = SimpleDateFormat("yyyyMMdd-HHmmss", Locale.ROOT).format(Date())
             val backupsRoot = File(context.filesDir, BACKUP_DIR)
-            val dest = File(backupsRoot, stamp)
-            if (!dest.mkdirs() && !dest.isDirectory) {
-                Timber.tag(TAG).w("could not create backup dir %s; skipping snapshot", dest.path)
-                return
-            }
+
+            // Dedup: if the newest existing snapshot copied an identical source, this is a repeat of
+            // an already-captured state (crash loop, stuck corrupt header, downgrade loop). Skip —
+            // no snapshot, no prune — so churn is bounded.
+            val sourceSig = sourceSignature(onDiskVersion, dbFile)
+            if (newestSnapshotMeta(backupsRoot) == sourceSig) return
+
+            val stamp = stampFormat.format(Instant.now())
+            val versionLabel = onDiskVersion?.toString() ?: "unknown"
+            val dest = File(backupsRoot, "v$versionLabel-$stamp")
+            dest.mkdirs() // failure here surfaces as a copyTo throw → outer catch owns it (one WARN)
 
             var copied = 0
             for (suffix in FILE_SUFFIXES) {
@@ -77,7 +113,11 @@ internal object DatabaseBackup {
                 }
             }
 
-            prune(backupsRoot)
+            // Write the dedup marker LAST so a snapshot that fails mid-copy leaves no marker and is
+            // retried (rather than being mistaken for a complete capture of this source).
+            File(dest, META_FILE).writeText(sourceSig)
+
+            prune(backupsRoot, dest)
 
             Timber.tag(TAG).i(
                 "pre-migration DB snapshot taken (onDisk=%s → code=%d): %d file(s) → %s",
@@ -93,33 +133,53 @@ internal object DatabaseBackup {
     }
 
     /**
-     * Read SQLite's `user_version` from the file header (big-endian int at byte offset 60) without
-     * opening the DB. Returns null if the file is too short or unreadable.
+     * Read SQLite's `user_version` the way SQLite resolves it — a single **read-only open** that
+     * reads through the WAL — rather than the raw main-file header (byte 60), which is stale until a
+     * checkpoint under WAL journaling and would misclassify post-migration launches. Cheap (one open,
+     * no writes). Returns null on any failure (missing/corrupt/locked → snapshot defensively).
      */
     private fun readUserVersion(dbFile: File): Int? = try {
-        RandomAccessFile(dbFile, "r").use { raf ->
-            if (raf.length() < 64) return null
-            raf.seek(60)
-            val b = ByteArray(4)
-            raf.readFully(b)
-            ((b[0].toInt() and 0xFF) shl 24) or
-                ((b[1].toInt() and 0xFF) shl 16) or
-                ((b[2].toInt() and 0xFF) shl 8) or
-                (b[3].toInt() and 0xFF)
-        }
+        SQLiteDatabase.openDatabase(dbFile.path, null, SQLiteDatabase.OPEN_READONLY).use { it.version }
     } catch (t: Throwable) {
         Timber.tag(TAG).w(t, "could not read on-disk DB user_version; will snapshot defensively")
         null
     }
 
-    /** Keep only the [KEEP] newest snapshot subdirs (lexical == chronological for the stamp format). */
-    private fun prune(backupsRoot: File) {
+    /** The dedup signature of the current DB source: version + size + mtime, on one line. */
+    private fun sourceSignature(onDiskVersion: Int?, dbFile: File): String =
+        "version=${onDiskVersion?.toString() ?: "unknown"} " +
+            "length=${dbFile.length()} mtime=${dbFile.lastModified()}"
+
+    /** The [META_FILE] line of the newest existing snapshot dir (by mtime), or null if none/unreadable. */
+    private fun newestSnapshotMeta(backupsRoot: File): String? {
+        val newest = backupsRoot.listFiles { f -> f.isDirectory }
+            ?.maxByOrNull { it.lastModified() }
+            ?: return null
+        return try {
+            File(newest, META_FILE).takeIf { it.isFile }?.readText()?.trim()
+        } catch (_: Throwable) {
+            null
+        }
+    }
+
+    /**
+     * Keep the [KEEP] newest snapshot dirs (by `lastModified`, since the version prefix breaks lexical
+     * ordering), including [dest]. [dest] is never a prune candidate — the just-created backup must
+     * survive even a clock skew that makes an older dir look newer. Logs ONE WARN if any delete fails.
+     */
+    private fun prune(backupsRoot: File, dest: File) {
         val dirs = backupsRoot.listFiles { f -> f.isDirectory }
-            ?.sortedBy { it.name }
+            ?.sortedByDescending { it.lastModified() }
             ?: return
-        if (dirs.size <= KEEP) return
-        for (old in dirs.dropLast(KEEP)) {
-            old.deleteRecursively()
+        val victims = dirs
+            .filter { it != dest }
+            .drop(KEEP - 1) // dest counts toward KEEP but is excluded above, so keep KEEP-1 others
+        var anyFailed = false
+        for (old in victims) {
+            if (!old.deleteRecursively()) anyFailed = true
+        }
+        if (anyFailed) {
+            Timber.tag(TAG).w("failed to fully delete one or more pruned DB snapshot dirs")
         }
     }
 }

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/di/DatabaseModule.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/di/DatabaseModule.kt
@@ -37,18 +37,36 @@ object DatabaseModule {
      * Belt: [DatabaseBackup.backupIfUpgradePending] snapshots the current DB files just before Room
      * opens them when an upgrade is pending, so even a botched future migration is recoverable. It is
      * failure-tolerant — a backup failure can never prevent the app from starting.
+     *
+     * **Eager open (loud-at-startup, not loud-at-first-query).** Room opens the file lazily, on the
+     * first DAO call. But the first DB consumers — the `AnalyticsProjector` drain and `StateManagerV2`
+     * crash recovery — run inside broad `catch (Exception)` supervision that would SWALLOW the
+     * missing-migration `IllegalStateException`, leaving the app limping silently: the exact opposite
+     * of this module's stated loud-fail posture. So we force the open here by touching
+     * `openHelper.writableDatabase`, which runs the open — and any pending migration, and any
+     * no-path-for-this-version throw — deterministically at **injection time**. An injection-time
+     * crash no supervisor can swallow.
+     *
+     * Tradeoff (accepted for this single-user alpha): this puts the open (ms-scale; real DDL on an
+     * upgrade launch) plus the pre-open backup copy on the first-injection thread — Application
+     * startup, likely main. Determinism is chosen over lazy stealth failure. Residual: a very large
+     * DB copied on an upgrade launch stalls startup — accepted, once per release.
      */
     @Provides
     @Singleton
     fun provideDatabase(@ApplicationContext context: Context): DashBuddyDatabase {
         DatabaseBackup.backupIfUpgradePending(context, DashBuddyDatabase.NAME, DashBuddyDatabase.VERSION)
-        return Room.databaseBuilder(
+        val db = Room.databaseBuilder(
             context,
             DashBuddyDatabase::class.java,
             DashBuddyDatabase.NAME
         )
             // Intentionally NO .fallbackToDestructiveMigration(...) — see KDoc above (#690).
             .build()
+        // Force the open now so a missing migration throws at injection time (a crash no consumer's
+        // supervision can swallow), not lazily on the first DAO call. See KDoc.
+        db.openHelper.writableDatabase
+        return db
     }
 
     @Provides

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/di/DatabaseModule.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/di/DatabaseModule.kt
@@ -20,15 +20,34 @@ import javax.inject.Singleton
 @InstallIn(SingletonComponent::class)
 object DatabaseModule {
 
+    /**
+     * Opens the durable database with **no destructive fallback** — a deliberate data-safety choice
+     * (#690, the long-noted #314 follow-up).
+     *
+     * `app_events` is the analytics **source of truth**: the read-model tables (delivery/session/
+     * offer records) are a rebuildable projection folded from it, so losing `app_events` loses the
+     * driver's history irrecoverably. `.fallbackToDestructiveMigration(true)` would let Room silently
+     * DROP-and-recreate every table on any version it lacks a path for — a silent wipe of that
+     * source of truth. Omitting it means such an upgrade throws `IllegalStateException` at open: a
+     * **loud crash instead of a silent wipe**. For a single-user alpha that is the correct posture —
+     * the dev can back up + resolve rather than lose data unknowingly. The committed
+     * `AutoMigration`s (8→9, 9→10) provide the real upgrade paths, so this never fires on a supported
+     * upgrade; the guard exists for a *future* forgotten migration.
+     *
+     * Belt: [DatabaseBackup.backupIfUpgradePending] snapshots the current DB files just before Room
+     * opens them when an upgrade is pending, so even a botched future migration is recoverable. It is
+     * failure-tolerant — a backup failure can never prevent the app from starting.
+     */
     @Provides
     @Singleton
     fun provideDatabase(@ApplicationContext context: Context): DashBuddyDatabase {
+        DatabaseBackup.backupIfUpgradePending(context, DashBuddyDatabase.NAME, DashBuddyDatabase.VERSION)
         return Room.databaseBuilder(
             context,
             DashBuddyDatabase::class.java,
-            "dashbuddy-v2.db"
+            DashBuddyDatabase.NAME
         )
-            .fallbackToDestructiveMigration(true)
+            // Intentionally NO .fallbackToDestructiveMigration(...) — see KDoc above (#690).
             .build()
     }
 

--- a/core/database/src/test/java/cloud/trotter/dashbuddy/core/database/SchemaVersionGuardTest.kt
+++ b/core/database/src/test/java/cloud/trotter/dashbuddy/core/database/SchemaVersionGuardTest.kt
@@ -1,0 +1,105 @@
+package cloud.trotter.dashbuddy.core.database
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Cheap **unit-level** guard (#690) — this one DOES gate PR CI (the `MigrationTestHelper`
+ * migration-correctness tests are instrumented/androidTest and only run under
+ * `:core:database:connectedAndroidTest`, which the PR workflow does not invoke).
+ *
+ * With the destructive fallback retired, a version bump that forgets to regenerate the exported
+ * schema JSON (or bumps the schema without bumping the code) would ship a DB whose declared version
+ * has no committed schema — an upgrade path that can only fail loudly at runtime on a device. This
+ * test catches that class of mistake at build time by asserting:
+ *
+ *  1. an exported schema JSON exists for the version the code ships ([DashBuddyDatabase.VERSION],
+ *     which is also the `@Database(version = …)` value — same SSOT const);
+ *  2. [DashBuddyDatabase.VERSION] equals the **newest** committed schema file;
+ *  3. every schema file's internal `database.version` matches its filename number (a mis-copied
+ *     schema is caught);
+ *  4. the committed schema versions are contiguous (no gap that would strand an upgrade path).
+ */
+class SchemaVersionGuardTest {
+
+    private val schemaDir: File by lazy { locateSchemaDir() }
+
+    private val schemaVersions: List<Int> by lazy {
+        schemaDir.listFiles { f -> f.isFile && f.name.endsWith(".json") }
+            ?.mapNotNull { it.nameWithoutExtension.toIntOrNull() }
+            ?.sorted()
+            ?: emptyList()
+    }
+
+    @Test
+    fun exportedSchemaExistsForDeclaredVersion() {
+        val schemaFile = File(schemaDir, "${DashBuddyDatabase.VERSION}.json")
+        assertTrue(
+            "No exported schema JSON for DB version ${DashBuddyDatabase.VERSION} " +
+                "(expected ${schemaFile.path}). Bump the version → regenerate the schema " +
+                "(exportSchema) → add the AutoMigration + its MigrationTestHelper case.",
+            schemaFile.isFile,
+        )
+    }
+
+    @Test
+    fun declaredVersionMatchesNewestSchema() {
+        assertTrue("No schema JSONs found under ${schemaDir.path}", schemaVersions.isNotEmpty())
+        val newest = schemaVersions.max()
+        assertEquals(
+            "@Database version (DashBuddyDatabase.VERSION) must equal the newest committed schema. " +
+                "If you bumped the schema, bump VERSION too; if you bumped VERSION, regenerate the schema.",
+            newest,
+            DashBuddyDatabase.VERSION,
+        )
+    }
+
+    @Test
+    fun eachSchemaFileDeclaresItsOwnFilenameVersion() {
+        for (version in schemaVersions) {
+            val file = File(schemaDir, "$version.json")
+            val declared = Json.parseToJsonElement(file.readText())
+                .jsonObject["database"]!!.jsonObject["version"]!!.jsonPrimitive.int
+            assertEquals(
+                "Schema ${file.name} declares database.version=$declared — a mis-copied/mis-named schema.",
+                version,
+                declared,
+            )
+        }
+    }
+
+    @Test
+    fun committedSchemaVersionsAreContiguous() {
+        assertTrue("No schema JSONs found under ${schemaDir.path}", schemaVersions.isNotEmpty())
+        val expected = (schemaVersions.first()..schemaVersions.last()).toList()
+        assertEquals(
+            "Committed schema versions have a gap ($schemaVersions) — an upgrade path would be stranded.",
+            expected,
+            schemaVersions,
+        )
+    }
+
+    /**
+     * JVM unit tests run with the working directory at the module root (`core/database`), but be
+     * robust to a repo-root cwd too. The exported schemas live under
+     * `schemas/<db-class-fqcn>/` (see `room.schemaLocation` in build.gradle.kts).
+     */
+    private fun locateSchemaDir(): File {
+        val rel = "schemas/${DashBuddyDatabase::class.java.name}"
+        val candidates = listOf(
+            File(rel),
+            File("core/database", rel),
+        )
+        return candidates.firstOrNull { it.isDirectory }
+            ?: error(
+                "Could not locate exported schema dir '$rel' (cwd=${File(".").absolutePath}). " +
+                    "Tried: ${candidates.joinToString { it.path }}",
+            )
+    }
+}

--- a/core/database/src/test/java/cloud/trotter/dashbuddy/core/database/SchemaVersionGuardTest.kt
+++ b/core/database/src/test/java/cloud/trotter/dashbuddy/core/database/SchemaVersionGuardTest.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Test
 import java.io.File
 
@@ -14,19 +15,29 @@ import java.io.File
  * migration-correctness tests are instrumented/androidTest and only run under
  * `:core:database:connectedAndroidTest`, which the PR workflow does not invoke).
  *
- * With the destructive fallback retired, a version bump that forgets to regenerate the exported
- * schema JSON (or bumps the schema without bumping the code) would ship a DB whose declared version
- * has no committed schema — an upgrade path that can only fail loudly at runtime on a device. This
- * test catches that class of mistake at build time by asserting:
+ * With the destructive fallback retired, a version bump that forgets its `AutoMigration` edge would
+ * ship a DB whose declared version has no upgrade path — a loud runtime crash on a device. This test
+ * catches that class of mistake at build time. The load-bearing check is
+ * [migrationEdgesChainFromSupportedBaseToDeclaredVersion]: a **source scan** of the migration edges
+ * (`@Database` is BINARY retention — see below — so the edges are read from source, not reflection),
+ * which is exactly the forgotten-`AutoMigration` class the retired fallback used to mask.
  *
- *  1. an exported schema JSON exists for the version the code ships ([DashBuddyDatabase.VERSION],
- *     which is also the `@Database(version = …)` value — same SSOT const);
- *  2. [DashBuddyDatabase.VERSION] equals the **newest** committed schema file;
- *  3. every schema file's internal `database.version` matches its filename number (a mis-copied
- *     schema is caught);
- *  4. the committed schema versions are contiguous (no gap that would strand an upgrade path).
+ * **What CI can and cannot catch here.** The schema-JSON checks (tests 1–3) run against files KSP
+ * **regenerates during the build**, so in CI they can only ever see a freshly-exported, internally
+ * consistent schema — they CANNOT catch a schema JSON that was never *committed*. That
+ * commit-enforcement is a separate CI step (`Schemas committed (Room export drift)` in
+ * `pr-check.yml`), not this test. These checks still earn their keep: they catch local-dev drift
+ * (a VERSION bump run before an `exportSchema` regen) fast, without a device.
  */
 class SchemaVersionGuardTest {
+
+    /**
+     * The oldest on-disk schema version this build supports upgrading FROM. On-disk versions below
+     * this (and downgrades) are an intentional loud crash at startup (#690), with a fresh pre-crash
+     * snapshot taken by `DatabaseBackup`. Bump this only when a floor is deliberately raised (dropping
+     * an old migration edge), which is a data-migration decision, not a routine version bump.
+     */
+    private val supportedBase = 8
 
     private val schemaDir: File by lazy { locateSchemaDir() }
 
@@ -79,9 +90,73 @@ class SchemaVersionGuardTest {
         assertTrue("No schema JSONs found under ${schemaDir.path}", schemaVersions.isNotEmpty())
         val expected = (schemaVersions.first()..schemaVersions.last()).toList()
         assertEquals(
-            "Committed schema versions have a gap ($schemaVersions) — an upgrade path would be stranded.",
+            "Committed schema *files* have a numbering gap ($schemaVersions). NB: this asserts the " +
+                "exported-schema filenames are contiguous, NOT that a migration edge exists between " +
+                "them — migrationEdgesChainFromSupportedBaseToDeclaredVersion() owns that claim.",
             expected,
             schemaVersions,
+        )
+    }
+
+    /**
+     * The load-bearing #690 guard: the committed **migration edges** must chain from [supportedBase]
+     * to [DashBuddyDatabase.VERSION] with no gap. Source-scanned rather than reflected because
+     * `@Database` (which carries `autoMigrations`) has **BINARY retention** — the `AutoMigration`
+     * annotations are not visible at runtime. We scan the `@Database` source for `AutoMigration(from,
+     * to)` and (if any) `DatabaseModule` for manual `Migration(from, to)` registrations, then walk
+     * the edges from [supportedBase]: a forgotten edge (the exact mistake the retired destructive
+     * fallback used to paper over) leaves a hole and fails here at build time, not loudly on a device.
+     */
+    @Test
+    fun migrationEdgesChainFromSupportedBaseToDeclaredVersion() {
+        val edgeRegex = Regex("""AutoMigration\s*\(\s*from\s*=\s*(\d+)\s*,\s*to\s*=\s*(\d+)""")
+        val manualRegex = Regex("""\bMigration\s*\(\s*(\d+)\s*,\s*(\d+)\s*\)""")
+
+        val dbSource = locateSourceFile(
+            "src/main/java/cloud/trotter/dashbuddy/core/database/DashBuddyDatabase.kt",
+        ).readText()
+        val moduleSource = locateSourceFile(
+            "src/main/java/cloud/trotter/dashbuddy/core/database/di/DatabaseModule.kt",
+        ).readText()
+
+        val edges = buildList {
+            edgeRegex.findAll(dbSource).forEach { m ->
+                add(m.groupValues[1].toInt() to m.groupValues[2].toInt())
+            }
+            manualRegex.findAll(moduleSource).forEach { m ->
+                add(m.groupValues[1].toInt() to m.groupValues[2].toInt())
+            }
+        }
+
+        assertTrue(
+            "No migration edges found by source scan. Expected AutoMigration(from,to) on @Database " +
+                "chaining $supportedBase → ${DashBuddyDatabase.VERSION}.",
+            edges.isNotEmpty(),
+        )
+
+        val edgesByFrom = edges.groupBy { it.first }
+        var cur = supportedBase
+        val visited = mutableSetOf<Int>()
+        while (cur < DashBuddyDatabase.VERSION) {
+            if (!visited.add(cur)) {
+                fail("Migration edges form a cycle at v$cur (edges=$edges).")
+                return
+            }
+            val next = edgesByFrom[cur]?.maxOfOrNull { it.second }
+                ?: run {
+                    fail(
+                        "No migration edge from v$cur — the chain $supportedBase → " +
+                            "${DashBuddyDatabase.VERSION} is broken (edges=$edges). Add the missing " +
+                            "AutoMigration(from = $cur, to = ${cur + 1}).",
+                    )
+                    return
+                }
+            cur = next
+        }
+        assertEquals(
+            "Migration edges overshoot the declared version (reached v$cur, edges=$edges).",
+            DashBuddyDatabase.VERSION,
+            cur,
         )
     }
 
@@ -99,6 +174,16 @@ class SchemaVersionGuardTest {
         return candidates.firstOrNull { it.isDirectory }
             ?: error(
                 "Could not locate exported schema dir '$rel' (cwd=${File(".").absolutePath}). " +
+                    "Tried: ${candidates.joinToString { it.path }}",
+            )
+    }
+
+    /** Locate a module source file, robust to a module-root or repo-root cwd (see [locateSchemaDir]). */
+    private fun locateSourceFile(rel: String): File {
+        val candidates = listOf(File(rel), File("core/database", rel))
+        return candidates.firstOrNull { it.isFile }
+            ?: error(
+                "Could not locate source file '$rel' (cwd=${File(".").absolutePath}). " +
                     "Tried: ${candidates.joinToString { it.path }}",
             )
     }

--- a/core/database/src/test/java/cloud/trotter/dashbuddy/core/database/di/DatabaseBackupTest.kt
+++ b/core/database/src/test/java/cloud/trotter/dashbuddy/core/database/di/DatabaseBackupTest.kt
@@ -1,0 +1,149 @@
+package cloud.trotter.dashbuddy.core.database.di
+
+import android.content.Context
+import android.database.sqlite.SQLiteDatabase
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import java.io.File
+
+/**
+ * #690 review — unit coverage for [DatabaseBackup] (the pre-open safety belt). Runs under Robolectric
+ * for a real [Context] (getDatabasePath/filesDir) and a real [SQLiteDatabase] so we can set an
+ * on-disk `user_version` and exercise the WAL-aware read. This is a **unit** test — it gates PR CI
+ * (unlike the instrumented `MigrationTest`).
+ *
+ * Covers: a version MISMATCH (upgrade AND downgrade) takes a snapshot; a same-version launch skips;
+ * the dedup marker skips a second identical snapshot; and prune keeps [KEEP] total including the
+ * just-created dir and never deletes it.
+ */
+@RunWith(RobolectricTestRunner::class)
+class DatabaseBackupTest {
+
+    private lateinit var context: Context
+    private val dbName = "backup-test.db"
+    private val backupsRoot: File
+        get() = File(context.filesDir, "db-backups")
+
+    @Before
+    fun setUp() {
+        context = RuntimeEnvironment.getApplication()
+        clean()
+    }
+
+    @After
+    fun tearDown() = clean()
+
+    private fun clean() {
+        backupsRoot.deleteRecursively()
+        for (suffix in listOf("", "-shm", "-wal")) {
+            context.getDatabasePath(dbName + suffix).delete()
+        }
+    }
+
+    /** Create a real SQLite DB file at [version] with one table + row so it has non-trivial length. */
+    private fun createDbAtVersion(version: Int) {
+        val f = context.getDatabasePath(dbName)
+        f.parentFile?.mkdirs()
+        SQLiteDatabase.openOrCreateDatabase(f, null).use { db ->
+            db.execSQL("CREATE TABLE IF NOT EXISTS t(x TEXT)")
+            db.execSQL("INSERT INTO t(x) VALUES ('hello')")
+            db.version = version
+        }
+    }
+
+    private fun snapshotDirs(): List<File> =
+        backupsRoot.listFiles { f -> f.isDirectory }?.toList() ?: emptyList()
+
+    @Test
+    fun versionMismatch_upgrade_takesSnapshot() {
+        createDbAtVersion(9)
+
+        DatabaseBackup.backupIfUpgradePending(context, dbName, currentVersion = 10)
+
+        val dirs = snapshotDirs()
+        assertEquals("one snapshot expected on an upgrade mismatch", 1, dirs.size)
+        val dir = dirs.single()
+        assertTrue("dir is version-prefixed with the ON-DISK version", dir.name.startsWith("v9-"))
+        assertTrue("db file copied", File(dir, dbName).isFile)
+        assertTrue("dedup marker written", File(dir, "source.meta").isFile)
+    }
+
+    @Test
+    fun versionMismatch_downgrade_takesSnapshot() {
+        // On-disk is NEWER than the code (dev sideloads an older APK to bisect) — must still snapshot
+        // before Room's loud downgrade throw.
+        createDbAtVersion(11)
+
+        DatabaseBackup.backupIfUpgradePending(context, dbName, currentVersion = 10)
+
+        val dirs = snapshotDirs()
+        assertEquals("one snapshot expected on a downgrade mismatch", 1, dirs.size)
+        assertTrue("dir prefixed with the on-disk (newer) version", dirs.single().name.startsWith("v11-"))
+    }
+
+    @Test
+    fun sameVersion_skips() {
+        createDbAtVersion(10)
+
+        DatabaseBackup.backupIfUpgradePending(context, dbName, currentVersion = 10)
+
+        assertFalse("no backups dir on a same-version launch", backupsRoot.exists() && snapshotDirs().isNotEmpty())
+    }
+
+    @Test
+    fun dedupMarker_skipsSecondIdenticalSnapshot() {
+        createDbAtVersion(9)
+
+        DatabaseBackup.backupIfUpgradePending(context, dbName, currentVersion = 10)
+        val dir = snapshotDirs().single()
+        val copied = File(dir, dbName)
+        assertTrue(copied.isFile)
+
+        // Remove the copied DB but KEEP the marker. A second call against the UNCHANGED source must
+        // dedup on the marker and return BEFORE copying — so the removed file stays absent. (If dedup
+        // were broken it would re-copy, since same-second timestamp reuses the dir name.)
+        assertTrue(copied.delete())
+        DatabaseBackup.backupIfUpgradePending(context, dbName, currentVersion = 10)
+
+        assertFalse("dedup should have skipped the re-copy", copied.isFile)
+        assertEquals("still exactly one snapshot dir", 1, snapshotDirs().size)
+    }
+
+    @Test
+    fun prune_keepsKeepIncludingJustCreated_andNeverDeletesJustCreated() {
+        createDbAtVersion(9)
+
+        // Three pre-existing snapshot dirs with distinct OLD mtimes and a marker that will NOT match
+        // the current source (so dedup does not short-circuit the new snapshot).
+        val old1 = mkOldSnapshot("v1-old1", mtime = 1_000L)
+        val old2 = mkOldSnapshot("v1-old2", mtime = 2_000L)
+        val old3 = mkOldSnapshot("v1-old3", mtime = 3_000L)
+
+        DatabaseBackup.backupIfUpgradePending(context, dbName, currentVersion = 10)
+
+        val dirs = snapshotDirs()
+        assertEquals("prune keeps KEEP=2 total", 2, dirs.size)
+        val justCreated = dirs.firstOrNull { it.name.startsWith("v9-") }
+        assertNotNull("the just-created snapshot must survive prune", justCreated)
+        // The two oldest fakes are evicted; the newest fake (old3) is the other survivor.
+        assertTrue("newest surviving fake is old3", dirs.any { it == old3 })
+        assertFalse("oldest fake evicted", old1.exists())
+        assertFalse("2nd-oldest fake evicted", old2.exists())
+    }
+
+    private fun mkOldSnapshot(name: String, mtime: Long): File {
+        val d = File(backupsRoot, name)
+        d.mkdirs()
+        File(d, "source.meta").writeText("version=1 length=1 mtime=1")
+        d.setLastModified(mtime)
+        return d
+    }
+}


### PR DESCRIPTION
> [!NOTE]
> **Superseded in part by the adversarial review (commit 16ff5583).** The detection described below evolved: the raw byte-60 header read was replaced by a **WAL-aware** read-only `SQLiteDatabase.version` (the header is stale until checkpoint under WAL); snapshots now fire on ANY version mismatch (incl. downgrade), carry a `source.meta` dedup marker bounding crash-loop churn, use version-prefixed dirs, and prune never evicts the just-created dir. `DatabaseModule` now **eagerly opens** the DB at injection time so a missing migration is a deterministic startup crash (lazy first-query failure was swallowed by consumer supervision). CI gained a `Schemas committed` drift step and the guard test gained a migration-edge source-scan; a Robolectric `DatabaseBackupTest` gates CI. See the Adversarial review comment for the full findings.

Closes #690.

## The threat
`app_events` is the analytics **source of truth** — the read-model tables (delivery/session/offer records) are a rebuildable projection folded from it, so losing `app_events` loses the driver's history irrecoverably. `.fallbackToDestructiveMigration(true)` let Room silently DROP-and-recreate every table on any version it lacked a path for: a **silent wipe** of that log on a schema mismatch. (The 2026-07-05 clear was confirmed by the dev to be a *manual* app-data clear, **not** a destructive-migration incident — so this is the long-noted #314 follow-up hardening, normal priority, not an incident fix.)

## Loud-fail posture (the load-bearing change)
`DatabaseModule.provideDatabase` drops `.fallbackToDestructiveMigration(true)`. With it gone and the committed `AutoMigration`s (8→9, 9→10) covering the supported upgrades, an upgrade Room has no path for now throws `IllegalStateException` at open — a **loud crash instead of a silent wipe**. For a single-user alpha that is the correct posture: the dev backs up + resolves rather than losing history unknowingly. The builder is KDoc'd explaining the deliberate no-fallback choice.

## Backup belt (detection approach: header user_version)
`DatabaseBackup.backupIfUpgradePending` runs immediately before Room opens the DB. It detects a pending upgrade by reading SQLite's `user_version` **straight from the file header** (big-endian int at byte offset 60 — the value Room stores its schema version in) **without opening the DB** — an O(1) header read, so the common no-change launch reads 4 bytes and returns (no copy-every-launch cost). When the on-disk version is older than the code's `DashBuddyDatabase.VERSION` (or the header can't be read → snapshot defensively), it copies `dashbuddy-v2.db` + `-shm` + `-wal` to a timestamped `db-backups/<yyyyMMdd-HHmmss>/` subdir under `filesDir`, keeping the **last 2** (older pruned). It is **failure-tolerant by construction** — every path is wrapped; a backup failure logs one WARN under a stable tag (`DbBackup`) and continues, so it can NEVER prevent the app from starting. A pre-migration snapshot means even a botched *future* migration is recoverable.

## Tests — honest CI-reality caveat
- **`SchemaVersionGuardTest` (unit — DOES gate PR CI).** Asserts an exported schema JSON exists for `DashBuddyDatabase.VERSION` (the same SSOT const the `@Database(version = …)` annotation uses), that `VERSION` equals the newest committed schema, that each schema file's internal `database.version` matches its filename, and that the versions are contiguous. Catches a forgotten `exportSchema` regen or a version bump without a schema — cheaply, at unit-test time.
- **`MigrationTest` (instrumented — does NOT gate PR CI).** A chained `MigrationTestHelper` 8→9→10 that seeds `app_events` at v8 and proves the rows survive the full auto-migration chain with payload/metadata intact. This complements the existing per-edge `AnalyticsMigration8to9Test` / `AnalyticsMigration9to10Test`.

**CI caveat (real and pre-existing):** `MigrationTestHelper` tests are **instrumented** (`androidTest` — they need the schema assets + a device/emulator) and the PR workflow (`pr-check.yml`) runs unit tests only (`testDebugUnitTest :domain:test`), **not** `connectedAndroidTest`. So the migration-*correctness* test will **not** gate this PR — it is the right artifact regardless (run locally via `./gradlew :core:database:connectedAndroidTest`, and a future instrumented-CI job picks it up). The **unit** `SchemaVersionGuardTest` is what actually gates. The androidTest source set is confirmed to **compile** (`:core:database:compileDebugAndroidTestKotlin` green).

## Verification
- `JAVA_HOME=/usr/lib/jvm/java-25-openjdk ./gradlew testDebugUnitTest :domain:test` — GREEN (incl. `SchemaVersionGuardTest`).
- `:core:database:compileDebugAndroidTestKotlin` — GREEN (instrumented test builds).

## Docs
CLAUDE.md `:core:database` module note gains the data-safety posture (no destructive fallback; loud-fail; the backup belt; the `VERSION` SSOT) **and** the schema-change release checklist: **bump `DashBuddyDatabase.VERSION` → regenerate the exported schema JSON → add the `AutoMigration`/`Migration` → add its `MigrationTestHelper` case.**

### Design-goal review
- **6 — Security & privacy first (the load-bearing goal).** This is a **data-safety / fail-loud (not fail-silent)** change directly defending the on-device source-of-truth pledge: the durable log can no longer be silently destroyed by a schema mismatch — a mismatch fails loud, and a pre-open snapshot makes even a bad future migration recoverable. The backup is on-device only, logs no PII (version numbers + a file count under a stable tag), and is bounded (last 2) + failure-tolerant (never blocks startup).
- **3 — Single responsibility.** The backup logic is its own small `DatabaseBackup` object, not piled into `DatabaseModule`.
- **5 — SSOT.** Schema version is one const (`DashBuddyDatabase.VERSION`) consumed by the `@Database` annotation, the backup detector, and the CI guard; DB file name likewise (`DashBuddyDatabase.NAME`). `SchemaVersionGuardTest` turns the version↔schema relationship into an enforced invariant rather than a hand-maintained pair.
- **7 — Semantic, PII-safe logging.** New sites: INFO milestone for a snapshot taken (version numbers + count, no PII), WARN for a tolerated backup/header-read failure, under the stable `DbBackup` tag.
- **8 — Platform-agnostic core.** No platform literals introduced; change is storage-layer only.

Note: this PR touches only `:core:database` + CLAUDE.md — no `:core:state` / `:core:pipeline` / `:domain` / rule-JSON logic, so the platform-agnosticism review surface is minimal.
