### PR TITLE
fix(#438): B2 — UiInput/Loopback platform+offer identity (item 8a)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/OfferActionReceiver.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/OfferActionReceiver.kt
@@ -34,7 +34,7 @@ class OfferActionReceiver : BroadcastReceiver() {
 
     override fun onReceive(context: Context, intent: Intent) {
         val uiInput = uiInputFrom(intent) ?: return
-        Timber.i("OfferActionReceiver: %s on %s", uiInput.action, uiInput.targetPlatform?.wire ?: "?")
+        Timber.tag("Effects").i("OfferActionReceiver: %s on %s", uiInput.action, uiInput.targetPlatform?.wire ?: "?")
         // #457: dismiss the heads-up immediately — the dasher acted. (Offer resolution also fires
         // CancelOfferNotification, but cancel now so the banner/shade entry doesn't linger.)
         NotificationManagerCompat.from(context).cancel(BubbleManager.OFFER_NOTIFICATION_ID)

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/OfferActionReceiver.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/OfferActionReceiver.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import androidx.core.app.NotificationManagerCompat
 import cloud.trotter.dashbuddy.core.state.StateManagerV2
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.ui.bubble.BubbleManager
 import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
@@ -32,19 +33,35 @@ class OfferActionReceiver : BroadcastReceiver() {
     }
 
     override fun onReceive(context: Context, intent: Intent) {
-        val action = intent.getStringExtra(EXTRA_ACTION) ?: return
-        Timber.i("OfferActionReceiver: %s", action)
+        val uiInput = uiInputFrom(intent) ?: return
+        Timber.i("OfferActionReceiver: %s on %s", uiInput.action, uiInput.targetPlatform?.wire ?: "?")
         // #457: dismiss the heads-up immediately — the dasher acted. (Offer resolution also fires
         // CancelOfferNotification, but cancel now so the banner/shade entry doesn't linger.)
         NotificationManagerCompat.from(context).cancel(BubbleManager.OFFER_NOTIFICATION_ID)
         val deps = EntryPointAccessors.fromApplication(context.applicationContext, Deps::class.java)
-        deps.stateManager().dispatch(
-            Observation.UiInput(timestamp = System.currentTimeMillis(), action = action),
-        )
+        deps.stateManager().dispatch(uiInput)
     }
 
     companion object {
         const val ACTION = "cloud.trotter.dashbuddy.action.OFFER_ACTION"
         const val EXTRA_ACTION = "offer_action"
+        const val EXTRA_PLATFORM = "offer_platform"
+        const val EXTRA_OFFER_HASH = "offer_hash"
+
+        /**
+         * Map the broadcast extras to the dispatched [Observation.UiInput] (#438 item 8a). The acted
+         * offer's identity (platform wire + offerHash) rides the PendingIntent extras so the input
+         * targets the owning region — an Unknown-platform tap steps no region post-#682. Pure +
+         * Hilt-free so the dispatch shape is unit-testable without the receiver's entry-point lookup.
+         */
+        fun uiInputFrom(intent: Intent): Observation.UiInput? {
+            val action = intent.getStringExtra(EXTRA_ACTION) ?: return null
+            return Observation.UiInput(
+                timestamp = System.currentTimeMillis(),
+                action = action,
+                targetPlatform = intent.getStringExtra(EXTRA_PLATFORM)?.let(Platform::fromWire),
+                offerHash = intent.getStringExtra(EXTRA_OFFER_HASH),
+            )
+        }
     }
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
@@ -352,6 +352,10 @@ class SideEffectEngine @Inject constructor(
                     Observation.Loopback(
                         timestamp = System.currentTimeMillis(),
                         effect = Observation.Loopback.EFFECT_OFFER_EVALUATED,
+                        // #438 item 8a: stamp the offer's platform (carried on the effect) so the
+                        // loopback lands on the owning region — an Unknown-platform loopback steps
+                        // no region post-#682, silently killing the offer's notification/TTS.
+                        targetPlatform = effect.platform,
                         payload = ObservationPayload.EvaluationResult(
                             action = result.action.name,
                             offerHash = effect.offerHash,
@@ -375,7 +379,7 @@ class SideEffectEngine @Inject constructor(
                 pendingOfferNotifications[hashKey]?.cancel()
                 val job = engineScope.launch(start = CoroutineStart.LAZY) {
                     delay(OFFER_NOTIFICATION_DELAY_MS)
-                    bubbleManager.postOfferNotification(effect.offer, effect.evaluation)
+                    bubbleManager.postOfferNotification(effect.offer, effect.evaluation, effect.platform)
                 }
                 job.invokeOnCompletion { pendingOfferNotifications.remove(hashKey, job) }
                 pendingOfferNotifications[hashKey] = job

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManager.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManager.kt
@@ -278,7 +278,7 @@ class BubbleManager @Inject constructor(
      * DoorDash from the accessibility live-window set and fails the verified click (#457).
      * Formatting happens HERE at the UI edge (#436) — the engine hands over the domain evaluation.
      */
-    fun postOfferNotification(offer: FlowCardSnapshot.Offer, evaluation: OfferEvaluation) {
+    fun postOfferNotification(offer: FlowCardSnapshot.Offer, evaluation: OfferEvaluation, platform: Platform) {
         val summary = evaluation.toNotificationSummary()
         val persona = evaluation.notificationPersona()
         // #551 P7: the offer summary ends with the merchant name (raw third-party UI text), so
@@ -286,7 +286,7 @@ class BubbleManager @Inject constructor(
         Timber.tag("Chat").i("offer posted [%s] (%d chars)", persona.displayName, summary.length)
         Timber.tag("Chat").d("[%s]: %s", persona.displayName, summary)
         scope.launch { chatRepository.saveMessage(activeSessionId.value, summary.toString(), persona) }
-        showOfferHeadsUp(offer, summary, persona)
+        showOfferHeadsUp(offer, summary, persona, platform)
     }
 
     /**
@@ -298,7 +298,7 @@ class BubbleManager @Inject constructor(
      * inflation and regress the #457 action surface; `setContentText` keeps a text body for surfaces
      * that don't render custom views (Wear/Auto). Dismissed by [cancelOfferNotification].
      */
-    private fun showOfferHeadsUp(offer: FlowCardSnapshot.Offer, summary: CharSequence, persona: ChatPersona) {
+    private fun showOfferHeadsUp(offer: FlowCardSnapshot.Offer, summary: CharSequence, persona: ChatPersona, platform: Platform) {
         val openBubble = Intent(context, BubbleActivity::class.java).apply { action = Intent.ACTION_VIEW }
         val contentIntent = PendingIntent.getActivity(
             context, REQUEST_CODE_OFFER_CONTENT, openBubble,
@@ -314,9 +314,9 @@ class BubbleManager @Inject constructor(
             .setAutoCancel(true)
             .setTimeoutAfter(OFFER_HEADS_UP_TIMEOUT_MS)
             .setStyle(NotificationCompat.DecoratedCustomViewStyle())
-            .setCustomContentView(buildOfferCardView(offer, R.layout.notif_offer_compact, expanded = false))
-            .setCustomHeadsUpContentView(buildOfferCardView(offer, R.layout.notif_offer_compact, expanded = false))
-            .setCustomBigContentView(buildOfferCardView(offer, R.layout.notif_offer_expanded, expanded = true))
+            .setCustomContentView(buildOfferCardView(offer, R.layout.notif_offer_compact, expanded = false, platform))
+            .setCustomHeadsUpContentView(buildOfferCardView(offer, R.layout.notif_offer_compact, expanded = false, platform))
+            .setCustomBigContentView(buildOfferCardView(offer, R.layout.notif_offer_expanded, expanded = true, platform))
         // #583: Accept/Decline are now brand-styled TextViews INSIDE the custom card
         // (wired via setOnClickPendingIntent in buildOfferCardView), not the system action row —
         // the two can't coexist without doubling the buttons. Field-gated: if a dash shows the
@@ -340,6 +340,7 @@ class BubbleManager @Inject constructor(
         offer: FlowCardSnapshot.Offer,
         layoutRes: Int,
         expanded: Boolean,
+        platform: Platform,
     ): RemoteViews {
         val rv = RemoteViews(context.packageName, layoutRes)
         val action = offer.evaluationAction?.let { runCatching { OfferAction.valueOf(it) }.getOrNull() }
@@ -394,11 +395,11 @@ class BubbleManager @Inject constructor(
         // Brand-styled Accept/Decline (both layouts) — fire the same broadcast as the old action row.
         rv.setOnClickPendingIntent(
             R.id.notif_btn_decline,
-            offerActionPendingIntent(OfferIntent.DECLINE, REQUEST_CODE_DECLINE),
+            offerActionPendingIntent(OfferIntent.DECLINE, REQUEST_CODE_DECLINE, platform, offer.offerHash),
         )
         rv.setOnClickPendingIntent(
             R.id.notif_btn_accept,
-            offerActionPendingIntent(OfferIntent.ACCEPT, REQUEST_CODE_ACCEPT),
+            offerActionPendingIntent(OfferIntent.ACCEPT, REQUEST_CODE_ACCEPT, platform, offer.offerHash),
         )
 
         if (expanded) {
@@ -436,11 +437,23 @@ class BubbleManager @Inject constructor(
         notificationManager.cancel(OFFER_NOTIFICATION_ID)
     }
 
-    /** #583: the Accept/Decline broadcast, wired onto the in-card buttons via setOnClickPendingIntent. */
-    private fun offerActionPendingIntent(action: String, requestCode: Int): PendingIntent {
+    /**
+     * #583: the Accept/Decline broadcast, wired onto the in-card buttons via setOnClickPendingIntent.
+     * #438 item 8a: the acted offer's platform wire + offerHash ride the extras so the dispatched
+     * `UiInput` carries a real target platform (identity-less taps step no region post-#682). The
+     * fixed request codes stay — per-offer PendingIntent identity is B4 (#438 item 8b).
+     */
+    private fun offerActionPendingIntent(
+        action: String,
+        requestCode: Int,
+        platform: Platform,
+        offerHash: String,
+    ): PendingIntent {
         val intent = Intent(context, OfferActionReceiver::class.java).apply {
             this.action = OfferActionReceiver.ACTION
             putExtra(OfferActionReceiver.EXTRA_ACTION, action)
+            putExtra(OfferActionReceiver.EXTRA_PLATFORM, platform.wire)
+            putExtra(OfferActionReceiver.EXTRA_OFFER_HASH, offerHash)
         }
         return PendingIntent.getBroadcast(
             context, requestCode, intent,

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleViewModel.kt
@@ -195,8 +195,20 @@ class BubbleViewModel @Inject constructor(
     fun declineOffer() = onOfferAction(OfferIntent.DECLINE)
 
     private fun onOfferAction(action: String) {
+        // #438 item 8a: stamp the acted offer's identity from the state the bubble renders so the
+        // dispatched UiInput targets the owning region (an Unknown-platform tap steps no region
+        // post-#682). The pending offer's platform is its own provenance, not the focused/global
+        // one — they coincide today (offers live on R0), diverge under B3's platform-owned offers.
+        val pendingOffer = stateManager.state.value.regions.flow.pendingOffer
+        val platform = pendingOffer?.sourceRuleId?.let(Platform::fromRuleId)?.takeIf { it != Platform.Unknown }
+            ?: focusedPlatform.value
         stateManager.dispatch(
-            Observation.UiInput(timestamp = System.currentTimeMillis(), action = action)
+            Observation.UiInput(
+                timestamp = System.currentTimeMillis(),
+                action = action,
+                targetPlatform = platform,
+                offerHash = pendingOffer?.offerHash,
+            )
         )
         _collapse.tryEmit(Unit)
     }

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
@@ -206,6 +206,51 @@ class EffectMapTest {
     }
 
     @Test
+    fun `EvaluateOffer carries the offer's OWN platform, not the active-platform mirror (#438 item 8a)`() {
+        // sourceRuleId is the offer's provenance; activePlatform is the global R0 mirror this pack
+        // removes. They deliberately DIVERGE here (offer=DoorDash, active=Uber) so the assertion
+        // proves the stamp reads sourceRuleId, not next.activePlatform.
+        val prev = AppState(regions = Regions(flow = FlowRegion(flow = Flow.Idle)))
+        val next = AppState(regions = Regions(
+            flow = FlowRegion(
+                flow = Flow.OfferPresented,
+                pendingOffer = testPendingOffer.copy(sourceRuleId = "doordash.screen.offer"),
+                activePlatform = Platform.Uber,
+            ),
+        ))
+
+        val effects = effectMap.diff(prev, next, screenObs(flow = Flow.OfferPresented, parsed = testOfferFields))
+
+        val eval = effects.filterIsInstance<AppEffect.EvaluateOffer>().single()
+        assertEquals("Stamps the offer's own platform", Platform.DoorDash, eval.platform)
+    }
+
+    @Test
+    fun `evaluation landing stamps PostOfferNotification with the offer's platform (#438 item 8a)`() {
+        val prev = AppState(regions = Regions(
+            flow = FlowRegion(
+                flow = Flow.OfferPresented,
+                pendingOffer = testPendingOffer.copy(sourceRuleId = "doordash.screen.offer"),
+                activePlatform = Platform.Uber,
+            ),
+        ))
+        val next = AppState(regions = Regions(
+            flow = FlowRegion(
+                flow = Flow.OfferPresented,
+                pendingOffer = testPendingOffer.copy(
+                    sourceRuleId = "doordash.screen.offer", evaluation = testEvaluation,
+                ),
+                activePlatform = Platform.Uber,
+            ),
+        ))
+
+        val effects = effectMap.diff(prev, next, screenObs(flow = Flow.OfferPresented))
+
+        val post = effects.filterIsInstance<AppEffect.PostOfferNotification>().single()
+        assertEquals("Notification carries the offer's own platform", Platform.DoorDash, post.platform)
+    }
+
+    @Test
     fun `evaluation landing on the pending offer emits PostOfferNotification`() {
         // The async eval loopback attaches the evaluation to the SAME pending offer
         // (eval null → non-null). EffectMap surfaces it as a heads-up notification here,
@@ -1503,6 +1548,46 @@ class EffectMapTest {
             boundsInScreen = cloud.trotter.dashbuddy.domain.model.accessibility.BoundingBox(0, 0, 100, 50),
             pathFingerprint = "fp",
         )
+
+    @Test
+    fun `a UiInput accept resolves the platform from its OWN carried identity (#438 item 8a)`() {
+        // The tap carries targetPlatform=Uber; R0's activePlatform is DoorDash. The action must fire
+        // on the tap's carried platform (the offer it acted on), not the global active-platform mirror.
+        val offer = testPendingOffer.copy(
+            sourceRuleId = "uber.screen.offer",
+            targets = mapOf("acceptButton" to testNodeRef()),
+        )
+        val state = AppState(regions = Regions(
+            flow = FlowRegion(flow = Flow.OfferPresented, pendingOffer = offer, activePlatform = Platform.DoorDash),
+        ))
+        val obs = Observation.UiInput(
+            timestamp = 1L, action = OfferIntent.ACCEPT,
+            targetPlatform = Platform.Uber, offerHash = "hash-123",
+        )
+
+        val effects = effectMap.diff(state, state, obs)
+
+        val action = effects.filterIsInstance<AppEffect.PerformRuleAction>().single()
+        assertEquals(Platform.Uber, action.platform)
+    }
+
+    @Test
+    fun `a UiInput without carried identity falls back to the active platform (#438 item 8a)`() {
+        // A legacy/identity-less tap (Unknown) must behave as today — resolve via R0 activePlatform.
+        val offer = testPendingOffer.copy(
+            sourceRuleId = "doordash.screen.offer",
+            targets = mapOf("acceptButton" to testNodeRef()),
+        )
+        val state = AppState(regions = Regions(
+            flow = FlowRegion(flow = Flow.OfferPresented, pendingOffer = offer, activePlatform = Platform.DoorDash),
+        ))
+        val obs = Observation.UiInput(timestamp = 1L, action = OfferIntent.ACCEPT)
+
+        val effects = effectMap.diff(state, state, obs)
+
+        val action = effects.filterIsInstance<AppEffect.PerformRuleAction>().single()
+        assertEquals(Platform.DoorDash, action.platform)
+    }
 
     @Test
     fun `collapsed summary with expand target schedules a deferred EXPAND_EARNINGS`() {

--- a/app/src/test/java/cloud/trotter/dashbuddy/state/effects/OfferActionReceiverTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/state/effects/OfferActionReceiverTest.kt
@@ -1,0 +1,54 @@
+package cloud.trotter.dashbuddy.state.effects
+
+import android.content.Intent
+import cloud.trotter.dashbuddy.domain.state.OfferIntent
+import cloud.trotter.dashbuddy.domain.state.Platform
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * #438 item 8a: the notification-action broadcast maps its identity extras onto the dispatched
+ * [Observation.UiInput], so an Accept/Decline from the heads-up carries a real target platform +
+ * offerHash (an Unknown-platform tap steps no region post-#682). Robolectric supplies the Intent.
+ */
+@RunWith(RobolectricTestRunner::class)
+class OfferActionReceiverTest {
+
+    private fun intentWith(action: String?, platformWire: String?, offerHash: String?) =
+        Intent(OfferActionReceiver.ACTION).apply {
+            action?.let { putExtra(OfferActionReceiver.EXTRA_ACTION, it) }
+            platformWire?.let { putExtra(OfferActionReceiver.EXTRA_PLATFORM, it) }
+            offerHash?.let { putExtra(OfferActionReceiver.EXTRA_OFFER_HASH, it) }
+        }
+
+    @Test
+    fun `accept extras yield a UiInput with a real platform and offer hash`() {
+        val ui = OfferActionReceiver.uiInputFrom(
+            intentWith(OfferIntent.ACCEPT, Platform.Uber.wire, "offer-U"),
+        )!!
+
+        assertEquals(OfferIntent.ACCEPT, ui.action)
+        assertEquals(Platform.Uber, ui.targetPlatform)
+        assertEquals(Platform.Uber, ui.platform) // the derived override honours the stamp
+        assertEquals("offer-U", ui.offerHash)
+    }
+
+    @Test
+    fun `decline extras carry the DoorDash identity`() {
+        val ui = OfferActionReceiver.uiInputFrom(
+            intentWith(OfferIntent.DECLINE, Platform.DoorDash.wire, "offer-D"),
+        )!!
+
+        assertEquals(OfferIntent.DECLINE, ui.action)
+        assertEquals(Platform.DoorDash, ui.targetPlatform)
+        assertEquals("offer-D", ui.offerHash)
+    }
+
+    @Test
+    fun `a broadcast with no action is dropped`() {
+        assertNull(OfferActionReceiver.uiInputFrom(intentWith(null, Platform.Uber.wire, "x")))
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngineTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngineTest.kt
@@ -445,26 +445,26 @@ class SideEffectEngineTest {
     fun `a resolved offer cancels the pending notification post`() = runTest {
         val engine = buildEngine(StandardTestDispatcher(testScheduler))
 
-        engine.process(AppEffect.PostOfferNotification(testEvaluation(), testOfferCard(), offerHash = "hash-9"))
+        engine.process(AppEffect.PostOfferNotification(testEvaluation(), testOfferCard(), offerHash = "hash-9", platform = Platform.DoorDash))
         runCurrent()
         engine.process(AppEffect.CancelOfferNotification(offerHash = "hash-9"))
         runCurrent()
         advanceTimeBy(SideEffectEngine.OFFER_NOTIFICATION_DELAY_MS + 100)
         runCurrent()
 
-        verify(bubbleManager, never()).postOfferNotification(any(), any())
+        verify(bubbleManager, never()).postOfferNotification(any(), any(), any())
     }
 
     @Test
     fun `an unresolved offer notification still posts after the settle delay`() = runTest {
         val engine = buildEngine(StandardTestDispatcher(testScheduler))
 
-        engine.process(AppEffect.PostOfferNotification(testEvaluation(), testOfferCard(), offerHash = "hash-9"))
+        engine.process(AppEffect.PostOfferNotification(testEvaluation(), testOfferCard(), offerHash = "hash-9", platform = Platform.DoorDash))
         runCurrent()
         advanceTimeBy(SideEffectEngine.OFFER_NOTIFICATION_DELAY_MS + 100)
         runCurrent()
 
-        verify(bubbleManager, times(1)).postOfferNotification(any(), any())
+        verify(bubbleManager, times(1)).postOfferNotification(any(), any(), any())
     }
 
     @Test
@@ -472,15 +472,41 @@ class SideEffectEngineTest {
         // The offer heads-up is now a SEPARATE notification (own id), not the self-replacing bubble,
         // so once it has posted, resolution must explicitly dismiss it.
         val engine = buildEngine(StandardTestDispatcher(testScheduler))
-        engine.process(AppEffect.PostOfferNotification(testEvaluation(), testOfferCard(), offerHash = "hash-9"))
+        engine.process(AppEffect.PostOfferNotification(testEvaluation(), testOfferCard(), offerHash = "hash-9", platform = Platform.DoorDash))
         runCurrent()
         advanceTimeBy(SideEffectEngine.OFFER_NOTIFICATION_DELAY_MS + 100)
         runCurrent()
-        verify(bubbleManager, times(1)).postOfferNotification(any(), any())
+        verify(bubbleManager, times(1)).postOfferNotification(any(), any(), any())
 
         engine.process(AppEffect.CancelOfferNotification(offerHash = "hash-9"))
         runCurrent()
         verify(bubbleManager, times(1)).cancelOfferNotification()
+    }
+
+    @Test
+    fun `EvaluateOffer stamps the offer's platform onto the eval loopback (#438 item 8a)`() = runTest {
+        // Pre-B3 the evaluation still lands in R0 — this asserts the STAMPING (identity carried on
+        // the loopback), not the region landing. Without the stamp an Unknown-platform loopback
+        // steps no region post-#682, silently killing the offer's notification/TTS.
+        val engine = buildEngine(StandardTestDispatcher(testScheduler))
+        whenever(offerEvaluator.evaluate(any(), any())).thenReturn(testEvaluation())
+        val collected = mutableListOf<cloud.trotter.dashbuddy.domain.model.state.StateEvent>()
+        val job = launch { engine.events.collect { collected += it } }
+        runCurrent()
+
+        engine.process(
+            AppEffect.EvaluateOffer(
+                cloud.trotter.dashbuddy.domain.model.offer.ParsedOffer(offerHash = "hash-U", payAmount = 7.5),
+                offerHash = "hash-U",
+                platform = Platform.Uber,
+            ),
+        )
+        runCurrent()
+        job.cancel()
+
+        val loop = collected.filterIsInstance<cloud.trotter.dashbuddy.domain.pipeline.Observation.Loopback>().single()
+        assertEquals(Platform.Uber, loop.targetPlatform)
+        assertEquals(Platform.Uber, loop.platform)
     }
 
     @Test

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/AppEffect.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/AppEffect.kt
@@ -138,9 +138,15 @@ sealed class AppEffect {
     /**
      * Evaluate the pending offer. [offerHash] rides the async round-trip so the result
      * can be correlated back — a replaced offer must never inherit the previous offer's
-     * evaluation (#345).
+     * evaluation (#345). [platform] is the offer's own provenance (derived from its
+     * `sourceRuleId`, #438 item 8a) so the eval loopback can stamp identity onto the
+     * result — an identity-less loopback lands on no region post-#682.
      */
-    data class EvaluateOffer(val parsedOffer: ParsedOffer, val offerHash: String) : AppEffect()
+    data class EvaluateOffer(
+        val parsedOffer: ParsedOffer,
+        val offerHash: String,
+        val platform: Platform,
+    ) : AppEffect()
     /** Speak the offer's evaluation aloud (verdict + headline economics). Fires on eval-landing. */
     data class SpeakOffer(val evaluation: OfferEvaluation) : AppEffect()
 
@@ -161,6 +167,12 @@ sealed class AppEffect {
         val offer: FlowCardSnapshot.Offer,
         /** Keys the engine's delayed post so [CancelOfferNotification] can abort it (#436). */
         val offerHash: String?,
+        /**
+         * The offer's platform (#438 item 8a), derived from its `sourceRuleId`. Rides the
+         * notification's Accept/Decline PendingIntent extras so the dispatched [UiInput]
+         * carries a real target platform instead of deriving [Platform.Unknown].
+         */
+        val platform: Platform,
     ) : AppEffect()
 
     /**

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -142,8 +142,11 @@ class EffectMap @Inject constructor() {
             add(logEffect(sessionId, AppEventType.OFFER_RECEIVED, obs.timestamp, receivedPayload))
 
             // Evaluate (the heads-up notification + spoken read fire later, once the async
-            // evaluation lands on the pending offer — see the eval-landing block below).
-            add(AppEffect.EvaluateOffer(offer.parsedOffer, nextOffer.offerHash))
+            // evaluation lands on the pending offer — see the eval-landing block below). The
+            // platform is the OFFER's own provenance (#438 item 8a) — its sourceRuleId, not
+            // next.activePlatform (the global mirror this pack removes) — so the eval loopback
+            // lands on the region that owns the offer even behind another platform's screen.
+            add(AppEffect.EvaluateOffer(offer.parsedOffer, nextOffer.offerHash, offerPlatform(nextOffer)))
         }
 
         // Offer replaced (different hash)
@@ -174,7 +177,7 @@ class EffectMap @Inject constructor() {
 
             // Evaluate the new offer (notification + spoken read fire on eval-landing below).
             val offer = nextOffer.offerFields
-            add(AppEffect.EvaluateOffer(offer.parsedOffer, nextOffer.offerHash))
+            add(AppEffect.EvaluateOffer(offer.parsedOffer, nextOffer.offerHash, offerPlatform(nextOffer)))
         }
 
         // Evaluation landed (async loopback) → fire the offer's UI side-effects: the heads-up
@@ -198,7 +201,7 @@ class EffectMap @Inject constructor() {
                 expiresAt = expiresAt,
                 countdownSeconds = parsedOffer.initialCountdownSeconds,
             )
-            add(AppEffect.PostOfferNotification(landedEval, offerCard, nextOffer.offerHash))
+            add(AppEffect.PostOfferNotification(landedEval, offerCard, nextOffer.offerHash, offerPlatform(nextOffer)))
             add(AppEffect.SpeakOffer(landedEval))
         }
 
@@ -298,7 +301,12 @@ class EffectMap @Inject constructor() {
             }
             if (action != null) {
                 val onOfferFlow = next.flow == Flow.OfferPresented || prev.flow == Flow.OfferPresented
-                val platform = next.activePlatform ?: prev.activePlatform
+                // #438 item 8a: resolve the platform from the tap's OWN carried identity
+                // (obs.platform, stamped by the bubble/notification dispatch), not the global
+                // next.activePlatform mirror this pack removes. An identity-less legacy tap
+                // (Unknown) falls back to the R0 active-platform chain — today's behavior.
+                val carried = obs.platform.takeIf { it != Platform.Unknown }
+                val platform = carried ?: next.activePlatform ?: prev.activePlatform
                 val offer = next.pendingOffer ?: prev.pendingOffer
                 val target = offer?.targets?.get(action.targetBindName)
                 when {
@@ -1316,6 +1324,13 @@ class EffectMap @Inject constructor() {
     // =========================================================================
     // HELPERS
     // =========================================================================
+
+    /**
+     * The offer's own platform (#438 item 8a), from its `sourceRuleId` via the [Platform]
+     * registry — NOT `next.activePlatform`, the global mirror this pack removes. Used to
+     * stamp identity onto the eval loopback + notification so they land on the owning region.
+     */
+    private fun offerPlatform(offer: PendingOffer): Platform = Platform.fromRuleId(offer.sourceRuleId)
 
     private fun resolveOfferOutcome(obs: Observation, prevOffer: PendingOffer? = null): AppEventType {
         // 0. Decline-commit latch (#594): a DECLINE-intent click already committed this offer's

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/ObservationJournal.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/ObservationJournal.kt
@@ -33,6 +33,10 @@ internal data class InternalObsPayload(
     val effect: String? = null,
     val targetPlatform: String? = null,
     val payload: ObservationPayload? = null,
+    // #438 item 8a: UiInput's offer identity round-trips so a recovery-replayed accept/decline
+    // targets the owning region (an identity-less UiInput Unknown-skips at StateMachine.kt:75).
+    // Additive: old journal rows without this key decode with a null default.
+    val offerHash: String? = null,
 )
 
 /**
@@ -108,9 +112,18 @@ class ObservationJournal @Inject constructor(
                 InternalObsPayload(targetPlatform = obs.targetPlatform?.wire, payload = obs.payload)
             } else null
         // Persisting the REAL action is safe: PerformRuleAction is classified
-        // external (#341), so recovery can never replay an offer tap from it.
-        is Observation.UiInput -> InternalObsPayload(action = obs.action)
-        is Observation.Loopback -> InternalObsPayload(effect = obs.effect, payload = obs.payload)
+        // external (#341), so recovery can never replay an offer tap from it. Identity
+        // (targetPlatform/offerHash) round-trips so the replayed input lands on its region (#438 8a).
+        is Observation.UiInput -> InternalObsPayload(
+            action = obs.action,
+            targetPlatform = obs.targetPlatform?.wire,
+            offerHash = obs.offerHash,
+        )
+        is Observation.Loopback -> InternalObsPayload(
+            effect = obs.effect,
+            targetPlatform = obs.targetPlatform?.wire,
+            payload = obs.payload,
+        )
         else -> null
     }
 
@@ -170,11 +183,14 @@ class ObservationJournal @Inject constructor(
             "internal.ui" -> Observation.UiInput(
                 timestamp = occurredAt,
                 action = payload?.action ?: "replay",
+                targetPlatform = payload?.targetPlatform?.let(Platform::fromWire),
+                offerHash = payload?.offerHash,
             )
 
             "internal.loopback" -> Observation.Loopback(
                 timestamp = occurredAt,
                 effect = payload?.effect ?: "replay",
+                targetPlatform = payload?.targetPlatform?.let(Platform::fromWire),
                 // Typed payload round-trips losslessly (#366) — a replayed
                 // offer_evaluated lands its evaluation with no key rebuilding.
                 payload = payload?.payload,

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/ObservationJournalTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/ObservationJournalTest.kt
@@ -156,6 +156,69 @@ class ObservationJournalTest {
     }
 
     @Test
+    fun `UiInput offer identity survives the round-trip (#438 item 8a)`() = runTest {
+        val dao = FakeObservationDao()
+        val journal = ObservationJournal(dao)
+        journal.start(CoroutineScope(SupervisorJob() + StandardTestDispatcher(testScheduler)), StandardTestDispatcher(testScheduler))
+
+        journal.append(
+            Observation.UiInput(
+                timestamp = 1L, action = "accept_offer",
+                targetPlatform = Platform.Uber, offerHash = "offer-U",
+            ),
+            state(1),
+        )
+        advanceUntilIdle()
+        val ui = journal.tailAfter(0).single() as Observation.UiInput
+
+        assertEquals("accept_offer", ui.action)
+        assertEquals(Platform.Uber, ui.targetPlatform)
+        assertEquals(Platform.Uber, ui.platform) // derived override honours the stamp
+        assertEquals("offer-U", ui.offerHash)
+    }
+
+    @Test
+    fun `Loopback target platform survives the round-trip (#438 item 8a)`() = runTest {
+        val dao = FakeObservationDao()
+        val journal = ObservationJournal(dao)
+        journal.start(CoroutineScope(SupervisorJob() + StandardTestDispatcher(testScheduler)), StandardTestDispatcher(testScheduler))
+
+        journal.append(
+            Observation.Loopback(
+                timestamp = 1L, effect = "offer_evaluated",
+                targetPlatform = Platform.DoorDash,
+                payload = ObservationPayload.EvaluationResult(action = "ACCEPT", offerHash = "offer-A"),
+            ),
+            state(1),
+        )
+        advanceUntilIdle()
+        val loop = journal.tailAfter(0).single() as Observation.Loopback
+
+        assertEquals(Platform.DoorDash, loop.targetPlatform)
+        assertEquals(Platform.DoorDash, loop.platform)
+    }
+
+    @Test
+    fun `an OLD journal row without the new identity fields still decodes (#438 item 8a)`() = runTest {
+        // Additive-JSON contract: a UiInput row persisted before B2 carries only `action` in its
+        // payloadJson. The new offerHash/targetPlatform keys must decode to null defaults, not throw.
+        val dao = FakeObservationDao()
+        val journal = ObservationJournal(dao)
+        dao.inserted += ObservationEntity(
+            occurredAt = 7L, sessionId = null, pipelineId = "internal.ui", ruleId = null,
+            platform = Platform.Unknown.name, flow = null, modeHint = null, parsedJson = "{}",
+            captureId = null, metadataJson = "{}", correlationVersion = 1L,
+            payloadJson = """{"action":"accept_offer"}""",
+        )
+
+        val ui = journal.tailAfter(0).single() as Observation.UiInput
+        assertEquals("accept_offer", ui.action)
+        assertEquals(null, ui.targetPlatform)
+        assertEquals(null, ui.offerHash)
+        assertEquals(Platform.Unknown, ui.platform) // no stamp, no ruleId → Unknown (today's fallback)
+    }
+
+    @Test
     fun `flow observations round-trip their parsed fields`() = runTest {
         val dao = FakeObservationDao()
         val journal = ObservationJournal(dao)

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/Observation.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/Observation.kt
@@ -11,8 +11,9 @@ import cloud.trotter.dashbuddy.domain.state.Platform
  * consumes. Extends [StateEvent] so it can flow through the existing
  * state machine merge alongside engine events.
  *
- * The `platform` for any observation is derived from [ruleId] via
- * [Platform.fromRuleId].
+ * The `platform` for an observation defaults to [Platform.fromRuleId] on
+ * [ruleId]; subtypes that receive no ruleId ([Timeout], [UiInput], [Loopback])
+ * carry an explicit `targetPlatform` that takes precedence (#342 / #438 8a).
  */
 sealed interface Observation : cloud.trotter.dashbuddy.domain.model.state.StateEvent {
     override val timestamp: Long

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/Observation.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/Observation.kt
@@ -130,7 +130,19 @@ sealed interface Observation : cloud.trotter.dashbuddy.domain.model.state.StateE
         override val ruleId: String? = null,
         override val metadata: ReplayMetadata = ReplayMetadata.EMPTY,
         val action: String,
-    ) : Observation
+        /**
+         * The platform the offer being acted on belongs to (#438 item 8a). Like
+         * [Timeout.targetPlatform] (#342), a UiInput carries no ruleId, so without an
+         * explicit target it derives [Platform.Unknown] and post-#682 never steps any
+         * region — an identity-less accept/decline would land nowhere. The bubble/
+         * notification dispatch stamps the acted offer's platform. Null = not scoped.
+         */
+        val targetPlatform: Platform? = null,
+        /** The offer this input targets (#438 item 8a) — correlates the tap to its offer. */
+        val offerHash: String? = null,
+    ) : Observation {
+        override val platform: Platform get() = targetPlatform ?: Platform.fromRuleId(ruleId)
+    }
 
     /** A loopback event from the side-effect engine back into the state machine. */
     data class Loopback(
@@ -139,9 +151,18 @@ sealed interface Observation : cloud.trotter.dashbuddy.domain.model.state.StateE
         override val ruleId: String? = null,
         override val metadata: ReplayMetadata = ReplayMetadata.EMPTY,
         val effect: String,
+        /**
+         * The platform the looped-back offer belongs to (#438 item 8a) — same
+         * identity-less-observation problem as [UiInput.targetPlatform]: the eval
+         * loopback carries no ruleId, so the owning region never sees it. Stamped
+         * from the [AppEffect.EvaluateOffer]'s effect-carried platform. Null = not scoped.
+         */
+        val targetPlatform: Platform? = null,
         /** Typed loopback context (#366) — e.g. the landed offer evaluation. */
         val payload: ObservationPayload? = null,
     ) : Observation {
+        override val platform: Platform get() = targetPlatform ?: Platform.fromRuleId(ruleId)
+
         companion object {
             /** Effect token for the async offer-evaluation loopback (#402). */
             const val EFFECT_OFFER_EVALUATED = "offer_evaluated"


### PR DESCRIPTION
## B2 — item 8a: observation identity (the load-bearing slice)

Prerequisite for **B3** (platform-owned offers) in the [#438 multiplatform correctness pack](../blob/master/docs/design/multiplatform-correctness-pack.md) — see the **"B2 — item 8a"** section. `Observation.UiInput` and `Observation.Loopback` carry no platform, so `Platform.fromRuleId(null) = Unknown`; post-#682 an Unknown observation steps **no** region (`StateMachine.kt:75`). Under B3 an identity-less eval loopback / notification tap would land on no region's offer — breaking every offer notification/TTS, single-platform included. So identity stamping must land **before** the move. This follows the established `Observation.Timeout.targetPlatform` precedent (#342), fixed for the exact same bug class.

### What changed
- **`:domain`** — `Observation.UiInput` + `Observation.Loopback` gain `targetPlatform: Platform? = null` and the `override val platform get() = targetPlatform ?: Platform.fromRuleId(ruleId)` override; `UiInput` gains `offerHash` (Loopback already carries it on `EvaluationResult`).
- **`AppEffect.EvaluateOffer` + `AppEffect.PostOfferNotification`** gain a `platform` field, populated at the `EffectMap` emission sites from the **offer's own `sourceRuleId`** via the `Platform` registry — NOT `next.activePlatform` (the global mirror this pack removes). `PostOfferNotification` needs it too because the notification path is the only way the platform reaches `BubbleManager` for the extras.
- **Emission/threading** — `SideEffectEngine` stamps the effect-carried platform onto the eval `Loopback`; the notification Accept/Decline **PendingIntent extras** (`BubbleManager` → `OfferActionReceiver`) carry platform wire + offerHash; `BubbleViewModel` stamps the acted offer's identity from the rendered state. Request codes / notification ids are **unchanged** — per-offer PendingIntent identity is B4.
- **`EffectMap` UiInput block** resolves `platform` from the tap's own carried identity (`obs.platform`), falling back to the active-platform chain when the carried platform is `Unknown` (legacy taps behave exactly as today). The `pendingOffer` resolution itself is untouched — offers still live on R0 until B3.
- **`ObservationJournal` codec** persists + restores `targetPlatform` (UiInput/Loopback) and UiInput's `offerHash`. Additive JSON — old journal rows decode unchanged (verified by an explicit old-row test).

### Acceptance (all green)
- `OfferActionReceiverTest` — notification extras → a `UiInput` with a real platform + offerHash (Accept/Decline); no-action broadcast dropped. Dispatch shape extracted to a pure, Hilt-free `uiInputFrom(intent)` so it is unit-testable.
- `EffectMapTest` — `EvaluateOffer` and `PostOfferNotification` carry the offer's **own** platform even when `activePlatform` deliberately diverges; a carried-identity `UiInput` fires `PerformRuleAction` on the carried platform; an identity-less `UiInput` falls back to `activePlatform`.
- `SideEffectEngineTest` — processing `EvaluateOffer` emits a `Loopback` stamped with the offer's platform (asserts the **stamping**, not region landing — pre-B3 the evaluation still lands in R0).
- `ObservationJournalTest` — UiInput + Loopback identity round-trips; an OLD row without the new fields still decodes.
- Full suite: `./gradlew testDebugUnitTest :domain:test` — **BUILD SUCCESSFUL**.

### Scope note / deviation
The spec's item 2 names only `EvaluateOffer` as gaining `platform`. Threading the platform to the notification's PendingIntent extras (item 4) requires `PostOfferNotification` to carry it too — the same "the engine cannot stamp what it doesn't hold" reasoning (vet M2), same `sourceRuleId`→`Platform.fromRuleId` derivation. This is the minimal consequence of item 4, not a scope expansion.

### Design-goal review
- **P1 (UDF).** Identity is stamped at the edges (dispatch sites, effect emission) and carried as immutable data on observations/effects; reducers stay pure — the `EffectMap` diff only *reads* carried identity, and the `Loopback` stamp happens in the side-effect engine, not a reducer.
- **P3 (SRP).** `OfferActionReceiver`'s intent→UiInput mapping extracted to a pure `uiInputFrom` (also what makes it testable); `EffectMap` gains one small `offerPlatform(offer)` helper rather than inlining the derivation at three sites.
- **P5 (SSOT).** Platform identity derives from **one** source — the offer's `sourceRuleId` through the `Platform` registry — at every emission site; no second copy, no `activePlatform` mirror. The journal restores the same identity it persisted (no hand-maintained parallel).
- **P6 (security/privacy).** `offerHash` is already an edge-hashed correlation token; no raw PII added to extras, effects, or the journal. INFO log in the receiver carries only the platform wire + action (PII-safe).
- **P8 (platform-agnostic core).** No new platform literals — identity flows exclusively through `Platform.fromRuleId` / `Platform.fromWire`. New vocabulary (`targetPlatform`, effect `platform`) is a `Platform`-keyed value, never a magic string + a `when`. Adding a platform needs zero edits here.

Follow-ups: B3 (move offers to `PlatformRegion`), B4 (per-offer PendingIntent identity via `data` URI + per-offer notification ids).


### Adversarial review

Fable adversarial reviewer ran against head `0b0d2491` — verdict **APPROVE, zero must-fix**; the flagged `PostOfferNotification.platform` deviation **ACCEPTED** (`FlowCardSnapshot.Offer` carries no provenance, so the effect is the only carrier; same vet-M2 reasoning, same `offerPlatform` SSOT). Key verified properties: every production `UiInput`/`Loopback` construction site is identity-stamped (table in review) and the journal round-trips it, so the B3 load-bearing property holds; null `sourceRuleId` → Unknown resolves through the exact pre-B2 fallback chain (no behavior change); **the highest-risk behavior change — platform-stamped UiInput/Loopback now step a region for the first time — was walked to ground and is commit-only** (lazy-expiry commits identical to a timer wake one tick early; `lastActedFlow` not stamped, per B1's rule; `armAcceptStash` idempotent + ownership-gated; a UiInput can never newly latch an accept at R0). Security: receiver `exported="false"`, PendingIntents `FLAG_IMMUTABLE`, extras carry wire + hash only (no PII); the known pre-B4 PendingIntent clobber is unchanged and a post-B2 platform mismatch now **fails closed** at the label-verified click gate (strictly not-worse). Five LOW nice-to-haves: two fixed in `7a23ac71` (Effects tag on the touched INFO line; stale `Observation` platform KDoc); the rest ride forward — carried-`offerHash` check at resolution (B4's hash pinning), single `PendingOffer`→platform helper (B3 retires the third copy), and a commit-only characterization test (added to B3's acceptance).
