### PR TITLE
cleanup(#692): P7 log residuals — per-type timer levels, EIA WARN fold, tag sweep

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
@@ -129,7 +129,7 @@ class SideEffectEngine @Inject constructor(
      * uncaught failure must never reach the default handler and kill the process (#341).
      */
     private val effectExceptionHandler = CoroutineExceptionHandler { _, t ->
-        Timber.e(t, "SideEffectEngine: effect coroutine crashed (isolated)")
+        Timber.tag("Effects").e(t, "SideEffectEngine: effect coroutine crashed (isolated)")
     }
 
     /**
@@ -164,7 +164,7 @@ class SideEffectEngine @Inject constructor(
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Exception) {
-                    Timber.e(e, "Effect failed (isolated): %s", item.effect::class.simpleName)
+                    Timber.tag("Effects").e(e, "Effect failed (isolated): %s", item.effect::class.simpleName)
                 }
             }
         }
@@ -182,13 +182,13 @@ class SideEffectEngine @Inject constructor(
         // window (matching the snapshot horizon recovery replays over).
         val key = effect.effectKey
         if (key != null && effectsFiredDao.hasBeenFired(key)) {
-            Timber.d("Skipping already-fired effect: %s", key)
+            Timber.tag("Effects").d("Skipping already-fired effect: %s", key)
             return
         }
 
         // Suppress external effects during recovery
         if (recovering && isExternalEffect(effect)) {
-            Timber.d("Suppressing external effect during recovery: %s", effect::class.simpleName)
+            Timber.tag("Effects").d("Suppressing external effect during recovery: %s", effect::class.simpleName)
             return
         }
         when (effect) {
@@ -228,20 +228,20 @@ class SideEffectEngine @Inject constructor(
                     // .i not .v (#457): a throttled USER offer tap would otherwise be
                     // invisible under release log filtering — one of the silent drop
                     // points a shade Accept/Decline could die at.
-                    Timber.i(
+                    Timber.tag("Effects").i(
                         "Throttled action %s (%s) — within %dms of the last fire",
                         throttleKey, effect.trigger, RULE_ACTION_THROTTLE_MS,
                     )
                     return
                 }
                 if (!permissionTierChecker.isGranted(PermissionTier.ACCESSIBILITY)) {
-                    Timber.w("Denied %s — ACCESSIBILITY tier not granted (fail closed)", effect.action.wire)
+                    Timber.tag("Effects").w("Denied %s — ACCESSIBILITY tier not granted (fail closed)", effect.action.wire)
                     return
                 }
                 if (effect.trigger == ActionTrigger.AUTOMATION &&
                     !capabilityGrants.isActionGranted(effect.sourceRuleId, effect.action)
                 ) {
-                    Timber.w(
+                    Timber.tag("Effects").w(
                         "Denied %s — no granted capability for rule '%s' (fail closed)",
                         effect.action.wire, effect.sourceRuleId,
                     )
@@ -254,11 +254,11 @@ class SideEffectEngine @Inject constructor(
                 if (effect.action == RuleAction.CONFIRM_DECLINE &&
                     !strategyRepository.automationConfig.first().quickDeclinesEnabled
                 ) {
-                    Timber.i("Skipped %s — quick declines off (dasher confirms manually)", effect.action.wire)
+                    Timber.tag("Effects").i("Skipped %s — quick declines off (dasher confirms manually)", effect.action.wire)
                     return
                 }
                 stampThrottle(throttleKey, now)
-                Timber.i("Performing %s on %s", effect.action.wire, effect.platform.wire)
+                Timber.tag("Effects").i("Performing %s on %s", effect.action.wire, effect.platform.wire)
                 // #602: performVerifiedClick is suspend because it bounded-retries a
                 // transient "no live windows" read (a SystemUI shade/lock takeover
                 // between a notification tap and the re-resolve). We're already inside
@@ -281,7 +281,7 @@ class SideEffectEngine @Inject constructor(
                 // at completion so the 1000ms spacing anchors to the actual dispatch.
                 stampThrottle(throttleKey, System.currentTimeMillis())
                 if (!clicked) {
-                    Timber.w(
+                    Timber.tag("Effects").w(
                         "%s did not fire — target failed resolution/verification (fail closed, user acts manually)",
                         effect.action.wire,
                     )
@@ -294,7 +294,7 @@ class SideEffectEngine @Inject constructor(
                 val throttle = effect.effect.throttleMs ?: DEFAULT_ACTION_THROTTLE_MS
                 val lastFired = actionLastFiredAt[effectKey] ?: 0L
                 if (lastFired + throttle > now) {
-                    Timber.v("Throttled effect: %s", effectKey)
+                    Timber.tag("Effects").v("Throttled effect: %s", effectKey)
                     return
                 }
                 stampThrottle(effectKey, now)
@@ -445,7 +445,7 @@ class SideEffectEngine @Inject constructor(
      */
     private suspend fun dispatchRuleEffect(e: RequestedEffect): Boolean {
         if (!permissionTierChecker.isGranted(e.verb.tier)) {
-            Timber.w("Denied effect %s — permission tier %s not granted", e.verb, e.verb.tier)
+            Timber.tag("Effects").w("Denied effect %s — permission tier %s not granted", e.verb, e.verb.tier)
             return false
         }
         when (e.verb) {
@@ -456,7 +456,7 @@ class SideEffectEngine @Inject constructor(
             // Deliberate no-ops (#359): offer evaluation + speech fire from
             // EffectMap's eval-landing diff, never from rule verbs.
             EffectVerb.EVALUATE_OFFER, EffectVerb.SPEAK ->
-                Timber.d("Rule verb %s is EffectMap-driven — no-op at the engine", e.verb)
+                Timber.tag("Effects").d("Rule verb %s is EffectMap-driven — no-op at the engine", e.verb)
 
             // --- Lifecycle verbs ---
             EffectVerb.SESSION_START -> sessionStartFromArgs(e.args)
@@ -467,7 +467,7 @@ class SideEffectEngine @Inject constructor(
             // bypassing the arbiter). No shipped rule declares these; the branches are inert no-ops.
             EffectVerb.ODOMETER_START, EffectVerb.ODOMETER_STOP,
             EffectVerb.ODOMETER_PAUSE, EffectVerb.ODOMETER_RESUME ->
-                Timber.w("Rule verb %s is retired — the odometer is cross-platform arbitrated (#438 B5)", e.verb)
+                Timber.tag("Effects").w("Rule verb %s is retired — the odometer is cross-platform arbitrated (#438 B5)", e.verb)
             EffectVerb.SCHEDULE_TIMEOUT -> scheduleTimeoutFromArgs(
                 e.args,
                 Platform.fromRuleId(e.ruleId).takeIf { it != Platform.Unknown },
@@ -505,7 +505,7 @@ class SideEffectEngine @Inject constructor(
     private fun captureEvidence(effect: AppEffect.CaptureScreenshot): Boolean {
         val config = strategyRepository.evidenceConfig.value
         if (!config.allows(effect.category)) {
-            Timber.i(
+            Timber.tag("Effects").i(
                 "Evidence capture suppressed (%s, category=%s) — EvidenceConfig denies it",
                 effect.filenamePrefix, effect.category,
             )
@@ -566,7 +566,7 @@ class SideEffectEngine @Inject constructor(
         val type = try {
             TimeoutType.valueOf(typeWire)
         } catch (_: IllegalArgumentException) {
-            Timber.w("Unknown timeout type: %s", typeWire)
+            Timber.tag("Effects").w("Unknown timeout type: %s", typeWire)
             return
         }
         val durationMs = args["durationMs"]?.toLongOrNull() ?: return
@@ -594,7 +594,28 @@ class SideEffectEngine @Inject constructor(
         activeTimers[key]?.cancel()
         val job = engineScope.launch(start = CoroutineStart.LAZY) {
             delay(durationMs)
-            Timber.w("Timer Expired: %s", type)
+            // #692 P7: level is per-type, not one blanket WARN under the catch-all `App` tag.
+            // GRACE_COMMIT/MODE_RESUME_COMMIT/SESSION_PAUSED_SAFETY are all "a grace timer waking
+            // a commit" verbatim — the taxonomy's defended-invariant WARN bucket (a graced
+            // destructive commit, a graced mode resume, and the paused-too-long safety net all
+            // fire because an expected screen-driven transition never showed up). SETTLE_UI and
+            // OFFER_EXPIRY are routine steps of their OWN normal lifecycle, not invariants firing:
+            // SETTLE_UI expired ~8x in one field dash as its ordinary debounce-settle path, and
+            // OFFER_EXPIRY's common case is an offer overlay vanishing without a confirming frame
+            // (expected — most offers resolve via an explicit screen/click well before this
+            // fallback fires). The accept-latched no-op branch (a defended invariant in its own
+            // right) lives downstream in OfferLifecycle/EffectMap and isn't distinguishable at
+            // this call site, so it isn't logged here.
+            when (type) {
+                TimeoutType.GRACE_COMMIT,
+                TimeoutType.MODE_RESUME_COMMIT,
+                TimeoutType.SESSION_PAUSED_SAFETY,
+                -> Timber.tag("Effects").w("Timer Expired: %s", type)
+
+                TimeoutType.SETTLE_UI,
+                TimeoutType.OFFER_EXPIRY,
+                -> Timber.tag("Effects").d("Timer Expired: %s", type)
+            }
             _events.emit(
                 TimeoutEvent(
                     timestamp = System.currentTimeMillis(),
@@ -614,7 +635,7 @@ class SideEffectEngine @Inject constructor(
         val type = try {
             TimeoutType.valueOf(typeWire)
         } catch (_: IllegalArgumentException) {
-            Timber.w("Unknown timeout type: %s", typeWire)
+            Timber.tag("Effects").w("Unknown timeout type: %s", typeWire)
             return
         }
         // Untracking happens via the job's self-removing completion handler.

--- a/app/src/main/java/cloud/trotter/dashbuddy/worker/DailyGasPriceWorker.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/worker/DailyGasPriceWorker.kt
@@ -24,14 +24,14 @@ class DailyGasPriceWorker @AssistedInject constructor(
 ) : CoroutineWorker(appContext, workerParams) {
 
     override suspend fun doWork(): Result {
-        Timber.i("Waking up to run DailyGasPriceWorker...")
+        Timber.tag("Network").i("Waking up to run DailyGasPriceWorker...")
 
         return try {
             // 1. Check if the user actually wants us to auto-update.
             // Using .first() grabs the current snapshot of the Flow.
             val isAuto = appPreferencesRepository.isGasPriceAuto.first()
             if (!isAuto) {
-                Timber.i("Auto gas price is disabled in Settings. Going back to sleep.")
+                Timber.tag("Network").i("Auto gas price is disabled in Settings. Going back to sleep.")
                 return Result.success() // Tell Android the job is "done"
             }
 
@@ -39,20 +39,31 @@ class DailyGasPriceWorker @AssistedInject constructor(
             val fuelType = appPreferencesRepository.fuelType.first()
 
             // 3. Hit the EIA API and save it to DataStore
-            Timber.i("Fetching latest gas price for ${fuelType.name}...")
+            Timber.tag("Network").i("Fetching latest gas price for ${fuelType.name}...")
             val result = gasPriceRepository.fetchAndSaveCurrentGasPrice(fuelType)
 
             // 4. Report back to the Android OS
             if (result.isSuccess) {
-                Timber.i("Successfully updated gas prices in background.")
+                Timber.tag("Network").i("Successfully updated gas prices in background.")
                 Result.success()
             } else {
-                Timber.w("Failed to fetch gas prices. WorkManager will retry later.")
+                // #692 P7: ONE WARN line for this failure now (folded with the ERROR that used to
+                // fire inside EiaFuelPrice for the same event) — carries the underlying reason so
+                // folding the two lines loses no diagnostic value. A WorkManager-retried network
+                // fetch is not lost data / a crashed subsystem (it succeeded yesterday and
+                // self-heals), so WARN — not ERROR — is the right level. (#348: exceptionOrNull's
+                // message never contains the api_key — it's either our own "empty/invalid data" /
+                // "location not available" text or the underlying network exception's message, none
+                // of which echo the request's query params.)
+                Timber.tag("Network").w(
+                    "Failed to fetch gas prices (%s) — WorkManager will retry later.",
+                    result.exceptionOrNull()?.message ?: "unknown reason",
+                )
                 Result.retry() // Tells Android to try again during the next maintenance window
             }
 
         } catch (e: Exception) {
-            Timber.e(e, "Fatal error executing DailyGasPriceWorker")
+            Timber.tag("Network").e(e, "Fatal error executing DailyGasPriceWorker")
             Result.failure() // Hard fail, don't retry until the next 24-hour cycle
         }
     }

--- a/core/network/src/main/java/cloud/trotter/dashbuddy/core/network/fuel/price/eia/EiaFuelPrice.kt
+++ b/core/network/src/main/java/cloud/trotter/dashbuddy/core/network/fuel/price/eia/EiaFuelPrice.kt
@@ -26,7 +26,7 @@ class EiaFuelPrice @Inject constructor(
             }
             val regionCode = getRegionCode(userLocation)
 
-            Timber.i("Fetching Gas Price for ${fuelType.name} in region: $regionCode")
+            Timber.tag("Network").i("Fetching Gas Price for ${fuelType.name} in region: $regionCode")
 
             val seriesId = buildSeriesId(fuelType, regionCode)
 
@@ -34,13 +34,21 @@ class EiaFuelPrice @Inject constructor(
             val latestPrice = response.response.data.firstOrNull()?.value
 
             if (latestPrice != null && latestPrice > 0f) {
-                Timber.i("Successfully fetched EIA gas price: $$latestPrice")
+                Timber.tag("Network").i("Successfully fetched EIA gas price: $$latestPrice")
                 Result.success(latestPrice)
             } else {
                 Result.failure(Exception("EIA API returned empty or invalid data"))
             }
         } catch (e: Exception) {
-            Timber.e(e, "Failed to fetch from EIA API")
+            // #692 P7: this used to be its own ERROR line, double-reporting with the WorkManager
+            // caller's WARN ("Failed to fetch gas prices... will retry later") for the exact same
+            // failure. A WorkManager-retried fetch is neither lost data nor a crashed subsystem, so
+            // there is exactly ONE shareable line for this failure now — the caller's WARN, which
+            // carries this exception's message. This site keeps the full exception + stack trace on
+            // the DEBUG firehose only, for on-device diagnosis. (#348: no secret is logged here —
+            // the api_key never appears in an exception message; HTTP client secret redaction is
+            // separately enforced in NetworkClientFactory.)
+            Timber.tag("Network").d(e, "Failed to fetch from EIA API")
             Result.failure(e)
         }
     }
@@ -70,7 +78,7 @@ class EiaFuelPrice @Inject constructor(
         return if (!stateName.isNullOrEmpty()) {
             mapStateToPaddRegion(stateName)
         } else {
-            Timber.w("State not specified in UserLocation, falling back to National Average.")
+            Timber.tag("Network").w("State not specified in UserLocation, falling back to National Average.")
             "NUS"
         }
     }
@@ -101,7 +109,7 @@ class EiaFuelPrice @Inject constructor(
             "WASHINGTON", "OREGON", "CALIFORNIA", "NEVADA", "ARIZONA", "ALASKA", "HAWAII" -> "R50"
 
             else -> {
-                Timber.w("Unrecognized state ($stateName), falling back to National Average.")
+                Timber.tag("Network").w("Unrecognized state ($stateName), falling back to National Average.")
                 "NUS"
             }
         }

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/OfferLifecycle.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/OfferLifecycle.kt
@@ -210,7 +210,16 @@ private fun PlatformRegionStepper.expireOffer(
 ): PlatformRegion {
     val hash = (obs.payload as? ObservationPayload.OfferExpiry)?.offerHash ?: return region
     val target = region.pendingOffers.firstOrNull { it.offerHash == hash } ?: return region
-    if (target.acceptedAt != null || target.isAcceptLatched()) return region
+    if (target.acceptedAt != null || target.isAcceptLatched()) {
+        // Defended invariant (Principle 7 WARN; #692 review F1): a phantom timeout was suppressed
+        // on an ACCEPTED offer — firing it would have logged a false OFFER_TIMEOUT and destroyed
+        // the mint (the #526 regression class). Hash only, no PII.
+        Timber.tag("StateMachine").w(
+            "OFFER_EXPIRY no-op (#438 B3): offer %s is accept-latched/accepted — phantom timeout suppressed",
+            hash,
+        )
+        return region
+    }
     return region.copy(pendingOffers = region.pendingOffers.filterNot {
         it.offerHash == hash && it.acceptedAt == null
     })


### PR DESCRIPTION
Closes #692.

## What changed

**1. `SideEffectEngine.scheduleTimer`'s `"Timer Expired: %s"` — was a blanket WARN under the catch-all `App` tag, now per-type under `Timber.tag("Effects")`:**

| `TimeoutType` | Level | Rationale |
|---|---|---|
| `GRACE_COMMIT` | WARN | Wakes the state machine when a `pendingDestructive` grace deadline lapses (#431) — a screen-driven commit that was *expected* to arrive never did, so the timer fires the commit itself. This is "a grace timer waking a commit" verbatim — the taxonomy's WARN defended-invariant bucket. |
| `MODE_RESUME_COMMIT` | WARN | Same class as `GRACE_COMMIT` (#605) — wakes a graced screen-implied Paused→Online resume. Kept as a separate enum value from `GRACE_COMMIT` for correctness reasons unrelated to logging (see the type's kdoc), but the log-level rationale is identical. |
| `SESSION_PAUSED_SAFETY` | WARN | The paused-too-long safety net (`PlatformRegionStepper.handleTimeout`) forces Paused→Offline when no resume showed up in time — functionally the same "grace timer waking a[n expected mode] commit" pattern as the two above. |
| `SETTLE_UI` | DEBUG | A routine debounce-settle step in its own normal lifecycle, not an invariant firing — the issue's field-log receipt shows it expiring ~8×/dash as expected behavior. |
| `OFFER_EXPIRY` | DEBUG | The common case is an offer overlay vanishing without a confirming frame — expected, since most offers resolve via an explicit screen/click well before this fallback timer fires (#438 B3). The accept-latched no-op branch *is* a defended invariant, but it's decided downstream in `OfferLifecycle`/`EffectMap`, not distinguishable at this call site, so it isn't specially logged here (documented in-code). |

**2. EIA fetch double-report folded into one WARN.** `EiaFuelPrice.getFuelPrice`'s catch block used to log its own `Timber.e(e, "Failed to fetch from EIA API")` — an ERROR, untagged — for the exact same failure that `DailyGasPriceWorker.doWork` then logged again as `Timber.w("Failed to fetch gas prices. WorkManager will retry later.")`. A WorkManager-retried network fetch is not lost data or a crashed subsystem (it succeeded the previous morning and self-heals), so:
   - `EiaFuelPrice` now logs the full exception + stack trace at **DEBUG** (firehose-only diagnostic detail), tagged `Network`.
   - `DailyGasPriceWorker` now logs the **single** shareable **WARN**, tagged `Network`, and includes the underlying reason: `"Failed to fetch gas prices (%s) — WorkManager will retry later."` with `result.exceptionOrNull()?.message`.
   - The genuine crash path (`catch (e: Exception)` around the whole `doWork` body, which hard-fails without retry) stays **ERROR** — that one really is a lost cycle.

**3. Tag sweep on the touched files.** Every remaining untagged `Timber.<level>` call in `SideEffectEngine.kt`, `EiaFuelPrice.kt`, and `DailyGasPriceWorker.kt` now carries its component's stable tag (`Effects` for the engine — matching the tag already used at the `logFromArgs` rule-LOG site; `Network` for the two EIA/gas-price files — no prior convention existed for this concern, so `Network` was picked as descriptive and applied consistently across both files). No level changes beyond the two call sites above; this is tag-only for the sweep.

## PII-safety statement

No log line touched here carries raw store/customer/address text — this file mostly logs enum names (`TimeoutType`), rule/action wire names, throttle keys, permission tiers, and (for the EIA files) fuel type names, US state names/PADD region codes, and gas prices. `EiaFuelPrice`'s `apiKey` field is never interpolated into any log line, before or after this change (#348) — the two touched INFO lines log the fetched region code / price, not the key; the DEBUG exception-detail line logs `e.message`, which per `EiaApi`'s retrofit interface is either our own "empty/invalid data"/"location not available" text or the underlying `IOException`/`HttpException` message, none of which echo request query params. Secret redaction at the HTTP-client level (`NetworkClientFactory`'s `redactQueryParams("api_key")`) is untouched by this PR. All INFO+ lines touched remain PII-safe by construction.

### Design-goal review

1. **Semantic, PII-safe logging (Principle 7)** — this PR's entire purpose. Level choices now match the taxonomy definition text-for-text (WARN = "a grace timer waking a commit"; DEBUG = normal per-step lifecycle); every touched call site carries a stable component tag instead of the catch-all `App`; no INFO+ line carries raw PII (see statement above). Conforms.
2. **Security & privacy first (Principle 6)** — the #348 api_key redaction posture is unchanged and re-verified in this PR (see PII-safety statement); no new log site newly exposes a secret. Conforms.
3. **Single responsibility / minimal diff (Principle 3)** — log-line-only changes, no behavior change; scope held to the three files the issue named plus their existing untagged call sites, not a repo-wide sweep. Conforms.
4. **Platform-agnostic core (Principle 8)** — not touched; no rule/state vocabulary or platform literals involved in this diff (log lines only, in `:app` and `:core:network`, neither of which this principle's `:core:state`/`:core:pipeline`/`:domain`/rule-JSON scope applies to).

No violations found; nothing filed.

[Bounded sonnet build against a fable-scoped task; full unit suite (`testDebugUnitTest` + `:domain:test`) green, plus targeted `EiaFuelPriceTest`/`SideEffectEngineTest` runs before the full suite.]


### Adversarial review

Fable adversarial reviewer ran against head `f25e2116` — verdict **APPROVE-WITH-FIXES** (one should-fix, zero must-fix). The level table was **upheld on all five types** after attack — notably SESSION_PAUSED_SAFETY was verified a genuine defended invariant (armed with the pause's own remaining time, cancelled by any observed resume/offline — it fires only when we lost sight of the app), and OFFER_EXPIRY→DEBUG is right per the taxonomy's drowning rule (it's the routine resolution path for overlay offers; the OFFER_TIMEOUT app_event keeps the milestone durable). The EIA fold was judged **faithful and NOT a new leak** — the reviewer walked every reachable exception class (`HttpException` carries "HTTP code reason" without the URL; OkHttp deliberately keeps URLs/query strings out of exception messages; EIA 4xx throws before body conversion) so the enriched WARN cannot embed the `api_key`, while chronic-failure visibility (daily 403s) actually improved. **The one finding (F1), fixed in `4463886b`:** the accept-latched OFFER_EXPIRY no-op — a defended invariant of the #526 phantom-timeout class — went DEBUG-invisible, and the builder's "logged downstream" claim was false; a WARN now fires at the decision point in `OfferLifecycle.expireOffer` (the `pruneExpiredSurvivors` precedent, hash-only, no PII). Informational: `FuelPriceRepository`'s untagged ERROR is on the location/DataStore path (out of this issue's scope) — future sweep candidate.
