### PR TITLE
fix(#438): B5 — cross-platform odometer arbitration (item 9)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/OdometerEffectHandler.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/OdometerEffectHandler.kt
@@ -29,9 +29,11 @@ class OdometerEffectHandler @Inject constructor(
     fun startUp() {
         Timber.i("Effect: Starting Odometer & Notification")
         try {
-            // 1. Start the Logic (Coroutines Job)
+            // 1. Start the Logic (Coroutines Job). #438 B5: NO resetSession() here — the odometer
+            // is arbitrated at the cross-platform tier (StartOdometer fires only on the 0→1
+            // live-session crossing), and the per-session anchor rides StartSession
+            // ([onSessionStarted]) so a second concurrent session can't zero the first's miles.
             odometerRepository.startTracking()
-            odometerRepository.resetSession()
 
             // 2. Post the Notification (User Trust UI)
             val notification = createNotification()
@@ -40,6 +42,15 @@ class OdometerEffectHandler @Inject constructor(
         } catch (e: Exception) {
             Timber.e(e, "Failed to start Odometer")
         }
+    }
+
+    /**
+     * #438 B5: anchor a session's miles to the current odometer total at its start. Rides the
+     * per-platform StartSession effect (not the global StartOdometer), so each session gets its OWN
+     * anchor. Idempotent in the repository — a grace-resume re-arm never moves an existing anchor.
+     */
+    fun onSessionStarted(sessionId: String) {
+        odometerRepository.startSessionTracking(sessionId)
     }
 
     fun shutDown() {

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
@@ -307,7 +307,13 @@ class SideEffectEngine @Inject constructor(
 
             is AppEffect.SpeakOffer -> ttsEffectHandler.speakOffer(effect.evaluation)
 
-            is AppEffect.StartSession -> bubbleManager.startSession(effect.sessionId, effect.platformName)
+            is AppEffect.StartSession -> {
+                bubbleManager.startSession(effect.sessionId, effect.platformName)
+                // #438 B5: anchor THIS session's odometer miles (per-session anchor). External
+                // effect → suppressed on recovery, which is correct: the anchor persisted across
+                // the crash, so recovery reconciliation re-establishes tracking without re-anchoring.
+                odometerEffectHandler.onSessionStarted(effect.sessionId)
+            }
             is AppEffect.EndSession -> bubbleManager.endSession(effect.platformName)
             is AppEffect.StartOdometer -> odometerEffectHandler.startUp()
             is AppEffect.StopOdometer -> odometerEffectHandler.shutDown()
@@ -455,10 +461,13 @@ class SideEffectEngine @Inject constructor(
             // --- Lifecycle verbs ---
             EffectVerb.SESSION_START -> sessionStartFromArgs(e.args)
             EffectVerb.SESSION_END -> sessionEndFromArgs(e.args)
-            EffectVerb.ODOMETER_START -> odometerEffectHandler.startUp()
-            EffectVerb.ODOMETER_STOP -> odometerEffectHandler.shutDown()
-            EffectVerb.ODOMETER_PAUSE -> odometerEffectHandler.pause()
-            EffectVerb.ODOMETER_RESUME -> odometerEffectHandler.resume()
+            // #438 B5 (vet L6): the odometer is arbitrated at the cross-platform tier
+            // (EffectMap.diffCrossPlatform). RETIRED as rule verbs — a rule must not be able to
+            // command the odometer directly (a future ruleset could otherwise zero a live session,
+            // bypassing the arbiter). No shipped rule declares these; the branches are inert no-ops.
+            EffectVerb.ODOMETER_START, EffectVerb.ODOMETER_STOP,
+            EffectVerb.ODOMETER_PAUSE, EffectVerb.ODOMETER_RESUME ->
+                Timber.w("Rule verb %s is retired — the odometer is cross-platform arbitrated (#438 B5)", e.verb)
             EffectVerb.SCHEDULE_TIMEOUT -> scheduleTimeoutFromArgs(
                 e.args,
                 Platform.fromRuleId(e.ruleId).takeIf { it != Platform.Unknown },

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/data/location/OdometerRepositoryPerSessionTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/data/location/OdometerRepositoryPerSessionTest.kt
@@ -1,0 +1,110 @@
+package cloud.trotter.dashbuddy.core.data.location
+
+import cloud.trotter.dashbuddy.core.datastore.odometer.OdometerLocalDataSource
+import cloud.trotter.dashbuddy.core.location.LocationDataSource
+import cloud.trotter.dashbuddy.domain.model.location.Coordinates
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+/**
+ * #438 B5 (item 9) — per-session odometer anchors. Replaces the single global anchor + `resetSession()`
+ * so two concurrent sessions accrue miles independently and a second session starting can't zero the
+ * first's. `metadata.odometer` (the cumulative reading) is untouched.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class OdometerRepositoryPerSessionTest {
+
+    private val locationUpdates = MutableSharedFlow<Coordinates>(extraBufferCapacity = 64)
+
+    private val location: LocationDataSource = mock {
+        on { this.locationUpdates } doReturn locationUpdates
+    }
+
+    private val local: OdometerLocalDataSource = mock {
+        on { totalMetersFlow } doReturn flowOf(0.0)
+        on { currentSessionIdFlow } doReturn flowOf(null)
+        on { sessionAnchorFlow(any()) } doReturn flowOf(null)
+    }
+
+    private fun repo(dispatcher: TestDispatcher) =
+        OdometerRepository(local, location, dispatcher)
+
+    // ~110 m north per step (0.001° latitude), comfortably over the 5 m gate.
+    private suspend fun drive(vararg latitudes: Double) {
+        for (lat in latitudes) locationUpdates.emit(Coordinates(lat, 0.0))
+    }
+
+    @Test
+    fun `sessions A and B accrue independently, B starting does not reset A`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val repo = repo(dispatcher)
+        repo.startTracking()
+
+        // Session A anchors at 0.
+        repo.startSessionTracking("A")
+        drive(0.000, 0.001, 0.002) // two accrued deltas
+        val milesAtB = repo.getCurrentMiles()
+        assertTrue("some miles accrued before B", milesAtB > 0.0)
+
+        // Session B starts mid-A. Its anchor is the CURRENT total — it must NOT move A's anchor (0).
+        repo.startSessionTracking("B")
+        assertEquals("B starts at ~0 miles", 0.0, repo.getCurrentSessionMiles("B"), 1e-6)
+
+        // Drive further: both sessions accrue the SAME new delta.
+        drive(0.002, 0.003, 0.004)
+        val total = repo.getCurrentMiles()
+
+        // A saw the WHOLE dash (anchor 0) — proof B's start didn't zero it (the old global-reset bug).
+        assertEquals("A miles == full cumulative total", total, repo.getCurrentSessionMiles("A"), 1e-6)
+        // B saw only the post-B leg.
+        assertEquals("B miles == total − milesAtB", total - milesAtB, repo.getCurrentSessionMiles("B"), 1e-6)
+        // And they differ by exactly A's pre-B accrual — independent anchors.
+        assertEquals(
+            "A − B == A's pre-B accrual",
+            milesAtB,
+            repo.getCurrentSessionMiles("A") - repo.getCurrentSessionMiles("B"),
+            1e-6,
+        )
+    }
+
+    @Test
+    fun `re-arming a live session does not move its anchor (idempotent grace-resume)`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val repo = repo(dispatcher)
+        repo.startTracking()
+
+        repo.startSessionTracking("A")
+        drive(0.000, 0.001, 0.002)
+        val before = repo.getCurrentSessionMiles("A")
+
+        // A grace-resume re-arm of the SAME session must be a no-op on the anchor (moving it would
+        // zero the session's accrued miles — the exact concurrency bug the per-session anchor fixes).
+        repo.startSessionTracking("A")
+        assertEquals("anchor unchanged on re-arm", before, repo.getCurrentSessionMiles("A"), 1e-6)
+    }
+
+    @Test
+    fun `getCurrentMiles is the raw cumulative reading — the metadata_odometer invariant is preserved`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val repo = repo(dispatcher)
+        repo.startTracking()
+
+        // No session anchoring at all — getCurrentMiles reports the raw cumulative total regardless,
+        // and it equals sessionMilesFlow with a zero anchor (the projector's metadata.odometer input).
+        drive(0.000, 0.001, 0.002)
+        val cumulative = repo.getCurrentMiles()
+        assertTrue("cumulative accrued", cumulative > 0.0)
+        assertEquals("no-arg session flow with no anchor == cumulative", cumulative, repo.sessionMilesFlow.first(), 1e-6)
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
@@ -17,6 +17,7 @@ import cloud.trotter.dashbuddy.domain.pipeline.RequestedEffect
 import cloud.trotter.dashbuddy.domain.pipeline.TimeoutType
 import cloud.trotter.dashbuddy.domain.pipeline.TransitionTrigger
 import cloud.trotter.dashbuddy.domain.state.AppState
+import cloud.trotter.dashbuddy.domain.state.CrossPlatformRegion
 import cloud.trotter.dashbuddy.domain.state.DestructiveKind
 import cloud.trotter.dashbuddy.domain.state.Flow
 import cloud.trotter.dashbuddy.domain.state.FlowRegion
@@ -546,7 +547,10 @@ class EffectMapTest {
         ))
 
         val newSession = Session("sess-new", startedAt = 1000L)
+        // #438 B5: StartOdometer now fires from the cross-platform activeSessionCount 0→1 crossing —
+        // the StateMachine derives this region; the test sets it to exercise the arbitration.
         val next = AppState(regions = Regions(
+            crossPlatform = CrossPlatformRegion(activeSessionCount = 1),
             platforms = mapOf(platform to PlatformRegion(platform, mode = Mode.Online, session = newSession)),
         ))
 
@@ -561,10 +565,13 @@ class EffectMapTest {
     fun `session end emits DASH_STOP, StopOdometer, EndSession`() {
         val (platform, onlineRegion) = stateWithPlatform(mode = Mode.Online, sessionId = "sess-1")
         val prev = AppState(regions = Regions(
+            crossPlatform = CrossPlatformRegion(activeSessionCount = 1),
             platforms = mapOf(platform to onlineRegion),
         ))
 
+        // #438 B5: StopOdometer now fires from the cross-platform activeSessionCount 1→0 crossing.
         val next = AppState(regions = Regions(
+            crossPlatform = CrossPlatformRegion(activeSessionCount = 0),
             platforms = mapOf(platform to PlatformRegion(platform, mode = Mode.Offline)),
         ))
 
@@ -706,7 +713,7 @@ class EffectMapTest {
     // =========================================================================
 
     @Test
-    fun `pickup start emits PICKUP_NAV_STARTED and ResumeOdometer`() {
+    fun `pickup start emits PICKUP_NAV_STARTED`() {
         val (platform, _) = stateWithPlatform()
         val prevRegion = PlatformRegion(platform, mode = Mode.Online, session = Session("sess-1", startedAt = 100L))
         val prev = AppState(regions = Regions(
@@ -726,7 +733,9 @@ class EffectMapTest {
         val effects = effectMap.diff(prev, next, screenObs(flow = Flow.TaskPickupNavigation, parsed = ParsedFields.TaskFields(storeName = "Chipotle", phase = TaskPhase.PICKUP, subFlow = TaskSubFlow.NAVIGATION)))
 
         assertTrue("Should emit PICKUP_NAV_STARTED", effects.logEventTypes().contains(AppEventType.PICKUP_NAV_STARTED))
-        assertTrue("Should emit ResumeOdometer", effects.any { it is AppEffect.ResumeOdometer })
+        // #438 B5: odometer Resume is no longer emitted per pickup-nav edge — it's cross-platform
+        // arbitrated (offer→nav is moving→moving, no stationary crossing; today's Resume here was a
+        // redundant no-op). See OdometerArbitrationTest.
         assertTrue("Should emit UpdateBubble with store name", effects.any {
             it is AppEffect.UpdateBubble && it.text.contains("Chipotle")
         })
@@ -853,7 +862,7 @@ class EffectMapTest {
     }
 
     @Test
-    fun `stacked pickup transition fires PICKUP_NAV_STARTED and ResumeOdometer for the new task`() {
+    fun `stacked pickup transition fires PICKUP_NAV_STARTED for the new task`() {
         // Costa Pacifica pickup completed (moved to recentTasks) and a new
         // Chili's pickup task minted by the stepper. The diff-task gate must
         // fire even though prevTask is non-null — it now keys on "taskId changed".
@@ -898,10 +907,8 @@ class EffectMapTest {
             "Stacked transition should emit PICKUP_NAV_STARTED for the new task",
             effects.logEventTypes().contains(AppEventType.PICKUP_NAV_STARTED),
         )
-        assertTrue(
-            "Stacked transition should emit ResumeOdometer for the inter-store leg",
-            effects.any { it is AppEffect.ResumeOdometer },
-        )
+        // #438 B5: the inter-store leg's odometer Resume is cross-platform arbitrated (the
+        // arrived→nav stationary→moving crossing) — see OdometerArbitrationTest, not this per-edge diff.
         assertTrue(
             "Bubble should announce the new store",
             effects.any { it is AppEffect.UpdateBubble && it.text.contains("Chili") },
@@ -1019,7 +1026,8 @@ class EffectMapTest {
 
         assertTrue("Should emit PICKUP_CONFIRMED", effects.logEventTypes().contains(AppEventType.PICKUP_CONFIRMED))
         assertTrue("Should emit DELIVERY_NAV_STARTED", effects.logEventTypes().contains(AppEventType.DELIVERY_NAV_STARTED))
-        assertTrue("Should emit ResumeOdometer", effects.any { it is AppEffect.ResumeOdometer })
+        // #438 B5: the drive's odometer Resume is cross-platform arbitrated (arrived→nav crossing) —
+        // see OdometerArbitrationTest, not this per-edge diff.
         assertTrue(
             "Should NOT emit DELIVERY_CONFIRMED on a pickup-leaving transition",
             !effects.logEventTypes().contains(AppEventType.DELIVERY_CONFIRMED),
@@ -1070,11 +1078,12 @@ class EffectMapTest {
     }
 
     @Test
-    fun `stacked leg-2 dropoff (dropoff to a new dropoff) mints DELIVERY_NAV_STARTED, ResumeOdometer, and a Heading-to bubble (#603)`() {
+    fun `stacked leg-2 dropoff (dropoff to a new dropoff) mints DELIVERY_NAV_STARTED and a Heading-to bubble (#603)`() {
         // A multi-drop stack: leg-1's drop is retired and leg-2's drop becomes active — a
         // different taskId, freshly minted on THIS frame (startedAt == obs.timestamp). Both
         // sides are DROPOFF, so the pickup→dropoff branch never sees it; before #603 leg-2 was
-        // a silent drop (no nav event, no odometer resume, no bubble).
+        // a silent drop (no nav event, no bubble). #438 B5: the odometer resume for its drive is
+        // cross-platform arbitrated now (see OdometerArbitrationTest), no longer a per-edge emit.
         val (platform, _) = stateWithPlatform()
         val session = Session("sess-1", startedAt = 100L)
         val leg1 = Task(
@@ -1100,7 +1109,6 @@ class EffectMapTest {
         ))
 
         assertTrue("leg-2 must mint DELIVERY_NAV_STARTED", effects.logEventTypes().contains(AppEventType.DELIVERY_NAV_STARTED))
-        assertTrue("leg-2 must resume the odometer for its drive", effects.any { it is AppEffect.ResumeOdometer })
         assertTrue(
             "leg-1's drop is confirmed as the active task moves on",
             effects.logEventTypes().contains(AppEventType.DELIVERY_CONFIRMED),
@@ -1144,7 +1152,7 @@ class EffectMapTest {
     }
 
     @Test
-    fun `arrival at pickup emits PauseOdometer and PICKUP_ARRIVED`() {
+    fun `arrival at pickup emits PICKUP_ARRIVED`() {
         val (platform, _) = stateWithPlatform()
         val session = Session("sess-1", startedAt = 100L)
         val navTask = Task(taskId = "task-1", jobId = "job-1", phase = TaskPhase.PICKUP, storeName = "Chipotle", startedAt = 900L, arrivedAt = null)
@@ -1161,12 +1169,13 @@ class EffectMapTest {
 
         val effects = effectMap.diff(prev, next, screenObs(flow = Flow.TaskPickupArrived, parsed = ParsedFields.TaskFields(storeName = "Chipotle", phase = TaskPhase.PICKUP, subFlow = TaskSubFlow.ARRIVED)))
 
-        assertTrue("Should emit PauseOdometer", effects.any { it is AppEffect.PauseOdometer })
+        // #438 B5: PauseOdometer is cross-platform arbitrated (all-live-stationary crossing) — see
+        // OdometerArbitrationTest, not this per-edge diff.
         assertTrue("Should emit PICKUP_ARRIVED", effects.logEventTypes().contains(AppEventType.PICKUP_ARRIVED))
     }
 
     @Test
-    fun `arrival at dropoff emits PauseOdometer and DELIVERY_ARRIVED`() {
+    fun `arrival at dropoff emits DELIVERY_ARRIVED`() {
         val (platform, _) = stateWithPlatform()
         val session = Session("sess-1", startedAt = 100L)
         val navTask = Task(taskId = "task-1", jobId = "job-1", phase = TaskPhase.DROPOFF, storeName = "Chipotle", startedAt = 900L, arrivedAt = null)
@@ -1183,7 +1192,7 @@ class EffectMapTest {
 
         val effects = effectMap.diff(prev, next, screenObs(flow = Flow.TaskDropoffArrived, parsed = ParsedFields.TaskFields(phase = TaskPhase.DROPOFF, subFlow = TaskSubFlow.ARRIVED)))
 
-        assertTrue("Should emit PauseOdometer", effects.any { it is AppEffect.PauseOdometer })
+        // #438 B5: PauseOdometer is cross-platform arbitrated — see OdometerArbitrationTest.
         assertTrue("Should emit DELIVERY_ARRIVED", effects.logEventTypes().contains(AppEventType.DELIVERY_ARRIVED))
     }
 
@@ -2100,6 +2109,7 @@ class EffectMapTest {
 
         val newSession = Session("sess-new", startedAt = 1000L)
         val next = AppState(regions = Regions(
+            crossPlatform = CrossPlatformRegion(activeSessionCount = 1),
             platforms = mapOf(platform to PlatformRegion(platform, mode = Mode.Online, session = newSession)),
         ))
 

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/state/OdometerArbitrationTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/state/OdometerArbitrationTest.kt
@@ -1,0 +1,234 @@
+package cloud.trotter.dashbuddy.core.state
+
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
+import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.state.AppState
+import cloud.trotter.dashbuddy.domain.state.CrossPlatformRegion
+import cloud.trotter.dashbuddy.domain.state.Flow
+import cloud.trotter.dashbuddy.domain.state.Mode
+import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.domain.state.PlatformRegion
+import cloud.trotter.dashbuddy.domain.state.Regions
+import cloud.trotter.dashbuddy.domain.state.Session
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #438 B5 (item 9) — the cross-platform odometer arbitration ([EffectMap.diffCrossPlatform] +
+ * [OdometerArbiter]). The four odometer effects moved OFF each platform's session/task diff onto one
+ * global decision, so two concurrent sessions no longer collide on one GPS + one anchor:
+ *  - Start/Stop on the live-session count crossing 0↔1;
+ *  - Pause when EVERY live region is parked, Resume when ANY starts moving.
+ */
+class OdometerArbitrationTest {
+
+    private val effectMap = EffectMap()
+
+    private fun obs(): Observation = Observation.Screen(
+        timestamp = 1_000L,
+        captureId = "cap",
+        ruleId = "doordash.screen.test",
+        metadata = ReplayMetadata.EMPTY,
+        flow = null,
+        modeHint = null,
+        parsed = ParsedFields.None,
+    )
+
+    /** A live region for [platform] whose last-acted flow determines its stationary level. */
+    private fun region(platform: Platform, lastActedFlow: Flow?): PlatformRegion =
+        PlatformRegion(
+            platform = platform,
+            mode = Mode.Online,
+            session = Session("sess-${platform.wire}", startedAt = 100L),
+            lastActedFlow = lastActedFlow,
+        )
+
+    private fun state(activeSessionCount: Int, vararg regions: PlatformRegion): AppState =
+        AppState(
+            regions = Regions(
+                crossPlatform = CrossPlatformRegion(activeSessionCount = activeSessionCount),
+                platforms = regions.associateBy { it.platform },
+            ),
+        )
+
+    private fun diff(prev: AppState, next: AppState): List<AppEffect> = effectMap.diff(prev, next, obs())
+
+    // =====================================================================================
+    // Start/Stop — the live-session count crossing (dual-session interleave)
+    // =====================================================================================
+
+    @Test
+    fun `Start emits only on the 0 to 1 crossing`() {
+        val prev = state(0)
+        val next = state(1, region(Platform.DoorDash, Flow.Idle))
+        val effects = diff(prev, next)
+        assertEquals("exactly one StartOdometer", 1, effects.count { it is AppEffect.StartOdometer })
+        assertFalse("no StopOdometer", effects.any { it is AppEffect.StopOdometer })
+    }
+
+    @Test
+    fun `a second concurrent session start does NOT re-emit StartOdometer (no zeroing)`() {
+        // Count 1→2 as Uber comes online alongside a live DoorDash session. A re-fired Start would
+        // reset the odometer and zero DoorDash's accrued miles — the concurrency bug B5 removes. With
+        // per-session anchors the second session gets its OWN anchor, untouched by DoorDash's.
+        val prev = state(1, region(Platform.DoorDash, Flow.TaskPickupNavigation))
+        val next = state(
+            2,
+            region(Platform.DoorDash, Flow.TaskPickupNavigation),
+            region(Platform.Uber, Flow.Idle),
+        )
+        assertFalse("no StartOdometer on 1→2", diff(prev, next).any { it is AppEffect.StartOdometer })
+    }
+
+    @Test
+    fun `first session ending while a second is live does NOT emit StopOdometer`() {
+        // Count 2→1: DoorDash ends but Uber is still dashing — killing GPS here would strand Uber's
+        // odometer mid-drive. Stop must wait for the LAST live session to end.
+        val prev = state(
+            2,
+            region(Platform.DoorDash, Flow.TaskDropoffNavigation),
+            region(Platform.Uber, Flow.TaskPickupNavigation),
+        )
+        val next = state(1, region(Platform.Uber, Flow.TaskPickupNavigation))
+        assertFalse("no StopOdometer on 2→1", diff(prev, next).any { it is AppEffect.StopOdometer })
+    }
+
+    @Test
+    fun `Stop emits only on the 1 to 0 crossing`() {
+        val prev = state(1, region(Platform.Uber, Flow.TaskPickupNavigation))
+        val next = state(0)
+        val effects = diff(prev, next)
+        assertEquals("exactly one StopOdometer", 1, effects.count { it is AppEffect.StopOdometer })
+        assertFalse("no ResumeOdometer on the count-drop edge", effects.any { it is AppEffect.ResumeOdometer })
+    }
+
+    @Test
+    fun `ending a dash while parked at a drop stops GPS, never a phantom Resume`() {
+        // 1→0 from a stationary region: the naive "arrived→something moving" would read Resume, but
+        // the count crossing owns this edge — bothLive is false, so no Pause/Resume can leak.
+        val prev = state(1, region(Platform.DoorDash, Flow.TaskDropoffArrived))
+        val next = state(0)
+        val effects = diff(prev, next)
+        assertTrue("StopOdometer", effects.any { it is AppEffect.StopOdometer })
+        assertFalse("no ResumeOdometer", effects.any { it is AppEffect.ResumeOdometer })
+        assertFalse("no PauseOdometer", effects.any { it is AppEffect.PauseOdometer })
+    }
+
+    // =====================================================================================
+    // Pause/Resume — the all-live-stationary crossing
+    // =====================================================================================
+
+    @Test
+    fun `single platform Pause fires on arrival (moving to stationary)`() {
+        val prev = state(1, region(Platform.DoorDash, Flow.TaskPickupNavigation))
+        val next = state(1, region(Platform.DoorDash, Flow.TaskPickupArrived))
+        val effects = diff(prev, next)
+        assertTrue("PauseOdometer on arrival", effects.any { it is AppEffect.PauseOdometer })
+        assertFalse("no ResumeOdometer", effects.any { it is AppEffect.ResumeOdometer })
+    }
+
+    @Test
+    fun `single platform Resume fires on leaving an arrived task (stationary to moving)`() {
+        val prev = state(1, region(Platform.DoorDash, Flow.TaskPickupArrived))
+        val next = state(1, region(Platform.DoorDash, Flow.TaskDropoffNavigation))
+        val effects = diff(prev, next)
+        assertTrue("ResumeOdometer on departure", effects.any { it is AppEffect.ResumeOdometer })
+        assertFalse("no PauseOdometer", effects.any { it is AppEffect.PauseOdometer })
+    }
+
+    @Test
+    fun `PostTask entry from an arrived drop resumes, from a drive is a no-op`() {
+        // Leaving an arrived drop for PostTask is a stationary→moving crossing → Resume.
+        val fromArrived = diff(
+            state(1, region(Platform.DoorDash, Flow.TaskDropoffArrived)),
+            state(1, region(Platform.DoorDash, Flow.PostTask)),
+        )
+        assertTrue("Resume when PostTask follows an arrived drop", fromArrived.any { it is AppEffect.ResumeOdometer })
+
+        // PostTask following a still-moving drive (no arrival) is NOT a crossing — today's per-edge
+        // Resume here was a redundant no-op (GPS already running); the predicate correctly elides it.
+        val fromDrive = diff(
+            state(1, region(Platform.DoorDash, Flow.TaskDropoffNavigation)),
+            state(1, region(Platform.DoorDash, Flow.PostTask)),
+        )
+        assertFalse("no redundant Resume when PostTask follows a drive", fromDrive.any { it is AppEffect.ResumeOdometer })
+    }
+
+    @Test
+    fun `Pause requires ALL live regions stationary — one still driving blocks it`() {
+        // DoorDash arrives while Uber is still driving: NOT all stationary → no Pause (Uber's drive
+        // must keep GPS alive). This is the headline concurrency fix.
+        val prev = state(
+            2,
+            region(Platform.DoorDash, Flow.TaskPickupNavigation),
+            region(Platform.Uber, Flow.TaskPickupNavigation),
+        )
+        val next = state(
+            2,
+            region(Platform.DoorDash, Flow.TaskPickupArrived),
+            region(Platform.Uber, Flow.TaskPickupNavigation),
+        )
+        assertFalse("no Pause while Uber still drives", diff(prev, next).any { it is AppEffect.PauseOdometer })
+    }
+
+    @Test
+    fun `Pause fires once BOTH live regions are stationary`() {
+        val prev = state(
+            2,
+            region(Platform.DoorDash, Flow.TaskPickupArrived),
+            region(Platform.Uber, Flow.TaskPickupNavigation),
+        )
+        val next = state(
+            2,
+            region(Platform.DoorDash, Flow.TaskPickupArrived),
+            region(Platform.Uber, Flow.TaskDropoffArrived),
+        )
+        assertTrue("Pause once both parked", diff(prev, next).any { it is AppEffect.PauseOdometer })
+    }
+
+    @Test
+    fun `Resume fires when one of two parked regions starts moving again`() {
+        val prev = state(
+            2,
+            region(Platform.DoorDash, Flow.TaskPickupArrived),
+            region(Platform.Uber, Flow.TaskDropoffArrived),
+        )
+        val next = state(
+            2,
+            region(Platform.DoorDash, Flow.TaskDropoffNavigation),
+            region(Platform.Uber, Flow.TaskDropoffArrived),
+        )
+        assertTrue("Resume when one region leaves its arrival", diff(prev, next).any { it is AppEffect.ResumeOdometer })
+    }
+
+    // =====================================================================================
+    // Recovery reconciliation (OdometerArbiter.recoveryReconciliation) — the vet M6 seam
+    // =====================================================================================
+
+    @Test
+    fun `recovery with no live session reconciles to nothing`() {
+        val restored = state(0)
+        assertTrue(OdometerArbiter.recoveryReconciliation(restored).isEmpty())
+    }
+
+    @Test
+    fun `recovery mid-drive re-establishes GPS with a Start (the lost-miles fix)`() {
+        val restored = state(1, region(Platform.DoorDash, Flow.TaskDropoffNavigation))
+        val effects = OdometerArbiter.recoveryReconciliation(restored)
+        assertEquals("Start only (moving)", listOf<Class<*>>(AppEffect.StartOdometer::class.java), effects.map { it::class.java })
+    }
+
+    @Test
+    fun `recovery parked at a drop re-establishes GPS then pauses it`() {
+        val restored = state(1, region(Platform.DoorDash, Flow.TaskDropoffArrived))
+        val effects = OdometerArbiter.recoveryReconciliation(restored)
+        assertEquals(
+            "Start then Pause (parked)",
+            listOf(AppEffect.StartOdometer::class.java, AppEffect.PauseOdometer::class.java),
+            effects.map { it::class.java },
+        )
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/replay/OdometerPredicateEquivalenceTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/replay/OdometerPredicateEquivalenceTest.kt
@@ -1,0 +1,161 @@
+package cloud.trotter.dashbuddy.replay
+
+import cloud.trotter.dashbuddy.core.state.AppEffect
+import cloud.trotter.dashbuddy.core.state.OdometerArbiter
+import cloud.trotter.dashbuddy.domain.state.AppState
+import cloud.trotter.dashbuddy.domain.state.Flow
+import cloud.trotter.dashbuddy.domain.state.PlatformRegion
+import cloud.trotter.dashbuddy.domain.state.TaskPhase
+import cloud.trotter.dashbuddy.test.util.SessionReplay
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #438 B5 (item 9) — checks the cross-platform odometer **stationary predicate against today's
+ * per-edge odometer emissions** on the single-platform replay fixtures (the vet's acceptance bar).
+ *
+ * The comparison is over the **GPS on/off timeline** each approach produces, folded per step. Rather
+ * than assert bit-identical (the predicate deliberately elides today's redundant Resume-while-moving
+ * no-ops, and it FIXES one latent today-bug — see below), it proves three properties:
+ *
+ *  1. **No regression** — the predicate never leaves GPS off (paused/stopped) at a step where today's
+ *     edge-based code had it on. A lost Resume = lost IRS miles; there are zero.
+ *  2. **Semantic correctness** — at every step the predicate's GPS level equals the ground truth
+ *     `activeSessionCount > 0 && !allLiveStationary` ([OdometerArbiter], the SSOT the diff uses).
+ *  3. **The divergences are all improvements** — every step where the predicate and today's edges
+ *     differ is one where the predicate turns GPS **on during an active drive** (a moving,
+ *     non-arrived flow) that today left paused, because today's odometer keys on the **active task**
+ *     and the task lagged in an ARRIVED state while the *flow* moved on. There are exactly THREE such
+ *     steps across the corpus today, all the same shape:
+ *       - `two_pickup_stack` final frame: the mamamargies drop's *navigation* screen, but the active
+ *         task still shows the just-completed billmiller drop (ARRIVED) — today's odometer stays
+ *         paused through the whole drive to mamamargies.
+ *       - `receipt_skip` `waiting_for_offer` + `offer_popup` frames: the driver returns to
+ *         waiting/an offer while the delivered drop's task is still ARRIVED (the skipped receipt
+ *         never retired it) — today stays paused while idle/repositioning.
+ *     All are predicate=ON / today=OFF (never the reverse). This is precisely the task-subphase lag
+ *     the vet chose a **flow**-based predicate to fix — a strict improvement, not a regression.
+ *     Documented + reported for adversarial ratification; the count is pinned so a NEW divergence
+ *     (or a regression) trips this test.
+ */
+class OdometerPredicateEquivalenceTest {
+
+    private enum class Gps { ON, OFF }
+
+    private val fixtures = listOf(
+        "snapshots/sessions/single_delivery_2026_06_16",
+        "snapshots/sessions/two_pickup_stack_2026_07_05",
+        "snapshots/sessions/walgreens_placeholder_2026_06_21",
+        "snapshots/sessions/receipt_skip_2026_06_29",
+        "snapshots/sessions/addon_phantom_2026_06_21",
+    )
+
+    /** The NEW arbitration's GPS timeline — fold the emitted odometer effects, one state per step. */
+    private fun actualTimeline(steps: List<SessionReplay.ReplayStep>): List<Gps> {
+        var gps = Gps.OFF
+        return steps.map { step ->
+            for (e in step.effects) gps = when (e) {
+                is AppEffect.StartOdometer, is AppEffect.ResumeOdometer -> Gps.ON
+                is AppEffect.StopOdometer, is AppEffect.PauseOdometer -> Gps.OFF
+                else -> gps
+            }
+            gps
+        }
+    }
+
+    /** TODAY'S per-edge rules, reconstructed independently from the region state trace (see class doc). */
+    private fun oracleTimeline(steps: List<SessionReplay.ReplayStep>): List<Gps> {
+        var gps = Gps.OFF
+        var prev = AppState()
+        return steps.map { step ->
+            val next = step.stateAfter
+            val platforms = prev.regions.platforms.keys + next.regions.platforms.keys
+            for (p in platforms) for (op in oldEdges(prev.regions.platforms[p], next.regions.platforms[p])) gps = op
+            prev = next
+            gps
+        }
+    }
+
+    private fun oldEdges(prev: PlatformRegion?, next: PlatformRegion?): List<Gps> = buildList {
+        val prevLive = prev?.session != null
+        val nextLive = next?.session != null
+        if (!prevLive && nextLive) add(Gps.ON)   // StartOdometer (session start)
+        if (prevLive && !nextLive) add(Gps.OFF)  // StopOdometer (session end)
+        if (!nextLive) return@buildList
+        val pt = prev?.activeTask
+        val nt = next?.activeTask
+        if (nt?.arrivedAt != null && pt?.arrivedAt == null) add(Gps.OFF)                          // PauseOdometer (arrival)
+        if (nt != null && nt.phase == TaskPhase.PICKUP && pt?.taskId != nt.taskId) add(Gps.ON)    // Resume (new pickup nav)
+        if (nt?.phase == TaskPhase.DROPOFF && nt.taskId != pt?.taskId) add(Gps.ON)                // Resume (new dropoff leg)
+        if (next?.lastActedFlow == Flow.PostTask && prev?.lastActedFlow != Flow.PostTask) add(Gps.ON) // Resume (PostTask entry)
+    }
+
+    /** The GPS ground truth per step, straight from the arbiter (property 2's SSOT). */
+    private fun semanticTimeline(steps: List<SessionReplay.ReplayStep>): List<Gps> = steps.map { step ->
+        val s = step.stateAfter
+        val live = s.regions.crossPlatform.activeSessionCount > 0
+        if (live && !OdometerArbiter.allLiveStationary(s.regions.platforms)) Gps.ON else Gps.OFF
+    }
+
+    /** A live region on a moving (non-arrived) flow — the shape of the today-bug the predicate fixes. */
+    private fun anyLiveMoving(step: SessionReplay.ReplayStep): Boolean =
+        step.stateAfter.regions.platforms.values.any {
+            it.session != null && it.lastActedFlow != Flow.TaskPickupArrived && it.lastActedFlow != Flow.TaskDropoffArrived
+        }
+
+    @Test
+    fun `predicate never regresses vs today's per-edge odometer (no lost Resume)`() {
+        for (fixture in fixtures) {
+            val steps = SessionReplay.reduce(fixture)
+            val actual = actualTimeline(steps)
+            val oracle = oracleTimeline(steps)
+            actual.indices.forEach { i ->
+                assertFalse(
+                    "REGRESSION on $fixture step $i: predicate OFF while today had GPS ON",
+                    actual[i] == Gps.OFF && oracle[i] == Gps.ON,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `predicate GPS level equals the semantic ground truth at every step`() {
+        for (fixture in fixtures) {
+            val steps = SessionReplay.reduce(fixture)
+            assertEquals(
+                "predicate GPS level diverges from ground truth on $fixture",
+                semanticTimeline(steps),
+                actualTimeline(steps),
+            )
+        }
+    }
+
+    @Test
+    fun `every divergence from today's edges is GPS-on during an active drive (an improvement)`() {
+        var divergences = 0
+        for (fixture in fixtures) {
+            val steps = SessionReplay.reduce(fixture)
+            val actual = actualTimeline(steps)
+            val oracle = oracleTimeline(steps)
+            actual.indices.forEach { i ->
+                if (actual[i] != oracle[i]) {
+                    divergences++
+                    assertTrue(
+                        "$fixture step $i: a divergence must be predicate=ON, today=OFF",
+                        actual[i] == Gps.ON && oracle[i] == Gps.OFF,
+                    )
+                    assertTrue(
+                        "$fixture step $i: the improvement must be GPS-on during a live moving flow",
+                        anyLiveMoving(steps[i]),
+                    )
+                }
+            }
+        }
+        // Exactly THREE known improvements across the corpus (see class doc): two_pickup_stack's
+        // mamamargies-drive frame + receipt_skip's two waiting/offer frames, all today-left-paused
+        // during a live moving flow. Pinned so a NEW divergence (or any regression) trips this test.
+        assertEquals("exactly the three known task-lag GPS-during-drive improvements", 3, divergences)
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/replay/OdometerPredicateEquivalenceTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/replay/OdometerPredicateEquivalenceTest.kt
@@ -44,12 +44,18 @@ class OdometerPredicateEquivalenceTest {
 
     private enum class Gps { ON, OFF }
 
+    // The FULL session corpus — every fixture under snapshots/sessions/ (adversarial-review MED:
+    // the first cut listed 5 and silently dodged an oracle-ordering artifact on teardown_ghost;
+    // the corpus-wide claim needs the corpus).
     private val fixtures = listOf(
+        "snapshots/sessions/addon_phantom_2026_06_21",
+        "snapshots/sessions/decline_race_2026_06_30",
+        "snapshots/sessions/ghost_offer_2026_06_14",
+        "snapshots/sessions/receipt_skip_2026_06_29",
         "snapshots/sessions/single_delivery_2026_06_16",
+        "snapshots/sessions/teardown_ghost_2026_06_28",
         "snapshots/sessions/two_pickup_stack_2026_07_05",
         "snapshots/sessions/walgreens_placeholder_2026_06_21",
-        "snapshots/sessions/receipt_skip_2026_06_29",
-        "snapshots/sessions/addon_phantom_2026_06_21",
     )
 
     /** The NEW arbitration's GPS timeline — fold the emitted odometer effects, one state per step. */
@@ -86,9 +92,13 @@ class OdometerPredicateEquivalenceTest {
         if (!nextLive) return@buildList
         val pt = prev?.activeTask
         val nt = next?.activeTask
-        if (nt?.arrivedAt != null && pt?.arrivedAt == null) add(Gps.OFF)                          // PauseOdometer (arrival)
+        // Emission ORDER is faithful to master's diffTask (adversarial-review MED): the task-change
+        // Resumes fire BEFORE the arrival Pause, so a mint+arrive-in-one-frame step (teardown_ghost's
+        // offer → pickup_shopping) folds to OFF — Resume then Pause — exactly as real master did.
+        // The first-cut oracle applied the Pause first and manufactured phantom "regressions" there.
         if (nt != null && nt.phase == TaskPhase.PICKUP && pt?.taskId != nt.taskId) add(Gps.ON)    // Resume (new pickup nav)
         if (nt?.phase == TaskPhase.DROPOFF && nt.taskId != pt?.taskId) add(Gps.ON)                // Resume (new dropoff leg)
+        if (nt?.arrivedAt != null && pt?.arrivedAt == null) add(Gps.OFF)                          // PauseOdometer (arrival)
         if (next?.lastActedFlow == Flow.PostTask && prev?.lastActedFlow != Flow.PostTask) add(Gps.ON) // Resume (PostTask entry)
     }
 
@@ -134,14 +144,14 @@ class OdometerPredicateEquivalenceTest {
 
     @Test
     fun `every divergence from today's edges is GPS-on during an active drive (an improvement)`() {
-        var divergences = 0
+        val divergences = mutableListOf<Pair<String, Int>>()
         for (fixture in fixtures) {
             val steps = SessionReplay.reduce(fixture)
             val actual = actualTimeline(steps)
             val oracle = oracleTimeline(steps)
             actual.indices.forEach { i ->
                 if (actual[i] != oracle[i]) {
-                    divergences++
+                    divergences += fixture.substringAfterLast('/') to i
                     assertTrue(
                         "$fixture step $i: a divergence must be predicate=ON, today=OFF",
                         actual[i] == Gps.ON && oracle[i] == Gps.OFF,
@@ -153,9 +163,19 @@ class OdometerPredicateEquivalenceTest {
                 }
             }
         }
-        // Exactly THREE known improvements across the corpus (see class doc): two_pickup_stack's
-        // mamamargies-drive frame + receipt_skip's two waiting/offer frames, all today-left-paused
-        // during a live moving flow. Pinned so a NEW divergence (or any regression) trips this test.
-        assertEquals("exactly the three known task-lag GPS-during-drive improvements", 3, divergences)
+        // EXACTLY these three known improvements across the whole corpus (see class doc):
+        // two_pickup_stack's mamamargies-drive final frame + receipt_skip's waiting/offer frames,
+        // all today-left-paused during a live moving flow. Pinned as (fixture, step) pairs —
+        // not a bare count (adversarial-review LOW) — so a NEW divergence appearing while an old
+        // one vanishes cannot pass silently.
+        assertEquals(
+            "exactly the three known task-lag GPS-during-drive improvements",
+            listOf(
+                "receipt_skip_2026_06_29" to 2,
+                "receipt_skip_2026_06_29" to 3,
+                "two_pickup_stack_2026_07_05" to 9,
+            ),
+            divergences.sortedWith(compareBy({ it.first }, { it.second })),
+        )
     }
 }

--- a/app/src/test/java/cloud/trotter/dashbuddy/test/util/SessionReplay.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/test/util/SessionReplay.kt
@@ -120,12 +120,14 @@ object SessionReplay {
         replayRecognition(loadSession(pathFromResources))
 
     /** One replayed step: the source frame (null for an injected synthetic obs), what it recognized
-     *  as, the state after, and the events it emitted. */
+     *  as, the state after, the events it emitted, and the full [AppEffect] list (for effect-level
+     *  assertions like the #438 B5 odometer-arbitration equivalence proof). */
     data class ReplayStep(
         val frame: ReplayFrame?,
         val observation: Observation,
         val stateAfter: AppState,
         val events: List<AppEvent>,
+        val effects: List<AppEffect> = emptyList(),
     )
 
     /**
@@ -290,6 +292,7 @@ object SessionReplay {
                 observation = obs,
                 stateAfter = state,
                 events = transition.effects.filterIsInstance<AppEffect.LogEvent>().map { it.event },
+                effects = transition.effects,
             )
         }
     }

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/location/OdometerRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/location/OdometerRepository.kt
@@ -28,17 +28,29 @@ class OdometerRepository @Inject constructor(
     private var trackingJob: Job? = null
 
     // State
+    /**
+     * The cumulative device odometer total (meters). THE `metadata.odometer` input the analytics
+     * projector reads (#314) — a raw cumulative reading. #438 B5 does NOT change its semantics; only
+     * the per-session anchor bookkeeping below changed.
+     */
     private val _meters = MutableStateFlow(0.0)
-    private val _anchor = MutableStateFlow(0.0)
 
-    val sessionMeters = combine(_meters, _anchor) { current, anchor ->
-        (current - anchor).coerceAtLeast(0.0)
-    }
+    /**
+     * #438 B5: per-session start anchors (sessionId → odometer meters at session start). Replaces the
+     * single global `_anchor`, so two concurrent sessions accrue miles independently and a second
+     * session starting can't zero the first's total.
+     */
+    private val _anchors = MutableStateFlow<Map<String, Double>>(emptyMap())
 
-    // Public Output: Reactive Session Miles
-    val sessionMilesFlow: Flow<Double> = sessionMeters.map { meters ->
-        meters * metersToMiles
-    }
+    /** The session the no-arg [sessionMilesFlow] tracks (the HUD's "session miles" view). */
+    private val _currentSessionId = MutableStateFlow<String?>(null)
+
+    // Public Output: Reactive Session Miles for the CURRENT session (the HUD's "session miles").
+    val sessionMilesFlow: Flow<Double> =
+        combine(_meters, _anchors, _currentSessionId) { total, anchors, sid ->
+            val anchor = sid?.let { anchors[it] } ?: 0.0
+            (total - anchor).coerceAtLeast(0.0) * metersToMiles
+        }
 
     private var lastCoords: Coordinates? = null
     private val metersToMiles = 0.000621371
@@ -50,16 +62,40 @@ class OdometerRepository @Inject constructor(
         // single source of truth after startup; saves flow one-way to disk.
         scope.launch {
             _meters.value = odometerLocalDataSource.totalMetersFlow.first()
-            _anchor.value = odometerLocalDataSource.sessionAnchorFlow.first()
+            // #438 B5: restore the current session's anchor so HUD miles survive a crash.
+            val currentId = odometerLocalDataSource.currentSessionIdFlow.first()
+            if (currentId != null) {
+                _currentSessionId.value = currentId
+                val anchor = odometerLocalDataSource.sessionAnchorFlow(currentId).first()
+                if (anchor != null) _anchors.value = mapOf(currentId to anchor)
+            }
         }
     }
 
-    fun resetSession() {
-        Timber.Forest.i("Resetting Session Odometer")
-        val currentTotal = _meters.value
-        _anchor.value = currentTotal
-        scope.launch { odometerLocalDataSource.saveSessionAnchor(currentTotal) }
+    /**
+     * #438 B5: anchor [sessionId] to the current cumulative total the first time it starts, and mark
+     * it the current session. **Idempotent** — a grace-resume that re-arms the session MUST NOT move
+     * an existing anchor (that would zero the session's accrued miles, the exact concurrency bug this
+     * replaces). Replaces the old global `resetSession()`.
+     */
+    fun startSessionTracking(sessionId: String) {
+        _currentSessionId.value = sessionId
+        if (_anchors.value.containsKey(sessionId)) return
+        val anchor = _meters.value
+        _anchors.value = _anchors.value + (sessionId to anchor)
+        scope.launch { odometerLocalDataSource.saveSessionAnchor(sessionId, anchor) }
     }
+
+    /**
+     * #438 B5: per-session miles — session A and B accrue independently. A session with no anchor yet
+     * reads 0 (anchor defaults to the current total). #528 consumes these + the overlap flag for
+     * per-drop / GPS $/mi.
+     */
+    fun sessionMilesFlow(sessionId: String): Flow<Double> =
+        combine(_meters, _anchors) { total, anchors ->
+            val anchor = anchors[sessionId] ?: total
+            (total - anchor).coerceAtLeast(0.0) * metersToMiles
+        }
 
     fun startTracking() {
         if (trackingJob?.isActive == true) return
@@ -94,8 +130,15 @@ class OdometerRepository @Inject constructor(
         scope.launch { odometerLocalDataSource.saveTotalMeters(newTotal) }
     }
 
-    fun getCurrentSessionMiles(): Double =
-        (_meters.value - _anchor.value).coerceAtLeast(0.0) * metersToMiles
+    /** Miles accrued by [sessionId] (its total delta since its anchor). */
+    fun getCurrentSessionMiles(sessionId: String): Double {
+        val anchor = _anchors.value[sessionId] ?: _meters.value
+        return (_meters.value - anchor).coerceAtLeast(0.0) * metersToMiles
+    }
 
+    /**
+     * The raw cumulative device odometer reading (miles) — the projector's `metadata.odometer` input
+     * (#314). Unaffected by the #438 B5 per-session anchor change (it reads [_meters] only).
+     */
     fun getCurrentMiles(): Double = _meters.value * metersToMiles
 }

--- a/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/odometer/OdometerLocalDataSource.kt
+++ b/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/odometer/OdometerLocalDataSource.kt
@@ -4,6 +4,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.doublePreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
 import cloud.trotter.dashbuddy.core.datastore.di.OdometerPreferences
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -16,18 +17,41 @@ class OdometerLocalDataSource @Inject constructor(
 ) {
     private object Keys {
         val TOTAL_METERS = doublePreferencesKey("total_meters")
-        val SESSION_ANCHOR = doublePreferencesKey("session_anchor")
+
+        /**
+         * #438 B5: the id of the session whose miles the no-arg [OdometerRepository.sessionMilesFlow]
+         * (the HUD's "session miles") tracks, persisted so a crash recovery restores the right anchor.
+         */
+        val CURRENT_SESSION_ID = stringPreferencesKey("current_session_id")
+
+        /**
+         * #438 B5: per-session anchor keys — the odometer total at each session's start. Replaces the
+         * single global `session_anchor`, so a SECOND concurrent session gets its OWN anchor and can't
+         * zero the first's accrued miles.
+         */
+        fun sessionAnchor(sessionId: String) = doublePreferencesKey("session_anchor_$sessionId")
     }
 
     val totalMetersFlow: Flow<Double> = ds.data.map { it[Keys.TOTAL_METERS] ?: 0.0 }
-    val sessionAnchorFlow: Flow<Double> = ds.data.map { it[Keys.SESSION_ANCHOR] ?: 0.0 }
+    val currentSessionIdFlow: Flow<String?> = ds.data.map { it[Keys.CURRENT_SESSION_ID] }
+
+    fun sessionAnchorFlow(sessionId: String): Flow<Double?> =
+        ds.data.map { it[Keys.sessionAnchor(sessionId)] }
 
     suspend fun saveTotalMeters(meters: Double) {
         ds.edit { it[Keys.TOTAL_METERS] = meters }
     }
 
-    suspend fun saveSessionAnchor(anchor: Double) {
-        ds.edit { it[Keys.SESSION_ANCHOR] = anchor }
+    /**
+     * Persist [sessionId]'s anchor and mark it the current session in one edit. The old single
+     * `session_anchor` (double) key is intentionally left orphaned — dev is the only user, and a
+     * mid-session upgrade merely resets that one session's HUD miles to 0 until re-anchored (alpha).
+     */
+    suspend fun saveSessionAnchor(sessionId: String, anchor: Double) {
+        ds.edit {
+            it[Keys.sessionAnchor(sessionId)] = anchor
+            it[Keys.CURRENT_SESSION_ID] = sessionId
+        }
     }
 
     suspend fun clear() {

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -92,6 +92,9 @@ class EffectMap @Inject constructor() {
         // #438 B3: a HUD accept/decline resolves by the tap's OWN carried (platform, offerHash)
         // against that platform's owned offers — no global-flow precondition (vet M4).
         addAll(diffOfferAction(obs, next))
+        // #438 B5 (item 9): odometer arbitration is a CROSS-PLATFORM decision — one GPS, one global
+        // total — so it diffs the aggregate ONCE, not per platform region.
+        addAll(diffCrossPlatform(prev, next))
         val allPlatforms = (prev.regions.platforms.keys + next.regions.platforms.keys).distinct()
         for (p in allPlatforms) {
             addAll(
@@ -104,6 +107,45 @@ class EffectMap @Inject constructor() {
                     obs,
                 )
             )
+        }
+    }
+
+    // =========================================================================
+    // CROSS-PLATFORM DIFFS
+    // =========================================================================
+
+    /**
+     * #438 B5 (item 9): the odometer arbitration. The four odometer effects moved OFF each
+     * platform's session/task diff — where a 2nd concurrent session's Start zeroed the 1st's
+     * miles, the 1st ending killed GPS under the 2nd, and one platform's arrival paused GPS on
+     * the other's drive — onto ONE cross-platform decision:
+     *  - **Start/Stop** on the live-session count crossing 0↔1 (`activeSessionCount`, derived by
+     *    [CrossPlatformRegionStepper]; the vet confirmed the count includes paused + grace-window
+     *    sessions — correct for "is any dash open").
+     *  - **Pause/Resume** on the [OdometerArbiter] stationary level, gated to a *continuously*-live
+     *    window (both counts > 0) so a session start/end edge routes through Start/Stop and never a
+     *    phantom Pause/Resume (e.g. ending a dash while parked at a drop must Stop, not Resume).
+     *    Pause fires when every live region becomes stationary; Resume when any starts moving.
+     *
+     * Single-platform behavior is byte-identical in GPS on/off state (proven against the replay
+     * fixtures, [cloud.trotter.dashbuddy] `OdometerPredicateEquivalenceTest`); the only difference
+     * is this elides today's redundant Resume-while-already-moving emissions (session-start pickup
+     * nav, PostTask entry from a non-arrived drive), which `startTracking()` already no-ops.
+     */
+    private fun diffCrossPlatform(prev: AppState, next: AppState): List<AppEffect> = buildList {
+        val prevCount = prev.regions.crossPlatform.activeSessionCount
+        val nextCount = next.regions.crossPlatform.activeSessionCount
+        when {
+            prevCount == 0 && nextCount > 0 -> add(AppEffect.StartOdometer)
+            prevCount > 0 && nextCount == 0 -> add(AppEffect.StopOdometer)
+        }
+        if (prevCount > 0 && nextCount > 0) {
+            val prevStationary = OdometerArbiter.allLiveStationary(prev.regions.platforms)
+            val nextStationary = OdometerArbiter.allLiveStationary(next.regions.platforms)
+            when {
+                !prevStationary && nextStationary -> add(AppEffect.PauseOdometer)
+                prevStationary && !nextStationary -> add(AppEffect.ResumeOdometer)
+            }
         }
     }
 
@@ -145,7 +187,7 @@ class EffectMap @Inject constructor() {
             addAll(diffMode(p, next, obs))
             addAll(diffGraceTimer(p, next, obs))
             addAll(diffModeResumeTimer(p, next, obs))
-            addAll(diffTask(p, next, actedPrevFlow, actedNextFlow, obs))
+            addAll(diffTask(p, next, obs))
             addAll(diffPostTask(p, next, actedNextFlow, obs))
             addAll(diffNotification(obs))
 
@@ -395,7 +437,10 @@ class EffectMap @Inject constructor() {
                                 ),
                             ),
                         )
-                        add(AppEffect.StopOdometer)
+                        // #438 B5: StopOdometer now emits from diffCrossPlatform on the
+                        // activeSessionCount 1→0 crossing (this session end is that crossing when
+                        // it's the last live session), so one platform ending can't kill GPS under
+                        // another still-live dash.
                         add(AppEffect.UpdateBubble("Session Ended. Total: $earnings", ChatPersona.Dispatcher))
                         // #606: no CaptureScreenshot here — the dash_summary
                         // rule effect (doordash.json) already owns the
@@ -419,7 +464,7 @@ class EffectMap @Inject constructor() {
                                 ),
                             ),
                         )
-                        add(AppEffect.StopOdometer)
+                        // #438 B5: StopOdometer arbitrated at the cross-platform tier (see above).
                     }
                     add(AppEffect.EndSession(prev.platform.name))
                 }
@@ -444,7 +489,10 @@ class EffectMap @Inject constructor() {
                             startScreen = "WaitingForOffer",
                         )
                         add(logEffect(nextSession.sessionId, AppEventType.DASH_START, obs.timestamp, payload))
-                        add(AppEffect.StartOdometer)
+                        // #438 B5: StartOdometer now emits from diffCrossPlatform on the
+                        // activeSessionCount 0→1 crossing, so a SECOND concurrent session starting
+                        // does NOT re-fire Start (which would zero the first's accrued miles). The
+                        // per-session anchor rides StartSession (odometerRepository.startSessionTracking).
                         add(AppEffect.StartSession(nextSession.sessionId, next.platform.name))
                     } else if (nextSession != null && prevSession?.sessionId == nextSession.sessionId) {
                         // Grace resume — same session, no start effects needed
@@ -581,15 +629,13 @@ class EffectMap @Inject constructor() {
     private fun diffTask(
         prev: PlatformRegion,
         next: PlatformRegion,
-        actedPrevFlow: Flow,
-        actedNextFlow: Flow,
         obs: Observation,
     ): List<AppEffect> {
         // Diffs are computed from prev/next region state for EVERY observation type:
         // lazy expiry can retire a task on a non-flow observation (a routed timeout,
         // #342), and that closure must still emit DELIVERY_CONFIRMED (#345).
-        // #438 item 5: the flow reads below are THIS region's own acted flow, not the global R0.
-        val nextFlowVal = actedNextFlow
+        // #438 B5: the acted-flow reads that drove the (now cross-platform-arbitrated) odometer
+        // Pause/Resume were removed here — the task edges below emit only log events + bubbles.
         val sessionId = next.session?.sessionId ?: prev.session?.sessionId
 
         return buildList {
@@ -621,7 +667,8 @@ class EffectMap @Inject constructor() {
                     val storeName = nextTask.storeName ?: UNKNOWN_STORE
                     val payload = pickupPayload(nextTask, storeName)
                     add(logEffect(sessionId, AppEventType.PICKUP_NAV_STARTED, obs.timestamp, payload))
-                    add(AppEffect.ResumeOdometer)
+                    // #438 B5: ResumeOdometer is arbitrated by the cross-platform stationary
+                    // predicate (diffCrossPlatform), no longer emitted per pickup-nav edge.
 
                     val persona = determinePickupPersona(
                         nextTask.activity,
@@ -690,7 +737,9 @@ class EffectMap @Inject constructor() {
                 if (arrivedOverride != null) {
                     addAll(arrivedOverride)
                 } else {
-                    add(AppEffect.PauseOdometer)
+                    // #438 B5: PauseOdometer is arbitrated by the cross-platform stationary
+                    // predicate (diffCrossPlatform) — it fires only when ALL live regions are
+                    // parked, so one platform's arrival can't pause GPS mid-drive on another's leg.
 
                     when (nextTask.phase) {
                         TaskPhase.PICKUP -> add(
@@ -751,10 +800,10 @@ class EffectMap @Inject constructor() {
                 }
             }
 
-            // Post-task: delivery completed (this region's own PostTask entry, #438 item 5).
-            if (nextFlowVal == Flow.PostTask && actedPrevFlow != Flow.PostTask) {
-                add(AppEffect.ResumeOdometer)
-            }
+            // #438 B5: the PostTask-entry ResumeOdometer moved to the cross-platform stationary
+            // predicate (diffCrossPlatform). Leaving an arrived drop for PostTask is a
+            // stationary→moving crossing there; entering PostTask from a non-arrived drive was a
+            // redundant no-op Resume (GPS already running) and is correctly elided.
         }
     }
 
@@ -784,7 +833,9 @@ class EffectMap @Inject constructor() {
                 deliveryPhasePayload(task = task, phaseStartedAt = obs.timestamp),
             ),
         )
-        add(AppEffect.ResumeOdometer)
+        // #438 B5: ResumeOdometer arbitrated by the cross-platform stationary predicate
+        // (diffCrossPlatform) — leaving an arrived pickup/drop for the next leg is the
+        // stationary→moving crossing that resumes GPS there.
         // #568: store-flavored label ("Heading to H-E-B's customer") — friendlier
         // than the raw 6-char hash, and it disambiguates a multi-store stack's drops.
         val customer = customerLabel(task.storeName)

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/OdometerArbiter.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/OdometerArbiter.kt
@@ -1,0 +1,82 @@
+package cloud.trotter.dashbuddy.core.state
+
+import cloud.trotter.dashbuddy.domain.state.AppState
+import cloud.trotter.dashbuddy.domain.state.Flow
+import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.domain.state.PlatformRegion
+
+/**
+ * #438 B5 (item 9) — the pure odometer arbitration predicate, the single source of truth
+ * shared by [EffectMap] (the diff-level Start/Stop/Pause/Resume decision) and [StateManagerV2]
+ * (the crash-recovery reconciliation). A function of region state only — no Android, no wall
+ * clock, no DB read — so it composes into the pure diff and can be replayed deterministically.
+ *
+ * **Why it exists.** The odometer was a global GPS singleton + one session anchor commanded by
+ * EACH platform's own session/task diff. Under concurrency that breaks three ways: a second
+ * session's Start zeroed the first's accrued miles, the first session ending killed GPS under
+ * the second, and one platform's store arrival paused GPS mid-drive on the other's leg. B5 lifts
+ * the decision to the cross-platform tier:
+ *  - GPS runs while ANY session is live (the live-session count, [Platform]-agnostic);
+ *  - GPS pauses only when EVERY live region is stationary (parked at an arrived task) and resumes
+ *    the moment ANY live region starts moving again.
+ *
+ * The attribution decision the layer above enforces (locked, dev 2026-07-06): task-execution
+ * miles belong to that task's platform; dual-online idle miles are full-to-each with an overlap
+ * flag; every aggregate/IRS/CSV read anchors to the real odometer total (never Σ per-session).
+ */
+object OdometerArbiter {
+
+    /**
+     * The arrived task sub-flows — a region is "stationary" (parked) in exactly these
+     * ([Flow.TaskPickupArrived]/[Flow.TaskDropoffArrived]). Every nav/idle/offer flow — and
+     * `PostTask` — is moving.
+     */
+    private val STATIONARY_FLOWS = setOf(Flow.TaskPickupArrived, Flow.TaskDropoffArrived)
+
+    /**
+     * A region's own stationary signal (vet M6): **stationary ⇔ its last acted flow is an arrived
+     * task sub-flow and not PostTask.** Keyed off [PlatformRegion.lastActedFlow] (the flow THIS
+     * region drove, #438 item 5) rather than `activeTask.subPhase == ARRIVED`, because the two
+     * diverge at PostTask-under-retire-grace — the task is still ARRIVED but the flow is `PostTask`,
+     * where today's per-edge logic already Resumed. Reading the flow makes `PostTask` moving (it is
+     * not in [STATIONARY_FLOWS]), so the predicate matches today's Resume-on-PostTask-entry edge.
+     * A null `lastActedFlow` (legacy pre-B1 snapshot, or a region that never acted on a screen)
+     * reads moving.
+     */
+    fun isStationary(region: PlatformRegion): Boolean = region.lastActedFlow in STATIONARY_FLOWS
+
+    /**
+     * ALL live regions are stationary (and there is at least one). A live region is one holding a
+     * session — the same definition [CrossPlatformRegionStepper] counts into `activeSessionCount`,
+     * so "no live session" is vacuously **false** here: with nothing dashing there is nothing to
+     * pause (the count crossing owns Start/Stop). Pause fires when this flips false→true across a
+     * step, Resume when it flips true→false — the level-crossing the caller diffs.
+     */
+    fun allLiveStationary(platforms: Map<Platform, PlatformRegion>): Boolean {
+        val live = platforms.values.filter { it.session != null }
+        return live.isNotEmpty() && live.all { isStationary(it) }
+    }
+
+    /**
+     * #438 B5 recovery reconciliation (vet M6): the odometer effects to (re-)fire on the first live
+     * observation after a crash, given the [restored] state. Odometer effects are recovery-suppressed
+     * externals, so GPS is dead after a restore — and a level-*crossing* Resume can't restart it (the
+     * level is already "moving", so no crossing fires; the whole post-crash leg's miles would be lost).
+     *
+     *  - No live session → nothing (GPS correctly off).
+     *  - A live session, moving → [AppEffect.StartOdometer] (re-establishes tracking + the
+     *    notification; the per-session anchor persisted across the crash, so no reset).
+     *  - A live session, ALL live regions parked → Start **then** [AppEffect.PauseOdometer], matching
+     *    the restored "stationary at a drop" level (GPS re-registered but paused; the next Resume
+     *    crossing restarts it on departure).
+     *
+     * Idempotent by construction: [OdometerEffectHandler]'s start/stop no-op if already in that state.
+     */
+    fun recoveryReconciliation(restored: AppState): List<AppEffect> {
+        if (restored.regions.crossPlatform.activeSessionCount <= 0) return emptyList()
+        return buildList {
+            add(AppEffect.StartOdometer)
+            if (allLiveStationary(restored.regions.platforms)) add(AppEffect.PauseOdometer)
+        }
+    }
+}

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/StateManagerV2.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/StateManagerV2.kt
@@ -39,6 +39,17 @@ class StateManagerV2 @Inject constructor(
     private val _state = MutableStateFlow(AppState())
     val state = _state.asStateFlow()
 
+    /**
+     * #438 B5 (item 9): armed by [restoreState] when a snapshot restore recovered a NON-fresh
+     * state; consumed on the first LIVE observation to reconcile the odometer. Odometer effects are
+     * recovery-suppressed externals ([SideEffectEngine] `isExternalEffect`), so after a crash GPS is
+     * dead — and a level-*crossing* Resume won't re-fire (the level is already "moving" at restore →
+     * no crossing → GPS stays dead until a full pause→resume cycle, losing IRS miles for the whole
+     * post-crash leg). The reconciliation re-establishes tracking for a still-live session directly,
+     * at the edge (never inside a pure reducer).
+     */
+    private var recoveryReconcilePending = false
+
     fun initialize() {
         Timber.i("Initializing V2 State Machine (multi-region)...")
         journal.start(scope, ioDispatcher)
@@ -72,6 +83,17 @@ class StateManagerV2 @Inject constructor(
         val obs = toObservation(stateEvent) ?: return
 
         val currentState = _state.value
+
+        // #438 B5: on the FIRST live observation after a crash recovery, re-establish the odometer
+        // for a still-live session (recovery suppressed the Start/Resume that normally would run).
+        // Emitted at the edge, keyed off the restored (pre-step) state, BEFORE the obs steps — the
+        // effects are idempotent (startTracking/stopTracking no-op if already in that state), so any
+        // crossing the incoming obs itself produces is harmless on top.
+        if (recoveryReconcilePending) {
+            recoveryReconcilePending = false
+            reconcileOdometerAfterRecovery(currentState)
+        }
+
         val transition = stateMachine.step(currentState, obs)
 
         // Update state
@@ -100,6 +122,21 @@ class StateManagerV2 @Inject constructor(
         }
     }
 
+    /**
+     * #438 B5: reconcile the odometer to the [restored] state after a crash. If any session is live
+     * (`activeSessionCount > 0`), re-emit [AppEffect.StartOdometer] (re-establishes GPS tracking +
+     * the ongoing notification; the per-session anchor persisted across the crash, so no reset), and
+     * — if EVERY live region is parked ([OdometerArbiter.allLiveStationary]) — a [AppEffect.PauseOdometer]
+     * so GPS matches the restored "stationary at a drop" level. A moving restore leaves GPS running.
+     * Emitted on the LIVE path (`recovering = false`), so it actually fires (recovery suppresses it).
+     */
+    private fun reconcileOdometerAfterRecovery(restored: AppState) {
+        val effects = OdometerArbiter.recoveryReconciliation(restored)
+        if (effects.isEmpty()) return
+        Timber.i("Recovery odometer reconciliation: %s", effects.map { it::class.simpleName })
+        effects.forEach { engine.process(it, correlationVersion = restored.correlationVersion) }
+    }
+
     companion object {
         /** Prune the observation journal every N accepted observations. */
         private const val JOURNAL_PRUNE_EVERY = 500L
@@ -124,6 +161,8 @@ class StateManagerV2 @Inject constructor(
             if (tail.isEmpty()) {
                 Timber.i("Restored from snapshot at cv=%d, no tail", restored.correlationVersion)
                 _state.value = restored.state
+                // #438 B5: recovered a non-fresh state → reconcile the odometer on the first live obs.
+                recoveryReconcilePending = true
                 return
             }
 
@@ -146,6 +185,8 @@ class StateManagerV2 @Inject constructor(
             }
 
             _state.value = finalState
+            // #438 B5: recovered a non-fresh state → reconcile the odometer on the first live obs.
+            recoveryReconcilePending = true
             Timber.i("Recovery complete — state at cv=%d", finalState.correlationVersion)
         } catch (e: Exception) {
             Timber.e(e, "State recovery failed — starting fresh")

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -106,6 +106,20 @@ was found **broken-in-part** (raw PII in capture envelopes) and moved to that en
   now WARN-aborts to manual rather than acting on the wrong one). A banner that acts on the wrong
   offer, or a stale banner that survives its offer, is a B4 regression — capture it.
   - Confirmed: 0/2
+- **🆕 NEW — odometer arbitration holds single-platform (#438 B5 / PR).** The GPS odometer moved off
+  each platform's own diff onto one cross-platform decision (starts once when a dash opens, pauses
+  when parked at a stop, resumes on leaving, stops when the dash ends). Single-platform behavior
+  must feel **identical**. On a normal DoorDash dash, watch the odometer + session miles: (1) the
+  "Odometer Active" notification appears **once** at dash start (not re-created per offer/leg); (2)
+  the **session miles** in the bubble HUD climb during drives and hold steady while you're parked at
+  a pickup/dropoff, then resume climbing when you leave; (3) at dash end the miles look right for the
+  distance you actually drove (compare to your car's trip odometer if handy). One improvement to
+  watch for specifically: on a **stacked multi-drop** (two drops back-to-back) and on a **skipped/late
+  receipt**, the odometer should now keep counting the drive to the next stop even when the app's
+  active-task display lags on the previous drop (today's build wrongly paused there). Miles that look
+  far too low (odometer stuck paused through a drive) or a session-miles value that resets to ~0
+  mid-dash is a B5 regression — capture it. (#438 B5 / PR)
+  - Confirmed: 0/2
 - **🆕 NEW — edit a delivery directly + cash tips (#688 phase A / PR).** In **Analytics → a dash →
   the delivery drill-down**, **tap a delivery row** (or its pencil) → the **Adjust delivery** dialog:
   Store name / Pay / Tip / Cash tip / Miles / Note. This replaces the pay-only editor and is the real


### PR DESCRIPTION
## Summary

B5 of the #438 multiplatform correctness pack (item 9). The GPS odometer was a **global singleton + one session anchor commanded by each platform's own diff** — the Principle-8 failure single-platform testing masks. Concurrency broke it three ways: a second session's Start **zeroed** the first's miles, the first session ending **killed GPS** under the second, and one platform's arrival **paused GPS mid-drive** on the other's leg.

Design doc: [`docs/design/multiplatform-correctness-pack.md` § "B5 — item 9: odometer arbitration"](../blob/master/docs/design/multiplatform-correctness-pack.md).

### The change
- **Arbitrate at the diff level.** `AppEffect.StartOdometer`/`StopOdometer` moved off the per-platform region diffs onto a new `EffectMap.diffCrossPlatform` — Start on `activeSessionCount` 0→1, Stop on 1→0 (the count includes paused/grace sessions, per the vet).
- **Stationary predicate (vet M6), `OdometerArbiter` SSOT.** `stationary ⇔ the region's own lastActedFlow is an arrived task sub-flow` (flow-based, not `activeTask.subPhase` — handles PostTask-under-grace and task-resolution lag). Pause when ALL live regions are parked; Resume when any starts moving. Both `EffectMap` (diff-level) and `StateManagerV2` (recovery) read this one predicate.
- **Recovery reconciliation (vet M6).** Odometer effects are recovery-suppressed externals, so a level-crossing Resume can't restart GPS after a crash (level already "moving" → no crossing → GPS dead → lost IRS miles). `StateManagerV2` re-establishes tracking on the **first live observation** for a still-live session (`OdometerArbiter.recoveryReconciliation`: Start, +Pause if parked).
- **Per-session anchors.** Dropped `resetSession()` from `OdometerEffectHandler.startUp()`; anchors are per-`sessionId` keys in `OdometerLocalDataSource`; the repository serves per-session/per-platform miles flows + the global total. The anchor rides the per-platform `StartSession` effect (idempotent — a grace-resume never moves an existing anchor).
- **Retired rule-verb odometer effects (vet L6).** `ODOMETER_START/STOP/PAUSE/RESUME` route to a WARN no-op at the `SideEffectEngine` dispatch — a rule can no longer command the odometer past the arbiter. (Enum kept; deleting it cascades across `:domain`/`:core:pipeline` for no gain.)

### Locked attribution decision (dev, 2026-07-06 — implemented, not re-litigated)
Task-execution miles belong to the task's platform; dual-online **idle** miles are full-to-each live session with an overlap flag; **every aggregate/IRS/CSV read anchors to the real odometer total**, so double-counting is structurally impossible at the read site. The analytics-side overlap **column/exposure is #528's work** — B5 is the arbitration + per-session anchor layer only.

### `metadata.odometer` invariant
Unchanged. It's stamped from `OdometerRepository.getCurrentMiles()` = the raw cumulative `_meters` reading; the anchor change touches only session-total bookkeeping. Guarded by `OdometerRepositoryPerSessionTest`.

## Predicate-equivalence evidence
`OdometerPredicateEquivalenceTest` folds each replay fixture's odometer effects to a GPS on/off timeline and compares against an **independent reconstruction of today's per-edge rules**. Three properties, all green:
1. **No regression** — zero steps where the predicate leaves GPS off while today had it on (no lost Resume).
2. **Semantic correctness** — the predicate's GPS level equals the ground truth `activeSessionCount>0 && !allLiveStationary` at every step.
3. **Every divergence is an improvement** — exactly **3** steps (all predicate=ON / today=OFF), pinned so a new divergence trips the test.

**⚠️ Reviewer note — the vet's "predicate ≡ today's edges" is slightly too strong.** The predicate is a strict *improvement*, not bit-identical. The 3 divergences are all the same shape: today's odometer keys on the **active task**, so when the task lags in an ARRIVED state while the *flow* moves on, today leaves GPS **paused through a real drive** (lost miles). The flow-based predicate correctly resumes:
- `two_pickup_stack` final frame — the mamamargies drop's *navigation* screen, but the active task still shows the just-completed billmiller drop (ARRIVED). Today's odometer stays paused the whole drive to mamamargies.
- `receipt_skip` `waiting_for_offer` + `offer_popup` — the driver returns to waiting/an offer while the delivered drop's task is still ARRIVED (the skipped receipt never retired it). Today stays paused while idle/repositioning.

This is exactly the task-subphase lag the vet chose a flow-based predicate to fix — so it is behaving as designed, and there are **no regressions**. Flagged here for the adversarial reviewer to ratify (the alternative — matching today's task-keyed pauses bit-for-bit — would preserve the lost-miles bug and was not the predicate the spec specified).

## Tests
- `OdometerArbitrationTest` — dual-session interleave (2nd Start no re-fire / no zeroing; 1st Stop no-op while 2nd live; Stop only on 1→0), Pause-requires-all-stationary (DD arrived + Uber driving → no Pause; both → Pause; one resumes → Resume), recovery reconciliation seam.
- `OdometerPredicateEquivalenceTest` — the 3 properties above.
- `OdometerRepositoryPerSessionTest` — A and B accrue independently, B starting doesn't reset A, idempotent re-arm, `metadata.odometer` invariant.
- Existing `EffectMapTest` per-edge odometer assertions updated (odometer decoupled from the log/bubble edges).
- Full suite green: `JAVA_HOME=/usr/lib/jvm/java-25 ./gradlew testDebugUnitTest :domain:test`.

Field-test checklist item added (single-platform odometer: starts once, pauses at stops, session miles look right; #438 B5, Confirmed 0/2).

## Design-goal review
- **1 UDF** — reducers stay pure: the arbitration is a `diff` of region snapshots (no wall clock); recovery reconciliation is emitted at the `StateManagerV2` edge, never inside a stepper. Per-session anchoring is an effect handler at the edge.
- **3 Single responsibility** — the predicate is factored into `OdometerArbiter` rather than grown inline in `EffectMap`/`StateManagerV2`.
- **5 SSOT** — one `OdometerArbiter` predicate feeds both the diff-level Pause/Resume and the recovery reconciliation; one `metadata.odometer` definition preserved; per-session anchors replace the drifted global-reset path.
- **6 Security/privacy** — no capture/network/PII surface touched; odometer is on-device GPS totals only.
- **8 Platform-agnostic core** — the arbitration is keyed by live-session count + a `Platform`-map predicate; **zero platform literals**. Adding a platform needs no `:core:state` edits. Rule verbs can no longer command the odometer (arbiter-owned).

## Adversarial review
Pending — fable adversarial `/code-review` + `/security-review` to follow (do not merge before).

### Adversarial review

Fable adversarial reviewer ran against head `2b51ecf5`, **independently re-deriving the predicate-vs-today comparison with its own per-step instrumentation over all 8 session fixtures** (the PR had run 5). Verdict: **APPROVE-WITH-FIXES**; the flagged predicate deviation is **ACCEPTED-AS-IMPROVEMENT** — each of the 3 divergences was re-derived and confirmed a today-bug (the `two_pickup_stack` final frame is a live navigation screen with the active task lagging on the completed drop — GPS paused through the whole last leg; the `receipt_skip` waiting/offer frames match every other fixture's normal GPS-ON idle posture, today's OFF being an artifact of the un-retired task; the asymmetry — parked-ON costs a little battery, driving-OFF loses deductible miles irrecoverably — favors the predicate everywhere). Zero predicate=OFF/today=ON steps corpus-wide. **Required fix, applied in `3395410a`:** the shipped equivalence oracle applied master's Pause/Resume in the wrong order (arrival Pause before the task-change Resumes) and the fixture list omitted `teardown_ghost`/`decline_race`/`ghost_offer` — `teardown_ghost`'s mint+arrive-in-one-frame step would have FAILED the shipped test purely from the oracle artifact. The oracle now folds master's true emission order, runs the full corpus, and pins the divergences as `(fixture, step)` pairs. Everything else came back clean: Stop fires at grace **commit** never mid-grace (same `session != null` definition on both sides of the arbitration); no Pause+Stop double-emission (crossings and Pause/Resume are mutually exclusive per step); recovery reconciliation can't double-Start (no crossing on restore + handler idempotency guard, and odometer effects carry no effectKey so dedup can't swallow it); per-session anchors are write-once and independent; `metadata.odometer` raw-cumulative semantics pinned by test and untouched by anchor bookkeeping; rule-verb odometer effects retired fail-closed at dispatch (WARN, correct P7 level); `OdometerArbiter` is a pure single SSOT feeding both EffectMap and recovery (P1/P5), zero platform literals (P8). Minor deviations (public arbiter, enum retention) ACCEPTED. LOW ride-alongs recorded: anchor-key accumulation (alpha-fine), restore-all-anchors for the dual-session crash case (#528), BubbleViewModel's no-arg session-miles flow tracks last-started session (migrate with the dual-platform HUD).
