### PR TITLE
cleanup(#439): dead vocabulary cull — verified against current master

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/replay/ClassifyGateCaptureFuzzTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/replay/ClassifyGateCaptureFuzzTest.kt
@@ -123,7 +123,7 @@ class ClassifyGateCaptureFuzzTest {
     private fun event(tree: UiNode) = PipelineEvent.Screen(
         timestamp = 1_000L,
         tree = tree,
-        snapshot = TreeSnapshot(tree, packageName = pkg, source = TreeSnapshot.Source.STATE_CHANGED),
+        snapshot = TreeSnapshot(tree, packageName = pkg),
         packageName = pkg,
     )
 

--- a/app/src/test/java/cloud/trotter/dashbuddy/test/util/SessionReplay.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/test/util/SessionReplay.kt
@@ -108,7 +108,7 @@ object SessionReplay {
             val event = PipelineEvent.Screen(
                 timestamp = frame.capturedAtMs,
                 tree = frame.node,
-                snapshot = TreeSnapshot(frame.node, TreeSnapshot.Source.WINDOWS_CHANGED, packageName = pkg),
+                snapshot = TreeSnapshot(frame.node, packageName = pkg),
                 packageName = pkg,
             )
             classifier.classify(event).copy(timestamp = frame.capturedAtMs)
@@ -267,7 +267,7 @@ object SessionReplay {
                         PipelineEvent.Screen(
                             timestamp = f.capturedAtMs,
                             tree = f.node,
-                            snapshot = TreeSnapshot(f.node, TreeSnapshot.Source.WINDOWS_CHANGED, packageName = pkg),
+                            snapshot = TreeSnapshot(f.node, packageName = pkg),
                             packageName = pkg,
                         ),
                     ).copy(timestamp = f.capturedAtMs)

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/TreeSnapshot.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/TreeSnapshot.kt
@@ -4,24 +4,14 @@ import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
 
 /**
  * A captured UI tree annotated with pipeline metadata.
- *
- * Carries the source sub-pipe and the accumulated [contentChangeTypes] bitmask
- * from [android.view.accessibility.AccessibilityEvent.getContentChangeTypes].
- * This lets downstream stages (dedup, classification, capture) make smarter
- * decisions about whether a tree snapshot represents a meaningful change.
  */
 data class TreeSnapshot(
     val tree: UiNode,
-    val source: Source,
-    /** OR-accumulated bitmask of AccessibilityEvent content change type flags. */
-    val contentChangeTypes: Int = 0,
     /** Package name of the app that triggered this snapshot. */
     val packageName: String? = null,
     /** Window metadata when captured via WINDOWS_CHANGED (multi-window enumeration). */
     val windowContext: WindowContext? = null,
 ) {
-    enum class Source { CONTENT_CHANGED, STATE_CHANGED, WINDOWS_CHANGED }
-
     data class WindowContext(
         val windowId: Int,
         /** TYPE_APPLICATION=1, TYPE_INPUT_METHOD=2, TYPE_SYSTEM=3, TYPE_ACCESSIBILITY_OVERLAY=4 */

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/event/type/window/content_changed/ContentChangedPipeline.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/event/type/window/content_changed/ContentChangedPipeline.kt
@@ -34,7 +34,9 @@ class ContentChangedPipeline @Inject constructor(
             Timber.d("💧 DRIP: triggered by %s, accumulated types=0x%02x", it.className, pendingChangeTypes.get())
         }
         .mapNotNull { event ->
-            val types = pendingChangeTypes.getAndSet(0)
+            // Reset for the next debounce window; the accumulated bitmask itself is
+            // logged above (#439 — TreeSnapshot no longer carries it, never consumed).
+            pendingChangeTypes.set(0)
             val snapshot = source.getCurrentRootSnapshot() ?: return@mapNotNull null
             // Attribute to the window actually on screen, not the triggering event. Drop snapshots
             // of non-target windows (our own bubble overlay, launcher, etc.) so we never recognize
@@ -51,8 +53,6 @@ class ContentChangedPipeline @Inject constructor(
             }
             TreeSnapshot(
                 tree = snapshot.tree,
-                source = TreeSnapshot.Source.CONTENT_CHANGED,
-                contentChangeTypes = types,
                 packageName = snapshot.packageName,
             )
         }

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/event/type/window/state_changed/StateChangedPipeline.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/event/type/window/state_changed/StateChangedPipeline.kt
@@ -32,8 +32,6 @@ class StateChangedPipeline @Inject constructor(
             }
             TreeSnapshot(
                 tree = snapshot.tree,
-                source = TreeSnapshot.Source.STATE_CHANGED,
-                contentChangeTypes = event.contentChangeTypes,
                 packageName = snapshot.packageName,
             )
         }

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/event/type/window/windows_changed/WindowsChangedPipeline.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/event/type/window/windows_changed/WindowsChangedPipeline.kt
@@ -71,7 +71,6 @@ class WindowsChangedPipeline @Inject constructor(
 
                     TreeSnapshot(
                         tree = tree,
-                        source = TreeSnapshot.Source.WINDOWS_CHANGED,
                         packageName = pkg,
                         windowContext = TreeSnapshot.WindowContext(
                             windowId = w.id,

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureRedactionTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureRedactionTest.kt
@@ -62,7 +62,6 @@ class CaptureRedactionTest {
         snapshot = TreeSnapshot(
             tree = tree,
             packageName = "com.doordash.driverapp",
-            source = TreeSnapshot.Source.STATE_CHANGED,
         ),
         packageName = "com.doordash.driverapp",
     )

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureScrubTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/CaptureScrubTest.kt
@@ -37,7 +37,6 @@ class CaptureScrubTest {
         snapshot = TreeSnapshot(
             tree = tree,
             packageName = "com.doordash.driverapp",
-            source = TreeSnapshot.Source.STATE_CHANGED,
         ),
         packageName = "com.doordash.driverapp",
     )

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/StateManagerV2.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/StateManagerV2.kt
@@ -96,10 +96,10 @@ class StateManagerV2 @Inject constructor(
 
         val transition = stateMachine.step(currentState, obs)
 
-        // Update state
-        if (transition.newState != currentState) {
-            _state.value = transition.newState
-        }
+        // Update state. `correlationVersion` increments unconditionally in
+        // StateMachine.step (#439) — newState is NEVER structurally equal to
+        // currentState, so the old `!=` guard here was always true; removed.
+        _state.value = transition.newState
 
         // Persist observation to the append-only log (ordered single writer, #352)
         journal.append(obs, transition.newState)

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/Session.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/Session.kt
@@ -12,6 +12,5 @@ data class Session(
     val startedAt: Long,
     val earningMode: SessionType? = null,
     val runningEarnings: Double = 0.0,
-    val runningMiles: Double = 0.0,
     val accumulatedDeliveryPay: Double = 0.0,
 )


### PR DESCRIPTION
Closes part of #439 — dead vocabulary / dormant-machinery cull.

The issue was filed 2026-06-11 and is **partially stale**: a prior commit
(747d2ec3, merged via PR #488) already handled items 1, 2, and half of item 5.
This PR re-verifies every item against **current master** (post-#438 B-series)
and handles the remainder.

### Per-item verdict

| # | Item | Verdict | Evidence |
|---|---|---|---|
| 1 | `TimeoutType.RETRY_CLICK`/`DECLINE_POPUP_WAIT`/`SCREENSHOT_WAIT` + `TimeoutEvent.type` default | **Already done** (PR #488) | `grep` for the three enum values across the tree returns nothing; `TimeoutEvent.type` has no default today (`domain/.../TimeoutEvent.kt:11`, comment already cites #439). `OFFER_EXPIRY` (added by #438 B3) is untouched — confirmed still present and live. |
| 2 | `AppEffect.PlayNotificationSound` / `AppEffect.SequentialEffect` | **Already done** (PR #488) | `grep` for both names across the tree returns nothing — types and their `SideEffectEngine` arms are gone. |
| 3 | `TransitionPolicy` Expected/Unexpected dormant classification | **Kept — dormant but live machinery, not dead code** | `grep -r "outcomes" matchers/rules/` returns **zero** hits — no rule declares `outcomes`, so `TransitionPolicy.classify()`'s `prevOutcomes == null` branch (`core/state/.../TransitionPolicy.kt:118`) always short-circuits to `Expected` before the `Unexpected` branch can fire. However this is fully wired, not vestigial: the rule schema/compiler/`ObservationClassifier` populate `expectedOutcomes` end-to-end, `PlatformRegionStepper.kt:315-316` passes it into `classify()`, and `EffectMap.kt:503` reads `lastTransitionKind == TransitionKind.Unexpected` to pick `SessionStartSource.RECOVERY` vs `INTERACTION`. Deleting it means ripping rule-schema support for a documented, data-gated feature across `RuleCompiler`/`CompiledRules`/`Ruleset`/`docs/rules.schema.json` — a bigger, riskier change than a vocabulary cull, and CLAUDE.md's guidance for this exact item ("be conservative — when in doubt, keep and report") says keep. Filed as-is; a future PR should either author a rule with `outcomes` or make the call to strip the machinery deliberately. |
| 4a | `Session.runningMiles` never written | **Deleted** | Only the field declaration existed; no writer/reader anywhere in the tree, no test referenced it by name (all call sites use named-arg construction, so removal is source-compatible). |
| 4b | `Job.tasks` never populated | **Stale — skipped** | #526/#699 landed since the issue was filed: `Job.tasks` is now actively populated (pickup/dropoff placeholders) and read throughout `PlatformRegionStepper`, `JobAcceptFlow`, `EffectMap`, `StoreChainProjection`, `OfferPayFallback`. Fully alive. |
| 4c | `PendingOffer.returnFlow` "only in log payloads" | **Kept — log-payload consumer counts as live** | `OfferLifecycle.kt:111` stamps it from `lastActedFlow`; `EffectMap.offerPayload()` (`EffectMap.kt:1276`) reads it into `OfferPayload.returnFlow`, which is an `app_events` log payload (event-sourcing fidelity — per the task's explicit guidance, this is a live consumer, not dead data). |
| 4d | `CrossPlatformRegion.totalsToday/ThisWeek/Lifetime` never computed | **Already done** (#314) | `CrossPlatformRegion.kt:14` documents the fields were deleted with #314 PR3; `PeriodTotals` moved to the `:domain:analytics` read-model and is populated by `AnalyticsRepository`. Nothing left to cull. |
| 5a | `TreeSnapshot.contentChangeTypes` + `TreeSnapshot.Source` produced, never consumed | **Deleted** | All three sub-pipelines (`ContentChangedPipeline`, `StateChangedPipeline`, `WindowsChangedPipeline`) constructed both fields, but `CaptureWriter` (the only downstream reader of `PipelineEvent.Screen.snapshot`) only ever reads `.windowContext` — confirmed by grep, no site reads `.source` or `.contentChangeTypes` off a `TreeSnapshot`. Removed both from the data class; producers updated (the OR-accumulated bitmask + its `Timber.d`/`Timber.v` debug trace in `ContentChangedPipeline`/`StateChangedPipeline` stay — that's a legitimate local debug log, unrelated to the removed model field); test fixtures (`CaptureRedactionTest`, `CaptureScrubTest`, `ClassifyGateCaptureFuzzTest`, `SessionReplay`) updated to match the new 2-field/no-`source` shape. |
| 5b | `AccessibilityListener.instance` companion | **Already done** (PR #488) | `grep` for `AccessibilityListener.instance` / `_instance` returns nothing. |
| 6 | `StateManagerV2`'s dead `newState != currentState` guard | **Deleted** | `StateMachine.step()` unconditionally sets `correlationVersion = prev.correlationVersion + 1` on every call (`StateMachine.kt:49`) and `AppState` is a plain `data class` — so the generated `equals()` always differs and the guard's `false` branch was unreachable. Replaced with an unconditional assignment + a comment explaining why. |

### Design-goal review

- **P3 (single responsibility / no oversized files)** — no file grew; several got smaller (`TreeSnapshot.kt` dropped an inert enum + field, `Session.kt` dropped an inert field, `StateManagerV2.kt` dropped a dead branch).
- **P5 (SSOT)** — this PR *removes* stale/duplicate vocabulary rather than adding any; nothing is now derived from two places. The one live-but-dormant item (#3, `TransitionPolicy` outcomes) remains the single source for expected/unexpected classification — no second copy was introduced.
- **P4 (Kotlin/Android practices)** — deletions keep named-argument construction idiomatic; no behavior change, confirmed by full green test run (see below).
- **P8 (platform-agnostic core)** — none of the touched code is platform-specific; no new platform literals introduced.

No UDF/Reactive-UI/security-relevant surface was touched (no new I/O, no rule/capture changes beyond dropping two unread fields from an internal pipeline DTO), so those principles don't apply to this diff.

### Test results

- `:domain:test`, `:core:state:testDebugUnitTest`, `:core:pipeline:testDebugUnitTest` — green (targeted, run first).
- `:app:compileDebugUnitTestKotlin` — green (sanity-checked before the full run since I edited `:app` test fixtures).
- Full `./gradlew testDebugUnitTest :domain:test` — **BUILD SUCCESSFUL**, all modules, run once at the end.

No behavior change; this is a pure dead-code/dead-field removal + one comment/log tidy.



### Adversarial review

Fable adversarial reviewer ran against head `cbc28cf7` — verdict **APPROVE, zero findings**. Every per-item verdict independently confirmed: the deleted items are dead by direct evidence (`runningMiles` had zero readers/writers and old snapshots decode via `ignoreUnknownKeys` with the always-default value; `TreeSnapshot` never reaches disk so no capture/fixture is invalidated; the `StateManagerV2` guard was dead by two independent mechanisms — unconditional `correlationVersion` increment AND `MutableStateFlow`'s own equality conflation). The kept items' reasoning verified accurate — the dormant `TransitionPolicy` classification is genuinely wired (incl. a second live consumer the PR body didn't claim: `healActiveLifecycle` gating), and `returnFlow` feeds a live `app_events` payload. The Pledge-adjacent test edits remove only the deleted constructor arg — zero assertions weakened, verified line-by-line. Full suite green in an isolated worktree; CI green on head. Reviewer recommendation adopted: #439 closes with this PR; the one remaining item (activate-or-strip the outcomes classification) is a design decision, filed as its own issue.
