### PR TITLE
feat(#691): offer-pay fallback for receipt-less completions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,7 +293,11 @@ tables (`delivery_records`/`session_records`/`offer_records`) via the pure `Reco
 (`:domain`). The fold is **exactly-once** — records + a watermark advance in one `db.withTransaction`, record
 PKs are the source `sequenceId` (REPLACE-idempotent) — so the **one-time backfill is just the first drain from
 watermark 0**, and a `projectorVersion` bump wipes + refolds the whole log (rebuild ≡ backfill). Realized
-inputs come from the log: pay from `DeliveryPayload.dropRealizedPay`/`totalPay` (#528), miles from
+inputs come from the log: pay from `DeliveryPayload.dropRealizedPay`/`totalPay` (#528), else — when the
+WHOLE job was receipt-less (a DoorDash shop order shows no per-delivery receipt) — a `PayBasis.OFFER_PAY`
+ESTIMATE from `DeliveryPayload.offerPayShare`, the accepted offer's total split equally across the job's
+owed drops at the mint site and consumed by the fold only if no sibling drop already folded a real receipt
+(#691); miles from
 `metadata.odometer` partition deltas, time from timestamps. **Economics are FROZEN per record, never
 recomputed** (dev decision): each `delivery_record` stores `netProfit` + `frozenCostPerMile` + its frozen
 `frozenFuelPerMile`/`frozenNonFuelPerMile` split (#659, the 4-step true-net waterfall Gross → −Fuel → −Non-fuel

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/SessionDetailScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/SessionDetailScreen.kt
@@ -43,6 +43,7 @@ import cloud.trotter.dashbuddy.core.designsystem.component.AppChip
 import cloud.trotter.dashbuddy.core.designsystem.component.AppStatTile
 import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
 import cloud.trotter.dashbuddy.domain.analytics.DeliveryRecord
+import cloud.trotter.dashbuddy.domain.analytics.PayBasis
 import cloud.trotter.dashbuddy.domain.analytics.SessionDetail
 import cloud.trotter.dashbuddy.domain.format.Formats
 import cloud.trotter.dashbuddy.domain.format.formatClockTime
@@ -279,6 +280,15 @@ private fun DeliveryRow(delivery: DeliveryRecord, onAdjust: () -> Unit) {
             delivery.tip?.let {
                 Text(
                     text = "incl. ${Formats.money(it)} tip",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = c.text3,
+                )
+            }
+            // #691: a receipt-less shop delivery's pay is an equal-split ESTIMATE of the accepted
+            // offer, not a captured receipt — disclose it (never-silent, the #689 precedent).
+            if (delivery.payBasis == PayBasis.OFFER_PAY) {
+                Text(
+                    text = "est. offer pay",
                     style = MaterialTheme.typography.bodySmall,
                     color = c.text3,
                 )

--- a/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsDaoProjectorSupportTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsDaoProjectorSupportTest.kt
@@ -61,10 +61,11 @@ class AnalyticsDaoProjectorSupportTest {
         platform: String = "doordash",
         odo: Double? = null,
         completedAt: Long = 3_000,
+        payBasis: String = "RECEIPT_TOTAL",
     ) = DeliveryRecordEntity(
         eventSequenceId = seq, sessionId = sessionId, platform = platform, jobId = jobId, taskId = "T$seq",
         storeName = "S", customerHash = null, addressHash = null, phaseStartedAt = 0, arrivedAt = null,
-        completedAt = completedAt, deadlineMillis = null, realizedPay = 5.0, payBasis = "RECEIPT_TOTAL",
+        completedAt = completedAt, deadlineMillis = null, realizedPay = 5.0, payBasis = payBasis,
         tip = null, basePay = null, odometerAtCompletion = odo, realizedMiles = null, realizedMinutes = null,
         frozenCostPerMile = null, netProfit = null, costBasis = "NONE",
     )
@@ -160,5 +161,19 @@ class AnalyticsDaoProjectorSupportTest {
         dao.upsertOffer(offer(30, "A", cpm = null))  // null cpm skipped
         assertEquals("newest non-null offer cpm", 0.35, dao.lastOfferCostPerMileInSession("A")!!, 1e-9)
         assertNull(dao.lastOfferCostPerMileInSession("nobody"))
+    }
+
+    @Test
+    fun `receiptedJobIdsInSession includes DROP_SHARE-RECEIPT_TOTAL-SUSPECT and excludes OFFER_PAY-NONE (#691 FIX3)`() = runBlocking {
+        dao.upsertDelivery(delivery(1, "A", "J1", payBasis = "DROP_SHARE"))
+        dao.upsertDelivery(delivery(2, "A", "J2", payBasis = "RECEIPT_TOTAL"))
+        dao.upsertDelivery(delivery(3, "A", "J3", payBasis = "SUSPECT_FULL_RECEIPT"))
+        dao.upsertDelivery(delivery(4, "A", "J4", payBasis = "OFFER_PAY"))
+        dao.upsertDelivery(delivery(5, "A", "J5", payBasis = "NONE"))
+        assertEquals(
+            "SUSPECT counts as receipt evidence; OFFER_PAY/NONE do not",
+            setOf("J1", "J2", "J3"),
+            dao.receiptedJobIdsInSession("A").toSet(),
+        )
     }
 }

--- a/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsProjectorTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsProjectorTest.kt
@@ -189,6 +189,103 @@ class AnalyticsProjectorTest {
         assertEquals(0.40, delivery.frozenCostPerMile!!, 1e-9)
     }
 
+    /** A two-drop job: T1 receipted (DROP_SHARE), T2 receipt-less carrying an offer-pay estimate. */
+    private suspend fun seedMixedReceiptJob(sid: String = "S1") {
+        insert(
+            AppEventType.DASH_START, sid, 1_000,
+            SessionStartPayload(sid, Platform.DoorDash.name, 1_000, SessionStartSource.INTERACTION, "x"),
+            odometer = 100.0,
+        )
+        insert(
+            AppEventType.OFFER_ACCEPTED, sid, 2_000,
+            OfferPayload(
+                offerHash = "h1",
+                parsedOffer = ParsedOffer(offerHash = "h1", payAmount = 12.0, distanceMiles = 3.0),
+                evaluation = eval(0.25), outcome = AppEventType.OFFER_ACCEPTED,
+                presentedAt = 1_970, decidedAt = 2_000, returnFlow = Flow.Idle,
+            ),
+        )
+        // T1 (seq 3): a receipt-derived share → marks jobId J1 receipted.
+        insert(
+            AppEventType.DELIVERY_COMPLETED, sid, 3_000,
+            DeliveryPayload(
+                jobId = "J1", taskId = "T1", storeName = "StoreX", customerHash = "c1",
+                phaseStartedAt = 2_400, completedAt = 3_000, dropRealizedPay = 6.0,
+            ),
+            odometer = 104.0,
+        )
+        // T2 (seq 4): a receipt-less sibling carrying an offer-pay estimate. The mixed-receipt guard
+        // must DENY it (job already receipted) → NONE — even though a batch boundary splits it from T1.
+        insert(
+            AppEventType.DELIVERY_COMPLETED, sid, 3_500,
+            DeliveryPayload(
+                jobId = "J1", taskId = "T2", storeName = "StoreX", customerHash = "c2",
+                phaseStartedAt = 3_100, completedAt = 3_500, offerPayShare = 6.48,
+            ),
+            odometer = 106.0,
+        )
+    }
+
+    @Test
+    fun `receiptedJobIds hydrates across a batch boundary — live order == from-zero refold (#691)`() = runBlocking {
+        seedMixedReceiptJob()
+
+        // Batch 1 stops after T1 (watermark → 3); T2 is left for a fresh projector to resume.
+        projector().processBatch(limit = 3)
+        assertEquals(3L, analyticsDao.getWatermark()!!.watermarkSequenceId)
+
+        // The resumed projector has empty in-memory state — it must SELECT the receipted jobId back
+        // out of delivery_records to keep the guard armed across the boundary.
+        val resumed = projector()
+        resumed.processBatch(limit = 100)
+        assertNull(resumed.processBatch(limit = 100))
+
+        val liveT2 = analyticsDao.deliveryRecord(4)!!
+        assertEquals("guard survives the boundary → the sibling gets no estimate", "NONE", liveT2.payBasis)
+        assertNull(liveT2.realizedPay)
+
+        // From-zero refold (one drain, no boundary) must reproduce the SAME row — proof the live path
+        // is rebuild-faithful. A broken hydration would make liveT2 OFFER_PAY (6.48) here but NONE below.
+        analyticsDao.setWatermark(AnalyticsProjectionStateEntity(watermarkSequenceId = 4, projectorVersion = 99))
+        projector().catchUp()
+        val refoldT2 = analyticsDao.deliveryRecord(4)!!
+        assertEquals("live order == from-zero refold", liveT2.payBasis, refoldT2.payBasis)
+        assertEquals(liveT2.realizedPay, refoldT2.realizedPay)
+    }
+
+    @Test
+    fun `a wholly receipt-less job folds an OFFER_PAY row from the offer-pay share (#691)`() = runBlocking {
+        // No receipt anywhere on the job: T1 carries only an offer-pay estimate → OFFER_PAY, real net.
+        insert(
+            AppEventType.DASH_START, "S1", 1_000,
+            SessionStartPayload("S1", Platform.DoorDash.name, 1_000, SessionStartSource.INTERACTION, "x"),
+            odometer = 100.0,
+        )
+        insert(
+            AppEventType.OFFER_ACCEPTED, "S1", 2_000,
+            OfferPayload(
+                offerHash = "h1",
+                parsedOffer = ParsedOffer(offerHash = "h1", payAmount = 12.0, distanceMiles = 3.0),
+                evaluation = eval(0.25), outcome = AppEventType.OFFER_ACCEPTED,
+                presentedAt = 1_970, decidedAt = 2_000, returnFlow = Flow.Idle,
+            ),
+        )
+        insert(
+            AppEventType.DELIVERY_COMPLETED, "S1", 3_000,
+            DeliveryPayload(
+                jobId = "J1", taskId = "T1", storeName = "StoreX", customerHash = "c1",
+                phaseStartedAt = 2_400, completedAt = 3_000, offerPayShare = 12.95,
+            ),
+            odometer = 105.0,
+        )
+        projector().catchUp()
+
+        val d = analyticsDao.deliveryRecord(3)!!
+        assertEquals("OFFER_PAY", d.payBasis)
+        assertEquals(12.95, d.realizedPay!!, 1e-9)
+        assertEquals("net = pay − 5mi × 0.25", 12.95 - 5.0 * 0.25, d.netProfit!!, 1e-9)
+    }
+
     @Test
     fun `re-running a drained log rewrites identical tables`() = runBlocking {
         seedFullSession()

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/SessionDetailViewModelTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/SessionDetailViewModelTest.kt
@@ -48,8 +48,8 @@ class SessionDetailViewModelTest {
     private fun delivery(id: String) = DeliveryRecord(
         eventSequenceId = 1L, sessionId = id, platform = Platform.DoorDash, jobId = "job-1",
         taskId = "task-1", storeName = "Wendys", completedAt = 1_700_001_000_000L,
-        realizedPay = 8.0, netProfit = 3.0, realizedMiles = 3.0, realizedMinutes = 10.0,
-        tip = 2.0, basePay = 6.0,
+        realizedPay = 8.0, payBasis = "DROP_SHARE", netProfit = 3.0, realizedMiles = 3.0,
+        realizedMinutes = 10.0, tip = 2.0, basePay = 6.0,
     )
 
     private fun buildViewModel(sessionId: String) = SessionDetailViewModel(

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsMappers.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsMappers.kt
@@ -22,6 +22,7 @@ internal fun DeliveryRecordEntity.toDomain(): DeliveryRecord = DeliveryRecord(
     storeName = storeName,
     completedAt = completedAt,
     realizedPay = realizedPay,
+    payBasis = payBasis,
     netProfit = netProfit,
     realizedMiles = realizedMiles,
     realizedMinutes = realizedMinutes,

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjector.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjector.kt
@@ -280,6 +280,7 @@ class AnalyticsProjector @Inject constructor(
         val lastDelivery = analyticsDao.lastDeliveryInSession(sessionId)
         return session.toContext(
             deliveredJobIds = analyticsDao.deliveredJobIdsInSession(sessionId).toSet(),
+            receiptedJobIds = analyticsDao.receiptedJobIdsInSession(sessionId).toSet(),
             prevDropOdometer = lastDelivery?.odometerAtCompletion,
             prevDropAt = lastDelivery?.completedAt,
             lastEvaluatedCostPerMile = analyticsDao.lastOfferCostPerMileInSession(sessionId),
@@ -337,6 +338,7 @@ class AnalyticsProjector @Inject constructor(
 
     private fun SessionRecordEntity.toContext(
         deliveredJobIds: Set<String> = emptySet(),
+        receiptedJobIds: Set<String> = emptySet(),
         prevDropOdometer: Double? = null,
         prevDropAt: Long? = null,
         lastEvaluatedCostPerMile: Double? = null,
@@ -358,6 +360,7 @@ class AnalyticsProjector @Inject constructor(
         offersTimeout = offersTimeout,
         deliveries = deliveries,
         deliveredJobIds = deliveredJobIds,
+        receiptedJobIds = receiptedJobIds,
         prevDropOdometer = prevDropOdometer,
         prevDropAt = prevDropAt,
         lastEvaluatedCostPerMile = lastEvaluatedCostPerMile,

--- a/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/CsvExporterTest.kt
+++ b/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/CsvExporterTest.kt
@@ -24,6 +24,7 @@ class CsvExporterTest {
         store: String?,
         completedAt: Long = generatedAt,
         pay: Double? = 8.50,
+        basis: String = "DROP_SHARE",
     ) = DeliveryRecordEntity(
         eventSequenceId = seq,
         sessionId = "s1",
@@ -38,7 +39,7 @@ class CsvExporterTest {
         completedAt = completedAt,
         deadlineMillis = null,
         realizedPay = pay,
-        payBasis = "DROP_SHARE",
+        payBasis = basis,
         tip = 3.25,
         basePay = 5.25,
         odometerAtCompletion = 1000.0,
@@ -86,6 +87,14 @@ class CsvExporterTest {
             "2026-07-05,14:03:27,DoorDash,H-E-B,8.50,3.25,5.25,4.20,12.50,0.165,7.81,DROP_SHARE,OFFER_FROZEN",
             lines[1],
         )
+    }
+
+    @Test fun deliveries_offerPayBasis_appearsVerbatim() {
+        // #691: an OFFER_PAY estimate row exports its pay_basis verbatim so the basis column IS the
+        // never-silent disclosure for the tax-preparer artifact (no separate UI qualifier needed).
+        val out = CsvExporter.export(listOf(delivery(1, "H-E-B", basis = "OFFER_PAY")), emptyList(), utc, generatedAt)
+        val row = out.deliveriesCsv.trim().lines()[1]
+        assertTrue("OFFER_PAY basis missing in: $row", row.endsWith(",OFFER_PAY,OFFER_FROZEN"))
     }
 
     @Test fun deliveries_storeWithComma_isQuoted() {

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import cloud.trotter.dashbuddy.domain.analytics.PayBasis
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -350,15 +351,20 @@ interface AnalyticsDao {
     suspend fun deliveredJobIdsInSession(id: String): List<String>
 
     /**
-     * The distinct jobIds already recorded with **receipt-derived** pay (`DROP_SHARE` /
-     * `RECEIPT_TOTAL`) for a session — rehydrates the fold's #691 mixed-receipt guard set across a
-     * drain/batch boundary (mirrors [deliveredJobIdsInSession]), so a receipt-less sibling folded in
-     * a LATER batch is still denied the offer-pay estimate. Deliberately excludes `USER_CORRECTED`
-     * (a documented hydration wrinkle, #691 VET F1) and the estimate/none bases.
+     * The distinct jobIds already recorded with **receipt evidence** (`DROP_SHARE` / `RECEIPT_TOTAL`
+     * / `SUSPECT_FULL_RECEIPT`) for a session — rehydrates the fold's #691 mixed-receipt guard set
+     * across a drain/batch boundary (mirrors [deliveredJobIdsInSession]), so a receipt-less sibling
+     * folded in a LATER batch is still denied the offer-pay estimate. `SUSPECT_FULL_RECEIPT` is
+     * included: its money was nulled (#653), but the receipt still proves the job is not receipt-less.
+     * The IN-list is compile-time-concatenated from [PayBasis]'s `const val`s (legal in an annotation)
+     * so it derives from the SAME SSOT as the in-fold guard ([PayBasis.RECEIPT_EVIDENCE]) — the two
+     * sides can never drift. Deliberately excludes `USER_CORRECTED` (a documented hydration wrinkle,
+     * #691 VET F1; closed by v11 receipt-evidence persistence, #703) and the estimate/none bases.
      */
     @Query(
         "SELECT DISTINCT jobId FROM delivery_records WHERE sessionId = :id " +
-            "AND payBasis IN ('DROP_SHARE', 'RECEIPT_TOTAL')"
+            "AND payBasis IN ('" + PayBasis.DROP_SHARE + "', '" + PayBasis.RECEIPT_TOTAL +
+            "', '" + PayBasis.SUSPECT_FULL_RECEIPT + "')"
     )
     suspend fun receiptedJobIdsInSession(id: String): List<String>
 

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
@@ -350,6 +350,19 @@ interface AnalyticsDao {
     suspend fun deliveredJobIdsInSession(id: String): List<String>
 
     /**
+     * The distinct jobIds already recorded with **receipt-derived** pay (`DROP_SHARE` /
+     * `RECEIPT_TOTAL`) for a session — rehydrates the fold's #691 mixed-receipt guard set across a
+     * drain/batch boundary (mirrors [deliveredJobIdsInSession]), so a receipt-less sibling folded in
+     * a LATER batch is still denied the offer-pay estimate. Deliberately excludes `USER_CORRECTED`
+     * (a documented hydration wrinkle, #691 VET F1) and the estimate/none bases.
+     */
+    @Query(
+        "SELECT DISTINCT jobId FROM delivery_records WHERE sessionId = :id " +
+            "AND payBasis IN ('DROP_SHARE', 'RECEIPT_TOTAL')"
+    )
+    suspend fun receiptedJobIdsInSession(id: String): List<String>
+
+    /**
      * The most recent closing offer's frozen operating-cost-per-mile in a session — rehydrates the
      * fold's session-uniform frozen-economy basis on a mid-session restart so a delivery folded
      * after the restart still resolves `OFFER_FROZEN` (PR2). Prefers offer provenance, never a

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -28,6 +28,7 @@ import cloud.trotter.dashbuddy.domain.state.DestructiveKind
 import cloud.trotter.dashbuddy.domain.state.DropPayApportioner
 import cloud.trotter.dashbuddy.domain.state.Flow
 import cloud.trotter.dashbuddy.domain.state.FlowRegion
+import cloud.trotter.dashbuddy.domain.state.Job
 import cloud.trotter.dashbuddy.domain.state.Mode
 import cloud.trotter.dashbuddy.domain.state.TransitionKind
 import cloud.trotter.dashbuddy.domain.state.ParsedFields
@@ -420,6 +421,13 @@ class EffectMap @Inject constructor() {
                             parsedPay = p.lastPostTaskFields?.parsedPay,
                             dropoffTasks = jobDropoffTasks(next, p.activeJob?.jobId),
                         )[completedTask.taskId]
+                        // #691: when the whole job was receipt-less, stamp this drop's equal-split
+                        // share of the accepted-offer pay so it folds a real net row (not $0-unattr).
+                        val offerShare = offerPayShareFor(
+                            job = p.activeJob,
+                            postTaskFields = p.lastPostTaskFields,
+                            taskId = completedTask.taskId,
+                        )
                         val payload = deliveryCompletedPayload(
                             task = completedTask,
                             jobId = p.activeJob?.jobId,
@@ -427,6 +435,7 @@ class EffectMap @Inject constructor() {
                             postTaskFields = p.lastPostTaskFields,
                             sessionEarnings = next.session?.runningEarnings ?: p.session?.runningEarnings,
                             dropRealizedPay = dropShare,
+                            offerPayShare = offerShare,
                         )
                         // #518: scope idempotency to the completed task, not obs.timestamp, so a
                         // re-entered PostTask receipt can't re-fire (and double-count) the same
@@ -493,6 +502,15 @@ class EffectMap @Inject constructor() {
                     // naturally gets null pay (#528's job), never a normal receipted delivery's pay.
                     val postTaskFields = p.lastPostTaskFields
                         ?.takeIf { p.lastAnnouncedPostTaskTaskId == task.taskId }
+                    // #691: eligibility is JOB-scoped on the whole job's receipt state
+                    // (p.lastPostTaskFields), not the per-task-pinned `postTaskFields` above — a
+                    // receipt-less close-out (no pay screen at all) stamps every owed drop's
+                    // equal-split offer share; a job that showed any receipt stamps none.
+                    val offerShare = offerPayShareFor(
+                        job = closedJob,
+                        postTaskFields = p.lastPostTaskFields,
+                        taskId = task.taskId,
+                    )
                     val payload = deliveryCompletedPayload(
                         task = task,
                         jobId = closedJob.jobId,
@@ -500,6 +518,7 @@ class EffectMap @Inject constructor() {
                         postTaskFields = postTaskFields,
                         sessionEarnings = next.session?.runningEarnings ?: p.session?.runningEarnings,
                         dropRealizedPay = dropShares[task.taskId],
+                        offerPayShare = offerShare,
                     )
                     add(
                         logEffect(
@@ -1424,6 +1443,7 @@ class EffectMap @Inject constructor() {
         postTaskFields: ParsedFields.PostTaskFields?,
         sessionEarnings: Double?,
         dropRealizedPay: Double? = null,
+        offerPayShare: Double? = null,
     ): DeliveryPayload = DeliveryPayload(
         jobId = jobId ?: task?.jobId ?: "unknown",
         taskId = task?.taskId ?: "unknown",
@@ -1439,8 +1459,42 @@ class EffectMap @Inject constructor() {
         totalPay = postTaskFields?.totalPay,
         parsedPay = postTaskFields?.parsedPay,
         dropRealizedPay = dropRealizedPay,
+        offerPayShare = offerPayShare,
         sessionEarningsAtCompletion = sessionEarnings,
     )
+
+    /**
+     * #691 offer-pay estimate share for [task] when the closing [job] was WHOLLY receipt-less — the
+     * write-side stamp that lets a receipt-less shop delivery fold a real net row instead of a
+     * $0-unattributed one. Null (no stamp) unless:
+     * - **W1-a (job-scoped):** the job showed NO post-task receipt at all ([postTaskFields] == null).
+     *   A `PostTaskFields` is captured only from an observed pay screen (its `totalPay` is non-null by
+     *   type), and receipt fields are pinned per-task at close-out — so a sibling of a receipted drop
+     *   is receipt-less BY DESIGN and must not be stamped. The test is the WHOLE job's receipt state,
+     *   not this mint's per-drop inputs (a mint-scoped test would over-count a collapsed bare-total
+     *   receipt: receipt + (N−1)/N × offer). The fold's `receiptedJobIds` guard is defense-in-depth.
+     * - **W1-c (denominator):** the split is over the job's OWN owed dropoff set ([Job.tasks] DROPOFF,
+     *   distinct by id) — NOT the identity-filtered mint denominator, which shrinks at a mid-stack
+     *   PostTask-exit and would hand that one drop the FULL offer total (1.5×). A vanished drop's share
+     *   stays parked on its unminted placeholder → minted sums degrade BELOW the offer total, never
+     *   above (the one-sided error the read-side MAX-floor already tolerates).
+     * - **W1-b (numerator):** [Job.offerPayTotal] is nullable — a pay-less offer yields null →
+     *   [DropPayApportioner.equalSplit] returns the empty map → no stamp.
+     *
+     * Pure: derives only from region records; no wall clock.
+     */
+    private fun offerPayShareFor(
+        job: Job?,
+        postTaskFields: ParsedFields.PostTaskFields?,
+        taskId: String,
+    ): Double? {
+        if (job == null) return null
+        if (postTaskFields != null) return null // job showed a receipt → not eligible (W1-a)
+        val ownDropoffs = job.tasks
+            .filter { it.phase == TaskPhase.DROPOFF }
+            .distinctBy { it.taskId }
+        return DropPayApportioner.equalSplit(job.offerPayTotal, ownDropoffs)[taskId]
+    }
 
     /**
      * The job's delivered dropoff tasks — the completion rows the [DropPayApportioner] splits the

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -30,6 +30,7 @@ import cloud.trotter.dashbuddy.domain.state.Flow
 import cloud.trotter.dashbuddy.domain.state.FlowRegion
 import cloud.trotter.dashbuddy.domain.state.Job
 import cloud.trotter.dashbuddy.domain.state.Mode
+import cloud.trotter.dashbuddy.domain.state.OfferPayFallback
 import cloud.trotter.dashbuddy.domain.state.TransitionKind
 import cloud.trotter.dashbuddy.domain.state.ParsedFields
 import cloud.trotter.dashbuddy.domain.state.PickupActivity
@@ -423,10 +424,14 @@ class EffectMap @Inject constructor() {
                         )[completedTask.taskId]
                         // #691: when the whole job was receipt-less, stamp this drop's equal-split
                         // share of the accepted-offer pay so it folds a real net row (not $0-unattr).
+                        // FIX 1: a PostTask-exit mint's job may still be OPEN — stamp only when this is
+                        // the LAST OPEN owed dropoff (requireFinalShape), so a mid-stack pay-less exit
+                        // can't over-count (estimate-then-late-receipt / add-on drift / cents drift).
                         val offerShare = offerPayShareFor(
+                            region = p,
                             job = p.activeJob,
-                            postTaskFields = p.lastPostTaskFields,
                             taskId = completedTask.taskId,
+                            requireFinalShape = true,
                         )
                         val payload = deliveryCompletedPayload(
                             task = completedTask,
@@ -505,11 +510,13 @@ class EffectMap @Inject constructor() {
                     // #691: eligibility is JOB-scoped on the whole job's receipt state
                     // (p.lastPostTaskFields), not the per-task-pinned `postTaskFields` above — a
                     // receipt-less close-out (no pay screen at all) stamps every owed drop's
-                    // equal-split offer share; a job that showed any receipt stamps none.
+                    // equal-split offer share; a job that showed any PAY-BEARING receipt stamps none.
+                    // The close-out job is already CLOSED → its shape is final (requireFinalShape=false).
                     val offerShare = offerPayShareFor(
+                        region = p,
                         job = closedJob,
-                        postTaskFields = p.lastPostTaskFields,
                         taskId = task.taskId,
+                        requireFinalShape = false,
                     )
                     val payload = deliveryCompletedPayload(
                         task = task,
@@ -1464,36 +1471,73 @@ class EffectMap @Inject constructor() {
     )
 
     /**
-     * #691 offer-pay estimate share for [task] when the closing [job] was WHOLLY receipt-less — the
+     * #691 offer-pay estimate share for [taskId] of [job] when the job was WHOLLY receipt-less — the
      * write-side stamp that lets a receipt-less shop delivery fold a real net row instead of a
-     * $0-unattributed one. Null (no stamp) unless:
-     * - **W1-a (job-scoped):** the job showed NO post-task receipt at all ([postTaskFields] == null).
-     *   A `PostTaskFields` is captured only from an observed pay screen (its `totalPay` is non-null by
-     *   type), and receipt fields are pinned per-task at close-out — so a sibling of a receipted drop
-     *   is receipt-less BY DESIGN and must not be stamped. The test is the WHOLE job's receipt state,
-     *   not this mint's per-drop inputs (a mint-scoped test would over-count a collapsed bare-total
-     *   receipt: receipt + (N−1)/N × offer). The fold's `receiptedJobIds` guard is defense-in-depth.
-     * - **W1-c (denominator):** the split is over the job's OWN owed dropoff set ([Job.tasks] DROPOFF,
-     *   distinct by id) — NOT the identity-filtered mint denominator, which shrinks at a mid-stack
-     *   PostTask-exit and would hand that one drop the FULL offer total (1.5×). A vanished drop's share
-     *   stays parked on its unminted placeholder → minted sums degrade BELOW the offer total, never
-     *   above (the one-sided error the read-side MAX-floor already tolerates).
-     * - **W1-b (numerator):** [Job.offerPayTotal] is nullable — a pay-less offer yields null →
-     *   [DropPayApportioner.equalSplit] returns the empty map → no stamp.
+     * $0-unattributed one. Thin edge over the pure [OfferPayFallback] policy: this computes the two
+     * inputs only the region can see — the job-scoped receipt-evidence verdict
+     * ([receiptSuppressesEstimate]) and the per-site final-shape flag — then delegates the eligibility
+     * + split, and owns the observability WARN (FIX 6) for an eligible-but-unsplit drop.
+     *
+     * [requireFinalShape] is true at the PostTask-exit mint (job may still be open — stamp only the
+     * LAST OPEN owed drop) and false at the #596 close-out (job already closed → final shape).
+     */
+    private fun offerPayShareFor(
+        region: PlatformRegion,
+        job: Job?,
+        taskId: String,
+        requireFinalShape: Boolean,
+    ): Double? {
+        if (job == null) return null
+        val result = OfferPayFallback.shareFor(
+            job = job,
+            mintingTaskId = taskId,
+            suppressedByReceipt = receiptSuppressesEstimate(region, job),
+            requireFinalShape = requireFinalShape,
+        )
+        if (result.eligibleButUnsplit) {
+            // The drop is estimate-ELIGIBLE (receipt-less, final shape) yet got NO share — a pay-less
+            // offer or a minting task outside the owed set (the quoted>delivered halving class). WARN
+            // it so the silent-denominator miss is observable. PII-safe: counts + jobId only, no
+            // store/customer text, stable tag (Principle 7; the #699 D6 join-miss precedent).
+            Timber.tag("StateMachine").w(
+                "#691 offer-pay estimate eligible but unsplit: job %s, %d owed dropoffs, offerTotal=%s " +
+                    "— no share stamped; these dollars ride the unattributed bucket",
+                job.jobId,
+                job.tasks.count { it.phase == TaskPhase.DROPOFF },
+                if (job.offerPayTotal == null) "null" else "present",
+            )
+        }
+        return result.share
+    }
+
+    /**
+     * #691 receipt-evidence verdict: does [job] show a PAY-BEARING post-task receipt attributable to
+     * ITSELF — in which case the offer-pay estimate is withheld (a real receipt is truth)?
+     *
+     * Two guards, both learned from the adversarial review:
+     * - **Pay-bearing (FIX 2a):** `ParsedFieldsFactory.buildPostTask` coerces a missing total to
+     *   `0.0`, so a transient `delivery_summary_collapsed` frame that fails to parse produces a $0.00
+     *   `PostTaskFields` — a pseudo-receipt. A real $0 delivery receipt isn't a thing, so a $0 total
+     *   with no itemized `parsedPay` is NOT evidence and must NOT suppress the estimate. Same
+     *   predicate the fold uses (`RecordFolds.payBearingReceipt`) — one definition, two sites.
+     * - **Job-scoped (FIX 2b):** `lastPostTaskFields`/`lastAnnouncedPostTaskTaskId` are REGION-scoped
+     *   and survive `completeActiveJob` clearing `lastPostTaskFields` (the announce id is NOT cleared),
+     *   so a flickered PREVIOUS-job receipt can re-set them. Suppress only when the receipt is
+     *   attributable to THIS job: the announce id is in this job's tasks, OR is null (conservative —
+     *   fail-closed against over-count), OR is not PROVABLY another job's task. Do NOT suppress only
+     *   when the announce id provably belongs to a DIFFERENT job's task (the stale cross-job flicker).
      *
      * Pure: derives only from region records; no wall clock.
      */
-    private fun offerPayShareFor(
-        job: Job?,
-        postTaskFields: ParsedFields.PostTaskFields?,
-        taskId: String,
-    ): Double? {
-        if (job == null) return null
-        if (postTaskFields != null) return null // job showed a receipt → not eligible (W1-a)
-        val ownDropoffs = job.tasks
-            .filter { it.phase == TaskPhase.DROPOFF }
-            .distinctBy { it.taskId }
-        return DropPayApportioner.equalSplit(job.offerPayTotal, ownDropoffs)[taskId]
+    private fun receiptSuppressesEstimate(region: PlatformRegion, job: Job): Boolean {
+        val fields = region.lastPostTaskFields ?: return false
+        val payBearing = fields.parsedPay != null || fields.totalPay > 0.0
+        if (!payBearing) return false
+        val announceId = region.lastAnnouncedPostTaskTaskId ?: return true // null → conservative suppress
+        if (job.tasks.any { it.taskId == announceId }) return true // this job's receipt → suppress
+        val regionTasks = region.recentTasks + listOfNotNull(region.activeTask)
+        val provablyAnotherJob = regionTasks.any { it.taskId == announceId && it.jobId != job.jobId }
+        return !provablyAnotherJob // unknown id → conservative suppress; foreign id → do not suppress
     }
 
     /**

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/OfferPayFallbackEffectMapTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/OfferPayFallbackEffectMapTest.kt
@@ -1,0 +1,236 @@
+package cloud.trotter.dashbuddy.core.state
+
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
+import cloud.trotter.dashbuddy.domain.model.event.AppEventType
+import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryPayload
+import cloud.trotter.dashbuddy.domain.model.pay.ParsedPay
+import cloud.trotter.dashbuddy.domain.model.pay.ParsedPayItem
+import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.state.AcceptedOfferEconomics
+import cloud.trotter.dashbuddy.domain.state.AppState
+import cloud.trotter.dashbuddy.domain.state.CrossPlatformRegion
+import cloud.trotter.dashbuddy.domain.state.Flow
+import cloud.trotter.dashbuddy.domain.state.FlowRegion
+import cloud.trotter.dashbuddy.domain.state.Job
+import cloud.trotter.dashbuddy.domain.state.Mode
+import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.domain.state.PlatformRegion
+import cloud.trotter.dashbuddy.domain.state.Regions
+import cloud.trotter.dashbuddy.domain.state.Session
+import cloud.trotter.dashbuddy.domain.state.Task
+import cloud.trotter.dashbuddy.domain.state.TaskPhase
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #691 — the write-side offer-pay fallback stamp at both `DELIVERY_COMPLETED` mint sites (PostTask
+ * exit + #596 close-out). When the whole job was receipt-less, each owed drop's completion carries
+ * an equal-split share of the accepted-offer pay ([DeliveryPayload.offerPayShare]) so the fold can
+ * produce a real net row instead of a $0-unattributed one. The guards under test are the VET
+ * amendments: W1-a (job-scoped eligibility — a collapsed bare-total receipt does NOT stamp
+ * siblings), W1-c (denominator is the job's OWN owed dropoff set — a mid-stack mint takes its share,
+ * not the full total), and W1-b (a pay-less offer stamps nothing).
+ */
+class OfferPayFallbackEffectMapTest {
+
+    private val effectMap = EffectMap()
+
+    private fun appState(
+        flow: FlowRegion = FlowRegion(),
+        platforms: Map<Platform, PlatformRegion> = emptyMap(),
+    ) = AppState(
+        regions = Regions(flow = flow, platforms = platforms, crossPlatform = CrossPlatformRegion()),
+    )
+
+    private fun screenObs(flow: Flow?, timestamp: Long) = Observation.Screen(
+        timestamp = timestamp,
+        captureId = null,
+        ruleId = "test.rule",
+        metadata = ReplayMetadata.EMPTY,
+        flow = flow,
+        modeHint = null,
+        parsed = ParsedFields.None,
+    )
+
+    private fun dropoff(
+        id: String,
+        store: String?,
+        cust: String?,
+        completedAt: Long? = 400L,
+    ) = Task(
+        taskId = id,
+        jobId = "J",
+        phase = TaskPhase.DROPOFF,
+        storeName = store,
+        customerNameHash = cust,
+        startedAt = 300L,
+        completedAt = completedAt,
+    )
+
+    /** A job carrying an accepted-offer pay total and its owed dropoff mirror ([Job.tasks], W1-c). */
+    private fun job(offerPay: Double?, tasks: List<Task>) = Job(
+        jobId = "J",
+        offerStoreHint = emptyList(),
+        parentOfferHash = null,
+        acceptedOffers = listOf(
+            AcceptedOfferEconomics(offerHash = "h", payAmount = offerPay, acceptedAt = 50L),
+        ),
+        tasks = tasks,
+        startedAt = 50L,
+    )
+
+    private fun completedRows(prev: AppState, next: AppState, obs: Observation): List<DeliveryPayload> =
+        effectMap.diff(prev, next, obs)
+            .filterIsInstance<AppEffect.LogEvent>()
+            .filter { it.event.type == AppEventType.DELIVERY_COMPLETED }
+            .map { it.event.payload as DeliveryPayload }
+
+    private fun cents(v: Double): Long = Math.round(v * 100.0)
+
+    @Test
+    fun `receipt-less close-out stamps every drop an equal-split offer share`() {
+        // A wholly receipt-less two-drop shop job (offer $12.95, no post-delivery receipt) closes.
+        val dropA = dropoff("d1", "H-E-B", "cA", completedAt = 400L)
+        val dropB = dropoff("d2", "H-E-B", "cB", completedAt = 410L)
+        val regionPrev = PlatformRegion(
+            platform = Platform.DoorDash,
+            mode = Mode.Online,
+            session = Session("s1", startedAt = 100L, runningEarnings = 40.0),
+            activeJob = job(offerPay = 12.95, tasks = listOf(dropA, dropB)),
+            recentTasks = listOf(dropA, dropB),
+            lastPostTaskFields = null,
+        )
+        val regionNext = regionPrev.copy(activeJob = null)
+
+        val prev = appState(FlowRegion(flow = Flow.Idle), mapOf(Platform.DoorDash to regionPrev))
+        val next = appState(FlowRegion(flow = Flow.Idle), mapOf(Platform.DoorDash to regionNext))
+
+        val rows = completedRows(prev, next, screenObs(Flow.Idle, timestamp = 3000L))
+        assertEquals("both drops complete", 2, rows.size)
+        val a = rows.single { it.taskId == "d1" }
+        val b = rows.single { it.taskId == "d2" }
+        assertEquals("12.95 / 2, remainder to last", 6.48, a.offerPayShare!!, 0.0001)
+        assertEquals(6.47, b.offerPayShare!!, 0.0001)
+        assertEquals("shares sum EXACTLY to the offer total", 1295L, rows.sumOf { cents(it.offerPayShare!!) })
+        assertNull("no receipt → no dropRealizedPay", a.dropRealizedPay)
+        assertNull(a.totalPay)
+    }
+
+    @Test
+    fun `W1-a — a collapsed bare-total receipt pinned to one drop leaves siblings UNSTAMPED`() {
+        // The whole-job receipt state is NOT empty (a bare totalPay landed, parsedPay null → the
+        // apportioner returns an empty map). Receipt fields are pinned to d1; d2 is receipt-less BY
+        // DESIGN. Without the job-scoped W1-a guard, d2 would get an offer share on top of d1's
+        // receipt → ~1.9× the real pay. It must stay unstamped.
+        val dropA = dropoff("d1", "H-E-B", "cA", completedAt = 400L)
+        val dropB = dropoff("d2", "H-E-B", "cB", completedAt = 410L)
+        val postFields = ParsedFields.PostTaskFields(totalPay = 10.0, parsedPay = null, sessionEarnings = 40.0)
+        val regionPrev = PlatformRegion(
+            platform = Platform.DoorDash,
+            mode = Mode.Online,
+            session = Session("s1", startedAt = 100L, runningEarnings = 40.0),
+            activeJob = job(offerPay = 12.95, tasks = listOf(dropA, dropB)),
+            recentTasks = listOf(dropA, dropB),
+            lastPostTaskFields = postFields,
+            lastAnnouncedPostTaskTaskId = "d1",
+        )
+        val regionNext = regionPrev.copy(activeJob = null)
+
+        val prev = appState(FlowRegion(flow = Flow.Idle), mapOf(Platform.DoorDash to regionPrev))
+        val next = appState(FlowRegion(flow = Flow.Idle), mapOf(Platform.DoorDash to regionNext))
+
+        val rows = completedRows(prev, next, screenObs(Flow.Idle, timestamp = 3000L))
+        assertEquals(2, rows.size)
+        rows.forEach { assertNull("job showed a receipt → no offer-pay estimate on any drop", it.offerPayShare) }
+        // The pinned drop still carries its bare receipt total; the sibling stays null (as today).
+        assertEquals(10.0, rows.single { it.taskId == "d1" }.totalPay!!, 0.0001)
+        assertNull(rows.single { it.taskId == "d2" }.totalPay)
+    }
+
+    @Test
+    fun `W1-c — a mid-stack PostTask exit takes the drop's share, not the full offer total`() {
+        // A receipt-less mid-stack completion: d1 completes while its sibling d2 is still owed (an
+        // unresolved, identity-less placeholder). The identity-firewall mint denominator would shrink
+        // to just d1 → d1 would take the WHOLE $12.95 (1.5×+ over-count). W1-c splits over the job's
+        // OWN owed dropoff set (Job.tasks, 2 drops) → d1 gets its 6.48 share; d2's 6.47 mints when it
+        // resolves. The job stays open (no close-out this step).
+        val d1 = dropoff("d1", "H-E-B", "cA", completedAt = null)
+        val placeholder = dropoff("d2", null, cust = null, completedAt = null) // identity-less, owed
+        val activeJob = job(offerPay = 12.95, tasks = listOf(d1, placeholder))
+        val regionPrev = PlatformRegion(
+            platform = Platform.DoorDash,
+            mode = Mode.Online,
+            session = Session("s1", startedAt = 100L, runningEarnings = 40.0),
+            activeJob = activeJob,
+            recentTasks = listOf(d1),
+            lastPostTaskFields = null,
+        )
+        val regionNext = regionPrev.copy() // job stays open (mid-stack)
+
+        val prev = appState(FlowRegion(flow = Flow.PostTask), mapOf(Platform.DoorDash to regionPrev))
+        val next = appState(FlowRegion(flow = Flow.Idle), mapOf(Platform.DoorDash to regionNext))
+
+        val rows = completedRows(prev, next, screenObs(Flow.Idle, timestamp = 3000L))
+        assertEquals("only d1 completes at the mid-stack exit", 1, rows.size)
+        assertEquals(
+            "d1 takes ITS 6.48 share (offer/2), NOT the full 12.95 — W1-c denominator is the owed set",
+            6.48, rows.single().offerPayShare!!, 0.0001,
+        )
+        // The sibling's remainder is deterministic by taskId order: equalSplit gives d2 → 6.47, so
+        // the two eventual rows sum to 12.95 (never 1.5× = 19.42).
+        val d2Share = cloud.trotter.dashbuddy.domain.state.DropPayApportioner
+            .equalSplit(12.95, listOf(d1, placeholder))["d2"]!!
+        assertEquals(6.47, d2Share, 0.0001)
+        assertEquals("Σ of both eventual rows == offer total", 1295L, cents(6.48) + cents(d2Share))
+    }
+
+    @Test
+    fun `W1-b — a pay-less offer stamps no offer share`() {
+        val dropA = dropoff("d1", "H-E-B", "cA", completedAt = 400L)
+        val regionPrev = PlatformRegion(
+            platform = Platform.DoorDash,
+            mode = Mode.Online,
+            session = Session("s1", startedAt = 100L, runningEarnings = 0.0),
+            activeJob = job(offerPay = null, tasks = listOf(dropA)),
+            recentTasks = listOf(dropA),
+            lastPostTaskFields = null,
+        )
+        val regionNext = regionPrev.copy(activeJob = null)
+
+        val prev = appState(FlowRegion(flow = Flow.Idle), mapOf(Platform.DoorDash to regionPrev))
+        val next = appState(FlowRegion(flow = Flow.Idle), mapOf(Platform.DoorDash to regionNext))
+
+        val rows = completedRows(prev, next, screenObs(Flow.Idle, timestamp = 3000L))
+        assertEquals(1, rows.size)
+        assertNull("no offer pay → no estimate row", rows.single().offerPayShare)
+        assertNull(rows.single().dropRealizedPay)
+    }
+
+    @Test
+    fun `an accepted-never-delivered job mints no completion and no offer dollars`() {
+        // The seq-53 counter-fixture shape: an accepted offer whose job never completes a dropoff.
+        // No mint fires → no offerPayShare is ever stamped. Here the job is open with a PICKUP only
+        // and no flow transition that could complete a delivery.
+        val pickup = Task(
+            taskId = "p1", jobId = "J", phase = TaskPhase.PICKUP,
+            storeName = "H-E-B", customerNameHash = null, startedAt = 300L, completedAt = null,
+        )
+        val region = PlatformRegion(
+            platform = Platform.DoorDash,
+            mode = Mode.Online,
+            session = Session("s1", startedAt = 100L, runningEarnings = 0.0),
+            activeJob = job(offerPay = 24.25, tasks = listOf(pickup)),
+            recentTasks = emptyList(),
+            lastPostTaskFields = null,
+        )
+        // Same state prev→next (no completion, no close-out).
+        val prev = appState(FlowRegion(flow = Flow.TaskPickupNavigation), mapOf(Platform.DoorDash to region))
+        val next = appState(FlowRegion(flow = Flow.TaskPickupNavigation), mapOf(Platform.DoorDash to region))
+
+        val rows = completedRows(prev, next, screenObs(Flow.TaskPickupNavigation, timestamp = 3000L))
+        assertTrue("no completion mint → no offer dollars", rows.isEmpty())
+    }
+}

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/OfferPayFallbackEffectMapTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/OfferPayFallbackEffectMapTest.kt
@@ -151,12 +151,12 @@ class OfferPayFallbackEffectMapTest {
     }
 
     @Test
-    fun `W1-c — a mid-stack PostTask exit takes the drop's share, not the full offer total`() {
+    fun `FIX1 — a mid-stack PostTask exit does NOT stamp (not the last open owed drop)`() {
         // A receipt-less mid-stack completion: d1 completes while its sibling d2 is still owed (an
-        // unresolved, identity-less placeholder). The identity-firewall mint denominator would shrink
-        // to just d1 → d1 would take the WHOLE $12.95 (1.5×+ over-count). W1-c splits over the job's
-        // OWN owed dropoff set (Job.tasks, 2 drops) → d1 gets its 6.48 share; d2's 6.47 mints when it
-        // resolves. The job stays open (no close-out this step).
+        // unresolved, identity-less placeholder, completedAt == null). FIX 1's final-shape gate stamps
+        // a PostTask-exit drop ONLY when it is the LAST OPEN owed dropoff. d2 is not yet done → d1 is
+        // mid-stack → NO stamp (the traded class: its dollars ride unattributed; it got nothing
+        // pre-#691 too). This kills the estimate-then-late-receipt / cents-drift-across-mints over-count.
         val d1 = dropoff("d1", "H-E-B", "cA", completedAt = null)
         val placeholder = dropoff("d2", null, cust = null, completedAt = null) // identity-less, owed
         val activeJob = job(offerPay = 12.95, tasks = listOf(d1, placeholder))
@@ -175,16 +175,170 @@ class OfferPayFallbackEffectMapTest {
 
         val rows = completedRows(prev, next, screenObs(Flow.Idle, timestamp = 3000L))
         assertEquals("only d1 completes at the mid-stack exit", 1, rows.size)
-        assertEquals(
-            "d1 takes ITS 6.48 share (offer/2), NOT the full 12.95 — W1-c denominator is the owed set",
-            6.48, rows.single().offerPayShare!!, 0.0001,
+        assertNull("mid-stack exit → no offer stamp (final-shape gate)", rows.single().offerPayShare)
+    }
+
+    @Test
+    fun `FIX1 — the LAST open owed drop completing at a PostTask exit IS stamped`() {
+        // d1 already delivered earlier (completedAt set). d2 is the final owed drop and completes at
+        // this PostTask exit → final-shape holds → d2 is stamped its share (no over-count: d1 was
+        // stamped on its own earlier exit).
+        val d1 = dropoff("d1", "H-E-B", "cA", completedAt = 380L)
+        val d2 = dropoff("d2", "H-E-B", "cB", completedAt = null) // completes now (active)
+        val activeJob = job(offerPay = 12.95, tasks = listOf(d1, d2))
+        val regionPrev = PlatformRegion(
+            platform = Platform.DoorDash,
+            mode = Mode.Online,
+            session = Session("s1", startedAt = 100L, runningEarnings = 40.0),
+            activeJob = activeJob,
+            activeTask = d2,
+            recentTasks = listOf(d1),
+            lastPostTaskFields = null,
         )
-        // The sibling's remainder is deterministic by taskId order: equalSplit gives d2 → 6.47, so
-        // the two eventual rows sum to 12.95 (never 1.5× = 19.42).
-        val d2Share = cloud.trotter.dashbuddy.domain.state.DropPayApportioner
-            .equalSplit(12.95, listOf(d1, placeholder))["d2"]!!
-        assertEquals(6.47, d2Share, 0.0001)
-        assertEquals("Σ of both eventual rows == offer total", 1295L, cents(6.48) + cents(d2Share))
+        val regionNext = regionPrev.copy(activeTask = d2.copy(completedAt = 3000L))
+
+        val prev = appState(FlowRegion(flow = Flow.PostTask), mapOf(Platform.DoorDash to regionPrev))
+        val next = appState(FlowRegion(flow = Flow.Idle), mapOf(Platform.DoorDash to regionNext))
+
+        val rows = completedRows(prev, next, screenObs(Flow.Idle, timestamp = 3000L))
+        assertEquals(1, rows.size)
+        assertEquals("last open owed drop → stamped its 6.47 share", 6.47, rows.single().offerPayShare!!, 0.0001)
+    }
+
+    @Test
+    fun `FIX1 — a solo receipt-less drop at a PostTask exit is stamped (seq-10 shape)`() {
+        // The 07-05 seq-10 shape: a single-drop receipt-less job completes at its PostTask exit. It is
+        // trivially the last open owed drop → stamped the whole offer total.
+        val d1 = dropoff("d1", "H-E-B", "cA", completedAt = null)
+        val activeJob = job(offerPay = 7.50, tasks = listOf(d1))
+        val regionPrev = PlatformRegion(
+            platform = Platform.DoorDash,
+            mode = Mode.Online,
+            session = Session("s1", startedAt = 100L, runningEarnings = 20.0),
+            activeJob = activeJob,
+            activeTask = d1,
+            recentTasks = listOf(d1),
+            lastPostTaskFields = null,
+        )
+        val regionNext = regionPrev.copy(activeTask = d1.copy(completedAt = 3000L))
+
+        val prev = appState(FlowRegion(flow = Flow.PostTask), mapOf(Platform.DoorDash to regionPrev))
+        val next = appState(FlowRegion(flow = Flow.Idle), mapOf(Platform.DoorDash to regionNext))
+
+        val rows = completedRows(prev, next, screenObs(Flow.Idle, timestamp = 3000L))
+        assertEquals(1, rows.size)
+        assertEquals("solo final drop stamped the whole offer", 7.50, rows.single().offerPayShare!!, 0.0001)
+    }
+
+    @Test
+    fun `FIX2a — a 0-coerced pseudo-receipt does NOT suppress the offer stamp`() {
+        // A transient delivery_summary_collapsed frame coerces totalPay to 0.0 (buildPostTask ?: 0.0)
+        // AND is pinned to d1 as lastPostTaskFields. It is NOT pay-bearing (0.0, no parsedPay), so it
+        // must NOT suppress the estimate — the solo receipt-less drop is still stamped.
+        val d1 = dropoff("d1", "H-E-B", "cA", completedAt = 400L)
+        val zeroReceipt = ParsedFields.PostTaskFields(totalPay = 0.0, parsedPay = null, sessionEarnings = 20.0)
+        val regionPrev = PlatformRegion(
+            platform = Platform.DoorDash,
+            mode = Mode.Online,
+            session = Session("s1", startedAt = 100L, runningEarnings = 20.0),
+            activeJob = job(offerPay = 7.50, tasks = listOf(d1)),
+            recentTasks = listOf(d1),
+            lastPostTaskFields = zeroReceipt,
+            lastAnnouncedPostTaskTaskId = "d1",
+        )
+        val regionNext = regionPrev.copy(activeJob = null)
+
+        val prev = appState(FlowRegion(flow = Flow.Idle), mapOf(Platform.DoorDash to regionPrev))
+        val next = appState(FlowRegion(flow = Flow.Idle), mapOf(Platform.DoorDash to regionNext))
+
+        val rows = completedRows(prev, next, screenObs(Flow.Idle, timestamp = 3000L))
+        assertEquals(1, rows.size)
+        assertEquals("0-dollar pseudo-receipt is not pay-bearing → estimate stands", 7.50, rows.single().offerPayShare!!, 0.0001)
+    }
+
+    @Test
+    fun `FIX2b — a stale PREVIOUS-job receipt (announce id = another job's task) does NOT suppress`() {
+        // completeActiveJob cleared lastPostTaskFields but NOT lastAnnouncedPostTaskTaskId. A flickered
+        // receipt from a PRIOR job re-set a pay-bearing lastPostTaskFields whose announce id ("old")
+        // provably belongs to a DIFFERENT job's task (in recentTasks). It must NOT suppress THIS
+        // receipt-less job's estimate.
+        val oldDrop = Task(taskId = "old", jobId = "JPREV", phase = TaskPhase.DROPOFF, customerNameHash = "cx", startedAt = 10L, completedAt = 50L)
+        val d1 = dropoff("d1", "H-E-B", "cA", completedAt = 400L)
+        val stalePayBearing = ParsedFields.PostTaskFields(totalPay = 11.0, parsedPay = null, sessionEarnings = 40.0)
+        val regionPrev = PlatformRegion(
+            platform = Platform.DoorDash,
+            mode = Mode.Online,
+            session = Session("s1", startedAt = 100L, runningEarnings = 40.0),
+            activeJob = job(offerPay = 7.50, tasks = listOf(d1)),
+            recentTasks = listOf(oldDrop, d1),
+            lastPostTaskFields = stalePayBearing,
+            lastAnnouncedPostTaskTaskId = "old", // provably JPREV's task
+        )
+        val regionNext = regionPrev.copy(activeJob = null)
+
+        val prev = appState(FlowRegion(flow = Flow.Idle), mapOf(Platform.DoorDash to regionPrev))
+        val next = appState(FlowRegion(flow = Flow.Idle), mapOf(Platform.DoorDash to regionNext))
+
+        val rows = completedRows(prev, next, screenObs(Flow.Idle, timestamp = 3000L))
+        val d = rows.single { it.taskId == "d1" }
+        assertEquals("stale foreign-job receipt does not suppress → estimate stands", 7.50, d.offerPayShare!!, 0.0001)
+    }
+
+    @Test
+    fun `FIX2b — an unattributable pay-bearing receipt (announce id null) SUPPRESSES (fail-closed)`() {
+        // A pay-bearing lastPostTaskFields with a NULL announce id cannot be attributed to any task.
+        // Fail-closed against over-count: suppress the estimate (a receipt might belong to this job).
+        val d1 = dropoff("d1", "H-E-B", "cA", completedAt = 400L)
+        val unattributable = ParsedFields.PostTaskFields(totalPay = 11.0, parsedPay = null, sessionEarnings = 40.0)
+        val regionPrev = PlatformRegion(
+            platform = Platform.DoorDash,
+            mode = Mode.Online,
+            session = Session("s1", startedAt = 100L, runningEarnings = 40.0),
+            activeJob = job(offerPay = 7.50, tasks = listOf(d1)),
+            recentTasks = listOf(d1),
+            lastPostTaskFields = unattributable,
+            lastAnnouncedPostTaskTaskId = null,
+        )
+        val regionNext = regionPrev.copy(activeJob = null)
+
+        val prev = appState(FlowRegion(flow = Flow.Idle), mapOf(Platform.DoorDash to regionPrev))
+        val next = appState(FlowRegion(flow = Flow.Idle), mapOf(Platform.DoorDash to regionNext))
+
+        val rows = completedRows(prev, next, screenObs(Flow.Idle, timestamp = 3000L))
+        assertNull("unattributable pay-bearing receipt → suppress (fail-closed)", rows.single().offerPayShare)
+    }
+
+    @Test
+    fun `FIX6 — an eligible drop with a pay-less offer logs one PII-safe WARN`() {
+        val logged = mutableListOf<String>()
+        val tree = object : timber.log.Timber.Tree() {
+            override fun log(priority: Int, tag: String?, message: String, t: Throwable?) { logged += message }
+        }
+        timber.log.Timber.plant(tree)
+        try {
+            // Receipt-less, final-shape (close-out) job with a PAY-LESS offer → eligible but the split
+            // yields nothing → one WARN, no share.
+            val d1 = dropoff("d1", "H-E-B", "cA", completedAt = 400L)
+            val regionPrev = PlatformRegion(
+                platform = Platform.DoorDash,
+                mode = Mode.Online,
+                session = Session("s1", startedAt = 100L, runningEarnings = 0.0),
+                activeJob = job(offerPay = null, tasks = listOf(d1)),
+                recentTasks = listOf(d1),
+                lastPostTaskFields = null,
+            )
+            val regionNext = regionPrev.copy(activeJob = null)
+            val prev = appState(FlowRegion(flow = Flow.Idle), mapOf(Platform.DoorDash to regionPrev))
+            val next = appState(FlowRegion(flow = Flow.Idle), mapOf(Platform.DoorDash to regionNext))
+            val rows = completedRows(prev, next, screenObs(Flow.Idle, timestamp = 3000L))
+            assertNull(rows.single().offerPayShare)
+        } finally {
+            timber.log.Timber.uproot(tree)
+        }
+        assertEquals(
+            "one eligible-but-unsplit WARN surfaced", 1,
+            logged.count { it.contains("offer-pay estimate eligible but unsplit") },
+        )
     }
 
     @Test

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -73,6 +73,21 @@ card's **mechanical** half, #577 (re-confirmed, 24/24, ~0.55 s — with a new po
 that entry's Bug #1), the #457 path, and #554 ShadowProjector (2/2). The #462/#460 dropoff item
 was found **broken-in-part** (raw PII in capture envelopes) and moved to that entry's Bug #7.)_
 
+- **🆕 NEW — receipt-less shop delivery shows est. offer pay, not $0-unattributed (#691 / PR).**
+  Do a **DoorDash shop order** (grocery/convenience — the kind that shows NO per-delivery receipt at
+  the end; pay lives only on the offer + the running dash total). After it completes, open **Analytics
+  → the dash → the delivery drill-down**.
+  How to tell it's working: (1) the delivery row shows a **real pay figure with an "est. offer pay"
+  qualifier** under it, NOT a `$0` / "Unknown"-style row, and the Money-tab unattributed callout
+  shrinks accordingly. (2) On a **receipt-less shop STACK** (2+ orders, no receipt), the two drop rows
+  are **≈ equal halves of the offer pay shown at accept** (e.g. a $12.95 stack → ~$6.48 / ~$6.47),
+  summing to the offer total — not one drop taking the whole thing and the other $0. (3) A shop order
+  that DID show a receipt still uses the receipt (basis DROP_SHARE/RECEIPT_TOTAL), no "est." qualifier.
+  **NOTE (expected, not a bug):** net for a receipt-less shop is now **pay − mileage cost**, which is
+  **LOWER** than the old unattributed-callout number (that number was raw pay with no cost) — a lower,
+  more honest figure is correct. (#691 / PR)
+  - Confirmed: 0/2
+
 - **🆕 NEW — multi-pickup stack: symmetric pickup placeholders + store re-attribution (#526 / PR).**
   Accept a **multi-store stack** (two+ orders from DIFFERENT stores in one offer — e.g. the 07-05
   Bill Miller BBQ + Mama Margies). Watch the whole run: both pickups AND both drops.

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -86,6 +86,17 @@ was found **broken-in-part** (raw PII in capture envelopes) and moved to that en
   **NOTE (expected, not a bug):** net for a receipt-less shop is now **pay − mileage cost**, which is
   **LOWER** than the old unattributed-callout number (that number was raw pay with no cost) — a lower,
   more honest figure is correct. (#691 / PR)
+  - **(4) 🆕 UBER SCOPE (PR #702 round 2): Uber deliveries now show est. offer pay platform-wide.**
+    Uber has no post-trip receipt rules at all (`uber.screen.post_trip` has no parse), so EVERY Uber
+    delivery now folds an OFFER_PAY estimate (the platform-agnostic mechanism working as designed, P8).
+    This changes Uber analytics **wholesale** — **sanity-check the est. offer pay against your actual
+    Uber earnings** (the offer's guaranteed quote vs what Uber actually paid, incl. surge/tips added
+    after). Flag any drift.
+  - **(5) 🆕 REGRESSION WATCH (PR #702 round 2): a collapsed/transient summary must NOT force $0.**
+    On a receipt-less drop, watch that the row shows the **est. offer pay**, NOT a `$0.00` receipted
+    row — a transient `delivery_summary_collapsed` frame used to coerce a `$0` pseudo-receipt that
+    masked the estimate. If any receipt-less drop reads `$0.00` (basis RECEIPT_TOTAL) instead of an
+    est. figure, capture the session and flag it.
   - Confirmed: 0/2
 
 - **🆕 NEW — multi-pickup stack: symmetric pickup placeholders + store re-attribution (#526 / PR).**

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/AnalyticsRecords.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/AnalyticsRecords.kt
@@ -22,8 +22,14 @@ data class DeliveryRecord(
     val taskId: String,
     val storeName: String?,
     val completedAt: Long,
-    /** dropRealizedPay ?: totalPay. */
+    /** dropRealizedPay ?: totalPay ?: offerPayShare. */
     val realizedPay: Double?,
+    /**
+     * Provenance of [realizedPay] ([cloud.trotter.dashbuddy.domain.analytics.PayBasis]) — drives the
+     * drill-down's "est. offer pay" qualifier on an `OFFER_PAY` estimate row (#691, the never-silent
+     * disclosure the #689 precedent set).
+     */
+    val payBasis: String,
     /** Frozen realized net against the accepted offer's cost basis — never re-costed. */
     val netProfit: Double?,
     val realizedMiles: Double?,

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/RecordFolds.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/RecordFolds.kt
@@ -58,6 +58,18 @@ object PayBasis {
      * event remains in the log — the re-price is a later event, never a destructive edit.
      */
     const val USER_CORRECTED = "USER_CORRECTED"
+
+    /**
+     * The bases that PROVE a receipt existed for a job (#691 mixed-receipt guard). [DROP_SHARE] /
+     * [RECEIPT_TOTAL] carry receipt dollars directly; [SUSPECT_FULL_RECEIPT] is a receipt whose
+     * money was nulled as a double-count guard (#653) — the receipt still HAPPENED, so it must deny
+     * the offer-pay estimate to a receipt-less sibling of the same job. This is the ONE definition
+     * both sides of the guard derive from: the in-fold `receiptedJobIds` accumulation here and the
+     * `AnalyticsDao.receiptedJobIdsInSession` hydration IN-list (built from the same const vals).
+     * Deliberately EXCLUDES [USER_CORRECTED] (a documented hydration wrinkle, #691 VET F1; closed by
+     * the v11 receipt-evidence persistence, #703) and the estimate/none bases.
+     */
+    val RECEIPT_EVIDENCE: List<String> = listOf(DROP_SHARE, RECEIPT_TOTAL, SUSPECT_FULL_RECEIPT)
 }
 
 /**
@@ -376,31 +388,47 @@ object RecordFolds {
             priorDeliveryForThisJob && p.parsedPay != null && p.dropRealizedPay == null &&
                 p.customerHash == null && p.addressHash == null
 
+        // #691 receipt-evidence predicate: a completion carries PAY-BEARING receipt evidence iff it
+        // has an itemized receipt OR a POSITIVE bare total. `totalPay` is coerced from the pay screen
+        // by `ParsedFieldsFactory.buildPostTask` as `f.double("totalPay") ?: 0.0`, so a transient
+        // `delivery_summary_collapsed` frame that fails to parse its final value produces a $0.00
+        // `PostTaskFields` — a pseudo-receipt. A real $0 delivery receipt isn't a thing, so a 0.0
+        // total is NOT receipt evidence and must not suppress the offer-pay estimate. The same
+        // predicate gates stamp-suppression at the EffectMap edge (one definition, two sites).
+        val payBearingReceipt = p.parsedPay != null || (p.totalPay ?: 0.0) > 0.0
+
         // #691 mixed-receipt guard: an offer-pay ESTIMATE (an equal split of the offer total)
         // assumes the WHOLE job is receipt-less. If a sibling drop of this job already folded a REAL
         // receipt this session, mixing the two over-counts invisibly (the reported-total
         // reconciliation floors at 0), so a receipt-less drop of such a job keeps NONE. Defense-in-
         // depth behind the EffectMap job-scoped stamp condition (which is the primary control).
+        // FIX 4: a null session context fails CLOSED — with no `receiptedJobIds` to consult we cannot
+        // rule out a sibling receipt, so an OFFER_PAY estimate is withheld (matching the suspect
+        // check's degraded-context under-count direction — never over-count on missing context).
         val jobAlreadyReceipted = ctx != null && p.jobId in ctx.receiptedJobIds
-        val useOfferShare = !suspectFullReceipt &&
-            p.dropRealizedPay == null && p.totalPay == null &&
+        val useOfferShare = ctx != null && !suspectFullReceipt &&
+            p.dropRealizedPay == null && !payBearingReceipt &&
             p.offerPayShare != null && !jobAlreadyReceipted
 
-        // Pay + basis. dropRealizedPay is a per-drop share (possibly of a multi-drop receipt);
-        // its absence with a bare totalPay means the whole receipt landed on this one drop. With
-        // neither, the #691 offer-pay estimate is the fallback before NONE.
+        // Pay + basis. dropRealizedPay is a per-drop share (possibly of a multi-drop receipt); its
+        // absence with a bare totalPay means the whole receipt landed on this one drop. With neither,
+        // the #691 offer-pay estimate is the fallback before NONE. OFFER_PAY is evaluated ABOVE
+        // RECEIPT_TOTAL so a STAMPED estimate on a $0-coerced pseudo-receipt folds as the estimate,
+        // not as $0.00 — but ONLY when `offerPayShare` is present (null on ALL pre-#691 events), so a
+        // historical $0-total row with no stamp still folds RECEIPT_TOTAL $0.00 byte-for-byte (no
+        // PROJECTOR_VERSION bump; the un-stamped $0-pseudo-receipt residual rides to #703).
         val realizedPay = when {
             suspectFullReceipt -> null
             p.dropRealizedPay != null -> p.dropRealizedPay
-            p.totalPay != null -> p.totalPay
             useOfferShare -> p.offerPayShare
+            p.totalPay != null -> p.totalPay
             else -> null
         }
         val payBasis = when {
             suspectFullReceipt -> PayBasis.SUSPECT_FULL_RECEIPT
             p.dropRealizedPay != null -> PayBasis.DROP_SHARE
-            p.totalPay != null -> PayBasis.RECEIPT_TOTAL
             useOfferShare -> PayBasis.OFFER_PAY
+            p.totalPay != null -> PayBasis.RECEIPT_TOTAL
             else -> PayBasis.NONE
         }
         // tip/basePay only when this drop IS the job's sole drop — i.e. it carries the WHOLE receipt.
@@ -469,9 +497,11 @@ object RecordFolds {
             costBasis = costBasis,
         )
 
-        // #691: mark the job receipted once any drop folds real receipt pay, so a later receipt-less
+        // #691: mark the job receipted once any drop folds RECEIPT EVIDENCE, so a later receipt-less
         // sibling of the same job is denied the offer-pay estimate (the mixed-receipt guard above).
-        val jobReceipted = payBasis == PayBasis.DROP_SHARE || payBasis == PayBasis.RECEIPT_TOTAL
+        // Includes SUSPECT_FULL_RECEIPT (#653): its money was nulled, but the receipt still HAPPENED,
+        // so it proves the job is not receipt-less. SSOT with the DAO hydration IN-list.
+        val jobReceipted = payBasis in PayBasis.RECEIPT_EVIDENCE
         val newCtx = ctx?.copy(
             deliveries = ctx.deliveries + 1,
             deliveredJobIds = ctx.deliveredJobIds + p.jobId,

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/RecordFolds.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/RecordFolds.kt
@@ -32,6 +32,18 @@ object PayBasis {
      * still counts as a delivery / advances the partition anchors — only its money is nulled.
      */
     const val SUSPECT_FULL_RECEIPT = "SUSPECT_FULL_RECEIPT"
+    /**
+     * An ESTIMATE basis (#691): the accepted offer's guaranteed total, split EQUALLY across the
+     * job's owed dropoffs, stamped at completion when the WHOLE job was receipt-less (a DoorDash
+     * shop order shows no per-delivery receipt — pay lives only on the offer + the running dash
+     * total). The platform's actual per-drop split is unknowable without a receipt, so the honest
+     * estimate is the offer total ÷ drops. Consumed only when no sibling drop of the same job folded
+     * with receipt-derived pay (the mixed-receipt guard); tip/base stay null (no itemization).
+     * Surfaced as "est. offer pay" in the UI and as `OFFER_PAY` in the CSV `pay_basis` column so the
+     * estimate is never silent (the #689 precedent).
+     */
+    const val OFFER_PAY = "OFFER_PAY"
+
     /** No pay signal on the completion (receipt-skipped #596). */
     const val NONE = "NONE"
 
@@ -364,13 +376,31 @@ object RecordFolds {
             priorDeliveryForThisJob && p.parsedPay != null && p.dropRealizedPay == null &&
                 p.customerHash == null && p.addressHash == null
 
+        // #691 mixed-receipt guard: an offer-pay ESTIMATE (an equal split of the offer total)
+        // assumes the WHOLE job is receipt-less. If a sibling drop of this job already folded a REAL
+        // receipt this session, mixing the two over-counts invisibly (the reported-total
+        // reconciliation floors at 0), so a receipt-less drop of such a job keeps NONE. Defense-in-
+        // depth behind the EffectMap job-scoped stamp condition (which is the primary control).
+        val jobAlreadyReceipted = ctx != null && p.jobId in ctx.receiptedJobIds
+        val useOfferShare = !suspectFullReceipt &&
+            p.dropRealizedPay == null && p.totalPay == null &&
+            p.offerPayShare != null && !jobAlreadyReceipted
+
         // Pay + basis. dropRealizedPay is a per-drop share (possibly of a multi-drop receipt);
-        // its absence with a bare totalPay means the whole receipt landed on this one drop.
-        val realizedPay = if (suspectFullReceipt) null else p.dropRealizedPay ?: p.totalPay
+        // its absence with a bare totalPay means the whole receipt landed on this one drop. With
+        // neither, the #691 offer-pay estimate is the fallback before NONE.
+        val realizedPay = when {
+            suspectFullReceipt -> null
+            p.dropRealizedPay != null -> p.dropRealizedPay
+            p.totalPay != null -> p.totalPay
+            useOfferShare -> p.offerPayShare
+            else -> null
+        }
         val payBasis = when {
             suspectFullReceipt -> PayBasis.SUSPECT_FULL_RECEIPT
             p.dropRealizedPay != null -> PayBasis.DROP_SHARE
             p.totalPay != null -> PayBasis.RECEIPT_TOTAL
+            useOfferShare -> PayBasis.OFFER_PAY
             else -> PayBasis.NONE
         }
         // tip/basePay only when this drop IS the job's sole drop — i.e. it carries the WHOLE receipt.
@@ -439,9 +469,13 @@ object RecordFolds {
             costBasis = costBasis,
         )
 
+        // #691: mark the job receipted once any drop folds real receipt pay, so a later receipt-less
+        // sibling of the same job is denied the offer-pay estimate (the mixed-receipt guard above).
+        val jobReceipted = payBasis == PayBasis.DROP_SHARE || payBasis == PayBasis.RECEIPT_TOTAL
         val newCtx = ctx?.copy(
             deliveries = ctx.deliveries + 1,
             deliveredJobIds = ctx.deliveredJobIds + p.jobId,
+            receiptedJobIds = if (jobReceipted) ctx.receiptedJobIds + p.jobId else ctx.receiptedJobIds,
             // Advance the miles anchor only when this drop had an odometer, so a null-odometer drop
             // folds its miles into the next drop instead of resetting the partition; the time anchor
             // always advances (time is always known).

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/SessionFoldContext.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/SessionFoldContext.kt
@@ -39,6 +39,16 @@ data class SessionFoldContext(
     val deliveries: Int = 0,
     /** Distinct delivered jobIds — [jobsCompleted] is its size (counts a stacked job once). */
     val deliveredJobIds: Set<String> = emptySet(),
+    /**
+     * Distinct jobIds that have folded ≥1 drop with **receipt-derived** pay (`DROP_SHARE` /
+     * `RECEIPT_TOTAL`) this session — the #691 mixed-receipt guard. A receipt-less drop of such a job
+     * keeps `PayBasis.NONE` rather than stamping an offer-pay estimate (an equal split of the offer
+     * total assumes the WHOLE job is receipt-less; mixing a real receipt with offer-share estimates
+     * would over-count invisibly under the one-sided `MAX(reported − Σ, 0)` unattributed floor). This
+     * is fold-side defense-in-depth — the EffectMap job-scoped stamp condition is the primary control.
+     * NOT populated by `USER_CORRECTED` (a documented hydration wrinkle, #691 VET F1).
+     */
+    val receiptedJobIds: Set<String> = emptySet(),
     /** Partition anchor: odometer at the previous completion; null ⇒ fall back to [startOdometer]. */
     val prevDropOdometer: Double? = null,
     /** Partition anchor: time at the previous completion; null ⇒ fall back to [startedAt]. */

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/payload/AppEventPayloads.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/payload/AppEventPayloads.kt
@@ -127,6 +127,19 @@ data class DeliveryPayload(
      * [cloud.trotter.dashbuddy.domain.state.DropPayApportioner].
      */
     val dropRealizedPay: Double? = null,
+    /**
+     * This drop's equal-split share of the job's accepted-offer pay (#691) — an ESTIMATE, stamped
+     * ONLY when the closing job was WHOLLY receipt-less (no receipt dollars anywhere on it) AND this
+     * drop's own receipt inputs are absent, so a receipt-less shop delivery folds a real net row
+     * instead of a $0-unattributed one. The platform's true per-drop split is unknowable without a
+     * receipt, so the whole job's offer total is divided equally across its owed dropoffs
+     * ([cloud.trotter.dashbuddy.domain.state.DropPayApportioner.equalSplit], cents-exact
+     * remainder-to-last). Null on any receipted mint, on a pay-less offer, and on all pre-#691 events
+     * (nullable-with-default → old rows deserialize identically → the fold reproduces today's
+     * `PayBasis.NONE` rows byte-for-byte, no `PROJECTOR_VERSION` bump). Consumed by the fold only as
+     * `PayBasis.OFFER_PAY` and only when no sibling drop of this job already folded a real receipt.
+     */
+    val offerPayShare: Double? = null,
     /** Session running total at the moment of completion. */
     val sessionEarningsAtCompletion: Double? = null,
 ) : AppEventPayload

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/DropPayApportioner.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/DropPayApportioner.kt
@@ -66,8 +66,51 @@ object DropPayApportioner {
             drops.associate { it.taskId to evenShare }
         }
 
-        // Reconcile to integer cents so the shares sum EXACTLY to the receipt total; the rounding
-        // remainder goes to the last drop.
+        return reconcileToCents(drops, rawShares, totalCents)
+    }
+
+    /**
+     * An **equal split of a bare total** across the job's dropoffs (#691) — the offer-pay fallback
+     * for a wholly receipt-less job (a DoorDash shop order shows NO per-delivery receipt; pay exists
+     * only on the accepted offer + the running dash total). Unlike [apportion], which deliberately
+     * refuses to split a bare [ParsedPay]-less total, this splits an ESTIMATE ([Job.offerPayTotal],
+     * the accepted-offer guaranteed pay) equally: the platform's actual per-drop split is unknowable
+     * without a receipt, so the honest estimate is the offer total divided evenly.
+     *
+     * Reuses the SAME cents-exact remainder-to-last invariant as [apportion] ([reconcileToCents]), so
+     * the emitted shares sum EXACTLY to [total] in integer cents and no drop double-counts.
+     *
+     * Returns an **empty map** when [total] is null, ≤ 0, or [dropoffTasks] is empty — a pay-less
+     * offer (or a partial-null stack that summed to null) must not stamp $0 estimate rows. The caller
+     * records `null` per drop → the fold keeps `PayBasis.NONE` for those completions.
+     *
+     * [dropoffTasks] is the job's OWN owed-dropoff set (deduped by `taskId`); the denominator and the
+     * shares are derived from it.
+     */
+    fun equalSplit(total: Double?, dropoffTasks: List<Task>): Map<String, Double> {
+        if (total == null || total <= 0.0) return emptyMap()
+        val drops = dropoffTasks.distinctBy { it.taskId }
+        if (drops.isEmpty()) return emptyMap()
+
+        val totalCents = toCents(total)
+        if (drops.size == 1) {
+            return mapOf(drops.first().taskId to totalCents / 100.0)
+        }
+        val evenShare = total / drops.size
+        val rawShares = drops.associate { it.taskId to evenShare }
+        return reconcileToCents(drops, rawShares, totalCents)
+    }
+
+    /**
+     * Reconcile per-drop raw (double) shares to integer cents so they sum EXACTLY to [totalCents];
+     * the rounding remainder is assigned to the LAST drop. The one splitting invariant shared by
+     * [apportion] (tip-matched or even receipt split) and [equalSplit] (offer-pay estimate split).
+     */
+    private fun reconcileToCents(
+        drops: List<Task>,
+        rawShares: Map<String, Double>,
+        totalCents: Long,
+    ): Map<String, Double> {
         val result = LinkedHashMap<String, Double>(drops.size)
         var assigned = 0L
         drops.forEachIndexed { index, drop ->

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/Job.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/Job.kt
@@ -48,6 +48,17 @@ data class Job(
     /** Total accepted gross pay across all offers in this job. */
     val totalPayAmount: Double get() = acceptedOffers.sumOf { it.payAmount ?: 0.0 }
 
+    /**
+     * Nullable total accepted gross pay — the numerator for the #691 offer-pay fallback estimate
+     * (an equal split across the job's receipt-less drops). Unlike [totalPayAmount], which floors a
+     * missing per-offer pay at 0.0, this returns null when NO offer carried a pay amount (a pay-less
+     * offer must not stamp $0 estimate rows) and honestly UNDER-counts a partial-null stack (an
+     * add-on with no captured pay contributes nothing). Follows the [blendedNetPay] nullability
+     * precedent. Do not conflate with [totalPayAmount]; the live task-card economics still use that.
+     */
+    val offerPayTotal: Double?
+        get() = acceptedOffers.mapNotNull { it.payAmount }.takeIf { it.isNotEmpty() }?.sum()
+
     /** Total accepted net pay (after operating costs) across all offers. */
     val totalNetPay: Double get() = acceptedOffers.sumOf { it.netPay ?: 0.0 }
 

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/OfferPayFallback.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/OfferPayFallback.kt
@@ -1,0 +1,74 @@
+package cloud.trotter.dashbuddy.domain.state
+
+/**
+ * The pure eligibility + share policy for the #691 offer-pay fallback estimate — the write-side
+ * decision of whether (and how much of) a job's accepted-offer pay to stamp on a receipt-less
+ * completion so it folds a real net row instead of a $0-unattributed one.
+ *
+ * Extracted out of `EffectMap` (which was already past the oversized bar) so the policy lives next
+ * to its sibling [DropPayApportioner] in `:domain` and is unit-testable without the state machine.
+ * `EffectMap` keeps a thin call: it computes the two region-derived inputs it alone can see — the
+ * receipt-evidence verdict ([suppressedByReceipt], from the job-scoped pay-bearing `PostTaskFields`)
+ * and, per mint site, whether a final-shape gate applies — and hands them here.
+ *
+ * Pure and side-effect-free; derives only from the passed records. No wall clock, no logging (the
+ * caller owns the observability WARN, #691 FIX 6).
+ */
+object OfferPayFallback {
+
+    /**
+     * The outcome of a fallback decision.
+     *
+     * @property share the drop's dollars, or null when no estimate is stamped.
+     * @property eligibleButUnsplit true when every eligibility gate passed (a receipt-less,
+     *   final-shape job) yet the equal split produced NO share for this drop — a pay-less offer
+     *   ([Job.offerPayTotal] null) or a minting task absent from the job's owed dropoff set. The
+     *   caller logs ONE PII-safe WARN on this (the silent-denominator-miss observability seam), so
+     *   the quoted>delivered halving / pay-less-offer classes are visible instead of silent.
+     */
+    data class Result(val share: Double?, val eligibleButUnsplit: Boolean)
+
+    private val NONE = Result(share = null, eligibleButUnsplit = false)
+
+    /**
+     * The fallback share for [mintingTaskId] of [job].
+     *
+     * @param job the closing/exiting job.
+     * @param mintingTaskId the dropoff being completed at this mint.
+     * @param suppressedByReceipt the receipt-evidence verdict: the job showed a PAY-BEARING receipt
+     *   attributable to itself → NOT eligible (a real receipt is truth; an estimate would over-count
+     *   under the read-side MAX-floored reconciliation). Computed at the region edge.
+     * @param requireFinalShape when true (the PostTask-exit mint, whose job may still be open), stamp
+     *   ONLY if [mintingTaskId] is the LAST OPEN owed dropoff — i.e. every OTHER dropoff of the job
+     *   has already completed. This kills the estimate-then-late-receipt over-count, add-on drift,
+     *   and cents-drift-across-mints: a mid-stack pay-less exit stays unstamped (→ `NONE` forever, its
+     *   dollars ride the unattributed bucket — the class got nothing pre-#691 either, no regression).
+     *   The #596 close-out mint passes false: the job is already closed, so its shape is final.
+     */
+    fun shareFor(
+        job: Job,
+        mintingTaskId: String,
+        suppressedByReceipt: Boolean,
+        requireFinalShape: Boolean,
+    ): Result {
+        if (suppressedByReceipt) return NONE
+
+        // The denominator is the job's OWN owed dropoff set (deduped) — NOT the identity-filtered
+        // mint denominator, which shrinks at a mid-stack exit and would hand one drop the full total.
+        val ownDropoffs = job.tasks
+            .filter { it.phase == TaskPhase.DROPOFF }
+            .distinctBy { it.taskId }
+
+        if (requireFinalShape) {
+            val everyOtherDropDone = ownDropoffs
+                .filter { it.taskId != mintingTaskId }
+                .all { it.completedAt != null }
+            if (!everyOtherDropDone) return NONE // mid-stack exit — not the last open owed drop
+        }
+
+        val share = DropPayApportioner.equalSplit(job.offerPayTotal, ownDropoffs)[mintingTaskId]
+        // Eligible (all gates passed) but the split yielded nothing: pay-less offer or a minting task
+        // outside the owed set. Surface it (FIX 6) rather than silently dropping the estimate.
+        return Result(share = share, eligibleButUnsplit = share == null)
+    }
+}

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/RecordFoldsTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/RecordFoldsTest.kt
@@ -105,6 +105,7 @@ class RecordFoldsTest {
         totalPay: Double? = null,
         dropRealizedPay: Double? = null,
         parsedPay: ParsedPay? = null,
+        offerPayShare: Double? = null,
         odo: Double? = null,
         phaseStartedAt: Long = at - 600_000,
         // Identity-bearing by default (a real delivered drop). A #498/#653 phantom payload has
@@ -118,6 +119,7 @@ class RecordFoldsTest {
             addressHash = if (identityLess) null else "addr-$taskId",
             phaseStartedAt = phaseStartedAt, arrivedAt = at - 120_000, completedAt = at,
             totalPay = totalPay, parsedPay = parsedPay, dropRealizedPay = dropRealizedPay,
+            offerPayShare = offerPayShare,
         ),
         odometer = odo,
     )
@@ -593,6 +595,148 @@ class RecordFoldsTest {
         )
         assertEquals("real platform from DASH_START is preserved", Platform.DoorDash, outcomes.last().context!!.platform)
         assertEquals(Platform.DoorDash, ctx!!.platform)
+    }
+
+    // ── #691 offer-pay fallback for receipt-less completions ─────────────
+
+    @Test
+    fun `a receipt-less drop with an offer-pay share folds OFFER_PAY with a real net`() {
+        val s = "OP1"
+        // A wholly receipt-less shop delivery: no dropRealizedPay, no totalPay, no parsedPay — just
+        // the write-side offer-pay estimate. Folds OFFER_PAY with net computed against the frozen cpm.
+        val (outcomes, ctx) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 100.0),
+                offerAccepted(s, 2_000, "h1", eval(net = 9.0, dist = 3.0, opCpm = 0.25)),
+                delivery(s, 3_000, "J1", "T1", offerPayShare = 12.95, odo = 105.0),
+            ),
+        )
+        val d = outcomes[2].delivery!!
+        assertEquals(PayBasis.OFFER_PAY, d.payBasis)
+        assertEquals(12.95, d.realizedPay!!, 1e-9)
+        assertNull("no itemization on an offer-pay estimate", d.tip)
+        assertNull(d.basePay)
+        assertEquals(CostBasis.OFFER_FROZEN, d.costBasis)
+        assertEquals("net = pay − miles × cpm (5 mi × 0.25)", 12.95 - 5.0 * 0.25, d.netProfit!!, 1e-9)
+        assertEquals("offer-pay is NOT a receipt — job stays unreceipted", emptySet<String>(), ctx!!.receiptedJobIds)
+    }
+
+    @Test
+    fun `precedence — a real receipt beats an offer-pay share on the same drop`() {
+        val s = "OP2"
+        // Even if a stray offerPayShare is present, dropRealizedPay/totalPay win (a receipt is truth).
+        val (dropShareOut, _) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 0.0),
+                delivery(s, 3_000, "J1", "T1", dropRealizedPay = 7.0, offerPayShare = 99.0, odo = 4.0),
+            ),
+        )
+        val d1 = dropShareOut[1].delivery!!
+        assertEquals(PayBasis.DROP_SHARE, d1.payBasis)
+        assertEquals(7.0, d1.realizedPay!!, 1e-9)
+
+        val (totalOut, _) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 0.0),
+                delivery(s, 3_000, "J2", "T2", totalPay = 11.0, offerPayShare = 99.0, odo = 4.0),
+            ),
+        )
+        val d2 = totalOut[1].delivery!!
+        assertEquals(PayBasis.RECEIPT_TOTAL, d2.payBasis)
+        assertEquals(11.0, d2.realizedPay!!, 1e-9)
+    }
+
+    @Test
+    fun `mixed-receipt guard — a receipt-first sibling denies OFFER_PAY to the later receipt-less drop`() {
+        val s = "OP3"
+        // Drop 1 of J1 folds a real receipt → the job is marked receipted. Drop 2 of J1 is
+        // receipt-less but carries an offer-pay share: the guard keeps it NONE (mixing a real
+        // receipt with an offer-total estimate would over-count under the MAX-floored reconciliation).
+        val (outcomes, ctx) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 0.0),
+                delivery(s, 2_000, "J1", "T1", dropRealizedPay = 6.0, parsedPay = parsedPay(4.0, 2.0), odo = 4.0),
+                delivery(s, 3_000, "J1", "T2", offerPayShare = 6.48, odo = 8.0),
+            ),
+        )
+        val d2 = outcomes[2].delivery!!
+        assertEquals("sibling already receipted ⇒ no offer-pay estimate", PayBasis.NONE, d2.payBasis)
+        assertNull(d2.realizedPay)
+        assertEquals(setOf("J1"), ctx!!.receiptedJobIds)
+    }
+
+    @Test
+    fun `mixed-receipt guard — offer-pay first, then a receipt sibling — the documented reverse order stands`() {
+        val s = "OP4"
+        // The reverse order: an offer-pay drop folds first (job not yet receipted → OFFER_PAY), then a
+        // receipt drop of the same job arrives. Per-task events are immutable — the offer-pay row is
+        // NOT retroactively unwound; the receipt drop uses its own receipt. Documented residual.
+        val (outcomes, ctx) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 0.0),
+                delivery(s, 2_000, "J1", "T1", offerPayShare = 6.48, odo = 4.0),
+                delivery(s, 3_000, "J1", "T2", dropRealizedPay = 6.0, parsedPay = parsedPay(4.0, 2.0), odo = 8.0),
+            ),
+        )
+        assertEquals(PayBasis.OFFER_PAY, outcomes[1].delivery!!.payBasis)
+        assertEquals(PayBasis.DROP_SHARE, outcomes[2].delivery!!.payBasis)
+        assertEquals("the receipt drop still marks the job receipted", setOf("J1"), ctx!!.receiptedJobIds)
+    }
+
+    @Test
+    fun `a suspect full-receipt still wins over an offer-pay share`() {
+        val s = "OP5"
+        // The #653 suspect check is evaluated first and unchanged: an identity-less phantom full
+        // receipt on an already-delivered job is SUSPECT even if an offerPayShare is present.
+        val (outcomes, _) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 0.0),
+                delivery(s, 2_000, "J1", "T1", dropRealizedPay = 10.0, parsedPay = parsedPay(7.0, 3.0), odo = 4.0),
+                delivery(s, 3_000, "J1", "T2", totalPay = 10.0, parsedPay = parsedPay(7.0, 3.0), offerPayShare = 5.0, odo = 5.0, identityLess = true),
+            ),
+        )
+        val phantom = outcomes[2].delivery!!
+        assertEquals(PayBasis.SUSPECT_FULL_RECEIPT, phantom.payBasis)
+        assertNull(phantom.realizedPay)
+    }
+
+    @Test
+    fun `a receipt-less drop with NO offer-pay share stays NONE — old payloads refold byte-identically`() {
+        val s = "OP6"
+        // A pre-#691 event carries no offerPayShare (deserializes null) → the fold reproduces today's
+        // NONE row exactly. This is the rebuild-faithful, no-PROJECTOR_VERSION-bump guarantee.
+        val (outcomes, _) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 0.0),
+                delivery(s, 3_000, "J1", "T1", odo = 4.0),
+            ),
+            currentCpm = 0.30,
+        )
+        val d = outcomes[1].delivery!!
+        assertEquals(PayBasis.NONE, d.payBasis)
+        assertNull(d.realizedPay)
+        assertNull("no pay ⇒ no net even with a cpm", d.netProfit)
+    }
+
+    @Test
+    fun `an OFFER_PAY drop with null miles gets null net but still shrinks unattributed (machine semantics)`() {
+        val s = "OP7"
+        // VET item E: a receipt-less drop with a valid offer-pay share but NO odometer → realizedMiles
+        // is null → netProfit is null (machine semantics, the #660-family null-net seam, deliberately
+        // not widened), while realizedPay is still set so period unattributedPay shrinks. Asserted so
+        // the choice is pinned.
+        val (outcomes, _) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 100.0),
+                offerAccepted(s, 2_000, "h1", eval(net = 9.0, dist = 3.0, opCpm = 0.25)),
+                delivery(s, 3_000, "J1", "T1", offerPayShare = 12.95, odo = null),
+            ),
+        )
+        val d = outcomes[2].delivery!!
+        assertEquals(PayBasis.OFFER_PAY, d.payBasis)
+        assertEquals(12.95, d.realizedPay!!, 1e-9)
+        assertNull("null miles ⇒ null net (machine semantics)", d.netProfit)
+        assertNull(d.realizedMiles)
     }
 
     // ── User corrections (#650) ─────────────────────────────────────────

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/RecordFoldsTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/RecordFoldsTest.kt
@@ -739,6 +739,73 @@ class RecordFoldsTest {
         assertNull(d.realizedMiles)
     }
 
+    @Test
+    fun `a stamped estimate on a 0-coerced pseudo-receipt folds OFFER_PAY, not RECEIPT_TOTAL 0-dollars (#691 FIX2)`() {
+        val s = "OP8"
+        // A transient delivery_summary_collapsed frame coerces totalPay to 0.0 (buildPostTask ?: 0.0)
+        // — a pseudo-receipt. With an offer-pay stamp present, OFFER_PAY must win over a $0.00
+        // RECEIPT_TOTAL (the estimate is not silenced by a non-pay-bearing total).
+        val (outcomes, _) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 0.0),
+                delivery(s, 3_000, "J1", "T1", totalPay = 0.0, offerPayShare = 6.48, odo = 4.0),
+            ),
+        )
+        val d = outcomes[1].delivery!!
+        assertEquals(PayBasis.OFFER_PAY, d.payBasis)
+        assertEquals(6.48, d.realizedPay!!, 1e-9)
+    }
+
+    @Test
+    fun `a 0-coerced pseudo-receipt with NO stamp still folds RECEIPT_TOTAL 0-dollars (no-bump residual, #691 FIX2)`() {
+        val s = "OP9"
+        // The no-PROJECTOR_VERSION-bump guarantee: an un-stamped $0-coerced total is INDISTINGUISHABLE
+        // from a historical $0 RECEIPT_TOTAL row (offerPayShare is null on both), so it must refold to
+        // RECEIPT_TOTAL $0.00 byte-for-byte. The residual $0-pseudo-receipt rides to #703 (v11).
+        val (outcomes, _) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 0.0),
+                delivery(s, 3_000, "J1", "T1", totalPay = 0.0, odo = 4.0),
+            ),
+        )
+        val d = outcomes[1].delivery!!
+        assertEquals(PayBasis.RECEIPT_TOTAL, d.payBasis)
+        assertEquals(0.0, d.realizedPay!!, 1e-9)
+    }
+
+    @Test
+    fun `a SUSPECT full-receipt sibling marks the job receipted and denies OFFER_PAY (#691 FIX3)`() {
+        val s = "OP10"
+        // T1: a normal delivered drop of J1 (adds J1 to deliveredJobIds, NONE pay). T2: an identity-less
+        // phantom full receipt of J1 → SUSPECT_FULL_RECEIPT (money nulled) — but the receipt HAPPENED,
+        // so J1 is now receipt-bearing. T3: a receipt-less offer-share sibling of J1 must be DENIED.
+        val (outcomes, ctx) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 0.0),
+                delivery(s, 2_000, "J1", "T1", odo = 4.0),
+                delivery(s, 2_500, "J1", "T2", totalPay = 10.0, parsedPay = parsedPay(7.0, 3.0), odo = 5.0, identityLess = true),
+                delivery(s, 3_000, "J1", "T3", offerPayShare = 6.0, odo = 6.0),
+            ),
+        )
+        assertEquals(PayBasis.SUSPECT_FULL_RECEIPT, outcomes[2].delivery!!.payBasis)
+        assertEquals("SUSPECT proves a receipt existed → job receipted", setOf("J1"), ctx!!.receiptedJobIds)
+        assertEquals("offer-share sibling denied by the SUSPECT-armed guard", PayBasis.NONE, outcomes[3].delivery!!.payBasis)
+    }
+
+    @Test
+    fun `offer-pay fails CLOSED with no session context — NONE, not an estimate (#691 FIX4)`() {
+        // A session-less DELIVERY_COMPLETED carrying an offer-pay share resolves no context, so the
+        // mixed-receipt guard cannot be consulted → the estimate is withheld (degraded-context
+        // under-count direction, never over-count).
+        val out = RecordFolds.foldEvent(
+            delivery(sid = null, at = 2_000, jobId = "J1", taskId = "T1", offerPayShare = 6.48, odo = 4.0),
+            context = null,
+            currentCostPerMile = 0.25,
+        )
+        assertEquals(PayBasis.NONE, out.delivery!!.payBasis)
+        assertNull(out.delivery!!.realizedPay)
+    }
+
     // ── User corrections (#650) ─────────────────────────────────────────
 
     private fun manualDelivery(

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/state/DropPayApportionerTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/state/DropPayApportionerTest.kt
@@ -148,4 +148,51 @@ class DropPayApportionerTest {
         val shares = DropPayApportioner.apportion(receipt, drops)
         assertSumsToReceipt(shares, receipt)
     }
+
+    // ── #691 equalSplit: the offer-pay fallback for a wholly receipt-less job ──
+
+    @Test
+    fun `equalSplit — two drops, cents-exact remainder to last`() {
+        // Offer total $12.95 over 2 drops: 6.475 → toCents rounds first to 648, remainder 647 last.
+        val drops = listOf(drop("d1", "H-E-B"), drop("d2", "H-E-B"))
+        val shares = DropPayApportioner.equalSplit(12.95, drops)
+        assertEquals(6.48, shares.getValue("d1"), 0.0001)
+        assertEquals(6.47, shares.getValue("d2"), 0.0001)
+        assertEquals("shares sum EXACTLY to the offer total", 1295L, shares.values.sumOf { cents(it) })
+    }
+
+    @Test
+    fun `equalSplit — single drop takes the whole offer total`() {
+        val shares = DropPayApportioner.equalSplit(26.50, listOf(drop("d1", "Target")))
+        assertEquals(26.50, shares.getValue("d1"), 0.0001)
+    }
+
+    @Test
+    fun `equalSplit — empty denominator yields empty map`() {
+        assertTrue(DropPayApportioner.equalSplit(12.95, emptyList()).isEmpty())
+    }
+
+    @Test
+    fun `equalSplit — null total yields empty map`() {
+        assertTrue(DropPayApportioner.equalSplit(null, listOf(drop("d1", "H-E-B"))).isEmpty())
+    }
+
+    @Test
+    fun `equalSplit — zero total yields empty map`() {
+        assertTrue(DropPayApportioner.equalSplit(0.0, listOf(drop("d1", "H-E-B"))).isEmpty())
+    }
+
+    @Test
+    fun `equalSplit — negative total yields empty map`() {
+        assertTrue(DropPayApportioner.equalSplit(-5.0, listOf(drop("d1", "H-E-B"))).isEmpty())
+    }
+
+    @Test
+    fun `equalSplit — dedupes drops by taskId`() {
+        // A duplicated task id must not inflate the denominator.
+        val drops = listOf(drop("d1", "H-E-B"), drop("d1", "H-E-B"), drop("d2", "H-E-B"))
+        val shares = DropPayApportioner.equalSplit(9.00, drops)
+        assertEquals(2, shares.size)
+        assertEquals(900L, shares.values.sumOf { cents(it) })
+    }
 }

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/state/OfferPayFallbackTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/state/OfferPayFallbackTest.kt
@@ -1,0 +1,69 @@
+package cloud.trotter.dashbuddy.domain.state
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** #691 — the pure eligibility + share policy extracted out of EffectMap (FIX 5). */
+class OfferPayFallbackTest {
+
+    private fun drop(id: String, completedAt: Long?) = Task(
+        taskId = id, jobId = "J", phase = TaskPhase.DROPOFF,
+        customerNameHash = "c-$id", startedAt = 100L, completedAt = completedAt,
+    )
+
+    private fun job(offerPay: Double?, tasks: List<Task>) = Job(
+        jobId = "J", offerStoreHint = emptyList(), parentOfferHash = null,
+        acceptedOffers = listOf(AcceptedOfferEconomics(offerHash = "h", payAmount = offerPay, acceptedAt = 50L)),
+        tasks = tasks, startedAt = 50L,
+    )
+
+    @Test
+    fun `a receipt suppresses the estimate entirely`() {
+        val j = job(12.95, listOf(drop("d1", 400L)))
+        val r = OfferPayFallback.shareFor(j, "d1", suppressedByReceipt = true, requireFinalShape = false)
+        assertNull(r.share)
+        assertFalse("suppressed is not an unsplit-miss", r.eligibleButUnsplit)
+    }
+
+    @Test
+    fun `final-shape gate blocks a mid-stack drop and stamps the last open drop`() {
+        val j = job(12.95, listOf(drop("d1", null), drop("d2", null)))
+        // d1 minting while d2 still owed → not final shape → no stamp.
+        val mid = OfferPayFallback.shareFor(j, "d1", suppressedByReceipt = false, requireFinalShape = true)
+        assertNull("mid-stack → no stamp", mid.share)
+        assertFalse(mid.eligibleButUnsplit)
+
+        // d2 is the last open owed drop once d1 completed.
+        val j2 = job(12.95, listOf(drop("d1", 380L), drop("d2", null)))
+        val last = OfferPayFallback.shareFor(j2, "d2", suppressedByReceipt = false, requireFinalShape = true)
+        assertEquals(6.47, last.share!!, 1e-9)
+    }
+
+    @Test
+    fun `close-out (no final-shape requirement) stamps every owed drop's equal share`() {
+        val j = job(12.95, listOf(drop("d1", 400L), drop("d2", 410L)))
+        val a = OfferPayFallback.shareFor(j, "d1", suppressedByReceipt = false, requireFinalShape = false)
+        val b = OfferPayFallback.shareFor(j, "d2", suppressedByReceipt = false, requireFinalShape = false)
+        assertEquals(6.48, a.share!!, 1e-9)
+        assertEquals(6.47, b.share!!, 1e-9)
+    }
+
+    @Test
+    fun `a pay-less offer is eligible-but-unsplit (the WARN signal)`() {
+        val j = job(offerPay = null, tasks = listOf(drop("d1", 400L)))
+        val r = OfferPayFallback.shareFor(j, "d1", suppressedByReceipt = false, requireFinalShape = false)
+        assertNull(r.share)
+        assertTrue("eligible but the split yielded nothing", r.eligibleButUnsplit)
+    }
+
+    @Test
+    fun `a minting task outside the owed set is eligible-but-unsplit`() {
+        val j = job(12.95, listOf(drop("d1", 400L)))
+        val r = OfferPayFallback.shareFor(j, "ghost", suppressedByReceipt = false, requireFinalShape = false)
+        assertNull(r.share)
+        assertTrue(r.eligibleButUnsplit)
+    }
+}


### PR DESCRIPTION
## What & why

DoorDash shows **no per-delivery receipt for shop orders** — the pay exists only on the accepted **offer** and the running dash total. So a receipt-less shop delivery folds a `PayBasis.NONE` row today: it contributes **$0** to `Σ realizedPay` and its dollars only surface one-sidedly via the `MAX(reported − Σ, 0)` unattributed bucket, with **no real net row**.

This adds an **`OFFER_PAY` estimate basis**: when the *whole job* was receipt-less, each owed drop's completion is stamped with an equal-split share of the accepted-offer pay, and the fold produces a real net row (pay − mileage cost). A later receipt never double-counts — a per-job mixed-receipt guard denies the estimate to any job that folded a real receipt.

### Field grounding (07-05 dash)
- $39.45 / ~60% of that dash's pay was receipt-less shop work landing as `$0`-unattributed.
- The offer `payAmount` == the receipt totals **to the cent** on every receipted drop that day (31.27, 33.75; corrected solo 26.50; corrected stack 7.60+5.35 = 12.95) — so the accepted-offer total is a well-calibrated estimate of realized pay, and an equal split is the honest per-drop apportionment when no receipt exists.
- Counter-fixture: an accepted offer (seq 53, $24.25) that never delivered must produce **no row, no dollars** — structurally satisfied (the stamp fires only inside a completion mint).

## How (milestones)

- **M1 `:domain`** — `PayBasis.OFFER_PAY`; `DeliveryPayload.offerPayShare` (nullable-with-default); `DropPayApportioner.equalSplit(total, dropoffTasks)` reusing the extracted cents-exact remainder-to-last invariant; `Job.offerPayTotal` (nullable, `blendedNetPay` precedent — `totalPayAmount` untouched).
- **M2 `:domain` fold** — precedence `dropRealizedPay -> totalPay -> offerPayShare -> NONE` (suspect check unchanged and first); `SessionFoldContext.receiptedJobIds` mixed-receipt guard; tip/base stay null; net computes normally.
- **M3 `:core:state`** — `EffectMap` stamps `offerPayShare` at both mint sites, gated on the **job-scoped** W1-a condition (job showed no post-task receipt at all) with the **W1-c** owed-dropoff-set denominator (`Job.tasks`, not the identity-filtered mint denominator) and the **W1-b** nullable numerator.
- **M4 `:core:data`** — `AnalyticsDao.receiptedJobIdsInSession` hydrated into `hydrate()`/`toContext()` so the guard survives a drain/batch boundary; multi-batch projector test asserts live-order == from-zero refold.
- **M5 read-model + `:app`** — `DeliveryRecord.payBasis` + mapper; `SessionDetailScreen` "est. offer pay" qualifier on `OFFER_PAY` rows; CSV exports `pay_basis` verbatim.
- **M6 docs** — CLAUDE.md §5 payBasis sentence; field-test checklist item.

**No schema change.** `payBasis` is a string column; `OFFER_PAY` is a new value; v10 stands. **No `PROJECTOR_VERSION` bump** — pre-#691 events lack `offerPayShare` (deserialize null) -> the fold reproduces today's `NONE` rows byte-for-byte (asserted).

## Security / privacy posture

No new PII and no network. `offerPayShare` is a dollar figure derived from the driver's own accepted-offer economics (already in the event log); the split is over identity-bearing/owed task ids only. The estimate is **never silent** — disclosed via the `OFFER_PAY` basis in both the drill-down UI ("est. offer pay") and the CSV `pay_basis` column (the #689 precedent). The untrusted-input boundaries (recognition, capture, effects actuation) are untouched.

### Design-goal review

- **1 (UDF / purity).** The fold and `EffectMap` stamp are pure — `obs.timestamp` only, no wall clock, no IO; `offerPayShareFor` derives solely from region records. Projector exactly-once preserved (records + watermark in one `db.withTransaction`).
- **5 (SSOT).** The split invariant is extracted (`DropPayApportioner.reconcileToCents`) and shared by `apportion` (receipt) and `equalSplit` (offer estimate) — one splitting owner, not a re-implemented copy. `PayBasis`/`CostBasis` remain the fold's provenance SSOT.
- **6 (security & privacy).** Estimate honesty disclosed at every read surface; no plaintext/PII added; fail-soft (null numerator/denominator -> no stamp, no $0 row).
- **8 (platform-agnostic core).** No platform literals added. `OFFER_PAY` goes through the enumerated `PayBasis` contract, not a magic string in a `when` on a platform; the write-side condition keys off region state, not `== Platform.DoorDash`. The DoorDash-shop framing lives only in comments/docs.

### Named residuals (from the fable design + VET)

- **W1-d — phantom add-on economics.** A vanished accepted add-on offer now becomes visible costed dollars split across real drops, and the one-sided `MAX(reported − Σ, 0)` floors any over-count silently. **Follow-up to file:** surface the raw negative `reported − Σ` in the Money-tab callout instead of MAX-flooring (a read-side over-attribution flag).
- **USER_CORRECTED hydration wrinkle.** `receiptedJobIdsInSession` excludes `USER_CORRECTED`: an on-dash correction of an open job's receipted row *before* its sibling folds across a batch boundary is a rare divergence — documented, not fixed.
- **Session-scope seam.** The offer<->delivery link is absent in the log; cpm is session-uniform, and the offer-pay total rides in-memory `Job.acceptedOffers` at the mint site (post-#526 teardown-race-proof) — the same session-granularity basis the frozen economy already uses.
- **Null-miles net seam.** An `OFFER_PAY` row with `realizedMiles == null` gets `netProfit == null` (machine semantics, the #660-family seam, deliberately not widened) while its pay still shrinks `unattributedPay` — asserted in a test.
- **Add-on-mid-stack denominator shift.** An add-on accepted between a mid-stack stamp and close-out shifts the owed-dropoff denominator (bounded, rare) — the minted sum degrades *below* the offer total, never above.
- **Reverse mixed-receipt order.** Offer-pay drop folded, then a receipt sibling arrives later in the same job: per-task events are immutable, the receipt drop uses its own receipt, the reconciliation absorbs the delta, the driver can correct (#688) — documented, left to stand.
- **OFFER_PAY is future-only.** Historical `NONE` rows can't be backfilled (no `PROJECTOR_VERSION` bump by design); the 07-05 rows stay `USER_CORRECTED` (already hand-fixed).

Closes #691


---

## Fix round 2 — adversarial review (3 fable finders)

The pre-merge review found an interacting family rooted in per-mint share computation + a weak receipt predicate. Fixes (all in this branch, gates green: `testDebugUnitTest :domain:test` + `*AllMatchersSuite*`):

**Final-shape gate (FIX 1).** A PostTask-exit mint stamps the offer share only when the drop is the **last open owed dropoff** (every other DROPOFF task completed); the close-out mint is inherently final. Kills the CONFIRMED estimate-then-late-receipt over-count, add-on drift, cents-drift-across-mints, and the under-counted-placeholder 1.5×.
- **Traded class (no regression):** a mid-stack drop minted at a *pay-less* PostTask exit stays `NONE` forever (its event key is burned; close-out can't re-mint). That class got nothing before #691 either — its dollars ride the unattributed bucket.

**$0-pseudo-receipt fix (FIX 2a) — a regression that would have shipped.** `ParsedFieldsFactory.buildPostTask` coerces a missing total to `0.0` (`f.double("totalPay") ?: 0.0`), so a transient `delivery_summary_collapsed` frame creates a `$0.00` `PostTaskFields`. A single **pay-bearing** predicate (`totalPay > 0.0 || parsedPay != null`) now gates both (i) stamp-suppression at the two mint sites (a non-pay-bearing `$0` receipt no longer suppresses a legit estimate) and (ii) the fold (a STAMPED `$0` mint folds `OFFER_PAY`, evaluated above `RECEIPT_TOTAL`).

**Job-scoped suppression (FIX 2b).** `lastPostTaskFields` / `lastAnnouncedPostTaskTaskId` are REGION-scoped and survive `completeActiveJob` (which clears the fields but **not** the announce id), so a flickered PREVIOUS-job receipt can re-set them. Suppression is now attributed to THIS job: the announce id is in this job's tasks, OR null (fail-closed), OR not provably another job's task; a provably-foreign announce id does not suppress.

**jobReceipted SSOT + SUSPECT (FIX 3).** `PayBasis.RECEIPT_EVIDENCE = [DROP_SHARE, RECEIPT_TOTAL, SUSPECT_FULL_RECEIPT]` is the one definition both the in-fold guard and the `AnalyticsDao` hydration IN-list (compile-time-concatenated from the same `const val`s) derive from. `SUSPECT_FULL_RECEIPT` now proves a receipt existed (its money was nulled, but the receipt happened).

**Fail-closed context (FIX 4).** `OFFER_PAY` requires a non-null session context (no ctx → `NONE`), matching the suspect-check's degraded-context under-count direction.

**Policy extraction (FIX 5).** The eligibility + share logic is a pure `OfferPayFallback` object in `:domain` next to `DropPayApportioner`; `EffectMap` keeps a thin call (it was already past the oversized bar).

**Observability (FIX 6).** One PII-safe WARN (counts + jobId only, `StateMachine` tag, the #699 D6 join-miss precedent) when a drop is estimate-ELIGIBLE but gets no share (pay-less offer / task outside the owed set) — the quoted>delivered halving class is now observable.

### Uber scope disclosure (field-validate)
`uber.screen.post_trip` has **no parse** → `Flow.PostTask` with no fields → Uber deliveries (which have **no receipt rules at all**) now fold `OFFER_PAY` estimates **platform-wide**. This is the platform-agnostic mechanism working as designed (P8), but it changes Uber analytics wholesale. Field-test item added: *"Uber deliveries now show est. offer pay — sanity-check against actual Uber earnings."*

### Residuals (documented)
- **Quoted>delivered halving.** A canceled order in a stack → the sole delivered drop still gets `total/N`; the vanished drop's share rides unattributed (one-sided, below the offer total — the read-side MAX-floor tolerates it). The FIX 6 WARN surfaces the denominator miss.
- **No-bump $0 residual.** An *un-stamped* `$0`-coerced total still folds `RECEIPT_TOTAL $0.00` (indistinguishable from a historical `$0` row — `offerPayShare` is null on both), so historical rows refold **byte-identical** (no `PROJECTOR_VERSION` bump). A *stamped* `$0` mint folds `OFFER_PAY` correctly.
- **`USER_CORRECTED` hydration wrinkle.** A re-priced row loses its receipt basis for the cross-batch guard.
- Both residuals are closed by **#703** (v11 receipt-evidence persistence — a `PROJECTOR_VERSION`-bump migration).

### Verify outcomes
- **Announce-id semantics:** `lastAnnouncedPostTaskTaskId` is set alongside `lastPostTaskFields` (`updateSessionFields`, to `activeTask ?: recentTasks.last`) but **not cleared** by `completeActiveJob`/`endSession` (which clear `lastPostTaskFields`) — confirming the stale-cross-job-receipt vector FIX 2b defends.
- **$0-fold no-bump decision:** historical `$0` `RECEIPT_TOTAL` rows **are** possible in old logs (the coercion is old), so a fold-side `totalPay>0` requirement would force a bump. Reality forced the **no-bump path**: keep `RECEIPT_TOTAL` for un-stamped `totalPay==0.0`; the pay-bearing predicate acts write-side (suppression) + fold-side only to let a *stamped* `$0` fold `OFFER_PAY` (gated on `offerPayShare` presence, null on all historical rows). Verified byte-identical via `RecordFoldsTest` (un-stamped `$0` → `RECEIPT_TOTAL $0.00`).
