### PR TITLE
fix(#438): B1 — per-region lifecycle edges (lastActedFlow)

### DIFF
--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -350,11 +350,13 @@ class EffectMap @Inject constructor() {
         // #438 item 5 (D3): the lifecycle edges below diff THIS region's own acted flow, not the
         // shared global R0 flow — `diff` iterates every platform, but under concurrency R0.flow is
         // whatever platform last touched the screen (so a foreign frame used to fire this platform's
-        // PostTask edges). Each side falls back to the matching GLOBAL flow only for legacy snapshots
-        // (lastActedFlow=null), which reproduces the pre-B1 behavior byte-for-byte — a region that
-        // has ever acted carries a non-null lastActedFlow, so the fallback is never taken for one that
-        // owns a task to (spuriously) complete. Under B1 the observing region stamps its own flow, so
-        // a non-observing region — where p === next → actedPrev == actedNext — never sees an edge.
+        // PostTask edges). Each side falls back to the matching GLOBAL flow only while
+        // lastActedFlow is null, which reproduces the pre-B1 behavior byte-for-byte. The fallback
+        // is never taken for a region that acted POST-B1 (its first own flow frame stamps it);
+        // a legacy pre-B1 snapshot decodes task-owning regions with lastActedFlow=null and keeps
+        // pre-B1 behavior until each region's first own frame heals it — a one-shot, accepted
+        // residual. Under B1 the observing region stamps its own flow, so a stamped non-observing
+        // region — where p === next → actedPrev == actedNext — never sees an edge.
         val actedPrevFlow = p.lastActedFlow ?: prevFlow.flow
         val actedNextFlow = next.lastActedFlow ?: nextFlow.flow
 

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -347,26 +347,36 @@ class EffectMap @Inject constructor() {
         if (next == null) return emptyList()
         val p = prev ?: PlatformRegion(platform)
 
+        // #438 item 5 (D3): the lifecycle edges below diff THIS region's own acted flow, not the
+        // shared global R0 flow — `diff` iterates every platform, but under concurrency R0.flow is
+        // whatever platform last touched the screen (so a foreign frame used to fire this platform's
+        // PostTask edges). Each side falls back to the matching GLOBAL flow only for legacy snapshots
+        // (lastActedFlow=null), which reproduces the pre-B1 behavior byte-for-byte — a region that
+        // has ever acted carries a non-null lastActedFlow, so the fallback is never taken for one that
+        // owns a task to (spuriously) complete. Under B1 the observing region stamps its own flow, so
+        // a non-observing region — where p === next → actedPrev == actedNext — never sees an edge.
+        val actedPrevFlow = p.lastActedFlow ?: prevFlow.flow
+        val actedNextFlow = next.lastActedFlow ?: nextFlow.flow
+
         return buildList {
             addAll(diffMode(p, next, obs))
             addAll(diffGraceTimer(p, next, obs))
             addAll(diffModeResumeTimer(p, next, obs))
-            addAll(diffTask(p, next, prevFlow, nextFlow, obs))
-            addAll(diffPostTask(p, next, nextFlow, obs))
+            addAll(diffTask(p, next, actedPrevFlow, actedNextFlow, obs))
+            addAll(diffPostTask(p, next, actedNextFlow, obs))
             addAll(diffNotification(obs))
 
-            // Delivery completed: leaving PostTask for a non-PostTask flow.
-            //
-            // `diff` iterates over all platforms, but `nextFlow.flow` is global.
-            // On PostTask exit the condition fires for every platform that has a
-            // PlatformRegion entry; only the one that actually owned the delivery
-            // has `completedTask` non-null. Skip the rest — without this guard,
-            // non-owning platforms emit a degenerate DELIVERY_COMPLETED row via
-            // deliveryCompletedPayload's "unknown" fallback.
+            // Delivery completed: THIS region's own acted flow leaving PostTask for a non-PostTask
+            // flow (#438 item 5 — was the global `prevFlow.flow`/`nextFlow.flow`, which fired this
+            // block for every platform whenever ANY platform's frame moved R0 off PostTask). The
+            // per-region diff means a non-observing region (p === next → actedPrev == actedNext)
+            // never sees the exit, and a foreign platform's frame can't drive this completion. The
+            // downstream `completedTask` job-scoping (#518, below) still defends the same-platform
+            // cross-JOB leak, which B1 does not obviate.
             // Task ids the PostTask-exit block emits a DELIVERY_COMPLETED for this step — the #596
             // close-out block below must NOT re-emit them (dual-mint exclusivity, amdt #2).
             val emittedThisStep = mutableSetOf<String>()
-            if (prevFlow.flow == Flow.PostTask && nextFlow.flow != Flow.PostTask) {
+            if (actedPrevFlow == Flow.PostTask && actedNextFlow != Flow.PostTask) {
                 val taskCompletedOverride = triggerOverrideEffects(obs, TransitionTrigger.TASK_COMPLETED)
                 if (taskCompletedOverride != null) {
                     addAll(taskCompletedOverride)
@@ -788,14 +798,15 @@ class EffectMap @Inject constructor() {
     private fun diffTask(
         prev: PlatformRegion,
         next: PlatformRegion,
-        prevFlow: FlowRegion,
-        nextFlow: FlowRegion,
+        actedPrevFlow: Flow,
+        actedNextFlow: Flow,
         obs: Observation,
     ): List<AppEffect> {
         // Diffs are computed from prev/next region state for EVERY observation type:
         // lazy expiry can retire a task on a non-flow observation (a routed timeout,
         // #342), and that closure must still emit DELIVERY_CONFIRMED (#345).
-        val nextFlowVal = nextFlow.flow
+        // #438 item 5: the flow reads below are THIS region's own acted flow, not the global R0.
+        val nextFlowVal = actedNextFlow
         val sessionId = next.session?.sessionId ?: prev.session?.sessionId
 
         return buildList {
@@ -957,8 +968,8 @@ class EffectMap @Inject constructor() {
                 }
             }
 
-            // Post-task: delivery completed
-            if (nextFlowVal == Flow.PostTask && prevFlow.flow != Flow.PostTask) {
+            // Post-task: delivery completed (this region's own PostTask entry, #438 item 5).
+            if (nextFlowVal == Flow.PostTask && actedPrevFlow != Flow.PostTask) {
                 add(AppEffect.ResumeOdometer)
             }
         }
@@ -1082,10 +1093,12 @@ class EffectMap @Inject constructor() {
     private fun diffPostTask(
         prev: PlatformRegion,
         next: PlatformRegion,
-        nextFlow: FlowRegion,
+        actedNextFlow: Flow,
         obs: Observation,
     ): List<AppEffect> {
-        if (nextFlow.flow != Flow.PostTask) return emptyList()
+        // #438 item 5: gate on THIS region's own acted flow — the obs is global, so without this a
+        // non-observing region would also fire the "Saved: $X" bubble on the owner's PostTask frame.
+        if (actedNextFlow != Flow.PostTask) return emptyList()
         val flowObs = obs as? Observation.FlowObservation ?: return emptyList()
         val parsed = flowObs.parsed as? ParsedFields.PostTaskFields ?: return emptyList()
 

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/JobAcceptFlow.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/JobAcceptFlow.kt
@@ -332,9 +332,13 @@ internal fun PlatformRegionStepper.armAcceptStash(
 /**
  * #526 FIX2a: does [po] belong to [region]'s platform? The offer's platform is read from its
  * `sourceRuleId` (via [Platform.fromRuleId]), falling back to the flow's active platform. A
- * KNOWN foreign platform blocks arming (the shared-FlowRegion cross-platform bleed); an
- * [Platform.Unknown] result (e.g. an unattributed test fixture) can't be told apart, so it
- * arms as before — arming is non-destructive and consumption is still offerHash-guarded.
+ * KNOWN foreign platform is blocked; an [Platform.Unknown] result (e.g. an unattributed test
+ * fixture) can't be told apart, so it passes — fail-open. Two call sites: stash ARMING
+ * ([armAcceptStash], non-destructive, consumption still offerHash-guarded) and, since #438 B1,
+ * the accept-edge CONSUMPTION read in `updateJobLifecycle` (destructive — it mints economics).
+ * Production rule ids are prefix-namespaced so provenance always resolves there; B3 (the offer
+ * move onto [PlatformRegion]) retires this gate entirely, and should it survive in any form,
+ * the consumption site should fail closed instead.
  * Keyed only by the [Platform] registry — no platform literals (Principle 8).
  */
 internal fun PlatformRegionStepper.offerBelongsToRegion(po: PendingOffer, flow: FlowRegion, region: PlatformRegion): Boolean {

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
@@ -82,11 +82,28 @@ class PlatformRegionStepper @Inject constructor() {
         nextFlow: FlowRegion,
         obs: Observation,
         policy: TransitionPolicy,
-    ): PlatformRegion = armAcceptStash(
-        reconcileDropoffStore(reconcileJobTasks(stepCore(prev, prevFlow, nextFlow, obs, policy))),
-        nextFlow,
+    ): PlatformRegion = stampLastActedFlow(
+        armAcceptStash(
+            reconcileDropoffStore(reconcileJobTasks(stepCore(prev, prevFlow, nextFlow, obs, policy))),
+            nextFlow,
+            obs,
+        ),
         obs,
     )
+
+    /**
+     * #438 item 5 (D3): record the last **non-null** own-platform flow this region stepped on
+     * ([PlatformRegion.lastActedFlow]) so the per-region lifecycle edges diff against the flow THIS
+     * platform acted on — not the shared global R0 flow. Stamped HERE in the [step] wrapper (not
+     * inside [updateLifecycle]) so the SessionEnded / Offline early-returns can't skip it. A
+     * non-FlowObservation (Timeout/UiInput/Loopback) or a flow-less FlowObservation (flow=null
+     * clicks/notifications) leaves it unchanged — such a frame is not this platform acting on a
+     * screen, and `nextFlow.flow` on it is whatever platform last owned R0.
+     */
+    private fun stampLastActedFlow(region: PlatformRegion, obs: Observation): PlatformRegion {
+        val flow = (obs as? Observation.FlowObservation)?.flow ?: return region
+        return if (region.lastActedFlow == flow) region else region.copy(lastActedFlow = flow)
+    }
 
 
     internal fun isStashExpired(stash: AcceptStash, obs: Observation): Boolean =
@@ -527,8 +544,15 @@ class PlatformRegionStepper @Inject constructor() {
         }
 
         var r = region
-        val prev = prevFlow.flow
-        val next = nextFlow.flow
+        // #438 item 5 (D3): the lifecycle edges below diff THIS region's own acted flow, not the
+        // shared global R0 flow. `region.lastActedFlow` is still the pre-step value here (the stamp
+        // runs in the [step] wrapper, after stepCore). Fallback to the global prev flow for legacy
+        // snapshots (lastActedFlow=null) keeps single-platform behavior byte-identical — the sole
+        // region acts on every own frame, so its lastActedFlow tracks R0.flow. A flow-less own obs
+        // (flow=null) is not a flow edge (next=prev), never a diff against the other platform's
+        // nextFlow.flow.
+        val prev = region.lastActedFlow ?: prevFlow.flow
+        val next = obs.flow ?: prev
 
         // Update session fields from observations
         r = updateSessionFields(r, obs)
@@ -655,15 +679,28 @@ class PlatformRegionStepper @Inject constructor() {
         // time, and distance accumulate) rather than being silently dropped. Deduped by
         // offerHash so a re-entered OfferPresented for the same offer (screen oscillation)
         // does not double-count.
-        if (prevFlowVal == Flow.OfferPresented && nextFlowVal.isTaskFlow()) {
+        //
+        // #438 item 5: the accept TRIGGER is a GLOBAL R0 read — the offer lives in the shared
+        // FlowRegion until B3 moves it onto the platform (the vet's interim cross-region read; B3
+        // deletes it). It is deliberately NOT the per-region `prevFlowVal`: a task frame follows the
+        // offer frame, so this platform's OWN prior acted flow is already the offer only when it
+        // stepped that offer screen — telescoped/at-once sequences would otherwise never fire. The
+        // per-region `nextFlowVal.isTaskFlow()` scopes the reaction to the platform that got the
+        // task frame, and offerBelongsToRegion (#526 FIX2a — the same provenance gate armAcceptStash
+        // uses) ensures ONLY the owning platform consumes the offer. A foreign/absent offer falls
+        // through to the D1c / bare job-start below instead of minting an empty-economics accept —
+        // the concurrency fix (an Uber offer in R0 must not become a DoorDash job's economics).
+        if (prevFlow.flow == Flow.OfferPresented && nextFlowVal.isTaskFlow()) {
             // Accept-adjacent (happy path): the offer is still on prevFlow. Read it straight off the
             // pending offer (the direct source); prefer the stash's acceptedAt when it matches this
             // offer — the accept-CLICK time, not this task frame (#526 D1a). Consumption clears the
             // stash inside the mint helpers.
-            val pending = prevFlow.pendingOffer
-            val stash = region.lastAcceptedOffer?.takeIf { !isStashExpired(it, obs) }
-            val acceptedAt = stash?.takeIf { it.offerHash == pending?.offerHash }?.acceptedAt ?: obs.timestamp
-            return consumeAcceptIntoJob(region, obs, acceptInputsFromPending(pending, acceptedAt))
+            val pending = prevFlow.pendingOffer?.takeIf { offerBelongsToRegion(it, prevFlow, region) }
+            if (pending != null) {
+                val stash = region.lastAcceptedOffer?.takeIf { !isStashExpired(it, obs) }
+                val acceptedAt = stash?.takeIf { it.offerHash == pending.offerHash }?.acceptedAt ?: obs.timestamp
+                return consumeAcceptIntoJob(region, obs, acceptInputsFromPending(pending, acceptedAt))
+            }
         }
 
         // #526 D1c: the F3 race — an add-on accepted while a job is active, but a `waiting_for_offer`

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
@@ -576,7 +576,7 @@ class PlatformRegionStepper @Inject constructor() {
         r = updateRatings(r, obs)
 
         // Job lifecycle
-        r = updateJobLifecycle(r, prev, next, prevFlow, nextFlow, obs)
+        r = updateJobLifecycle(r, prev, next, prevFlow, obs)
 
         // Task lifecycle
         r = updateTaskLifecycle(r, prev, next, obs, policy)
@@ -671,7 +671,6 @@ class PlatformRegionStepper @Inject constructor() {
         prevFlowVal: Flow,
         nextFlowVal: Flow,
         prevFlow: FlowRegion,
-        nextFlow: FlowRegion,
         obs: Observation.FlowObservation,
     ): PlatformRegion {
         // Offer accepted → capture its economics onto the job. A first accept STARTS a new

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/PerRegionLifecycleEdgesTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/PerRegionLifecycleEdgesTest.kt
@@ -1,0 +1,274 @@
+package cloud.trotter.dashbuddy.core.state
+
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
+import cloud.trotter.dashbuddy.domain.model.event.AppEventType
+import cloud.trotter.dashbuddy.domain.model.offer.ParsedOffer
+import cloud.trotter.dashbuddy.domain.model.order.OrderType
+import cloud.trotter.dashbuddy.domain.model.order.ParsedOrder
+import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.state.AppState
+import cloud.trotter.dashbuddy.domain.state.Flow
+import cloud.trotter.dashbuddy.domain.state.FlowRegion
+import cloud.trotter.dashbuddy.domain.state.Job
+import cloud.trotter.dashbuddy.domain.state.Mode
+import cloud.trotter.dashbuddy.domain.state.OfferIntent
+import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import cloud.trotter.dashbuddy.domain.state.PendingOffer
+import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.domain.state.PlatformRegion
+import cloud.trotter.dashbuddy.domain.state.Regions
+import cloud.trotter.dashbuddy.domain.state.Session
+import cloud.trotter.dashbuddy.domain.state.Task
+import cloud.trotter.dashbuddy.domain.state.TaskPhase
+import cloud.trotter.dashbuddy.domain.state.TaskSubFlow
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #438 item 5 (D3) — **per-region lifecycle edges**.
+ *
+ * The R0 [FlowRegion] is a single global slot, but its flow drove every platform's lifecycle edges
+ * (accept, PostTask entry/exit). Under concurrency the global flow is whatever platform last touched
+ * the screen, so a foreign frame fired THIS platform's edges — a job minted from the other platform's
+ * offer, a premature completion from a non-observing region. B1 stamps [PlatformRegion.lastActedFlow]
+ * (the last non-null flow THIS region stepped) and diffs every lifecycle edge against it, in both the
+ * stepper and [EffectMap]. Single-platform behavior is identical (the region acts on every own frame,
+ * so its lastActedFlow tracks R0.flow, and a null falls back to the global flow).
+ */
+class PerRegionLifecycleEdgesTest {
+
+    private val stepper = PlatformRegionStepper()
+    private val policy = TransitionPolicy()
+
+    private val machine = StateMachine(
+        flowStepper = FlowRegionStepper(),
+        platformStepper = PlatformRegionStepper(),
+        crossPlatformStepper = CrossPlatformRegionStepper(),
+        transitionPolicy = TransitionPolicy(),
+        effectMap = EffectMap(),
+    )
+
+    // ---- helpers ----
+
+    private fun order(i: Int, store: String) = ParsedOrder(
+        orderIndex = i, orderType = OrderType.PICKUP, storeName = store,
+        itemCount = 1, isItemCountEstimated = false, badges = emptySet(),
+    )
+
+    /** A shared-R0 flow holding a DoorDash accept-latched offer (as if DoorDash just presented it). */
+    private fun doordashOfferFlow(hash: String = "dd-offer") = FlowRegion(
+        flow = Flow.OfferPresented,
+        pendingOffer = PendingOffer(
+            offerHash = hash,
+            offerFields = ParsedFields.OfferFields(
+                parsedOffer = ParsedOffer(
+                    offerHash = hash, payAmount = 14.0, distanceMiles = 5.0,
+                    timeToCompleteMinutes = 20L, orders = listOf(order(0, "Bill Miller BBQ")),
+                ),
+            ),
+            presentedAt = 500L,
+            returnFlow = Flow.Idle,
+            lastClickIntent = OfferIntent.ACCEPT,
+            sourceRuleId = "doordash.screen.offer",
+        ),
+        sourceRuleId = "doordash.screen.offer",
+        activePlatform = Platform.DoorDash,
+    )
+
+    private fun uberPickupNav(t: Long) = Observation.Screen(
+        timestamp = t, captureId = null, ruleId = "uber.screen.pickup_nav",
+        metadata = ReplayMetadata.EMPTY, flow = Flow.TaskPickupNavigation, modeHint = Mode.Online,
+        parsed = ParsedFields.TaskFields(
+            phase = TaskPhase.PICKUP, subFlow = TaskSubFlow.NAVIGATION, storeName = "Uber Diner",
+        ),
+    )
+
+    private fun uberIdle(t: Long) = Observation.Screen(
+        timestamp = t, captureId = null, ruleId = "uber.screen.idle",
+        metadata = ReplayMetadata.EMPTY, flow = Flow.Idle, modeHint = Mode.Online,
+        parsed = ParsedFields.None,
+    )
+
+    // =====================================================================
+    // (a) NO CROSS-PLATFORM JOB MINT / ECONOMICS
+    // =====================================================================
+
+    @Test
+    fun `an Uber task frame does not mint a job from a DoorDash offer in the shared R0`() {
+        // The Uber region is online and has already acted on its own idle frame — the realistic
+        // concurrent case. A DoorDash accept-latched offer sits in the shared R0.
+        val uber = PlatformRegion(
+            platform = Platform.Uber, mode = Mode.Online,
+            session = Session("u-sess", startedAt = 100L),
+            lastActedFlow = Flow.Idle,
+        )
+        val ddOfferFlow = doordashOfferFlow()
+        // R0 becomes an Uber pickup nav (the frame pops the offer, activePlatform → Uber).
+        val nextFlow = FlowRegion(flow = Flow.TaskPickupNavigation, activePlatform = Platform.Uber)
+
+        val result = stepper.step(uber, ddOfferFlow, nextFlow, uberPickupNav(1_000L), policy)
+
+        // The Uber region mints its OWN bare job (a genuine Uber task) — never the DoorDash offer's.
+        assertTrue(
+            "no cross-platform economics: the Uber job carries no accepted offer",
+            result.activeJob?.acceptedOffers.isNullOrEmpty(),
+        )
+        assertNotEquals(
+            "the Uber job is NOT parented to the DoorDash offer",
+            "dd-offer", result.activeJob?.parentOfferHash,
+        )
+        // Uber acted on its own pickup flow.
+        assertEquals(Flow.TaskPickupNavigation, result.lastActedFlow)
+    }
+
+    // =====================================================================
+    // (b) NO PREMATURE COMPLETION FROM A NON-OBSERVING REGION
+    // =====================================================================
+
+    @Test
+    fun `a DoorDash region on PostTask does not complete when an Uber frame moves the global flow`() {
+        val dropoff = Task(
+            taskId = "dd-drop", jobId = "dd-job", phase = TaskPhase.DROPOFF,
+            storeName = "HEB", customerNameHash = "cx-1", startedAt = 300L, arrivedAt = 400L,
+        )
+        val ddRegion = PlatformRegion(
+            platform = Platform.DoorDash, mode = Mode.Online,
+            session = Session("dd-sess", startedAt = 100L),
+            activeJob = Job("dd-job", offerStoreHint = listOf("HEB"), parentOfferHash = "o1", startedAt = 200L, tasks = listOf(dropoff)),
+            activeTask = dropoff,
+            lastPostTaskFields = ParsedFields.PostTaskFields(totalPay = 12.0),
+            lastAnnouncedPostTaskTaskId = "dd-drop",
+            lastActedFlow = Flow.PostTask,
+        )
+        val uberRegion = PlatformRegion(
+            platform = Platform.Uber, mode = Mode.Online,
+            session = Session("u-sess", startedAt = 100L),
+            lastActedFlow = Flow.Idle,
+        )
+        // The global R0 currently shows PostTask (DoorDash owns it); the incoming Uber frame moves it.
+        val prev = AppState(
+            regions = Regions(
+                flow = FlowRegion(flow = Flow.PostTask, activePlatform = Platform.DoorDash),
+                platforms = mapOf(Platform.DoorDash to ddRegion, Platform.Uber to uberRegion),
+            ),
+            timestamp = 1_000L,
+        )
+
+        val transition = machine.step(prev, uberIdle(1_200L))
+
+        val completed = transition.effects
+            .filterIsInstance<AppEffect.LogEvent>()
+            .filter { it.event.type == AppEventType.DELIVERY_COMPLETED }
+        assertTrue(
+            "the DoorDash delivery must NOT complete off an Uber frame (it never left its own PostTask)",
+            completed.isEmpty(),
+        )
+        // The DoorDash region is untouched — its PostTask is intact for its own next frame.
+        assertEquals(Flow.PostTask, transition.newState.regions.platforms.getValue(Platform.DoorDash).lastActedFlow)
+    }
+
+    @Test
+    fun `a DoorDash PostTask receipt fires exactly one Saved bubble - none from the non-observing Uber region`() {
+        val ddDrop = Task(
+            taskId = "dd-drop", jobId = "dd-job", phase = TaskPhase.DROPOFF,
+            storeName = "HEB", customerNameHash = "cx-1", startedAt = 300L, arrivedAt = 400L,
+        )
+        val ddRegion = PlatformRegion(
+            platform = Platform.DoorDash, mode = Mode.Online,
+            session = Session("dd-sess", startedAt = 100L),
+            activeJob = Job("dd-job", offerStoreHint = listOf("HEB"), parentOfferHash = "o1", startedAt = 200L, tasks = listOf(ddDrop)),
+            activeTask = ddDrop,
+            lastActedFlow = Flow.TaskDropoffArrived,
+        )
+        // The Uber region is mid-pickup with its own active task — the non-observing region.
+        val uPick = Task(taskId = "u-pick", jobId = "u-job", phase = TaskPhase.PICKUP, storeName = "Uber Diner", startedAt = 300L)
+        val uberRegion = PlatformRegion(
+            platform = Platform.Uber, mode = Mode.Online,
+            session = Session("u-sess", startedAt = 100L),
+            activeJob = Job("u-job", offerStoreHint = listOf("Uber Diner"), parentOfferHash = null, startedAt = 200L),
+            activeTask = uPick,
+            lastActedFlow = Flow.TaskPickupNavigation,
+        )
+        val prev = AppState(
+            regions = Regions(
+                flow = FlowRegion(flow = Flow.TaskDropoffArrived, activePlatform = Platform.DoorDash),
+                platforms = mapOf(Platform.DoorDash to ddRegion, Platform.Uber to uberRegion),
+            ),
+            timestamp = 1_000L,
+        )
+        // A DoorDash PostTask receipt frame (its own).
+        val ddPostTask = Observation.Screen(
+            timestamp = 1_500L, captureId = null, ruleId = "doordash.screen.post_task",
+            metadata = ReplayMetadata.EMPTY, flow = Flow.PostTask, modeHint = Mode.Online,
+            parsed = ParsedFields.PostTaskFields(totalPay = 12.0),
+        )
+
+        val transition = machine.step(prev, ddPostTask)
+
+        val savedBubbles = transition.effects
+            .filterIsInstance<AppEffect.UpdateBubble>()
+            .filter { it.text.startsWith("Saved:") }
+        assertEquals(
+            "exactly one receipt bubble — the non-observing Uber region must not fire one off DoorDash's receipt",
+            1, savedBubbles.size,
+        )
+    }
+
+    // =====================================================================
+    // (c) A FLOW-LESS OWN-PLATFORM OBSERVATION NEITHER STAMPS NOR FIRES EDGES
+    // =====================================================================
+
+    @Test
+    fun `a flow-less own-platform notification does not stamp lastActedFlow`() {
+        val dropoff = Task(
+            taskId = "dd-drop", jobId = "dd-job", phase = TaskPhase.DROPOFF,
+            storeName = "HEB", customerNameHash = "cx-1", startedAt = 300L, arrivedAt = 400L,
+        )
+        val region = PlatformRegion(
+            platform = Platform.DoorDash, mode = Mode.Online,
+            session = Session("dd-sess", startedAt = 100L),
+            activeJob = Job("dd-job", offerStoreHint = listOf("HEB"), parentOfferHash = "o1", startedAt = 200L),
+            activeTask = dropoff,
+            lastActedFlow = Flow.TaskDropoffNavigation,
+        )
+        // A flow-less DoorDash notification (flow = null) — not this platform acting on a screen.
+        val notif = Observation.Notification(
+            timestamp = 2_000L, captureId = null, ruleId = "doordash.notif.order_update",
+            metadata = ReplayMetadata.EMPTY, flow = null, modeHint = null, parsed = ParsedFields.None,
+        )
+
+        val result = stepper.step(region, FlowRegion(flow = Flow.Idle), FlowRegion(flow = Flow.Idle), notif, policy)
+
+        assertEquals(
+            "a flow-less obs leaves lastActedFlow unchanged (never imports the global flow)",
+            Flow.TaskDropoffNavigation, result.lastActedFlow,
+        )
+        // No lifecycle edge fired: the active task/job survive untouched (next == prev, not a flow edge).
+        assertEquals("dd-drop", result.activeTask?.taskId)
+        assertEquals("dd-job", result.activeJob?.jobId)
+        assertNull("no destructive edge armed by a flow-less obs", result.pendingDestructive)
+    }
+
+    // =====================================================================
+    // STAMPING — a flow-bearing own observation records lastActedFlow
+    // =====================================================================
+
+    @Test
+    fun `a flow-bearing observation stamps lastActedFlow`() {
+        val region = PlatformRegion(
+            platform = Platform.DoorDash, mode = Mode.Online,
+            session = Session("dd-sess", startedAt = 100L),
+        )
+        val result = stepper.step(
+            region, FlowRegion(flow = Flow.Idle), FlowRegion(flow = Flow.Idle), uberIdle(1_000L).copy(
+                ruleId = "doordash.screen.idle",
+            ),
+            policy,
+        )
+        assertEquals(Flow.Idle, result.lastActedFlow)
+    }
+}

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/PerRegionLifecycleEdgesTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/PerRegionLifecycleEdgesTest.kt
@@ -24,6 +24,7 @@ import cloud.trotter.dashbuddy.domain.state.TaskSubFlow
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -113,6 +114,8 @@ class PerRegionLifecycleEdgesTest {
         val result = stepper.step(uber, ddOfferFlow, nextFlow, uberPickupNav(1_000L), policy)
 
         // The Uber region mints its OWN bare job (a genuine Uber task) — never the DoorDash offer's.
+        // Pin the mint itself: without it the two negatives below pass vacuously on a no-job step.
+        assertNotNull("the fall-through bare-mints an Uber job", result.activeJob)
         assertTrue(
             "no cross-platform economics: the Uber job carries no accepted offer",
             result.activeJob?.acceptedOffers.isNullOrEmpty(),

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -73,6 +73,15 @@ card's **mechanical** half, #577 (re-confirmed, 24/24, ~0.55 s — with a new po
 that entry's Bug #1), the #457 path, and #554 ShadowProjector (2/2). The #462/#460 dropoff item
 was found **broken-in-part** (raw PII in capture envelopes) and moved to that entry's Bug #7.)_
 
+- **🆕 NEW — per-region lifecycle edges hold single-platform behavior (#438 B1 / PR #707).** The
+  state machine's job/task edges now fire off each platform's OWN last-acted flow instead of the
+  global screen flow (a latent multi-platform fix — single-platform behavior should be **byte
+  identical**). Watch that a normal DoorDash dash is unchanged: accepts still mint jobs **with
+  economics** (offer $ visible on the job/receipt), exactly one "Saved: $X" receipt bubble per
+  delivery, no spurious/premature completions, dash summary ends the session normally. Anything
+  that looks like a missing accept (job with no offer pay) or a doubled/missing completion is a
+  B1 regression — capture it.
+  - Confirmed: 0/2
 - **🆕 NEW — edit a delivery directly + cash tips (#688 phase A / PR).** In **Analytics → a dash →
   the delivery drill-down**, **tap a delivery row** (or its pencil) → the **Adjust delivery** dialog:
   Store name / Pay / Tip / Cash tip / Miles / Note. This replaces the pay-only editor and is the real

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/PlatformRegion.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/PlatformRegion.kt
@@ -88,6 +88,23 @@ data class PlatformRegion(
      * Plain data (kotlinx-serializable); all timestamps are `obs.timestamp`, so it is replay-stable.
      */
     val lastAcceptedOffer: AcceptStash? = null,
+    /**
+     * The last **non-null** [Flow] this region actually stepped on (#438 item 5 / D3). The global
+     * R0 [FlowRegion] is shared, so under concurrency `FlowRegion.flow` is whatever platform last
+     * touched the screen; keying this region's lifecycle edges (PostTask entry/exit, task
+     * retire/completion) off the *global* flow lets a foreign platform's frame fire THIS platform's
+     * edges (a premature completion, a duplicate receipt bubble). This records the flow this
+     * platform's own observations drove, so the edge diffs are per-region. (The accept edge's
+     * cross-platform guard is separate — `offerBelongsToRegion`, since the offer still lives in the
+     * shared R0 until B3.)
+     *
+     * Stamped by the [step] wrapper from `flowObs.flow` — NOT `nextFlow.flow`: a flow-less obs
+     * (flow=null clicks/notifications) leaves it unchanged, because `nextFlow.flow` on such a frame
+     * is the other platform's flow (the exact contamination this removes). Default-null so existing
+     * snapshots deserialize unchanged; a null value falls back to the global flow at the read sites,
+     * making single-platform behavior identical.
+     */
+    val lastActedFlow: Flow? = null,
 )
 
 /**


### PR DESCRIPTION
## Summary

B1 of the #438 multiplatform-correctness pack. Fixes item 5 (D3): the single global R0 `FlowRegion` drove **every** platform's lifecycle edges, so under concurrency a foreign platform's frame fired THIS platform's edges — a job minted from the other platform's offer, a premature `DELIVERY_COMPLETED` / duplicate receipt bubble from a non-observing region. Single-platform field testing masks all of it (Principle 8's known failure mode).

Design doc: `docs/design/multiplatform-correctness-pack.md` § **"B1 — item 5: per-region lifecycle edges (D3)"**.

### Change shape
- **`:domain` `PlatformRegion`** gains `lastActedFlow: Flow? = null` (decode-compat default) — the last **non-null** flow THIS region stepped on.
- **`PlatformRegionStepper`** stamps it in the `step()` wrapper (the `armAcceptStash` slot), **not** inside `updateLifecycle` (whose SessionEnded/Offline early-returns would skip it). A non-FlowObservation or a flow-less FlowObservation (flow=null clicks/notifications) leaves it unchanged.
- The stepper's lifecycle edges derive both sides per-region: `prev = region.lastActedFlow ?: prevFlow.flow`, `next = obs.flow ?: prev`.
- **`EffectMap`**: the PostTask-exit `DELIVERY_COMPLETED` mint, `diffTask`'s PostTask `ResumeOdometer`, and `diffPostTask`'s gate diff the region pair's acted flows (`actedPrevFlow`/`actedNextFlow`) instead of the global flow. Each side falls back to the matching **global** flow only while `lastActedFlow=null`, reproducing pre-B1 behavior byte-for-byte. The fallback is never taken for a region that acted **post-B1** (its first own flow frame stamps it); a **legacy pre-B1 snapshot** decodes task-owning regions with `lastActedFlow=null` and keeps pre-B1 behavior until each region's first own frame heals it — a one-shot, accepted residual (review MED-1).
- The accept-edge `prevFlow.pendingOffer` read gets the `offerBelongsToRegion` gate (the #526 FIX2a interim, until B3 deletes the cross-region read), plus a `pending != null` fall-through so a foreign/absent offer routes to the bare job-start rather than minting an empty-economics accept.
- The EffectMap #518 same-platform cross-**JOB** completion guard is **retained** — it has no separable cross-platform half — with a comment noting B1 now guards the reducer edge side.

### Spec deviation (flagged for the adversarial pass)
The spec's B1 bullet says make **both sides** of the accept edge per-region (`prevFlowVal`). Taken literally this breaks existing **single-platform** tests: `PickupPlaceholderTest` (and the stacked-pickup/add-on tests) telescope "offer appears → accept" into one step, skipping the intermediate OfferPresented frame, so the region's own `lastActedFlow` lags and a per-region accept **trigger** would never fire. The offer genuinely lives in the shared R0 in B1 (the spec itself notes "B3 deletes the cross-region read"), so I kept the accept **trigger** as a global R0 read and moved the cross-platform guard to `offerBelongsToRegion` + fall-through. This achieves the same concurrency safety (an Uber offer in R0 cannot become a DoorDash job's economics — proved by the new test) while keeping "all existing tests green unchanged." Only the completion/task-retire edges use the per-region flow. Called out here so the reviewer can weigh the deviation rather than take my framing.

### Tests
New `:core:state` `PerRegionLifecycleEdgesTest`:
- (a) an Uber task frame does **not** mint a job from a DoorDash offer sitting in the shared R0 (no cross-platform economics);
- (b) a DoorDash region on PostTask does **not** complete when an Uber frame moves the global flow; a DoorDash PostTask receipt fires **exactly one** "Saved:" bubble (none from the non-observing Uber region);
- (c) a flow-less own-platform notification neither stamps `lastActedFlow` nor fires edges; plus a stamping guard.

`./gradlew testDebugUnitTest :domain:test` — **BUILD SUCCESSFUL**. All existing unit tests + every replay fixture (SingleDelivery, GhostOffer, TwoPickupStack, TeardownGhost, DeclineRace, AddonPhantom, ReceiptSkip, Walgreens, …) green unchanged.

### Design-goal review
- **1 (UDF purity):** Steppers stay pure — `lastActedFlow` is stamped from `obs`-derived flow only (no wall clock), driven by `obs.timestamp` elsewhere; replay-stable. All edge logic remains in the reducer; effects still diff at the `EffectMap` edge. No side effects added to reducers.
- **5 (SSOT):** `lastActedFlow` is a single owned field; the read sites derive `actedPrev/actedNextFlow` from it with a documented global fallback rather than keeping a second copy of the flow. No duplicated flow state.
- **6 (security/privacy):** No capture/network/effects boundary touched; `lastActedFlow` holds an enum `Flow`, no PII. Neutral.
- **8 (platform-agnostic core):** No new platform literals in logic — the fix is keyed on the per-`Platform` region map and the existing registry-based `offerBelongsToRegion` (`Platform.fromRuleId`), never `== Platform.DoorDash`/package strings. The new tests use `Platform.DoorDash`/`Platform.Uber` generically as two arbitrary platforms (either direction reproduces the bug). This is itself the item-5 Principle-8 fix (a global-singular resource commanded by per-platform signals).
- **Reactive UI:** not touched (no Compose surface).

### Adversarial review

Fable adversarial reviewer ran against head `45f01da1` (correctness / design principles 1–8 / security), including an **empirical master-probe**: the three behavioral tests were ported to a master worktree and **all three fail on master** (foreign-economics mint; premature cross-platform `DELIVERY_COMPLETED`; duplicate receipt bubble from the non-observing region) — the tests are genuine regression pins. Verdict: **APPROVE-WITH-FIXES**; both flagged spec deviations **ACCEPTED** (the global accept trigger buys no safety beyond the ownership-gated consumption and would break telescoped sequences; the `?: actedPrevFlow` alternative would neuter legacy-region edges). The review also confirmed a bonus fix: master double-accumulates delivery pay on a DD-receipt → Uber-frame → DD-receipt interleave; B1's per-region `prev` prevents it. Findings applied in `7511491e`: MED-1 (corrected the overstated unreachability claim — comment + this body), LOW-2 (`offerBelongsToRegion` KDoc for the new destructive call site; fail-closed consumption noted for B3), LOW-3 (dropped the unused global `nextFlow` param — an attractive-nuisance handle), LOW-4 (pinned the bare-mint in test (a), previously vacuously passable), PROCESS-6 (field-test checklist item added). Security: no posture change (no untrusted-input, pledge, capture, or capability surface touched). P8 pass: no platform literals in logic; this PR is itself an item-5 P8 remediation.
