### PR TITLE
fix(#438): B6 — per-platform grace/timing seam (item 6)

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/state/TransitionPolicyTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/state/TransitionPolicyTest.kt
@@ -5,6 +5,7 @@ import cloud.trotter.dashbuddy.domain.pipeline.Observation
 import cloud.trotter.dashbuddy.domain.state.Flow
 import cloud.trotter.dashbuddy.domain.state.Mode
 import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.domain.state.TransitionKind
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -136,6 +137,6 @@ class TransitionPolicyTest {
 
     @Test
     fun `grace period defaults to 10 seconds`() {
-        assertEquals(10_000L, policy.gracePeriodMs)
+        assertEquals(10_000L, policy.gracePeriodMs(Platform.DoorDash))
     }
 }

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/di/SettingsBindModule.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/di/SettingsBindModule.kt
@@ -1,9 +1,11 @@
 package cloud.trotter.dashbuddy.core.data.di
 
 import cloud.trotter.dashbuddy.core.data.settings.PlatformPreferencesRepository
+import cloud.trotter.dashbuddy.domain.settings.GraceConfigProvider
 import cloud.trotter.dashbuddy.domain.settings.PlatformPreferences
 import dagger.Binds
 import dagger.Module
+import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
@@ -22,4 +24,19 @@ abstract class SettingsBindModule {
     abstract fun bindPlatformPreferences(
         impl: PlatformPreferencesRepository,
     ): PlatformPreferences
+
+    companion object {
+        /**
+         * The per-platform grace/timing snapshot provider (#438 item 6, vet M7).
+         * Reads [PlatformPreferences.graceConfig]`.value` synchronously — the
+         * `evidenceConfig.value` snapshot pattern — so the pure steppers and
+         * `EffectMap` never collect a Flow inside a reducer. See
+         * [GraceConfigProvider] for the pre-accepted replay-determinism tradeoff.
+         */
+        @Provides
+        @Singleton
+        fun provideGraceConfigProvider(
+            preferences: PlatformPreferences,
+        ): GraceConfigProvider = GraceConfigProvider { preferences.graceConfig.value }
+    }
 }

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/settings/PlatformPreferencesRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/settings/PlatformPreferencesRepository.kt
@@ -56,6 +56,10 @@ class PlatformPreferencesRepository @Inject constructor(
      * every platform resolves to [GraceConfig.DEFAULT] (behavior identical to the
      * former compile-time constants). When a dev-settings editor lands it swaps
      * this for a DataStore-backed flow; the read seam is already in place.
+     * CONSTRAINT: that swap MUST use `stateIn(scope, SharingStarted.Eagerly, …)`
+     * like [enabledPackages] above — the consumer is a synchronous `.value` read
+     * with NO collector, so a `WhileSubscribed` flow would freeze it at the
+     * initial empty map forever (adversarial-review INFO-3).
      */
     override val graceConfig: StateFlow<Map<Platform, GraceConfig>> =
         MutableStateFlow(emptyMap())

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/settings/PlatformPreferencesRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/settings/PlatformPreferencesRepository.kt
@@ -4,10 +4,12 @@ import android.content.Context
 import android.content.pm.PackageManager
 import cloud.trotter.dashbuddy.domain.di.ApplicationScope
 import cloud.trotter.dashbuddy.core.datastore.settings.PlatformPreferencesDataSource
+import cloud.trotter.dashbuddy.domain.settings.GraceConfig
 import cloud.trotter.dashbuddy.domain.settings.PlatformPreferences
 import cloud.trotter.dashbuddy.domain.state.Platform
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
@@ -47,6 +49,16 @@ class PlatformPreferencesRepository @Inject constructor(
             SharingStarted.Eagerly,
             enabledPlatforms.value.mapNotNull { it.packageName }.toSet(),
         )
+
+    /**
+     * Per-platform grace/timing overrides (#438 item 6). No persistence store or
+     * settings-UI writer exists yet, so this materializes to an empty map today —
+     * every platform resolves to [GraceConfig.DEFAULT] (behavior identical to the
+     * former compile-time constants). When a dev-settings editor lands it swaps
+     * this for a DataStore-backed flow; the read seam is already in place.
+     */
+    override val graceConfig: StateFlow<Map<Platform, GraceConfig>> =
+        MutableStateFlow(emptyMap())
 
     /** Check which supported platforms are installed on device. */
     fun detectInstalledPlatforms(): Set<Platform> =

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/notification/NotificationFilterTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/notification/NotificationFilterTest.kt
@@ -1,6 +1,7 @@
 package cloud.trotter.dashbuddy.core.pipeline.notification
 
 import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData
+import cloud.trotter.dashbuddy.domain.settings.GraceConfig
 import cloud.trotter.dashbuddy.domain.settings.PlatformPreferences
 import cloud.trotter.dashbuddy.domain.state.Platform
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -25,6 +26,8 @@ class NotificationFilterTest {
             get() = MutableStateFlow(
                 enabledPlatforms.value.mapNotNull { it.packageName }.toSet()
             )
+        override val graceConfig: StateFlow<Map<Platform, GraceConfig>> =
+            MutableStateFlow(emptyMap())
     }
 
     private fun raw(packageName: String) = RawNotificationData(

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -18,6 +18,8 @@ import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStartPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStartSource
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStopPayload
 import cloud.trotter.dashbuddy.domain.model.pay.displayLabel
+import cloud.trotter.dashbuddy.domain.settings.GraceConfig
+import cloud.trotter.dashbuddy.domain.settings.GraceConfigProvider
 import cloud.trotter.dashbuddy.domain.state.OfferIntent
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
 import cloud.trotter.dashbuddy.domain.pipeline.ParsedFieldsGate
@@ -56,23 +58,38 @@ import cloud.trotter.dashbuddy.domain.state.customerLabel
  * Cross-platform transitions → aggregate bookkeeping (currently none).
  */
 @Singleton
-class EffectMap @Inject constructor() {
+class EffectMap @Inject constructor(
+    /**
+     * Per-platform grace/timing snapshot (#438 item 6, vet M7). Same
+     * eagerly-materialized synchronous value provider `TransitionPolicy` takes —
+     * read once per [diff], never collected inside a reducer; defaults to code
+     * constants when unbound so `EffectMap()` in tests is behavior-identical.
+     * Replay-determinism tradeoff pre-accepted (see [GraceConfigProvider]).
+     */
+    private val graceConfig: GraceConfigProvider,
+) {
+
+    /** Test/default convenience — code-constant timing for every platform. */
+    constructor() : this(GraceConfigProvider.Defaults)
 
     companion object {
         /**
          * Safety buffer added to the platform's reported pause countdown
          * before scheduling the offline timeout. Accounts for clock skew
-         * between the parsed timestamp and the actual timer start.
+         * between the parsed timestamp and the actual timer start. Re-exported
+         * from [GraceConfig] (the SSOT) for comment/test back-compat; the live
+         * value is now per-platform via [graceConfig].
          */
-        const val PAUSE_TIMEOUT_BUFFER_MS = 1000L
+        const val PAUSE_TIMEOUT_BUFFER_MS = GraceConfig.PAUSE_TIMEOUT_BUFFER_MS
 
         /**
          * Settle delay before the EXPAND_EARNINGS tap (#425) — lets the
          * post-delivery summary finish animating so the bound chevron's
          * fingerprint still matches what gets tapped. Carried over from the
-         * former rule-declared click's `delayMs`.
+         * former rule-declared click's `delayMs`. Re-exported from [GraceConfig]
+         * (the SSOT); the live value is now per-platform via [graceConfig].
          */
-        const val EXPAND_SETTLE_MS = 500L
+        const val EXPAND_SETTLE_MS = GraceConfig.EXPAND_SETTLE_MS
 
         /**
          * #438 B3 (vet H1/L5): de-facto offer TTL when the offer rule parses no countdown (none do
@@ -535,7 +552,8 @@ class EffectMap @Inject constructor() {
                     } else {
                         val flowObs = obs as? Observation.FlowObservation
                         val pausedFields = flowObs?.parsed as? ParsedFields.PausedFields
-                        val durationMs = (pausedFields?.remainingMillis ?: 0L) + PAUSE_TIMEOUT_BUFFER_MS
+                        val durationMs = (pausedFields?.remainingMillis ?: 0L) +
+                            graceConfig.forPlatform(next.platform).pauseTimeoutBufferMs
 
                         val pausePayload = SessionPausedPayload(
                             sessionId = sessionId,
@@ -1059,7 +1077,7 @@ class EffectMap @Inject constructor() {
         if (!collapsed) return emptyList()
         return listOf(
             AppEffect.ScheduleTimeout(
-                durationMs = EXPAND_SETTLE_MS,
+                durationMs = graceConfig.forPlatform(flowObs.platform).expandSettleMs,
                 type = TimeoutType.SETTLE_UI,
                 platform = flowObs.platform.takeIf { it != Platform.Unknown },
                 payload = ObservationPayload.DeferredAction(
@@ -1093,7 +1111,7 @@ class EffectMap @Inject constructor() {
         if (!hasLiveOffer) return emptyList()
         return listOf(
             AppEffect.ScheduleTimeout(
-                durationMs = EXPAND_SETTLE_MS,
+                durationMs = graceConfig.forPlatform(flowObs.platform).expandSettleMs,
                 type = TimeoutType.SETTLE_UI,
                 platform = flowObs.platform.takeIf { it != Platform.Unknown },
                 payload = ObservationPayload.DeferredAction(

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -62,7 +62,9 @@ class EffectMap @Inject constructor(
     /**
      * Per-platform grace/timing snapshot (#438 item 6, vet M7). Same
      * eagerly-materialized synchronous value provider `TransitionPolicy` takes —
-     * read once per [diff], never collected inside a reducer; defaults to code
+     * one atomic read at each use site, never collected inside a reducer (each
+     * value is stored into state/a timer immediately, so a mid-[diff] config flip
+     * is equivalent to the edit landing between steps); defaults to code
      * constants when unbound so `EffectMap()` in tests is behavior-identical.
      * Replay-determinism tradeoff pre-accepted (see [GraceConfigProvider]).
      */

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
@@ -305,7 +305,7 @@ class PlatformRegionStepper @Inject constructor() {
                     lastObservedAt = obs.timestamp,
                     pendingModeResume = PendingModeResume(
                         since = since,
-                        deadline = since + policy.pauseResumeGraceMs,
+                        deadline = since + policy.pauseResumeGraceMs(current.platform),
                     ),
                 )
             }
@@ -388,7 +388,7 @@ class PlatformRegionStepper @Inject constructor() {
                         pendingDestructive = PendingDestructive(
                             kind = DestructiveKind.SESSION_END,
                             since = obs.timestamp,
-                            deadline = obs.timestamp + policy.gracePeriodMs,
+                            deadline = obs.timestamp + policy.gracePeriodMs(region.platform),
                         ),
                     )
                 }
@@ -508,7 +508,7 @@ class PlatformRegionStepper @Inject constructor() {
         // shows AFTER the idle/offline screen, mid-grace.
         if (obs.flow == Flow.SessionEnded && region.session != null) {
             val endFields = obs.parsed as? ParsedFields.SessionEndedFields
-            val newDeadline = obs.timestamp + policy.authoritativeGraceMs
+            val newDeadline = obs.timestamp + policy.authoritativeGraceMs(region.platform)
             val existing = region.pendingDestructive
             val pend = if (existing?.kind == DestructiveKind.SESSION_END) {
                 // Offline-grace already armed (idle/offline before summary) —
@@ -1052,7 +1052,7 @@ class PlatformRegionStepper @Inject constructor() {
         // dashing" (single-slot pending — noted on the issue).
         val postTask = region.activeTask
         if (nextFlowVal == Flow.PostTask && postTask != null) {
-            val newDeadline = obs.timestamp + policy.authoritativeGraceMs
+            val newDeadline = obs.timestamp + policy.authoritativeGraceMs(region.platform)
             val existing = region.pendingDestructive
             val pend = if (existing?.kind == DestructiveKind.TASK_RETIRE) {
                 // Already armed (idle-grace, or an earlier receipt frame) —
@@ -1089,8 +1089,8 @@ class PlatformRegionStepper @Inject constructor() {
                     pendingDestructive = PendingDestructive(
                         kind = DestructiveKind.TASK_RETIRE,
                         since = obs.timestamp,
-                        // Through the injected policy (#406): the static constant ignored overrides.
-                        deadline = obs.timestamp + policy.gracePeriodMs,
+                        // Through the injected policy (#406/#438 item 6): per-platform grace.
+                        deadline = obs.timestamp + policy.gracePeriodMs(region.platform),
                         // #596: record where the task was left FOR. A retire armed by the dasher
                         // deliberating on a mid-route add-on offer (`OfferPresented`) must NOT let
                         // T1/T2 close-out fire on the still-undelivered final drop; an idle/waiting

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/TransitionPolicy.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/TransitionPolicy.kt
@@ -1,8 +1,11 @@
 package cloud.trotter.dashbuddy.core.state
 
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.settings.GraceConfig
+import cloud.trotter.dashbuddy.domain.settings.GraceConfigProvider
 import cloud.trotter.dashbuddy.domain.state.Flow
 import cloud.trotter.dashbuddy.domain.state.Mode
+import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.domain.state.TransitionKind
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -17,10 +20,28 @@ import javax.inject.Singleton
  * - Session grace period protects sessions from brief offline blips.
  */
 @Singleton
-class TransitionPolicy @Inject constructor() {
+class TransitionPolicy @Inject constructor(
+    /**
+     * Per-platform grace/timing snapshot (#438 item 6, vet M7). Injected as an
+     * eagerly-materialized synchronous value provider — the `evidenceConfig.value`
+     * pattern — read ONCE per step-driven accessor call, never collected inside
+     * a reducer. Defaults to [GraceConfigProvider.Defaults] (code constants) when
+     * unbound, so the pure steppers and every test's `TransitionPolicy()` behave
+     * exactly as the former compile-time constants.
+     *
+     * Replay-determinism tradeoff (a grace edited between a live run and its
+     * crash replay changes replayed commit timing) is pre-accepted — see
+     * [GraceConfigProvider] / the #438 design doc §B6.
+     */
+    private val graceConfig: GraceConfigProvider,
+) {
+
+    /** Test/default convenience — code-constant timing for every platform. */
+    constructor() : this(GraceConfigProvider.Defaults)
 
     companion object {
-        const val DEFAULT_GRACE_MS = 10_000L
+        // Re-exported from [GraceConfig] (the SSOT) for existing test/comment refs.
+        const val DEFAULT_GRACE_MS = GraceConfig.DEFAULT_GRACE_MS
 
         /**
          * Short grace for destructive transitions armed by an authoritative-
@@ -28,7 +49,7 @@ class TransitionPolicy @Inject constructor() {
          * contradicting task-flow frame to land and cancel a misrecognition;
          * short enough that real session ends commit promptly.
          */
-        const val AUTHORITATIVE_GRACE_MS = 2_500L
+        const val AUTHORITATIVE_GRACE_MS = GraceConfig.AUTHORITATIVE_GRACE_MS
 
         /**
          * Grace for a screen-implied resume out of [Mode.Paused] (#605). Must
@@ -38,14 +59,20 @@ class TransitionPolicy @Inject constructor() {
          * resume's card/log lands promptly — the resume is not glance-critical,
          * so a ≤8s lag after the dasher taps Resume is acceptable.
          */
-        const val PAUSE_RESUME_GRACE_MS = 8_000L
+        const val PAUSE_RESUME_GRACE_MS = GraceConfig.PAUSE_RESUME_GRACE_MS
     }
 
-    val gracePeriodMs: Long = DEFAULT_GRACE_MS
+    /** Provisional-destructive commit grace for [platform] (#438 item 6). */
+    fun gracePeriodMs(platform: Platform): Long =
+        graceConfig.forPlatform(platform).gracePeriodMs
 
-    val authoritativeGraceMs: Long = AUTHORITATIVE_GRACE_MS
+    /** Authoritative-signal destructive grace for [platform] (#431/#438 item 6). */
+    fun authoritativeGraceMs(platform: Platform): Long =
+        graceConfig.forPlatform(platform).authoritativeGraceMs
 
-    val pauseResumeGraceMs: Long = PAUSE_RESUME_GRACE_MS
+    /** Screen-implied resume-from-Paused grace for [platform] (#605/#438 item 6). */
+    fun pauseResumeGraceMs(platform: Platform): Long =
+        graceConfig.forPlatform(platform).pauseResumeGraceMs
 
     /**
      * Determine what mode a flow + modeHint combination implies.

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/PerPlatformGraceConfigTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/PerPlatformGraceConfigTest.kt
@@ -1,0 +1,193 @@
+package cloud.trotter.dashbuddy.core.state
+
+import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
+import cloud.trotter.dashbuddy.domain.model.accessibility.BoundingBox
+import cloud.trotter.dashbuddy.domain.pipeline.NodeRef
+import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.pipeline.TimeoutType
+import cloud.trotter.dashbuddy.domain.settings.GraceConfig
+import cloud.trotter.dashbuddy.domain.settings.GraceConfigProvider
+import cloud.trotter.dashbuddy.domain.state.AppState
+import cloud.trotter.dashbuddy.domain.state.DestructiveKind
+import cloud.trotter.dashbuddy.domain.state.Flow
+import cloud.trotter.dashbuddy.domain.state.FlowRegion
+import cloud.trotter.dashbuddy.domain.state.Job
+import cloud.trotter.dashbuddy.domain.state.Mode
+import cloud.trotter.dashbuddy.domain.state.ParsedFields
+import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.domain.state.PlatformRegion
+import cloud.trotter.dashbuddy.domain.state.Regions
+import cloud.trotter.dashbuddy.domain.state.Session
+import cloud.trotter.dashbuddy.domain.state.Task
+import cloud.trotter.dashbuddy.domain.state.TaskPhase
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * #438 item 6 (B6) — the per-platform grace/timing seam. One [GraceConfig]
+ * per [Platform] behind the injected [GraceConfigProvider] snapshot; a
+ * platform absent from the override map resolves to [GraceConfig.DEFAULT]
+ * (today's code constants), so overriding ONE platform's timing must never
+ * move another platform's deadlines.
+ *
+ * Principle 8: the lookups are keyed by the REGION's / OBSERVATION's own
+ * platform through the config map — the platform literals below are test
+ * fixture data, not logic.
+ */
+class PerPlatformGraceConfigTest {
+
+    /** Every field differs from the default so a wrong-field read can't pass. */
+    private val ddOverride = GraceConfig(
+        gracePeriodMs = 5_000L,
+        authoritativeGraceMs = 1_200L,
+        pauseResumeGraceMs = 4_000L,
+        pauseTimeoutBufferMs = 2_500L,
+        expandSettleMs = 900L,
+    )
+
+    /** Overrides DoorDash only — Uber must fall back to [GraceConfig.DEFAULT]. */
+    private val provider = GraceConfigProvider { mapOf(Platform.DoorDash to ddOverride) }
+
+    private val stepper = PlatformRegionStepper()
+    private val policy = TransitionPolicy(provider)
+    private val effectMap = EffectMap(provider)
+
+    // ---- helpers ----
+
+    private fun taskRegion(platform: Platform) = PlatformRegion(
+        platform = platform,
+        mode = Mode.Online,
+        session = Session("sess-${platform.wire}", startedAt = 100L),
+        activeJob = Job("job-1", offerStoreHint = emptyList(), parentOfferHash = null, startedAt = 200L),
+        activeTask = Task(
+            taskId = "task-1", jobId = "job-1", phase = TaskPhase.PICKUP,
+            storeName = "Store", startedAt = 300L, arrivedAt = 800L,
+        ),
+    )
+
+    private fun idleObs(platform: Platform, timestamp: Long) = Observation.Screen(
+        timestamp = timestamp, captureId = null, ruleId = "${platform.wire}.screen.idle",
+        metadata = ReplayMetadata.EMPTY, flow = Flow.Idle, modeHint = Mode.Online,
+        parsed = ParsedFields.None,
+    )
+
+    private fun postTaskObs(platform: Platform, timestamp: Long) = Observation.Screen(
+        timestamp = timestamp, captureId = null, ruleId = "${platform.wire}.screen.delivery_summary",
+        metadata = ReplayMetadata.EMPTY, flow = Flow.PostTask, modeHint = Mode.Online,
+        parsed = ParsedFields.None,
+    )
+
+    /** Arm the idle-flash TASK_RETIRE grace and return the pending deadline. */
+    private fun idleGraceDeadline(platform: Platform): Long {
+        val prevFlow = FlowRegion(flow = Flow.TaskPickupArrived)
+        val obs = idleObs(platform, timestamp = 1_000L)
+        val next = stepper.step(taskRegion(platform), prevFlow, FlowRegion(flow = Flow.Idle), obs, policy)
+        assertEquals(DestructiveKind.TASK_RETIRE, next.pendingDestructive?.kind)
+        return next.pendingDestructive!!.deadline
+    }
+
+    /** Arm the PostTask authoritative TASK_RETIRE grace and return the deadline. */
+    private fun postTaskGraceDeadline(platform: Platform): Long {
+        val prevFlow = FlowRegion(flow = Flow.TaskDropoffArrived)
+        val obs = postTaskObs(platform, timestamp = 1_000L)
+        val next = stepper.step(taskRegion(platform), prevFlow, FlowRegion(flow = Flow.PostTask), obs, policy)
+        assertEquals(DestructiveKind.TASK_RETIRE, next.pendingDestructive?.kind)
+        return next.pendingDestructive!!.deadline
+    }
+
+    // ---- stepper side: pendingDestructive deadlines key per platform ----
+
+    @Test
+    fun `overridden platform's pendingDestructive deadline uses ITS gracePeriodMs`() {
+        assertEquals(1_000L + 5_000L, idleGraceDeadline(Platform.DoorDash))
+    }
+
+    @Test
+    fun `the OTHER platform's grace deadline is unaffected by the override`() {
+        assertEquals(1_000L + GraceConfig.DEFAULT_GRACE_MS, idleGraceDeadline(Platform.Uber))
+    }
+
+    @Test
+    fun `authoritative grace keys per platform the same way`() {
+        assertEquals(1_000L + 1_200L, postTaskGraceDeadline(Platform.DoorDash))
+        assertEquals(1_000L + GraceConfig.AUTHORITATIVE_GRACE_MS, postTaskGraceDeadline(Platform.Uber))
+    }
+
+    @Test
+    fun `pause-resume grace keys per platform`() {
+        // Paused region sees an online-implying (non-offer) screen → arms
+        // PendingModeResume with the platform's own pauseResumeGraceMs (#605).
+        fun resumeDeadline(platform: Platform): Long {
+            val paused = PlatformRegion(
+                platform = platform, mode = Mode.Paused,
+                session = Session("sess-1", startedAt = 100L),
+            )
+            val obs = idleObs(platform, timestamp = 2_000L).copy(flow = Flow.TaskPickupNavigation)
+            val next = stepper.step(paused, FlowRegion(flow = Flow.Idle), FlowRegion(flow = Flow.TaskPickupNavigation), obs, policy)
+            return next.pendingModeResume!!.deadline
+        }
+        assertEquals(2_000L + 4_000L, resumeDeadline(Platform.DoorDash))
+        assertEquals(2_000L + GraceConfig.PAUSE_RESUME_GRACE_MS, resumeDeadline(Platform.Uber))
+    }
+
+    @Test
+    fun `an unbound provider resolves every platform to the code-constant defaults`() {
+        val defaults = TransitionPolicy()
+        for (p in Platform.entries) {
+            assertEquals(GraceConfig.DEFAULT_GRACE_MS, defaults.gracePeriodMs(p))
+            assertEquals(GraceConfig.AUTHORITATIVE_GRACE_MS, defaults.authoritativeGraceMs(p))
+            assertEquals(GraceConfig.PAUSE_RESUME_GRACE_MS, defaults.pauseResumeGraceMs(p))
+        }
+    }
+
+    // ---- EffectMap side: pause buffer + expand settle key per platform ----
+
+    private fun pauseTimeoutDuration(platform: Platform): Long {
+        val online = PlatformRegion(
+            platform = platform, mode = Mode.Online,
+            session = Session("sess-1", startedAt = 100L),
+        )
+        val prev = AppState(regions = Regions(platforms = mapOf(platform to online)))
+        val next = AppState(regions = Regions(platforms = mapOf(platform to online.copy(mode = Mode.Paused))))
+        val obs = Observation.Screen(
+            timestamp = 1_000L, captureId = null, ruleId = "${platform.wire}.screen.paused",
+            metadata = ReplayMetadata.EMPTY, flow = null, modeHint = Mode.Paused,
+            parsed = ParsedFields.PausedFields(remainingText = "5:00", remainingMillis = 300_000L),
+        )
+        val timeout = effectMap.diff(prev, next, obs)
+            .filterIsInstance<AppEffect.ScheduleTimeout>()
+            .single { it.type == TimeoutType.SESSION_PAUSED_SAFETY }
+        return timeout.durationMs
+    }
+
+    @Test
+    fun `pause safety-timeout buffer keys per platform`() {
+        assertEquals(300_000L + 2_500L, pauseTimeoutDuration(Platform.DoorDash))
+        assertEquals(300_000L + GraceConfig.PAUSE_TIMEOUT_BUFFER_MS, pauseTimeoutDuration(Platform.Uber))
+    }
+
+    private fun expandSettleDuration(platform: Platform): Long {
+        val obs = Observation.Screen(
+            timestamp = 1_000L, captureId = null,
+            ruleId = "${platform.wire}.screen.delivery_summary_collapsed",
+            metadata = ReplayMetadata.EMPTY, flow = Flow.PostTask, modeHint = Mode.Online,
+            parsed = ParsedFields.PostTaskFields(totalPay = 25.0, isExpanded = false),
+            targets = mapOf(
+                "expandButton" to NodeRef(
+                    viewIdSuffix = "id/btn", text = null, classNameHint = null,
+                    boundsInScreen = BoundingBox(0, 0, 10, 10), pathFingerprint = "0/1",
+                ),
+            ),
+        )
+        val timeout = effectMap.diff(AppState(), AppState(), obs)
+            .filterIsInstance<AppEffect.ScheduleTimeout>()
+            .single { it.type == TimeoutType.SETTLE_UI }
+        return timeout.durationMs
+    }
+
+    @Test
+    fun `expand-settle delay keys per platform`() {
+        assertEquals(900L, expandSettleDuration(Platform.DoorDash))
+        assertEquals(GraceConfig.EXPAND_SETTLE_MS, expandSettleDuration(Platform.Uber))
+    }
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/settings/GraceConfig.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/settings/GraceConfig.kt
@@ -1,0 +1,75 @@
+package cloud.trotter.dashbuddy.domain.settings
+
+import cloud.trotter.dashbuddy.domain.state.Platform
+
+/**
+ * Per-platform grace / timing configuration (#438 item 6, Principle 8 — the
+ * per-platform timing seam). One grace-constant set used to time every
+ * platform; the values are genuinely platform-specific (e.g. [expandSettleMs]
+ * waits on DoorDash's summary-dialog animation, not a universal truth), so they
+ * are keyed by [Platform] instead of hard-coded globals.
+ *
+ * The five fields are seeded with today's compile-time constants (formerly
+ * `TransitionPolicy.DEFAULT_GRACE_MS` / `AUTHORITATIVE_GRACE_MS` /
+ * `PAUSE_RESUME_GRACE_MS` and `EffectMap.PAUSE_TIMEOUT_BUFFER_MS` /
+ * `EXPAND_SETTLE_MS`). This companion is now the SSOT for those defaults;
+ * `TransitionPolicy` / `EffectMap` re-export them only for test/comment
+ * back-compat.
+ *
+ * A platform absent from the override map resolves to [DEFAULT], so with no
+ * saved overrides every platform behaves exactly as the old constants did.
+ */
+data class GraceConfig(
+    /** Provisional-destructive commit grace (session end / task retire on idle). */
+    val gracePeriodMs: Long = DEFAULT_GRACE_MS,
+    /** Short grace for an authoritative-looking destructive signal (#431). */
+    val authoritativeGraceMs: Long = AUTHORITATIVE_GRACE_MS,
+    /** Grace for a screen-implied resume out of Paused (#605). */
+    val pauseResumeGraceMs: Long = PAUSE_RESUME_GRACE_MS,
+    /** Safety buffer added to a reported pause countdown before the offline timeout. */
+    val pauseTimeoutBufferMs: Long = PAUSE_TIMEOUT_BUFFER_MS,
+    /** Settle delay before the EXPAND_EARNINGS tap (waits on the dialog animation). */
+    val expandSettleMs: Long = EXPAND_SETTLE_MS,
+) {
+    companion object {
+        const val DEFAULT_GRACE_MS = 10_000L
+        const val AUTHORITATIVE_GRACE_MS = 2_500L
+        const val PAUSE_RESUME_GRACE_MS = 8_000L
+        const val PAUSE_TIMEOUT_BUFFER_MS = 1_000L
+        const val EXPAND_SETTLE_MS = 500L
+
+        /** Code-constant default applied to any platform without an override. */
+        val DEFAULT = GraceConfig()
+    }
+}
+
+/**
+ * Synchronous value provider for the per-platform [GraceConfig] snapshot (#438
+ * item 6, vet M7). The Hilt-bound implementation reads
+ * [PlatformPreferences.graceConfig]`.value` — the same eagerly-materialized
+ * `.value` snapshot pattern the engine already uses for `evidenceConfig` — so
+ * the pure steppers and `EffectMap` read it exactly ONCE per `step()` / `diff()`
+ * and never collect a Flow inside a reducer.
+ *
+ * REPLAY-DETERMINISM TRADEOFF (pre-accepted, #438 design doc §B6): a grace edited
+ * between a live run and its crash replay changes the replayed commit timing — a
+ * DataStore-backed value is not replay-stable the way the old compile-time
+ * constants were. Accepted for the single-user alpha (grace edits are rare dev
+ * actions and the journal replays observations, not effect timing); documented
+ * here and at every injection site so the adversarial review doesn't re-litigate
+ * it.
+ */
+fun interface GraceConfigProvider {
+
+    /** The current per-platform override snapshot. Read once per step/diff. */
+    fun snapshot(): Map<Platform, GraceConfig>
+
+    /** The config for [platform], falling back to [GraceConfig.DEFAULT]. */
+    fun forPlatform(platform: Platform): GraceConfig =
+        snapshot()[platform] ?: GraceConfig.DEFAULT
+
+    companion object {
+        /** Code-constant defaults — the test / fallback provider (no overrides). */
+        val Defaults = GraceConfigProvider { emptyMap() }
+    }
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/settings/GraceConfig.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/settings/GraceConfig.kt
@@ -48,8 +48,11 @@ data class GraceConfig(
  * item 6, vet M7). The Hilt-bound implementation reads
  * [PlatformPreferences.graceConfig]`.value` — the same eagerly-materialized
  * `.value` snapshot pattern the engine already uses for `evidenceConfig` — so
- * the pure steppers and `EffectMap` read it exactly ONCE per `step()` / `diff()`
- * and never collect a Flow inside a reducer.
+ * the pure steppers and `EffectMap` never collect a Flow inside a reducer. Each
+ * use site reads one atomic snapshot **synchronously at the moment it computes a
+ * deadline/duration**, and every value is immediately stored in state or a timer
+ * — so a config flip landing mid-step is observationally identical to the edit
+ * landing between two steps (the five fields carry no cross-field invariant).
  *
  * REPLAY-DETERMINISM TRADEOFF (pre-accepted, #438 design doc §B6): a grace edited
  * between a live run and its crash replay changes the replayed commit timing — a
@@ -61,7 +64,7 @@ data class GraceConfig(
  */
 fun interface GraceConfigProvider {
 
-    /** The current per-platform override snapshot. Read once per step/diff. */
+    /** The current per-platform override snapshot — one atomic read per use site. */
     fun snapshot(): Map<Platform, GraceConfig>
 
     /** The config for [platform], falling back to [GraceConfig.DEFAULT]. */

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/settings/PlatformPreferences.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/settings/PlatformPreferences.kt
@@ -20,4 +20,15 @@ interface PlatformPreferences {
 
     /** Package names of the enabled platforms (listener-level event filtering). */
     val enabledPackages: StateFlow<Set<String>>
+
+    /**
+     * Per-platform grace / timing overrides (#438 item 6). Materialized ONCE
+     * (#356); the timing consumers read `.value` synchronously at their step /
+     * diff via [GraceConfigProvider]. A platform absent from the map uses
+     * [GraceConfig.DEFAULT] (the code constants). No settings UI writes this yet
+     * — the seam ships ahead of the editor, so today the map is empty and every
+     * platform resolves to defaults (behavior identical to the former
+     * compile-time constants).
+     */
+    val graceConfig: StateFlow<Map<Platform, GraceConfig>>
 }


### PR DESCRIPTION
B6 — the LAST item of the #438 multiplatform correctness pack: the per-platform timing seam (item 6). Spec: [`docs/design/multiplatform-correctness-pack.md` §B6](https://github.com/sjtrotter/DashBuddy/blob/master/docs/design/multiplatform-correctness-pack.md#b6--item-6-per-platform-timing-seam).

## Summary

One grace-constant set used to time every platform — the last "global-singular resource commanded by per-platform signals" in the pack. This PR makes every grace/timing value keyed by `Platform`:

- **`GraceConfig`** (`:domain` settings, new): `gracePeriodMs` / `authoritativeGraceMs` / `pauseResumeGraceMs` / `pauseTimeoutBufferMs` / `expandSettleMs`, seeded with today's constants (10 000 / 2 500 / 8 000 / 1 000 / 500). Its companion is now the SSOT for those defaults; the old `TransitionPolicy` / `EffectMap` constants re-export it for test/comment back-compat.
- **`PlatformPreferences.graceConfig`** (#355 read interface): `StateFlow<Map<Platform, GraceConfig>>`, materialized once (#356). Today the repository serves an empty map — every platform resolves to `GraceConfig.DEFAULT`.
- **`GraceConfigProvider`** (vet M7 mechanism): an eagerly-materialized **synchronous snapshot** value provider (the `strategyRepository.evidenceConfig.value` pattern `SideEffectEngine` already uses), bound in `SettingsBindModule` as `{ preferences.graceConfig.value }`. The pure steppers and `EffectMap` stay config-**reactive**-free — the value is read at the accessor/diff, never collected inside a reducer. Tests' `TransitionPolicy()` / `EffectMap()` use an unannotated no-arg convenience constructor bound to `GraceConfigProvider.Defaults` (code constants).
- **`TransitionPolicy`** gains platform-keyed accessors — `gracePeriodMs(platform)` / `authoritativeGraceMs(platform)` / `pauseResumeGraceMs(platform)` — replacing the scalar `val`s; all 5 `PlatformRegionStepper` call sites pass the **region's own** platform.
- **`EffectMap`**'s two constants fold into the same config: the pause safety-timeout buffer keys on the pausing region's platform, the `SETTLE_UI` expand/confirm-decline settle keys on the observing screen's platform (`EXPAND_SETTLE_MS` waits on DoorDash's dialog animation — genuinely per-platform).

Mirrors the `TransitionDefaults` per-platform-override precedent. Distinct from #439 (dormant `classify()` path) and #254 (per-driver auto-tuning).

## No settings UI yet — deliberate

The **seam is the deliverable**: values come from `PlatformPreferences` with code-constant defaults, and no editor writes the store yet (the repository's flow is an empty map). A dev-settings editor can land later without touching `:core:state`.

## Replay-determinism tradeoff (pre-accepted — do not re-litigate)

A grace edited between a live run and its crash replay changes replayed commit timing — today's compile-time constants were replay-stable, a DataStore-backed value is not. **Pre-accepted in the design doc (§B6, vet M7)** for the single-user alpha: grace edits are rare dev actions, and the journal replays observations, not effect timing. Noted in code at every injection site (`GraceConfigProvider` KDoc, `TransitionPolicy` / `EffectMap` constructor KDocs, `SettingsBindModule`).

## Acceptance (spec)

- **Defaults identical:** full suite + replay fixtures green unchanged (`testDebugUnitTest` + `:domain:test`). The unbound provider resolves every platform to the code constants (asserted).
- **One-platform override isolated:** `PerPlatformGraceConfigTest` overrides every DoorDash field and asserts (a) DoorDash's `pendingDestructive` deadlines (idle-grace, authoritative PostTask) and `pendingModeResume` deadline use the override, (b) Uber's deadlines are byte-unchanged at the defaults.
- **EffectMap side keys the same way:** pause safety-timeout duration (`remainingMillis + pauseTimeoutBufferMs`) and the `SETTLE_UI` settle delay assert per-platform values with the other platform unaffected.
- **P8:** lookups keyed by `Platform` through the config map — no platform literals in logic (test fixtures only).

### Design-goal review

1. **UDF (P1):** steppers/`EffectMap` stay pure w.r.t. reactivity — the config is a synchronous snapshot read per step/diff (vet M7), never a Flow collection inside a reducer; deadlines remain driven by `obs.timestamp`.
2. **SSOT (P5):** the five timing defaults now have ONE owner (`GraceConfig`'s companion); `TransitionPolicy`/`EffectMap` constants re-export instead of duplicating. The preference is materialized once (#356 pattern) and every consumer reads the same `.value`.
3. **Single responsibility (P3):** config shape + provider live in `:domain` settings beside `PlatformPreferences` (#355 precedent); binding in `:core:data`; consumers unchanged in shape.
4. **Kotlin/Android practices (P4):** data class + `fun interface`; Hilt `@Provides`; the two-constructor split exists because Dagger rejects default args on an `@Inject` constructor (two generated ctors) — the no-arg convenience is unannotated.
5. **Security & privacy (P6):** no new input surface, network, or PII; timing values only. Fail-safe: an absent override resolves to code constants.
6. **Semantic logging (P7):** no new log sites.
7. **Platform-agnostic core (P8):** the seam is the point — per-platform timing values are keyed by `Platform` through the config map, resolved from the region's/observation's own platform. No new platform literals in `:core:state`/`:domain` logic (the DoorDash mention in `GraceConfig`/`EffectMap` KDoc is documentation of why the value is per-platform, and `PerPlatformGraceConfigTest`'s literals are fixtures).
8. **Reactive UI:** not touched (no UI surface; the future editor is out of scope).

No field-test checklist item added: with no overrides written, behavior is provably identical to master (defaults byte-identical, full suite green unchanged) — there is nothing new to observe on-dash until a settings editor exists.

Closes the #438 items 5–9 pack (B1–B6 complete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



### Adversarial review

Fable adversarial reviewer ran against head `21317106` — verdict **APPROVE, nothing merge-blocking**; both disclosed deviations ACCEPTED (the no-arg secondary constructor is the standard Hilt-invisible workaround for Dagger's one-injectable-constructor rule; the test call-site updates are forced and mechanical) and the no-field-test-item claim AGREED (the store is a hard-coded empty map — nothing observable until an editor exists, matching the design doc's own follow-ups list). Verified: defaults equivalence is compile-enforced (the old scalar constants were deleted, all re-exports alias the single `GraceConfig` SSOT — zero direct reads remain in main code, and the unbound-provider sweep pins code-constant values for every `Platform.entries`); all 8 read sites key on the correct platform (region's platform for its own lifecycle graces, pausing region for the pause buffer, observed screen for SETTLE_UI); DI direction is clean through `:domain` (no `:core:state → :core:data` edge); the backing flow is a plain `MutableStateFlow` so no `WhileSubscribed` staleness trap exists today; and a final B1–B5 coherence pass found no re-coupling (offer lifecycle, actuation identity, OdometerArbiter, replay harness all untouched and green). Polish applied in `1bcc5919`: the provider/EffectMap KDocs now say what the code does (one atomic read per use site — a mid-step config flip is equivalent to the edit landing between steps; the five fields carry no cross-field invariant), and the repository KDoc pins the future DataStore swap to `SharingStarted.Eagerly` (a `WhileSubscribed` flow would freeze the collector-less `.value` read forever). Recorded, not fixed: three override-test blind-spot sites (verified correct by inspection), and `OFFER_EXPIRY_DEFAULT_MS` as a natural future `GraceConfig` field if it ever needs tuning.
