### PR TITLE
feat(#688 phase A): DELIVERY_ADJUSTMENT + cash tips + v11 (#703)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -307,8 +307,16 @@ recomputed** (dev decision): each `delivery_record` stores `netProfit` + `frozen
 `OfferEvaluation.operatingCostPerMile` (session granularity — the offer→delivery `jobId` link is absent in the
 log, but cpm is session-uniform), so editing economy settings only affects **future** evaluations — a record is
 an immutable historical fact. Session hydration rehydrates `started` from a persisted `session_records.startSource`
-marker (#659, retro finding 2), not the old "has a real platform" heuristic. The v9→v10 migration is
-additive-only (five nullable columns — delivery +2, offer +2, session +1; `PROJECTOR_VERSION` bump refolds them from the log). `NetProfit`
+marker (#659, retro finding 2), not the old "has a real platform" heuristic. Each `delivery_record` also
+carries `cashTip` (driver-entered cash — the tip vocabulary's driver-attested source; kept OUTSIDE
+`realizedPay`/`netProfit` and added to gross/net only at the read sites, so the reconciliation's
+Σ-attributed stays structurally cash-free, #688) and `originalPayBasis` (the payBasis stamped at FIRST fold,
+never rewritten by a correction — the #691 receipt-evidence hydration reads `COALESCE(originalPayBasis,
+payBasis)` so a re-priced `USER_CORRECTED` row keeps its original receipt evidence, #703). The v9→v10 migration is
+additive-only (five nullable columns — delivery +2, offer +2, session +1); the v10→v11 migration is likewise
+additive-only (delivery +2 — `cashTip`/`originalPayBasis`; `PROJECTOR_VERSION` 3→4 refolds them from the log,
+populating `originalPayBasis` for all history — the bump is #703's requirement, not a corrections one, and it
+also re-stamps `CURRENT_FALLBACK` rows against today's economy). `NetProfit`
 (`:domain`) is the one shared cost-math SSOT for both the offer estimate and the frozen realized net.
 `AnalyticsRepository` (`:core:data`, **DAO-only — no economy dependency**, so historical net is structurally
 immutable) serves period economics (`SUM(netProfit)` frozen + `unattributedPay`; all-pay gross =
@@ -326,8 +334,14 @@ excluded; no network. #650 corrections are now IN: the per-dash drill-down (`Ses
 re-price of an existing row → `USER_CORRECTED`, net recomputed against that row's OWN frozen cpm) via the
 write-side `CorrectionRepository`; the projector folds them non-destructively (the original event/row is never
 deleted) and rebuild-faithfully (a from-zero refold replays a correction after its target and reproduces
-identical rows — no PROJECTOR_VERSION bump needed, the new event types can't exist in already-folded history).
-Session-categorize of an unattributed remainder is deferred (#650 follow-up). Related: #653/#655.
+identical rows — the correction event types can't exist in already-folded history). #688 phase A widens the
+re-price into `DELIVERY_ADJUSTMENT` — the drill-down's tap-a-delivery / pencil opens one **Adjust delivery**
+dialog (store/pay/tip/cash-tip/miles/note) writing a single all-optional-fields event; the orchestrator
+applies each non-null field by-PK (payBasis flips to `USER_CORRECTED` **iff pay changes** so a store/tip/cash
+edit never drops an "est. offer pay" disclosure; a MANUAL row stays MANUAL; net recomputes only when pay/miles
+change, against the row's OWN frozen cpm; `originalPayBasis` preserved via `row.copy`). Legacy `PAY_ADJUSTMENT`
+stays fully readable for history; new UI writes only `DELIVERY_ADJUSTMENT`. Phase B (per-leg mileage, #688) is
+deferred. Session-categorize of an unattributed remainder is deferred (#650 follow-up). Related: #653/#655/#703.
 
 ## Development Principles
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/MoneyTab.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/MoneyTab.kt
@@ -343,8 +343,11 @@ private fun TopStoresCard(stores: List<StoreEconomics>) {
 
 /**
  * Recent dashes, newest first. Sessions don't carry a frozen net, so the money column shows the
- * platform-reported earnings (an em dash until a summary is seen). Each row is tappable → the
- * read-only per-dash drill-down ([onOpenSession], #650).
+ * platform-reported earnings (an em dash until a summary is seen), with a small "+cash" line below it
+ * when the dash has driver-entered cash tips (#688 F7) — every sibling gross surface (hero, per-day
+ * chart, drill-down) is cash-inclusive, so this keeps the recent-dashes row from showing a different
+ * gross one tap away. Cash is shown ADDITIVELY, never folded into the reported number (the label stays
+ * honest). Each row is tappable → the read-only per-dash drill-down ([onOpenSession], #650).
  */
 @Composable
 private fun RecentDashesCard(sessions: List<SessionRecord>, onOpenSession: (String) -> Unit) {
@@ -379,11 +382,21 @@ private fun RecentDashesCard(sessions: List<SessionRecord>, onOpenSession: (Stri
                     // Platform label is registry-resolved (never a literal) — Principle 8.
                     AppChip(text = session.platform.shortName.ifEmpty { session.platform.displayName })
                     Spacer(Modifier.width(10.dp))
-                    Text(
-                        text = session.reportedEarnings?.let { Formats.money(it) } ?: EMPTY_VALUE,
-                        style = AppTheme.num.smNum,
-                        color = c.text,
-                    )
+                    Column(horizontalAlignment = Alignment.End) {
+                        Text(
+                            text = session.reportedEarnings?.let { Formats.money(it) } ?: EMPTY_VALUE,
+                            style = AppTheme.num.smNum,
+                            color = c.text,
+                        )
+                        // Additive-only cash marker (#688 F7) — never folded into the reported number.
+                        if (session.cashTips > UNATTRIBUTED_EPSILON) {
+                            Text(
+                                text = "+${Formats.money(session.cashTips)} cash",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = c.good,
+                            )
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/SessionDetailScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/SessionDetailScreen.kt
@@ -377,13 +377,24 @@ private fun CenteredMessage(text: String, modifier: Modifier = Modifier) {
     }
 }
 
-/** A blank or non-blank-but-positive number parses; a non-blank invalid one does not. */
-private fun optionalMoney(text: String): Double? = text.takeIf { it.isNotBlank() }?.toDoubleOrNull()
-private fun String.isBlankOrValidMoney(): Boolean = isBlank() || (toDoubleOrNull()?.let { it > 0.0 } == true)
-private fun String.isValidMoney(): Boolean = toDoubleOrNull()?.let { it > 0.0 } == true
+/**
+ * Parse an optional numeric field (F9): blank ⇒ null (unchanged); a non-blank field ⇒ its parsed
+ * value ONLY when it is **finite** (a pasted `1e999` parses to `Infinity`, which the codec would then
+ * reject with a crash, #705 F4a) — else null. This owns ONLY finiteness + parseability; **range**
+ * validation (> 0 for money, ≥ 0 for tip/cash/miles) belongs to the `isValid*`/`isBlankOr*` checks
+ * below. Used for pay/tip/cash/miles alike (it is not money-specific), so it is deliberately un-named
+ * for money.
+ */
+private fun optionalNumber(text: String): Double? =
+    text.takeIf { it.isNotBlank() }?.toDoubleOrNull()?.takeIf { it.isFinite() }
 
-/** Blank, or a parseable non-negative number — for tip/cash/miles fields (0 is a valid entry). */
-private fun String.isBlankOrNonNegative(): Boolean = isBlank() || (toDoubleOrNull()?.let { it >= 0.0 } == true)
+/** A finite, strictly-positive money value (F4a: `isFinite` rejects a pasted `1e999`). */
+private fun String.isValidMoney(): Boolean = toDoubleOrNull()?.let { it.isFinite() && it > 0.0 } == true
+private fun String.isBlankOrValidMoney(): Boolean = isBlank() || isValidMoney()
+
+/** Blank, or a finite non-negative number — for tip/cash/miles fields (0 is a valid entry; F4a). */
+private fun String.isBlankOrNonNegative(): Boolean =
+    isBlank() || (toDoubleOrNull()?.let { it.isFinite() && it >= 0.0 } == true)
 
 /**
  * Add-a-missed-delivery dialog (#650/#688) — store (optional), pay (required, > 0), tip (optional,
@@ -420,8 +431,8 @@ private fun AddMissedDeliveryDialog(
                 onClick = {
                     onConfirm(
                         pay.toDouble(),
-                        optionalMoney(tip),
-                        optionalMoney(cashTip),
+                        optionalNumber(tip),
+                        optionalNumber(cashTip),
                         store.trim().takeIf { it.isNotBlank() },
                         note.trim().takeIf { it.isNotBlank() },
                     )
@@ -454,19 +465,27 @@ private fun AdjustDeliveryDialog(
         note: String?,
     ) -> Unit,
 ) {
-    var store by remember { mutableStateOf(target.storeName ?: "") }
-    var pay by remember { mutableStateOf(target.realizedPay?.toString() ?: "") }
-    var tip by remember { mutableStateOf(target.tip?.toString() ?: "") }
-    var cashTip by remember { mutableStateOf(target.cashTip?.toString() ?: "") }
-    var miles by remember { mutableStateOf(target.realizedMiles?.toString() ?: "") }
-    var note by remember { mutableStateOf("") }
+    // All field state is keyed on [target] (F6): a mid-edit Room re-emission that produces a DIFFERENT
+    // target snapshot re-initialises the fields from it, so the change-diff below never compares an
+    // edit against a stale prefill. An equal re-emission (data-class equality) leaves the edit intact.
+    var store by remember(target) { mutableStateOf(target.storeName ?: "") }
+    var pay by remember(target) { mutableStateOf(target.realizedPay?.toString() ?: "") }
+    var tip by remember(target) { mutableStateOf(target.tip?.toString() ?: "") }
+    var cashTip by remember(target) { mutableStateOf(target.cashTip?.toString() ?: "") }
+    var miles by remember(target) { mutableStateOf(target.realizedMiles?.toString() ?: "") }
+    var note by remember(target) { mutableStateOf("") }
 
-    // Parsed values (blank ⇒ null ⇒ unchanged).
+    // FIX 5: a SUSPECT_FULL_RECEIPT row's money was nulled as a #653 double-count guard — editing pay
+    // back onto it re-opens the double count (its siblings keep their shares). Disable the Pay field
+    // (the orchestrator also blocks it as a second gate); tip is prefilled null on such a row anyway.
+    val payLocked = target.payBasis == PayBasis.SUSPECT_FULL_RECEIPT
+
+    // Parsed values (blank ⇒ null ⇒ unchanged; F9 optionalNumber rejects a non-finite paste).
     val storeParsed = store.trim().takeIf { it.isNotBlank() }
-    val payParsed = optionalMoney(pay)
-    val tipParsed = optionalMoney(tip)
-    val cashParsed = optionalMoney(cashTip)
-    val milesParsed = optionalMoney(miles)
+    val payParsed = optionalNumber(pay)
+    val tipParsed = optionalNumber(tip)
+    val cashParsed = optionalNumber(cashTip)
+    val milesParsed = optionalNumber(miles)
     val noteParsed = note.trim().takeIf { it.isNotBlank() }
 
     // Per-field validity: pay > 0 (when present); tip/cash/miles ≥ 0 (when present).
@@ -476,8 +495,9 @@ private fun AdjustDeliveryDialog(
     val milesValid = miles.isBlankOrNonNegative()
 
     // Changed-field detection on PARSED values (prefill round-trips via toString, so an untouched
-    // field parses back equal and is not sent).
-    val storeChanged = storeParsed != null && storeParsed != target.storeName
+    // field parses back equal and is not sent). Store compares TRIMMED-vs-TRIMMED (F6) so a
+    // machine-parsed trailing-space store name doesn't ship a phantom newStoreName on a cash-only edit.
+    val storeChanged = storeParsed != null && storeParsed != (target.storeName?.trim() ?: "")
     val payChanged = payParsed != null && payParsed != target.realizedPay
     val tipChanged = tipParsed != null && tipParsed != target.tip
     val cashChanged = cashParsed != null && cashParsed != target.cashTip
@@ -492,8 +512,12 @@ private fun AdjustDeliveryDialog(
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 MoneyField(store, { store = it }, "Store name", numeric = false)
-                MoneyField(pay, { pay = it }, "Pay")
-                MoneyField(tip, { tip = it }, "Tip (included in pay)")
+                MoneyField(
+                    pay, { pay = it }, "Pay",
+                    enabled = !payLocked,
+                    supportingText = if (payLocked) "de-duplicated receipt — edit the real drop's row" else null,
+                )
+                MoneyField(tip, { tip = it }, "Tip (included in pay)", enabled = !payLocked)
                 MoneyField(cashTip, { cashTip = it }, "Cash tip")
                 MoneyField(miles, { miles = it }, "Miles")
                 MoneyField(note, { note = it }, "Note (optional)", numeric = false)
@@ -519,12 +543,21 @@ private fun AdjustDeliveryDialog(
 }
 
 @Composable
-private fun MoneyField(value: String, onValueChange: (String) -> Unit, label: String, numeric: Boolean = true) {
+private fun MoneyField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: String,
+    numeric: Boolean = true,
+    enabled: Boolean = true,
+    supportingText: String? = null,
+) {
     OutlinedTextField(
         value = value,
         onValueChange = onValueChange,
         label = { Text(label) },
         singleLine = true,
+        enabled = enabled,
+        supportingText = supportingText?.let { { Text(it) } },
         keyboardOptions = if (numeric) KeyboardOptions(keyboardType = KeyboardType.Decimal) else KeyboardOptions.Default,
         modifier = Modifier.fillMaxWidth(),
     )

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/SessionDetailScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/SessionDetailScreen.kt
@@ -1,5 +1,6 @@
 package cloud.trotter.dashbuddy.ui.main.analytics
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -91,7 +92,7 @@ fun SessionDetailScreen(
             detail != null -> DashDetailContent(
                 detail = detail,
                 onAddManualDelivery = viewModel::addManualDelivery,
-                onAdjustPay = viewModel::adjustPay,
+                onAdjustDelivery = viewModel::adjustDelivery,
                 modifier = Modifier
                     .padding(padding)
                     .verticalScroll(rememberScrollState())
@@ -109,8 +110,16 @@ fun SessionDetailScreen(
 @Composable
 private fun DashDetailContent(
     detail: SessionDetail,
-    onAddManualDelivery: (pay: Double, tip: Double?, storeName: String?, note: String?) -> Unit,
-    onAdjustPay: (targetEventSequenceId: Long, newPay: Double, note: String?) -> Unit,
+    onAddManualDelivery: (pay: Double, tip: Double?, cashTip: Double?, storeName: String?, note: String?) -> Unit,
+    onAdjustDelivery: (
+        targetEventSequenceId: Long,
+        newStoreName: String?,
+        newPay: Double?,
+        newTip: Double?,
+        newCashTip: Double?,
+        newMiles: Double?,
+        note: String?,
+    ) -> Unit,
     modifier: Modifier,
 ) {
     // Correction dialog state — hoisted here, stateless children below (Principle 1 / 3).
@@ -145,18 +154,18 @@ private fun DashDetailContent(
     if (showAddDialog) {
         AddMissedDeliveryDialog(
             onDismiss = { showAddDialog = false },
-            onConfirm = { pay, tip, store, note ->
-                onAddManualDelivery(pay, tip, store, note)
+            onConfirm = { pay, tip, cashTip, store, note ->
+                onAddManualDelivery(pay, tip, cashTip, store, note)
                 showAddDialog = false
             },
         )
     }
     adjustTarget?.let { target ->
-        AdjustPayDialog(
-            currentPay = target.realizedPay,
+        AdjustDeliveryDialog(
+            target = target,
             onDismiss = { adjustTarget = null },
-            onConfirm = { newPay, note ->
-                onAdjustPay(target.eventSequenceId, newPay, note)
+            onConfirm = { store, newPay, newTip, newCashTip, newMiles, note ->
+                onAdjustDelivery(target.eventSequenceId, store, newPay, newTip, newCashTip, newMiles, note)
                 adjustTarget = null
             },
         )
@@ -212,6 +221,16 @@ private fun HeaderCard(detail: SessionDetail) {
                 modifier = Modifier.weight(1f),
             )
         }
+        // Cash tips render as their OWN line (#688 F4) — the "Gross (reported)" tile stays cash-free
+        // (it's the platform-reported total), so cash is never silently folded into a mislabelled tile.
+        if (detail.cashTips > UNATTRIBUTED_EPSILON) {
+            Spacer(Modifier.height(6.dp))
+            Text(
+                text = "+${Formats.money(detail.cashTips)} cash tips",
+                style = MaterialTheme.typography.bodySmall,
+                color = c.good,
+            )
+        }
     }
 }
 
@@ -255,7 +274,14 @@ private fun DeliveriesCard(
 @Composable
 private fun DeliveryRow(delivery: DeliveryRecord, onAdjust: () -> Unit) {
     val c = AppTheme.colors
-    Row(verticalAlignment = Alignment.Top) {
+    // The whole row is the tap target (the dev's tap-a-delivery entry) AND the pencil opens the same
+    // edit dialog — both route to [onAdjust].
+    Row(
+        verticalAlignment = Alignment.Top,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onAdjust() },
+    ) {
         Column(Modifier.weight(1f)) {
             Text(
                 text = delivery.storeName ?: "Unknown store",
@@ -284,6 +310,14 @@ private fun DeliveryRow(delivery: DeliveryRecord, onAdjust: () -> Unit) {
                     color = c.text3,
                 )
             }
+            // Driver-entered cash tip (#688) — its own line; added to net below (display-level only).
+            delivery.cashTip?.takeIf { it > UNATTRIBUTED_EPSILON }?.let {
+                Text(
+                    text = "+${Formats.money(it)} cash",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = c.good,
+                )
+            }
             // #691: a receipt-less shop delivery's pay is an equal-split ESTIMATE of the accepted
             // offer, not a captured receipt — disclose it (never-silent, the #689 precedent).
             if (delivery.payBasis == PayBasis.OFFER_PAY) {
@@ -293,7 +327,9 @@ private fun DeliveryRow(delivery: DeliveryRecord, onAdjust: () -> Unit) {
                     color = c.text3,
                 )
             }
-            val net = delivery.netProfit
+            // Net includes the cash tip at display level only (the frozen netProfit column stays
+            // cash-free); a null-net row (no cost basis) stays an em dash even with cash present.
+            val net = delivery.netProfit?.let { it + (delivery.cashTip ?: 0.0) }
             Text(
                 text = "net ${net?.let { Formats.money(it) } ?: EMPTY_VALUE}",
                 style = MaterialTheme.typography.bodySmall,
@@ -308,7 +344,7 @@ private fun DeliveryRow(delivery: DeliveryRecord, onAdjust: () -> Unit) {
         IconButton(onClick = onAdjust) {
             Icon(
                 Icons.Default.Edit,
-                contentDescription = "Adjust pay",
+                contentDescription = "Adjust delivery",
                 tint = AppTheme.colors.text3,
             )
         }
@@ -346,21 +382,25 @@ private fun optionalMoney(text: String): Double? = text.takeIf { it.isNotBlank()
 private fun String.isBlankOrValidMoney(): Boolean = isBlank() || (toDoubleOrNull()?.let { it > 0.0 } == true)
 private fun String.isValidMoney(): Boolean = toDoubleOrNull()?.let { it > 0.0 } == true
 
+/** Blank, or a parseable non-negative number — for tip/cash/miles fields (0 is a valid entry). */
+private fun String.isBlankOrNonNegative(): Boolean = isBlank() || (toDoubleOrNull()?.let { it >= 0.0 } == true)
+
 /**
- * Add-a-missed-delivery dialog (#650) — store (optional), pay (required, > 0), tip (optional, > 0
- * when present), note (optional). Confirm stays disabled until pay is valid and any entered tip is
- * valid. Stateless w/ hoisted local field state per the codebase idiom.
+ * Add-a-missed-delivery dialog (#650/#688) — store (optional), pay (required, > 0), tip (optional,
+ * ≥ 0 when present), cash tip (optional, ≥ 0 when present), note (optional). Confirm stays disabled
+ * until pay is valid and any entered tip/cash is valid. Stateless w/ hoisted local field state.
  */
 @Composable
 private fun AddMissedDeliveryDialog(
     onDismiss: () -> Unit,
-    onConfirm: (pay: Double, tip: Double?, storeName: String?, note: String?) -> Unit,
+    onConfirm: (pay: Double, tip: Double?, cashTip: Double?, storeName: String?, note: String?) -> Unit,
 ) {
     var store by remember { mutableStateOf("") }
     var pay by remember { mutableStateOf("") }
     var tip by remember { mutableStateOf("") }
+    var cashTip by remember { mutableStateOf("") }
     var note by remember { mutableStateOf("") }
-    val valid = pay.isValidMoney() && tip.isBlankOrValidMoney()
+    val valid = pay.isValidMoney() && tip.isBlankOrNonNegative() && cashTip.isBlankOrNonNegative()
 
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -369,7 +409,8 @@ private fun AddMissedDeliveryDialog(
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 MoneyField(store, { store = it }, "Store (optional)", numeric = false)
                 MoneyField(pay, { pay = it }, "Pay")
-                MoneyField(tip, { tip = it }, "Tip (optional)")
+                MoneyField(tip, { tip = it }, "Tip (included in pay)")
+                MoneyField(cashTip, { cashTip = it }, "Cash tip (optional)")
                 MoneyField(note, { note = it }, "Note (optional)", numeric = false)
             }
         },
@@ -380,6 +421,7 @@ private fun AddMissedDeliveryDialog(
                     onConfirm(
                         pay.toDouble(),
                         optionalMoney(tip),
+                        optionalMoney(cashTip),
                         store.trim().takeIf { it.isNotBlank() },
                         note.trim().takeIf { it.isNotBlank() },
                     )
@@ -391,34 +433,85 @@ private fun AddMissedDeliveryDialog(
 }
 
 /**
- * Adjust-pay dialog (#650) — prefilled with the delivery's current pay, note optional. Confirm stays
- * disabled until the new pay is a positive number.
+ * Adjust-delivery dialog (#688) — the one multi-field editor: Store name / Pay / Tip / Cash tip /
+ * Miles / Note. Each money/miles field is prefilled cent-faithfully via `toString()` (NOT
+ * `Formats.decimal`, which rounds and would drop cents from the round-trip). **Blank = unchanged**
+ * (a store name can't be cleared to empty — intended; clearing a value is not supported). Only fields
+ * whose PARSED value differs from the row's current value ship in the event; a blank/unchanged field
+ * → null. Save stays disabled until every entered field is valid AND at least one parsed field
+ * differs (or a note is present, #688 F6 — a note-only annotation is a valid edit).
  */
 @Composable
-private fun AdjustPayDialog(
-    currentPay: Double?,
+private fun AdjustDeliveryDialog(
+    target: DeliveryRecord,
     onDismiss: () -> Unit,
-    onConfirm: (newPay: Double, note: String?) -> Unit,
+    onConfirm: (
+        newStoreName: String?,
+        newPay: Double?,
+        newTip: Double?,
+        newCashTip: Double?,
+        newMiles: Double?,
+        note: String?,
+    ) -> Unit,
 ) {
-    // Prefill with a parse-faithful value (NOT Formats.decimal, which rounds to 1 digit and would
-    // silently drop cents from the round-trip).
-    var pay by remember { mutableStateOf(currentPay?.toString() ?: "") }
+    var store by remember { mutableStateOf(target.storeName ?: "") }
+    var pay by remember { mutableStateOf(target.realizedPay?.toString() ?: "") }
+    var tip by remember { mutableStateOf(target.tip?.toString() ?: "") }
+    var cashTip by remember { mutableStateOf(target.cashTip?.toString() ?: "") }
+    var miles by remember { mutableStateOf(target.realizedMiles?.toString() ?: "") }
     var note by remember { mutableStateOf("") }
-    val valid = pay.isValidMoney()
+
+    // Parsed values (blank ⇒ null ⇒ unchanged).
+    val storeParsed = store.trim().takeIf { it.isNotBlank() }
+    val payParsed = optionalMoney(pay)
+    val tipParsed = optionalMoney(tip)
+    val cashParsed = optionalMoney(cashTip)
+    val milesParsed = optionalMoney(miles)
+    val noteParsed = note.trim().takeIf { it.isNotBlank() }
+
+    // Per-field validity: pay > 0 (when present); tip/cash/miles ≥ 0 (when present).
+    val payValid = pay.isBlankOrValidMoney()
+    val tipValid = tip.isBlankOrNonNegative()
+    val cashValid = cashTip.isBlankOrNonNegative()
+    val milesValid = miles.isBlankOrNonNegative()
+
+    // Changed-field detection on PARSED values (prefill round-trips via toString, so an untouched
+    // field parses back equal and is not sent).
+    val storeChanged = storeParsed != null && storeParsed != target.storeName
+    val payChanged = payParsed != null && payParsed != target.realizedPay
+    val tipChanged = tipParsed != null && tipParsed != target.tip
+    val cashChanged = cashParsed != null && cashParsed != target.cashTip
+    val milesChanged = milesParsed != null && milesParsed != target.realizedMiles
+
+    val anyChange = storeChanged || payChanged || tipChanged || cashChanged || milesChanged || noteParsed != null
+    val valid = payValid && tipValid && cashValid && milesValid && anyChange
 
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("Adjust pay") },
+        title = { Text("Adjust delivery") },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                MoneyField(store, { store = it }, "Store name", numeric = false)
                 MoneyField(pay, { pay = it }, "Pay")
+                MoneyField(tip, { tip = it }, "Tip (included in pay)")
+                MoneyField(cashTip, { cashTip = it }, "Cash tip")
+                MoneyField(miles, { miles = it }, "Miles")
                 MoneyField(note, { note = it }, "Note (optional)", numeric = false)
             }
         },
         confirmButton = {
             TextButton(
                 enabled = valid,
-                onClick = { onConfirm(pay.toDouble(), note.trim().takeIf { it.isNotBlank() }) },
+                onClick = {
+                    onConfirm(
+                        if (storeChanged) storeParsed else null,
+                        if (payChanged) payParsed else null,
+                        if (tipChanged) tipParsed else null,
+                        if (cashChanged) cashParsed else null,
+                        if (milesChanged) milesParsed else null,
+                        noteParsed,
+                    )
+                },
             ) { Text("Save") }
         },
         dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/SessionDetailViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/SessionDetailViewModel.kt
@@ -18,13 +18,13 @@ import javax.inject.Inject
 /**
  * State holder for the per-dash drill-down (#650) — one immutable [SessionDetailUiState] assembled
  * reactively from [AnalyticsRepository.sessionDetail] (Principle 1 — UDF, state out), plus the two
- * correction intents ([addManualDelivery] / [adjustPay], events up). The sessionId is read from
+ * correction intents ([addManualDelivery] / [adjustDelivery], events up). The sessionId is read from
  * [SavedStateHandle] (the nav argument), so this VM needs no explicit initializer.
  *
  * Reactive by construction: the source is a Room-invalidation `Flow`, so the header + rows re-emit
  * as the projector folds each delivery — a **review** surface, not a per-second tick (no
  * `rememberNow()` clock; same reframe as the hub #657). The corrections are **events, never
- * destructive edits**: an intent appends a `MANUAL_DELIVERY`/`PAY_ADJUSTMENT` to the log via
+ * destructive edits**: an intent appends a `MANUAL_DELIVERY`/`DELIVERY_ADJUSTMENT` to the log via
  * [CorrectionRepository]; the projector folds it and Room invalidation refreshes this screen — there
  * is NO optimistic local mutation. Read-model only, no economy dependency, no new PII surface (store
  * names are driver-owned; no customer hashes are exposed).
@@ -54,7 +54,7 @@ class SessionDetailViewModel @Inject constructor(
      * happened; miles are v1-null (not asked for). The projector folds it (payBasis `MANUAL`) and the
      * read-model Flow refreshes the screen.
      */
-    fun addManualDelivery(pay: Double, tip: Double?, storeName: String?, note: String?) {
+    fun addManualDelivery(pay: Double, tip: Double?, cashTip: Double?, storeName: String?, note: String?) {
         val session = uiState.value.detail?.session
         val completedAt = session?.endedAt ?: session?.startedAt ?: System.currentTimeMillis()
         viewModelScope.launch {
@@ -63,6 +63,7 @@ class SessionDetailViewModel @Inject constructor(
                 storeName = storeName,
                 pay = pay,
                 tip = tip,
+                cashTip = cashTip,
                 completedAt = completedAt,
                 miles = null,
                 note = note,
@@ -71,16 +72,28 @@ class SessionDetailViewModel @Inject constructor(
     }
 
     /**
-     * Append a driver re-price of a recorded delivery (#650). The projector rewrites the target row
-     * (payBasis `USER_CORRECTED`, net recomputed against its own frozen cpm) and the read-model Flow
-     * refreshes the screen.
+     * Append a driver multi-field edit of a recorded delivery (#688). Only the changed fields are
+     * non-null; the projector re-applies the target row (payBasis → `USER_CORRECTED` only when pay
+     * changes, net recomputed against its own frozen cpm) and the read-model Flow refreshes the screen.
      */
-    fun adjustPay(targetEventSequenceId: Long, newPay: Double, note: String?) {
+    fun adjustDelivery(
+        targetEventSequenceId: Long,
+        newStoreName: String?,
+        newPay: Double?,
+        newTip: Double?,
+        newCashTip: Double?,
+        newMiles: Double?,
+        note: String?,
+    ) {
         viewModelScope.launch {
-            correctionRepository.adjustDeliveryPay(
+            correctionRepository.adjustDelivery(
                 targetEventSequenceId = targetEventSequenceId,
                 sessionId = sessionId,
+                newStoreName = newStoreName,
                 newPay = newPay,
+                newTip = newTip,
+                newCashTip = newCashTip,
+                newMiles = newMiles,
                 note = note,
             )
         }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/SessionDetailViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/SessionDetailViewModel.kt
@@ -8,11 +8,13 @@ import cloud.trotter.dashbuddy.core.data.analytics.CorrectionRepository
 import cloud.trotter.dashbuddy.domain.analytics.SessionDetail
 import cloud.trotter.dashbuddy.ui.main.navigation.Screen
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 /**
@@ -58,16 +60,26 @@ class SessionDetailViewModel @Inject constructor(
         val session = uiState.value.detail?.session
         val completedAt = session?.endedAt ?: session?.startedAt ?: System.currentTimeMillis()
         viewModelScope.launch {
-            correctionRepository.addManualDelivery(
-                sessionId = sessionId,
-                storeName = storeName,
-                pay = pay,
-                tip = tip,
-                cashTip = cashTip,
-                completedAt = completedAt,
-                miles = null,
-                note = note,
-            )
+            // F4c: never crash the launch on a rejected correction (a validation `require` throwing, a
+            // codec/write failure). Alpha-acceptable silent reject — the record simply doesn't append;
+            // the dialog's own validators are the primary guard, this is the fail-closed backstop.
+            try {
+                correctionRepository.addManualDelivery(
+                    sessionId = sessionId,
+                    storeName = storeName,
+                    pay = pay,
+                    tip = tip,
+                    cashTip = cashTip,
+                    completedAt = completedAt,
+                    miles = null,
+                    note = note,
+                )
+            } catch (e: CancellationException) {
+                throw e // cooperative cancellation — never swallow it
+            } catch (e: Exception) {
+                // P7: counts/ids only — no note/store text.
+                Timber.tag(TAG).w(e, "addManualDelivery rejected for session %s", sessionId)
+            }
         }
     }
 
@@ -86,17 +98,30 @@ class SessionDetailViewModel @Inject constructor(
         note: String?,
     ) {
         viewModelScope.launch {
-            correctionRepository.adjustDelivery(
-                targetEventSequenceId = targetEventSequenceId,
-                sessionId = sessionId,
-                newStoreName = newStoreName,
-                newPay = newPay,
-                newTip = newTip,
-                newCashTip = newCashTip,
-                newMiles = newMiles,
-                note = note,
-            )
+            // F4c: fail-closed backstop — a rejected adjustment must not crash the launch (see
+            // addManualDelivery). Alpha-acceptable silent reject; the dialog validators are primary.
+            try {
+                correctionRepository.adjustDelivery(
+                    targetEventSequenceId = targetEventSequenceId,
+                    sessionId = sessionId,
+                    newStoreName = newStoreName,
+                    newPay = newPay,
+                    newTip = newTip,
+                    newCashTip = newCashTip,
+                    newMiles = newMiles,
+                    note = note,
+                )
+            } catch (e: CancellationException) {
+                throw e // cooperative cancellation — never swallow it
+            } catch (e: Exception) {
+                // P7: counts/ids only — no note/store text.
+                Timber.tag(TAG).w(e, "adjustDelivery rejected for delivery seq %d", targetEventSequenceId)
+            }
         }
+    }
+
+    private companion object {
+        private const val TAG = "SessionDetailVm"
     }
 }
 

--- a/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsProjectorTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsProjectorTest.kt
@@ -18,6 +18,7 @@ import cloud.trotter.dashbuddy.domain.evaluation.UserEconomy
 import cloud.trotter.dashbuddy.domain.model.event.AppEventCodec
 import cloud.trotter.dashbuddy.domain.model.event.AppEventType
 import cloud.trotter.dashbuddy.domain.model.event.payload.AppEventPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryAdjustmentPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.ManualDeliveryPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.OfferPayload
@@ -729,6 +730,230 @@ class AnalyticsProjectorTest {
             deliveriesBefore, analyticsDao.deliveriesBetween(Long.MIN_VALUE, Long.MAX_VALUE),
         )
         assertEquals(sessionsBefore, analyticsDao.sessionsBetween(Long.MIN_VALUE, Long.MAX_VALUE))
+    }
+
+    // ── DELIVERY_ADJUSTMENT (#688) + #703 originalPayBasis ──────────────
+
+    @Test
+    fun `a DELIVERY_ADJUSTMENT applies every field by-PK and flips a machine row to USER_CORRECTED on a pay edit (#688)`() = runBlocking {
+        val seq = seedCorrectableSession(deliveryPay = 10.0, reportedEarnings = 20.0)
+        projector().catchUp()
+
+        insert(
+            AppEventType.DELIVERY_ADJUSTMENT, "S1", 6_000,
+            DeliveryAdjustmentPayload(
+                targetEventSequenceId = seq, sessionId = "S1", newStoreName = "Bill Millers",
+                newPay = 15.0, newTip = 4.0, newCashTip = 3.0, newMiles = 8.0, note = "edit",
+            ),
+        )
+        projector().catchUp()
+
+        val d = analyticsDao.deliveryRecord(seq)!!
+        assertEquals("Bill Millers", d.storeName)
+        assertEquals(15.0, d.realizedPay!!, 1e-9)
+        assertEquals(4.0, d.tip!!, 1e-9)
+        assertEquals(3.0, d.cashTip!!, 1e-9)
+        assertEquals(8.0, d.realizedMiles!!, 1e-9)
+        assertEquals("USER_CORRECTED", d.payBasis)
+        // Net recomputed against the row's OWN frozen cpm (0.25) over the EDITED 8 miles.
+        assertEquals(15.0 - 8.0 * 0.25, d.netProfit!!, 1e-9)
+        assertEquals("frozen cpm untouched by the edit", 0.25, d.frozenCostPerMile!!, 1e-9)
+        assertEquals("originalPayBasis preserved (#703)", "RECEIPT_TOTAL", d.originalPayBasis)
+    }
+
+    @Test
+    fun `a store-only edit on an OFFER_PAY row keeps the basis and its disclosure (VET F1 regression)`() = runBlocking {
+        // A wholly receipt-less job → T1 folds OFFER_PAY (the "est. offer pay" disclosure row).
+        insert(
+            AppEventType.DASH_START, "S1", 1_000,
+            SessionStartPayload("S1", Platform.DoorDash.name, 1_000, SessionStartSource.INTERACTION, "x"),
+            odometer = 100.0,
+        )
+        insert(
+            AppEventType.OFFER_ACCEPTED, "S1", 2_000,
+            OfferPayload(
+                offerHash = "h1",
+                parsedOffer = ParsedOffer(offerHash = "h1", payAmount = 12.0, distanceMiles = 3.0),
+                evaluation = eval(0.25), outcome = AppEventType.OFFER_ACCEPTED,
+                presentedAt = 1_970, decidedAt = 2_000, returnFlow = Flow.Idle,
+            ),
+        )
+        val seq = insert(
+            AppEventType.DELIVERY_COMPLETED, "S1", 3_000,
+            DeliveryPayload(
+                jobId = "J1", taskId = "T1", storeName = "StoreX", customerHash = "c1",
+                phaseStartedAt = 2_400, completedAt = 3_000, offerPayShare = 12.95,
+            ),
+            odometer = 105.0,
+        )
+        projector().catchUp()
+        val before = analyticsDao.deliveryRecord(seq)!!
+        assertEquals("OFFER_PAY", before.payBasis)
+
+        // A store-name-only edit must NOT flip the basis (which would drop the estimate disclosure).
+        insert(
+            AppEventType.DELIVERY_ADJUSTMENT, "S1", 6_000,
+            DeliveryAdjustmentPayload(targetEventSequenceId = seq, sessionId = "S1", newStoreName = "Bill Millers"),
+        )
+        projector().catchUp()
+
+        val d = analyticsDao.deliveryRecord(seq)!!
+        assertEquals("Bill Millers", d.storeName)
+        assertEquals("basis (and the est. offer pay disclosure) survives a non-pay edit", "OFFER_PAY", d.payBasis)
+        assertEquals("pay is unchanged", 12.95, d.realizedPay!!, 1e-9)
+        assertEquals(before.netProfit!!, d.netProfit!!, 1e-9)
+    }
+
+    @Test
+    fun `a cashTip-only edit does not flip payBasis and leaves netProfit byte-identical (D6c)`() = runBlocking {
+        val seq = seedCorrectableSession(deliveryPay = 10.0, reportedEarnings = 20.0)
+        projector().catchUp()
+        val before = analyticsDao.deliveryRecord(seq)!!
+
+        insert(
+            AppEventType.DELIVERY_ADJUSTMENT, "S1", 6_000,
+            DeliveryAdjustmentPayload(targetEventSequenceId = seq, sessionId = "S1", newCashTip = 6.0),
+        )
+        projector().catchUp()
+
+        val d = analyticsDao.deliveryRecord(seq)!!
+        assertEquals(6.0, d.cashTip!!, 1e-9)
+        assertEquals("cash is a side column — basis untouched", before.payBasis, d.payBasis)
+        assertEquals("netProfit byte-identical (cash never enters net)", before.netProfit, d.netProfit)
+        assertEquals(before.realizedPay, d.realizedPay)
+    }
+
+    @Test
+    fun `a MANUAL row edited via DELIVERY_ADJUSTMENT stays MANUAL with the net-additive policy (#688)`() = runBlocking {
+        insert(
+            AppEventType.MANUAL_DELIVERY, "MISSED", 5_000,
+            ManualDeliveryPayload(sessionId = "MISSED", pay = 9.0, completedAt = 5_000),
+        )
+        projector().catchUp()
+        val seq = analyticsDao.lastDeliveryInSession("MISSED")!!.eventSequenceId
+
+        insert(
+            AppEventType.DELIVERY_ADJUSTMENT, "MISSED", 6_000,
+            DeliveryAdjustmentPayload(targetEventSequenceId = seq, sessionId = "MISSED", newPay = 12.0, newCashTip = 2.0),
+        )
+        projector().catchUp()
+
+        val d = analyticsDao.deliveryRecord(seq)!!
+        assertEquals("a driver statement stays a driver statement", "MANUAL", d.payBasis)
+        assertEquals(12.0, d.realizedPay!!, 1e-9)
+        assertEquals(2.0, d.cashTip!!, 1e-9)
+        assertEquals("net keeps the MANUAL missing-terms-as-0 policy over final values", 12.0, d.netProfit!!, 1e-9)
+        assertEquals("MANUAL", d.originalPayBasis)
+    }
+
+    @Test
+    fun `a note-only DELIVERY_ADJUSTMENT is a no-op apply (VET F6)`() = runBlocking {
+        val seq = seedCorrectableSession()
+        projector().catchUp()
+        val before = analyticsDao.deliveryRecord(seq)!!
+
+        insert(
+            AppEventType.DELIVERY_ADJUSTMENT, "S1", 6_000,
+            DeliveryAdjustmentPayload(targetEventSequenceId = seq, sessionId = "S1", note = "bill millers actually"),
+        )
+        projector().catchUp()
+
+        assertEquals("a note-only edit changes no column", before, analyticsDao.deliveryRecord(seq))
+    }
+
+    @Test
+    fun `a DELIVERY_ADJUSTMENT with a missing target is skipped and the watermark still advances (#688)`() = runBlocking {
+        seedCorrectableSession()
+        projector().catchUp()
+        val before = analyticsDao.lastDeliveryInSession("S1")!!
+
+        insert(
+            AppEventType.DELIVERY_ADJUSTMENT, "S1", 6_000,
+            DeliveryAdjustmentPayload(targetEventSequenceId = 9_999, sessionId = "S1", newPay = 99.0),
+        )
+        projector().catchUp() // must not throw
+
+        assertEquals("the target delivery is unchanged", before, analyticsDao.lastDeliveryInSession("S1"))
+        assertEquals("the watermark advanced past the skipped adjustment", 5L, analyticsDao.getWatermark()!!.watermarkSequenceId)
+    }
+
+    @Test
+    fun `an adjustment in a later batch equals a from-zero refold and originalPayBasis is populated (#688 determinism)`() = runBlocking {
+        val seq = seedCorrectableSession(deliveryPay = 10.0, reportedEarnings = 20.0)
+        insert(
+            AppEventType.DELIVERY_ADJUSTMENT, "S1", 6_000,
+            DeliveryAdjustmentPayload(
+                targetEventSequenceId = seq, sessionId = "S1", newStoreName = "Bill Millers",
+                newPay = 15.0, newCashTip = 3.0,
+            ),
+        )
+
+        // Live incremental: small batches force the adjustment into a LATER batch than its target.
+        val live = projector()
+        while (live.processBatch(limit = 1) != null) { /* drain one event at a time */ }
+        val liveRow = analyticsDao.deliveryRecord(seq)!!
+        assertEquals("Bill Millers", liveRow.storeName)
+        assertEquals(15.0, liveRow.realizedPay!!, 1e-9)
+        assertEquals("USER_CORRECTED", liveRow.payBasis)
+        assertEquals("originalPayBasis stamped and preserved across batches (#703)", "RECEIPT_TOTAL", liveRow.originalPayBasis)
+
+        // From-zero refold (one drain, no boundary) must reproduce a byte-identical row.
+        analyticsDao.setWatermark(AnalyticsProjectionStateEntity(watermarkSequenceId = seq + 1, projectorVersion = 99))
+        projector().catchUp()
+        assertEquals("live == from-zero refold", liveRow, analyticsDao.deliveryRecord(seq))
+    }
+
+    @Test
+    fun `a re-priced receipted row still denies a receipt-less sibling folded after a restart (#703 hydration COALESCE)`() = runBlocking {
+        // T1 receipted (DROP_SHARE) then re-priced to USER_CORRECTED; the job's originalPayBasis stays
+        // DROP_SHARE, so the #691 mixed-receipt guard must still see the job as receipted when the
+        // receipt-less sibling T2 is folded by a FRESH projector (empty in-memory → DB hydration).
+        insert(
+            AppEventType.DASH_START, "S1", 1_000,
+            SessionStartPayload("S1", Platform.DoorDash.name, 1_000, SessionStartSource.INTERACTION, "x"),
+            odometer = 100.0,
+        )
+        insert(
+            AppEventType.OFFER_ACCEPTED, "S1", 2_000,
+            OfferPayload(
+                offerHash = "h1",
+                parsedOffer = ParsedOffer(offerHash = "h1", payAmount = 12.0, distanceMiles = 3.0),
+                evaluation = eval(0.25), outcome = AppEventType.OFFER_ACCEPTED,
+                presentedAt = 1_970, decidedAt = 2_000, returnFlow = Flow.Idle,
+            ),
+        )
+        val t1 = insert(
+            AppEventType.DELIVERY_COMPLETED, "S1", 3_000,
+            DeliveryPayload(
+                jobId = "J1", taskId = "T1", storeName = "StoreX", customerHash = "c1",
+                phaseStartedAt = 2_400, completedAt = 3_000, dropRealizedPay = 6.0,
+            ),
+            odometer = 104.0,
+        )
+        insert(
+            AppEventType.DELIVERY_ADJUSTMENT, "S1", 4_000,
+            DeliveryAdjustmentPayload(targetEventSequenceId = t1, sessionId = "S1", newPay = 7.0),
+        )
+        // Drain everything so far; T1 is now USER_CORRECTED (originalPayBasis DROP_SHARE).
+        projector().catchUp()
+        assertEquals("USER_CORRECTED", analyticsDao.deliveryRecord(t1)!!.payBasis)
+        assertEquals("originalPayBasis keeps the first-fold receipt evidence", "DROP_SHARE", analyticsDao.deliveryRecord(t1)!!.originalPayBasis)
+
+        // T2 (receipt-less sibling) arrives LATER — a fresh projector must hydrate the receipted-jobId
+        // set from the DB via COALESCE(originalPayBasis, payBasis) and DENY the offer-pay estimate.
+        insert(
+            AppEventType.DELIVERY_COMPLETED, "S1", 5_000,
+            DeliveryPayload(
+                jobId = "J1", taskId = "T2", storeName = "StoreX", customerHash = "c2",
+                phaseStartedAt = 4_500, completedAt = 5_000, offerPayShare = 6.48,
+            ),
+            odometer = 106.0,
+        )
+        projector().catchUp()
+
+        val t2Row = analyticsDao.deliveryRecord(analyticsDao.lastDeliveryInSession("S1")!!.eventSequenceId)!!
+        assertEquals("the re-priced sibling still proves the job receipted → estimate denied", "NONE", t2Row.payBasis)
+        assertNull(t2Row.realizedPay)
     }
 
     @Test(expected = CancellationException::class)

--- a/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsProjectorTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsProjectorTest.kt
@@ -956,6 +956,130 @@ class AnalyticsProjectorTest {
         assertNull(t2Row.realizedPay)
     }
 
+    // ── #705 fix round: sequence-ordered apply (F1), F3 null-session cash, F5 SUSPECT block ──
+
+    @Test
+    fun `a PAY_ADJUSTMENT sequenced after a DELIVERY_ADJUSTMENT on one row wins in a single batch (#705 F1)`() = runBlocking {
+        val seq = seedCorrectableSession(deliveryPay = 10.0, reportedEarnings = 30.0)
+        // DA (earlier seq) sets pay 15; PA (later seq) sets pay 20. In true LOG order the PA is last and
+        // must win. The old type-partitioned apply ran ALL PAs before ALL DAs, so the DA (15) wrongly won.
+        insert(
+            AppEventType.DELIVERY_ADJUSTMENT, "S1", 6_000,
+            DeliveryAdjustmentPayload(targetEventSequenceId = seq, sessionId = "S1", newPay = 15.0),
+        )
+        insert(
+            AppEventType.PAY_ADJUSTMENT, "S1", 7_000,
+            PayAdjustmentPayload(targetEventSequenceId = seq, sessionId = "S1", newPay = 20.0),
+        )
+        projector().catchUp() // both fold in ONE batch
+
+        val d = analyticsDao.deliveryRecord(seq)!!
+        assertEquals("the later-sequenced PAY_ADJUSTMENT wins, not the type-order-last DELIVERY_ADJUSTMENT", 20.0, d.realizedPay!!, 1e-9)
+        assertEquals("USER_CORRECTED", d.payBasis)
+        assertEquals(20.0 - 5.0 * 0.25, d.netProfit!!, 1e-9)
+    }
+
+    @Test
+    fun `the PA-after-DA interleave is batch-boundary-invariant (#705 F1 determinism)`() = runBlocking {
+        val seq = seedCorrectableSession(deliveryPay = 10.0, reportedEarnings = 30.0)
+        insert(
+            AppEventType.DELIVERY_ADJUSTMENT, "S1", 6_000,
+            DeliveryAdjustmentPayload(targetEventSequenceId = seq, sessionId = "S1", newPay = 15.0),
+        )
+        insert(
+            AppEventType.PAY_ADJUSTMENT, "S1", 7_000,
+            PayAdjustmentPayload(targetEventSequenceId = seq, sessionId = "S1", newPay = 20.0),
+        )
+        // One event per batch forces the DA and PA into SEPARATE batches — same final row as one batch.
+        val live = projector()
+        while (live.processBatch(limit = 1) != null) { /* drain one event at a time */ }
+
+        assertEquals("across batches == single batch: the PA still wins", 20.0, analyticsDao.deliveryRecord(seq)!!.realizedPay!!, 1e-9)
+    }
+
+    @Test
+    fun `a DELIVERY_ADJUSTMENT cash edit is dropped on a null-session row while other fields apply (#705 F3)`() = runBlocking {
+        // A DELIVERY_COMPLETED with NO sessionId folds a session-less delivery row (the invariant violator).
+        val seq = insert(
+            AppEventType.DELIVERY_COMPLETED, null, 3_000,
+            DeliveryPayload(
+                jobId = "J1", taskId = "T1", storeName = "StoreX",
+                phaseStartedAt = 2_400, completedAt = 3_000, totalPay = 10.0,
+            ),
+            odometer = 105.0,
+        )
+        projector().catchUp()
+        assertNull("precondition: the row is session-less", analyticsDao.deliveryRecord(seq)!!.sessionId)
+
+        insert(
+            AppEventType.DELIVERY_ADJUSTMENT, null, 6_000,
+            DeliveryAdjustmentPayload(
+                targetEventSequenceId = seq, sessionId = null, newStoreName = "Bill Millers", newCashTip = 5.0,
+            ),
+        )
+        projector().catchUp()
+
+        val d = analyticsDao.deliveryRecord(seq)!!
+        assertNull("cash tip ignored on a null-session row (F3 sessionful-cash invariant)", d.cashTip)
+        assertEquals("every other field still applies", "Bill Millers", d.storeName)
+    }
+
+    /** A prior identity-bearing drop of J1, then an identity-less whole-receipt drop → SUSPECT_FULL_RECEIPT. */
+    private suspend fun seedSuspectFullReceiptRow(): Long {
+        insert(
+            AppEventType.DASH_START, "S1", 1_000,
+            SessionStartPayload("S1", Platform.DoorDash.name, 1_000, SessionStartSource.INTERACTION, "x"),
+            odometer = 100.0,
+        )
+        // T1: an identity-bearing receipt-share drop → job J1 has now delivered ≥1 drop this session.
+        insert(
+            AppEventType.DELIVERY_COMPLETED, "S1", 2_000,
+            DeliveryPayload(
+                jobId = "J1", taskId = "T1", storeName = "StoreX", customerHash = "c1",
+                phaseStartedAt = 1_500, completedAt = 2_000, dropRealizedPay = 6.0,
+            ),
+            odometer = 102.0,
+        )
+        // T2: identity-less, whole receipt, no apportioned share → SUSPECT_FULL_RECEIPT (money nulled).
+        return insert(
+            AppEventType.DELIVERY_COMPLETED, "S1", 3_000,
+            DeliveryPayload(
+                jobId = "J1", taskId = "T2", storeName = "StoreX",
+                phaseStartedAt = 2_500, completedAt = 3_000,
+                parsedPay = cloud.trotter.dashbuddy.domain.model.pay.ParsedPay(
+                    appPayComponents = listOf(cloud.trotter.dashbuddy.domain.model.pay.ParsedPayItem("Base Pay", 10.0)),
+                    customerTips = emptyList(),
+                ),
+            ),
+            odometer = 104.0,
+        )
+    }
+
+    @Test
+    fun `a DELIVERY_ADJUSTMENT pay-tip edit is blocked on a SUSPECT_FULL_RECEIPT row while store-cash still apply (#705 F5)`() = runBlocking {
+        val seq = seedSuspectFullReceiptRow()
+        projector().catchUp()
+        val before = analyticsDao.deliveryRecord(seq)!!
+        assertEquals("precondition: the de-monetized double-count guard row", "SUSPECT_FULL_RECEIPT", before.payBasis)
+        assertNull(before.realizedPay)
+
+        insert(
+            AppEventType.DELIVERY_ADJUSTMENT, "S1", 6_000,
+            DeliveryAdjustmentPayload(
+                targetEventSequenceId = seq, sessionId = "S1",
+                newStoreName = "Bill Millers", newPay = 25.0, newTip = 5.0, newCashTip = 3.0,
+            ),
+        )
+        projector().catchUp()
+
+        val d = analyticsDao.deliveryRecord(seq)!!
+        assertNull("pay stays nulled — editing it back re-opens the #653 double count", d.realizedPay)
+        assertNull("tip is blocked alongside pay", d.tip)
+        assertEquals("basis unchanged (no pay edit took effect)", "SUSPECT_FULL_RECEIPT", d.payBasis)
+        assertEquals("store still applies", "Bill Millers", d.storeName)
+        assertEquals("cash still applies (a sessionful row, so F3 permits it)", 3.0, d.cashTip!!, 1e-9)
+    }
+
     @Test(expected = CancellationException::class)
     fun `currentCostPerMile does not swallow CancellationException (retro finding 3)`(): Unit = runBlocking {
         // A blanket `runCatching` around the DataStore read would catch a CancellationException too

--- a/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsRepositoryTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsRepositoryTest.kt
@@ -58,6 +58,7 @@ class AnalyticsRepositoryTest {
         net: Double?,
         completedAt: Long,
         platform: String = "doordash",
+        cashTip: Double? = null,
     ) = DeliveryRecordEntity(
         eventSequenceId = seq,
         sessionId = sessionId,
@@ -81,6 +82,7 @@ class AnalyticsRepositoryTest {
         frozenCostPerMile = 0.30,
         netProfit = net,
         costBasis = "OFFER_FROZEN",
+        cashTip = cashTip,
     )
 
     private fun session(
@@ -158,6 +160,58 @@ class AnalyticsRepositoryTest {
         assertEquals(7.0, eco.netProfit, 1e-9)     // the stored frozen net, verbatim
         assertEquals(0.0, eco.unattributedPay, 1e-9)
         assertEquals(10.0, eco.grossEarnings, 1e-9)
+    }
+
+    /**
+     * #688 locked accounting: cash tips ADD to net and gross but STAY OUT of the unattributed
+     * reconciliation (which still compares reported against the cash-free delivered pay). The exact
+     * SUMs: reported 50 > delivered 40 → 10 unattributed, unchanged by the $5 cash; net rises by 5;
+     * gross rises by 5.
+     */
+    @Test
+    fun `cash tips add to net and gross but leave unattributed unchanged (#688)`() = runBlocking {
+        dao.upsertSession(session("S1", base, reportedEarnings = 50.0, durationMillis = 2 * hour, startOdo = 100.0, lastOdo = 110.0, deliveries = 2, jobsCompleted = 1))
+        dao.upsertDelivery(delivery(1, "S1", "J1", "Wendys", pay = 25.0, net = 20.0, completedAt = base + hour, cashTip = 5.0))
+        dao.upsertDelivery(delivery(2, "S1", "J1", "Wendys", pay = 15.0, net = 13.0, completedAt = base + 2 * hour))
+
+        val eco = repo.periodEconomics(AnalyticsPeriod.LIFETIME).first()
+        // Frozen delivery net 20+13 = 33; unattributed 10; cash 5 → net = 48.
+        assertEquals(48.0, eco.netProfit, 1e-9)
+        assertEquals("unattributed compares cash-free delivered pay, so cash never shrinks it", 10.0, eco.unattributedPay, 1e-9)
+        // Gross = 50 reported + 5 cash.
+        assertEquals(55.0, eco.grossEarnings, 1e-9)
+        // Delivered pay (totals.earnings) is cash-free.
+        assertEquals(40.0, eco.totals.earnings, 1e-9)
+        // Invariant (#688 F3): gross − net == the pre-cash operating cost (cash cancels).
+        val cost = eco.grossEarnings - eco.netProfit
+        assertEquals("cash cancels in cost: (50+5) − (43+5) == 50 − 43", 50.0 - 43.0, cost, 1e-9)
+    }
+
+    /** A null-net row's cash is still counted in period net (cash lives outside netProfit). */
+    @Test
+    fun `a null-net row still contributes its cash tip to period net and gross (#688)`() = runBlocking {
+        dao.upsertSession(session("S1", base, reportedEarnings = null, durationMillis = hour, startOdo = 0.0, lastOdo = 0.0, deliveries = 1, jobsCompleted = 1))
+        dao.upsertDelivery(delivery(1, "S1", "J1", "Wendys", pay = 8.0, net = null, completedAt = base + hour, cashTip = 4.0))
+
+        val eco = repo.periodEconomics(AnalyticsPeriod.LIFETIME).first()
+        assertEquals("frozen net 0 (null) + unattributed 0 + cash 4", 4.0, eco.netProfit, 1e-9)
+        assertEquals("gross = delivered 8 + cash 4", 12.0, eco.grossEarnings, 1e-9)
+    }
+
+    @Test
+    fun `perStoreEconomics adds cash to gross and net, order stays on cash-free pay (#688 F5)`() = runBlocking {
+        dao.upsertSession(session("S1", base, reportedEarnings = null, durationMillis = 4 * hour, startOdo = 0.0, lastOdo = 0.0, deliveries = 2, jobsCompleted = 2))
+        // Wendys realized pay 9 (< Chipotle 10) but a big cash tip; the sort stays on cash-free pay,
+        // so Chipotle (10) still leads Wendys (9) even though Wendys' cash-inclusive gross is larger.
+        dao.upsertDelivery(delivery(1, "S1", "J1", "Wendys", pay = 9.0, net = 7.0, completedAt = base + hour, cashTip = 6.0))
+        dao.upsertDelivery(delivery(2, "S1", "J2", "Chipotle", pay = 10.0, net = 8.0, completedAt = base + 2 * hour))
+
+        val stores = repo.perStoreEconomics(AnalyticsPeriod.LIFETIME).first()
+        assertEquals("order stays on cash-free realized pay: Chipotle 10 > Wendys 9", "Chipotle", stores[0].storeName)
+        assertEquals("Wendys", stores[1].storeName)
+        assertEquals("Wendys gross = pay 9 + cash 6", 15.0, stores[1].gross, 1e-9)
+        assertEquals("Wendys net = frozen net 7 + cash 6", 13.0, stores[1].net, 1e-9)
+        assertEquals("Chipotle has no cash", 10.0, stores[0].gross, 1e-9)
     }
 
     @Test

--- a/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsRepositoryTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsRepositoryTest.kt
@@ -199,19 +199,47 @@ class AnalyticsRepositoryTest {
     }
 
     @Test
-    fun `perStoreEconomics adds cash to gross and net, order stays on cash-free pay (#688 F5)`() = runBlocking {
+    fun `perStoreEconomics adds cash to gross and net, and ranks by cash-inclusive gross (#688 F5, #705 F8)`() = runBlocking {
         dao.upsertSession(session("S1", base, reportedEarnings = null, durationMillis = 4 * hour, startOdo = 0.0, lastOdo = 0.0, deliveries = 2, jobsCompleted = 2))
-        // Wendys realized pay 9 (< Chipotle 10) but a big cash tip; the sort stays on cash-free pay,
-        // so Chipotle (10) still leads Wendys (9) even though Wendys' cash-inclusive gross is larger.
+        // Wendys realized pay 9 (< Chipotle 10) but a big cash tip lifts its cash-inclusive gross to 15.
+        // F8: the mapped list is re-sorted by gross DESC, so the cash-heavy store leads despite the
+        // DAO's cash-free `ORDER BY pay` pre-sort ranking it second.
         dao.upsertDelivery(delivery(1, "S1", "J1", "Wendys", pay = 9.0, net = 7.0, completedAt = base + hour, cashTip = 6.0))
         dao.upsertDelivery(delivery(2, "S1", "J2", "Chipotle", pay = 10.0, net = 8.0, completedAt = base + 2 * hour))
 
         val stores = repo.perStoreEconomics(AnalyticsPeriod.LIFETIME).first()
-        assertEquals("order stays on cash-free realized pay: Chipotle 10 > Wendys 9", "Chipotle", stores[0].storeName)
-        assertEquals("Wendys", stores[1].storeName)
-        assertEquals("Wendys gross = pay 9 + cash 6", 15.0, stores[1].gross, 1e-9)
-        assertEquals("Wendys net = frozen net 7 + cash 6", 13.0, stores[1].net, 1e-9)
-        assertEquals("Chipotle has no cash", 10.0, stores[0].gross, 1e-9)
+        assertEquals("ranked by cash-inclusive gross: Wendys 15 > Chipotle 10", "Wendys", stores[0].storeName)
+        assertEquals("Chipotle", stores[1].storeName)
+        assertEquals("Wendys gross = pay 9 + cash 6", 15.0, stores[0].gross, 1e-9)
+        assertEquals("Wendys net = frozen net 7 + cash 6", 13.0, stores[0].net, 1e-9)
+        assertEquals("Chipotle has no cash", 10.0, stores[1].gross, 1e-9)
+    }
+
+    /** F8 null-net + cash presentation: a store whose only row has a null frozen net but a cash tip surfaces net = cash. */
+    @Test
+    fun `perStoreEconomics surfaces net = cash for a null-net store with cash (#705 F8)`() = runBlocking {
+        dao.upsertSession(session("S1", base, reportedEarnings = null, durationMillis = hour, startOdo = 0.0, lastOdo = 0.0, deliveries = 1, jobsCompleted = 1))
+        dao.upsertDelivery(delivery(1, "S1", "J1", "Wendys", pay = 8.0, net = null, completedAt = base + hour, cashTip = 5.0))
+
+        val stores = repo.perStoreEconomics(AnalyticsPeriod.LIFETIME).first()
+        assertEquals("net = frozen 0 (null) + cash 5", 5.0, stores[0].net, 1e-9)
+        assertEquals("gross = pay 8 + cash 5", 13.0, stores[0].gross, 1e-9)
+    }
+
+    /** F7: the recent-dashes read path carries each session's Σ cash tips (never folded into reportedEarnings). */
+    @Test
+    fun `recentSessions carries per-session cash tips as its own field (#705 F7)`() = runBlocking {
+        dao.upsertSession(session("S1", base, reportedEarnings = 40.0, durationMillis = 2 * hour, startOdo = 0.0, lastOdo = 0.0, deliveries = 2, jobsCompleted = 1))
+        dao.upsertDelivery(delivery(1, "S1", "J1", "Wendys", pay = 9.0, net = 7.0, completedAt = base + hour, cashTip = 6.0))
+        dao.upsertDelivery(delivery(2, "S1", "J1", "Wendys", pay = 11.0, net = 9.0, completedAt = base + 2 * hour, cashTip = 4.0))
+        // A second dash with no cash tips at all → cash 0.
+        dao.upsertSession(session("S2", base + 10 * hour, reportedEarnings = 20.0, durationMillis = hour, startOdo = 0.0, lastOdo = 0.0, deliveries = 1, jobsCompleted = 1))
+        dao.upsertDelivery(delivery(3, "S2", "J2", "Chipotle", pay = 20.0, net = 17.0, completedAt = base + 11 * hour))
+
+        val sessions = repo.recentSessions(limit = 10).first().associateBy { it.sessionId }
+        assertEquals("S1 cash = 6 + 4", 10.0, sessions.getValue("S1").cashTips, 1e-9)
+        assertEquals("reportedEarnings untouched by cash", 40.0, sessions.getValue("S1").reportedEarnings!!, 1e-9)
+        assertEquals("a cash-free dash reports 0 cash", 0.0, sessions.getValue("S2").cashTips, 1e-9)
     }
 
     @Test

--- a/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsSessionDetailTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/analytics/AnalyticsSessionDetailTest.kt
@@ -76,6 +76,7 @@ class AnalyticsSessionDetailTest {
         completedAt: Long,
         realizedPay: Double? = 8.0,
         storeName: String? = "Wendys",
+        cashTip: Double? = null,
     ) = DeliveryRecordEntity(
         eventSequenceId = seq,
         sessionId = sessionId,
@@ -99,6 +100,7 @@ class AnalyticsSessionDetailTest {
         frozenCostPerMile = null,
         netProfit = null,
         costBasis = "NONE",
+        cashTip = cashTip,
     )
 
     @Test
@@ -130,6 +132,18 @@ class AnalyticsSessionDetailTest {
         val detail = repo.sessionDetail("S").first()!!
         assertEquals(18.0, detail.deliveredPay, 1e-9)
         assertEquals(7.0, detail.unattributedPay, 1e-9)          // 25 − 18
+    }
+
+    @Test
+    fun `cashTips sums the per-delivery cash and leaves deliveredPay-unattributed cash-free (#688)`() = runBlocking {
+        dao.upsertSession(session("S", reportedEarnings = 25.0))
+        dao.upsertDelivery(delivery(1, "S", completedAt = base + hour, realizedPay = 8.0, cashTip = 3.0))
+        dao.upsertDelivery(delivery(2, "S", completedAt = base + 2 * hour, realizedPay = 10.0, cashTip = 1.5))
+
+        val detail = repo.sessionDetail("S").first()!!
+        assertEquals(4.5, detail.cashTips, 1e-9)
+        assertEquals("deliveredPay stays cash-free", 18.0, detail.deliveredPay, 1e-9)
+        assertEquals("unattributed compares cash-free delivered pay", 7.0, detail.unattributedPay, 1e-9)
     }
 
     @Test

--- a/app/src/test/java/cloud/trotter/dashbuddy/analytics/CorrectionRepositoryTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/analytics/CorrectionRepositoryTest.kt
@@ -1,0 +1,99 @@
+package cloud.trotter.dashbuddy.analytics
+
+import cloud.trotter.dashbuddy.core.data.analytics.CorrectionRepository
+import cloud.trotter.dashbuddy.core.data.event.AppEventRepo
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+
+/**
+ * #705 F4d — the write-side [CorrectionRepository] `require` boundaries (previously ZERO coverage).
+ * Every money/miles field must be **finite** (a non-finite value would reach `AppEventCodec` and throw
+ * a `SerializationException` deep in the append), pay finite > 0, tip/cash/miles finite ≥ 0, and
+ * `adjustDelivery` needs at least one changed field or a note. A rejected input must throw
+ * `IllegalArgumentException` BEFORE any event is appended; a valid one appends exactly once.
+ */
+class CorrectionRepositoryTest {
+
+    private val appEventRepo: AppEventRepo = mock()
+    private val repo = CorrectionRepository(appEventRepo)
+
+    private fun rejects(block: suspend CorrectionRepository.() -> Unit) {
+        assertThrows(IllegalArgumentException::class.java) { runBlocking { repo.block() } }
+    }
+
+    // ── addManualDelivery ───────────────────────────────────────────────
+
+    @Test fun `addManualDelivery rejects a zero pay`() = rejects { manual(pay = 0.0) }
+    @Test fun `addManualDelivery rejects a negative pay`() = rejects { manual(pay = -1.0) }
+    @Test fun `addManualDelivery rejects a NaN pay`() = rejects { manual(pay = Double.NaN) }
+    @Test fun `addManualDelivery rejects an infinite pay`() = rejects { manual(pay = Double.POSITIVE_INFINITY) }
+    @Test fun `addManualDelivery rejects a negative tip`() = rejects { manual(pay = 5.0, tip = -0.01) }
+    @Test fun `addManualDelivery rejects an infinite cash tip`() = rejects { manual(pay = 5.0, cashTip = Double.POSITIVE_INFINITY) }
+    @Test fun `addManualDelivery rejects a NaN cash tip`() = rejects { manual(pay = 5.0, cashTip = Double.NaN) }
+    @Test fun `addManualDelivery rejects a negative miles`() = rejects { manual(pay = 5.0, miles = -0.5) }
+    @Test fun `addManualDelivery rejects an infinite miles`() = rejects { manual(pay = 5.0, miles = Double.NEGATIVE_INFINITY) }
+
+    @Test
+    fun `addManualDelivery accepts a finite positive pay with zero and null optionals`() = runTest {
+        repo.manual(pay = 5.0, tip = 0.0, cashTip = 0.0, miles = 0.0)
+        repo.manual(pay = 5.0, tip = null, cashTip = null, miles = null)
+        verify(appEventRepo, times(2)).appendUserEvent(any(), anyOrNull())
+    }
+
+    // ── adjustDelivery ──────────────────────────────────────────────────
+
+    @Test
+    fun `adjustDelivery rejects an empty edit with no note`() = rejects { adjustDelivery(targetEventSequenceId = 1L, sessionId = "S1") }
+
+    @Test fun `adjustDelivery rejects a zero newPay`() = rejects { adjust(newPay = 0.0) }
+    @Test fun `adjustDelivery rejects a negative newPay`() = rejects { adjust(newPay = -1.0) }
+    @Test fun `adjustDelivery rejects a NaN newPay`() = rejects { adjust(newPay = Double.NaN) }
+    @Test fun `adjustDelivery rejects an infinite newPay`() = rejects { adjust(newPay = Double.POSITIVE_INFINITY) }
+    @Test fun `adjustDelivery rejects a negative newTip`() = rejects { adjust(newTip = -1.0) }
+    @Test fun `adjustDelivery rejects an infinite newCashTip`() = rejects { adjust(newCashTip = Double.NEGATIVE_INFINITY) }
+    @Test fun `adjustDelivery rejects a negative newMiles`() = rejects { adjust(newMiles = -0.5) }
+    @Test fun `adjustDelivery rejects a NaN newMiles`() = rejects { adjust(newMiles = Double.NaN) }
+
+    @Test
+    fun `adjustDelivery accepts a note-only edit and a finite positive pay edit`() = runTest {
+        repo.adjustDelivery(targetEventSequenceId = 1L, sessionId = "S1", note = "just a note")
+        repo.adjust(newPay = 12.0, newTip = 0.0, newCashTip = 0.0, newMiles = 0.0)
+        verify(appEventRepo, times(2)).appendUserEvent(any(), anyOrNull())
+    }
+
+    @Test
+    fun `a rejected addManualDelivery appends nothing`() = runTest {
+        assertThrows(IllegalArgumentException::class.java) { runBlocking { repo.manual(pay = 0.0) } }
+        verify(appEventRepo, never()).appendUserEvent(any(), anyOrNull())
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────
+
+    private suspend fun CorrectionRepository.manual(
+        pay: Double,
+        tip: Double? = null,
+        cashTip: Double? = null,
+        miles: Double? = null,
+    ) = addManualDelivery(
+        sessionId = "S1", storeName = "StoreX", pay = pay, tip = tip, cashTip = cashTip,
+        completedAt = 1_000L, miles = miles, note = null,
+    )
+
+    private suspend fun CorrectionRepository.adjust(
+        newPay: Double? = null,
+        newTip: Double? = null,
+        newCashTip: Double? = null,
+        newMiles: Double? = null,
+    ) = adjustDelivery(
+        targetEventSequenceId = 1L, sessionId = "S1",
+        newPay = newPay, newTip = newTip, newCashTip = newCashTip, newMiles = newMiles,
+    )
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/SessionDetailViewModelTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/SessionDetailViewModelTest.kt
@@ -108,18 +108,18 @@ class SessionDetailViewModelTest {
         val job = launch { viewModel.uiState.collect {} }
         testScheduler.advanceUntilIdle()
 
-        viewModel.addManualDelivery(pay = 9.5, tip = 2.0, storeName = "Chipotle", note = "missed")
+        viewModel.addManualDelivery(pay = 9.5, tip = 2.0, cashTip = 3.0, storeName = "Chipotle", note = "missed")
         testScheduler.advanceUntilIdle()
 
         // completedAt defaults to the loaded session's endedAt; miles is v1-null.
         verify(correctionRepository).addManualDelivery(
-            eq("s1"), eq("Chipotle"), eq(9.5), eq(2.0), eq(1_700_003_600_000L), isNull(), eq("missed"),
+            eq("s1"), eq("Chipotle"), eq(9.5), eq(2.0), eq(3.0), eq(1_700_003_600_000L), isNull(), eq("missed"),
         )
         job.cancel()
     }
 
     @Test
-    fun `adjustPay intent appends via the repository with the target seq and the VM sessionId`() = runTest {
+    fun `adjustDelivery intent appends via the repository with the target seq and the VM sessionId`() = runTest {
         Dispatchers.setMain(StandardTestDispatcher(testScheduler))
         val detail = SessionDetail(session("s1"), listOf(delivery("s1")))
         whenever(analyticsRepository.sessionDetail(eq("s1"))).thenReturn(flowOf(detail))
@@ -127,10 +127,15 @@ class SessionDetailViewModelTest {
         val job = launch { viewModel.uiState.collect {} }
         testScheduler.advanceUntilIdle()
 
-        viewModel.adjustPay(targetEventSequenceId = 42L, newPay = 15.0, note = "tip")
+        viewModel.adjustDelivery(
+            targetEventSequenceId = 42L, newStoreName = "Bill Millers", newPay = 15.0,
+            newTip = null, newCashTip = 4.0, newMiles = null, note = "tip",
+        )
         testScheduler.advanceUntilIdle()
 
-        verify(correctionRepository).adjustDeliveryPay(eq(42L), eq("s1"), eq(15.0), eq("tip"))
+        verify(correctionRepository).adjustDelivery(
+            eq(42L), eq("s1"), eq("Bill Millers"), eq(15.0), isNull(), eq(4.0), isNull(), eq("tip"),
+        )
         job.cancel()
     }
 }

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsMappers.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsMappers.kt
@@ -2,6 +2,7 @@ package cloud.trotter.dashbuddy.core.data.analytics
 
 import cloud.trotter.dashbuddy.core.database.analytics.DeliveryRecordEntity
 import cloud.trotter.dashbuddy.core.database.analytics.SessionRecordEntity
+import cloud.trotter.dashbuddy.core.database.analytics.SessionWithCashRow
 import cloud.trotter.dashbuddy.domain.analytics.DeliveryRecord
 import cloud.trotter.dashbuddy.domain.analytics.SessionRecord
 import cloud.trotter.dashbuddy.domain.state.Platform
@@ -50,3 +51,9 @@ internal fun SessionRecordEntity.toDomain(): SessionRecord = SessionRecord(
     offersDeclined = offersDeclined,
     offersTimeout = offersTimeout,
 )
+
+/**
+ * Recent-dashes row → domain (#688 F7): the embedded session row mapped as usual, with its Σ cash
+ * tips carried onto [SessionRecord.cashTips] for the additive "+cash" marker.
+ */
+internal fun SessionWithCashRow.toDomain(): SessionRecord = session.toDomain().copy(cashTips = cash)

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsMappers.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsMappers.kt
@@ -28,6 +28,7 @@ internal fun DeliveryRecordEntity.toDomain(): DeliveryRecord = DeliveryRecord(
     realizedMinutes = realizedMinutes,
     tip = tip,
     basePay = basePay,
+    cashTip = cashTip,
 )
 
 internal fun SessionRecordEntity.toDomain(): SessionRecord = SessionRecord(

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjector.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjector.kt
@@ -124,9 +124,14 @@ class AnalyticsProjector @Inject constructor(
 
     /** Fold catch-up batches until the log is drained past the watermark. */
     private suspend fun drain(): DrainStats {
+        // FIX 2 (drain-stable economy): read the live economy's cpm ONCE per drain/rebuild cycle and
+        // thread it through every batch. A per-batch read let an economy edit mid-refold freeze
+        // DIFFERENT `CURRENT_FALLBACK` cpm across batches of ONE rebuild — non-reproducible even by a
+        // second refold. One read per drain makes a whole drain economy-consistent by construction.
+        val currentCpm = currentCostPerMile()
         var acc = DrainStats()
         while (true) {
-            val batch = processBatch() ?: break
+            val batch = foldBatch(BATCH_SIZE, currentCpm) ?: break
             acc = DrainStats(
                 events = acc.events + batch.events,
                 deliveries = acc.deliveries + batch.deliveries,
@@ -139,22 +144,31 @@ class AnalyticsProjector @Inject constructor(
 
     /**
      * Fold ONE page of events after the watermark and commit records + the advanced watermark in one
-     * transaction. Returns the batch's counts, or null when the log is already drained. [limit]
-     * pages the fold (bounded memory over a long log); a test passes a small limit to force
-     * multi-batch behaviour and simulate a restart between batches.
+     * transaction. Public test/direct-call entrypoint: reads a fresh economy cpm then delegates to
+     * [foldBatch]. [limit] pages the fold (bounded memory over a long log); a test passes a small
+     * limit to force multi-batch behaviour and simulate a restart between batches. The [drain] loop
+     * uses [foldBatch] directly so a whole drain shares ONE cpm read (FIX 2).
      */
-    suspend fun processBatch(limit: Int = BATCH_SIZE): DrainStats? {
+    suspend fun processBatch(limit: Int = BATCH_SIZE): DrainStats? = foldBatch(limit, currentCostPerMile())
+
+    /**
+     * Fold ONE page of events against a pre-read [currentCpm], committing records + the advanced
+     * watermark in one transaction. Returns the batch's counts, or null when the log is already
+     * drained.
+     */
+    private suspend fun foldBatch(limit: Int, currentCpm: Double?): DrainStats? {
         val watermark = currentWatermark()
         val events = appEventRepo.getEventsAfter(after = watermark, limit = limit)
         if (events.isEmpty()) return null
 
-        val currentCpm = currentCostPerMile()
         val contexts = HashMap<String, SessionFoldContext>()
         val touched = LinkedHashSet<String>()
         val deliveries = ArrayList<DeliveryFold>()
         val offers = ArrayList<OfferFold>()
-        val payAdjustments = ArrayList<PayAdjustmentFold>()
-        val deliveryAdjustments = ArrayList<DeliveryAdjustmentFold>()
+        // FIX 1: one event-sequence-ordered stream of adjustment decisions (PAY_ADJUSTMENT +
+        // DELIVERY_ADJUSTMENT interleaved), NOT two type-partitioned lists. Type-order apply mis-ordered
+        // a PA sequenced after a DA on the same row when they shared a batch (incremental ≠ refold).
+        val adjustments = ArrayList<Adjustment>()
         var skips = 0
 
         for (ev in events) {
@@ -165,8 +179,8 @@ class AnalyticsProjector @Inject constructor(
             if (outcome.skip != null) skips++
             outcome.delivery?.let { deliveries += it }
             outcome.offer?.let { offers += it }
-            outcome.payAdjustment?.let { payAdjustments += it }
-            outcome.deliveryAdjustment?.let { deliveryAdjustments += it }
+            outcome.payAdjustment?.let { adjustments += Adjustment.Pay(ev.sequenceId, it) }
+            outcome.deliveryAdjustment?.let { adjustments += Adjustment.Delivery(ev.sequenceId, it) }
             outcome.context?.let { ctx ->
                 contexts[ctx.sessionId] = ctx
                 touched += ctx.sessionId
@@ -185,95 +199,17 @@ class AnalyticsProjector @Inject constructor(
             deliveries.forEach { analyticsDao.upsertDelivery(it.toEntity()) }
             offers.forEach { analyticsDao.upsertOffer(it.toEntity()) }
             touched.forEach { sid -> contexts[sid]?.let { analyticsDao.upsertSession(it.toEntity()) } }
-            // Apply driver PAY_ADJUSTMENT re-prices AFTER the batch's own delivery upserts (so a
-            // same-batch target is already written) and before the watermark. Determinism: a
-            // correction always sequences after its target's DELIVERY_COMPLETED, so a from-zero refold
-            // replays them in this same order and reproduces identical rows. The re-price recomputes
-            // net against the row's OWN frozen cpm (never today's economy — an immutable historical
-            // fact); tip/basePay are left untouched.
-            payAdjustments.forEach { adj ->
-                val row = analyticsDao.deliveryRecord(adj.targetEventSequenceId)
-                if (row == null) {
-                    adjustmentSkips++
-                    // P7: counts only, no payload text.
-                    Timber.tag(TAG).w("PAY_ADJUSTMENT: target row %d not found", adj.targetEventSequenceId)
-                } else {
-                    // A MANUAL row stays MANUAL (#650 review F1): a driver correcting their own
-                    // statement leaves it a driver statement (the audit trail lives in the log), and
-                    // its net keeps the MANUAL missing-terms-as-0 policy (net-additive) — the generic
-                    // machine recompute would null the net and drop the dollars from period SUM.
-                    // Machine rows flip to USER_CORRECTED with the machine recompute (null when not
-                    // computable — the pre-existing #660-family seam, not widened). Deterministic on
-                    // refold: the row's basis reads the same at apply time in live and refold order.
-                    val manual = row.payBasis == PayBasis.MANUAL
-                    val net = when {
-                        manual -> NetProfit.net(adj.newPay, row.realizedMiles ?: 0.0, row.frozenCostPerMile ?: 0.0)
-                        row.frozenCostPerMile != null && row.realizedMiles != null ->
-                            NetProfit.net(adj.newPay, row.realizedMiles!!, row.frozenCostPerMile!!)
-                        else -> null
-                    }
-                    analyticsDao.upsertDelivery(
-                        row.copy(
-                            realizedPay = adj.newPay,
-                            payBasis = if (manual) PayBasis.MANUAL else PayBasis.USER_CORRECTED,
-                            netProfit = net,
-                        ),
-                    )
+            // Apply the driver corrections AFTER the batch's own delivery upserts (so a same-batch
+            // target is already written) and before the watermark, in ONE event-sequence order (FIX 1).
+            // Each apply reads its target row fresh by-PK, so two edits of one row compose in log order.
+            // Determinism: a correction always sequences after its target's completion, so a from-zero
+            // refold replays this same ascending order and reproduces identical rows.
+            adjustments.sortedBy { it.sequenceId }.forEach { adj ->
+                val skipped = when (adj) {
+                    is Adjustment.Pay -> applyPayAdjustment(adj.fold)
+                    is Adjustment.Delivery -> applyDeliveryAdjustment(adj.fold)
                 }
-            }
-            // Apply driver DELIVERY_ADJUSTMENT (#688) multi-field re-applies, AFTER the pay-adjustment
-            // loop and the batch's own upserts. Event-order last-wins: each reads the row fresh (a
-            // prior same-batch upsert is already visible), so two edits of one row compose. Deterministic
-            // on refold — the list preserves sequence order, applied in the same fixed order every time.
-            deliveryAdjustments.forEach { adj ->
-                val row = analyticsDao.deliveryRecord(adj.targetEventSequenceId)
-                if (row == null) {
-                    adjustmentSkips++
-                    // P7: counts only, no payload text.
-                    Timber.tag(TAG).w("DELIVERY_ADJUSTMENT: target row %d not found", adj.targetEventSequenceId)
-                } else {
-                    // Copy each non-null field; null ⇒ that column is left unchanged.
-                    val newStore = adj.newStoreName ?: row.storeName
-                    val newPay = adj.newPay ?: row.realizedPay
-                    val newTip = adj.newTip ?: row.tip
-                    val newCashTip = adj.newCashTip ?: row.cashTip
-                    val newMiles = adj.newMiles ?: row.realizedMiles
-                    val manual = row.payBasis == PayBasis.MANUAL
-                    val payChanged = adj.newPay != null
-                    val milesChanged = adj.newMiles != null
-                    // Basis (VET F1): payBasis rewrites exactly when realizedPay does. A machine row
-                    // flips to USER_CORRECTED iff pay changed; a MANUAL row stays MANUAL; a cash/tip/
-                    // store-only edit leaves the basis (and its "est. offer pay" disclosure) intact.
-                    val newBasis = when {
-                        manual -> PayBasis.MANUAL
-                        payChanged -> PayBasis.USER_CORRECTED
-                        else -> row.payBasis
-                    }
-                    // Net recompute only when a net-bearing term (pay or miles) changed; otherwise the
-                    // stored netProfit is preserved byte-identically (cash/tip/store/note-only edits do
-                    // not touch net). MANUAL keeps the missing-terms-as-0 net-additive policy over the
-                    // FINAL values; a machine row recomputes against its OWN frozen cpm (null when any
-                    // term is missing — the pre-existing #660-family seam, now over the edited miles).
-                    val net = when {
-                        !payChanged && !milesChanged -> row.netProfit
-                        manual -> NetProfit.net(newPay ?: 0.0, newMiles ?: 0.0, row.frozenCostPerMile ?: 0.0)
-                        row.frozenCostPerMile != null && newPay != null && newMiles != null ->
-                            NetProfit.net(newPay, newMiles, row.frozenCostPerMile!!)
-                        else -> null
-                    }
-                    analyticsDao.upsertDelivery(
-                        // originalPayBasis (+ every unmentioned column) is preserved by `row.copy`.
-                        row.copy(
-                            storeName = newStore,
-                            realizedPay = newPay,
-                            tip = newTip,
-                            cashTip = newCashTip,
-                            realizedMiles = newMiles,
-                            payBasis = newBasis,
-                            netProfit = net,
-                        ),
-                    )
-                }
+                if (skipped) adjustmentSkips++
             }
             analyticsDao.setWatermark(
                 AnalyticsProjectionStateEntity(watermarkSequenceId = lastSeq, projectorVersion = PROJECTOR_VERSION),
@@ -283,12 +219,137 @@ class AnalyticsProjector @Inject constructor(
         Timber.tag(TAG).d(
             "batch: %d events (→seq %d) → %d deliveries, %d offers, %d sessions, %d re-priced, %d skipped",
             events.size, lastSeq, deliveries.size, offers.size, touched.size,
-            payAdjustments.size + deliveryAdjustments.size - adjustmentSkips, skips,
+            adjustments.size - adjustmentSkips, skips,
         )
         if (skips > 0) {
             Timber.tag(TAG).w("batch skipped %d event(s) with a missing/malformed payload", skips)
         }
         return DrainStats(events.size, deliveries.size, touched.size, offers.size)
+    }
+
+    /**
+     * A driver correction to apply by-PK inside the batch transaction, carrying the source event's
+     * [sequenceId] so the two correction event types merge into ONE log-ordered stream (FIX 1).
+     */
+    private sealed interface Adjustment {
+        val sequenceId: Long
+        data class Pay(override val sequenceId: Long, val fold: PayAdjustmentFold) : Adjustment
+        data class Delivery(override val sequenceId: Long, val fold: DeliveryAdjustmentFold) : Adjustment
+    }
+
+    /**
+     * Apply one legacy PAY_ADJUSTMENT re-price by-PK. Returns true iff the target row was missing (a
+     * counted skip, never a crash). A MANUAL row stays MANUAL (#650 review F1): a driver correcting
+     * their own statement leaves it a driver statement (the audit trail lives in the log), and its net
+     * keeps the MANUAL missing-terms-as-0 policy (net-additive) — the generic machine recompute would
+     * null the net and drop the dollars from period SUM. Machine rows flip to USER_CORRECTED with the
+     * machine recompute (null when not computable — the pre-existing #660-family seam, not widened).
+     * The re-price recomputes net against the row's OWN frozen cpm (never today's economy — an
+     * immutable historical fact); tip/basePay are left untouched.
+     */
+    private suspend fun applyPayAdjustment(adj: PayAdjustmentFold): Boolean {
+        val row = analyticsDao.deliveryRecord(adj.targetEventSequenceId) ?: run {
+            // P7: counts only, no payload text.
+            Timber.tag(TAG).w("PAY_ADJUSTMENT: target row %d not found", adj.targetEventSequenceId)
+            return true
+        }
+        val manual = row.payBasis == PayBasis.MANUAL
+        val net = when {
+            manual -> NetProfit.net(adj.newPay, row.realizedMiles ?: 0.0, row.frozenCostPerMile ?: 0.0)
+            row.frozenCostPerMile != null && row.realizedMiles != null ->
+                NetProfit.net(adj.newPay, row.realizedMiles!!, row.frozenCostPerMile!!)
+            else -> null
+        }
+        analyticsDao.upsertDelivery(
+            row.copy(
+                realizedPay = adj.newPay,
+                payBasis = if (manual) PayBasis.MANUAL else PayBasis.USER_CORRECTED,
+                netProfit = net,
+            ),
+        )
+        return false
+    }
+
+    /**
+     * Apply one driver DELIVERY_ADJUSTMENT (#688) multi-field re-apply by-PK. Returns true iff the
+     * target row was missing (a counted skip). Copies each non-null field; null ⇒ that column is left
+     * unchanged. Two same-row edits compose because each apply reads the row fresh (a prior same-batch
+     * upsert is already visible).
+     */
+    private suspend fun applyDeliveryAdjustment(adj: DeliveryAdjustmentFold): Boolean {
+        val row = analyticsDao.deliveryRecord(adj.targetEventSequenceId) ?: run {
+            // P7: counts only, no payload text.
+            Timber.tag(TAG).w("DELIVERY_ADJUSTMENT: target row %d not found", adj.targetEventSequenceId)
+            return true
+        }
+        // FIX 5 (#653 double-count guard): a SUSPECT_FULL_RECEIPT row's money was nulled because its
+        // siblings' shares already sum to the receipt — editing pay/tip back onto it re-opens the
+        // double count with one innocent tap. Block the pay+tip terms; store/cash/note still apply.
+        // `originalPayBasis` is the first-fold, never-rewritten basis, so this holds even after a
+        // prior non-pay edit. The dialog also disables the Pay field for these rows (a second gate).
+        val suspectReceipt = row.originalPayBasis == PayBasis.SUSPECT_FULL_RECEIPT
+        if (suspectReceipt && (adj.newPay != null || adj.newTip != null)) {
+            Timber.tag(TAG).w(
+                "DELIVERY_ADJUSTMENT: pay/tip edit blocked on SUSPECT_FULL_RECEIPT row %d (#653 double-count guard)",
+                adj.targetEventSequenceId,
+            )
+        }
+        val reqNewPay = if (suspectReceipt) null else adj.newPay
+        val reqNewTip = if (suspectReceipt) null else adj.newTip
+
+        // FIX 3 (#688 F3 invariant): cash is only meaningful on a SESSIONFUL row — gross counts it via a
+        // session join, net counts it session-inclusive. A null-session cash row would enter net but
+        // never gross, skewing the true-net waterfall cost negative. So drop a cash edit on a
+        // null-session row (one PII-safe WARN); every other field still applies. This makes the
+        // "cash-bearing rows are always sessionful" invariant real rather than merely documented.
+        val cashRejected = adj.newCashTip != null && row.sessionId == null
+        if (cashRejected) {
+            Timber.tag(TAG).w(
+                "DELIVERY_ADJUSTMENT: cash tip ignored on null-session row %d (F3 sessionful-cash invariant)",
+                adj.targetEventSequenceId,
+            )
+        }
+
+        val newStore = adj.newStoreName ?: row.storeName
+        val newPay = reqNewPay ?: row.realizedPay
+        val newTip = reqNewTip ?: row.tip
+        val newCashTip = if (cashRejected) row.cashTip else (adj.newCashTip ?: row.cashTip)
+        val newMiles = adj.newMiles ?: row.realizedMiles
+        val manual = row.payBasis == PayBasis.MANUAL
+        val payChanged = reqNewPay != null
+        val milesChanged = adj.newMiles != null
+        // Basis (VET F1): payBasis rewrites exactly when realizedPay does. A machine row flips to
+        // USER_CORRECTED iff pay changed; a MANUAL row stays MANUAL; a cash/tip/store-only edit leaves
+        // the basis (and its "est. offer pay" disclosure) intact.
+        val newBasis = when {
+            manual -> PayBasis.MANUAL
+            payChanged -> PayBasis.USER_CORRECTED
+            else -> row.payBasis
+        }
+        // Net recompute only when a net-bearing term (pay or miles) changed; otherwise the stored
+        // netProfit is preserved byte-identically (cash/tip/store/note-only edits do not touch net).
+        // MANUAL keeps the missing-terms-as-0 net-additive policy over the FINAL values; a machine row
+        // recomputes against its OWN frozen cpm (null when any term is missing — the #660-family seam).
+        val net = when {
+            !payChanged && !milesChanged -> row.netProfit
+            manual -> NetProfit.net(newPay ?: 0.0, newMiles ?: 0.0, row.frozenCostPerMile ?: 0.0)
+            row.frozenCostPerMile != null && newPay != null && newMiles != null ->
+                NetProfit.net(newPay, newMiles, row.frozenCostPerMile!!)
+            else -> null
+        }
+        analyticsDao.upsertDelivery(
+            // originalPayBasis (+ every unmentioned column) is preserved by `row.copy`.
+            row.copy(
+                storeName = newStore,
+                realizedPay = newPay,
+                tip = newTip,
+                cashTip = newCashTip,
+                realizedMiles = newMiles,
+                payBasis = newBasis,
+                netProfit = net,
+            ),
+        )
+        return false
     }
 
     // ── Version rebuild ─────────────────────────────────────────────────

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjector.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjector.kt
@@ -10,6 +10,7 @@ import cloud.trotter.dashbuddy.core.database.analytics.DeliveryRecordEntity
 import cloud.trotter.dashbuddy.core.database.analytics.OfferRecordEntity
 import cloud.trotter.dashbuddy.core.database.analytics.SessionRecordEntity
 import cloud.trotter.dashbuddy.core.database.event.AppEventDao
+import cloud.trotter.dashbuddy.domain.analytics.DeliveryAdjustmentFold
 import cloud.trotter.dashbuddy.domain.analytics.DeliveryFold
 import cloud.trotter.dashbuddy.domain.analytics.OfferFold
 import cloud.trotter.dashbuddy.domain.analytics.PayAdjustmentFold
@@ -153,6 +154,7 @@ class AnalyticsProjector @Inject constructor(
         val deliveries = ArrayList<DeliveryFold>()
         val offers = ArrayList<OfferFold>()
         val payAdjustments = ArrayList<PayAdjustmentFold>()
+        val deliveryAdjustments = ArrayList<DeliveryAdjustmentFold>()
         var skips = 0
 
         for (ev in events) {
@@ -164,6 +166,7 @@ class AnalyticsProjector @Inject constructor(
             outcome.delivery?.let { deliveries += it }
             outcome.offer?.let { offers += it }
             outcome.payAdjustment?.let { payAdjustments += it }
+            outcome.deliveryAdjustment?.let { deliveryAdjustments += it }
             outcome.context?.let { ctx ->
                 contexts[ctx.sessionId] = ctx
                 touched += ctx.sessionId
@@ -218,6 +221,60 @@ class AnalyticsProjector @Inject constructor(
                     )
                 }
             }
+            // Apply driver DELIVERY_ADJUSTMENT (#688) multi-field re-applies, AFTER the pay-adjustment
+            // loop and the batch's own upserts. Event-order last-wins: each reads the row fresh (a
+            // prior same-batch upsert is already visible), so two edits of one row compose. Deterministic
+            // on refold — the list preserves sequence order, applied in the same fixed order every time.
+            deliveryAdjustments.forEach { adj ->
+                val row = analyticsDao.deliveryRecord(adj.targetEventSequenceId)
+                if (row == null) {
+                    adjustmentSkips++
+                    // P7: counts only, no payload text.
+                    Timber.tag(TAG).w("DELIVERY_ADJUSTMENT: target row %d not found", adj.targetEventSequenceId)
+                } else {
+                    // Copy each non-null field; null ⇒ that column is left unchanged.
+                    val newStore = adj.newStoreName ?: row.storeName
+                    val newPay = adj.newPay ?: row.realizedPay
+                    val newTip = adj.newTip ?: row.tip
+                    val newCashTip = adj.newCashTip ?: row.cashTip
+                    val newMiles = adj.newMiles ?: row.realizedMiles
+                    val manual = row.payBasis == PayBasis.MANUAL
+                    val payChanged = adj.newPay != null
+                    val milesChanged = adj.newMiles != null
+                    // Basis (VET F1): payBasis rewrites exactly when realizedPay does. A machine row
+                    // flips to USER_CORRECTED iff pay changed; a MANUAL row stays MANUAL; a cash/tip/
+                    // store-only edit leaves the basis (and its "est. offer pay" disclosure) intact.
+                    val newBasis = when {
+                        manual -> PayBasis.MANUAL
+                        payChanged -> PayBasis.USER_CORRECTED
+                        else -> row.payBasis
+                    }
+                    // Net recompute only when a net-bearing term (pay or miles) changed; otherwise the
+                    // stored netProfit is preserved byte-identically (cash/tip/store/note-only edits do
+                    // not touch net). MANUAL keeps the missing-terms-as-0 net-additive policy over the
+                    // FINAL values; a machine row recomputes against its OWN frozen cpm (null when any
+                    // term is missing — the pre-existing #660-family seam, now over the edited miles).
+                    val net = when {
+                        !payChanged && !milesChanged -> row.netProfit
+                        manual -> NetProfit.net(newPay ?: 0.0, newMiles ?: 0.0, row.frozenCostPerMile ?: 0.0)
+                        row.frozenCostPerMile != null && newPay != null && newMiles != null ->
+                            NetProfit.net(newPay, newMiles, row.frozenCostPerMile!!)
+                        else -> null
+                    }
+                    analyticsDao.upsertDelivery(
+                        // originalPayBasis (+ every unmentioned column) is preserved by `row.copy`.
+                        row.copy(
+                            storeName = newStore,
+                            realizedPay = newPay,
+                            tip = newTip,
+                            cashTip = newCashTip,
+                            realizedMiles = newMiles,
+                            payBasis = newBasis,
+                            netProfit = net,
+                        ),
+                    )
+                }
+            }
             analyticsDao.setWatermark(
                 AnalyticsProjectionStateEntity(watermarkSequenceId = lastSeq, projectorVersion = PROJECTOR_VERSION),
             )
@@ -226,7 +283,7 @@ class AnalyticsProjector @Inject constructor(
         Timber.tag(TAG).d(
             "batch: %d events (→seq %d) → %d deliveries, %d offers, %d sessions, %d re-priced, %d skipped",
             events.size, lastSeq, deliveries.size, offers.size, touched.size,
-            payAdjustments.size - adjustmentSkips, skips,
+            payAdjustments.size + deliveryAdjustments.size - adjustmentSkips, skips,
         )
         if (skips > 0) {
             Timber.tag(TAG).w("batch skipped %d event(s) with a missing/malformed payload", skips)
@@ -402,6 +459,11 @@ class AnalyticsProjector @Inject constructor(
         frozenNonFuelPerMile = frozenNonFuelPerMile,
         netProfit = netProfit,
         costBasis = costBasis,
+        cashTip = cashTip,
+        // #703: stamp the first-fold basis ONCE, here at fold time. Every later correction apply
+        // preserves it via `row.copy`, so a re-priced row keeps its original receipt-evidence basis
+        // for the #691 hydration COALESCE.
+        originalPayBasis = payBasis,
     )
 
     private fun OfferFold.toEntity() = OfferRecordEntity(
@@ -445,9 +507,18 @@ class AnalyticsProjector @Inject constructor(
          * v3 (#653): the fold now drops a full-receipt stamp on an already-delivered multi-delivery
          * job as SUSPECT (`PayBasis.SUSPECT_FULL_RECEIPT`, no realizedPay/tip/base) instead of
          * double-counting the period SUM — the refold applies the guard to history.
-         * (#650 does NOT bump this: `MANUAL_DELIVERY`/`PAY_ADJUSTMENT` are new event types that cannot
-         * exist in already-folded history, so there is nothing to refold — a fresh drain folds them.)
+         * (#650 did NOT bump this: `MANUAL_DELIVERY`/`PAY_ADJUSTMENT` are new event types that cannot
+         * exist in already-folded history, so there was nothing to refold — a fresh drain folds them.)
+         * v4 (#703): the from-zero refold populates `originalPayBasis` (the first-fold basis, the
+         * receipt-evidence hydration anchor) for ALL history — corrections replay after their targets,
+         * so first-fold basis is reproduced faithfully, closing the #691 USER_CORRECTED hydration
+         * wrinkle for old rows too. This SUPERSEDES #650's "no bump needed" note: the bump is #703's
+         * refold requirement, not a corrections one (#688's DELIVERY_ADJUSTMENT is likewise a new event
+         * type that can't exist in folded history). Side effect (stated): the refold also re-stamps
+         * `CURRENT_FALLBACK` rows against today's economy (`CostBasis` is not rebuild-stable), so those
+         * rows' fallback net shifts on the bump — the same behaviour as the v2/v3 bumps. `cashTip`
+         * stays null in history (no cash events exist yet).
          */
-        private const val PROJECTOR_VERSION = 3
+        private const val PROJECTOR_VERSION = 4
     }
 }

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
@@ -102,10 +102,19 @@ class AnalyticsRepository @Inject constructor(
         }
 
     /**
-     * Per-store economics for [period], highest-earning store first — frozen net + realized gross.
+     * Per-store economics for [period], highest-**gross** store first — frozen net + realized gross.
      * Cash tips (#688 F5) are added to BOTH gross and net (`gross = realized pay + cash`, `net =
-     * frozen net + cash`) — explicit adds here, mirroring the period-level locked accounting; the
-     * DAO's `ORDER BY pay DESC` stays cash-free (sorted on realized pay, not the cash-inclusive gross).
+     * frozen net + cash`) — explicit adds here, mirroring the period-level locked accounting.
+     *
+     * **Cash-inclusive ordering (F8):** the DAO's `ORDER BY pay DESC` is a cash-free **stable
+     * pre-sort**; the final rank is re-sorted here by the cash-inclusive [StoreEconomics.gross] so a
+     * cash-heavy store isn't ranked below a lower-gross one whose cash the SQL sort key ignored. The
+     * repository owns the mapped-value ordering because cash is added here, not in SQL (Principle 5 —
+     * one owner for the gross number, one owner for the sort that uses it).
+     *
+     * **Null-net + cash presentation:** a store whose only row has a null frozen `net` (no cost basis)
+     * but a recorded `cashTip` surfaces as `net = 0 + cash` — i.e. "net = cash". Accepted: cash has no
+     * cost term to net out, so the driver-attested cash IS the honest net contribution of that row.
      */
     fun perStoreEconomics(period: AnalyticsPeriod): Flow<List<StoreEconomics>> =
         periodBoundariesFlow(period).flatMapLatest { (start, end) ->
@@ -117,7 +126,7 @@ class AnalyticsRepository @Inject constructor(
                         gross = it.pay + it.cash,
                         deliveries = it.deliveries,
                     )
-                }
+                }.sortedByDescending { it.gross }
             }
         }
 

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
@@ -77,7 +77,7 @@ class AnalyticsRepository @Inject constructor(
                         deliveredPay = d.pay, deliveryNet = d.net, deliveries = d.deliveries,
                         jobs = d.jobs, miles = s.miles, onlineMillis = s.onlineMillis,
                         gross = g.gross, unattributed = g.unattributed,
-                        fuelCost = d.fuelCost, nonFuelCost = d.nonFuelCost,
+                        fuelCost = d.fuelCost, nonFuelCost = d.nonFuelCost, cash = d.cash,
                     )
                 }
             } else {
@@ -95,17 +95,29 @@ class AnalyticsRepository @Inject constructor(
                         deliveries = d?.deliveries ?: 0, jobs = d?.jobs ?: 0,
                         miles = s?.miles ?: 0.0, onlineMillis = s?.onlineMillis ?: 0L,
                         gross = g?.gross ?: 0.0, unattributed = g?.unattributed ?: 0.0,
-                        fuelCost = d?.fuelCost, nonFuelCost = d?.nonFuelCost,
+                        fuelCost = d?.fuelCost, nonFuelCost = d?.nonFuelCost, cash = d?.cash ?: 0.0,
                     )
                 }
             }
         }
 
-    /** Per-store economics for [period], highest-earning store first — frozen net + realized gross. */
+    /**
+     * Per-store economics for [period], highest-earning store first — frozen net + realized gross.
+     * Cash tips (#688 F5) are added to BOTH gross and net (`gross = realized pay + cash`, `net =
+     * frozen net + cash`) — explicit adds here, mirroring the period-level locked accounting; the
+     * DAO's `ORDER BY pay DESC` stays cash-free (sorted on realized pay, not the cash-inclusive gross).
+     */
     fun perStoreEconomics(period: AnalyticsPeriod): Flow<List<StoreEconomics>> =
         periodBoundariesFlow(period).flatMapLatest { (start, end) ->
             analyticsDao.deliveryTotalsByStore(start, end).map { rows ->
-                rows.map { StoreEconomics(storeName = it.storeName, net = it.net, gross = it.pay, deliveries = it.deliveries) }
+                rows.map {
+                    StoreEconomics(
+                        storeName = it.storeName,
+                        net = it.net + it.cash,
+                        gross = it.pay + it.cash,
+                        deliveries = it.deliveries,
+                    )
+                }
             }
         }
 
@@ -257,8 +269,13 @@ class AnalyticsRepository @Inject constructor(
         unattributed: Double,
         fuelCost: Double?,
         nonFuelCost: Double?,
+        cash: Double,
     ): PeriodEconomics {
-        val net = deliveryNet + unattributed
+        // Locked accounting (#688): cash tips add to BOTH net and gross. [gross] already includes the
+        // cash sum (folded in the DAO's `grossAndUnattributed`); net adds it here (it is deliberately
+        // OUTSIDE the frozen delivery `netProfit`, so it can't be lost to a null-net row). The
+        // waterfall's cost = gross − net is unchanged (cash cancels), so the 4-step reconcile holds.
+        val net = deliveryNet + unattributed + cash
         val hours = onlineMillis / 3_600_000.0
         return PeriodEconomics(
             totals = PeriodTotals(

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/CorrectionRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/CorrectionRepository.kt
@@ -3,15 +3,17 @@ package cloud.trotter.dashbuddy.core.data.analytics
 import cloud.trotter.dashbuddy.core.data.event.AppEventRepo
 import cloud.trotter.dashbuddy.domain.model.event.AppEvent
 import cloud.trotter.dashbuddy.domain.model.event.AppEventType
+import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryAdjustmentPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.ManualDeliveryPayload
-import cloud.trotter.dashbuddy.domain.model.event.payload.PayAdjustmentPayload
 import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * Write-side entry point for driver corrections (#650) — appends `MANUAL_DELIVERY` / `PAY_ADJUSTMENT`
- * events to the durable `app_events` log. Deliberately SEPARATE from the read-side [AnalyticsRepository]
+ * Write-side entry point for driver corrections (#650/#688) — appends `MANUAL_DELIVERY` /
+ * `DELIVERY_ADJUSTMENT` events to the durable `app_events` log. (The legacy `PAY_ADJUSTMENT` event
+ * stays fully readable by the fold/projector for history, but the new UI writes only the widened
+ * `DELIVERY_ADJUSTMENT`.) Deliberately SEPARATE from the read-side [AnalyticsRepository]
  * (Principle 3 — single responsibility: one repository reads the projected records, another writes the
  * correction events; they never share a code path). Corrections are **events, never destructive edits**:
  * the original capture and its provenance stay in the log; the projector folds the correction on its
@@ -37,6 +39,7 @@ class CorrectionRepository @Inject constructor(
         storeName: String?,
         pay: Double,
         tip: Double?,
+        cashTip: Double?,
         completedAt: Long,
         miles: Double?,
         note: String?,
@@ -51,6 +54,7 @@ class CorrectionRepository @Inject constructor(
                     storeName = storeName,
                     pay = pay,
                     tip = tip,
+                    cashTip = cashTip,
                     completedAt = completedAt,
                     miles = miles,
                     note = note,
@@ -62,32 +66,53 @@ class CorrectionRepository @Inject constructor(
     }
 
     /**
-     * Append a driver re-price of an already-recorded delivery (#650). [targetEventSequenceId] is the
-     * PK of the `delivery_record` to re-price; [sessionId] is for attribution/liveness only. The
-     * projector rewrites the target row's realizedPay to [newPay] (payBasis → `USER_CORRECTED`, net
-     * recomputed against the row's own frozen cost basis) on its next drain — the original event stays.
+     * Append a driver multi-field edit of an already-recorded delivery (#688) — the widened
+     * correction. [targetEventSequenceId] is the PK of the target `delivery_record`; [sessionId] is
+     * for attribution/liveness only. Every new-value field is optional (null ⇒ that column is left
+     * unchanged); the projector re-applies the target row on its next drain (payBasis → `USER_CORRECTED`
+     * only when [newPay] changes, per the never-silent disclosure rule; net recomputed against the row's
+     * own frozen cost basis) — the original event stays.
+     *
+     * Validation: at least one new-value field OR [note] must be non-null (a note-only annotation is
+     * valid, #688 F6); money is > 0 where present, tip/cash ≥ 0, miles ≥ 0.
      */
-    suspend fun adjustDeliveryPay(
+    suspend fun adjustDelivery(
         targetEventSequenceId: Long,
         sessionId: String?,
-        newPay: Double,
-        note: String?,
+        newStoreName: String? = null,
+        newPay: Double? = null,
+        newTip: Double? = null,
+        newCashTip: Double? = null,
+        newMiles: Double? = null,
+        note: String? = null,
     ) {
+        require(
+            newStoreName != null || newPay != null || newTip != null ||
+                newCashTip != null || newMiles != null || note != null,
+        ) { "DELIVERY_ADJUSTMENT must change at least one field or carry a note" }
+        require(newPay == null || newPay > 0.0) { "newPay must be positive" }
+        require(newTip == null || newTip >= 0.0) { "newTip must be non-negative" }
+        require(newCashTip == null || newCashTip >= 0.0) { "newCashTip must be non-negative" }
+        require(newMiles == null || newMiles >= 0.0) { "newMiles must be non-negative" }
         appEventRepo.appendUserEvent(
             AppEvent(
-                type = AppEventType.PAY_ADJUSTMENT,
+                type = AppEventType.DELIVERY_ADJUSTMENT,
                 occurredAt = System.currentTimeMillis(),
                 sessionId = sessionId,
-                payload = PayAdjustmentPayload(
+                payload = DeliveryAdjustmentPayload(
                     targetEventSequenceId = targetEventSequenceId,
                     sessionId = sessionId,
+                    newStoreName = newStoreName,
                     newPay = newPay,
+                    newTip = newTip,
+                    newCashTip = newCashTip,
+                    newMiles = newMiles,
                     note = note,
                 ),
             ),
         )
-        // P7: no note text — counts/ids only.
-        Timber.tag(TAG).i("PAY_ADJUSTMENT appended for delivery seq %d", targetEventSequenceId)
+        // P7: no note/store text — counts/ids only.
+        Timber.tag(TAG).i("DELIVERY_ADJUSTMENT appended for delivery seq %d", targetEventSequenceId)
     }
 
     private companion object {

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/CorrectionRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/CorrectionRepository.kt
@@ -33,6 +33,10 @@ class CorrectionRepository @Inject constructor(
      * are optional driver knowledge. [completedAt] is when the delivery happened (the caller picks an
      * honest default, e.g. the session's end/start). The projector folds it into a `delivery_record`
      * (payBasis `MANUAL`) on its next drain.
+     *
+     * Validation (#705 F4b — parity with [adjustDelivery], which this method previously lacked
+     * entirely): every money/miles value must be **finite** (a non-finite value would reach
+     * `AppEventCodec` and throw a `SerializationException`), pay finite > 0, tip/cash/miles finite ≥ 0.
      */
     suspend fun addManualDelivery(
         sessionId: String,
@@ -44,6 +48,10 @@ class CorrectionRepository @Inject constructor(
         miles: Double?,
         note: String?,
     ) {
+        require(pay.isFinite() && pay > 0.0) { "pay must be a finite positive amount" }
+        require(tip == null || (tip.isFinite() && tip >= 0.0)) { "tip must be finite and non-negative" }
+        require(cashTip == null || (cashTip.isFinite() && cashTip >= 0.0)) { "cashTip must be finite and non-negative" }
+        require(miles == null || (miles.isFinite() && miles >= 0.0)) { "miles must be finite and non-negative" }
         appEventRepo.appendUserEvent(
             AppEvent(
                 type = AppEventType.MANUAL_DELIVERY,
@@ -90,10 +98,12 @@ class CorrectionRepository @Inject constructor(
             newStoreName != null || newPay != null || newTip != null ||
                 newCashTip != null || newMiles != null || note != null,
         ) { "DELIVERY_ADJUSTMENT must change at least one field or carry a note" }
-        require(newPay == null || newPay > 0.0) { "newPay must be positive" }
-        require(newTip == null || newTip >= 0.0) { "newTip must be non-negative" }
-        require(newCashTip == null || newCashTip >= 0.0) { "newCashTip must be non-negative" }
-        require(newMiles == null || newMiles >= 0.0) { "newMiles must be non-negative" }
+        // Every money/miles value must be FINITE (#705 F4b): a non-finite value (e.g. a pasted `1e999`
+        // → `Infinity`) would reach `AppEventCodec` and throw a `SerializationException`.
+        require(newPay == null || (newPay.isFinite() && newPay > 0.0)) { "newPay must be a finite positive amount" }
+        require(newTip == null || (newTip.isFinite() && newTip >= 0.0)) { "newTip must be finite and non-negative" }
+        require(newCashTip == null || (newCashTip.isFinite() && newCashTip >= 0.0)) { "newCashTip must be finite and non-negative" }
+        require(newMiles == null || (newMiles.isFinite() && newMiles >= 0.0)) { "newMiles must be finite and non-negative" }
         appEventRepo.appendUserEvent(
             AppEvent(
                 type = AppEventType.DELIVERY_ADJUSTMENT,

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/CsvExporter.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/CsvExporter.kt
@@ -48,7 +48,7 @@ object CsvExporter {
     const val SUMMARY_FILENAME = "summary.csv"
 
     private val DELIVERY_HEADER = listOf(
-        "date", "time", "platform", "store", "gross_pay", "tip", "base_pay",
+        "date", "time", "platform", "store", "gross_pay", "tip", "base_pay", "cash_tip",
         "miles", "minutes", "frozen_cost_per_mile", "net_profit", "pay_basis", "cost_basis",
     )
 
@@ -96,6 +96,7 @@ object CsvExporter {
                         Csv.money(r.realizedPay),
                         Csv.money(r.tip),
                         Csv.money(r.basePay),
+                        Csv.money(r.cashTip),
                         Csv.decimal(r.realizedMiles),
                         Csv.decimal(r.realizedMinutes),
                         Csv.money(r.frozenCostPerMile, digits = 3),
@@ -167,6 +168,7 @@ object CsvExporter {
             .toSortedMap()
         val totalReported = sessions.mapNotNull { it.reportedEarnings }.sum()
         val totalRealized = deliveries.mapNotNull { it.realizedPay }.sum()
+        val totalCashTips = deliveries.mapNotNull { it.cashTip }.sum()
 
         val sb = StringBuilder()
         sb.append(Csv.row(listOf(Csv.textField("metric"), Csv.textField("value")))).append('\n')
@@ -188,6 +190,7 @@ object CsvExporter {
         line("total_deliveries", Csv.int(deliveries.size))
         line("total_reported_earnings", Csv.money(totalReported))
         line("total_realized_delivery_pay", Csv.money(totalRealized))
+        line("total_cash_tips", Csv.money(totalCashTips))
         return sb.toString()
     }
 }

--- a/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/CsvExporterTest.kt
+++ b/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/CsvExporterTest.kt
@@ -25,6 +25,7 @@ class CsvExporterTest {
         completedAt: Long = generatedAt,
         pay: Double? = 8.50,
         basis: String = "DROP_SHARE",
+        cashTip: Double? = null,
     ) = DeliveryRecordEntity(
         eventSequenceId = seq,
         sessionId = "s1",
@@ -48,6 +49,7 @@ class CsvExporterTest {
         frozenCostPerMile = 0.165,
         netProfit = 7.81,
         costBasis = "OFFER_FROZEN",
+        cashTip = cashTip,
     )
 
     private fun session(
@@ -77,16 +79,30 @@ class CsvExporterTest {
     )
 
     @Test fun deliveries_headerAndRow_withPlatformDisplayName() {
-        val out = CsvExporter.export(listOf(delivery(1, "H-E-B")), emptyList(), utc, generatedAt)
+        val out = CsvExporter.export(listOf(delivery(1, "H-E-B", cashTip = 4.00)), emptyList(), utc, generatedAt)
         val lines = out.deliveriesCsv.trim().lines()
         assertEquals(
-            "date,time,platform,store,gross_pay,tip,base_pay,miles,minutes,frozen_cost_per_mile,net_profit,pay_basis,cost_basis",
+            "date,time,platform,store,gross_pay,tip,base_pay,cash_tip,miles,minutes,frozen_cost_per_mile,net_profit,pay_basis,cost_basis",
             lines[0],
         )
         assertEquals(
-            "2026-07-05,14:03:27,DoorDash,H-E-B,8.50,3.25,5.25,4.20,12.50,0.165,7.81,DROP_SHARE,OFFER_FROZEN",
+            "2026-07-05,14:03:27,DoorDash,H-E-B,8.50,3.25,5.25,4.00,4.20,12.50,0.165,7.81,DROP_SHARE,OFFER_FROZEN",
             lines[1],
         )
+    }
+
+    @Test fun deliveries_nullCashTip_isEmptyField() {
+        val out = CsvExporter.export(listOf(delivery(1, "H-E-B")), emptyList(), utc, generatedAt)
+        // cash_tip is column index 7 (date,time,platform,store,gross_pay,tip,base_pay,cash_tip).
+        assertEquals("", out.deliveriesCsv.trim().lines()[1].split(",")[7])
+    }
+
+    @Test fun summary_totalCashTips_line() {
+        val out = CsvExporter.export(
+            listOf(delivery(1, "S", cashTip = 4.00), delivery(2, "S", cashTip = 1.50)),
+            listOf(session()), utc, generatedAt,
+        )
+        assertTrue(out.summaryCsv.contains("total_cash_tips,5.50"))
     }
 
     @Test fun deliveries_offerPayBasis_appearsVerbatim() {

--- a/core/database/schemas/cloud.trotter.dashbuddy.core.database.DashBuddyDatabase/11.json
+++ b/core/database/schemas/cloud.trotter.dashbuddy.core.database.DashBuddyDatabase/11.json
@@ -1,0 +1,865 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 11,
+    "identityHash": "14fb3a62a27d2bf4bd9f918c749f9bb0",
+    "entities": [
+      {
+        "tableName": "app_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sequenceId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `aggregateId` TEXT, `eventType` TEXT NOT NULL, `eventPayload` TEXT NOT NULL, `occurredAt` INTEGER NOT NULL, `metadata` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "sequenceId",
+            "columnName": "sequenceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "aggregateId",
+            "columnName": "aggregateId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "eventType",
+            "columnName": "eventType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventPayload",
+            "columnName": "eventPayload",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "occurredAt",
+            "columnName": "occurredAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadata",
+            "columnName": "metadata",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "sequenceId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_app_events_aggregateId",
+            "unique": false,
+            "columnNames": [
+              "aggregateId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_app_events_aggregateId` ON `${TABLE_NAME}` (`aggregateId`)"
+          },
+          {
+            "name": "index_app_events_eventType",
+            "unique": false,
+            "columnNames": [
+              "eventType"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_app_events_eventType` ON `${TABLE_NAME}` (`eventType`)"
+          },
+          {
+            "name": "index_app_events_occurredAt",
+            "unique": false,
+            "columnNames": [
+              "occurredAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_app_events_occurredAt` ON `${TABLE_NAME}` (`occurredAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "app_state_snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`correlationVersion` INTEGER NOT NULL, `capturedAt` INTEGER NOT NULL, `sessionId` TEXT, `stateJson` TEXT NOT NULL, PRIMARY KEY(`correlationVersion`))",
+        "fields": [
+          {
+            "fieldPath": "correlationVersion",
+            "columnName": "correlationVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "capturedAt",
+            "columnName": "capturedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "stateJson",
+            "columnName": "stateJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "correlationVersion"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `dashId` TEXT, `text` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `personaType` TEXT NOT NULL, `personaName` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dashId",
+            "columnName": "dashId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personaType",
+            "columnName": "personaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personaName",
+            "columnName": "personaName",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_messages_dashId",
+            "unique": false,
+            "columnNames": [
+              "dashId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_messages_dashId` ON `${TABLE_NAME}` (`dashId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "effects_fired",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `effectKey` TEXT NOT NULL, `firedAt` INTEGER NOT NULL, `correlationVersion` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "effectKey",
+            "columnName": "effectKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firedAt",
+            "columnName": "firedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "correlationVersion",
+            "columnName": "correlationVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_effects_fired_effectKey",
+            "unique": true,
+            "columnNames": [
+              "effectKey"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_effects_fired_effectKey` ON `${TABLE_NAME}` (`effectKey`)"
+          }
+        ]
+      },
+      {
+        "tableName": "observations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sequenceId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `occurredAt` INTEGER NOT NULL, `sessionId` TEXT, `pipelineId` TEXT NOT NULL, `ruleId` TEXT, `platform` TEXT, `flow` TEXT, `modeHint` TEXT, `parsedJson` TEXT NOT NULL, `captureId` TEXT, `metadataJson` TEXT NOT NULL, `correlationVersion` INTEGER NOT NULL, `timeoutType` TEXT, `payloadJson` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "sequenceId",
+            "columnName": "sequenceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "occurredAt",
+            "columnName": "occurredAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pipelineId",
+            "columnName": "pipelineId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ruleId",
+            "columnName": "ruleId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "flow",
+            "columnName": "flow",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "modeHint",
+            "columnName": "modeHint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "parsedJson",
+            "columnName": "parsedJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "captureId",
+            "columnName": "captureId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "metadataJson",
+            "columnName": "metadataJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "correlationVersion",
+            "columnName": "correlationVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeoutType",
+            "columnName": "timeoutType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "payloadJson",
+            "columnName": "payloadJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "sequenceId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_observations_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_observations_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          },
+          {
+            "name": "index_observations_occurredAt",
+            "unique": false,
+            "columnNames": [
+              "occurredAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_observations_occurredAt` ON `${TABLE_NAME}` (`occurredAt`)"
+          },
+          {
+            "name": "index_observations_correlationVersion",
+            "unique": false,
+            "columnNames": [
+              "correlationVersion"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_observations_correlationVersion` ON `${TABLE_NAME}` (`correlationVersion`)"
+          }
+        ]
+      },
+      {
+        "tableName": "delivery_records",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`eventSequenceId` INTEGER NOT NULL, `sessionId` TEXT, `platform` TEXT NOT NULL, `jobId` TEXT NOT NULL, `taskId` TEXT NOT NULL, `storeName` TEXT, `customerHash` TEXT, `addressHash` TEXT, `phaseStartedAt` INTEGER NOT NULL, `arrivedAt` INTEGER, `completedAt` INTEGER NOT NULL, `deadlineMillis` INTEGER, `realizedPay` REAL, `payBasis` TEXT NOT NULL, `tip` REAL, `basePay` REAL, `odometerAtCompletion` REAL, `realizedMiles` REAL, `realizedMinutes` REAL, `frozenCostPerMile` REAL, `frozenFuelPerMile` REAL, `frozenNonFuelPerMile` REAL, `netProfit` REAL, `costBasis` TEXT NOT NULL, `cashTip` REAL, `originalPayBasis` TEXT, PRIMARY KEY(`eventSequenceId`))",
+        "fields": [
+          {
+            "fieldPath": "eventSequenceId",
+            "columnName": "eventSequenceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jobId",
+            "columnName": "jobId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "taskId",
+            "columnName": "taskId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storeName",
+            "columnName": "storeName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customerHash",
+            "columnName": "customerHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addressHash",
+            "columnName": "addressHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "phaseStartedAt",
+            "columnName": "phaseStartedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "arrivedAt",
+            "columnName": "arrivedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deadlineMillis",
+            "columnName": "deadlineMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "realizedPay",
+            "columnName": "realizedPay",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "payBasis",
+            "columnName": "payBasis",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tip",
+            "columnName": "tip",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "basePay",
+            "columnName": "basePay",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "odometerAtCompletion",
+            "columnName": "odometerAtCompletion",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "realizedMiles",
+            "columnName": "realizedMiles",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "realizedMinutes",
+            "columnName": "realizedMinutes",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "frozenCostPerMile",
+            "columnName": "frozenCostPerMile",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "frozenFuelPerMile",
+            "columnName": "frozenFuelPerMile",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "frozenNonFuelPerMile",
+            "columnName": "frozenNonFuelPerMile",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "netProfit",
+            "columnName": "netProfit",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "costBasis",
+            "columnName": "costBasis",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cashTip",
+            "columnName": "cashTip",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "originalPayBasis",
+            "columnName": "originalPayBasis",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "eventSequenceId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_delivery_records_completedAt",
+            "unique": false,
+            "columnNames": [
+              "completedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_delivery_records_completedAt` ON `${TABLE_NAME}` (`completedAt`)"
+          },
+          {
+            "name": "index_delivery_records_platform_completedAt",
+            "unique": false,
+            "columnNames": [
+              "platform",
+              "completedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_delivery_records_platform_completedAt` ON `${TABLE_NAME}` (`platform`, `completedAt`)"
+          },
+          {
+            "name": "index_delivery_records_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_delivery_records_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          },
+          {
+            "name": "index_delivery_records_sessionId_jobId",
+            "unique": false,
+            "columnNames": [
+              "sessionId",
+              "jobId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_delivery_records_sessionId_jobId` ON `${TABLE_NAME}` (`sessionId`, `jobId`)"
+          },
+          {
+            "name": "index_delivery_records_storeName",
+            "unique": false,
+            "columnNames": [
+              "storeName"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_delivery_records_storeName` ON `${TABLE_NAME}` (`storeName`)"
+          }
+        ]
+      },
+      {
+        "tableName": "session_records",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sessionId` TEXT NOT NULL, `platform` TEXT NOT NULL, `startedAt` INTEGER NOT NULL, `endedAt` INTEGER, `lastEventAt` INTEGER NOT NULL, `endSource` TEXT, `startSource` TEXT, `startOdometer` REAL, `lastOdometer` REAL, `reportedEarnings` REAL, `reportedDurationMillis` INTEGER, `offersReceived` INTEGER NOT NULL, `offersAccepted` INTEGER NOT NULL, `offersDeclined` INTEGER NOT NULL, `offersTimeout` INTEGER NOT NULL, `deliveries` INTEGER NOT NULL, `jobsCompleted` INTEGER NOT NULL, PRIMARY KEY(`sessionId`))",
+        "fields": [
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "startedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endedAt",
+            "columnName": "endedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastEventAt",
+            "columnName": "lastEventAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endSource",
+            "columnName": "endSource",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "startSource",
+            "columnName": "startSource",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "startOdometer",
+            "columnName": "startOdometer",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "lastOdometer",
+            "columnName": "lastOdometer",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "reportedEarnings",
+            "columnName": "reportedEarnings",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "reportedDurationMillis",
+            "columnName": "reportedDurationMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "offersReceived",
+            "columnName": "offersReceived",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "offersAccepted",
+            "columnName": "offersAccepted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "offersDeclined",
+            "columnName": "offersDeclined",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "offersTimeout",
+            "columnName": "offersTimeout",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deliveries",
+            "columnName": "deliveries",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jobsCompleted",
+            "columnName": "jobsCompleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sessionId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_session_records_startedAt",
+            "unique": false,
+            "columnNames": [
+              "startedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_session_records_startedAt` ON `${TABLE_NAME}` (`startedAt`)"
+          },
+          {
+            "name": "index_session_records_platform_startedAt",
+            "unique": false,
+            "columnNames": [
+              "platform",
+              "startedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_session_records_platform_startedAt` ON `${TABLE_NAME}` (`platform`, `startedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "offer_records",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`eventSequenceId` INTEGER NOT NULL, `sessionId` TEXT, `platform` TEXT NOT NULL, `offerHash` TEXT NOT NULL, `outcome` TEXT NOT NULL, `presentedAt` INTEGER NOT NULL, `decidedAt` INTEGER NOT NULL, `payAmount` REAL, `distanceMiles` REAL, `itemCount` INTEGER NOT NULL, `merchantName` TEXT, `score` REAL, `action` TEXT, `quality` TEXT, `estNetPay` REAL, `estDollarsPerHour` REAL, `estDollarsPerMile` REAL, `estTimeMinutes` REAL, `estOperatingCostPerMile` REAL, `estFuelPerMile` REAL, `estNonFuelPerMile` REAL, PRIMARY KEY(`eventSequenceId`))",
+        "fields": [
+          {
+            "fieldPath": "eventSequenceId",
+            "columnName": "eventSequenceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "offerHash",
+            "columnName": "offerHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "outcome",
+            "columnName": "outcome",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "presentedAt",
+            "columnName": "presentedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "decidedAt",
+            "columnName": "decidedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payAmount",
+            "columnName": "payAmount",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "distanceMiles",
+            "columnName": "distanceMiles",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "itemCount",
+            "columnName": "itemCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchantName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "action",
+            "columnName": "action",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "quality",
+            "columnName": "quality",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "estNetPay",
+            "columnName": "estNetPay",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "estDollarsPerHour",
+            "columnName": "estDollarsPerHour",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "estDollarsPerMile",
+            "columnName": "estDollarsPerMile",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "estTimeMinutes",
+            "columnName": "estTimeMinutes",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "estOperatingCostPerMile",
+            "columnName": "estOperatingCostPerMile",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "estFuelPerMile",
+            "columnName": "estFuelPerMile",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "estNonFuelPerMile",
+            "columnName": "estNonFuelPerMile",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "eventSequenceId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_offer_records_decidedAt",
+            "unique": false,
+            "columnNames": [
+              "decidedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offer_records_decidedAt` ON `${TABLE_NAME}` (`decidedAt`)"
+          },
+          {
+            "name": "index_offer_records_platform_decidedAt",
+            "unique": false,
+            "columnNames": [
+              "platform",
+              "decidedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offer_records_platform_decidedAt` ON `${TABLE_NAME}` (`platform`, `decidedAt`)"
+          },
+          {
+            "name": "index_offer_records_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offer_records_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          },
+          {
+            "name": "index_offer_records_offerHash",
+            "unique": false,
+            "columnNames": [
+              "offerHash"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offer_records_offerHash` ON `${TABLE_NAME}` (`offerHash`)"
+          }
+        ]
+      },
+      {
+        "tableName": "analytics_projection_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `watermarkSequenceId` INTEGER NOT NULL, `projectorVersion` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "watermarkSequenceId",
+            "columnName": "watermarkSequenceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "projectorVersion",
+            "columnName": "projectorVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '14fb3a62a27d2bf4bd9f918c749f9bb0')"
+    ]
+  }
+}

--- a/core/database/src/androidTest/java/cloud/trotter/dashbuddy/core/database/AnalyticsMigration10to11Test.kt
+++ b/core/database/src/androidTest/java/cloud/trotter/dashbuddy/core/database/AnalyticsMigration10to11Test.kt
@@ -1,0 +1,105 @@
+package cloud.trotter.dashbuddy.core.database
+
+import androidx.room.testing.MigrationTestHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * #688/#703 — execute the REAL committed `AutoMigration(10→11)` against a **populated** v10 database
+ * and prove it is additive-only: the pre-existing analytics rows survive and the two new nullable
+ * columns exist afterward (delivery_records.cashTip + delivery_records.originalPayBasis), left NULL
+ * by the ADD COLUMN (the `PROJECTOR_VERSION` 3→4 refold repopulates originalPayBasis from the
+ * immutable log; cashTip stays null in history — no cash events exist).
+ *
+ * Seeds a `USER_CORRECTED` row specifically: that basis is the #703 wrinkle (a re-priced row whose
+ * ORIGINAL fold basis was receipt evidence), and the migration must preserve it intact so the refold
+ * can re-stamp its originalPayBasis.
+ *
+ * Instrumented (androidTest) because [MigrationTestHelper] opens an on-disk SQLite DB via the
+ * framework factory and replays the exported schema JSONs. Runs under
+ * `:core:database:connectedAndroidTest`.
+ */
+@RunWith(AndroidJUnit4::class)
+class AnalyticsMigration10to11Test {
+
+    private val dbName = "migration-10-to-11-test"
+
+    @get:Rule
+    val helper = MigrationTestHelper(
+        InstrumentationRegistry.getInstrumentation(),
+        DashBuddyDatabase::class.java,
+        emptyList(),
+        FrameworkSQLiteOpenHelperFactory(),
+    )
+
+    @Test
+    fun migrate10To11_preservesAnalyticsRows_andAddsCashTipAndOriginalPayBasisColumns() {
+        // Create the schema at v10 and seed delivery rows (v10 column set) — one plain RECEIPT_TOTAL
+        // row and one USER_CORRECTED row (the #703 re-priced shape).
+        helper.createDatabase(dbName, 10).use { db ->
+            db.execSQL(
+                """INSERT INTO delivery_records
+                   (eventSequenceId, sessionId, platform, jobId, taskId, storeName, customerHash,
+                    addressHash, phaseStartedAt, arrivedAt, completedAt, deadlineMillis, realizedPay,
+                    payBasis, tip, basePay, odometerAtCompletion, realizedMiles, realizedMinutes,
+                    frozenCostPerMile, frozenFuelPerMile, frozenNonFuelPerMile, netProfit, costBasis)
+                   VALUES (1, 'S1', 'doordash', 'J1', 'T1', 'StoreX', NULL, NULL, 100, NULL, 3000,
+                           NULL, 10.0, 'RECEIPT_TOTAL', NULL, NULL, 105.0, 5.0, 1.0, 0.25, 0.10, 0.15,
+                           8.75, 'OFFER_FROZEN')""",
+            )
+            db.execSQL(
+                """INSERT INTO delivery_records
+                   (eventSequenceId, sessionId, platform, jobId, taskId, storeName, customerHash,
+                    addressHash, phaseStartedAt, arrivedAt, completedAt, deadlineMillis, realizedPay,
+                    payBasis, tip, basePay, odometerAtCompletion, realizedMiles, realizedMinutes,
+                    frozenCostPerMile, frozenFuelPerMile, frozenNonFuelPerMile, netProfit, costBasis)
+                   VALUES (2, 'S1', 'doordash', 'J2', 'T2', 'StoreY', NULL, NULL, 100, NULL, 4000,
+                           NULL, 15.0, 'USER_CORRECTED', NULL, NULL, 110.0, 5.0, 1.0, 0.25, 0.10, 0.15,
+                           13.75, 'OFFER_FROZEN')""",
+            )
+            db.execSQL(
+                """INSERT INTO session_records
+                   (sessionId, platform, startedAt, endedAt, lastEventAt, endSource, startOdometer,
+                    lastOdometer, reportedEarnings, reportedDurationMillis, offersReceived,
+                    offersAccepted, offersDeclined, offersTimeout, deliveries, jobsCompleted,
+                    startSource)
+                   VALUES ('S1', 'doordash', 1000, 5000, 5000, 'summary_screen', 100.0, 110.0, 25.0,
+                           4000, 1, 1, 0, 0, 2, 2, 'interaction')""",
+            )
+        }
+
+        // Run the real AutoMigration(10→11) and validate against the exported 11.json schema.
+        val db = helper.runMigrationsAndValidate(dbName, 11, true)
+
+        // The pre-existing rows survived (additive-only, not destructive).
+        db.query("SELECT COUNT(*) FROM delivery_records").use { c ->
+            c.moveToFirst()
+            assertEquals("delivery_records preserved across 10→11", 2, c.getInt(0))
+        }
+        // Data intact — the USER_CORRECTED row keeps its pay/basis (the #703 refold anchor).
+        db.query("SELECT payBasis, realizedPay FROM delivery_records WHERE eventSequenceId = 2").use { c ->
+            c.moveToFirst()
+            assertEquals("USER_CORRECTED", c.getString(0))
+            assertEquals(15.0, c.getDouble(1), 1e-9)
+        }
+
+        // The new nullable columns exist and are NULL on the migrated rows (repopulated by the refold).
+        db.query("SELECT cashTip, originalPayBasis FROM delivery_records WHERE eventSequenceId = 1").use { c ->
+            c.moveToFirst()
+            assertTrue("cashTip is NULL post-migration", c.isNull(0))
+            assertTrue("originalPayBasis is NULL post-migration", c.isNull(1))
+        }
+        db.query("SELECT cashTip, originalPayBasis FROM delivery_records WHERE eventSequenceId = 2").use { c ->
+            c.moveToFirst()
+            assertTrue("cashTip is NULL post-migration", c.isNull(0))
+            assertTrue("originalPayBasis is NULL post-migration (refold re-stamps it)", c.isNull(1))
+        }
+        db.close()
+    }
+}

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/DashBuddyDatabase.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/DashBuddyDatabase.kt
@@ -46,7 +46,18 @@ import cloud.trotter.dashbuddy.core.database.snapshot.AppStateSnapshotEntity
     // (retro finding 2 — `started` provenance). Every value repopulates from the
     // immutable log on the PROJECTOR_VERSION 1→2 refold, so the ADD COLUMN nulls are
     // transient. Additive ⇒ never wipes app_events or the existing analytics rows.
-    autoMigrations = [AutoMigration(from = 8, to = 9), AutoMigration(from = 9, to = 10)],
+    // v10→v11 (#688/#703) is additive-only: two new nullable columns on delivery_records
+    // — cashTip (driver-entered cash tip, added to gross/net only at read sites) and
+    // originalPayBasis (the first-fold payBasis, never rewritten by a correction — the
+    // #703 receipt-evidence hydration anchor). Both repopulate from the immutable log on
+    // the PROJECTOR_VERSION 3→4 refold this bump triggers (cashTip stays null in history —
+    // no cash events exist; originalPayBasis is stamped for every row). Additive ⇒ never
+    // wipes app_events or the existing analytics rows.
+    autoMigrations = [
+        AutoMigration(from = 8, to = 9),
+        AutoMigration(from = 9, to = 10),
+        AutoMigration(from = 10, to = 11),
+    ],
 )
 @TypeConverters(DataTypeConverters::class)
 abstract class DashBuddyDatabase : RoomDatabase() {
@@ -73,7 +84,7 @@ abstract class DashBuddyDatabase : RoomDatabase() {
          * this in lockstep with a new `schemas/**/<N>.json`, an `AutoMigration(N-1 → N)`, and its
          * `MigrationTestHelper` case — see the release checklist in CLAUDE.md.
          */
-        const val VERSION = 10
+        const val VERSION = 11
     }
 
 }

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
@@ -85,7 +85,8 @@ interface AnalyticsDao {
                   COUNT(*) AS deliveries,
                   COUNT(DISTINCT jobId) AS jobs,
                   SUM(frozenFuelPerMile * realizedMiles) AS fuelCost,
-                  SUM(frozenNonFuelPerMile * realizedMiles) AS nonFuelCost
+                  SUM(frozenNonFuelPerMile * realizedMiles) AS nonFuelCost,
+                  COALESCE(SUM(cashTip), 0) AS cash
            FROM delivery_records
            WHERE sessionId IN (SELECT sessionId FROM session_records
                                WHERE startedAt >= :start AND startedAt < :end)
@@ -101,7 +102,8 @@ interface AnalyticsDao {
                   COUNT(*) AS deliveries,
                   COUNT(DISTINCT jobId) AS jobs,
                   SUM(frozenFuelPerMile * realizedMiles) AS fuelCost,
-                  SUM(frozenNonFuelPerMile * realizedMiles) AS nonFuelCost
+                  SUM(frozenNonFuelPerMile * realizedMiles) AS nonFuelCost,
+                  COALESCE(SUM(cashTip), 0) AS cash
            FROM delivery_records
            WHERE sessionId IN (SELECT sessionId FROM session_records
                                WHERE startedAt >= :start AND startedAt < :end)
@@ -113,13 +115,16 @@ interface AnalyticsDao {
     /**
      * Per-store variant of [deliveryTotals] — same session-anchored join + null-session edge.
      * `ORDER BY pay DESC` is the **highest-earning store first** (realized gross), intentional so
-     * the store list leads with where the money came from.
+     * the store list leads with where the money came from. The order stays **cash-free** (realized
+     * pay only) on purpose — cash is added to the store's gross/net in the repository mapper (#688
+     * F5), not used as the sort key.
      */
     @Query(
         """SELECT storeName,
                   COALESCE(SUM(realizedPay), 0) AS pay,
                   COALESCE(SUM(netProfit), 0) AS net,
-                  COUNT(*) AS deliveries
+                  COUNT(*) AS deliveries,
+                  COALESCE(SUM(cashTip), 0) AS cash
            FROM delivery_records
            WHERE sessionId IN (SELECT sessionId FROM session_records
                                WHERE startedAt >= :start AND startedAt < :end)
@@ -163,9 +168,19 @@ interface AnalyticsDao {
      * redundant and wrong (it could split a midnight-spanning session's pay away from its reported
      * total). The `LEFT JOIN` is onto a `GROUP BY sessionId` subquery (one row per session), so
      * there is no fan-out.
+     *
+     * **Cash tips (#688 locked accounting):** `gross` adds each session's Σ `cashTip` (the subquery's
+     * `cashTip` alias) — cash is real earnings, so it belongs in gross. The `unattributed` CASE stays
+     * **untouched** (it still compares `reportedEarnings` against the cash-free `deliveredPay`), so a
+     * recorded cash tip raises gross/net without shrinking the reported-vs-captured reconciliation.
+     * **Invariant (#688 F3):** every cash-bearing row is sessionful (the drill-down writes only
+     * sessionful targets, MANUAL carries a sessionId) — so the cash counted into `net` (via
+     * [deliveryTotals]'s null-session-inclusive `cash`) and into `gross` here (session-join only) is
+     * the same amount; a null-session cash row would leak into net but not gross, which the invariant
+     * forbids.
      */
     @Query(
-        """SELECT COALESCE(SUM(COALESCE(s.reportedEarnings, d.deliveredPay, 0)), 0) AS gross,
+        """SELECT COALESCE(SUM(COALESCE(s.reportedEarnings, d.deliveredPay, 0) + COALESCE(d.cashTip, 0)), 0) AS gross,
                   COALESCE(SUM(
                     CASE WHEN s.reportedEarnings IS NOT NULL
                               AND s.reportedEarnings > COALESCE(d.deliveredPay, 0)
@@ -173,7 +188,7 @@ interface AnalyticsDao {
                          ELSE 0 END), 0) AS unattributed
            FROM session_records s
            LEFT JOIN (
-             SELECT sessionId, SUM(realizedPay) AS deliveredPay
+             SELECT sessionId, SUM(realizedPay) AS deliveredPay, SUM(cashTip) AS cashTip
              FROM delivery_records GROUP BY sessionId
            ) d ON d.sessionId = s.sessionId
            WHERE s.startedAt >= :start AND s.startedAt < :end"""
@@ -182,7 +197,7 @@ interface AnalyticsDao {
 
     @Query(
         """SELECT s.platform AS platform,
-                  COALESCE(SUM(COALESCE(s.reportedEarnings, d.deliveredPay, 0)), 0) AS gross,
+                  COALESCE(SUM(COALESCE(s.reportedEarnings, d.deliveredPay, 0) + COALESCE(d.cashTip, 0)), 0) AS gross,
                   COALESCE(SUM(
                     CASE WHEN s.reportedEarnings IS NOT NULL
                               AND s.reportedEarnings > COALESCE(d.deliveredPay, 0)
@@ -190,7 +205,7 @@ interface AnalyticsDao {
                          ELSE 0 END), 0) AS unattributed
            FROM session_records s
            LEFT JOIN (
-             SELECT sessionId, SUM(realizedPay) AS deliveredPay
+             SELECT sessionId, SUM(realizedPay) AS deliveredPay, SUM(cashTip) AS cashTip
              FROM delivery_records GROUP BY sessionId
            ) d ON d.sessionId = s.sessionId
            WHERE s.startedAt >= :start AND s.startedAt < :end
@@ -207,10 +222,10 @@ interface AnalyticsDao {
      */
     @Query(
         """SELECT s.startedAt AS startedAt,
-                  COALESCE(s.reportedEarnings, d.deliveredPay, 0) AS gross
+                  COALESCE(s.reportedEarnings, d.deliveredPay, 0) + COALESCE(d.cashTip, 0) AS gross
            FROM session_records s
            LEFT JOIN (
-             SELECT sessionId, SUM(realizedPay) AS deliveredPay
+             SELECT sessionId, SUM(realizedPay) AS deliveredPay, SUM(cashTip) AS cashTip
              FROM delivery_records GROUP BY sessionId
            ) d ON d.sessionId = s.sessionId
            WHERE s.startedAt >= :start AND s.startedAt < :end
@@ -358,13 +373,16 @@ interface AnalyticsDao {
      * included: its money was nulled (#653), but the receipt still proves the job is not receipt-less.
      * The IN-list is compile-time-concatenated from [PayBasis]'s `const val`s (legal in an annotation)
      * so it derives from the SAME SSOT as the in-fold guard ([PayBasis.RECEIPT_EVIDENCE]) — the two
-     * sides can never drift. Deliberately excludes `USER_CORRECTED` (a documented hydration wrinkle,
-     * #691 VET F1; closed by v11 receipt-evidence persistence, #703) and the estimate/none bases.
+     * sides can never drift. Matched on `COALESCE(originalPayBasis, payBasis)` (#703): a row re-priced
+     * to `USER_CORRECTED` keeps its FIRST-fold basis as receipt evidence via the persisted
+     * `originalPayBasis`, closing the #691 VET F1 hydration wrinkle even for re-priced rows; the
+     * COALESCE covers legacy rows whose `originalPayBasis` is still null (pre-`PROJECTOR_VERSION` 4
+     * refold). Deliberately excludes `USER_CORRECTED` itself and the estimate/none bases.
      */
     @Query(
         "SELECT DISTINCT jobId FROM delivery_records WHERE sessionId = :id " +
-            "AND payBasis IN ('" + PayBasis.DROP_SHARE + "', '" + PayBasis.RECEIPT_TOTAL +
-            "', '" + PayBasis.SUSPECT_FULL_RECEIPT + "')"
+            "AND COALESCE(originalPayBasis, payBasis) IN ('" + PayBasis.DROP_SHARE + "', '" +
+            PayBasis.RECEIPT_TOTAL + "', '" + PayBasis.SUSPECT_FULL_RECEIPT + "')"
     )
     suspend fun receiptedJobIdsInSession(id: String): List<String>
 

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
@@ -308,9 +308,22 @@ interface AnalyticsDao {
 
     // ── Drill-down list reads (future hub / #650) ────────────────────────
 
-    /** Most recent sessions, newest first — the "recent dashes" list. */
-    @Query("SELECT * FROM session_records ORDER BY startedAt DESC LIMIT :limit")
-    fun recentSessions(limit: Int): Flow<List<SessionRecordEntity>>
+    /**
+     * Most recent sessions, newest first — the "recent dashes" list — each with its Σ driver-entered
+     * cash tips (#688 F7). The cash comes from a LEFT-JOINed `GROUP BY sessionId` subquery (one row
+     * per session, no fan-out — the same shape as [sessionGrossRows]); a session with no cash rows
+     * gets `cash = 0`. Cash is a SEPARATE column, never folded into the session's reported earnings,
+     * so the list can render a "+cash" marker while the reported number stays verbatim.
+     */
+    @Query(
+        """SELECT s.*, COALESCE(d.cash, 0) AS cash
+           FROM session_records s
+           LEFT JOIN (
+             SELECT sessionId, SUM(cashTip) AS cash FROM delivery_records GROUP BY sessionId
+           ) d ON d.sessionId = s.sessionId
+           ORDER BY s.startedAt DESC LIMIT :limit"""
+    )
+    fun recentSessions(limit: Int): Flow<List<SessionWithCashRow>>
 
     /** Every delivery in a session, in completion order — the per-dash breakdown. */
     @Query("SELECT * FROM delivery_records WHERE sessionId = :sessionId ORDER BY completedAt ASC")

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsTotals.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsTotals.kt
@@ -18,6 +18,12 @@ data class DeliveryTotalsRow(
     val deliveries: Int,
     val jobs: Int,
     /**
+     * Σ driver-entered cash tips = `COALESCE(SUM(cashTip), 0)` (#688). Kept as its OWN alias — NOT
+     * folded into [pay]/[net] — so the locked accounting adds cash to gross/net explicitly at the
+     * repository while the reconciliation's Σ-attributed ([pay]) stays cash-free.
+     */
+    val cash: Double,
+    /**
      * Σ **frozen** fuel dollars for the period = `SUM(frozenFuelPerMile × realizedMiles)` (#659) —
      * the first-class fuel cost row of the 4-step true-net waterfall. Nullable and left un-`COALESCE`d
      * on purpose: SQL `SUM` of all-null terms is NULL, which is the "no frozen split coverage" signal
@@ -36,6 +42,8 @@ data class PlatformDeliveryTotalsRow(
     val net: Double,
     val deliveries: Int,
     val jobs: Int,
+    /** Σ driver-entered cash tips for the platform's period rows (#688) — see [DeliveryTotalsRow.cash]. */
+    val cash: Double,
     /** Σ frozen fuel dollars for the platform's period rows (#659) — see [DeliveryTotalsRow.fuelCost]. */
     val fuelCost: Double?,
     /** Σ frozen non-fuel dollars for the platform's period rows (#659). */
@@ -48,6 +56,8 @@ data class StoreTotalsRow(
     val pay: Double,
     val net: Double,
     val deliveries: Int,
+    /** Σ driver-entered cash tips for the store's period rows (#688) — see [DeliveryTotalsRow.cash]. */
+    val cash: Double,
 )
 
 /**

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsTotals.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsTotals.kt
@@ -1,11 +1,26 @@
 package cloud.trotter.dashbuddy.core.database.analytics
 
+import androidx.room.Embedded
+
 /**
  * Aggregate query-result projections for [AnalyticsDao] (#314). Plain POJOs Room
  * maps SUM/COUNT rows into — NOT entities, NOT persisted. They stay in
  * `:core:database` next to the DAO whose queries produce them; the read-side
  * repository (`:core:data`, PR3) folds economy in on top.
  */
+
+/**
+ * One recent session row + its Σ driver-entered cash tips (#688 F7). [session] is the whole
+ * `session_records` row (`@Embedded`); [cash] is `COALESCE(SUM(cashTip), 0)` over that session's
+ * delivery rows — a LEFT-JOINed `GROUP BY sessionId` subquery (one row per session, no fan-out, the
+ * same shape as `AnalyticsDao.sessionGrossRows`). Kept as its OWN column — never folded into the
+ * session row — so the recent-dashes list can show a "+cash" marker WITHOUT rewriting the
+ * platform-reported earnings number (the label stays honest; cash is additive-visible only).
+ */
+data class SessionWithCashRow(
+    @Embedded val session: SessionRecordEntity,
+    val cash: Double,
+)
 
 /**
  * Cross-platform delivery totals for a period. [net] is Σ **frozen** per-delivery net

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/DeliveryRecordEntity.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/DeliveryRecordEntity.kt
@@ -95,4 +95,24 @@ data class DeliveryRecordEntity(
     val netProfit: Double?,
     /** Provenance of the cost basis: "OFFER_FROZEN" | "CAPTURED" | "CURRENT_FALLBACK" | "NONE". */
     val costBasis: String,
+
+    // ── Driver-attested side columns (#688, v11) ────────────────────────────
+    /**
+     * Driver-entered CASH tip (#688). The tip provenance vocabulary: [tip] = platform-reported
+     * (on-app / receipt `totalTip`, sole-drop) · `cashTip` = driver-entered cash · a #550
+     * post-delivery additional tip is a future third source (its own column when the toast capture
+     * lands). Written ONLY by driver events (DELIVERY_ADJUSTMENT / MANUAL_DELIVERY), never by a
+     * machine completion. **Locked accounting:** cash lives OUTSIDE [realizedPay] and [netProfit] —
+     * it is added to gross/net only at the read sites, so the reconciliation's Σ-attributed
+     * (`SUM(realizedPay)`) stays structurally cash-free.
+     */
+    val cashTip: Double? = null,
+    /**
+     * The [payBasis] stamped at FIRST fold (#703), **never rewritten by any correction** (every
+     * orchestrator apply preserves it via `row.copy`; only the fold-time `toEntity` sets it). The
+     * #691 receipt-evidence hydration reads `COALESCE(originalPayBasis, payBasis)`, so a row re-priced
+     * to `USER_CORRECTED` still proves its original receipt evidence to a receipt-less sibling. Null
+     * on legacy rows until the `PROJECTOR_VERSION` 3→4 refold populates it from the immutable log.
+     */
+    val originalPayBasis: String? = null,
 )

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -73,6 +73,23 @@ card's **mechanical** half, #577 (re-confirmed, 24/24, ~0.55 s — with a new po
 that entry's Bug #1), the #457 path, and #554 ShadowProjector (2/2). The #462/#460 dropoff item
 was found **broken-in-part** (raw PII in capture envelopes) and moved to that entry's Bug #7.)_
 
+- **🆕 NEW — edit a delivery directly + cash tips (#688 phase A / PR).** In **Analytics → a dash →
+  the delivery drill-down**, **tap a delivery row** (or its pencil) → the **Adjust delivery** dialog:
+  Store name / Pay / Tip / Cash tip / Miles / Note. This replaces the pay-only editor and is the real
+  fix for the 07-05 "bill millers" workaround (editing the store name into a note).
+  How to tell it's working: (1) **Edit a store name directly** — change a drop's store to the correct
+  merchant, Save; the row's store name updates and the per-store breakdown (Money tab → Top stores)
+  re-buckets it under the corrected name. The "est. offer pay" qualifier on an estimate row must
+  **survive a store-name-only edit** (a non-pay edit must NOT flip it to a corrected/plain row). (2)
+  **Add a cash tip** to a delivery (or on Add-missed-delivery): the dash header gains a separate
+  **"+$X cash tips"** line, the row shows a **"+$X cash"** line and its net rises by the cash — BUT the
+  **"Gross (reported)" tile and the unattributed callout do NOT shrink** (cash adds to gross/net, it is
+  NOT reconciled against reported). (3) Re-price a captured drop's Pay: net recomputes and (on a
+  machine row) the basis reads corrected; a MANUAL row stays MANUAL. (4) Nothing is destroyed — the
+  original event stays; a projector rebuild reproduces the edited rows. **Phase B (per-leg mileage) is
+  deferred.** (#688 phase A / PR)
+  - Confirmed: 0/2
+
 - **🆕 NEW — receipt-less shop delivery shows est. offer pay, not $0-unattributed (#691 / PR).**
   Do a **DoorDash shop order** (grocery/convenience — the kind that shows NO per-delivery receipt at
   the end; pay lives only on the offer + the running dash total). After it completes, open **Analytics

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/AnalyticsRecords.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/AnalyticsRecords.kt
@@ -60,4 +60,11 @@ data class SessionRecord(
     val offersAccepted: Int,
     val offersDeclined: Int,
     val offersTimeout: Int,
+    /**
+     * Σ driver-entered cash tips across this session's deliveries (#688 F7) — populated on the
+     * recent-dashes read path only; `0.0` everywhere cash isn't queried. Rendered as an additive
+     * "+cash" marker beside the reported earnings (never folded INTO [reportedEarnings], which stays
+     * the platform-verbatim number).
+     */
+    val cashTips: Double = 0.0,
 )

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/AnalyticsRecords.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/AnalyticsRecords.kt
@@ -36,6 +36,11 @@ data class DeliveryRecord(
     val realizedMinutes: Double?,
     val tip: Double?,
     val basePay: Double?,
+    /**
+     * Driver-entered cash tip (#688) — the driver-attested tip source. Added to gross/net at the
+     * read sites only (never inside [realizedPay]/[netProfit]); null on a machine completion.
+     */
+    val cashTip: Double? = null,
 )
 
 /** One dash session. */

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/RecordFolds.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/RecordFolds.kt
@@ -3,6 +3,7 @@ package cloud.trotter.dashbuddy.domain.analytics
 import cloud.trotter.dashbuddy.domain.evaluation.NetProfit
 import cloud.trotter.dashbuddy.domain.model.event.AppEventType
 import cloud.trotter.dashbuddy.domain.model.event.SequencedAppEvent
+import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryAdjustmentPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.ManualDeliveryPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.OfferPayload
@@ -66,8 +67,10 @@ object PayBasis {
      * the offer-pay estimate to a receipt-less sibling of the same job. This is the ONE definition
      * both sides of the guard derive from: the in-fold `receiptedJobIds` accumulation here and the
      * `AnalyticsDao.receiptedJobIdsInSession` hydration IN-list (built from the same const vals).
-     * Deliberately EXCLUDES [USER_CORRECTED] (a documented hydration wrinkle, #691 VET F1; closed by
-     * the v11 receipt-evidence persistence, #703) and the estimate/none bases.
+     * Deliberately EXCLUDES [USER_CORRECTED] (formerly a hydration wrinkle, #691 VET F1; CLOSED by
+     * the v11 receipt-evidence persistence, #703 — the DAO now hydrates on `COALESCE(originalPayBasis,
+     * payBasis)`, so a re-priced row keeps its FIRST-fold basis as receipt evidence) and the
+     * estimate/none bases.
      */
     val RECEIPT_EVIDENCE: List<String> = listOf(DROP_SHARE, RECEIPT_TOTAL, SUSPECT_FULL_RECEIPT)
 }
@@ -119,6 +122,8 @@ data class DeliveryFold(
     val realizedPay: Double?,
     val payBasis: String,
     val tip: Double?,
+    /** Driver-entered cash tip (#688) — set only on a MANUAL fold; null on a machine completion. */
+    val cashTip: Double?,
     val basePay: Double?,
     val odometerAtCompletion: Double?,
     val realizedMiles: Double?,
@@ -178,6 +183,12 @@ data class FoldOutcome(
      * orchestrator applies it inside the batch transaction after the delivery/offer upserts.
      */
     val payAdjustment: PayAdjustmentFold? = null,
+    /**
+     * A driver DELIVERY_ADJUSTMENT decision (#688): the widened multi-field re-apply. Same shape as
+     * [payAdjustment] — the pure fold decides WHICH row and WHICH fields change; the orchestrator
+     * applies it by-PK inside the batch transaction after the upserts.
+     */
+    val deliveryAdjustment: DeliveryAdjustmentFold? = null,
 )
 
 /**
@@ -190,6 +201,24 @@ data class FoldOutcome(
 data class PayAdjustmentFold(
     val targetEventSequenceId: Long,
     val newPay: Double,
+)
+
+/**
+ * A driver's widened re-apply decision (#688) — the pure fold's output for a DELIVERY_ADJUSTMENT.
+ * Every field is optional (null ⇒ that column of the target row is left unchanged); the orchestrator
+ * looks up [targetEventSequenceId] and copies each non-null field into the row, applying the basis /
+ * net rules (payBasis flips to `USER_CORRECTED` iff [newPay] is non-null on a machine row; MANUAL
+ * stays MANUAL; a cash/tip/store-only edit touches neither basis nor net). Because a DELIVERY_ADJUSTMENT
+ * always sequences after its target, a from-zero refold replays them in order and reproduces identical
+ * rows. `note` is intentionally absent — it lives only in the event payload and changes no column.
+ */
+data class DeliveryAdjustmentFold(
+    val targetEventSequenceId: Long,
+    val newStoreName: String? = null,
+    val newPay: Double? = null,
+    val newTip: Double? = null,
+    val newCashTip: Double? = null,
+    val newMiles: Double? = null,
 )
 
 /**
@@ -227,6 +256,7 @@ object RecordFolds {
             AppEventType.DELIVERY_COMPLETED -> foldDeliveryCompleted(event, context, currentCostPerMile)
             AppEventType.MANUAL_DELIVERY -> foldManualDelivery(event, context, currentCostPerMile)
             AppEventType.PAY_ADJUSTMENT -> foldPayAdjustment(event, context)
+            AppEventType.DELIVERY_ADJUSTMENT -> foldDeliveryAdjustment(event, context)
             AppEventType.DASH_STOP -> foldDashStop(event, context)
             // Every other session-attributed event just advances the liveness/odometer anchors so
             // the open-session duration and lastOdometer stay honest; the watermark still moves past
@@ -486,6 +516,7 @@ object RecordFolds {
             realizedPay = realizedPay,
             payBasis = payBasis,
             tip = tip,
+            cashTip = null, // machine completions never carry a driver cash tip (#688)
             basePay = basePay,
             odometerAtCompletion = odo,
             realizedMiles = realizedMiles,
@@ -573,6 +604,7 @@ object RecordFolds {
             realizedPay = p.pay,
             payBasis = PayBasis.MANUAL,
             tip = p.tip,
+            cashTip = p.cashTip, // driver-entered cash tip (#688) — the only fold that writes it
             basePay = null,
             odometerAtCompletion = null,
             // The driver's own stated miles — NOT a partition delta off the odometer.
@@ -617,6 +649,31 @@ object RecordFolds {
         return FoldOutcome(
             context = context,
             payAdjustment = PayAdjustmentFold(p.targetEventSequenceId, p.newPay),
+        )
+    }
+
+    /**
+     * A driver DELIVERY_ADJUSTMENT (#688) — the widened analog of [foldPayAdjustment]. The pure fold
+     * emits the [DeliveryAdjustmentFold] decision (which row, which fields); it CANNOT read the target
+     * `delivery_record` here, so the orchestrator applies the multi-field re-apply inside the batch
+     * transaction. The session context passes through UNTOUCHED (the #650 review F2 discipline): a
+     * re-apply is bookkeeping about a past row, not session activity — advancing liveness with the
+     * correction's wall-clock `occurredAt` would stretch a crash-orphaned session's online span.
+     */
+    private fun foldDeliveryAdjustment(event: SequencedAppEvent, context: SessionFoldContext?): FoldOutcome {
+        val e = event.event
+        val p = e.payload as? DeliveryAdjustmentPayload
+            ?: return FoldOutcome(context = context, skip = "DELIVERY_ADJUSTMENT: missing/malformed payload")
+        return FoldOutcome(
+            context = context,
+            deliveryAdjustment = DeliveryAdjustmentFold(
+                targetEventSequenceId = p.targetEventSequenceId,
+                newStoreName = p.newStoreName,
+                newPay = p.newPay,
+                newTip = p.newTip,
+                newCashTip = p.newCashTip,
+                newMiles = p.newMiles,
+            ),
         )
     }
 

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/SessionDetail.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/SessionDetail.kt
@@ -14,8 +14,19 @@ data class SessionDetail(
     val session: SessionRecord,
     val deliveries: List<DeliveryRecord>,   // completion order
 ) {
-    /** Σ captured delivery pay for THIS session (null pays counted as 0). */
+    /**
+     * Σ captured delivery pay for THIS session (null pays counted as 0). Deliberately CASH-FREE
+     * (#688 locked accounting): cash tips live outside `realizedPay`, so this stays the exact
+     * quantity the `unattributedPay` reconciliation compares against `reportedEarnings`.
+     */
     val deliveredPay: Double get() = deliveries.sumOf { it.realizedPay ?: 0.0 }
+
+    /**
+     * Σ driver-entered cash tips for THIS session (#688). Added to the displayed gross/net as its
+     * OWN line — never folded into [deliveredPay] or [unattributedPay], so recording a cash tip
+     * raises gross/net without shrinking the reported-vs-captured reconciliation.
+     */
+    val cashTips: Double get() = deliveries.sumOf { it.cashTip ?: 0.0 }
 
     /**
      * `reported − delivered` when the platform-reported total exceeds captured delivery pay, else

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/AppEventCodec.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/AppEventCodec.kt
@@ -1,6 +1,7 @@
 package cloud.trotter.dashbuddy.domain.model.event
 
 import cloud.trotter.dashbuddy.domain.model.event.payload.AppEventPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryAdjustmentPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.ManualDeliveryPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.OfferPayload
@@ -38,6 +39,7 @@ object AppEventCodec {
         is SessionStopPayload -> json.encodeToString(payload)
         is ManualDeliveryPayload -> json.encodeToString(payload)
         is PayAdjustmentPayload -> json.encodeToString(payload)
+        is DeliveryAdjustmentPayload -> json.encodeToString(payload)
     }
 
     /**
@@ -82,6 +84,9 @@ object AppEventCodec {
 
             AppEventType.PAY_ADJUSTMENT ->
                 json.decodeFromString<PayAdjustmentPayload>(payloadJson)
+
+            AppEventType.DELIVERY_ADJUSTMENT ->
+                json.decodeFromString<DeliveryAdjustmentPayload>(payloadJson)
 
             AppEventType.ZONE_SWITCH,
             AppEventType.NOTIFICATION_RECEIVED,

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/AppEventType.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/AppEventType.kt
@@ -28,6 +28,8 @@ enum class AppEventType {
     // --- User corrections (#650) ---
     MANUAL_DELIVERY, // A driver-entered missed delivery (durable correction event, never destructive)
     PAY_ADJUSTMENT,  // A driver re-price of an already-recorded delivery (the original event stays)
+    DELIVERY_ADJUSTMENT, // A driver multi-field edit of an already-recorded delivery (#688) — widens
+                         // PAY_ADJUSTMENT (store/pay/tip/cash-tip/miles/note); the original event stays
 
     // --- System / Generic ---
     SCREEN_VIEWED, // For generic screen transitions like "Earnings Screen"

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/payload/AppEventPayloads.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/payload/AppEventPayloads.kt
@@ -165,11 +165,60 @@ data class ManualDeliveryPayload(
     val storeName: String? = null,
     /** Required — the driver's stated pay for this delivery. */
     val pay: Double,
+    /** Platform-reported tip already included in [pay] (itemization only; sole-drop). */
     val tip: Double? = null,
+    /**
+     * Driver-entered CASH tip (#688) — the tip vocabulary's driver-attested source. Kept OUTSIDE
+     * [pay] (cash is added to gross/net only at the read sites, never baked into realizedPay/net) so
+     * the reconciliation's Σ-attributed stays structurally cash-free. Nullable-with-default: old
+     * events deserialize identically.
+     */
+    val cashTip: Double? = null,
     /** When the delivery happened; v1 the caller defaults it (e.g. the session's end/start). */
     val completedAt: Long,
     /** Driver-known miles, optional — the driver's statement, not an odometer partition delta. */
     val miles: Double? = null,
+    /** Driver-authored free text — driver-owned local data, never in INFO+ logs (P7). */
+    val note: String? = null,
+) : AppEventPayload
+
+/**
+ * Payload for `DELIVERY_ADJUSTMENT` (#688) — a driver multi-field edit of an already-recorded
+ * delivery, WIDENING [PayAdjustmentPayload] (which stays fully supported for history). It is an
+ * **event, never a destructive edit**: the original `DELIVERY_COMPLETED` (or `MANUAL_DELIVERY`)
+ * event and its provenance stay in the log; the projector re-applies the target `delivery_record`
+ * in place inside the batch transaction. Because a correction always sequences AFTER its target, a
+ * from-zero refold replays them in order and reproduces identical rows.
+ *
+ * Every new-value field is ALL-OPTIONAL: only the fields the driver changed are non-null, and a
+ * null field leaves the target row's value untouched. The provenance rules the orchestrator applies:
+ * a machine row's `payBasis` flips to `USER_CORRECTED` **iff [newPay] is non-null** (#688 VET F1 —
+ * payBasis rewrites exactly when realizedPay does, so a store-name/tip/cash edit never drops an
+ * "est. offer pay" disclosure); a MANUAL row stays MANUAL; cash/tip are driver-attested side columns
+ * (a [newCashTip]/[newTip]-only edit touches neither basis nor net).
+ *
+ * There is deliberately **no `newCompletedAt`** (#688 VET F2): editing the latest row's completedAt
+ * would make restart-incremental folding disagree with a from-zero refold (restart hydration reads
+ * `prevDropAt` from the corrected row while live context uses the payload's), reintroducing the
+ * determinism class #703 closes. Re-adding it later requires correction-immune anchor hydration
+ * (the projector must resolve `prevDropAt` from an origin the correction can't move).
+ */
+@Serializable
+data class DeliveryAdjustmentPayload(
+    /** PK (source `sequenceId`) of the `delivery_record` being edited. */
+    val targetEventSequenceId: Long,
+    /** For session attribution / liveness only — the fold never reads the target row through it. */
+    val sessionId: String? = null,
+    /** Driver-entered merchant name; null ⇒ unchanged. */
+    val newStoreName: String? = null,
+    /** New realized pay (> 0); null ⇒ unchanged. Flips a machine row to `USER_CORRECTED` (VET F1). */
+    val newPay: Double? = null,
+    /** New platform-reported tip already inside pay (itemization only, ≥ 0); null ⇒ unchanged. */
+    val newTip: Double? = null,
+    /** New driver-entered cash tip (≥ 0); null ⇒ unchanged. Side column — never touches basis/net. */
+    val newCashTip: Double? = null,
+    /** New driver-stated miles (≥ 0); null ⇒ unchanged. Recomputes net (no basis flip on its own). */
+    val newMiles: Double? = null,
     /** Driver-authored free text — driver-owned local data, never in INFO+ logs (P7). */
     val note: String? = null,
 ) : AppEventPayload

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/RecordFoldsTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/RecordFoldsTest.kt
@@ -8,6 +8,7 @@ import cloud.trotter.dashbuddy.domain.model.event.AppEventType
 import cloud.trotter.dashbuddy.domain.model.event.EventMetadata
 import cloud.trotter.dashbuddy.domain.model.event.SequencedAppEvent
 import cloud.trotter.dashbuddy.domain.model.event.payload.AppEventPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryAdjustmentPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.ManualDeliveryPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.OfferPayload
@@ -993,6 +994,60 @@ class RecordFoldsTest {
         // correction's wall-clock time (it would stretch an endedAt-null session's online span).
         assertEquals(ctx, out.context)
         assertEquals(1_000L, out.context!!.lastEventAt)
+    }
+
+    @Test
+    fun `DELIVERY_ADJUSTMENT emits the widened decision, no record, and passes the context through untouched (F2)`() {
+        val s = "M8"
+        val ctx = RecordFolds.foldEvent(dashStart(s, 1_000, odo = 0.0), null, null).context
+        val ev = ev(
+            AppEventType.DELIVERY_ADJUSTMENT, s, 5_000,
+            DeliveryAdjustmentPayload(
+                targetEventSequenceId = 42L, sessionId = s, newStoreName = "Bill Millers",
+                newPay = 15.5, newCashTip = 4.0, note = "fix",
+            ),
+        )
+        val out = RecordFolds.foldEvent(ev, ctx, null)
+
+        assertNull("a re-apply produces no delivery record in the pure fold", out.delivery)
+        assertNull(out.offer)
+        assertNull(out.payAdjustment)
+        val adj = out.deliveryAdjustment!!
+        assertEquals(42L, adj.targetEventSequenceId)
+        assertEquals("Bill Millers", adj.newStoreName)
+        assertEquals(15.5, adj.newPay!!, 1e-9)
+        assertEquals(4.0, adj.newCashTip!!, 1e-9)
+        assertNull("an unset field stays null (unchanged)", adj.newTip)
+        assertNull(adj.newMiles)
+        // Bookkeeping about a past row, not session activity: liveness must NOT advance to the
+        // correction's wall-clock time.
+        assertEquals(ctx, out.context)
+        assertEquals(1_000L, out.context!!.lastEventAt)
+    }
+
+    @Test
+    fun `a manual delivery carries the driver's cash tip on the fold (#688)`() {
+        val s = "M9"
+        val ev = ev(
+            AppEventType.MANUAL_DELIVERY, s, 2_000,
+            ManualDeliveryPayload(sessionId = s, pay = 9.0, cashTip = 5.0, completedAt = 2_000),
+        )
+        val ctx = RecordFolds.foldEvent(dashStart(s, 1_000, odo = 0.0), null, null).context
+        val d = RecordFolds.foldEvent(ev, ctx, null).delivery!!
+        assertEquals(5.0, d.cashTip!!, 1e-9)
+        assertEquals("cash stays OUTSIDE realizedPay", 9.0, d.realizedPay!!, 1e-9)
+    }
+
+    @Test
+    fun `a malformed DELIVERY_ADJUSTMENT payload is skipped, not folded (#688)`() {
+        val s = "MA"
+        val bad = SequencedAppEvent(
+            sequenceId = ++seq,
+            event = AppEvent(AppEventType.DELIVERY_ADJUSTMENT, occurredAt = 2_000, sessionId = s, payload = null),
+        )
+        val out = RecordFolds.foldEvent(bad, null, null)
+        assertNull(out.deliveryAdjustment)
+        assertNotNull(out.skip)
     }
 
     @Test


### PR DESCRIPTION
## #688 phase A — DELIVERY_ADJUSTMENT + cash tips + v11 (+#703)

Widens the driver-correction vocabulary into a single multi-field **Adjust delivery** edit and adds
per-delivery **cash tips**, both riding a new v11 column pair. Fable-vetted bounded build (design doc
+ VET amendments F1–F8).

Closes #703. **#688 phase A complete; phase B (per-leg mileage) is deferred** — not closed here.

### What landed
- **`DELIVERY_ADJUSTMENT`** event + `DeliveryAdjustmentPayload` (all-optional: store/pay/tip/cash-tip/
  miles/note) — widens `PAY_ADJUSTMENT` (which stays fully readable for history; new UI writes only
  the widened event). Pure `DeliveryAdjustmentFold` decision (context untouched); orchestrator applies
  each non-null field **by-PK inside the batch txn** after the upserts, event-order last-wins.
- **cashTip** (v11 column) written only by driver events (`DELIVERY_ADJUSTMENT` / `MANUAL_DELIVERY`).
- **originalPayBasis** (v11 column, #703) — the first-fold basis, never rewritten; hydration now reads
  `COALESCE(originalPayBasis, payBasis)` so a re-priced `USER_CORRECTED` row keeps its receipt evidence.
- v11 migration (`AutoMigration(10,11)` + committed `11.json` + `AnalyticsMigration10to11Test`);
  `PROJECTOR_VERSION` 3→4 refold populates `originalPayBasis` for all history.
- UI: `DeliveryRow` tap + pencil → one `AdjustDeliveryDialog`; `AddMissedDeliveryDialog` gains Cash tip;
  header "+$X cash tips" line + per-row "+$X cash" line; net incl. cash (display only).

### Locked accounting (dev-locked; #688 D2 / F3–F5)
Cash lives **outside** `realizedPay` and `netProfit` — added to gross/net **only at the read sites**:
- `net = deliveryNet + unattributed + cash`; gross includes cash (DAO subquery); **`unattributed`
  CASE untouched** — a cash tip raises gross/net but never shrinks the reported-vs-captured reconcile.
- Waterfall reconciles by construction (cash cancels in `cost = gross − net`).
- Per-store: `gross = pay + cash`, `net = net + cash`; `ORDER BY pay` stays cash-free.
- Drill-down "Gross (reported)" tile stays cash-free (F4); cash is its own line.
- **F3 invariant** (documented + tested): every cash-bearing row is sessionful, so cash counted into
  net (null-session-inclusive) equals cash counted into gross (session-join) — no leak.

### VET amendments folded in
- **F1**: machine `payBasis` flips to `USER_CORRECTED` **iff `newPay != null`** — a store/tip/cash edit
  on an `OFFER_PAY` row keeps its "est. offer pay" disclosure. Miles-only recomputes net without flipping.
- **F2**: **no `newCompletedAt`** (would break restart-incremental == from-zero-refold determinism);
  KDoc states what re-adding requires.
- **F6**: a note-only adjustment is valid and a no-op apply (tested).
- **F8**: blank = unchanged (store can't be cleared — documented); changed-detection on **parsed**
  values; cent-faithful `toString()` prefill; Save enabled only when ≥1 parsed field differs OR note.

### Tests
Pure fold (decision + context-untouched + malformed skip); orchestrator apply (every field, F1
pay-only flip, F1 `OFFER_PAY` store-only regression, cashTip-only byte-identical net, MANUAL stays
MANUAL, F6 no-op, missing-target skip, multi-batch determinism live==refold, **#703 hydration COALESCE
denies a re-priced sibling's estimate**); repo cash accounting (net/gross/unattributed, null-net cash,
per-store F5); SessionDetail cashTips; CSV `cash_tip` + `total_cash_tips`; per-step v11 migration.

Gates: `testDebugUnitTest :domain:test` GREEN; `:core:database:compileDebugAndroidTestKotlin` GREEN;
schema drift = only the committed `11.json`.

### Privacy posture (Principle 6/7)
No new capture, network, or PII surface. Driver-entered text (note / storeName): note stays
event-payload-only; storeName is merchant data (driver-owned, already rendered/exported). P7 logging
unchanged — the new correction log lines carry ids/counts only, never note/store text.

### Design-goal review
- **UDF (1)**: fold pure (context untouched); apply at the orchestrator edge inside the txn; UI dispatches
  intents, observes the read-model Flow. **MAD (2)** / **SRP (3)**: one dialog, write-side stays in
  `CorrectionRepository`, read-side untouched. **SSOT (5)**: `NetProfit` reused for every net; cash math
  has one owner per site; `PayBasis`/`RECEIPT_EVIDENCE` still the single receipt-evidence definition
  (now COALESCE-hydrated). **Security/privacy (6/7)**: above. **Platform-agnostic (8)**: no platform
  literals added; correction is data keyed by row, not by platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Fix round (adversarial review, 3 fable finders)

Hardening-grade defects found by the pre-merge adversarial pass, all fixed on-branch (3 commits;
`testDebugUnitTest` + `:domain:test` green, `:core:database:compileDebugAndroidTestKotlin` green,
`schemas/` clean, no `PROJECTOR_VERSION` change):

- **F1 — sequence-ordered adjustment apply.** The projector applied ALL `PAY_ADJUSTMENT` folds then
  ALL `DELIVERY_ADJUSTMENT` folds (type order, not event order), so a PA sequenced *after* a DA on the
  same row lost when they shared a batch (incremental ≠ refold). The two decision streams now merge
  into ONE list carrying each decision's source `sequenceId`, sorted ascending, applied in log order
  (each apply still re-reads the row by PK). Batch-boundary-invariant.
- **F2 — drain-stable economy read.** `currentCostPerMile` (feeds `CURRENT_FALLBACK` freezes + MANUAL
  recomputes) was read per-batch — an economy edit mid-refold froze DIFFERENT cpm across batches of one
  rebuild. Now read ONCE per drain/rebuild cycle and threaded through the batches. (The
  `CURRENT_FALLBACK` re-stamp-on-refold itself is the acknowledged v2/v3-precedent side effect above.)
- **F3 — null-session cash skip.** The `DELIVERY_ADJUSTMENT` apply now SKIPs `newCashTip` when
  `row.sessionId == null` (one PII-safe WARN) — makes the "cash-bearing rows are always sessionful"
  invariant real (a null-session cash row would enter net but never gross → waterfall cost skews
  negative). Other fields still apply.
- **F4 — non-finite + crash-safe validation.** (a) dialog validators + parser gain `isFinite()` (a
  pasted `1e999` passed `> 0` then crashed the codec in an uncaught `viewModelScope.launch`); (b)
  `CorrectionRepository` requires `isFinite` on every money/miles field on BOTH `adjustDelivery` and
  `addManualDelivery` (which had NO requires — added parity); (c) the ViewModel wraps both repository
  calls in try/catch (WARN, don't crash — an alpha-acceptable silent reject); (d) added
  `CorrectionRepositoryTest` covering every require boundary (zero coverage before).
- **F5 — `SUSPECT_FULL_RECEIPT` pay-edit block.** Applying `newPay`/`newTip` to a de-monetized phantom
  row re-opened the #653 double count via one innocent tap (the siblings keep their shares). The
  orchestrator now skips pay+tip on such rows (one WARN; store/cash/note still apply), and the dialog
  disables the Pay field for `payBasis == SUSPECT_FULL_RECEIPT` with helper text.
- **F6 — trim symmetry.** `storeChanged` compares trimmed-vs-trimmed so a machine-parsed trailing-space
  store name doesn't ship a phantom `newStoreName` on a cash-only edit; all dialog field state is keyed
  on `remember(target)` so a mid-edit Room re-emission re-inits rather than diffing a stale snapshot.
- **F7 — recent-dashes cash marker.** `RecentDashes` rows showed `reportedEarnings` verbatim while every
  sibling gross surface (hero, per-day chart, drill-down) is cash-inclusive. A per-session cash sum was
  added to the recent-sessions read path (`SessionWithCashRow` + LEFT-JOIN subquery), rendered as a
  small "+$X cash" line — NOT folded into the reported number (the label stays honest).
- **F8 — top-stores ordering.** `perStoreEconomics` mapped `gross = pay + cash` but the DAO ordered by
  cash-free pay, so a cash-heavy store ranked below a lower-gross one. The mapped list is now re-sorted
  by cash-inclusive gross descending (the SQL `ORDER BY pay` stays a stable pre-sort). KDoc notes the
  null-net + cash presentation (net = cash — cash has no cost term).
- **F9 — `optionalMoney` re-doc.** Renamed `optionalNumber` and re-documented to match the F4/F8
  semantics: it owns only finiteness/parseability; the `isValid*`/`isBlankOr*` checks own range.

### Disclosure — v4 refold can retroactively null a pre-#703 `OFFER_PAY` row

The v4 (`PROJECTOR_VERSION 4`) from-zero refold can retroactively null an `OFFER_PAY` row minted under
the pre-#703 hydration wrinkle (a process restart landing between a corrected-receipt sibling and a
stamped fold). The refold is the **CORRECT** fold, and this class is **unreachable in the actual device
history** (all 07-05 `PAY_ADJUSTMENT`s postdate every completion; pre-#691 payloads carry no
`offerPayShare`, so no historical row can take the offer-pay arm). It is, however, a **possible silent
retroactive deduction on other histories** — stated plainly rather than hidden.
