### PR TITLE
fix(#438): B4 — per-offer PendingIntent + notification identity (item 8b)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/OfferActionReceiver.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/OfferActionReceiver.kt
@@ -37,7 +37,10 @@ class OfferActionReceiver : BroadcastReceiver() {
         Timber.tag("Effects").i("OfferActionReceiver: %s on %s", uiInput.action, uiInput.targetPlatform?.wire ?: "?")
         // #457: dismiss the heads-up immediately — the dasher acted. (Offer resolution also fires
         // CancelOfferNotification, but cancel now so the banner/shade entry doesn't linger.)
-        NotificationManagerCompat.from(context).cancel(BubbleManager.OFFER_NOTIFICATION_ID)
+        // #438 B4: dismiss ONLY this offer's banner (per-offer id from the tap's own carried hash),
+        // not every offer heads-up — a concurrent/replacement offer keeps its banner.
+        NotificationManagerCompat.from(context)
+            .cancel(BubbleManager.offerNotificationId(uiInput.offerHash))
         val deps = EntryPointAccessors.fromApplication(context.applicationContext, Deps::class.java)
         deps.stateManager().dispatch(uiInput)
     }

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
@@ -393,8 +393,9 @@ class SideEffectEngine @Inject constructor(
                 // #457: the offer heads-up is now a SEPARATE notification (its own id), not the
                 // self-replacing bubble — so if it already posted, dismiss it explicitly when the
                 // offer resolves (accept/decline/timeout) so an Accept/Decline banner can't outlive
-                // the offer.
-                bubbleManager.cancelOfferNotification()
+                // the offer. #438 B4: pass the resolved offer's hash through so we dismiss ONLY that
+                // offer's banner (concurrent/replacement offers each keep their own).
+                bubbleManager.cancelOfferNotification(effect.offerHash)
             }
 
             // --- TIMING LOGIC (Pure Coroutines) ---

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManager.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManager.kt
@@ -94,16 +94,19 @@ class BubbleManager @Inject constructor(
          * the reserved [OFFER_NOTIFICATION_ID] — self-consistent post/cancel, and the sweep id for a
          * stale pre-B4 banner.
          *
-         * Collision posture (documented, accepted for the single-user alpha): `hashCode()` is a
-         * 32-bit space. Two live offers colliding on the same id → one banner replaces the other
-         * (no data loss; the state layer still resolves each tap by carried (platform, offerHash),
-         * B3). Probability ≈ 1/4e9 for two concurrent offers. Ids that would land on the reserved
-         * bubble (1) / offer (2) ids are nudged clear so a hash can never dismiss the wrong surface.
+         * Collision posture (documented, accepted for the single-user alpha): the id is the hash
+         * folded into the **disjoint namespace [2^30, 2^31)** — so it can NEVER land on any app
+         * fixed id (the bubble's 1, the reserved offer 2, the odometer handler's 101, or any
+         * future small constant; an enumerated "nudge" list would silently rot as ids are added —
+         * adversarial-review MED-1). Two live offers colliding within the 30-bit space → one
+         * banner replaces the other (no data loss; the state layer still resolves each tap by
+         * carried (platform, offerHash), B3). Probability ≈ 1/1e9 for two concurrent offers.
+         * The per-offer PendingIntents are released in `cancelOfferNotification` (LOW-1); an
+         * OS-side 90s [OFFER_HEADS_UP_TIMEOUT_MS] self-dismiss backstops any missed cancel.
          */
         fun offerNotificationId(offerHash: String?): Int {
             if (offerHash == null) return OFFER_NOTIFICATION_ID
-            val h = offerHash.hashCode()
-            return if (h == BUBBLE_NOTIFICATION_ID || h == OFFER_NOTIFICATION_ID) h + 2 else h
+            return (offerHash.hashCode() and 0x3FFF_FFFF) or 0x4000_0000
         }
 
         /**
@@ -481,6 +484,25 @@ class BubbleManager @Inject constructor(
      */
     fun cancelOfferNotification(offerHash: String?) {
         notificationManager.cancel(offerNotificationId(offerHash))
+        if (offerHash == null) return
+        // Release the offer's Accept/Decline PendingIntent records (adversarial-review LOW-1):
+        // cancelling a notification does NOT release its PIs, and per-offer URIs would otherwise
+        // accrue two system-server records per offer until process death. The cancel effect
+        // carries only the hash, not the platform the URI path needs — probe every registry
+        // platform with FLAG_NO_CREATE (a handful of lookups; keyed on the registry, no
+        // literals). filterEquals ignores extras, so action + data + component is enough to match.
+        for (platform in Platform.entries) {
+            for (action in listOf(OfferIntent.ACCEPT, OfferIntent.DECLINE)) {
+                val intent = Intent(context, OfferActionReceiver::class.java).apply {
+                    this.action = OfferActionReceiver.ACTION
+                    data = offerActionUri(platform, offerHash, action)
+                }
+                PendingIntent.getBroadcast(
+                    context, 0, intent,
+                    PendingIntent.FLAG_NO_CREATE or PendingIntent.FLAG_IMMUTABLE,
+                )?.cancel()
+            }
+        }
     }
 
     /**

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManager.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManager.kt
@@ -64,24 +64,65 @@ class BubbleManager @Inject constructor(
         const val BUBBLE_NOTIFICATION_ID = 1
 
         /**
-         * The separate heads-up OFFER notification id (#457). A NORMAL (non-bubble) notification so
+         * The reserved heads-up OFFER notification id (#457). A NORMAL (non-bubble) notification so
          * the dasher can act from the heads-up banner WITHOUT pulling the shade: pulling the shade
          * makes SystemUI foreground, which drops DoorDash's offer window from the accessibility
          * live-window set, failing the fail-closed verified click (the #457 field symptom). A
          * heads-up banner floats over DoorDash without displacing it, so the click lands.
+         *
+         * #438 B4: this fixed id is now the **null-hash fallback** for [offerNotificationId] —
+         * per-offer banners key on their offer hash so two concurrent offers get distinct ids and
+         * resolving one cancels only its own. It is also the id any pre-B4 stale banner was posted
+         * under, so a hash-less cancel sweeps it (and any stale banner self-dismisses via
+         * [OFFER_HEADS_UP_TIMEOUT_MS] regardless).
          */
         const val OFFER_NOTIFICATION_ID = 2
 
         /** Bubble expanded-view height (dp). */
         const val BUBBLE_DESIRED_HEIGHT_DP = 600
 
-        /** PendingIntent request codes for the offer notification actions (#367). */
-        const val REQUEST_CODE_ACCEPT = 10
-        const val REQUEST_CODE_DECLINE = 11
+        /** PendingIntent request code for the "open bubble" content intent (#367). */
         const val REQUEST_CODE_OFFER_CONTENT = 12
 
         /** Backstop auto-dismiss for the offer heads-up if a resolution cancel is somehow missed. */
         const val OFFER_HEADS_UP_TIMEOUT_MS = 90_000L
+
+        /**
+         * The stable per-offer heads-up notification id (#438 B4). Derived from the offer's hash so
+         * two concurrent offers (multi-platform or fast replacement) render as **distinct** banners
+         * and resolving one dismisses only its own. A null hash (legacy / hash-less offer) maps to
+         * the reserved [OFFER_NOTIFICATION_ID] — self-consistent post/cancel, and the sweep id for a
+         * stale pre-B4 banner.
+         *
+         * Collision posture (documented, accepted for the single-user alpha): `hashCode()` is a
+         * 32-bit space. Two live offers colliding on the same id → one banner replaces the other
+         * (no data loss; the state layer still resolves each tap by carried (platform, offerHash),
+         * B3). Probability ≈ 1/4e9 for two concurrent offers. Ids that would land on the reserved
+         * bubble (1) / offer (2) ids are nudged clear so a hash can never dismiss the wrong surface.
+         */
+        fun offerNotificationId(offerHash: String?): Int {
+            if (offerHash == null) return OFFER_NOTIFICATION_ID
+            val h = offerHash.hashCode()
+            return if (h == BUBBLE_NOTIFICATION_ID || h == OFFER_NOTIFICATION_ID) h + 2 else h
+        }
+
+        /**
+         * The per-offer Accept/Decline intent **identity** URI (#438 B4):
+         * `dashbuddy://offer/<platform-wire>/<offerHash>?action=<offer-intent>`. The scheme/host are
+         * fixed; the platform wire, offer hash, and action make it unique per (offer, button). Unlike
+         * extras, a `data` URI participates in [Intent.filterEquals], so two concurrent offers'
+         * PendingIntents no longer collide/clobber under `FLAG_UPDATE_CURRENT`. Built via
+         * [android.net.Uri.Builder] so the hash/wire are percent-encoded. The extras still carry the
+         * payload (B2); this is identity only.
+         */
+        fun offerActionUri(platform: Platform, offerHash: String, action: String): android.net.Uri =
+            android.net.Uri.Builder()
+                .scheme("dashbuddy")
+                .authority("offer")
+                .appendPath(platform.wire)
+                .appendPath(offerHash)
+                .appendQueryParameter("action", action)
+                .build()
     }
     // 1. ADDED: CoroutineScope for the suspend database calls
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
@@ -321,7 +362,8 @@ class BubbleManager @Inject constructor(
         // (wired via setOnClickPendingIntent in buildOfferCardView), not the system action row —
         // the two can't coexist without doubling the buttons. Field-gated: if a dash shows the
         // in-card buttons don't fire from the floating heads-up, revert to addAction(offerAction(…)).
-        notificationManager.notify(OFFER_NOTIFICATION_ID, builder.build())
+        // #438 B4: per-offer id so two concurrent offers don't clobber each other's banner.
+        notificationManager.notify(offerNotificationId(offer.offerHash), builder.build())
     }
 
     /**
@@ -395,11 +437,11 @@ class BubbleManager @Inject constructor(
         // Brand-styled Accept/Decline (both layouts) — fire the same broadcast as the old action row.
         rv.setOnClickPendingIntent(
             R.id.notif_btn_decline,
-            offerActionPendingIntent(OfferIntent.DECLINE, REQUEST_CODE_DECLINE, platform, offer.offerHash),
+            offerActionPendingIntent(OfferIntent.DECLINE, platform, offer.offerHash),
         )
         rv.setOnClickPendingIntent(
             R.id.notif_btn_accept,
-            offerActionPendingIntent(OfferIntent.ACCEPT, REQUEST_CODE_ACCEPT, platform, offer.offerHash),
+            offerActionPendingIntent(OfferIntent.ACCEPT, platform, offer.offerHash),
         )
 
         if (expanded) {
@@ -432,31 +474,38 @@ class BubbleManager @Inject constructor(
         return rv
     }
 
-    /** #457: dismiss the heads-up offer notification — on offer resolution or after the dasher acts. */
-    fun cancelOfferNotification() {
-        notificationManager.cancel(OFFER_NOTIFICATION_ID)
+    /**
+     * #457: dismiss the heads-up offer notification — on offer resolution or after the dasher acts.
+     * #438 B4: keyed per-offer by [offerNotificationId] so resolving offer A does not touch offer
+     * B's banner. A null hash maps to the reserved id (also sweeps any stale pre-B4 banner).
+     */
+    fun cancelOfferNotification(offerHash: String?) {
+        notificationManager.cancel(offerNotificationId(offerHash))
     }
 
     /**
      * #583: the Accept/Decline broadcast, wired onto the in-card buttons via setOnClickPendingIntent.
-     * #438 item 8a: the acted offer's platform wire + offerHash ride the extras so the dispatched
-     * `UiInput` carries a real target platform (identity-less taps step no region post-#682). The
-     * fixed request codes stay — per-offer PendingIntent identity is B4 (#438 item 8b).
+     * #438 B4: per-offer PendingIntent **identity** via an [offerActionUri] `data` URI — URIs
+     * participate in [Intent.filterEquals] (extras don't), so under `FLAG_UPDATE_CURRENT` two
+     * concurrent offers no longer collide/clobber each other's Accept/Decline intents. A single
+     * fixed request code is enough since the URI already makes each (offer, button) intent distinct.
+     * The extras still carry the payload (#438 item 8a: platform wire + offerHash → the dispatched
+     * `UiInput`'s target identity; identity-less taps step no region post-#682).
      */
     private fun offerActionPendingIntent(
         action: String,
-        requestCode: Int,
         platform: Platform,
         offerHash: String,
     ): PendingIntent {
         val intent = Intent(context, OfferActionReceiver::class.java).apply {
             this.action = OfferActionReceiver.ACTION
+            data = offerActionUri(platform, offerHash, action)
             putExtra(OfferActionReceiver.EXTRA_ACTION, action)
             putExtra(OfferActionReceiver.EXTRA_PLATFORM, platform.wire)
             putExtra(OfferActionReceiver.EXTRA_OFFER_HASH, offerHash)
         }
         return PendingIntent.getBroadcast(
-            context, requestCode, intent,
+            context, 0, intent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
         )
     }

--- a/app/src/test/java/cloud/trotter/dashbuddy/state/effects/OfferActionReceiverTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/state/effects/OfferActionReceiverTest.kt
@@ -3,7 +3,9 @@ package cloud.trotter.dashbuddy.state.effects
 import android.content.Intent
 import cloud.trotter.dashbuddy.domain.state.OfferIntent
 import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.ui.bubble.BubbleManager
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -50,5 +52,35 @@ class OfferActionReceiverTest {
     @Test
     fun `a broadcast with no action is dropped`() {
         assertNull(OfferActionReceiver.uiInputFrom(intentWith(null, Platform.Uber.wire, "x")))
+    }
+
+    /**
+     * #438 B4: the production PendingIntent now also carries a per-offer identity `data` URI. The
+     * receiver still reads identity from the extras (the URI is PendingIntent identity only), so a
+     * full production-shaped intent round-trips to the same UiInput — and the per-offer cancel id
+     * derived from the tap's own carried hash targets that offer's banner alone.
+     */
+    @Test
+    fun `a full production intent round-trips identity and yields the per-offer cancel id`() {
+        val intent = Intent(OfferActionReceiver.ACTION).apply {
+            data = BubbleManager.offerActionUri(Platform.DoorDash, "dd-7", OfferIntent.ACCEPT)
+            putExtra(OfferActionReceiver.EXTRA_ACTION, OfferIntent.ACCEPT)
+            putExtra(OfferActionReceiver.EXTRA_PLATFORM, Platform.DoorDash.wire)
+            putExtra(OfferActionReceiver.EXTRA_OFFER_HASH, "dd-7")
+        }
+        val ui = OfferActionReceiver.uiInputFrom(intent)!!
+
+        assertEquals(OfferIntent.ACCEPT, ui.action)
+        assertEquals(Platform.DoorDash, ui.targetPlatform)
+        assertEquals("dd-7", ui.offerHash)
+        // The receiver's inline dismiss uses this id — offer dd-7's banner, not any other offer's.
+        assertEquals(
+            BubbleManager.offerNotificationId("dd-7"),
+            BubbleManager.offerNotificationId(ui.offerHash),
+        )
+        assertNotEquals(
+            BubbleManager.offerNotificationId("dd-7"),
+            BubbleManager.offerNotificationId("uber-9"),
+        )
     }
 }

--- a/app/src/test/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngineTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngineTest.kt
@@ -480,7 +480,7 @@ class SideEffectEngineTest {
 
         engine.process(AppEffect.CancelOfferNotification(offerHash = "hash-9"))
         runCurrent()
-        verify(bubbleManager, times(1)).cancelOfferNotification()
+        verify(bubbleManager, times(1)).cancelOfferNotification("hash-9")
     }
 
     @Test

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManagerIdentityTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManagerIdentityTest.kt
@@ -46,16 +46,22 @@ class BubbleManagerIdentityTest {
     }
 
     @Test
-    fun `an offer id never collides with the reserved bubble or offer ids`() {
-        // Two 2-char strings whose hashCode() (s[0]*31 + s[1]) equals exactly 1 and 2 — the reserved
-        // bubble / offer ids. The helper must nudge them clear so a hash can't dismiss the wrong
-        // surface (the chathead / a legacy banner).
+    fun `an offer id can never equal ANY app fixed id - the disjoint-namespace property`() {
+        // Adversarial-review MED-1: an enumerated "nudge" list (1, 2) missed the odometer's 101 and
+        // would rot as ids are added. The property, not magic values: every derived id lives in
+        // [2^30, 2^31), disjoint from every small fixed constant — including hashes that land
+        // exactly ON a fixed id.
         val hashTo1 = String(charArrayOf(0.toChar(), 1.toChar())) // hashCode == 1
         val hashTo2 = String(charArrayOf(0.toChar(), 2.toChar())) // hashCode == 2
         assertEquals(BubbleManager.BUBBLE_NOTIFICATION_ID, hashTo1.hashCode()) // guard the fixture
         assertEquals(BubbleManager.OFFER_NOTIFICATION_ID, hashTo2.hashCode())
-        assertNotEquals(BubbleManager.BUBBLE_NOTIFICATION_ID, BubbleManager.offerNotificationId(hashTo1))
-        assertNotEquals(BubbleManager.OFFER_NOTIFICATION_ID, BubbleManager.offerNotificationId(hashTo2))
+        for (hash in listOf(hashTo1, hashTo2, "dd-1", "uber-2", "x")) {
+            val id = BubbleManager.offerNotificationId(hash)
+            assertTrue(
+                "derived id $id for '$hash' must sit in the disjoint [2^30, 2^31) namespace",
+                id >= 0x4000_0000,
+            )
+        }
     }
 
     // --- intent identity (data URI) ---

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManagerIdentityTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManagerIdentityTest.kt
@@ -1,0 +1,97 @@
+package cloud.trotter.dashbuddy.ui.bubble
+
+import android.content.Intent
+import cloud.trotter.dashbuddy.domain.state.OfferIntent
+import cloud.trotter.dashbuddy.domain.state.Platform
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * #438 B4 (actuation identity): the pure identity helpers on [BubbleManager] — the per-offer
+ * notification id and the per-offer intent-data URI — so two concurrent offers (multi-platform or
+ * fast replacement) get distinct banners AND distinct Accept/Decline PendingIntents. The
+ * distinctness is proved via [Intent.filterEquals], the exact equality PendingIntent identity uses
+ * (extras are excluded from it; the URI is what makes the intents distinct). Robolectric supplies
+ * `Uri`/`Intent`.
+ */
+@RunWith(RobolectricTestRunner::class)
+class BubbleManagerIdentityTest {
+
+    // --- notification id ---
+
+    @Test
+    fun `distinct offer hashes yield distinct notification ids`() {
+        assertNotEquals(
+            BubbleManager.offerNotificationId("dd-1"),
+            BubbleManager.offerNotificationId("uber-2"),
+        )
+    }
+
+    @Test
+    fun `notification id is stable for the same hash`() {
+        assertEquals(
+            BubbleManager.offerNotificationId("dd-1"),
+            BubbleManager.offerNotificationId("dd-1"),
+        )
+    }
+
+    @Test
+    fun `a null hash maps to the reserved legacy offer id`() {
+        assertEquals(BubbleManager.OFFER_NOTIFICATION_ID, BubbleManager.offerNotificationId(null))
+    }
+
+    @Test
+    fun `an offer id never collides with the reserved bubble or offer ids`() {
+        // Two 2-char strings whose hashCode() (s[0]*31 + s[1]) equals exactly 1 and 2 — the reserved
+        // bubble / offer ids. The helper must nudge them clear so a hash can't dismiss the wrong
+        // surface (the chathead / a legacy banner).
+        val hashTo1 = String(charArrayOf(0.toChar(), 1.toChar())) // hashCode == 1
+        val hashTo2 = String(charArrayOf(0.toChar(), 2.toChar())) // hashCode == 2
+        assertEquals(BubbleManager.BUBBLE_NOTIFICATION_ID, hashTo1.hashCode()) // guard the fixture
+        assertEquals(BubbleManager.OFFER_NOTIFICATION_ID, hashTo2.hashCode())
+        assertNotEquals(BubbleManager.BUBBLE_NOTIFICATION_ID, BubbleManager.offerNotificationId(hashTo1))
+        assertNotEquals(BubbleManager.OFFER_NOTIFICATION_ID, BubbleManager.offerNotificationId(hashTo2))
+    }
+
+    // --- intent identity (data URI) ---
+
+    private fun actionIntent(platform: Platform, hash: String, action: String): Intent =
+        // Only `data` differs across these intents; filterEquals then reduces to URI equality —
+        // exactly what distinguishes two offers' PendingIntents under FLAG_UPDATE_CURRENT.
+        Intent().apply { data = BubbleManager.offerActionUri(platform, hash, action) }
+
+    @Test
+    fun `two offers accept intents are filterEquals-distinct`() {
+        val a = actionIntent(Platform.DoorDash, "dd-1", OfferIntent.ACCEPT)
+        val b = actionIntent(Platform.Uber, "uber-2", OfferIntent.ACCEPT)
+        assertFalse("distinct offers must not filterEquals", a.filterEquals(b))
+    }
+
+    @Test
+    fun `same offer accept vs decline are filterEquals-distinct`() {
+        val accept = actionIntent(Platform.DoorDash, "dd-1", OfferIntent.ACCEPT)
+        val decline = actionIntent(Platform.DoorDash, "dd-1", OfferIntent.DECLINE)
+        assertFalse("accept and decline must not filterEquals", accept.filterEquals(decline))
+    }
+
+    @Test
+    fun `identical offer and action filterEquals the same`() {
+        val one = actionIntent(Platform.DoorDash, "dd-1", OfferIntent.ACCEPT)
+        val two = actionIntent(Platform.DoorDash, "dd-1", OfferIntent.ACCEPT)
+        assertTrue("same offer+action must be identity-equal", one.filterEquals(two))
+    }
+
+    @Test
+    fun `the uri carries platform hash and action`() {
+        val uri = BubbleManager.offerActionUri(Platform.DoorDash, "dd-1", OfferIntent.ACCEPT)
+        assertEquals("dashbuddy", uri.scheme)
+        assertEquals("offer", uri.authority)
+        assertEquals(listOf(Platform.DoorDash.wire, "dd-1"), uri.pathSegments)
+        assertEquals(OfferIntent.ACCEPT, uri.getQueryParameter("action"))
+    }
+}

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -94,6 +94,18 @@ was found **broken-in-part** (raw PII in capture envelopes) and moved to that en
   decline" still stands as Declined. Any offer that fails to card/speak/notify, an accept that mints a
   **bare** job (no offer pay), or a wrong/absent outcome card is a B3 regression — capture it.
   - Confirmed: 0/2
+- **🆕 NEW — heads-up banner acts on the RIGHT offer (#438 B4 / PR).** Each offer's heads-up
+  notification now has its own id + its own Accept/Decline intents (distinct per offer), so
+  concurrent or fast-replacement offers no longer clobber one another. On a normal DoorDash dash,
+  confirm single-offer behavior is unchanged: the banner posts, **Accept/Decline still fire the
+  verified click**, and the banner **disappears the moment the offer resolves** (accept / decline /
+  timeout) — no stale Accept/Decline banner lingering after the offer is gone. The multi-offer edge
+  (best seen if a second offer arrives while the first banner is still up, or an offer is replaced
+  same-platform): tapping the current banner acts on the **current** offer, and resolving one offer
+  leaves the other's banner untouched — a tap must never act on a **replaced/older** offer (that path
+  now WARN-aborts to manual rather than acting on the wrong one). A banner that acts on the wrong
+  offer, or a stale banner that survives its offer, is a B4 regression — capture it.
+  - Confirmed: 0/2
 - **🆕 NEW — edit a delivery directly + cash tips (#688 phase A / PR).** In **Analytics → a dash →
   the delivery drill-down**, **tap a delivery row** (or its pencil) → the **Adjust delivery** dialog:
   Store name / Pay / Tip / Cash tip / Miles / Note. This replaces the pay-only editor and is the real


### PR DESCRIPTION
## Summary

#438 **B4 — actuation identity end-to-end** (item 8b) of the multiplatform correctness pack. Gives each offer's heads-up banner its own identity so two concurrent offers — multi-platform, or a fast same-platform replacement — no longer collide/clobber each other's Accept/Decline PendingIntents or notifications, and resolving one dismisses **only** its own banner.

Design doc: `docs/design/multiplatform-correctness-pack.md` § "B4 — item 8b: actuation identity end-to-end". Builds on B1 (#707), B2 (#708), B3 (#709) — offers already live on `PlatformRegion.pendingOffers` and taps already resolve by carried `(platform, offerHash)` with hash-less fallback (B3). B4 closes the *actuation* half.

### What changed

1. **Per-offer PendingIntent identity via a `data` URI.** `dashbuddy://offer/<platform-wire>/<offerHash>?action=<offer-intent>` set as the Accept/Decline intent `data`. URIs participate in `Intent.filterEquals` (extras do **not**), so under `FLAG_UPDATE_CURRENT` two offers' intents are distinct instead of clobbering. Extras remain the payload carrier (B2); the URI is identity only. The fixed request codes 10/11 are removed — a single request code now suffices since the URI distinguishes intents.
2. **Per-offer notification ids.** `BubbleManager.offerNotificationId(offerHash)` = `offerHash.hashCode()`, replacing the single `OFFER_NOTIFICATION_ID = 2` for offer heads-ups. Null hash → the reserved id (legacy/sweep). Ids that would land on the reserved bubble (1) / offer (2) ids are nudged clear so a hash can never dismiss the wrong surface.
3. **`cancelOfferNotification(offerHash)`.** The last hop (`SideEffectEngine` → `BubbleManager`) now consumes the hash `AppEffect.CancelOfferNotification` already carried end-to-end, so cancel dismisses only the resolved offer's banner. The inline fixed-id cancel in `OfferActionReceiver` (was cancelling id 2 on **any** tap — vet L3) is migrated to the per-offer id from the tap's own carried hash.
4. **Tap resolution hash-pinning (B3) verified un-regressed.** B4 does not touch the `EffectMap`/`SideEffectEngine` tap resolution; the notification path's identity is carried on the extras (unchanged) and the URI only ensures the correct PendingIntent fires. No identity gap remained to extend.

### Consumer sweep (all migrated)

`grep` for `OFFER_NOTIFICATION_ID`, the fixed request codes, and `cancelOfferNotification`:

| Site | Before | After |
|---|---|---|
| `BubbleManager` `REQUEST_CODE_ACCEPT`=10 / `REQUEST_CODE_DECLINE`=11 | fixed request codes on both intents | **removed**; identity is the `data` URI, request code 0 |
| `BubbleManager.showOfferHeadsUp` `notify(OFFER_NOTIFICATION_ID, …)` | fixed id 2 | `notify(offerNotificationId(offer.offerHash), …)` |
| `BubbleManager.cancelOfferNotification()` | cancels id 2 | `cancelOfferNotification(offerHash)` → per-offer id |
| `SideEffectEngine` `CancelOfferNotification` hop | `cancelOfferNotification()` | passes `effect.offerHash` through |
| `OfferActionReceiver.onReceive` inline dismiss | `cancel(OFFER_NOTIFICATION_ID)` on any tap | `cancel(offerNotificationId(uiInput.offerHash))` |

`OFFER_NOTIFICATION_ID = 2` is **retained** as the reserved null-hash id (self-consistent post/cancel + the id any pre-B4 stale banner was posted under). `REQUEST_CODE_OFFER_CONTENT = 12` (open-bubble content intent) is unrelated and untouched. No other consumers exist. **#579 (voice)** and **#110 (auto-accept)** reference none of these symbols — they inherit the `(platform, offerHash)` contract unchanged; no work here.

### Edge cases (spec-called-out)

- **Two live offers / same-platform replacement:** distinct notification ids + `filterEquals`-distinct PendingIntents; resolving/tapping one leaves the other's banner and intents untouched.
- **Notification id from a String hash — collision posture (documented, accepted for the single-user alpha):** `hashCode()` is a 32-bit space; two concurrent offers colliding (~1/4e9) → one banner replaces the other, no data loss (the state layer still resolves each tap by carried `(platform, offerHash)`). Reserved-id collisions (1/2) are nudged clear.
- **App upgrade with a stale pre-B4 banner (old id 2):** a hash-less cancel maps to id 2 (a path that rarely fires — the effective backstop is the OS-side 90s setTimeoutAfter, which survives process death); regardless, the banner self-dismisses via the existing `OFFER_HEADS_UP_TIMEOUT_MS` (90s) backstop. No dismiss-on-startup machinery added (simplest correct).
- **Channel/behavior unchanged:** only ids + intent identity change.

### Tests

- **New `BubbleManagerIdentityTest`** (Robolectric): `offerNotificationId` distinct/stable/null-fallback/reserved-id-nudge; `offerActionUri` → two offers' and accept-vs-decline intents are `filterEquals`-distinct, identical offer+action equal, URI carries platform/hash/action.
- **`OfferActionReceiverTest` extended:** a full production-shaped intent (URI + extras) round-trips to the correct `UiInput` identity and the per-offer cancel id.
- **`SideEffectEngineTest`:** cancel asserts the hash passes through (`cancelOfferNotification("hash-9")`).
- Full suite green: `JAVA_HOME=/usr/lib/jvm/java-25 ./gradlew testDebugUnitTest :domain:test` → BUILD SUCCESSFUL.

Field-test checklist item added (`#438 B4`, Confirmed: 0/2).

### Design-goal review

- **1 (UDF):** unchanged — the reducer emits `CancelOfferNotification(offerHash)`; identity resolution is at the edge (`SideEffectEngine`/`BubbleManager`), never in a reducer.
- **3 (single responsibility):** identity helpers are small pure functions on `BubbleManager`'s companion; no file grew materially.
- **5 (SSOT):** `offerNotificationId` and `offerActionUri` are the single owners of per-offer id/URI derivation, shared by the post site, the cancel site, and `OfferActionReceiver`'s inline dismiss — no hand-copied id arithmetic. The URI's `action` is the `OfferIntent` constant (no second action vocabulary).
- **6 (security/privacy):** the URI carries the platform wire + `offerHash` (a hash, already edge-hashed) — no raw PII; no new logging. Notification content unchanged.
- **7 (logging):** no new INFO+ sites; existing `OfferActionReceiver` INFO line already PII-safe (action + platform wire).
- **8 (platform-agnostic):** no platform literals; identity is keyed by `platform.wire` + `offerHash` (data), no `== Platform.X`. `:core:state`/`:domain`/rule JSON untouched — this is an app-edge (`:app`) actuation change only.
- **Reactive UI:** N/A (notification actuation, not a Compose surface).

Do not merge — fable adversarial review follows.


### Adversarial review

Fable adversarial reviewer ran against head `997b7fd8` — verdict **APPROVE-WITH-FIXES**. All three flagged items adjudicated: URI action = `OfferIntent` constants **ACCEPT** (SSOT; nothing parses the URI), stale-banner posture **ACCEPT** (with the nuance that the 90s OS-side `setTimeoutAfter` is the real backstop — the null-hash sweep path essentially never fires), collision posture **ACCEPT for offer-vs-offer / REJECT as stated for reserved ids**: the two-id "nudge" missed the odometer handler's id 101 (an offer hash landing there would replace the "Odometer Active" trust notification, and the resolution cancel would then remove it for the session) and an enumerated list rots as ids are added. **Fixed in `9a2638fe`:** ids now fold into the disjoint [2^30, 2^31) namespace (can never equal ANY app fixed id; test pins the property, not magic values), and `cancelOfferNotification` releases the offer's PendingIntent records (LOW-1 — per-offer URIs would otherwise accrue two system-server PI records per offer until process death). Verified clean: the intent stays **explicit** (component set → the data URI cannot make it implicit; receiver `exported="false"`), `appendPath` percent-encodes any hash shape, the receiver reads extras only and URI/extras are built from the same triple at the same site (no constructible mismatch), `filterEquals` includes the query so accept/decline are distinct (and the test proves distinctness via `filterEquals` itself), every `CancelOfferNotification` emission carries the right hash and post/cancel share one derivation (P5), platform identity via wire/registry only (P8), no PII in the URI, no new INFO+ log sites (P7).
