### PR TITLE
chore(#57/#238/#694): bubble-screen split + neutral session vocabulary + strings.xml extraction

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleHelpers.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleHelpers.kt
@@ -1,0 +1,45 @@
+package cloud.trotter.dashbuddy.ui.bubble
+
+import android.text.Html
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+@Composable
+internal fun ModeRow(
+    label: String,
+    value: String,
+    valueColor: Color = MaterialTheme.colorScheme.onSurfaceVariant,
+) {
+    Row {
+        Text(
+            text = "$label: ",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodySmall,
+            color = valueColor
+        )
+    }
+}
+
+fun getPreviewText(html: String): String {
+    if (html.isBlank()) return ""
+
+    val spacedHtml = html
+        .replace("<br>", " // ")
+        .replace("<br/>", " // ")
+        .replace("</p>", " // ")
+        .replace("</div>", " // ")
+
+    val spanned = Html.fromHtml(spacedHtml, Html.FROM_HTML_MODE_COMPACT)
+    return spanned.toString().trim()
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManager.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManager.kt
@@ -206,7 +206,7 @@ class BubbleManager @Inject constructor(
         val channel = NotificationChannel(
             channelId, "DashBuddy Stream", NotificationManager.IMPORTANCE_HIGH
         ).apply {
-            description = "Live updates from your Dash"
+            description = "Live updates from your session"
             setAllowBubbles(true)
         }
         notificationManager.createNotificationChannel(channel)
@@ -291,7 +291,7 @@ class BubbleManager @Inject constructor(
         )
 
         val style = NotificationCompat.MessagingStyle(senderPerson)
-            .setConversationTitle("Current Dash")
+            .setConversationTitle("Current Session")
             .setGroupConversation(true)
             .addMessage(text, System.currentTimeMillis(), senderPerson)
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleScreen.kt
@@ -3,42 +3,25 @@ package cloud.trotter.dashbuddy.ui.bubble
 import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
-import android.text.Html
-import android.text.format.DateFormat
-import android.widget.TextView
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import cloud.trotter.dashbuddy.domain.format.Formats
-import cloud.trotter.dashbuddy.domain.format.formatDuration
-import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
@@ -49,34 +32,16 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import androidx.compose.ui.viewinterop.AndroidView
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import cloud.trotter.dashbuddy.domain.model.cards.CardStack
 import cloud.trotter.dashbuddy.domain.model.chat.ChatMessage
-import cloud.trotter.dashbuddy.domain.model.chat.ChatPersona
-import cloud.trotter.dashbuddy.domain.state.Flow
-import cloud.trotter.dashbuddy.domain.state.FlowRegion
 import cloud.trotter.dashbuddy.domain.state.Mode
-import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.domain.state.PlatformRegion
-import cloud.trotter.dashbuddy.domain.state.presentation
 import cloud.trotter.dashbuddy.ui.bubble.cards.FlowCardItem
-import cloud.trotter.dashbuddy.ui.formatters.color
-import cloud.trotter.dashbuddy.ui.formatters.getIconResId
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateMapOf
-import java.util.Date
 import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 
@@ -270,364 +235,4 @@ fun DashboardView(
         }
         LatestMessageTicker(messages = messages, onClick = onOpenChat)
     }
-}
-
-// ---------------------------------------------------------------------------
-// TopAppBar title — status badge (left side)
-// ---------------------------------------------------------------------------
-
-@Composable
-private fun StatusBadgeTitle(region: PlatformRegion?, flow: FlowRegion, platform: Platform?) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(6.dp)
-    ) {
-        // Platform label — only shown when a platform is active.
-        // Short name is the SSOT on the Platform enum (audit #9).
-        platform?.let {
-            Text(
-                text = it.shortName,
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
-                fontWeight = FontWeight.Medium,
-            )
-        }
-        val (badgeText, badgeColor) = statusBadge(region, flow.flow)
-        Surface(
-            shape = RoundedCornerShape(4.dp),
-            color = badgeColor.copy(alpha = 0.15f)
-        ) {
-            Text(
-                text = badgeText,
-                style = MaterialTheme.typography.labelSmall,
-                color = badgeColor,
-                fontWeight = FontWeight.Bold,
-                modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)
-            )
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
-// TopAppBar actions — session earnings + miles (right side, active dashes only)
-// ---------------------------------------------------------------------------
-
-@Composable
-private fun SessionMetricsActions(
-    region: PlatformRegion?,
-    earnings: Double,
-    miles: Double,
-    lastSessionSummary: SessionSummary?
-) {
-    val isActive = region?.mode == Mode.Online || region?.mode == Mode.Paused
-
-    val displayEarnings: Double?
-    val displayMiles: Double?
-    val dimmed: Boolean
-
-    when {
-        isActive -> {
-            displayEarnings = earnings
-            displayMiles = miles
-            dimmed = false
-        }
-        region?.mode == Mode.Offline && lastSessionSummary != null -> {
-            displayEarnings = lastSessionSummary.earnings
-            displayMiles = lastSessionSummary.miles
-            dimmed = true
-        }
-        else -> return
-    }
-
-    Row(
-        modifier = Modifier.padding(end = 12.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        val textColor = if (dimmed)
-            MaterialTheme.colorScheme.onSurface.copy(alpha = 0.45f)
-        else
-            MaterialTheme.colorScheme.onSurface
-
-        Text(
-            text = Formats.money(displayEarnings),
-            style = MaterialTheme.typography.titleSmall,
-            fontWeight = FontWeight.Bold,
-            color = textColor
-        )
-        Text(
-            text = "  ·  ",
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.25f)
-        )
-        Text(
-            text = "${Formats.decimal(displayMiles)} mi",
-            style = MaterialTheme.typography.titleSmall,
-            color = textColor
-        )
-    }
-}
-
-@Composable
-private fun statusBadge(region: PlatformRegion?, flow: Flow): Pair<String, Color> {
-    val c = AppTheme.colors
-
-    // Mode-driven badges — orthogonal to the flow phase (availability axis).
-    if (region?.mode == Mode.Paused) return "PAUSED" to c.warn
-    if (region == null || region.mode == Mode.Offline) {
-        return when (flow) {
-            Flow.SessionEnded -> "DONE" to c.neutral
-            else -> "OFFLINE" to c.neutral
-        }
-    }
-
-    // Flow-driven badges (online) — long-form label + color from the phase SSOT
-    // (PhasePresentation in :domain; the chip in FlowCardItem shares the row).
-    val p = flow.presentation
-    return p.longLabel to p.longColor.color(c)
-}
-
-@Composable
-private fun ModeIdle(lastSessionSummary: SessionSummary?) {
-    if (lastSessionSummary != null) {
-        Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-            Text(
-                text = "Last session",
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
-            )
-            Text(
-                text = Formats.money(lastSessionSummary.earnings),
-                style = MaterialTheme.typography.headlineMedium,
-                fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.primary
-            )
-            ModeRow(label = "Miles", value = "${Formats.decimal(lastSessionSummary.miles)} mi")
-            ModeRow(
-                label = "Duration",
-                value = formatDuration(lastSessionSummary.endedAt - lastSessionSummary.startedAt),
-            )
-        }
-    } else {
-        ModeRow(label = "Status", value = "Offline")
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Latest message ticker
-// ---------------------------------------------------------------------------
-
-@Composable
-fun LatestMessageTicker(messages: List<ChatMessage>, onClick: () -> Unit) {
-    val latest = messages.lastOrNull()
-
-    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick)
-            .padding(horizontal = 4.dp, vertical = 10.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        if (latest != null) {
-            Icon(
-                painter = painterResource(id = latest.persona.getIconResId()),
-                contentDescription = null,
-                modifier = Modifier.size(16.dp),
-                tint = Color.Unspecified
-            )
-            Spacer(modifier = Modifier.width(6.dp))
-            Text(
-                text = "${latest.persona.displayName}: ",
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.primary,
-                fontWeight = FontWeight.Bold
-            )
-            Text(
-                text = getPreviewText(latest.text),
-                style = MaterialTheme.typography.labelSmall,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.weight(1f),
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-        } else {
-            Text(
-                text = "No messages yet",
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
-                modifier = Modifier.weight(1f),
-                fontStyle = androidx.compose.ui.text.font.FontStyle.Italic
-            )
-        }
-        Spacer(modifier = Modifier.width(4.dp))
-        Icon(
-            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-            contentDescription = "Open chat",
-            modifier = Modifier.size(16.dp),
-            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
-        )
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Full chat view (unchanged)
-// ---------------------------------------------------------------------------
-
-@Composable
-fun FullChatView(messages: List<ChatMessage>) {
-    val listState = rememberLazyListState()
-
-    LaunchedEffect(messages.size) {
-        if (messages.isNotEmpty()) {
-            listState.animateScrollToItem(messages.size - 1)
-        }
-    }
-
-    LazyColumn(
-        state = listState,
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(horizontal = 12.dp),
-        verticalArrangement = Arrangement.Bottom,
-        contentPadding = PaddingValues(bottom = 16.dp)
-    ) {
-        items(messages, key = { it.id }) { msg ->
-            ChatBubble(msg)
-            Spacer(modifier = Modifier.height(8.dp))
-        }
-    }
-}
-
-@Composable
-fun ChatBubble(message: ChatMessage) {
-    val context = LocalContext.current
-
-    val isSystem =
-        message.persona is ChatPersona.Dispatcher || message.persona is ChatPersona.System
-
-    val nameColor = if (isSystem) {
-        MaterialTheme.colorScheme.secondary
-    } else {
-        MaterialTheme.colorScheme.primary
-    }
-
-    val timeString = remember(message.timestamp) {
-        DateFormat.getTimeFormat(context).format(Date(message.timestamp))
-    }
-
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.Start
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                // Deliberate 12dp chat-bubble radius — between the small/medium
-                // shape tokens; revisit if AppShapes grows a chat variant (#406).
-                .clip(RoundedCornerShape(12.dp))
-                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
-                .padding(12.dp)
-        ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Text(
-                    text = message.persona.displayName,
-                    style = MaterialTheme.typography.labelMedium,
-                    color = nameColor,
-                    fontWeight = FontWeight.Bold
-                )
-
-                Spacer(modifier = Modifier.width(6.dp))
-
-                Icon(
-                    painter = painterResource(id = message.persona.getIconResId()),
-                    contentDescription = null,
-                    modifier = Modifier.size(20.dp),
-                    tint = Color.Unspecified
-                )
-
-                Spacer(modifier = Modifier.weight(1f))
-
-                Text(
-                    text = timeString,
-                    // labelSmall already maps to the micro (10sp) token —
-                    // the explicit override duplicated it invisibly (#406).
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
-                )
-            }
-
-            Spacer(modifier = Modifier.height(4.dp))
-
-            HtmlText(
-                html = message.text,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-        }
-    }
-}
-
-@Composable
-fun HtmlText(
-    html: String,
-    modifier: Modifier = Modifier,
-    color: Color
-) {
-    val androidTextColor = color.toArgb()
-
-    AndroidView(
-        modifier = modifier,
-        factory = { context ->
-            TextView(context).apply {
-                setTextColor(androidTextColor)
-                textSize = 16f
-                movementMethod = android.text.method.LinkMovementMethod.getInstance()
-            }
-        },
-        update = { textView ->
-            textView.setTextColor(androidTextColor)
-            textView.text = Html.fromHtml(html, Html.FROM_HTML_MODE_COMPACT)
-        }
-    )
-}
-
-// ---------------------------------------------------------------------------
-// Shared helpers
-// ---------------------------------------------------------------------------
-
-@Composable
-private fun ModeRow(
-    label: String,
-    value: String,
-    valueColor: Color = MaterialTheme.colorScheme.onSurfaceVariant,
-) {
-    Row {
-        Text(
-            text = "$label: ",
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
-        )
-        Text(
-            text = value,
-            style = MaterialTheme.typography.bodySmall,
-            color = valueColor
-        )
-    }
-}
-
-
-
-fun getPreviewText(html: String): String {
-    if (html.isBlank()) return ""
-
-    val spacedHtml = html
-        .replace("<br>", " // ")
-        .replace("<br/>", " // ")
-        .replace("</p>", " // ")
-        .replace("</div>", " // ")
-
-    val spanned = Html.fromHtml(spacedHtml, Html.FROM_HTML_MODE_COMPACT)
-    return spanned.toString().trim()
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleScreen.kt
@@ -34,8 +34,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import cloud.trotter.dashbuddy.R
 import cloud.trotter.dashbuddy.domain.model.cards.CardStack
 import cloud.trotter.dashbuddy.domain.model.chat.ChatMessage
 import cloud.trotter.dashbuddy.domain.state.Mode
@@ -73,7 +75,7 @@ fun BubbleScreen(
             TopAppBar(
                 title = {
                     if (showFullChat) {
-                        Text("Chat History")
+                        Text(stringResource(R.string.bubble_screen_chat_history_title))
                     } else {
                         StatusBadgeTitle(
                             region = focusedRegion,
@@ -91,7 +93,7 @@ fun BubbleScreen(
                         IconButton(onClick = { showFullChat = false }) {
                             Icon(
                                 imageVector = Icons.Default.Close,
-                                contentDescription = "Close chat",
+                                contentDescription = stringResource(R.string.bubble_screen_content_desc_close_chat),
                                 tint = MaterialTheme.colorScheme.onSurface
                             )
                         }
@@ -179,7 +181,7 @@ fun DashboardView(
             }
             cardStack.isEmpty -> {
                 Text(
-                    text = "Waiting for activity…",
+                    text = stringResource(R.string.bubble_screen_waiting_for_activity),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/ChatViews.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/ChatViews.kt
@@ -1,0 +1,227 @@
+package cloud.trotter.dashbuddy.ui.bubble
+
+import android.text.Html
+import android.text.format.DateFormat
+import android.widget.TextView
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import cloud.trotter.dashbuddy.domain.model.chat.ChatMessage
+import cloud.trotter.dashbuddy.domain.model.chat.ChatPersona
+import cloud.trotter.dashbuddy.ui.formatters.getIconResId
+import java.util.Date
+
+// ---------------------------------------------------------------------------
+// Latest message ticker
+// ---------------------------------------------------------------------------
+
+@Composable
+fun LatestMessageTicker(messages: List<ChatMessage>, onClick: () -> Unit) {
+    val latest = messages.lastOrNull()
+
+    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 4.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        if (latest != null) {
+            Icon(
+                painter = painterResource(id = latest.persona.getIconResId()),
+                contentDescription = null,
+                modifier = Modifier.size(16.dp),
+                tint = Color.Unspecified
+            )
+            Spacer(modifier = Modifier.width(6.dp))
+            Text(
+                text = "${latest.persona.displayName}: ",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.primary,
+                fontWeight = FontWeight.Bold
+            )
+            Text(
+                text = getPreviewText(latest.text),
+                style = MaterialTheme.typography.labelSmall,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f),
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        } else {
+            Text(
+                text = "No messages yet",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                modifier = Modifier.weight(1f),
+                fontStyle = androidx.compose.ui.text.font.FontStyle.Italic
+            )
+        }
+        Spacer(modifier = Modifier.width(4.dp))
+        Icon(
+            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+            contentDescription = "Open chat",
+            modifier = Modifier.size(16.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Full chat view (unchanged)
+// ---------------------------------------------------------------------------
+
+@Composable
+fun FullChatView(messages: List<ChatMessage>) {
+    val listState = rememberLazyListState()
+
+    LaunchedEffect(messages.size) {
+        if (messages.isNotEmpty()) {
+            listState.animateScrollToItem(messages.size - 1)
+        }
+    }
+
+    LazyColumn(
+        state = listState,
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 12.dp),
+        verticalArrangement = Arrangement.Bottom,
+        contentPadding = PaddingValues(bottom = 16.dp)
+    ) {
+        items(messages, key = { it.id }) { msg ->
+            ChatBubble(msg)
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+    }
+}
+
+@Composable
+fun ChatBubble(message: ChatMessage) {
+    val context = LocalContext.current
+
+    val isSystem =
+        message.persona is ChatPersona.Dispatcher || message.persona is ChatPersona.System
+
+    val nameColor = if (isSystem) {
+        MaterialTheme.colorScheme.secondary
+    } else {
+        MaterialTheme.colorScheme.primary
+    }
+
+    val timeString = remember(message.timestamp) {
+        DateFormat.getTimeFormat(context).format(Date(message.timestamp))
+    }
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.Start
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                // Deliberate 12dp chat-bubble radius — between the small/medium
+                // shape tokens; revisit if AppShapes grows a chat variant (#406).
+                .clip(RoundedCornerShape(12.dp))
+                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
+                .padding(12.dp)
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(
+                    text = message.persona.displayName,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = nameColor,
+                    fontWeight = FontWeight.Bold
+                )
+
+                Spacer(modifier = Modifier.width(6.dp))
+
+                Icon(
+                    painter = painterResource(id = message.persona.getIconResId()),
+                    contentDescription = null,
+                    modifier = Modifier.size(20.dp),
+                    tint = Color.Unspecified
+                )
+
+                Spacer(modifier = Modifier.weight(1f))
+
+                Text(
+                    text = timeString,
+                    // labelSmall already maps to the micro (10sp) token —
+                    // the explicit override duplicated it invisibly (#406).
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                )
+            }
+
+            Spacer(modifier = Modifier.height(4.dp))
+
+            HtmlText(
+                html = message.text,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+fun HtmlText(
+    html: String,
+    modifier: Modifier = Modifier,
+    color: Color
+) {
+    val androidTextColor = color.toArgb()
+
+    AndroidView(
+        modifier = modifier,
+        factory = { context ->
+            TextView(context).apply {
+                setTextColor(androidTextColor)
+                textSize = 16f
+                movementMethod = android.text.method.LinkMovementMethod.getInstance()
+            }
+        },
+        update = { textView ->
+            textView.setTextColor(androidTextColor)
+            textView.text = Html.fromHtml(html, Html.FROM_HTML_MODE_COMPACT)
+        }
+    )
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/ChatViews.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/ChatViews.kt
@@ -36,10 +36,12 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import cloud.trotter.dashbuddy.R
 import cloud.trotter.dashbuddy.domain.model.chat.ChatMessage
 import cloud.trotter.dashbuddy.domain.model.chat.ChatPersona
 import cloud.trotter.dashbuddy.ui.formatters.getIconResId
@@ -85,7 +87,7 @@ fun LatestMessageTicker(messages: List<ChatMessage>, onClick: () -> Unit) {
             )
         } else {
             Text(
-                text = "No messages yet",
+                text = stringResource(R.string.bubble_chat_no_messages_yet),
                 style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
                 modifier = Modifier.weight(1f),
@@ -95,7 +97,7 @@ fun LatestMessageTicker(messages: List<ChatMessage>, onClick: () -> Unit) {
         Spacer(modifier = Modifier.width(4.dp))
         Icon(
             imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-            contentDescription = "Open chat",
+            contentDescription = stringResource(R.string.bubble_chat_content_desc_open_chat),
             modifier = Modifier.size(16.dp),
             tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
         )

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/ModeCards.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/ModeCards.kt
@@ -5,8 +5,10 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import cloud.trotter.dashbuddy.R
 import cloud.trotter.dashbuddy.domain.format.Formats
 import cloud.trotter.dashbuddy.domain.format.formatDuration
 
@@ -15,7 +17,7 @@ internal fun ModeIdle(lastSessionSummary: SessionSummary?) {
     if (lastSessionSummary != null) {
         Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
             Text(
-                text = "Last session",
+                text = stringResource(R.string.bubble_mode_idle_last_session_label),
                 style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
             )
@@ -25,13 +27,19 @@ internal fun ModeIdle(lastSessionSummary: SessionSummary?) {
                 fontWeight = FontWeight.Bold,
                 color = MaterialTheme.colorScheme.primary
             )
-            ModeRow(label = "Miles", value = "${Formats.decimal(lastSessionSummary.miles)} mi")
             ModeRow(
-                label = "Duration",
+                label = stringResource(R.string.bubble_mode_idle_miles_label),
+                value = "${Formats.decimal(lastSessionSummary.miles)} mi",
+            )
+            ModeRow(
+                label = stringResource(R.string.bubble_mode_idle_duration_label),
                 value = formatDuration(lastSessionSummary.endedAt - lastSessionSummary.startedAt),
             )
         }
     } else {
-        ModeRow(label = "Status", value = "Offline")
+        ModeRow(
+            label = stringResource(R.string.bubble_mode_idle_status_label),
+            value = stringResource(R.string.bubble_mode_idle_offline_value),
+        )
     }
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/ModeCards.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/ModeCards.kt
@@ -1,0 +1,37 @@
+package cloud.trotter.dashbuddy.ui.bubble
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import cloud.trotter.dashbuddy.domain.format.Formats
+import cloud.trotter.dashbuddy.domain.format.formatDuration
+
+@Composable
+internal fun ModeIdle(lastSessionSummary: SessionSummary?) {
+    if (lastSessionSummary != null) {
+        Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Text(
+                text = "Last session",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+            )
+            Text(
+                text = Formats.money(lastSessionSummary.earnings),
+                style = MaterialTheme.typography.headlineMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.primary
+            )
+            ModeRow(label = "Miles", value = "${Formats.decimal(lastSessionSummary.miles)} mi")
+            ModeRow(
+                label = "Duration",
+                value = formatDuration(lastSessionSummary.endedAt - lastSessionSummary.startedAt),
+            )
+        }
+    } else {
+        ModeRow(label = "Status", value = "Offline")
+    }
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/StatusBar.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/StatusBar.kt
@@ -1,0 +1,138 @@
+package cloud.trotter.dashbuddy.ui.bubble
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
+import cloud.trotter.dashbuddy.domain.format.Formats
+import cloud.trotter.dashbuddy.domain.state.Flow
+import cloud.trotter.dashbuddy.domain.state.FlowRegion
+import cloud.trotter.dashbuddy.domain.state.Mode
+import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.domain.state.PlatformRegion
+import cloud.trotter.dashbuddy.domain.state.presentation
+import cloud.trotter.dashbuddy.ui.formatters.color
+
+// ---------------------------------------------------------------------------
+// TopAppBar title — status badge (left side)
+// ---------------------------------------------------------------------------
+
+@Composable
+internal fun StatusBadgeTitle(region: PlatformRegion?, flow: FlowRegion, platform: Platform?) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp)
+    ) {
+        // Platform label — only shown when a platform is active.
+        // Short name is the SSOT on the Platform enum (audit #9).
+        platform?.let {
+            Text(
+                text = it.shortName,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                fontWeight = FontWeight.Medium,
+            )
+        }
+        val (badgeText, badgeColor) = statusBadge(region, flow.flow)
+        Surface(
+            shape = RoundedCornerShape(4.dp),
+            color = badgeColor.copy(alpha = 0.15f)
+        ) {
+            Text(
+                text = badgeText,
+                style = MaterialTheme.typography.labelSmall,
+                color = badgeColor,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)
+            )
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TopAppBar actions — session earnings + miles (right side, active sessions only)
+// ---------------------------------------------------------------------------
+
+@Composable
+internal fun SessionMetricsActions(
+    region: PlatformRegion?,
+    earnings: Double,
+    miles: Double,
+    lastSessionSummary: SessionSummary?
+) {
+    val isActive = region?.mode == Mode.Online || region?.mode == Mode.Paused
+
+    val displayEarnings: Double?
+    val displayMiles: Double?
+    val dimmed: Boolean
+
+    when {
+        isActive -> {
+            displayEarnings = earnings
+            displayMiles = miles
+            dimmed = false
+        }
+        region?.mode == Mode.Offline && lastSessionSummary != null -> {
+            displayEarnings = lastSessionSummary.earnings
+            displayMiles = lastSessionSummary.miles
+            dimmed = true
+        }
+        else -> return
+    }
+
+    Row(
+        modifier = Modifier.padding(end = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        val textColor = if (dimmed)
+            MaterialTheme.colorScheme.onSurface.copy(alpha = 0.45f)
+        else
+            MaterialTheme.colorScheme.onSurface
+
+        Text(
+            text = Formats.money(displayEarnings),
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.Bold,
+            color = textColor
+        )
+        Text(
+            text = "  ·  ",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.25f)
+        )
+        Text(
+            text = "${Formats.decimal(displayMiles)} mi",
+            style = MaterialTheme.typography.titleSmall,
+            color = textColor
+        )
+    }
+}
+
+@Composable
+private fun statusBadge(region: PlatformRegion?, flow: Flow): Pair<String, Color> {
+    val c = AppTheme.colors
+
+    // Mode-driven badges — orthogonal to the flow phase (availability axis).
+    if (region?.mode == Mode.Paused) return "PAUSED" to c.warn
+    if (region == null || region.mode == Mode.Offline) {
+        return when (flow) {
+            Flow.SessionEnded -> "DONE" to c.neutral
+            else -> "OFFLINE" to c.neutral
+        }
+    }
+
+    // Flow-driven badges (online) — long-form label + color from the phase SSOT
+    // (PhasePresentation in :domain; the chip in FlowCardItem shares the row).
+    val p = flow.presentation
+    return p.longLabel to p.longColor.color(c)
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardItem.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/cards/FlowCardItem.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import cloud.trotter.dashbuddy.R
 import cloud.trotter.dashbuddy.domain.format.Formats
 import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
@@ -155,7 +156,8 @@ private fun CardHeader(
             Icon(
                 imageVector = if (expanded) Icons.Default.KeyboardArrowDown
                 else Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                contentDescription = if (expanded) "Collapse" else "Expand",
+                contentDescription = if (expanded) stringResource(R.string.flow_card_content_desc_collapse)
+                else stringResource(R.string.flow_card_content_desc_expand),
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.size(18.dp),
             )
@@ -205,11 +207,13 @@ private fun cardSummary(snapshot: FlowCardSnapshot, isActive: Boolean): String =
 private fun awaitingSummary(snap: FlowCardSnapshot.Awaiting, isActive: Boolean): String {
     val now = if (isActive) rememberNow().value else (snap.phaseEndedAt ?: snap.phaseStartedAt)
     val elapsed = now - snap.phaseStartedAt
-    return if (isActive) "Waiting · ${formatDuration(elapsed)}" else "Waited ${formatDuration(elapsed)}"
+    return if (isActive) stringResource(R.string.flow_card_awaiting_active_format, formatDuration(elapsed))
+    else stringResource(R.string.flow_card_awaiting_frozen_format, formatDuration(elapsed))
 }
 
+@Composable
 private fun offerSummary(snap: FlowCardSnapshot.Offer): String {
-    val store = snap.storeNames.firstOrNull()?.takeIf { it.isNotBlank() } ?: "Offer"
+    val store = snap.storeNames.firstOrNull()?.takeIf { it.isNotBlank() } ?: stringResource(R.string.flow_card_offer_fallback_store)
     val pay = snap.payAmount?.let { " · ${Formats.money(it)}" } ?: ""
     // Outcome is rendered as a trailing chip in the header — see
     // CardHeader — so we omit it from the summary text.
@@ -222,7 +226,7 @@ private fun pickupSummary(snap: FlowCardSnapshot.Pickup, isActive: Boolean): Str
     val arrivedAt = snap.arrivedAt
     return when {
         isActive -> store
-        arrivedAt != null -> "$store · arrived ${formatTime(arrivedAt)}"
+        arrivedAt != null -> stringResource(R.string.flow_card_pickup_arrived_format, store, formatTime(arrivedAt))
         else -> store
     }
 }
@@ -233,11 +237,12 @@ private fun deliverySummary(snap: FlowCardSnapshot.Delivery, isActive: Boolean):
     val arrivedAt = snap.arrivedAt
     return when {
         isActive -> customer
-        arrivedAt != null -> "$customer · delivered ${formatTime(arrivedAt)}"
+        arrivedAt != null -> stringResource(R.string.flow_card_delivery_delivered_format, customer, formatTime(arrivedAt))
         else -> customer
     }
 }
 
+@Composable
 private fun postTaskSummary(snap: FlowCardSnapshot.PostTask): String {
     val store = snap.storeName?.let { "$it · " } ?: ""
     return store + Formats.money(snap.totalPay)
@@ -269,8 +274,8 @@ private fun AwaitingBody(snap: FlowCardSnapshot.Awaiting, isActive: Boolean) {
     ) {
         HeroBig(formatDuration(elapsed))
         Caption(
-            if (isActive) "since last offer"
-            else "before next offer"
+            if (isActive) stringResource(R.string.flow_card_since_last_offer)
+            else stringResource(R.string.flow_card_before_next_offer)
         )
     }
 }
@@ -321,7 +326,7 @@ private fun OfferBody(snap: FlowCardSnapshot.Offer, isActive: Boolean) {
                 AppGaugeRing(
                     progress = (score / 100.0).toFloat(),
                     value = score.toInt().toString(),
-                    label = "Score",
+                    label = stringResource(R.string.flow_card_score_gauge_label),
                     color = sc,
                     diameter = 60.dp,
                 )
@@ -329,19 +334,25 @@ private fun OfferBody(snap: FlowCardSnapshot.Offer, isActive: Boolean) {
             Column(modifier = Modifier.weight(1f)) {
                 val hourly = snap.dollarsPerHour
                 when {
-                    hourly != null -> Text("${Formats.money0(hourly)}/hr", style = AppTheme.num.heroNum, color = c.text, maxLines = 1)
+                    hourly != null -> Text(
+                        stringResource(R.string.flow_card_hourly_hero_format, Formats.money0(hourly)),
+                        style = AppTheme.num.heroNum, color = c.text, maxLines = 1,
+                    )
                     snap.payAmount != null -> Text(Formats.money(snap.payAmount!!), style = AppTheme.num.heroNum, color = c.text, maxLines = 1)
                 }
                 val net = snap.netPayAmount ?: snap.payAmount
+                val netLabel = stringResource(R.string.flow_card_net_secondary_format, net?.let { Formats.money(it) } ?: "")
+                val distanceLabel = snap.distanceMiles?.let { stringResource(R.string.flow_card_distance_secondary_format, Formats.decimal(it)) }
+                val perMileLabel = snap.dollarsPerMile?.let { stringResource(R.string.flow_card_per_mile_secondary_format, Formats.money(it)) }
                 val secondary = buildString {
-                    if (net != null) append("Net ${Formats.money(net)}")
-                    snap.distanceMiles?.let {
+                    if (net != null) append(netLabel)
+                    distanceLabel?.let {
                         if (isNotEmpty()) append(" · ")
-                        append("${Formats.decimal(it)} mi")
+                        append(it)
                     }
-                    snap.dollarsPerMile?.let {
+                    perMileLabel?.let {
                         if (isNotEmpty()) append(" · ")
-                        append("${Formats.money(it)}/mi")
+                        append(it)
                     }
                 }
                 if (secondary.isNotBlank()) {
@@ -468,17 +479,18 @@ private fun BadgeIcon(
 }
 
 /** Maps a badge enum name to a short label + brand color for the pill row. */
+@Composable
 private fun badgeMeta(name: String, c: AppColors): Pair<String, Color> = when (name) {
-    "SHOP" -> "Shop & Deliver" to c.stPickup
-    "HIGH_PAYING" -> "High pay" to c.good
-    "PRIORITY_ACCESS" -> "Priority" to c.stOffer
-    "RED_CARD" -> "Red Card" to c.bad
-    "ALCOHOL" -> "Alcohol" to c.warn
-    "LARGE_ORDER" -> "Large order" to c.neutral
-    "PIZZA_BAG" -> "Pizza bag" to c.neutral
-    "ALL_ORDERS_SAME_STORE" -> "Same store" to c.neutral
-    "BOTH_ORDERS_SAME_CUSTOMER" -> "Same customer" to c.neutral
-    "ITEMS_CAN_BE_ADDED" -> "Add-ons OK" to c.neutral
+    "SHOP" -> stringResource(R.string.flow_card_badge_shop_and_deliver) to c.stPickup
+    "HIGH_PAYING" -> stringResource(R.string.flow_card_badge_high_pay) to c.good
+    "PRIORITY_ACCESS" -> stringResource(R.string.flow_card_badge_priority) to c.stOffer
+    "RED_CARD" -> stringResource(R.string.flow_card_badge_red_card) to c.bad
+    "ALCOHOL" -> stringResource(R.string.flow_card_badge_alcohol) to c.warn
+    "LARGE_ORDER" -> stringResource(R.string.flow_card_badge_large_order) to c.neutral
+    "PIZZA_BAG" -> stringResource(R.string.flow_card_badge_pizza_bag) to c.neutral
+    "ALL_ORDERS_SAME_STORE" -> stringResource(R.string.flow_card_badge_same_store) to c.neutral
+    "BOTH_ORDERS_SAME_CUSTOMER" -> stringResource(R.string.flow_card_badge_same_customer) to c.neutral
+    "ITEMS_CAN_BE_ADDED" -> stringResource(R.string.flow_card_badge_add_ons_ok) to c.neutral
     else -> name.lowercase().replace('_', ' ').replaceFirstChar { it.uppercase() } to c.neutral
 }
 
@@ -552,7 +564,7 @@ private fun TaskBody(
     val c = AppTheme.colors
     val now = if (isActive) rememberNow().value else (phaseEndedAt ?: phaseStartedAt)
     val arrived = arrivedAt != null
-    val verb = if (isDrop) "deliver" else "pickup"
+    val verb = if (isDrop) stringResource(R.string.flow_card_verb_deliver) else stringResource(R.string.flow_card_verb_pickup)
     val overdue = deadlineMillis != null && now > deadlineMillis
     // Live realized $/hr — ticks with `now` (erodes past the deadline), so it is recomputed here
     // each tick from the snapshot's anchors via the TaskEconomics SSOT, never frozen at reduce
@@ -575,21 +587,21 @@ private fun TaskBody(
             val timerColor: Color
             when {
                 arrived -> {
-                    timerLabel = "Dwell"
+                    timerLabel = stringResource(R.string.flow_card_timer_dwell_label)
                     timerValue = formatCountdown(now - arrivedAt)
-                    timerSub = if (isDrop) "at door" else "at store"
+                    timerSub = if (isDrop) stringResource(R.string.flow_card_timer_at_door_sub) else stringResource(R.string.flow_card_timer_at_store_sub)
                     timerColor = deadlineMillis?.let { deadlineColor(it - arrivedAt) } ?: c.text
                 }
                 deadlineMillis != null -> {
-                    timerLabel = if (overdue) "Overdue" else "To go"
+                    timerLabel = if (overdue) stringResource(R.string.flow_card_timer_overdue_label) else stringResource(R.string.flow_card_timer_to_go_label)
                     timerValue = formatCountdown(deadlineMillis - now)
                     timerSub = null
                     timerColor = deadlineColor(deadlineMillis - now)
                 }
                 else -> {
-                    timerLabel = "Elapsed"
+                    timerLabel = stringResource(R.string.flow_card_timer_elapsed_label)
                     timerValue = formatDuration(now - phaseStartedAt)
-                    timerSub = "en route"
+                    timerSub = stringResource(R.string.flow_card_timer_en_route_sub)
                     timerColor = c.text
                 }
             }
@@ -606,11 +618,15 @@ private fun TaskBody(
             TaskMetric(
                 modifier = Modifier.weight(1f),
                 live = isActive && hourly != null,
-                label = "Running at",
-                value = if (hourly != null) "${Formats.money0(hourly)}/hr${if (overdue) " ↓" else ""}" else "—",
+                label = stringResource(R.string.flow_card_running_at_label),
+                value = if (hourly != null) {
+                    if (overdue) stringResource(R.string.flow_card_running_at_overdue_format, Formats.money0(hourly))
+                    else stringResource(R.string.flow_card_hourly_hero_format, Formats.money0(hourly))
+                } else "—",
                 // Sub line prefers the fixed $/mi efficiency; falls back to the erosion status.
-                sub = perMile?.let { "${Formats.money(it)}/mi" }
-                    ?: if (hourly == null) null else if (overdue) "dropping" else "on track",
+                sub = perMile?.let { stringResource(R.string.flow_card_per_mile_secondary_format, Formats.money(it)) }
+                    ?: if (hourly == null) null else if (overdue) stringResource(R.string.flow_card_running_at_dropping_sub)
+                    else stringResource(R.string.flow_card_running_at_on_track_sub),
                 color = hourly?.let { hourlyColor(it, c) } ?: c.text3,
             )
         }
@@ -619,12 +635,18 @@ private fun TaskBody(
         val caption = buildString {
             if (arrived && deadlineMillis != null) {
                 val margin = deadlineMillis - arrivedAt
-                append("arrived ${formatCountdown(kotlin.math.abs(margin))} ${if (margin >= 0) "early" else "late"} · ")
+                append(
+                    stringResource(
+                        R.string.flow_card_arrived_margin_format,
+                        formatCountdown(kotlin.math.abs(margin)),
+                        if (margin >= 0) stringResource(R.string.flow_card_margin_early) else stringResource(R.string.flow_card_margin_late),
+                    ),
+                )
             }
             when {
-                deadlineMillis == null -> append(if (arrived) "at stop" else "en route")
-                overdue -> append("${formatCountdown(now - deadlineMillis)} past $verb-by")
-                else -> append("$verb by ${formatTime(deadlineMillis)}")
+                deadlineMillis == null -> append(if (arrived) stringResource(R.string.flow_card_at_stop) else stringResource(R.string.flow_card_en_route))
+                overdue -> append(stringResource(R.string.flow_card_past_deadline_format, formatCountdown(now - deadlineMillis), verb))
+                else -> append(stringResource(R.string.flow_card_by_deadline_format, verb, formatTime(deadlineMillis)))
             }
         }
         Caption(caption)
@@ -639,7 +661,7 @@ private fun TaskBody(
                 ) {
                     Icon(Icons.Default.Close, contentDescription = null, tint = c.bad, modifier = Modifier.size(16.dp))
                     Text(
-                        "Below your floor — no longer worth the wait.",
+                        stringResource(R.string.flow_card_below_floor_warning),
                         style = MaterialTheme.typography.labelMedium,
                         color = c.bad,
                         fontWeight = FontWeight.SemiBold,
@@ -661,8 +683,14 @@ private fun TaskBody(
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
                     ) {
-                        Text("shop $shopped/$total", style = AppTheme.num.smNum, color = c.text, fontWeight = FontWeight.Bold, modifier = Modifier.weight(1f))
-                        Text("${Formats.decimal(pace)}/min", style = AppTheme.num.smNum, color = c.stPickup, fontWeight = FontWeight.Bold)
+                        Text(
+                            stringResource(R.string.flow_card_shop_progress_format, shopped, total),
+                            style = AppTheme.num.smNum, color = c.text, fontWeight = FontWeight.Bold, modifier = Modifier.weight(1f),
+                        )
+                        Text(
+                            stringResource(R.string.flow_card_shop_pace_format, Formats.decimal(pace)),
+                            style = AppTheme.num.smNum, color = c.stPickup, fontWeight = FontWeight.Bold,
+                        )
                     }
                 }
             }
@@ -671,8 +699,8 @@ private fun TaskBody(
         // ---- detail line — store/customer + lifecycle times ----
         val detail = buildString {
             append(primary)
-            arrivedAt?.let { append(" · arrived ${formatTime(it)}") }
-            confirmedAt?.let { append(" · picked up ${formatTime(it)}") }
+            arrivedAt?.let { append(stringResource(R.string.flow_card_detail_arrived_format, formatTime(it))) }
+            confirmedAt?.let { append(stringResource(R.string.flow_card_detail_picked_up_format, formatTime(it))) }
             if (arrivedAt == null && phaseEndedAt != null && !isActive) {
                 append(" · ${formatDuration(phaseEndedAt - phaseStartedAt)}")
             }
@@ -734,7 +762,7 @@ private fun PostTaskBody(snap: FlowCardSnapshot.PostTask) {
         verticalArrangement = Arrangement.spacedBy(2.dp),
     ) {
         HeroBig(Formats.money(snap.totalPay))
-        Caption("delivery total")
+        Caption(stringResource(R.string.flow_card_post_task_delivery_total))
         snap.parsedPay?.let { pay ->
             Column(
                 modifier = Modifier.padding(top = 6.dp),
@@ -744,12 +772,12 @@ private fun PostTaskBody(snap: FlowCardSnapshot.PostTask) {
                     BreakdownRow(item.type, Formats.money(item.amount))
                 }
                 pay.customerTips.forEach { tip ->
-                    BreakdownRow("tip · ${tip.displayLabel}", Formats.money(tip.amount))
+                    BreakdownRow(stringResource(R.string.flow_card_post_task_tip_format, tip.displayLabel), Formats.money(tip.amount))
                 }
             }
         }
         snap.sessionEarningsAtCompletion?.let {
-            Caption("session ${Formats.money(it)}")
+            Caption(stringResource(R.string.flow_card_post_task_session_format, Formats.money(it)))
         }
     }
 }
@@ -771,12 +799,12 @@ private fun OfferActionRow(onAccept: () -> Unit, onDecline: () -> Unit) {
             modifier = Modifier.weight(1f),
             border = BorderStroke(1.5.dp, c.bad),
             colors = ButtonDefaults.outlinedButtonColors(contentColor = c.bad),
-        ) { Text("Decline", fontWeight = FontWeight.Bold) }
+        ) { Text(stringResource(R.string.flow_card_action_decline), fontWeight = FontWeight.Bold) }
         Button(
             onClick = onAccept,
             modifier = Modifier.weight(1f),
             colors = ButtonDefaults.buttonColors(containerColor = c.good, contentColor = c.textInv),
-        ) { Text("Accept", fontWeight = FontWeight.Bold) }
+        ) { Text(stringResource(R.string.flow_card_action_accept), fontWeight = FontWeight.Bold) }
     }
 }
 
@@ -815,9 +843,9 @@ private fun BreakdownRow(label: String, value: String) {
 private fun OutcomeChip(outcome: AppEventType) {
     val c = AppTheme.colors
     val (text, color) = when (outcome) {
-        AppEventType.OFFER_ACCEPTED -> "Accepted" to c.good
-        AppEventType.OFFER_DECLINED -> "Declined" to c.bad
-        AppEventType.OFFER_TIMEOUT -> "Timed out" to c.neutral
+        AppEventType.OFFER_ACCEPTED -> stringResource(R.string.flow_card_outcome_accepted) to c.good
+        AppEventType.OFFER_DECLINED -> stringResource(R.string.flow_card_outcome_declined) to c.bad
+        AppEventType.OFFER_TIMEOUT -> stringResource(R.string.flow_card_outcome_timed_out) to c.neutral
         else -> outcome.name to MaterialTheme.colorScheme.onSurfaceVariant
     }
     Surface(

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/components/economy/EconomyAccordionRow.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/components/economy/EconomyAccordionRow.kt
@@ -23,9 +23,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import cloud.trotter.dashbuddy.R
 
 /**
  * A collapsible row used to organize Personal Economy inputs into compact
@@ -58,7 +60,8 @@ fun EconomyAccordionRow(
         ) {
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                contentDescription = if (expanded) "Collapse" else "Expand",
+                contentDescription = if (expanded) stringResource(R.string.economy_accordion_content_desc_collapse)
+                else stringResource(R.string.economy_accordion_content_desc_expand),
                 modifier = Modifier.rotate(rotation),
             )
             Text(
@@ -80,7 +83,7 @@ fun EconomyAccordionRow(
                 )
                 if (!isUserSet) {
                     Text(
-                        text = "(default)",
+                        text = stringResource(R.string.economy_accordion_default_hint),
                         style = MaterialTheme.typography.labelSmall,
                         color = MaterialTheme.colorScheme.outline,
                         fontStyle = FontStyle.Italic,

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/components/economy/EconomyEditor.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/components/economy/EconomyEditor.kt
@@ -15,9 +15,11 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import cloud.trotter.dashbuddy.R
 import cloud.trotter.dashbuddy.domain.format.Formats
 import cloud.trotter.dashbuddy.core.designsystem.theme.DashBuddyTheme
 import cloud.trotter.dashbuddy.domain.evaluation.EconomyField
@@ -54,15 +56,15 @@ fun EconomyEditor(
 
     // -------- Tires --------
     EconomyAccordionRow(
-        title = "Tires",
-        summary = "${Formats.money3(economy.tireCostPerMile)}/mi",
+        title = stringResource(R.string.economy_editor_tires_title),
+        summary = stringResource(R.string.economy_editor_per_mile_format, Formats.money3(economy.tireCostPerMile)),
         isUserSet = EconomyField.TIRE_COST in userSet || EconomyField.TIRE_LIFETIME in userSet,
     ) {
         PairedCurrencyAndIntervalInput(
-            costLabel = "Set of 4",
+            costLabel = stringResource(R.string.economy_editor_tires_cost_label),
             costValue = economy.tireSetCost,
             onCostChange = { onTiresChange(it, economy.tireLifetimeMi) },
-            intervalLabel = "Lifetime",
+            intervalLabel = stringResource(R.string.economy_editor_lifetime_label),
             intervalValue = economy.tireLifetimeMi,
             onIntervalChange = { onTiresChange(economy.tireSetCost, it) },
         )
@@ -70,15 +72,15 @@ fun EconomyEditor(
 
     // -------- Oil changes --------
     EconomyAccordionRow(
-        title = "Oil changes",
-        summary = "${Formats.money3(economy.oilCostPerMile)}/mi",
+        title = stringResource(R.string.economy_editor_oil_title),
+        summary = stringResource(R.string.economy_editor_per_mile_format, Formats.money3(economy.oilCostPerMile)),
         isUserSet = EconomyField.OIL_COST in userSet || EconomyField.OIL_INTERVAL in userSet,
     ) {
         PairedCurrencyAndIntervalInput(
-            costLabel = "Each",
+            costLabel = stringResource(R.string.economy_editor_each_label),
             costValue = economy.oilCost,
             onCostChange = { onOilChange(it, economy.oilIntervalMi) },
-            intervalLabel = "Every",
+            intervalLabel = stringResource(R.string.economy_editor_every_label),
             intervalValue = economy.oilIntervalMi,
             onIntervalChange = { onOilChange(economy.oilCost, it) },
         )
@@ -86,15 +88,15 @@ fun EconomyEditor(
 
     // -------- Brakes --------
     EconomyAccordionRow(
-        title = "Brakes",
-        summary = "${Formats.money3(economy.brakesCostPerMile)}/mi",
+        title = stringResource(R.string.economy_editor_brakes_title),
+        summary = stringResource(R.string.economy_editor_per_mile_format, Formats.money3(economy.brakesCostPerMile)),
         isUserSet = EconomyField.BRAKES_COST in userSet || EconomyField.BRAKES_INTERVAL in userSet,
     ) {
         PairedCurrencyAndIntervalInput(
-            costLabel = "Each",
+            costLabel = stringResource(R.string.economy_editor_each_label),
             costValue = economy.brakesCost,
             onCostChange = { onBrakesChange(it, economy.brakesIntervalMi) },
-            intervalLabel = "Every",
+            intervalLabel = stringResource(R.string.economy_editor_every_label),
             intervalValue = economy.brakesIntervalMi,
             onIntervalChange = { onBrakesChange(economy.brakesCost, it) },
         )
@@ -102,15 +104,15 @@ fun EconomyEditor(
 
     // -------- Fluids --------
     EconomyAccordionRow(
-        title = "Fluids",
-        summary = "${Formats.money3(economy.fluidsCostPerMile)}/mi",
+        title = stringResource(R.string.economy_editor_fluids_title),
+        summary = stringResource(R.string.economy_editor_per_mile_format, Formats.money3(economy.fluidsCostPerMile)),
         isUserSet = EconomyField.FLUIDS_COST in userSet || EconomyField.FLUIDS_INTERVAL in userSet,
     ) {
         PairedCurrencyAndIntervalInput(
-            costLabel = "Each",
+            costLabel = stringResource(R.string.economy_editor_each_label),
             costValue = economy.fluidsCost,
             onCostChange = { onFluidsChange(it, economy.fluidsIntervalMi) },
-            intervalLabel = "Every",
+            intervalLabel = stringResource(R.string.economy_editor_every_label),
             intervalValue = economy.fluidsIntervalMi,
             onIntervalChange = { onFluidsChange(economy.fluidsCost, it) },
         )
@@ -118,36 +120,36 @@ fun EconomyEditor(
 
     // -------- Misc repairs --------
     EconomyAccordionRow(
-        title = "Misc repairs",
-        summary = "${Formats.money3(economy.miscCostPerMile)}/mi",
+        title = stringResource(R.string.economy_editor_misc_title),
+        summary = stringResource(R.string.economy_editor_per_mile_format, Formats.money3(economy.miscCostPerMile)),
         isUserSet = EconomyField.MISC_YEARLY in userSet || EconomyField.MISC_YEARLY_MI in userSet,
     ) {
         PairedCurrencyAndIntervalInput(
-            costLabel = "Yearly budget",
+            costLabel = stringResource(R.string.economy_editor_misc_cost_label),
             costValue = economy.miscYearly,
             onCostChange = { onMiscChange(it, economy.miscYearlyMi) },
-            intervalLabel = "Driving",
+            intervalLabel = stringResource(R.string.economy_editor_misc_interval_label),
             intervalValue = economy.miscYearlyMi,
             onIntervalChange = { onMiscChange(economy.miscYearly, it) },
-            intervalSuffix = "mi/yr",
-            helperText = "Annual catch-all for repairs not in oil/brakes/fluids.",
+            intervalSuffix = stringResource(R.string.economy_editor_misc_interval_suffix),
+            helperText = stringResource(R.string.economy_editor_misc_helper),
         )
     }
 
     // -------- Depreciation --------
     EconomyAccordionRow(
-        title = "Depreciation",
+        title = stringResource(R.string.economy_editor_depreciation_title),
         summary = if (economy.includeDepreciation) {
-            "${Formats.money3(economy.depreciationCostPerMile)}/mi"
+            stringResource(R.string.economy_editor_per_mile_format, Formats.money3(economy.depreciationCostPerMile))
         } else {
-            "off"
+            stringResource(R.string.economy_editor_depreciation_off)
         },
         isUserSet = EconomyField.INCLUDE_DEPRECIATION in userSet ||
             EconomyField.PURCHASE_PRICE in userSet ||
             EconomyField.TOTAL_LIFETIME_MI in userSet,
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
-            Text("Include depreciation", modifier = Modifier.weight(1f))
+            Text(stringResource(R.string.economy_editor_depreciation_include_label), modifier = Modifier.weight(1f))
             Switch(
                 checked = economy.includeDepreciation,
                 onCheckedChange = {
@@ -157,32 +159,31 @@ fun EconomyEditor(
         }
         if (economy.includeDepreciation) {
             PairedCurrencyAndIntervalInput(
-                costLabel = "Purchase price",
+                costLabel = stringResource(R.string.economy_editor_purchase_price_label),
                 costValue = economy.purchasePrice,
                 onCostChange = { onDepreciationChange(true, it, economy.totalLifetimeMi) },
-                intervalLabel = "Lifetime",
+                intervalLabel = stringResource(R.string.economy_editor_lifetime_label),
                 intervalValue = economy.totalLifetimeMi,
                 onIntervalChange = { onDepreciationChange(true, economy.purchasePrice, it) },
-                helperText = "Total expected miles from new to retirement, " +
-                    "e.g. 200,000 for a typical sedan.",
+                helperText = stringResource(R.string.economy_editor_depreciation_helper),
             )
         }
     }
 
     // -------- Insurance --------
     EconomyAccordionRow(
-        title = "Insurance",
-        summary = "${Formats.money3(economy.insuranceCostPerMile)}/mi*",
+        title = stringResource(R.string.economy_editor_insurance_title),
+        summary = stringResource(R.string.economy_editor_per_mile_asterisk_format, Formats.money3(economy.insuranceCostPerMile)),
         isUserSet = EconomyField.INSURANCE_DELTA in userSet,
     ) {
         CurrencyInput(
-            label = "Extra for gig work",
+            label = stringResource(R.string.economy_editor_insurance_label),
             value = economy.insuranceDeltaPerMonth,
             onValueChange = onInsuranceChange,
-            suffix = "/mo",
+            suffix = stringResource(R.string.economy_editor_per_month_suffix),
         )
         Text(
-            text = "Monthly add-on for rideshare/delivery rider above your personal policy.",
+            text = stringResource(R.string.economy_editor_insurance_helper),
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
@@ -190,19 +191,18 @@ fun EconomyEditor(
 
     // -------- Registration --------
     EconomyAccordionRow(
-        title = "Registration",
-        summary = "${Formats.money3(economy.registrationCostPerMile)}/mi*",
+        title = stringResource(R.string.economy_editor_registration_title),
+        summary = stringResource(R.string.economy_editor_per_mile_asterisk_format, Formats.money3(economy.registrationCostPerMile)),
         isUserSet = EconomyField.REGISTRATION_DELTA in userSet,
     ) {
         CurrencyInput(
-            label = "Commercial delta",
+            label = stringResource(R.string.economy_editor_registration_label),
             value = economy.registrationDeltaPerYear,
             onValueChange = onRegistrationChange,
-            suffix = "/yr",
+            suffix = stringResource(R.string.economy_editor_per_year_suffix),
         )
         Text(
-            text = "Annual fee above your personal registration (commercial " +
-                "registration / inspection / endorsement).",
+            text = stringResource(R.string.economy_editor_registration_helper),
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
@@ -210,24 +210,24 @@ fun EconomyEditor(
 
     // -------- Phone & data --------
     EconomyAccordionRow(
-        title = "Phone & data",
-        summary = "${Formats.money3(economy.phoneCostPerMile)}/mi*",
+        title = stringResource(R.string.economy_editor_phone_title),
+        summary = stringResource(R.string.economy_editor_per_mile_asterisk_format, Formats.money3(economy.phoneCostPerMile)),
         isUserSet = EconomyField.PHONE_PLAN_TOTAL in userSet ||
             EconomyField.PHONE_PLAN_LINES in userSet ||
             EconomyField.PHONE_BUSINESS_PERCENT in userSet,
     ) {
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
             CurrencyInput(
-                label = "Plan total",
+                label = stringResource(R.string.economy_editor_phone_plan_total_label),
                 value = economy.phonePlanTotal,
                 onValueChange = {
                     onPhoneChange(it, economy.phonePlanLines, economy.phoneBusinessPercent)
                 },
-                suffix = "/mo",
+                suffix = stringResource(R.string.economy_editor_per_month_suffix),
                 modifier = Modifier.weight(1f),
             )
             IntegerInput(
-                label = "Lines",
+                label = stringResource(R.string.economy_editor_phone_lines_label),
                 value = economy.phonePlanLines,
                 onValueChange = {
                     onPhoneChange(economy.phonePlanTotal, it, economy.phoneBusinessPercent)
@@ -235,7 +235,7 @@ fun EconomyEditor(
                 modifier = Modifier.weight(1f),
             )
         }
-        Text("% for gig work: ${economy.phoneBusinessPercent.toInt()}%")
+        Text(stringResource(R.string.economy_editor_phone_business_percent_format, economy.phoneBusinessPercent.toInt()))
         Slider(
             value = economy.phoneBusinessPercent.toFloat(),
             onValueChange = {
@@ -245,9 +245,12 @@ fun EconomyEditor(
         )
         val perLine = economy.phonePlanTotal / economy.phonePlanLines.coerceAtLeast(1)
         Text(
-            text = "Your line: ${Formats.money(perLine)}/mo" +
-                " × ${economy.phoneBusinessPercent.toInt()}%" +
-                " = ${Formats.money(perLine * economy.phoneBusinessPercent / 100.0)}/mo for gig work",
+            text = stringResource(
+                R.string.economy_editor_phone_per_line_format,
+                Formats.money(perLine),
+                economy.phoneBusinessPercent.toInt(),
+                Formats.money(perLine * economy.phoneBusinessPercent / 100.0),
+            ),
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
@@ -255,12 +258,12 @@ fun EconomyEditor(
 
     // -------- Expected annual gig miles --------
     EconomyAccordionRow(
-        title = "Expected gig miles / yr",
-        summary = "${Formats.commaInt(economy.expectedAnnualMiles.toInt())} mi",
+        title = stringResource(R.string.economy_editor_annual_miles_title),
+        summary = stringResource(R.string.economy_editor_annual_miles_summary_format, Formats.commaInt(economy.expectedAnnualMiles.toInt())),
         isUserSet = EconomyField.EXPECTED_ANNUAL_MI in userSet,
     ) {
         Text(
-            text = "${Formats.commaInt(economy.expectedAnnualMiles.toInt())} miles per year",
+            text = stringResource(R.string.economy_editor_annual_miles_value_format, Formats.commaInt(economy.expectedAnnualMiles.toInt())),
             style = MaterialTheme.typography.bodyMedium,
             fontWeight = FontWeight.Medium,
         )
@@ -271,8 +274,7 @@ fun EconomyEditor(
             steps = 58, // 500-mile increments
         )
         Text(
-            text = "Used to amortize fixed costs (insurance, registration, phone) into " +
-                "a per-mile rate. Bigger number → smaller per-mile share.",
+            text = stringResource(R.string.economy_editor_annual_miles_helper),
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
@@ -286,7 +288,7 @@ fun VehicleClassPicker(
     onClassChange: (VehicleClass) -> Unit,
 ) {
     Text(
-        text = "Vehicle class",
+        text = stringResource(R.string.economy_editor_vehicle_class_title),
         style = MaterialTheme.typography.titleSmall,
         modifier = Modifier.padding(bottom = 4.dp),
     )
@@ -316,12 +318,12 @@ fun TrueCostFooter(operatingCostPerMile: Double) {
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Text(
-                text = "Your true cost: ${Formats.money(operatingCostPerMile)}/mi",
+                text = stringResource(R.string.economy_editor_true_cost_format, Formats.money(operatingCostPerMile)),
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
             )
             Text(
-                text = "IRS standard mileage rate: \$0.67/mi",
+                text = stringResource(R.string.economy_editor_irs_rate_note),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/MainActivity.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/MainActivity.kt
@@ -19,6 +19,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -39,6 +40,7 @@ import cloud.trotter.dashbuddy.ui.main.settings.SettingsHomeScreen
 import cloud.trotter.dashbuddy.ui.main.settings.StrategySettingsScreen
 import cloud.trotter.dashbuddy.ui.main.setup.wizard.WizardScreen
 import cloud.trotter.dashbuddy.core.designsystem.theme.DashBuddyTheme
+import cloud.trotter.dashbuddy.R
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -167,7 +169,7 @@ class MainActivity : ComponentActivity() {
                         // 5. Developer Options
                         composable(Screen.DeveloperSettings.route) {
                             PlaceholderScreen(
-                                title = "Developer Options",
+                                title = stringResource(R.string.main_activity_developer_options_title),
                                 onBack = { navController.popBackStack() }
                             )
                         }
@@ -198,7 +200,10 @@ fun PlaceholderScreen(title: String, onBack: () -> Unit) {
                 title = { Text(title) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.common_content_desc_back),
+                        )
                     }
                 }
             )
@@ -211,7 +216,7 @@ fun PlaceholderScreen(title: String, onBack: () -> Unit) {
             contentAlignment = Alignment.Center
         ) {
             Text(
-                text = "Construction Area 🚧\nComing Soon",
+                text = stringResource(R.string.main_activity_placeholder_construction),
                 style = MaterialTheme.typography.headlineSmall,
                 color = MaterialTheme.colorScheme.secondary
             )

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsScreen.kt
@@ -21,10 +21,12 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
+import cloud.trotter.dashbuddy.R
 import cloud.trotter.dashbuddy.core.designsystem.component.AppCard
 import cloud.trotter.dashbuddy.core.designsystem.component.AppSegmented
 import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
@@ -52,15 +54,21 @@ fun AnalyticsScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Analytics") },
+                title = { Text(stringResource(R.string.analytics_screen_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.common_content_desc_back),
+                        )
                     }
                 },
                 actions = {
                     IconButton(onClick = onExportCsv) {
-                        Icon(Icons.Default.FileDownload, contentDescription = "Export data (CSV)")
+                        Icon(
+                            Icons.Default.FileDownload,
+                            contentDescription = stringResource(R.string.analytics_screen_content_desc_export_csv),
+                        )
                     }
                 },
             )
@@ -126,11 +134,12 @@ fun AnalyticsScreen(
 /** The review windows offered by the Money period selector, in display order. */
 private data class PeriodOption(val period: AnalyticsPeriod, val label: String)
 
-private val PERIOD_OPTIONS = listOf(
-    PeriodOption(AnalyticsPeriod.TODAY, "Today"),
-    PeriodOption(AnalyticsPeriod.THIS_WEEK, "Week"),
-    PeriodOption(AnalyticsPeriod.THIS_MONTH, "Month"),
-    PeriodOption(AnalyticsPeriod.LIFETIME, "Lifetime"),
+@Composable
+private fun periodOptions(): List<PeriodOption> = listOf(
+    PeriodOption(AnalyticsPeriod.TODAY, stringResource(R.string.common_period_today)),
+    PeriodOption(AnalyticsPeriod.THIS_WEEK, stringResource(R.string.common_period_week)),
+    PeriodOption(AnalyticsPeriod.THIS_MONTH, stringResource(R.string.common_period_month)),
+    PeriodOption(AnalyticsPeriod.LIFETIME, stringResource(R.string.common_period_lifetime)),
 )
 
 @Composable
@@ -138,12 +147,13 @@ private fun PeriodSelector(
     selectedPeriod: AnalyticsPeriod,
     onSelectPeriod: (AnalyticsPeriod) -> Unit,
 ) {
-    val selectedLabel = PERIOD_OPTIONS.first { it.period == selectedPeriod }.label
+    val periodOptions = periodOptions()
+    val selectedLabel = periodOptions.first { it.period == selectedPeriod }.label
     AppSegmented(
-        options = PERIOD_OPTIONS.map { it.label },
+        options = periodOptions.map { it.label },
         selected = selectedLabel,
         onSelect = { label ->
-            PERIOD_OPTIONS.firstOrNull { it.label == label }?.let { onSelectPeriod(it.period) }
+            periodOptions.firstOrNull { it.label == label }?.let { onSelectPeriod(it.period) }
         },
         modifier = Modifier.fillMaxWidth(),
     )
@@ -153,13 +163,13 @@ private fun PeriodSelector(
 private fun ComingSoonCard(tab: AnalyticsTab) {
     AppCard(modifier = Modifier.fillMaxWidth()) {
         Text(
-            text = "${tab.label} — coming soon",
+            text = stringResource(R.string.analytics_screen_coming_soon_title, tab.label),
             style = MaterialTheme.typography.titleMedium,
             color = AppTheme.colors.text,
         )
         Spacer(Modifier.height(4.dp))
         Text(
-            text = "This tab lands in a later Analytics phase.",
+            text = stringResource(R.string.analytics_screen_coming_soon_desc),
             style = MaterialTheme.typography.bodyMedium,
             color = AppTheme.colors.text3,
         )

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/DecisionsTab.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/DecisionsTab.kt
@@ -13,8 +13,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import cloud.trotter.dashbuddy.R
 import cloud.trotter.dashbuddy.core.designsystem.component.AppCard
 import cloud.trotter.dashbuddy.core.designsystem.component.AppLegend
 import cloud.trotter.dashbuddy.core.designsystem.component.AppSegment
@@ -55,10 +57,10 @@ fun DecisionsTab(
 private fun OfferFunnelCard(decisions: DecisionEconomics) {
     val c = AppTheme.colors
     AppCard(modifier = Modifier.fillMaxWidth()) {
-        Text(text = "OFFER FUNNEL", style = MaterialTheme.typography.labelMedium, color = c.text3)
+        Text(text = stringResource(R.string.decisions_tab_offer_funnel_title), style = MaterialTheme.typography.labelMedium, color = c.text3)
         Spacer(Modifier.height(10.dp))
         if (decisions.received == 0) {
-            EmptyRow("No offers in this period yet.")
+            EmptyRow(stringResource(R.string.decisions_tab_no_offers_yet))
             return@AppCard
         }
 
@@ -66,8 +68,12 @@ private fun OfferFunnelCard(decisions: DecisionEconomics) {
         Text(text = rate, style = AppTheme.num.heroNum, color = c.text)
         Spacer(Modifier.height(2.dp))
         Text(
-            text = "acceptance rate · ${Formats.commaInt(decisions.received)} " +
-                if (decisions.received == 1) "offer" else "offers",
+            text = stringResource(
+                R.string.decisions_tab_acceptance_rate_caption,
+                Formats.commaInt(decisions.received),
+                if (decisions.received == 1) stringResource(R.string.decisions_tab_offer_singular)
+                else stringResource(R.string.decisions_tab_offer_plural),
+            ),
             style = MaterialTheme.typography.bodySmall,
             color = c.text3,
         )
@@ -75,9 +81,9 @@ private fun OfferFunnelCard(decisions: DecisionEconomics) {
 
         // Counts drive the bar; the legend surfaces the raw count per segment (the rate is the hero).
         val segments = listOf(
-            AppSegment("Accepted", decisions.accepted.toFloat(), c.good, note = Formats.commaInt(decisions.accepted)),
-            AppSegment("Declined", decisions.declined.toFloat(), c.bad, note = Formats.commaInt(decisions.declined)),
-            AppSegment("Timed out", decisions.timedOut.toFloat(), c.neutral, note = Formats.commaInt(decisions.timedOut)),
+            AppSegment(stringResource(R.string.decisions_tab_segment_accepted), decisions.accepted.toFloat(), c.good, note = Formats.commaInt(decisions.accepted)),
+            AppSegment(stringResource(R.string.decisions_tab_segment_declined), decisions.declined.toFloat(), c.bad, note = Formats.commaInt(decisions.declined)),
+            AppSegment(stringResource(R.string.decisions_tab_segment_timed_out), decisions.timedOut.toFloat(), c.neutral, note = Formats.commaInt(decisions.timedOut)),
         )
         AppStackBar(segments, height = 14.dp)
         Spacer(Modifier.height(10.dp))
@@ -93,19 +99,27 @@ private fun OfferFunnelCard(decisions: DecisionEconomics) {
 private fun ValueOfSayingNoCard(decisions: DecisionEconomics) {
     val c = AppTheme.colors
     AppCard(modifier = Modifier.fillMaxWidth()) {
-        Text(text = "VALUE OF SAYING NO", style = MaterialTheme.typography.labelMedium, color = c.text3)
+        Text(text = stringResource(R.string.decisions_tab_value_of_no_title), style = MaterialTheme.typography.labelMedium, color = c.text3)
         Spacer(Modifier.height(10.dp))
         if (decisions.declined == 0) {
             Text(text = EMPTY_VALUE, style = AppTheme.num.heroNum, color = c.text2)
             Spacer(Modifier.height(2.dp))
-            EmptyRow("No declines in this period.")
+            EmptyRow(stringResource(R.string.decisions_tab_no_declines_yet))
             return@AppCard
         }
-        Text(text = "~${Formats.money(decisions.declinedEstNet)}", style = AppTheme.num.heroNum, color = c.text)
+        Text(
+            text = stringResource(R.string.decisions_tab_est_net_skipped_format, Formats.money(decisions.declinedEstNet)),
+            style = AppTheme.num.heroNum,
+            color = c.text,
+        )
         Spacer(Modifier.height(2.dp))
         Text(
-            text = "est. net skipped across ${Formats.commaInt(decisions.declined)} declined " +
-                if (decisions.declined == 1) "offer" else "offers",
+            text = stringResource(
+                R.string.decisions_tab_est_net_skipped_caption,
+                Formats.commaInt(decisions.declined),
+                if (decisions.declined == 1) stringResource(R.string.decisions_tab_offer_singular)
+                else stringResource(R.string.decisions_tab_offer_plural),
+            ),
             style = MaterialTheme.typography.bodySmall,
             color = c.text3,
         )
@@ -121,30 +135,30 @@ private fun ValueOfSayingNoCard(decisions: DecisionEconomics) {
 private fun ScoreVsOutcomeCard(decisions: DecisionEconomics) {
     val c = AppTheme.colors
     AppCard(modifier = Modifier.fillMaxWidth()) {
-        Text(text = "SCORE VS OUTCOME", style = MaterialTheme.typography.labelMedium, color = c.text3)
+        Text(text = stringResource(R.string.decisions_tab_score_vs_outcome_title), style = MaterialTheme.typography.labelMedium, color = c.text3)
         Spacer(Modifier.height(10.dp))
         if (decisions.received == 0) {
-            EmptyRow("No offers in this period yet.")
+            EmptyRow(stringResource(R.string.decisions_tab_no_offers_yet))
             return@AppCard
         }
         // Header
         ComparisonRow(
             label = "",
-            score = "Avg score",
-            perHour = "Est. \$/hr",
+            score = stringResource(R.string.decisions_tab_avg_score_header),
+            perHour = stringResource(R.string.decisions_tab_est_per_hour_header),
             labelColor = c.text3,
             valueStyleHeader = true,
         )
         Spacer(Modifier.height(8.dp))
         ComparisonRow(
-            label = "Accepted",
+            label = stringResource(R.string.decisions_tab_segment_accepted),
             score = decisions.avgScoreAccepted?.let { Formats.decimal(it, 1) } ?: EMPTY_VALUE,
             perHour = decisions.avgEstPerHourAccepted?.let { Formats.money(it) } ?: EMPTY_VALUE,
             labelColor = c.good,
         )
         Spacer(Modifier.height(8.dp))
         ComparisonRow(
-            label = "Declined",
+            label = stringResource(R.string.decisions_tab_segment_declined),
             score = decisions.avgScoreDeclined?.let { Formats.decimal(it, 1) } ?: EMPTY_VALUE,
             perHour = decisions.avgEstPerHourDeclined?.let { Formats.money(it) } ?: EMPTY_VALUE,
             labelColor = c.bad,

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/MoneyTab.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/MoneyTab.kt
@@ -21,8 +21,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import cloud.trotter.dashbuddy.R
 import cloud.trotter.dashbuddy.core.designsystem.component.AppBar
 import cloud.trotter.dashbuddy.core.designsystem.component.AppBarChart
 import cloud.trotter.dashbuddy.core.designsystem.component.AppCallout
@@ -68,8 +70,7 @@ fun MoneyTab(
         StatTiles(economics)
         if (economics.unattributedPay > UNATTRIBUTED_EPSILON) {
             AppCallout(
-                text = "${Formats.money(economics.unattributedPay)} not attributed to any " +
-                    "delivery — bonuses/adjustments; review coming (#650)",
+                text = stringResource(R.string.money_tab_unattributed_callout_format, Formats.money(economics.unattributedPay)),
                 container = AppTheme.colors.warnBg,
                 modifier = Modifier.fillMaxWidth(),
             )
@@ -86,18 +87,18 @@ private fun EarningsHero(economics: PeriodEconomics) {
     val c = AppTheme.colors
     val netColor = if (economics.netProfit >= 0.0) c.good else c.bad
     AppCard(modifier = Modifier.fillMaxWidth()) {
-        Text(text = "GROSS EARNINGS", style = MaterialTheme.typography.labelMedium, color = c.text3)
+        Text(text = stringResource(R.string.money_tab_gross_earnings_title), style = MaterialTheme.typography.labelMedium, color = c.text3)
         Spacer(Modifier.height(4.dp))
         Text(text = Formats.money(economics.grossEarnings), style = AppTheme.num.heroNum, color = c.text)
         Spacer(Modifier.height(10.dp))
         FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
             AppChip(
-                text = "True net ${Formats.money(economics.netProfit)}",
+                text = stringResource(R.string.money_tab_true_net_chip_format, Formats.money(economics.netProfit)),
                 color = netColor,
                 container = if (economics.netProfit >= 0.0) c.goodBg else c.badBg,
             )
             AppChip(
-                text = "Net/hr ${economics.netPerHour?.let { Formats.money(it) } ?: EMPTY_VALUE}",
+                text = stringResource(R.string.money_tab_net_per_hour_chip_format, economics.netPerHour?.let { Formats.money(it) } ?: EMPTY_VALUE),
                 color = c.accent,
                 container = c.accentDim,
             )
@@ -114,10 +115,10 @@ private fun EarningsHero(economics: PeriodEconomics) {
 private fun EarningsByDayCard(days: List<DailyEarnings>) {
     val c = AppTheme.colors
     AppCard(modifier = Modifier.fillMaxWidth()) {
-        Text(text = "EARNINGS BY DAY", style = MaterialTheme.typography.labelMedium, color = c.text3)
+        Text(text = stringResource(R.string.money_tab_earnings_by_day_title), style = MaterialTheme.typography.labelMedium, color = c.text3)
         Spacer(Modifier.height(10.dp))
         if (days.all { it.gross <= 0.0 }) {
-            EmptyRow("No earnings in this period yet.")
+            EmptyRow(stringResource(R.string.money_tab_no_earnings_yet))
         } else {
             // Highlight the first day that hit the period's peak gross (only when someone earned).
             val bestDay = days.maxByOrNull { it.gross }?.takeIf { it.gross > 0.0 }?.date
@@ -132,7 +133,7 @@ private fun EarningsByDayCard(days: List<DailyEarnings>) {
             AppBarChart(bars = bars, modifier = Modifier.fillMaxWidth())
             Spacer(Modifier.height(8.dp))
             Text(
-                text = "gross per day · sessions count on their start day",
+                text = stringResource(R.string.money_tab_earnings_by_day_caption),
                 style = MaterialTheme.typography.bodySmall,
                 color = c.text3,
             )
@@ -224,7 +225,7 @@ private fun TrueNetWaterfall(economics: PeriodEconomics) {
     val scale = (listOf(0.0) + steps.map { it.amount }).max().takeIf { it > 0.0 } ?: 1.0
 
     AppCard(modifier = Modifier.fillMaxWidth()) {
-        Text(text = "TRUE NET", style = MaterialTheme.typography.labelMedium, color = c.text3)
+        Text(text = stringResource(R.string.money_tab_true_net_title), style = MaterialTheme.typography.labelMedium, color = c.text3)
         Spacer(Modifier.height(10.dp))
         steps.forEachIndexed { index, step ->
             if (index > 0) Spacer(Modifier.height(8.dp))
@@ -279,24 +280,24 @@ private fun StatTiles(economics: PeriodEconomics) {
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
         Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
             AppStatTile(
-                label = "Net/hr",
+                label = stringResource(R.string.money_tab_stat_net_per_hour),
                 value = economics.netPerHour?.let { Formats.money(it) } ?: EMPTY_VALUE,
                 modifier = Modifier.weight(1f),
             )
             AppStatTile(
-                label = "Net/mi",
+                label = stringResource(R.string.money_tab_stat_net_per_mile),
                 value = economics.netPerMile?.let { Formats.money(it) } ?: EMPTY_VALUE,
                 modifier = Modifier.weight(1f),
             )
         }
         Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
             AppStatTile(
-                label = "Miles",
+                label = stringResource(R.string.money_tab_stat_miles),
                 value = Formats.decimal(economics.totals.miles),
                 modifier = Modifier.weight(1f),
             )
             AppStatTile(
-                label = "Deliveries",
+                label = stringResource(R.string.money_tab_stat_deliveries),
                 value = Formats.commaInt(economics.totals.deliveries),
                 modifier = Modifier.weight(1f),
             )
@@ -309,23 +310,24 @@ private fun StatTiles(economics: PeriodEconomics) {
 private fun TopStoresCard(stores: List<StoreEconomics>) {
     val c = AppTheme.colors
     AppCard(modifier = Modifier.fillMaxWidth()) {
-        Text(text = "TOP STORES", style = MaterialTheme.typography.labelMedium, color = c.text3)
+        Text(text = stringResource(R.string.money_tab_top_stores_title), style = MaterialTheme.typography.labelMedium, color = c.text3)
         Spacer(Modifier.height(10.dp))
         if (stores.isEmpty()) {
-            EmptyRow("No store earnings in this period yet.")
+            EmptyRow(stringResource(R.string.money_tab_no_store_earnings_yet))
         } else {
             stores.forEachIndexed { index, store ->
                 if (index > 0) Spacer(Modifier.height(10.dp))
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Column(Modifier.weight(1f)) {
                         Text(
-                            text = store.storeName ?: "Unknown store",
+                            text = store.storeName ?: stringResource(R.string.money_tab_unknown_store),
                             style = MaterialTheme.typography.bodyMedium,
                             color = c.text,
                         )
                         Text(
                             text = "${Formats.commaInt(store.deliveries)} " +
-                                if (store.deliveries == 1) "delivery" else "deliveries",
+                                if (store.deliveries == 1) stringResource(R.string.time_tab_delivery_singular)
+                                else stringResource(R.string.time_tab_delivery_plural),
                             style = MaterialTheme.typography.bodySmall,
                             color = c.text3,
                         )
@@ -353,10 +355,10 @@ private fun TopStoresCard(stores: List<StoreEconomics>) {
 private fun RecentDashesCard(sessions: List<SessionRecord>, onOpenSession: (String) -> Unit) {
     val c = AppTheme.colors
     AppCard(modifier = Modifier.fillMaxWidth()) {
-        Text(text = "RECENT SESSIONS", style = MaterialTheme.typography.labelMedium, color = c.text3)
+        Text(text = stringResource(R.string.money_tab_recent_sessions_title), style = MaterialTheme.typography.labelMedium, color = c.text3)
         Spacer(Modifier.height(10.dp))
         if (sessions.isEmpty()) {
-            EmptyRow("No sessions recorded yet.")
+            EmptyRow(stringResource(R.string.money_tab_no_sessions_recorded_yet))
         } else {
             sessions.forEachIndexed { index, session ->
                 if (index > 0) Spacer(Modifier.height(10.dp))
@@ -374,7 +376,8 @@ private fun RecentDashesCard(sessions: List<SessionRecord>, onOpenSession: (Stri
                         )
                         Text(
                             text = "${Formats.commaInt(session.deliveries)} " +
-                                if (session.deliveries == 1) "delivery" else "deliveries",
+                                if (session.deliveries == 1) stringResource(R.string.time_tab_delivery_singular)
+                                else stringResource(R.string.time_tab_delivery_plural),
                             style = MaterialTheme.typography.bodySmall,
                             color = c.text3,
                         )
@@ -391,7 +394,7 @@ private fun RecentDashesCard(sessions: List<SessionRecord>, onOpenSession: (Stri
                         // Additive-only cash marker (#688 F7) — never folded into the reported number.
                         if (session.cashTips > UNATTRIBUTED_EPSILON) {
                             Text(
-                                text = "+${Formats.money(session.cashTips)} cash",
+                                text = stringResource(R.string.money_tab_cash_marker_format, Formats.money(session.cashTips)),
                                 style = MaterialTheme.typography.bodySmall,
                                 color = c.good,
                             )

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/MoneyTab.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/MoneyTab.kt
@@ -132,7 +132,7 @@ private fun EarningsByDayCard(days: List<DailyEarnings>) {
             AppBarChart(bars = bars, modifier = Modifier.fillMaxWidth())
             Spacer(Modifier.height(8.dp))
             Text(
-                text = "gross per day · dashes count on their start day",
+                text = "gross per day · sessions count on their start day",
                 style = MaterialTheme.typography.bodySmall,
                 color = c.text3,
             )
@@ -353,10 +353,10 @@ private fun TopStoresCard(stores: List<StoreEconomics>) {
 private fun RecentDashesCard(sessions: List<SessionRecord>, onOpenSession: (String) -> Unit) {
     val c = AppTheme.colors
     AppCard(modifier = Modifier.fillMaxWidth()) {
-        Text(text = "RECENT DASHES", style = MaterialTheme.typography.labelMedium, color = c.text3)
+        Text(text = "RECENT SESSIONS", style = MaterialTheme.typography.labelMedium, color = c.text3)
         Spacer(Modifier.height(10.dp))
         if (sessions.isEmpty()) {
-            EmptyRow("No dashes recorded yet.")
+            EmptyRow("No sessions recorded yet.")
         } else {
             sessions.forEachIndexed { index, session ->
                 if (index > 0) Spacer(Modifier.height(10.dp))

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/SessionDetailScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/SessionDetailScreen.kt
@@ -33,11 +33,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import cloud.trotter.dashbuddy.R
 import cloud.trotter.dashbuddy.core.designsystem.component.AppCallout
 import cloud.trotter.dashbuddy.core.designsystem.component.AppCard
 import cloud.trotter.dashbuddy.core.designsystem.component.AppChip
@@ -78,10 +80,13 @@ fun SessionDetailScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Session detail") },
+                title = { Text(stringResource(R.string.session_detail_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.common_content_desc_back),
+                        )
                     }
                 },
             )
@@ -100,7 +105,7 @@ fun SessionDetailScreen(
                     .fillMaxSize(),
             )
             // Post-load, a null detail means no session row exists for this id.
-            !uiState.loading -> CenteredMessage("Session not found.", Modifier.padding(padding))
+            !uiState.loading -> CenteredMessage(stringResource(R.string.session_detail_not_found), Modifier.padding(padding))
             // Pre-first-emission: keep the frame empty (the read-model emits promptly).
             else -> Box(Modifier.padding(padding).fillMaxSize())
         }
@@ -133,12 +138,11 @@ private fun DashDetailContent(
         if (hasCallout) {
             Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
                 AppCallout(
-                    text = "${Formats.money(detail.unattributedPay)} unaccounted on this session — the " +
-                        "platform reported more than the captured deliveries.",
+                    text = stringResource(R.string.session_detail_unaccounted_format, Formats.money(detail.unattributedPay)),
                     container = AppTheme.colors.warnBg,
                     modifier = Modifier.fillMaxWidth(),
                 )
-                TextButton(onClick = { showAddDialog = true }) { Text("Add missed delivery") }
+                TextButton(onClick = { showAddDialog = true }) { Text(stringResource(R.string.session_detail_add_missed_delivery)) }
             }
         }
         // With no callout, the add entry point lives at the bottom of the deliveries card — a missed
@@ -199,24 +203,28 @@ private fun HeaderCard(detail: SessionDetail) {
         }
         Spacer(Modifier.height(4.dp))
         Text(
-            text = "Duration ${dashDuration(session.startedAt, session.endedAt, session.reportedDurationMillis)}",
+            text = stringResource(
+                R.string.session_detail_duration_format,
+                dashDuration(session.startedAt, session.endedAt, session.reportedDurationMillis),
+            ),
             style = MaterialTheme.typography.bodySmall,
             color = c.text3,
         )
         Spacer(Modifier.height(12.dp))
         Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
             AppStatTile(
-                label = if (hasReported) "Gross (reported)" else "Gross (captured)",
+                label = if (hasReported) stringResource(R.string.session_detail_gross_reported_label)
+                else stringResource(R.string.session_detail_gross_captured_label),
                 value = Formats.money(gross),
                 modifier = Modifier.weight(1f),
             )
             AppStatTile(
-                label = "Miles",
+                label = stringResource(R.string.session_detail_stat_miles),
                 value = session.miles?.let { Formats.decimal(it) } ?: EMPTY_VALUE,
                 modifier = Modifier.weight(1f),
             )
             AppStatTile(
-                label = "Deliveries",
+                label = stringResource(R.string.session_detail_stat_deliveries),
                 value = Formats.commaInt(session.deliveries),
                 modifier = Modifier.weight(1f),
             )
@@ -226,7 +234,7 @@ private fun HeaderCard(detail: SessionDetail) {
         if (detail.cashTips > UNATTRIBUTED_EPSILON) {
             Spacer(Modifier.height(6.dp))
             Text(
-                text = "+${Formats.money(detail.cashTips)} cash tips",
+                text = stringResource(R.string.session_detail_cash_tips_format, Formats.money(detail.cashTips)),
                 style = MaterialTheme.typography.bodySmall,
                 color = c.good,
             )
@@ -254,10 +262,10 @@ private fun DeliveriesCard(
 ) {
     val c = AppTheme.colors
     AppCard(modifier = Modifier.fillMaxWidth()) {
-        Text(text = "DELIVERIES", style = MaterialTheme.typography.labelMedium, color = c.text3)
+        Text(text = stringResource(R.string.session_detail_deliveries_title), style = MaterialTheme.typography.labelMedium, color = c.text3)
         Spacer(Modifier.height(10.dp))
         if (deliveries.isEmpty()) {
-            EmptyRow("No deliveries captured for this session.")
+            EmptyRow(stringResource(R.string.session_detail_no_deliveries_yet))
         } else {
             deliveries.forEachIndexed { index, delivery ->
                 if (index > 0) Spacer(Modifier.height(14.dp))
@@ -266,7 +274,7 @@ private fun DeliveriesCard(
         }
         if (showAddButton) {
             Spacer(Modifier.height(6.dp))
-            TextButton(onClick = onAddMissed) { Text("Add missed delivery") }
+            TextButton(onClick = onAddMissed) { Text(stringResource(R.string.session_detail_add_missed_delivery)) }
         }
     }
 }
@@ -284,7 +292,7 @@ private fun DeliveryRow(delivery: DeliveryRecord, onAdjust: () -> Unit) {
     ) {
         Column(Modifier.weight(1f)) {
             Text(
-                text = delivery.storeName ?: "Unknown store",
+                text = delivery.storeName ?: stringResource(R.string.session_detail_unknown_store),
                 style = MaterialTheme.typography.bodyMedium,
                 color = c.text,
             )
@@ -305,7 +313,7 @@ private fun DeliveryRow(delivery: DeliveryRecord, onAdjust: () -> Unit) {
             )
             delivery.tip?.let {
                 Text(
-                    text = "incl. ${Formats.money(it)} tip",
+                    text = stringResource(R.string.session_detail_tip_included_format, Formats.money(it)),
                     style = MaterialTheme.typography.bodySmall,
                     color = c.text3,
                 )
@@ -313,7 +321,7 @@ private fun DeliveryRow(delivery: DeliveryRecord, onAdjust: () -> Unit) {
             // Driver-entered cash tip (#688) — its own line; added to net below (display-level only).
             delivery.cashTip?.takeIf { it > UNATTRIBUTED_EPSILON }?.let {
                 Text(
-                    text = "+${Formats.money(it)} cash",
+                    text = stringResource(R.string.session_detail_cash_format, Formats.money(it)),
                     style = MaterialTheme.typography.bodySmall,
                     color = c.good,
                 )
@@ -322,7 +330,7 @@ private fun DeliveryRow(delivery: DeliveryRecord, onAdjust: () -> Unit) {
             // offer, not a captured receipt — disclose it (never-silent, the #689 precedent).
             if (delivery.payBasis == PayBasis.OFFER_PAY) {
                 Text(
-                    text = "est. offer pay",
+                    text = stringResource(R.string.session_detail_est_offer_pay),
                     style = MaterialTheme.typography.bodySmall,
                     color = c.text3,
                 )
@@ -331,7 +339,7 @@ private fun DeliveryRow(delivery: DeliveryRecord, onAdjust: () -> Unit) {
             // cash-free); a null-net row (no cost basis) stays an em dash even with cash present.
             val net = delivery.netProfit?.let { it + (delivery.cashTip ?: 0.0) }
             Text(
-                text = "net ${net?.let { Formats.money(it) } ?: EMPTY_VALUE}",
+                text = stringResource(R.string.session_detail_net_format, net?.let { Formats.money(it) } ?: EMPTY_VALUE),
                 style = MaterialTheme.typography.bodySmall,
                 color = when {
                     net == null -> c.text3
@@ -344,7 +352,7 @@ private fun DeliveryRow(delivery: DeliveryRecord, onAdjust: () -> Unit) {
         IconButton(onClick = onAdjust) {
             Icon(
                 Icons.Default.Edit,
-                contentDescription = "Adjust delivery",
+                contentDescription = stringResource(R.string.session_detail_content_desc_adjust),
                 tint = AppTheme.colors.text3,
             )
         }
@@ -415,14 +423,14 @@ private fun AddMissedDeliveryDialog(
 
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("Add missed delivery") },
+        title = { Text(stringResource(R.string.session_detail_add_missed_delivery)) },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                MoneyField(store, { store = it }, "Store (optional)", numeric = false)
-                MoneyField(pay, { pay = it }, "Pay")
-                MoneyField(tip, { tip = it }, "Tip (included in pay)")
-                MoneyField(cashTip, { cashTip = it }, "Cash tip (optional)")
-                MoneyField(note, { note = it }, "Note (optional)", numeric = false)
+                MoneyField(store, { store = it }, stringResource(R.string.session_detail_field_store_optional), numeric = false)
+                MoneyField(pay, { pay = it }, stringResource(R.string.session_detail_field_pay))
+                MoneyField(tip, { tip = it }, stringResource(R.string.session_detail_field_tip_included))
+                MoneyField(cashTip, { cashTip = it }, stringResource(R.string.session_detail_field_cash_tip_optional))
+                MoneyField(note, { note = it }, stringResource(R.string.session_detail_field_note_optional), numeric = false)
             }
         },
         confirmButton = {
@@ -437,9 +445,9 @@ private fun AddMissedDeliveryDialog(
                         note.trim().takeIf { it.isNotBlank() },
                     )
                 },
-            ) { Text("Add") }
+            ) { Text(stringResource(R.string.session_detail_add_button)) }
         },
-        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+        dismissButton = { TextButton(onClick = onDismiss) { Text(stringResource(R.string.session_detail_cancel_button)) } },
     )
 }
 
@@ -508,19 +516,19 @@ private fun AdjustDeliveryDialog(
 
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("Adjust delivery") },
+        title = { Text(stringResource(R.string.session_detail_adjust_dialog_title)) },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                MoneyField(store, { store = it }, "Store name", numeric = false)
+                MoneyField(store, { store = it }, stringResource(R.string.session_detail_field_store_name), numeric = false)
                 MoneyField(
-                    pay, { pay = it }, "Pay",
+                    pay, { pay = it }, stringResource(R.string.session_detail_field_pay),
                     enabled = !payLocked,
-                    supportingText = if (payLocked) "de-duplicated receipt — edit the real drop's row" else null,
+                    supportingText = if (payLocked) stringResource(R.string.session_detail_field_pay_locked_supporting) else null,
                 )
-                MoneyField(tip, { tip = it }, "Tip (included in pay)", enabled = !payLocked)
-                MoneyField(cashTip, { cashTip = it }, "Cash tip")
-                MoneyField(miles, { miles = it }, "Miles")
-                MoneyField(note, { note = it }, "Note (optional)", numeric = false)
+                MoneyField(tip, { tip = it }, stringResource(R.string.session_detail_field_tip_included), enabled = !payLocked)
+                MoneyField(cashTip, { cashTip = it }, stringResource(R.string.session_detail_field_cash_tip))
+                MoneyField(miles, { miles = it }, stringResource(R.string.session_detail_stat_miles))
+                MoneyField(note, { note = it }, stringResource(R.string.session_detail_field_note_optional), numeric = false)
             }
         },
         confirmButton = {
@@ -536,9 +544,9 @@ private fun AdjustDeliveryDialog(
                         noteParsed,
                     )
                 },
-            ) { Text("Save") }
+            ) { Text(stringResource(R.string.session_detail_save_button)) }
         },
-        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+        dismissButton = { TextButton(onClick = onDismiss) { Text(stringResource(R.string.session_detail_cancel_button)) } },
     )
 }
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/SessionDetailScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/SessionDetailScreen.kt
@@ -78,7 +78,7 @@ fun SessionDetailScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Dash detail") },
+                title = { Text("Session detail") },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
@@ -100,7 +100,7 @@ fun SessionDetailScreen(
                     .fillMaxSize(),
             )
             // Post-load, a null detail means no session row exists for this id.
-            !uiState.loading -> CenteredMessage("Dash not found.", Modifier.padding(padding))
+            !uiState.loading -> CenteredMessage("Session not found.", Modifier.padding(padding))
             // Pre-first-emission: keep the frame empty (the read-model emits promptly).
             else -> Box(Modifier.padding(padding).fillMaxSize())
         }
@@ -133,7 +133,7 @@ private fun DashDetailContent(
         if (hasCallout) {
             Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
                 AppCallout(
-                    text = "${Formats.money(detail.unattributedPay)} unaccounted on this dash — the " +
+                    text = "${Formats.money(detail.unattributedPay)} unaccounted on this session — the " +
                         "platform reported more than the captured deliveries.",
                     container = AppTheme.colors.warnBg,
                     modifier = Modifier.fillMaxWidth(),
@@ -257,7 +257,7 @@ private fun DeliveriesCard(
         Text(text = "DELIVERIES", style = MaterialTheme.typography.labelMedium, color = c.text3)
         Spacer(Modifier.height(10.dp))
         if (deliveries.isEmpty()) {
-            EmptyRow("No deliveries captured for this dash.")
+            EmptyRow("No deliveries captured for this session.")
         } else {
             deliveries.forEachIndexed { index, delivery ->
                 if (index > 0) Spacer(Modifier.height(14.dp))

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/TimeTab.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/TimeTab.kt
@@ -68,7 +68,7 @@ private fun TimeSplitCard(time: TimeEconomics) {
         Text(text = "TIME SPLIT", style = MaterialTheme.typography.labelMedium, color = c.text3)
         Spacer(Modifier.height(10.dp))
         if (time.onlineMillis == 0L) {
-            EmptyRow("No dashes in this period yet.")
+            EmptyRow("No sessions in this period yet.")
             return@AppCard
         }
 
@@ -76,7 +76,7 @@ private fun TimeSplitCard(time: TimeEconomics) {
         Spacer(Modifier.height(2.dp))
         Text(
             text = "online across ${Formats.commaInt(time.sessions)} " +
-                if (time.sessions == 1) "dash" else "dashes",
+                if (time.sessions == 1) "session" else "sessions",
             style = MaterialTheme.typography.bodySmall,
             color = c.text3,
         )
@@ -94,12 +94,12 @@ private fun TimeSplitCard(time: TimeEconomics) {
 
         Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
             AppStatTile(
-                label = "Dashes",
+                label = "Sessions",
                 value = Formats.commaInt(time.sessions),
                 modifier = Modifier.weight(1f),
             )
             AppStatTile(
-                label = "Avg dash",
+                label = "Avg session",
                 value = time.avgDashMillis?.let { formatDuration(it) } ?: EMPTY_VALUE,
                 modifier = Modifier.weight(1f),
             )
@@ -128,7 +128,7 @@ private fun DeadheadCard(time: TimeEconomics) {
         Text(text = "$deadheadPct%", style = AppTheme.num.heroNum, color = c.text)
         Spacer(Modifier.height(2.dp))
         Text(
-            text = "miles with no delivery attached — after the last drop, or dashes with none",
+            text = "miles with no delivery attached — after the last drop, or sessions with none",
             style = MaterialTheme.typography.bodySmall,
             color = c.text3,
         )

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/TimeTab.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/TimeTab.kt
@@ -11,7 +11,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import cloud.trotter.dashbuddy.R
 import cloud.trotter.dashbuddy.core.designsystem.component.AppCard
 import cloud.trotter.dashbuddy.core.designsystem.component.AppGaugeRing
 import cloud.trotter.dashbuddy.core.designsystem.component.AppLegend
@@ -65,27 +67,32 @@ fun TimeTab(
 private fun TimeSplitCard(time: TimeEconomics) {
     val c = AppTheme.colors
     AppCard(modifier = Modifier.fillMaxWidth()) {
-        Text(text = "TIME SPLIT", style = MaterialTheme.typography.labelMedium, color = c.text3)
+        Text(text = stringResource(R.string.time_tab_time_split_title), style = MaterialTheme.typography.labelMedium, color = c.text3)
         Spacer(Modifier.height(10.dp))
         if (time.onlineMillis == 0L) {
-            EmptyRow("No sessions in this period yet.")
+            EmptyRow(stringResource(R.string.time_tab_no_sessions_yet))
             return@AppCard
         }
 
         Text(text = formatDuration(time.onlineMillis), style = AppTheme.num.heroNum, color = c.text)
         Spacer(Modifier.height(2.dp))
         Text(
-            text = "online across ${Formats.commaInt(time.sessions)} " +
-                if (time.sessions == 1) "session" else "sessions",
+            text = stringResource(
+                R.string.time_tab_online_across_format,
+                Formats.commaInt(time.sessions),
+                if (time.sessions == 1) stringResource(R.string.time_tab_session_singular)
+                else stringResource(R.string.time_tab_session_plural),
+            ),
             style = MaterialTheme.typography.bodySmall,
             color = c.text3,
         )
         Spacer(Modifier.height(14.dp))
 
+        val onDeliveryLabel = stringResource(R.string.time_tab_segment_on_delivery)
         val onDeliveryMillis = time.deliveryMillis ?: 0L
         val segments = listOf(
-            AppSegment("On delivery", onDeliveryMillis.toFloat(), c.good, note = formatDuration(onDeliveryMillis)),
-            AppSegment("Unattributed", time.unattributedMillis.toFloat(), c.neutral, note = formatDuration(time.unattributedMillis)),
+            AppSegment(onDeliveryLabel, onDeliveryMillis.toFloat(), c.good, note = formatDuration(onDeliveryMillis)),
+            AppSegment(stringResource(R.string.time_tab_segment_unattributed), time.unattributedMillis.toFloat(), c.neutral, note = formatDuration(time.unattributedMillis)),
         )
         AppStackBar(segments, height = 14.dp)
         Spacer(Modifier.height(10.dp))
@@ -94,12 +101,12 @@ private fun TimeSplitCard(time: TimeEconomics) {
 
         Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
             AppStatTile(
-                label = "Sessions",
+                label = stringResource(R.string.time_tab_sessions_stat_label),
                 value = Formats.commaInt(time.sessions),
                 modifier = Modifier.weight(1f),
             )
             AppStatTile(
-                label = "Avg session",
+                label = stringResource(R.string.time_tab_avg_session_stat_label),
                 value = time.avgDashMillis?.let { formatDuration(it) } ?: EMPTY_VALUE,
                 modifier = Modifier.weight(1f),
             )
@@ -117,10 +124,10 @@ private fun TimeSplitCard(time: TimeEconomics) {
 private fun DeadheadCard(time: TimeEconomics) {
     val c = AppTheme.colors
     AppCard(modifier = Modifier.fillMaxWidth()) {
-        Text(text = "DEADHEAD", style = MaterialTheme.typography.labelMedium, color = c.text3)
+        Text(text = stringResource(R.string.time_tab_deadhead_title), style = MaterialTheme.typography.labelMedium, color = c.text3)
         Spacer(Modifier.height(10.dp))
         if (time.miles <= 0.0) {
-            EmptyRow("No miles measured in this period yet.")
+            EmptyRow(stringResource(R.string.time_tab_no_miles_measured_yet))
             return@AppCard
         }
 
@@ -128,7 +135,7 @@ private fun DeadheadCard(time: TimeEconomics) {
         Text(text = "$deadheadPct%", style = AppTheme.num.heroNum, color = c.text)
         Spacer(Modifier.height(2.dp))
         Text(
-            text = "miles with no delivery attached — after the last drop, or sessions with none",
+            text = stringResource(R.string.time_tab_deadhead_caption),
             style = MaterialTheme.typography.bodySmall,
             color = c.text3,
         )
@@ -138,8 +145,8 @@ private fun DeadheadCard(time: TimeEconomics) {
         // sums to the period's odometer miles cleanly.
         val onDeliveryMiles = time.miles - time.unattributedMiles
         val segments = listOf(
-            AppSegment("On delivery", onDeliveryMiles.toFloat(), c.good, note = "${Formats.decimal(onDeliveryMiles, 1)} mi"),
-            AppSegment("Deadhead", time.unattributedMiles.toFloat(), c.neutral, note = "${Formats.decimal(time.unattributedMiles, 1)} mi"),
+            AppSegment(stringResource(R.string.time_tab_segment_on_delivery), onDeliveryMiles.toFloat(), c.good, note = "${Formats.decimal(onDeliveryMiles, 1)} mi"),
+            AppSegment(stringResource(R.string.time_tab_segment_deadhead), time.unattributedMiles.toFloat(), c.neutral, note = "${Formats.decimal(time.unattributedMiles, 1)} mi"),
         )
         AppStackBar(segments, height = 14.dp)
         Spacer(Modifier.height(10.dp))
@@ -152,24 +159,29 @@ private fun DeadheadCard(time: TimeEconomics) {
 private fun OnTimeCard(time: TimeEconomics) {
     val c = AppTheme.colors
     AppCard(modifier = Modifier.fillMaxWidth()) {
-        Text(text = "ON TIME", style = MaterialTheme.typography.labelMedium, color = c.text3)
+        Text(text = stringResource(R.string.time_tab_on_time_title), style = MaterialTheme.typography.labelMedium, color = c.text3)
         Spacer(Modifier.height(10.dp))
         val rate = time.onTimeRate
         if (rate == null) {
-            EmptyRow("No deliveries carried a deadline in this period.")
+            EmptyRow(stringResource(R.string.time_tab_no_deadline_deliveries_yet))
             return@AppCard
         }
 
         AppGaugeRing(
             progress = rate.toFloat(),
             value = "${(rate * 100.0).roundToInt()}%",
-            label = "on time",
+            label = stringResource(R.string.time_tab_gauge_on_time_label),
             color = c.good,
         )
         Spacer(Modifier.height(10.dp))
         Text(
-            text = "${Formats.commaInt(time.onTimeDeliveries)} of ${Formats.commaInt(time.deliveriesWithDeadline)} " +
-                (if (time.deliveriesWithDeadline == 1) "delivery" else "deliveries") + " with a deadline",
+            text = stringResource(
+                R.string.time_tab_deadline_caption_format,
+                Formats.commaInt(time.onTimeDeliveries),
+                Formats.commaInt(time.deliveriesWithDeadline),
+                if (time.deliveriesWithDeadline == 1) stringResource(R.string.time_tab_delivery_singular)
+                else stringResource(R.string.time_tab_delivery_plural),
+            ),
             style = MaterialTheme.typography.bodySmall,
             color = c.text3,
         )
@@ -180,8 +192,8 @@ private fun OnTimeCard(time: TimeEconomics) {
             val early = margin >= 0.0
             val magnitude = kotlin.math.abs(margin).roundToLong()
             Text(
-                text = if (early) "typically ${formatDuration(magnitude)} early"
-                else "typically ${formatDuration(magnitude)} late",
+                text = if (early) stringResource(R.string.time_tab_margin_early_format, formatDuration(magnitude))
+                else stringResource(R.string.time_tab_margin_late_format, formatDuration(magnitude)),
                 style = MaterialTheme.typography.bodySmall,
                 color = if (early) c.good else c.bad,
             )
@@ -194,10 +206,10 @@ private fun OnTimeCard(time: TimeEconomics) {
 private fun MileageTaxCard(time: TimeEconomics, period: AnalyticsPeriod) {
     val c = AppTheme.colors
     AppCard(modifier = Modifier.fillMaxWidth()) {
-        Text(text = "MILEAGE & TAX", style = MaterialTheme.typography.labelMedium, color = c.text3)
+        Text(text = stringResource(R.string.time_tab_mileage_tax_title), style = MaterialTheme.typography.labelMedium, color = c.text3)
         Spacer(Modifier.height(10.dp))
         if (time.miles <= 0.0) {
-            EmptyRow("No miles measured in this period yet.")
+            EmptyRow(stringResource(R.string.time_tab_no_miles_measured_yet))
             return@AppCard
         }
 
@@ -222,7 +234,7 @@ private fun MileageTaxCard(time: TimeEconomics, period: AnalyticsPeriod) {
         }
         Spacer(Modifier.height(6.dp))
         Text(
-            text = "standard-mileage method — not the app's operating-cost model; confirm with a tax preparer.",
+            text = stringResource(R.string.time_tab_mileage_tax_disclosure),
             style = MaterialTheme.typography.bodySmall,
             color = c.text3,
         )

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardScreen.kt
@@ -38,10 +38,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
+import cloud.trotter.dashbuddy.R
 import cloud.trotter.dashbuddy.core.designsystem.component.AppCard
 import cloud.trotter.dashbuddy.core.designsystem.component.AppSegmented
 import cloud.trotter.dashbuddy.core.designsystem.component.AppStatTile
@@ -88,7 +90,7 @@ fun DashboardScreen(
     Scaffold(
         floatingActionButton = {
             FloatingActionButton(onClick = onNavigateToSettings) {
-                Icon(Icons.Default.Settings, contentDescription = "Settings")
+                Icon(Icons.Default.Settings, contentDescription = stringResource(R.string.dashboard_screen_content_desc_settings))
             }
         }
     ) { padding ->
@@ -108,8 +110,8 @@ fun DashboardScreen(
                 // CASE 1: Permissions Missing (The Gate)
                 hasPermissions == false -> {
                     StatusCard(
-                        title = "Permissions Required",
-                        subtitle = "DashBuddy needs your attention. Please complete the popup.",
+                        title = stringResource(R.string.dashboard_screen_permissions_required_title),
+                        subtitle = stringResource(R.string.dashboard_screen_permissions_required_subtitle),
                         containerColor = MaterialTheme.colorScheme.errorContainer,
                         textColor = MaterialTheme.colorScheme.onErrorContainer
                     )
@@ -118,20 +120,20 @@ fun DashboardScreen(
                 // CASE 2: Permissions Granted, first run (The Guide)
                 uiState.isFirstRun -> {
                     StatusCard(
-                        title = "You have the Keys!",
-                        subtitle = "Permissions granted. Let's personalize your strategy so DashBuddy knows what offers you like.",
+                        title = stringResource(R.string.dashboard_screen_first_run_title),
+                        subtitle = stringResource(R.string.dashboard_screen_first_run_subtitle),
                         containerColor = MaterialTheme.colorScheme.secondaryContainer
                     )
                     Spacer(modifier = Modifier.height(16.dp))
                     Button(
                         modifier = Modifier.fillMaxWidth(),
                         onClick = onNavigateToWizard
-                    ) { Text("Personalize Strategy") }
+                    ) { Text(stringResource(R.string.dashboard_screen_personalize_strategy_button)) }
                     Spacer(modifier = Modifier.height(8.dp))
                     TextButton(
                         modifier = Modifier.fillMaxWidth(),
                         onClick = { viewModel.completeSetup() }
-                    ) { Text("Skip for now") }
+                    ) { Text(stringResource(R.string.dashboard_screen_skip_for_now_button)) }
                 }
 
                 // CASE 3: Ready — status card, a slim "tap for the bubble" pointer while
@@ -140,7 +142,8 @@ fun DashboardScreen(
                 else -> {
                     StatusCard(
                         title = uiState.statusText,
-                        subtitle = if (uiState.isDashing) "You're on the clock." else "All systems go.",
+                        subtitle = if (uiState.isDashing) stringResource(R.string.dashboard_screen_dashing_subtitle)
+                        else stringResource(R.string.dashboard_screen_ready_subtitle),
                         containerColor = MaterialTheme.colorScheme.primaryContainer
                     )
                     Spacer(modifier = Modifier.height(16.dp))
@@ -163,7 +166,7 @@ fun DashboardScreen(
                     Button(
                         modifier = Modifier.fillMaxWidth(),
                         onClick = { viewModel.showWelcomeBubble() }
-                    ) { Text("Show Bubble") }
+                    ) { Text(stringResource(R.string.dashboard_screen_show_bubble_button)) }
                 }
             }
         }
@@ -176,15 +179,13 @@ private const val EMPTY_VALUE = "—"
 /** The review windows offered by the period selector, in display order. */
 private data class PeriodOption(val period: AnalyticsPeriod, val label: String)
 
-private val PERIOD_OPTIONS = listOf(
-    PeriodOption(AnalyticsPeriod.TODAY, "Today"),
-    PeriodOption(AnalyticsPeriod.THIS_WEEK, "Week"),
-    PeriodOption(AnalyticsPeriod.THIS_MONTH, "Month"),
-    PeriodOption(AnalyticsPeriod.LIFETIME, "Lifetime"),
+@Composable
+private fun periodOptions(): List<PeriodOption> = listOf(
+    PeriodOption(AnalyticsPeriod.TODAY, stringResource(R.string.common_period_today)),
+    PeriodOption(AnalyticsPeriod.THIS_WEEK, stringResource(R.string.common_period_week)),
+    PeriodOption(AnalyticsPeriod.THIS_MONTH, stringResource(R.string.common_period_month)),
+    PeriodOption(AnalyticsPeriod.LIFETIME, stringResource(R.string.common_period_lifetime)),
 )
-
-private fun periodLabel(period: AnalyticsPeriod): String =
-    PERIOD_OPTIONS.first { it.period == period }.label
 
 /**
  * Slim online pointer (#657): while a dash is active the review surface just points
@@ -217,12 +218,13 @@ private fun PeriodReview(
     economics: PeriodEconomics,
     onSelectPeriod: (AnalyticsPeriod) -> Unit,
 ) {
-    val selectedLabel = periodLabel(selectedPeriod)
+    val periodOptions = periodOptions()
+    val selectedLabel = periodOptions.first { it.period == selectedPeriod }.label
     AppSegmented(
-        options = PERIOD_OPTIONS.map { it.label },
+        options = periodOptions.map { it.label },
         selected = selectedLabel,
         onSelect = { label ->
-            PERIOD_OPTIONS.firstOrNull { it.label == label }?.let { onSelectPeriod(it.period) }
+            periodOptions.firstOrNull { it.label == label }?.let { onSelectPeriod(it.period) }
         },
         modifier = Modifier.fillMaxWidth(),
     )
@@ -232,20 +234,20 @@ private fun PeriodReview(
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         AppStatTile(
-            label = "True Net",
+            label = stringResource(R.string.dashboard_screen_stat_true_net),
             value = Formats.money(economics.netProfit),
             sub = selectedLabel,
             valueColor = if (economics.netProfit >= 0.0) AppTheme.colors.good else AppTheme.colors.bad,
             modifier = Modifier.weight(1f),
         )
         AppStatTile(
-            label = "Net/hr",
+            label = stringResource(R.string.dashboard_screen_stat_net_per_hour),
             value = economics.netPerHour?.let { Formats.money(it) } ?: EMPTY_VALUE,
             sub = selectedLabel,
             modifier = Modifier.weight(1f),
         )
         AppStatTile(
-            label = "Miles",
+            label = stringResource(R.string.dashboard_screen_stat_miles),
             value = Formats.decimal(economics.totals.miles),
             sub = selectedLabel,
             modifier = Modifier.weight(1f),
@@ -263,14 +265,14 @@ private fun EntryTileGrid(onNavigate: (String) -> Unit) {
         ) {
             EntryTile(
                 icon = Icons.Filled.BarChart,
-                label = "Analytics",
+                label = stringResource(R.string.dashboard_screen_entry_analytics),
                 modifier = Modifier.weight(1f),
                 // #315 H1: routes to the Analytics hub (Money tab v1); other tabs stubbed.
                 onClick = { onNavigate(Screen.Analytics.route) },
             )
             EntryTile(
                 icon = Icons.Filled.Star,
-                label = "Ratings",
+                label = stringResource(R.string.dashboard_screen_entry_ratings),
                 modifier = Modifier.weight(1f),
                 onClick = { onNavigate(Screen.Ratings.route) },
             )
@@ -281,13 +283,13 @@ private fun EntryTileGrid(onNavigate: (String) -> Unit) {
         ) {
             EntryTile(
                 icon = Icons.Filled.Tune,
-                label = "Strategy",
+                label = stringResource(R.string.dashboard_screen_entry_strategy),
                 modifier = Modifier.weight(1f),
                 onClick = { onNavigate(Screen.StrategySettings.route) },
             )
             EntryTile(
                 icon = Icons.Filled.AttachMoney,
-                label = "Economy",
+                label = stringResource(R.string.dashboard_screen_entry_economy),
                 modifier = Modifier.weight(1f),
                 onClick = { onNavigate(Screen.EconomySettings.route) },
             )

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardScreen.kt
@@ -195,7 +195,7 @@ private fun periodLabel(period: AnalyticsPeriod): String =
 private fun DashingStatusRow(onTap: () -> Unit) {
     AppCard(modifier = Modifier.fillMaxWidth().clickable(onClick = onTap)) {
         Text(
-            text = "🟢 Dashing — tap for the bubble",
+            text = "🟢 Session active — tap for the bubble",
             style = MaterialTheme.typography.titleMedium,
             color = AppTheme.colors.text,
         )

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardViewModel.kt
@@ -30,7 +30,7 @@ import javax.inject.Inject
  * live mirror of the bubble HUD (#657). Exposes one immutable [DashboardUiState]
  * (Principle 1 — UDF) assembled reactively from:
  *  - [StateManagerV2] `AppState` — the flow/mode used for the status line + the slim
- *    "🟢 Dashing — tap for the bubble" pointer ([DashboardUiState.isDashing]),
+ *    "🟢 Session active — tap for the bubble" pointer ([DashboardUiState.isDashing]),
  *  - [AppStateRepository.isFirstRun] — the setup gate,
  *  - [AnalyticsRepository.periodEconomics] — the durable read-model totals for the
  *    user-selected window (frozen net, re-emits as the projector folds each delivery and
@@ -83,7 +83,7 @@ class DashboardViewModel @Inject constructor(
 
     fun showWelcomeBubble() {
         bubbleManager.postMessage(
-            text = "DashBuddy is ready. Open your platform and start a dash — I'll track everything from here.",
+            text = "DashBuddy is ready. Open your platform and start a session — I'll track everything from here.",
             ChatPersona.Dispatcher,
             expand = true
         )
@@ -99,8 +99,8 @@ class DashboardViewModel @Inject constructor(
     private fun statusText(flow: Flow, mode: Mode?): String {
         if (mode == null || mode == Mode.Offline) {
             return when (flow) {
-                Flow.SessionEnded -> "Dash Complete"
-                else -> "Ready to Dash"
+                Flow.SessionEnded -> "Session Complete"
+                else -> "Ready to start a session"
             }
         }
         if (mode == Mode.Paused) return "Paused"
@@ -111,7 +111,7 @@ class DashboardViewModel @Inject constructor(
             Flow.TaskPickupNavigation, Flow.TaskPickupArrived -> "Heading to Pickup"
             Flow.TaskDropoffNavigation, Flow.TaskDropoffArrived -> "Heading to Drop-off"
             Flow.PostTask -> "Delivery Complete"
-            Flow.SessionEnded -> "Dash Complete"
+            Flow.SessionEnded -> "Session Complete"
         }
     }
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/ratings/RatingsScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/ratings/RatingsScreen.kt
@@ -25,10 +25,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import cloud.trotter.dashbuddy.R
 import cloud.trotter.dashbuddy.core.designsystem.component.AppCard
 import cloud.trotter.dashbuddy.core.designsystem.component.AppGaugeRing
 import cloud.trotter.dashbuddy.core.designsystem.component.AppStatTile
@@ -52,10 +54,13 @@ fun RatingsScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Ratings") },
+                title = { Text(stringResource(R.string.ratings_screen_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.common_content_desc_back),
+                        )
                     }
                 },
             )
@@ -90,7 +95,7 @@ fun RatingsScreen(
 
             if (state.hasShoppingQuality) {
                 Text(
-                    "Shopping quality",
+                    stringResource(R.string.ratings_screen_shopping_quality_header),
                     style = androidx.compose.material3.MaterialTheme.typography.titleSmall,
                     color = AppTheme.colors.text2,
                 )
@@ -113,7 +118,7 @@ private fun HeadlineGauges(state: RatingsUiState) {
             AppGaugeRing(
                 progress = (it / 5.0).toFloat(),
                 value = Formats.decimal(it, digits = 2),
-                label = "Customer",
+                label = stringResource(R.string.ratings_screen_gauge_customer),
                 color = AppTheme.colors.accent,
             )
         }
@@ -121,7 +126,7 @@ private fun HeadlineGauges(state: RatingsUiState) {
             AppGaugeRing(
                 progress = (it / 100.0).toFloat(),
                 value = percentText(it),
-                label = "On-time",
+                label = stringResource(R.string.ratings_screen_gauge_on_time),
                 color = AppTheme.colors.accent,
             )
         }
@@ -129,7 +134,7 @@ private fun HeadlineGauges(state: RatingsUiState) {
             AppGaugeRing(
                 progress = (it / 100.0).toFloat(),
                 value = percentText(it),
-                label = "Completion",
+                label = stringResource(R.string.ratings_screen_gauge_completion),
                 color = AppTheme.colors.accent,
             )
         }
@@ -140,9 +145,9 @@ private fun HeadlineGauges(state: RatingsUiState) {
 @Composable
 private fun StandingTiles(state: RatingsUiState) {
     val tiles = buildList {
-        state.acceptanceRate?.let { add("Acceptance" to percentText(it)) }
-        state.deliveriesLast30Days?.let { add("Deliveries (30d)" to Formats.commaInt(it)) }
-        state.lifetimeDeliveries?.let { add("Lifetime deliveries" to Formats.commaInt(it)) }
+        state.acceptanceRate?.let { add(stringResource(R.string.ratings_screen_tile_acceptance) to percentText(it)) }
+        state.deliveriesLast30Days?.let { add(stringResource(R.string.ratings_screen_tile_deliveries_30d) to Formats.commaInt(it)) }
+        state.lifetimeDeliveries?.let { add(stringResource(R.string.ratings_screen_tile_lifetime_deliveries) to Formats.commaInt(it)) }
     }
     TileGrid(tiles)
 }
@@ -151,12 +156,12 @@ private fun StandingTiles(state: RatingsUiState) {
 @Composable
 private fun ShoppingQualityTiles(state: RatingsUiState) {
     val tiles = buildList {
-        state.originalItemsFoundRate?.let { add("Original items found" to percentText(it)) }
-        state.totalItemsFoundRate?.let { add("Total items found" to percentText(it)) }
-        state.substitutionIssuesRate?.let { add("Substitution issues" to percentText(it)) }
-        state.itemsWithQualityIssuesRate?.let { add("Quality issues" to percentText(it)) }
-        state.itemsWrongOrMissingRate?.let { add("Wrong or missing" to percentText(it)) }
-        state.lifetimeShoppingOrders?.let { add("Lifetime shops" to Formats.commaInt(it)) }
+        state.originalItemsFoundRate?.let { add(stringResource(R.string.ratings_screen_tile_original_items_found) to percentText(it)) }
+        state.totalItemsFoundRate?.let { add(stringResource(R.string.ratings_screen_tile_total_items_found) to percentText(it)) }
+        state.substitutionIssuesRate?.let { add(stringResource(R.string.ratings_screen_tile_substitution_issues) to percentText(it)) }
+        state.itemsWithQualityIssuesRate?.let { add(stringResource(R.string.ratings_screen_tile_quality_issues) to percentText(it)) }
+        state.itemsWrongOrMissingRate?.let { add(stringResource(R.string.ratings_screen_tile_wrong_or_missing) to percentText(it)) }
+        state.lifetimeShoppingOrders?.let { add(stringResource(R.string.ratings_screen_tile_lifetime_shops) to Formats.commaInt(it)) }
     }
     TileGrid(tiles)
 }
@@ -188,17 +193,16 @@ private fun RatingsEmpty(platformName: String?, modifier: Modifier = Modifier) {
     Box(modifier = modifier, contentAlignment = Alignment.Center) {
         AppCard {
             Text(
-                text = "No ratings yet",
+                text = stringResource(R.string.ratings_screen_empty_title),
                 style = AppTheme.num.lgNum,
                 color = AppTheme.colors.text,
             )
             Spacer(Modifier.height(6.dp))
             Text(
-                text = buildString {
-                    append("Open your ")
-                    append(platformName ?: "platform")
-                    append(" Ratings screen while DashBuddy is running and they'll show up here.")
-                },
+                text = stringResource(
+                    R.string.ratings_screen_empty_desc_format,
+                    platformName ?: stringResource(R.string.ratings_screen_empty_fallback_platform),
+                ),
                 style = androidx.compose.material3.MaterialTheme.typography.bodyMedium,
                 color = AppTheme.colors.text2,
                 textAlign = TextAlign.Center,

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/AboutScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/AboutScreen.kt
@@ -30,10 +30,12 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import cloud.trotter.dashbuddy.BuildConfig
+import cloud.trotter.dashbuddy.R
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -44,6 +46,8 @@ fun AboutScreen(
     val clicks by viewModel.versionClickCount.collectAsStateWithLifecycle()
     val isDevUnlocked by viewModel.isDevModeUnlocked.collectAsStateWithLifecycle(initialValue = false)
     val context = LocalContext.current
+    val devModeCountdownTemplate = stringResource(R.string.about_screen_dev_mode_countdown)
+    val devModeEnabledText = stringResource(R.string.about_screen_dev_mode_enabled)
 
     // Hold a reference to the toast so we can cancel it instantly on rapid clicks
     var currentToast by remember { mutableStateOf<Toast?>(null) }
@@ -53,13 +57,13 @@ fun AboutScreen(
             currentToast?.cancel()
             currentToast = Toast.makeText(
                 context,
-                "You are ${7 - clicks} steps away from being a developer.",
+                devModeCountdownTemplate.format(7 - clicks),
                 Toast.LENGTH_SHORT
             )
             currentToast?.show()
         } else if (clicks == 7 && !isDevUnlocked) {
             currentToast?.cancel()
-            currentToast = Toast.makeText(context, "Developer Mode Enabled!", Toast.LENGTH_LONG)
+            currentToast = Toast.makeText(context, devModeEnabledText, Toast.LENGTH_LONG)
             currentToast?.show()
             viewModel.unlockDeveloperMode()
         }
@@ -68,10 +72,13 @@ fun AboutScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("About") },
+                title = { Text(stringResource(R.string.about_screen_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.common_content_desc_back),
+                        )
                     }
                 }
             )
@@ -86,7 +93,7 @@ fun AboutScreen(
             Spacer(modifier = Modifier.height(48.dp))
 
             Text(
-                text = "DashBuddy",
+                text = stringResource(R.string.app_name),
                 style = MaterialTheme.typography.displaySmall,
                 fontWeight = FontWeight.Black,
                 color = MaterialTheme.colorScheme.primary
@@ -103,11 +110,11 @@ fun AboutScreen(
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 Text(
-                    text = "Version ${BuildConfig.VERSION_NAME}",
+                    text = stringResource(R.string.about_screen_version_format, BuildConfig.VERSION_NAME),
                     style = MaterialTheme.typography.titleMedium,
                 )
                 Text(
-                    text = "Build ${BuildConfig.VERSION_CODE}",
+                    text = stringResource(R.string.about_screen_build_format, BuildConfig.VERSION_CODE.toString()),
                     style = MaterialTheme.typography.bodySmall,
                     color = AppTheme.colors.text3
                 )
@@ -118,17 +125,17 @@ fun AboutScreen(
             Spacer(modifier = Modifier.height(32.dp))
 
             Text(
-                text = "Developer",
+                text = stringResource(R.string.about_screen_developer_label),
                 style = MaterialTheme.typography.labelLarge,
                 color = MaterialTheme.colorScheme.primary
             )
             Spacer(modifier = Modifier.height(8.dp))
             Text(
-                text = "Trotter Cloud Solutions", // Update with your actual info
+                text = stringResource(R.string.about_screen_developer_name),
                 style = MaterialTheme.typography.bodyLarge
             )
             Text(
-                text = "support@dashbuddy.app",
+                text = stringResource(R.string.about_screen_developer_email),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/DataExportScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/DataExportScreen.kt
@@ -81,7 +81,7 @@ fun DataExportScreen(
             Text(
                 "Pick a folder and DashBuddy writes three spreadsheet files into it:\n" +
                     "• deliveries.csv — one row per delivery\n" +
-                    "• sessions.csv — one row per dash\n" +
+                    "• sessions.csv — one row per session\n" +
                     "• summary.csv — totals + estimated IRS mileage deduction\n\n" +
                     "This is your own data, on-device — nothing is uploaded. Exports all history " +
                     "(a date-range picker is coming later).",

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/DataExportScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/DataExportScreen.kt
@@ -24,9 +24,11 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import cloud.trotter.dashbuddy.R
 
 /**
  * Free-tier CSV data export (#319). One folder pick → three CSVs (deliveries, sessions, summary)
@@ -57,10 +59,13 @@ fun DataExportScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Export Data") },
+                title = { Text(stringResource(R.string.data_export_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.common_content_desc_back),
+                        )
                     }
                 }
             )
@@ -74,17 +79,12 @@ fun DataExportScreen(
         ) {
             Spacer(Modifier.height(8.dp))
             Text(
-                "Export your mileage & earnings to CSV",
+                stringResource(R.string.data_export_csv_heading),
                 style = MaterialTheme.typography.titleMedium,
             )
             Spacer(Modifier.height(8.dp))
             Text(
-                "Pick a folder and DashBuddy writes three spreadsheet files into it:\n" +
-                    "• deliveries.csv — one row per delivery\n" +
-                    "• sessions.csv — one row per session\n" +
-                    "• summary.csv — totals + estimated IRS mileage deduction\n\n" +
-                    "This is your own data, on-device — nothing is uploaded. Exports all history " +
-                    "(a date-range picker is coming later).",
+                stringResource(R.string.data_export_csv_desc),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
@@ -97,7 +97,7 @@ fun DataExportScreen(
             ) {
                 Icon(Icons.Default.FileDownload, contentDescription = null)
                 Spacer(Modifier.height(0.dp))
-                Text("  Choose folder & export")
+                Text(stringResource(R.string.data_export_csv_button))
             }
 
             Spacer(Modifier.height(16.dp))
@@ -108,14 +108,14 @@ fun DataExportScreen(
                 }
                 is DataExportViewModel.ExportState.Success -> {
                     Text(
-                        "Exported ${s.filesWritten} files to the chosen folder.",
+                        stringResource(R.string.data_export_csv_success_format, s.filesWritten),
                         color = MaterialTheme.colorScheme.primary,
                         style = MaterialTheme.typography.bodyMedium,
                     )
                 }
                 is DataExportViewModel.ExportState.Error -> {
                     Text(
-                        "Export failed: ${s.message}",
+                        stringResource(R.string.data_export_csv_error_format, s.message),
                         color = MaterialTheme.colorScheme.error,
                         style = MaterialTheme.typography.bodyMedium,
                     )
@@ -127,16 +127,12 @@ fun DataExportScreen(
 
             // --- Bug-report (shareable log) export (#551) ---
             Text(
-                "Export a bug report",
+                stringResource(R.string.data_export_log_heading),
                 style = MaterialTheme.typography.titleMedium,
             )
             Spacer(Modifier.height(8.dp))
             Text(
-                "Pick a folder and DashBuddy writes dashbuddy-log.txt into it — the log the " +
-                    "developer needs to diagnose an issue.\n\n" +
-                    "INFO+ milestones only — no raw store, customer, or address text. Every line is " +
-                    "auto-scrubbed at the sink before it's written, so a leaked name can't reach the " +
-                    "file. On-device, nothing is uploaded.",
+                stringResource(R.string.data_export_log_desc),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
@@ -148,7 +144,7 @@ fun DataExportScreen(
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 Icon(Icons.Default.FileDownload, contentDescription = null)
-                Text("  Choose folder & export log")
+                Text(stringResource(R.string.data_export_log_button))
             }
 
             Spacer(Modifier.height(16.dp))
@@ -159,14 +155,14 @@ fun DataExportScreen(
                 }
                 is DataExportViewModel.LogExportState.Success -> {
                     Text(
-                        "Exported dashbuddy-log.txt — ${s.scrubbedLines} line(s) were auto-scrubbed.",
+                        stringResource(R.string.data_export_log_success_format, s.scrubbedLines),
                         color = MaterialTheme.colorScheme.primary,
                         style = MaterialTheme.typography.bodyMedium,
                     )
                 }
                 is DataExportViewModel.LogExportState.Error -> {
                     Text(
-                        "Log export failed: ${s.message}",
+                        stringResource(R.string.data_export_log_error_format, s.message),
                         color = MaterialTheme.colorScheme.error,
                         style = MaterialTheme.typography.bodyMedium,
                     )

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/EconomySettingsScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/EconomySettingsScreen.kt
@@ -21,8 +21,10 @@ import androidx.compose.runtime.Composable
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import cloud.trotter.dashbuddy.R
 import cloud.trotter.dashbuddy.ui.components.economy.EconomyEditor
 import cloud.trotter.dashbuddy.ui.components.economy.TrueCostFooter
 import cloud.trotter.dashbuddy.ui.components.economy.VehicleClassPicker
@@ -45,15 +47,18 @@ fun EconomySettingsScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Personal Economy") },
+                title = { Text(stringResource(R.string.economy_settings_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.common_content_desc_back),
+                        )
                     }
                 },
                 actions = {
                     TextButton(onClick = { viewModel.resetDefaults() }) {
-                        Text("Reset to defaults")
+                        Text(stringResource(R.string.economy_settings_reset_defaults))
                     }
                 },
             )
@@ -67,9 +72,7 @@ fun EconomySettingsScreen(
                 .padding(16.dp),
         ) {
             Text(
-                text = "Enter your real numbers so DashBuddy can show your true net pay. " +
-                    "Defaults are sensible estimates for your vehicle class but will be off — " +
-                    "tap any section to set actual values.",
+                text = stringResource(R.string.economy_settings_intro),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/EvidenceSettingsScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/EvidenceSettingsScreen.kt
@@ -77,8 +77,8 @@ fun EvidenceSettingsScreen(
             )
 
             SwitchRow(
-                label = "Save Dash Summary",
-                subtitle = "End of dash earnings report",
+                label = "Save Session Summary",
+                subtitle = "End of session earnings report",
                 checked = config.saveSessionSummaries,
                 onCheckedChange = {
                     viewModel.updateEvidenceConfig(

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/EvidenceSettingsScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/EvidenceSettingsScreen.kt
@@ -15,8 +15,10 @@ import androidx.compose.runtime.Composable
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import cloud.trotter.dashbuddy.R
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -29,10 +31,13 @@ fun EvidenceSettingsScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Evidence Locker") },
+                title = { Text(stringResource(R.string.evidence_settings_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.common_content_desc_back),
+                        )
                     }
                 }
             )
@@ -44,19 +49,19 @@ fun EvidenceSettingsScreen(
             // You might want to move SwitchRow to a shared 'Components.kt' file.
 
             SwitchRow(
-                label = "Master Record",
-                subtitle = "Global kill-switch for all data recording",
+                label = stringResource(R.string.evidence_settings_master_label),
+                subtitle = stringResource(R.string.evidence_settings_master_subtitle),
                 checked = config.masterEnabled,
                 onCheckedChange = { viewModel.setEvidenceMaster(it) }
             )
 
             HorizontalDivider(Modifier.padding(vertical = 8.dp))
 
-            Text("Granular Controls", modifier = Modifier.padding(16.dp))
+            Text(stringResource(R.string.evidence_settings_section_granular), modifier = Modifier.padding(16.dp))
 
             SwitchRow(
-                label = "Save Offers",
-                subtitle = "Keep full JSON/Screenshots of incoming offers",
+                label = stringResource(R.string.evidence_settings_offers_label),
+                subtitle = stringResource(R.string.evidence_settings_offers_subtitle),
                 checked = config.saveOffers,
                 onCheckedChange = {
                     viewModel.updateEvidenceConfig(
@@ -68,8 +73,8 @@ fun EvidenceSettingsScreen(
             )
 
             SwitchRow(
-                label = "Save Deliveries",
-                subtitle = "Track completion stats",
+                label = stringResource(R.string.evidence_settings_deliveries_label),
+                subtitle = stringResource(R.string.evidence_settings_deliveries_subtitle),
                 checked = config.saveDeliverySummaries,
                 onCheckedChange = {
                     viewModel.updateEvidenceConfig(config.saveOffers, it, config.saveSessionSummaries)
@@ -77,8 +82,8 @@ fun EvidenceSettingsScreen(
             )
 
             SwitchRow(
-                label = "Save Session Summary",
-                subtitle = "End of session earnings report",
+                label = stringResource(R.string.evidence_settings_session_label),
+                subtitle = stringResource(R.string.evidence_settings_session_subtitle),
                 checked = config.saveSessionSummaries,
                 onCheckedChange = {
                     viewModel.updateEvidenceConfig(

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/GeneralSettingsScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/GeneralSettingsScreen.kt
@@ -14,9 +14,11 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import cloud.trotter.dashbuddy.R
 
 /**
  * General app settings. Currently just the driving / glance-mode toggle (#318); Theme and
@@ -33,10 +35,13 @@ fun GeneralSettingsScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("General") },
+                title = { Text(stringResource(R.string.general_settings_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.common_content_desc_back),
+                        )
                     }
                 }
             )
@@ -44,14 +49,14 @@ fun GeneralSettingsScreen(
     ) { padding ->
         Column(Modifier.padding(padding).padding(horizontal = 16.dp)) {
             Text(
-                "Driving",
+                stringResource(R.string.general_settings_section_driving),
                 style = MaterialTheme.typography.labelLarge,
                 color = MaterialTheme.colorScheme.primary,
                 modifier = Modifier.padding(top = 16.dp, bottom = 4.dp)
             )
             SwitchRow(
-                label = "Driving glance mode",
-                subtitle = "Larger HUD text while on a session",
+                label = stringResource(R.string.general_settings_glance_mode_label),
+                subtitle = stringResource(R.string.general_settings_glance_mode_subtitle),
                 checked = glanceMode,
                 onCheckedChange = { viewModel.setGlanceMode(it) }
             )

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/GeneralSettingsScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/GeneralSettingsScreen.kt
@@ -51,7 +51,7 @@ fun GeneralSettingsScreen(
             )
             SwitchRow(
                 label = "Driving glance mode",
-                subtitle = "Larger HUD text while dashing",
+                subtitle = "Larger HUD text while on a session",
                 checked = glanceMode,
                 onCheckedChange = { viewModel.setGlanceMode(it) }
             )

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/PlatformSettingsScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/PlatformSettingsScreen.kt
@@ -25,9 +25,11 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import cloud.trotter.dashbuddy.R
 
 @Composable
 fun PlatformSettingsScreen(
@@ -46,11 +48,14 @@ fun PlatformSettingsScreen(
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.common_content_desc_back),
+                        )
                     }
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(
-                        "Gig Apps",
+                        stringResource(R.string.platform_settings_title),
                         style = MaterialTheme.typography.headlineMedium,
                         fontWeight = FontWeight.Bold,
                     )
@@ -75,9 +80,7 @@ fun PlatformSettingsScreen(
             item {
                 Spacer(modifier = Modifier.height(16.dp))
                 Text(
-                    "Choose which gig apps DashBuddy monitors. " +
-                        "Only apps with full rule support will provide live session tracking. " +
-                        "Other enabled apps will capture data for future updates.",
+                    stringResource(R.string.platform_settings_description),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.padding(horizontal = 8.dp),
@@ -112,7 +115,8 @@ private fun PlatformRow(
                     )
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(
-                        if (state.isInstalled) "Installed" else "Not installed",
+                        if (state.isInstalled) stringResource(R.string.platform_settings_installed)
+                        else stringResource(R.string.platform_settings_not_installed),
                         style = MaterialTheme.typography.labelSmall,
                         color = if (state.isInstalled) {
                             MaterialTheme.colorScheme.primary

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/SettingsHomeScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/SettingsHomeScreen.kt
@@ -35,9 +35,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import cloud.trotter.dashbuddy.R
 import cloud.trotter.dashbuddy.ui.main.navigation.Screen
 import cloud.trotter.dashbuddy.domain.format.Formats
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -62,7 +64,7 @@ fun SettingsHomeScreen(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Text(
-                        "Settings",
+                        stringResource(R.string.settings_home_title),
                         style = MaterialTheme.typography.headlineMedium,
                         fontWeight = FontWeight.Bold
                     )
@@ -79,11 +81,11 @@ fun SettingsHomeScreen(
             Spacer(modifier = Modifier.height(16.dp))
 
             // Section 0: Monitoring
-            SettingsGroup(title = "Monitoring") {
+            SettingsGroup(title = stringResource(R.string.settings_home_group_monitoring)) {
                 SettingsNavItem(
                     icon = Icons.Default.Apps,
-                    title = "Gig Apps",
-                    subtitle = "Choose which apps to monitor",
+                    title = stringResource(R.string.settings_home_item_gig_apps_title),
+                    subtitle = stringResource(R.string.settings_home_item_gig_apps_subtitle),
                     onClick = { onNavigate(Screen.PlatformSettings.route) }
                 )
             }
@@ -91,11 +93,11 @@ fun SettingsHomeScreen(
             Spacer(modifier = Modifier.height(16.dp))
 
             // Section 1: The Brain
-            SettingsGroup(title = "Automation & Intelligence") {
+            SettingsGroup(title = stringResource(R.string.settings_home_group_automation)) {
                 SettingsNavItem(
                     icon = Icons.Default.Tune,
-                    title = "Strategy Config",
-                    subtitle = "Rules, Pricing, and Simulation",
+                    title = stringResource(R.string.settings_home_item_strategy_title),
+                    subtitle = stringResource(R.string.settings_home_item_strategy_subtitle),
                     onClick = { onNavigate(Screen.StrategySettings.route) }
                 )
                 val eco = userEconomy
@@ -103,14 +105,14 @@ fun SettingsHomeScreen(
                     val costPerMi = eco.operatingCostPerMile
                     val defaultsCount = cloud.trotter.dashbuddy.domain.evaluation.EconomyField.entries.size -
                         eco.userSetFields.size
-                    "True cost: ${Formats.money(costPerMi)}/mi" +
-                        if (defaultsCount > 0) " · $defaultsCount defaults" else ""
+                    stringResource(R.string.settings_home_economy_true_cost_format, Formats.money(costPerMi)) +
+                        if (defaultsCount > 0) stringResource(R.string.settings_home_economy_defaults_suffix_format, defaultsCount) else ""
                 } else {
-                    "Tires, oil, depreciation, insurance, phone"
+                    stringResource(R.string.settings_home_economy_fallback_subtitle)
                 }
                 SettingsNavItem(
                     icon = Icons.Default.AttachMoney,
-                    title = "Personal Economy",
+                    title = stringResource(R.string.settings_home_item_economy_title),
                     subtitle = ecoSubtitle,
                     onClick = { onNavigate(Screen.EconomySettings.route) }
                 )
@@ -119,17 +121,17 @@ fun SettingsHomeScreen(
             Spacer(modifier = Modifier.height(16.dp))
 
             // Section 2: Data
-            SettingsGroup(title = "Data & Privacy") {
+            SettingsGroup(title = stringResource(R.string.settings_home_group_data_privacy)) {
                 SettingsNavItem(
                     icon = Icons.Default.Folder,
-                    title = "Evidence Locker",
-                    subtitle = "Manage screenshots and logs",
+                    title = stringResource(R.string.settings_home_item_evidence_title),
+                    subtitle = stringResource(R.string.settings_home_item_evidence_subtitle),
                     onClick = { onNavigate(Screen.EvidenceSettings.route) }
                 )
                 SettingsNavItem(
                     icon = Icons.Default.FileDownload,
-                    title = "Export Data (CSV)",
-                    subtitle = "Mileage & earnings for a spreadsheet or tax prep",
+                    title = stringResource(R.string.settings_home_item_export_title),
+                    subtitle = stringResource(R.string.settings_home_item_export_subtitle),
                     onClick = { onNavigate(Screen.DataExport.route) }
                 )
             }
@@ -137,25 +139,25 @@ fun SettingsHomeScreen(
             Spacer(modifier = Modifier.height(16.dp))
 
             // Section 3: General
-            SettingsGroup(title = "App System") {
+            SettingsGroup(title = stringResource(R.string.settings_home_group_app_system)) {
                 SettingsNavItem(
                     icon = Icons.Default.Settings,
-                    title = "General",
-                    subtitle = "Theme, Pro Mode, and Defaults",
+                    title = stringResource(R.string.settings_home_item_general_title),
+                    subtitle = stringResource(R.string.settings_home_item_general_subtitle),
                     onClick = { onNavigate(Screen.GeneralSettings.route) }
                 )
 
                 SettingsNavItem(
                     icon = Icons.Default.RocketLaunch,
-                    title = "Re-run Setup Wizard",
-                    subtitle = "Adjust vehicle and base targets",
+                    title = stringResource(R.string.settings_home_item_rerun_wizard_title),
+                    subtitle = stringResource(R.string.settings_home_item_rerun_wizard_subtitle),
                     onClick = { onNavigate(Screen.Wizard.route) }
                 )
 
                 SettingsNavItem(
                     icon = Icons.Default.Info,
-                    title = "About",
-                    subtitle = "Version, Support, and Developer info",
+                    title = stringResource(R.string.settings_home_item_about_title),
+                    subtitle = stringResource(R.string.settings_home_item_about_subtitle),
                     onClick = { onNavigate(Screen.AboutSettings.route) }
                 )
             }
@@ -167,11 +169,11 @@ fun SettingsHomeScreen(
             ) {
                 Column {
                     Spacer(modifier = Modifier.height(16.dp))
-                    SettingsGroup(title = "Developer Options") {
+                    SettingsGroup(title = stringResource(R.string.main_activity_developer_options_title)) {
                         SettingsNavItem(
                             icon = Icons.Default.BugReport,
-                            title = "Debug Menu",
-                            subtitle = "Log levels & Snapshot whitelist",
+                            title = stringResource(R.string.settings_home_item_debug_menu_title),
+                            subtitle = stringResource(R.string.settings_home_item_debug_menu_subtitle),
                             onClick = { onNavigate(Screen.DeveloperSettings.route) }
                         )
                     }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/StrategySettingsScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/StrategySettingsScreen.kt
@@ -35,10 +35,12 @@ import androidx.compose.ui.graphics.graphicsLayer
 import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import cloud.trotter.dashbuddy.R
 import cloud.trotter.dashbuddy.domain.format.Formats
 import cloud.trotter.dashbuddy.ui.main.settings.components.DraggableRuleRow
 import cloud.trotter.dashbuddy.ui.main.settings.components.FakeOfferCard
@@ -95,7 +97,7 @@ fun StrategySettingsScreen(
         ) {
             Column(Modifier.padding(16.dp)) {
                 Text(
-                    "The Lab",
+                    stringResource(R.string.strategy_settings_the_lab_title),
                     style = MaterialTheme.typography.headlineSmall,
                     fontWeight = FontWeight.Bold
                 )
@@ -118,7 +120,7 @@ fun StrategySettingsScreen(
                 ) {
                     Column(Modifier.weight(1f)) {
                         Text(
-                            "Pay: ${Formats.money(simPay.toDouble())}",
+                            stringResource(R.string.strategy_settings_sim_pay_format, Formats.money(simPay.toDouble())),
                             style = MaterialTheme.typography.labelSmall
                         )
                         Slider(
@@ -130,7 +132,7 @@ fun StrategySettingsScreen(
                     Spacer(Modifier.width(16.dp))
                     Column(Modifier.weight(1f)) {
                         Text(
-                            "Dist: ${Formats.decimal(simDist.toDouble())} mi",
+                            stringResource(R.string.strategy_settings_sim_dist_format, Formats.decimal(simDist.toDouble())),
                             style = MaterialTheme.typography.labelSmall
                         )
                         Slider(
@@ -155,26 +157,26 @@ fun StrategySettingsScreen(
             // Index 0
             item {
                 Text(
-                    "Global Overrides",
+                    stringResource(R.string.strategy_settings_global_overrides_title),
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.primary
                 )
                 Spacer(Modifier.height(8.dp))
                 SwitchRow(
-                    label = "🛡️ Protect Stats Mode",
-                    subtitle = "Auto-accept everything",
+                    label = stringResource(R.string.strategy_settings_protect_stats_label),
+                    subtitle = stringResource(R.string.strategy_settings_protect_stats_subtitle),
                     checked = config.protectStatsMode,
                     onCheckedChange = { viewModel.toggleProtectStats(it) }
                 )
                 SwitchRow(
-                    label = "🛒 Allow Shopping Orders",
-                    subtitle = "If off, Red Card orders are auto-declined",
+                    label = stringResource(R.string.strategy_settings_allow_shopping_label),
+                    subtitle = stringResource(R.string.strategy_settings_allow_shopping_subtitle),
                     checked = config.allowShopping,
                     onCheckedChange = { viewModel.toggleAllowShopping(it) }
                 )
                 SwitchRow(
-                    label = "⚡ Single-click declines",
-                    subtitle = "Auto-confirm DoorDash's 'are you sure?' so a decline is one tap",
+                    label = stringResource(R.string.strategy_settings_quick_declines_label),
+                    subtitle = stringResource(R.string.strategy_settings_quick_declines_subtitle),
                     checked = automation.quickDeclinesEnabled,
                     onCheckedChange = { viewModel.toggleQuickDeclines(it) }
                 )
@@ -184,12 +186,12 @@ fun StrategySettingsScreen(
             // Index 1
             item {
                 Text(
-                    "Priorities (Rack & Stack)",
+                    stringResource(R.string.strategy_settings_priorities_title),
                     style = MaterialTheme.typography.headlineSmall,
                     fontWeight = FontWeight.Bold
                 )
                 Text(
-                    "Drag to reorder. Top rules matter most.",
+                    stringResource(R.string.strategy_settings_priorities_hint),
                     style = MaterialTheme.typography.bodySmall,
                     color = AppTheme.colors.text3
                 )

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/components/FakeOfferCard.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/components/FakeOfferCard.kt
@@ -20,9 +20,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
 import androidx.compose.ui.unit.dp
+import cloud.trotter.dashbuddy.R
 import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
 import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
 import cloud.trotter.dashbuddy.domain.format.Formats
@@ -72,7 +74,11 @@ fun FakeOfferCard(
             ) {
                 // --- Recommendation + Score ---
                 Text(
-                    text = "${evaluation.action.recommendationLabel()}  ·  ${evaluation.score.toInt()}pts",
+                    text = stringResource(
+                        R.string.fake_offer_score_format,
+                        evaluation.action.recommendationLabel(),
+                        evaluation.score.toInt(),
+                    ),
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.Bold,
                     color = borderColor
@@ -82,30 +88,37 @@ fun FakeOfferCard(
 
                 // --- Pay line ---
                 if (hasAnyCost) {
-                    val netSuffix = if (evaluation.isUsingDefaults) " (est.)" else ""
+                    val payLineFormat = if (evaluation.isUsingDefaults)
+                        R.string.fake_offer_pay_line_estimate_format
+                    else
+                        R.string.fake_offer_pay_line_format
                     Text(
-                        text = "${Formats.money(evaluation.payAmount)} gross  →  ${Formats.money(evaluation.netPayAmount)} net$netSuffix",
+                        text = stringResource(
+                            payLineFormat,
+                            Formats.money(evaluation.payAmount),
+                            Formats.money(evaluation.netPayAmount),
+                        ),
                         style = MaterialTheme.typography.bodyLarge,
                         fontWeight = FontWeight.SemiBold,
                         color = animatedContentColor
                     )
                     if (hasFuelCost) {
                         Text(
-                            text = "−${Formats.money(evaluation.fuelCostEstimate)} fuel",
+                            text = stringResource(R.string.fake_offer_fuel_cost_format, Formats.money(evaluation.fuelCostEstimate)),
                             style = MaterialTheme.typography.bodySmall,
                             color = animatedContentColor.copy(alpha = 0.65f)
                         )
                     }
                     if (hasNonFuelCost) {
                         Text(
-                            text = "−${Formats.money(evaluation.nonFuelCostEstimate)} wear & fixed costs",
+                            text = stringResource(R.string.fake_offer_nonfuel_cost_format, Formats.money(evaluation.nonFuelCostEstimate)),
                             style = MaterialTheme.typography.bodySmall,
                             color = animatedContentColor.copy(alpha = 0.65f)
                         )
                     }
                 } else {
                     Text(
-                        text = "${Formats.money(evaluation.payAmount)}",
+                        text = Formats.money(evaluation.payAmount),
                         style = MaterialTheme.typography.bodyLarge,
                         fontWeight = FontWeight.SemiBold,
                         color = animatedContentColor
@@ -122,17 +135,17 @@ fun FakeOfferCard(
                     horizontalArrangement = Arrangement.SpaceEvenly
                 ) {
                     MetricCell(
-                        label = "\$/mi",
-                        value = "${Formats.money(evaluation.dollarsPerMile)}",
+                        label = stringResource(R.string.fake_offer_metric_dollar_per_mile_label),
+                        value = Formats.money(evaluation.dollarsPerMile),
                         color = animatedContentColor
                     )
                     MetricCell(
-                        label = "\$/hr",
-                        value = "${Formats.money(evaluation.dollarsPerHour)}",
+                        label = stringResource(R.string.fake_offer_metric_dollar_per_hour_label),
+                        value = Formats.money(evaluation.dollarsPerHour),
                         color = animatedContentColor
                     )
                     MetricCell(
-                        label = "items",
+                        label = stringResource(R.string.fake_offer_metric_items_label),
                         value = evaluation.itemCount.toInt().toString(),
                         color = animatedContentColor
                     )
@@ -146,13 +159,13 @@ fun FakeOfferCard(
                     horizontalArrangement = Arrangement.SpaceEvenly
                 ) {
                     MetricCell(
-                        label = "miles",
+                        label = stringResource(R.string.fake_offer_metric_miles_label),
                         value = Formats.decimal(evaluation.distanceMiles),
                         color = animatedContentColor
                     )
                     MetricCell(
-                        label = "est. time",
-                        value = "~${evaluation.estimatedTimeMinutes.toInt()} min",
+                        label = stringResource(R.string.fake_offer_metric_est_time_label),
+                        value = stringResource(R.string.fake_offer_metric_est_time_value_format, evaluation.estimatedTimeMinutes.toInt()),
                         color = animatedContentColor
                     )
                 }
@@ -164,7 +177,7 @@ fun FakeOfferCard(
             Spacer(modifier = Modifier.height(8.dp))
             evaluation.warnings.forEach { warning ->
                 Text(
-                    text = "\u26a0\ufe0f $warning",
+                    text = stringResource(R.string.fake_offer_warning_format, warning),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.error,
                     modifier = Modifier.padding(horizontal = 4.dp, vertical = 2.dp)

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/components/ReorderableRule.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/components/ReorderableRule.kt
@@ -22,9 +22,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
 import androidx.compose.ui.unit.dp
+import cloud.trotter.dashbuddy.R
 import cloud.trotter.dashbuddy.domain.evaluation.MetricType
 import cloud.trotter.dashbuddy.domain.evaluation.ScoringRule
 import java.util.Locale
@@ -54,7 +56,7 @@ fun DraggableRuleRow(
             // FIX 2: Apply the drag logic ONLY to this Icon
             Icon(
                 imageVector = Icons.Default.DragHandle,
-                contentDescription = "Reorder",
+                contentDescription = stringResource(R.string.reorderable_rule_content_desc_reorder),
                 tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
                 modifier = modifier // <--- The magic happens here
                     .size(24.dp)
@@ -66,7 +68,7 @@ fun DraggableRuleRow(
             Column(modifier = Modifier.weight(1f)) {
                 when (rule) {
                     is ScoringRule.MetricRule -> MetricContent(rule, onUpdate)
-                    is ScoringRule.MerchantRule -> Text("Merchant Rule (Coming Soon)")
+                    is ScoringRule.MerchantRule -> Text(stringResource(R.string.reorderable_rule_merchant_coming_soon))
                 }
             }
 
@@ -109,9 +111,18 @@ fun MetricContent(
         if (rule.isEnabled) {
             val formatted = when (type) {
                 MetricType.PAYOUT, MetricType.ACTIVE_HOURLY -> Formats.money(value.toDouble())
-                MetricType.DOLLAR_PER_MILE -> "${Formats.money(value.toDouble())}/mi"
-                MetricType.MAX_DISTANCE -> "${Formats.decimal(value.toDouble())} mi"
-                MetricType.ITEM_COUNT -> "${value.toInt()} items"
+                MetricType.DOLLAR_PER_MILE -> stringResource(
+                    R.string.reorderable_rule_dollar_per_mile_format,
+                    Formats.money(value.toDouble()),
+                )
+                MetricType.MAX_DISTANCE -> stringResource(
+                    R.string.reorderable_rule_distance_format,
+                    Formats.decimal(value.toDouble()),
+                )
+                MetricType.ITEM_COUNT -> stringResource(
+                    R.string.reorderable_rule_item_count_format,
+                    value.toInt(),
+                )
             }
             Text(
                 formatted,

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/permissions/PermissionCard.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/permissions/PermissionCard.kt
@@ -123,7 +123,11 @@ fun PermissionCard(
                 .padding(12.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Icon(Icons.Default.Security, contentDescription = "Privacy", tint = AppTheme.colors.good)
+            Icon(
+                Icons.Default.Security,
+                contentDescription = stringResource(R.string.permission_card_content_desc_privacy),
+                tint = AppTheme.colors.good,
+            )
             Text(
                 text = stringResource(id = R.string.perm_privacy_guarantee),
                 style = MaterialTheme.typography.bodySmall,
@@ -155,7 +159,7 @@ fun PermissionCard(
                 )
                 Icon(
                     imageVector = if (isExpanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
-                    contentDescription = "Expand",
+                    contentDescription = stringResource(R.string.permission_card_content_desc_expand),
                     tint = MaterialTheme.colorScheme.primary
                 )
             }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/WizardScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/WizardScreen.kt
@@ -290,7 +290,7 @@ fun WizardScreen(
                         .fillMaxWidth()
                         .height(56.dp)
                 ) {
-                    Text("Let's Go Dash", style = MaterialTheme.typography.titleMedium)
+                    Text("Let's Go", style = MaterialTheme.typography.titleMedium)
                 }
                 Spacer(modifier = Modifier.height(16.dp))
             }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/WizardScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/WizardScreen.kt
@@ -32,10 +32,12 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import cloud.trotter.dashbuddy.R
 import cloud.trotter.dashbuddy.domain.config.OfferStrategy
 import cloud.trotter.dashbuddy.ui.main.setup.wizard.cards.EconomyCostsCard
 import cloud.trotter.dashbuddy.ui.main.setup.wizard.cards.GasPriceCard
@@ -72,6 +74,17 @@ fun WizardScreen(
     // Skip writes nothing (#347).
     var skippedSetup by remember { mutableStateOf(false) }
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    // Pre-fetch string resources OUTSIDE the pager's plain (non-@Composable) formatter lambdas.
+    val shoppingItemsFormat = stringResource(R.string.wizard_screen_shopping_value_format)
+    val hourlyValueFormat = stringResource(R.string.wizard_screen_hourly_value_format)
+    val distanceValueFormat = stringResource(R.string.wizard_screen_distance_value_format)
+    val minPayoutFooterAuto = stringResource(R.string.wizard_screen_min_payout_footer_auto)
+    val minPayoutFooterFlag = stringResource(R.string.wizard_screen_min_payout_footer_flag)
+    val hourlyFooterAuto = stringResource(R.string.wizard_screen_hourly_footer_auto)
+    val hourlyFooterFlag = stringResource(R.string.wizard_screen_hourly_footer_flag)
+    val distanceFooterAuto = stringResource(R.string.wizard_screen_distance_footer_auto)
+    val distanceFooterFlag = stringResource(R.string.wizard_screen_distance_footer_flag)
 
     Scaffold(
         topBar = {
@@ -167,12 +180,12 @@ fun WizardScreen(
                     WizardStep.GOAL -> {
                         SelectionCard(
                             step = currentStep,
-                            option1Title = "Cherry Picker",
-                            option1Desc = "Maximize profit. Auto-decline unprofitable offers.",
-                            option2Title = "Protect Platinum",
-                            option2Desc = "Maintain high acceptance rate. Do not auto-decline anything.",
-                            option3Title = "Manual Mode",
-                            option3Desc = "Just show me the math. I will make my own decisions.",
+                            option1Title = stringResource(R.string.wizard_screen_goal_option1_title),
+                            option1Desc = stringResource(R.string.wizard_screen_goal_option1_desc),
+                            option2Title = stringResource(R.string.wizard_screen_goal_option2_title),
+                            option2Desc = stringResource(R.string.wizard_screen_goal_option2_desc),
+                            option3Title = stringResource(R.string.wizard_screen_goal_option3_title),
+                            option3Desc = stringResource(R.string.wizard_screen_goal_option3_desc),
                             selectedIndex = when (state.strategy) {
                                 OfferStrategy.CHERRY_PICKER -> 0
                                 OfferStrategy.PROTECT_PLATINUM -> 1
@@ -193,9 +206,9 @@ fun WizardScreen(
                     WizardStep.SHOPPING -> {
                         MetricSliderCard(
                             step = currentStep, value = state.maxItems, valueRange = 1f..100f,
-                            valueFormatter = { "${Formats.decimal(it.toDouble(), 0)} items" },
+                            valueFormatter = { shoppingItemsFormat.format(Formats.decimal(it.toDouble(), 0)) },
                             onValueChange = viewModel::updateMaxItems,
-                            footerText = "We'll use this to score shopping offers on the HUD."
+                            footerText = stringResource(R.string.wizard_screen_shopping_footer)
                         )
                     }
 
@@ -204,25 +217,25 @@ fun WizardScreen(
                             step = currentStep, value = state.minPayout, valueRange = 2f..20f,
                             valueFormatter = { Formats.money(it.toDouble()) },
                             onValueChange = viewModel::updateMinPayout,
-                            footerText = if (isCherryPicker) "We will auto-decline offers below this amount." else "We will flag offers below this amount in red."
+                            footerText = if (isCherryPicker) minPayoutFooterAuto else minPayoutFooterFlag
                         )
                     }
 
                     WizardStep.TARGET_HOURLY -> {
                         MetricSliderCard(
                             step = currentStep, value = state.targetHourly, valueRange = 10f..40f,
-                            valueFormatter = { "${Formats.money0(it.toDouble())} / hr" },
+                            valueFormatter = { hourlyValueFormat.format(Formats.money0(it.toDouble())) },
                             onValueChange = viewModel::updateTargetHourly,
-                            footerText = if (isCherryPicker) "We will auto-decline offers below this rate." else "We will flag offers below this rate in red."
+                            footerText = if (isCherryPicker) hourlyFooterAuto else hourlyFooterFlag
                         )
                     }
 
                     WizardStep.MAX_DISTANCE -> {
                         MetricSliderCard(
                             step = currentStep, value = state.maxDistance, valueRange = 1f..25f,
-                            valueFormatter = { "${Formats.decimal(it.toDouble())} mi" },
+                            valueFormatter = { distanceValueFormat.format(Formats.decimal(it.toDouble())) },
                             onValueChange = viewModel::updateMaxDistance,
-                            footerText = if (isCherryPicker) "We will auto-decline offers exceeding this distance." else "We will flag offers exceeding this distance in red."
+                            footerText = if (isCherryPicker) distanceFooterAuto else distanceFooterFlag
                         )
                     }
                 }
@@ -250,14 +263,14 @@ fun WizardScreen(
                 ) {
                     Icon(
                         Icons.Default.Check,
-                        contentDescription = "Success",
+                        contentDescription = stringResource(R.string.wizard_screen_content_desc_success),
                         modifier = Modifier.size(48.dp),
                         tint = MaterialTheme.colorScheme.onPrimaryContainer
                     )
                 }
                 Spacer(modifier = Modifier.height(24.dp))
                 Text(
-                    "You're all set!",
+                    stringResource(R.string.wizard_screen_all_set_title),
                     style = MaterialTheme.typography.headlineSmall,
                     fontWeight = FontWeight.Bold,
                     color = MaterialTheme.colorScheme.onSurface
@@ -265,9 +278,9 @@ fun WizardScreen(
                 Spacer(modifier = Modifier.height(16.dp))
                 Text(
                     if (skippedSetup) {
-                        "Setup skipped — nothing was changed. You can run the wizard anytime from the Settings menu."
+                        stringResource(R.string.wizard_screen_skipped_desc)
                     } else {
-                        "Your setup is complete. Remember, you can always tweak these targets, change your vehicle, or adjust your automation strategy later in the Settings menu."
+                        stringResource(R.string.wizard_screen_completed_desc)
                     },
                     style = MaterialTheme.typography.bodyLarge,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -290,7 +303,7 @@ fun WizardScreen(
                         .fillMaxWidth()
                         .height(56.dp)
                 ) {
-                    Text("Let's Go", style = MaterialTheme.typography.titleMedium)
+                    Text(stringResource(R.string.wizard_screen_lets_go), style = MaterialTheme.typography.titleMedium)
                 }
                 Spacer(modifier = Modifier.height(16.dp))
             }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/cards/GasPriceCard.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/cards/GasPriceCard.kt
@@ -23,8 +23,10 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import cloud.trotter.dashbuddy.R
 import cloud.trotter.dashbuddy.domain.format.Formats
 import cloud.trotter.dashbuddy.domain.model.vehicle.FuelType
 import cloud.trotter.dashbuddy.ui.main.setup.wizard.components.WizardCardHeader
@@ -53,7 +55,7 @@ fun GasPriceCard(
         Spacer(modifier = Modifier.height(32.dp))
 
         Text(
-            text = "What type of fuel do you use?",
+            text = stringResource(R.string.wizard_gas_price_fuel_type_question),
             style = MaterialTheme.typography.labelLarge,
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
@@ -77,9 +79,9 @@ fun GasPriceCard(
 
         if (fuelType == FuelType.ELECTRICITY) {
             Column(modifier = Modifier.fillMaxWidth()) {
-                Text("Manual EV Charging Costs", style = MaterialTheme.typography.titleMedium)
+                Text(stringResource(R.string.wizard_gas_price_ev_title), style = MaterialTheme.typography.titleMedium)
                 Text(
-                    text = "Because public Superchargers and home charging rates vary wildly, please set your average equivalent 'per-gallon' cost manually.",
+                    text = stringResource(R.string.wizard_gas_price_ev_desc),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
@@ -91,9 +93,9 @@ fun GasPriceCard(
                 horizontalArrangement = Arrangement.SpaceBetween
             ) {
                 Column(modifier = Modifier.weight(1f)) {
-                    Text("Auto-Update Gas Prices", style = MaterialTheme.typography.titleMedium)
+                    Text(stringResource(R.string.wizard_gas_price_auto_update_title), style = MaterialTheme.typography.titleMedium)
                     Text(
-                        text = "We'll fetch the regional average for your fuel type daily.",
+                        text = stringResource(R.string.wizard_gas_price_auto_update_desc),
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
@@ -120,7 +122,7 @@ fun GasPriceCard(
                     color = MaterialTheme.colorScheme.primary
                 )
                 Text(
-                    text = "Current Regional Average",
+                    text = stringResource(R.string.wizard_gas_price_current_regional_average),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/cards/MetricSliderCard.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/cards/MetricSliderCard.kt
@@ -14,9 +14,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import cloud.trotter.dashbuddy.R
 import cloud.trotter.dashbuddy.ui.main.setup.wizard.components.WizardCardHeader
 import cloud.trotter.dashbuddy.ui.main.setup.wizard.model.WizardStep
 
@@ -27,7 +29,7 @@ fun MetricSliderCard(
     valueRange: ClosedFloatingPointRange<Float>,
     valueFormatter: (Float) -> String,
     onValueChange: (Float) -> Unit,
-    footerText: String = "We'll use this to score your offers on the HUD."
+    footerText: String = stringResource(R.string.wizard_metric_slider_default_footer)
 ) {
     Column(
         modifier = Modifier

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/cards/VehicleCard.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/cards/VehicleCard.kt
@@ -27,9 +27,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import cloud.trotter.dashbuddy.R
 import cloud.trotter.dashbuddy.domain.format.Formats
 import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleClass
 import cloud.trotter.dashbuddy.ui.main.setup.wizard.components.VehicleDropdown
@@ -77,13 +79,13 @@ fun VehicleCard(
             FilterChip(
                 selected = vehicleClass == VehicleClass.SEDAN,
                 onClick = { onTypeSelected(VehicleClass.SEDAN) },
-                label = { Text("🚗 Car") }
+                label = { Text(stringResource(R.string.wizard_vehicle_card_type_car)) }
             )
             Spacer(modifier = Modifier.padding(8.dp))
             FilterChip(
                 selected = vehicleClass == VehicleClass.E_BIKE,
                 onClick = { onTypeSelected(VehicleClass.E_BIKE) },
-                label = { Text("🚲 E-Bike") }
+                label = { Text(stringResource(R.string.wizard_vehicle_card_type_ebike)) }
             )
         }
 
@@ -96,7 +98,7 @@ fun VehicleCard(
         ) {
             Column {
                 VehicleDropdown(
-                    label = "Year",
+                    label = stringResource(R.string.wizard_vehicle_card_year_label),
                     value = year,
                     options = availableYears,
                     onValueChanged = onYearSelected
@@ -105,7 +107,7 @@ fun VehicleCard(
                 Spacer(modifier = Modifier.height(8.dp))
 
                 VehicleDropdown(
-                    label = "Make",
+                    label = stringResource(R.string.wizard_vehicle_card_make_label),
                     value = make,
                     options = availableMakes,
                     onValueChanged = onMakeSelected,
@@ -118,7 +120,7 @@ fun VehicleCard(
                 AnimatedVisibility(visible = make.isNotBlank() && make != VEHICLE_NOT_LISTED) {
                     Column {
                         VehicleDropdown(
-                            label = "Model",
+                            label = stringResource(R.string.wizard_vehicle_card_model_label),
                             value = model,
                             options = availableModels,
                             onValueChanged = onModelSelected,
@@ -130,7 +132,7 @@ fun VehicleCard(
                         // Hide Trim dropdown if they clicked Not Listed for Model
                         AnimatedVisibility(visible = model.isNotBlank() && model != VEHICLE_NOT_LISTED) {
                             VehicleDropdown(
-                                label = "Trim / Options",
+                                label = stringResource(R.string.wizard_vehicle_card_trim_label),
                                 value = trim,
                                 options = availableTrims,
                                 onValueChanged = onTrimSelected,
@@ -169,17 +171,17 @@ fun VehicleCard(
                 ) {
                     Icon(
                         Icons.Default.Search,
-                        contentDescription = "Search",
+                        contentDescription = stringResource(R.string.wizard_vehicle_card_content_desc_search),
                         modifier = Modifier.size(20.dp)
                     )
                     Spacer(Modifier.size(8.dp))
-                    Text("Lookup my MPG on Google")
+                    Text(stringResource(R.string.wizard_vehicle_card_lookup_mpg))
                 }
 
                 Spacer(modifier = Modifier.height(24.dp))
 
                 Text(
-                    text = "${Formats.decimal(mpg.toDouble())} MPG",
+                    text = stringResource(R.string.wizard_vehicle_card_mpg_format, Formats.decimal(mpg.toDouble())),
                     style = MaterialTheme.typography.displaySmall,
                     fontWeight = FontWeight.Black,
                     color = MaterialTheme.colorScheme.primary
@@ -203,7 +205,7 @@ fun VehicleCard(
                 }
 
                 Text(
-                    text = "Slide to match your vehicle's combined MPG.",
+                    text = stringResource(R.string.wizard_vehicle_card_mpg_slider_hint),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.padding(top = 8.dp)
@@ -213,7 +215,7 @@ fun VehicleCard(
 
         if (vehicleClass == VehicleClass.E_BIKE) {
             Text(
-                text = "Awesome! We will ignore gas expenses and set your cost-per-mile to $0.",
+                text = stringResource(R.string.wizard_vehicle_card_ebike_note),
                 style = MaterialTheme.typography.bodyLarge,
                 color = MaterialTheme.colorScheme.primary,
                 textAlign = TextAlign.Center,

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/components/WizardBottomBar.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/components/WizardBottomBar.kt
@@ -10,7 +10,9 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import cloud.trotter.dashbuddy.R
 
 @Composable
 fun WizardBottomBar(
@@ -27,13 +29,14 @@ fun WizardBottomBar(
     ) {
         if (showBack) {
             OutlinedButton(onClick = onBackClick) {
-                Text("Back")
+                Text(stringResource(R.string.wizard_bottom_bar_back))
             }
         }
 
         Button(onClick = onNextClick) {
             Text(
-                text = if (isLastStep) "Finish & Save" else "Next",
+                text = if (isLastStep) stringResource(R.string.wizard_bottom_bar_finish_and_save)
+                else stringResource(R.string.wizard_bottom_bar_next),
                 style = MaterialTheme.typography.titleMedium
             )
         }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/components/WizardTopBar.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/components/WizardTopBar.kt
@@ -14,7 +14,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import cloud.trotter.dashbuddy.R
 
 @Composable
 fun WizardTopBar(
@@ -39,12 +41,12 @@ fun WizardTopBar(
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
-                text = "Step ${currentStep + 1} of $totalSteps",
+                text = stringResource(R.string.wizard_top_bar_step_of_total, currentStep + 1, totalSteps),
                 style = MaterialTheme.typography.labelLarge,
                 color = MaterialTheme.colorScheme.primary
             )
             TextButton(onClick = onSkip) {
-                Text("Skip Setup")
+                Text(stringResource(R.string.wizard_top_bar_skip_setup))
             }
         }
         LinearProgressIndicator(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">DashBuddy</string>
+    <string name="app_name" translatable="false">DashBuddy</string>
     <string name="this_is_the_bubble">This is the Bubble!</string>
     <string name="log_level">Log Level</string>
     <string name="save_log">Save Log</string>
@@ -108,4 +108,456 @@
 
     <string name="wizard_title_distance">Max Distance</string>
     <string name="wizard_desc_distance">How many miles are you willing to drive for a single order?</string>
+
+    <!-- ========================================================================= -->
+    <!-- #57 extraction pass — new entries below follow <screen>_<component>_<property>. -->
+    <!-- Pre-existing entries above predate the convention and were left as-is to avoid -->
+    <!-- unrelated churn across their existing call sites (PermissionCard/BottomSheet/Type, -->
+    <!-- WizardPhase/WizardStep). -->
+    <!-- ========================================================================= -->
+
+    <string name="common_content_desc_back">Back</string>
+
+    <string name="common_period_today">Today</string>
+    <string name="common_period_week">Week</string>
+    <string name="common_period_month">Month</string>
+    <string name="common_period_lifetime">Lifetime</string>
+
+    <!-- bubble/BubbleScreen.kt -->
+    <string name="bubble_screen_chat_history_title">Chat History</string>
+    <string name="bubble_screen_content_desc_close_chat">Close chat</string>
+    <string name="bubble_screen_waiting_for_activity">Waiting for activity…</string>
+
+    <!-- bubble/ChatViews.kt -->
+    <string name="bubble_chat_no_messages_yet">No messages yet</string>
+    <string name="bubble_chat_content_desc_open_chat">Open chat</string>
+
+    <!-- bubble/ModeCards.kt -->
+    <string name="bubble_mode_idle_last_session_label">Last session</string>
+    <string name="bubble_mode_idle_miles_label">Miles</string>
+    <string name="bubble_mode_idle_duration_label">Duration</string>
+    <string name="bubble_mode_idle_status_label">Status</string>
+    <string name="bubble_mode_idle_offline_value">Offline</string>
+
+    <!-- setup/wizard/components/WizardBottomBar.kt -->
+    <string name="wizard_bottom_bar_back">Back</string>
+    <string name="wizard_bottom_bar_finish_and_save">Finish &amp; Save</string>
+    <string name="wizard_bottom_bar_next">Next</string>
+
+    <!-- setup/wizard/components/WizardTopBar.kt -->
+    <string name="wizard_top_bar_step_of_total">Step %1$d of %2$d</string>
+    <string name="wizard_top_bar_skip_setup">Skip Setup</string>
+
+    <!-- setup/wizard/cards/MetricSliderCard.kt -->
+    <string name="wizard_metric_slider_default_footer">We\'ll use this to score your offers on the HUD.</string>
+
+    <!-- settings/GeneralSettingsScreen.kt -->
+    <string name="general_settings_title">General</string>
+    <string name="general_settings_section_driving">Driving</string>
+    <string name="general_settings_glance_mode_label">Driving glance mode</string>
+    <string name="general_settings_glance_mode_subtitle">Larger HUD text while on a session</string>
+
+    <!-- components/economy/EconomyAccordionRow.kt -->
+    <string name="economy_accordion_content_desc_collapse">Collapse</string>
+    <string name="economy_accordion_content_desc_expand">Expand</string>
+    <string name="economy_accordion_default_hint">(default)</string>
+
+    <!-- settings/EconomySettingsScreen.kt -->
+    <string name="economy_settings_title">Personal Economy</string>
+    <string name="economy_settings_reset_defaults">Reset to defaults</string>
+    <string name="economy_settings_intro">Enter your real numbers so DashBuddy can show your true net pay. Defaults are sensible estimates for your vehicle class but will be off — tap any section to set actual values.</string>
+
+    <!-- settings/AboutScreen.kt -->
+    <string name="about_screen_title">About</string>
+    <string name="about_screen_dev_mode_countdown">You are %1$d steps away from being a developer.</string>
+    <string name="about_screen_dev_mode_enabled">Developer Mode Enabled!</string>
+    <string name="about_screen_version_format">Version %1$s</string>
+    <string name="about_screen_build_format">Build %1$s</string>
+    <string name="about_screen_developer_label">Developer</string>
+    <string name="about_screen_developer_name">Trotter Cloud Solutions</string>
+    <string name="about_screen_developer_email" translatable="false">support@dashbuddy.app</string>
+
+    <!-- settings/PlatformSettingsScreen.kt -->
+    <string name="platform_settings_title">Gig Apps</string>
+    <string name="platform_settings_description">Choose which gig apps DashBuddy monitors. Only apps with full rule support will provide live session tracking. Other enabled apps will capture data for future updates.</string>
+    <string name="platform_settings_installed">Installed</string>
+    <string name="platform_settings_not_installed">Not installed</string>
+
+    <!-- settings/components/ReorderableRule.kt -->
+    <string name="reorderable_rule_content_desc_reorder">Reorder</string>
+    <string name="reorderable_rule_merchant_coming_soon">Merchant Rule (Coming Soon)</string>
+    <string name="reorderable_rule_dollar_per_mile_format" translatable="false">%1$s/mi</string>
+    <string name="reorderable_rule_distance_format" translatable="false">%1$s mi</string>
+    <string name="reorderable_rule_item_count_format">%1$d items</string>
+
+    <!-- setup/wizard/cards/GasPriceCard.kt -->
+    <string name="wizard_gas_price_fuel_type_question">What type of fuel do you use?</string>
+    <string name="wizard_gas_price_ev_title">Manual EV Charging Costs</string>
+    <string name="wizard_gas_price_ev_desc">Because public Superchargers and home charging rates vary wildly, please set your average equivalent \'per-gallon\' cost manually.</string>
+    <string name="wizard_gas_price_auto_update_title">Auto-Update Gas Prices</string>
+    <string name="wizard_gas_price_auto_update_desc">We\'ll fetch the regional average for your fuel type daily.</string>
+    <string name="wizard_gas_price_current_regional_average">Current Regional Average</string>
+
+    <!-- main/analytics/AnalyticsScreen.kt -->
+    <string name="analytics_screen_title">Analytics</string>
+    <string name="analytics_screen_content_desc_export_csv">Export data (CSV)</string>
+    <string name="analytics_screen_coming_soon_title">%1$s — coming soon</string>
+    <string name="analytics_screen_coming_soon_desc">This tab lands in a later Analytics phase.</string>
+
+    <!-- setup/permissions/PermissionCard.kt -->
+    <string name="permission_card_content_desc_privacy">Privacy</string>
+    <string name="permission_card_content_desc_expand">Expand</string>
+
+    <!-- settings/DataExportScreen.kt -->
+    <string name="data_export_title">Export Data</string>
+    <string name="data_export_csv_heading">Export your mileage &amp; earnings to CSV</string>
+    <string name="data_export_csv_desc">Pick a folder and DashBuddy writes three spreadsheet files into it:\n• deliveries.csv — one row per delivery\n• sessions.csv — one row per session\n• summary.csv — totals + estimated IRS mileage deduction\n\nThis is your own data, on-device — nothing is uploaded. Exports all history (a date-range picker is coming later).</string>
+    <string name="data_export_csv_button">  Choose folder &amp; export</string>
+    <string name="data_export_csv_success_format">Exported %1$d files to the chosen folder.</string>
+    <string name="data_export_csv_error_format">Export failed: %1$s</string>
+    <string name="data_export_log_heading">Export a bug report</string>
+    <string name="data_export_log_desc">Pick a folder and DashBuddy writes dashbuddy-log.txt into it — the log the developer needs to diagnose an issue.\n\nINFO+ milestones only — no raw store, customer, or address text. Every line is auto-scrubbed at the sink before it\'s written, so a leaked name can\'t reach the file. On-device, nothing is uploaded.</string>
+    <string name="data_export_log_button">  Choose folder &amp; export log</string>
+    <string name="data_export_log_success_format">Exported dashbuddy-log.txt — %1$d line(s) were auto-scrubbed.</string>
+    <string name="data_export_log_error_format">Log export failed: %1$s</string>
+
+    <!-- settings/components/FakeOfferCard.kt -->
+    <string name="fake_offer_score_format" translatable="false">%1$s  ·  %2$dpts</string>
+    <string name="fake_offer_pay_line_format" translatable="false">%1$s gross  →  %2$s net</string>
+    <string name="fake_offer_pay_line_estimate_format" translatable="false">%1$s gross  →  %2$s net (est.)</string>
+    <string name="fake_offer_fuel_cost_format" translatable="false">−%1$s fuel</string>
+    <string name="fake_offer_nonfuel_cost_format">−%1$s wear &amp; fixed costs</string>
+    <string name="fake_offer_metric_dollar_per_mile_label" translatable="false">$/mi</string>
+    <string name="fake_offer_metric_dollar_per_hour_label" translatable="false">$/hr</string>
+    <string name="fake_offer_metric_items_label">items</string>
+    <string name="fake_offer_metric_miles_label">miles</string>
+    <string name="fake_offer_metric_est_time_label">est. time</string>
+    <string name="fake_offer_metric_est_time_value_format" translatable="false">~%1$d min</string>
+    <string name="fake_offer_warning_format" translatable="false">⚠️ %1$s</string>
+
+    <!-- main/analytics/DecisionsTab.kt -->
+    <string name="decisions_tab_offer_funnel_title">OFFER FUNNEL</string>
+    <string name="decisions_tab_no_offers_yet">No offers in this period yet.</string>
+    <string name="decisions_tab_acceptance_rate_caption">acceptance rate · %1$s %2$s</string>
+    <string name="decisions_tab_offer_singular">offer</string>
+    <string name="decisions_tab_offer_plural">offers</string>
+    <string name="decisions_tab_segment_accepted">Accepted</string>
+    <string name="decisions_tab_segment_declined">Declined</string>
+    <string name="decisions_tab_segment_timed_out">Timed out</string>
+    <string name="decisions_tab_value_of_no_title">VALUE OF SAYING NO</string>
+    <string name="decisions_tab_no_declines_yet">No declines in this period.</string>
+    <string name="decisions_tab_est_net_skipped_format" translatable="false">~%1$s</string>
+    <string name="decisions_tab_est_net_skipped_caption">est. net skipped across %1$s declined %2$s</string>
+    <string name="decisions_tab_score_vs_outcome_title">SCORE VS OUTCOME</string>
+    <string name="decisions_tab_avg_score_header">Avg score</string>
+    <string name="decisions_tab_est_per_hour_header" translatable="false">Est. $/hr</string>
+
+    <!-- main/ratings/RatingsScreen.kt -->
+    <string name="ratings_screen_title">Ratings</string>
+    <string name="ratings_screen_gauge_customer">Customer</string>
+    <string name="ratings_screen_gauge_on_time">On-time</string>
+    <string name="ratings_screen_gauge_completion">Completion</string>
+    <string name="ratings_screen_tile_acceptance">Acceptance</string>
+    <string name="ratings_screen_tile_deliveries_30d">Deliveries (30d)</string>
+    <string name="ratings_screen_tile_lifetime_deliveries">Lifetime deliveries</string>
+    <string name="ratings_screen_shopping_quality_header">Shopping quality</string>
+    <string name="ratings_screen_tile_original_items_found">Original items found</string>
+    <string name="ratings_screen_tile_total_items_found">Total items found</string>
+    <string name="ratings_screen_tile_substitution_issues">Substitution issues</string>
+    <string name="ratings_screen_tile_quality_issues">Quality issues</string>
+    <string name="ratings_screen_tile_wrong_or_missing">Wrong or missing</string>
+    <string name="ratings_screen_tile_lifetime_shops">Lifetime shops</string>
+    <string name="ratings_screen_empty_title">No ratings yet</string>
+    <string name="ratings_screen_empty_fallback_platform">platform</string>
+    <string name="ratings_screen_empty_desc_format">Open your %1$s Ratings screen while DashBuddy is running and they\'ll show up here.</string>
+
+    <!-- main/MainActivity.kt -->
+    <string name="main_activity_developer_options_title">Developer Options</string>
+    <string name="main_activity_placeholder_construction">Construction Area 🚧\nComing Soon</string>
+
+    <!-- setup/wizard/cards/VehicleCard.kt -->
+    <string name="wizard_vehicle_card_type_car">🚗 Car</string>
+    <string name="wizard_vehicle_card_type_ebike">🚲 E-Bike</string>
+    <string name="wizard_vehicle_card_year_label">Year</string>
+    <string name="wizard_vehicle_card_make_label">Make</string>
+    <string name="wizard_vehicle_card_model_label">Model</string>
+    <string name="wizard_vehicle_card_trim_label">Trim / Options</string>
+    <string name="wizard_vehicle_card_content_desc_search">Search</string>
+    <string name="wizard_vehicle_card_lookup_mpg">Lookup my MPG on Google</string>
+    <string name="wizard_vehicle_card_mpg_format" translatable="false">%1$s MPG</string>
+    <string name="wizard_vehicle_card_mpg_slider_hint">Slide to match your vehicle\'s combined MPG.</string>
+    <string name="wizard_vehicle_card_ebike_note">Awesome! We will ignore gas expenses and set your cost-per-mile to $0.</string>
+
+    <!-- settings/SettingsHomeScreen.kt -->
+    <string name="settings_home_title">Settings</string>
+    <string name="settings_home_group_monitoring">Monitoring</string>
+    <string name="settings_home_item_gig_apps_title">Gig Apps</string>
+    <string name="settings_home_item_gig_apps_subtitle">Choose which apps to monitor</string>
+    <string name="settings_home_group_automation">Automation &amp; Intelligence</string>
+    <string name="settings_home_item_strategy_title">Strategy Config</string>
+    <string name="settings_home_item_strategy_subtitle">Rules, Pricing, and Simulation</string>
+    <string name="settings_home_economy_true_cost_format" translatable="false">True cost: %1$s/mi</string>
+    <string name="settings_home_economy_defaults_suffix_format"> · %1$d defaults</string>
+    <string name="settings_home_economy_fallback_subtitle">Tires, oil, depreciation, insurance, phone</string>
+    <string name="settings_home_item_economy_title">Personal Economy</string>
+    <string name="settings_home_group_data_privacy">Data &amp; Privacy</string>
+    <string name="settings_home_item_evidence_title">Evidence Locker</string>
+    <string name="settings_home_item_evidence_subtitle">Manage screenshots and logs</string>
+    <string name="settings_home_item_export_title">Export Data (CSV)</string>
+    <string name="settings_home_item_export_subtitle">Mileage &amp; earnings for a spreadsheet or tax prep</string>
+    <string name="settings_home_group_app_system">App System</string>
+    <string name="settings_home_item_general_title">General</string>
+    <string name="settings_home_item_general_subtitle">Theme, Pro Mode, and Defaults</string>
+    <string name="settings_home_item_rerun_wizard_title">Re-run Setup Wizard</string>
+    <string name="settings_home_item_rerun_wizard_subtitle">Adjust vehicle and base targets</string>
+    <string name="settings_home_item_about_title">About</string>
+    <string name="settings_home_item_about_subtitle">Version, Support, and Developer info</string>
+    <string name="settings_home_item_debug_menu_title">Debug Menu</string>
+    <string name="settings_home_item_debug_menu_subtitle">Log levels &amp; Snapshot whitelist</string>
+
+    <!-- settings/StrategySettingsScreen.kt -->
+    <string name="strategy_settings_the_lab_title">The Lab</string>
+    <string name="strategy_settings_sim_pay_format">Pay: %1$s</string>
+    <string name="strategy_settings_sim_dist_format">Dist: %1$s mi</string>
+    <string name="strategy_settings_global_overrides_title">Global Overrides</string>
+    <string name="strategy_settings_protect_stats_label">🛡️ Protect Stats Mode</string>
+    <string name="strategy_settings_protect_stats_subtitle">Auto-accept everything</string>
+    <string name="strategy_settings_allow_shopping_label">🛒 Allow Shopping Orders</string>
+    <string name="strategy_settings_allow_shopping_subtitle">If off, Red Card orders are auto-declined</string>
+    <string name="strategy_settings_quick_declines_label">⚡ Single-click declines</string>
+    <string name="strategy_settings_quick_declines_subtitle">Auto-confirm DoorDash\'s \'are you sure?\' so a decline is one tap</string>
+    <string name="strategy_settings_priorities_title">Priorities (Rack &amp; Stack)</string>
+    <string name="strategy_settings_priorities_hint">Drag to reorder. Top rules matter most.</string>
+
+    <!-- main/analytics/TimeTab.kt -->
+    <string name="time_tab_time_split_title">TIME SPLIT</string>
+    <string name="time_tab_no_sessions_yet">No sessions in this period yet.</string>
+    <string name="time_tab_online_across_format">online across %1$s %2$s</string>
+    <string name="time_tab_session_singular">session</string>
+    <string name="time_tab_session_plural">sessions</string>
+    <string name="time_tab_sessions_stat_label">Sessions</string>
+    <string name="time_tab_avg_session_stat_label">Avg session</string>
+    <string name="time_tab_segment_on_delivery">On delivery</string>
+    <string name="time_tab_segment_unattributed">Unattributed</string>
+    <string name="time_tab_deadhead_title">DEADHEAD</string>
+    <string name="time_tab_no_miles_measured_yet">No miles measured in this period yet.</string>
+    <string name="time_tab_deadhead_caption">miles with no delivery attached — after the last drop, or sessions with none</string>
+    <string name="time_tab_segment_deadhead">Deadhead</string>
+    <string name="time_tab_on_time_title">ON TIME</string>
+    <string name="time_tab_no_deadline_deliveries_yet">No deliveries carried a deadline in this period.</string>
+    <string name="time_tab_gauge_on_time_label">on time</string>
+    <string name="time_tab_deadline_caption_format">%1$s of %2$s %3$s with a deadline</string>
+    <string name="time_tab_delivery_singular">delivery</string>
+    <string name="time_tab_delivery_plural">deliveries</string>
+    <string name="time_tab_margin_early_format">typically %1$s early</string>
+    <string name="time_tab_margin_late_format">typically %1$s late</string>
+    <string name="time_tab_mileage_tax_title">MILEAGE &amp; TAX</string>
+    <string name="time_tab_mileage_tax_disclosure">standard-mileage method — not the app\'s operating-cost model; confirm with a tax preparer.</string>
+
+    <!-- setup/wizard/WizardScreen.kt -->
+    <string name="wizard_screen_goal_option1_title">Cherry Picker</string>
+    <string name="wizard_screen_goal_option1_desc">Maximize profit. Auto-decline unprofitable offers.</string>
+    <string name="wizard_screen_goal_option2_title">Protect Platinum</string>
+    <string name="wizard_screen_goal_option2_desc">Maintain high acceptance rate. Do not auto-decline anything.</string>
+    <string name="wizard_screen_goal_option3_title">Manual Mode</string>
+    <string name="wizard_screen_goal_option3_desc">Just show me the math. I will make my own decisions.</string>
+    <string name="wizard_screen_shopping_value_format" translatable="false">%1$s items</string>
+    <string name="wizard_screen_shopping_footer">We\'ll use this to score shopping offers on the HUD.</string>
+    <string name="wizard_screen_hourly_value_format" translatable="false">%1$s / hr</string>
+    <string name="wizard_screen_distance_value_format" translatable="false">%1$s mi</string>
+    <string name="wizard_screen_min_payout_footer_auto">We will auto-decline offers below this amount.</string>
+    <string name="wizard_screen_min_payout_footer_flag">We will flag offers below this amount in red.</string>
+    <string name="wizard_screen_hourly_footer_auto">We will auto-decline offers below this rate.</string>
+    <string name="wizard_screen_hourly_footer_flag">We will flag offers below this rate in red.</string>
+    <string name="wizard_screen_distance_footer_auto">We will auto-decline offers exceeding this distance.</string>
+    <string name="wizard_screen_distance_footer_flag">We will flag offers exceeding this distance in red.</string>
+    <string name="wizard_screen_content_desc_success">Success</string>
+    <string name="wizard_screen_all_set_title">You\'re all set!</string>
+    <string name="wizard_screen_skipped_desc">Setup skipped — nothing was changed. You can run the wizard anytime from the Settings menu.</string>
+    <string name="wizard_screen_completed_desc">Your setup is complete. Remember, you can always tweak these targets, change your vehicle, or adjust your automation strategy later in the Settings menu.</string>
+    <string name="wizard_screen_lets_go">Let\'s Go</string>
+
+    <!-- main/dashboard/DashboardScreen.kt -->
+    <string name="dashboard_screen_content_desc_settings">Settings</string>
+    <string name="dashboard_screen_permissions_required_title">Permissions Required</string>
+    <string name="dashboard_screen_permissions_required_subtitle">DashBuddy needs your attention. Please complete the popup.</string>
+    <string name="dashboard_screen_first_run_title">You have the Keys!</string>
+    <string name="dashboard_screen_first_run_subtitle">Permissions granted. Let\'s personalize your strategy so DashBuddy knows what offers you like.</string>
+    <string name="dashboard_screen_personalize_strategy_button">Personalize Strategy</string>
+    <string name="dashboard_screen_skip_for_now_button">Skip for now</string>
+    <string name="dashboard_screen_dashing_subtitle">You\'re on the clock.</string>
+    <string name="dashboard_screen_ready_subtitle">All systems go.</string>
+    <string name="dashboard_screen_show_bubble_button">Show Bubble</string>
+    <string name="dashboard_screen_stat_true_net">True Net</string>
+    <string name="dashboard_screen_stat_net_per_hour">Net/hr</string>
+    <string name="dashboard_screen_stat_miles">Miles</string>
+    <string name="dashboard_screen_entry_analytics">Analytics</string>
+    <string name="dashboard_screen_entry_ratings">Ratings</string>
+    <string name="dashboard_screen_entry_strategy">Strategy</string>
+    <string name="dashboard_screen_entry_economy">Economy</string>
+
+    <!-- components/economy/EconomyEditor.kt -->
+    <string name="economy_editor_per_mile_format" translatable="false">%1$s/mi</string>
+    <string name="economy_editor_per_mile_asterisk_format" translatable="false">%1$s/mi*</string>
+    <string name="economy_editor_tires_title">Tires</string>
+    <string name="economy_editor_tires_cost_label">Set of 4</string>
+    <string name="economy_editor_lifetime_label">Lifetime</string>
+    <string name="economy_editor_oil_title">Oil changes</string>
+    <string name="economy_editor_each_label">Each</string>
+    <string name="economy_editor_every_label">Every</string>
+    <string name="economy_editor_brakes_title">Brakes</string>
+    <string name="economy_editor_fluids_title">Fluids</string>
+    <string name="economy_editor_misc_title">Misc repairs</string>
+    <string name="economy_editor_misc_cost_label">Yearly budget</string>
+    <string name="economy_editor_misc_interval_label">Driving</string>
+    <string name="economy_editor_misc_interval_suffix" translatable="false">mi/yr</string>
+    <string name="economy_editor_misc_helper">Annual catch-all for repairs not in oil/brakes/fluids.</string>
+    <string name="economy_editor_depreciation_title">Depreciation</string>
+    <string name="economy_editor_depreciation_off">off</string>
+    <string name="economy_editor_depreciation_include_label">Include depreciation</string>
+    <string name="economy_editor_purchase_price_label">Purchase price</string>
+    <string name="economy_editor_depreciation_helper">Total expected miles from new to retirement, e.g. 200,000 for a typical sedan.</string>
+    <string name="economy_editor_insurance_title">Insurance</string>
+    <string name="economy_editor_insurance_label">Extra for gig work</string>
+    <string name="economy_editor_per_month_suffix" translatable="false">/mo</string>
+    <string name="economy_editor_insurance_helper">Monthly add-on for rideshare/delivery rider above your personal policy.</string>
+    <string name="economy_editor_registration_title">Registration</string>
+    <string name="economy_editor_registration_label">Commercial delta</string>
+    <string name="economy_editor_per_year_suffix" translatable="false">/yr</string>
+    <string name="economy_editor_registration_helper">Annual fee above your personal registration (commercial registration / inspection / endorsement).</string>
+    <string name="economy_editor_phone_title">Phone &amp; data</string>
+    <string name="economy_editor_phone_plan_total_label">Plan total</string>
+    <string name="economy_editor_phone_lines_label">Lines</string>
+    <string name="economy_editor_phone_business_percent_format">% for gig work: %1$d%%</string>
+    <string name="economy_editor_phone_per_line_format">Your line: %1$s/mo × %2$d%% = %3$s/mo for gig work</string>
+    <string name="economy_editor_annual_miles_title">Expected gig miles / yr</string>
+    <string name="economy_editor_annual_miles_summary_format" translatable="false">%1$s mi</string>
+    <string name="economy_editor_annual_miles_value_format">%1$s miles per year</string>
+    <string name="economy_editor_annual_miles_helper">Used to amortize fixed costs (insurance, registration, phone) into a per-mile rate. Bigger number → smaller per-mile share.</string>
+    <string name="economy_editor_vehicle_class_title">Vehicle class</string>
+    <string name="economy_editor_true_cost_format">Your true cost: %1$s/mi</string>
+    <string name="economy_editor_irs_rate_note" translatable="false">IRS standard mileage rate: $0.67/mi</string>
+
+    <!-- main/analytics/MoneyTab.kt -->
+    <string name="money_tab_gross_earnings_title">GROSS EARNINGS</string>
+    <string name="money_tab_true_net_chip_format">True net %1$s</string>
+    <string name="money_tab_net_per_hour_chip_format">Net/hr %1$s</string>
+    <string name="money_tab_earnings_by_day_title">EARNINGS BY DAY</string>
+    <string name="money_tab_no_earnings_yet">No earnings in this period yet.</string>
+    <string name="money_tab_earnings_by_day_caption">gross per day · sessions count on their start day</string>
+    <string name="money_tab_true_net_title">TRUE NET</string>
+    <string name="money_tab_stat_net_per_hour">Net/hr</string>
+    <string name="money_tab_stat_net_per_mile">Net/mi</string>
+    <string name="money_tab_stat_miles">Miles</string>
+    <string name="money_tab_stat_deliveries">Deliveries</string>
+    <string name="money_tab_top_stores_title">TOP STORES</string>
+    <string name="money_tab_no_store_earnings_yet">No store earnings in this period yet.</string>
+    <string name="money_tab_unknown_store">Unknown store</string>
+    <string name="money_tab_unattributed_callout_format">%1$s not attributed to any delivery — bonuses/adjustments; review coming (#650)</string>
+    <string name="money_tab_recent_sessions_title">RECENT SESSIONS</string>
+    <string name="money_tab_no_sessions_recorded_yet">No sessions recorded yet.</string>
+    <string name="money_tab_cash_marker_format">+%1$s cash</string>
+
+    <!-- main/analytics/SessionDetailScreen.kt -->
+    <string name="session_detail_title">Session detail</string>
+    <string name="session_detail_not_found">Session not found.</string>
+    <string name="session_detail_unaccounted_format">%1$s unaccounted on this session — the platform reported more than the captured deliveries.</string>
+    <string name="session_detail_add_missed_delivery">Add missed delivery</string>
+    <string name="session_detail_deliveries_title">DELIVERIES</string>
+    <string name="session_detail_no_deliveries_yet">No deliveries captured for this session.</string>
+    <string name="session_detail_gross_reported_label">Gross (reported)</string>
+    <string name="session_detail_gross_captured_label">Gross (captured)</string>
+    <string name="session_detail_stat_miles">Miles</string>
+    <string name="session_detail_stat_deliveries">Deliveries</string>
+    <string name="session_detail_duration_format">Duration %1$s</string>
+    <string name="session_detail_cash_tips_format">+%1$s cash tips</string>
+    <string name="session_detail_unknown_store">Unknown store</string>
+    <string name="session_detail_tip_included_format">incl. %1$s tip</string>
+    <string name="session_detail_cash_format">+%1$s cash</string>
+    <string name="session_detail_est_offer_pay">est. offer pay</string>
+    <string name="session_detail_net_format">net %1$s</string>
+    <string name="session_detail_content_desc_adjust">Adjust delivery</string>
+    <string name="session_detail_field_store_optional">Store (optional)</string>
+    <string name="session_detail_field_pay">Pay</string>
+    <string name="session_detail_field_tip_included">Tip (included in pay)</string>
+    <string name="session_detail_field_cash_tip_optional">Cash tip (optional)</string>
+    <string name="session_detail_field_note_optional">Note (optional)</string>
+    <string name="session_detail_add_button">Add</string>
+    <string name="session_detail_cancel_button">Cancel</string>
+    <string name="session_detail_adjust_dialog_title">Adjust delivery</string>
+    <string name="session_detail_field_store_name">Store name</string>
+    <string name="session_detail_field_pay_locked_supporting">de-duplicated receipt — edit the real drop\'s row</string>
+    <string name="session_detail_field_cash_tip">Cash tip</string>
+    <string name="session_detail_save_button">Save</string>
+
+    <!-- bubble/cards/FlowCardItem.kt -->
+    <string name="flow_card_content_desc_collapse">Collapse</string>
+    <string name="flow_card_content_desc_expand">Expand</string>
+    <string name="flow_card_awaiting_active_format">Waiting · %1$s</string>
+    <string name="flow_card_awaiting_frozen_format">Waited %1$s</string>
+    <string name="flow_card_offer_fallback_store">Offer</string>
+    <string name="flow_card_pickup_arrived_format">%1$s · arrived %2$s</string>
+    <string name="flow_card_delivery_delivered_format">%1$s · delivered %2$s</string>
+    <string name="flow_card_since_last_offer">since last offer</string>
+    <string name="flow_card_before_next_offer">before next offer</string>
+    <string name="flow_card_score_gauge_label">Score</string>
+    <string name="flow_card_hourly_hero_format" translatable="false">%1$s/hr</string>
+    <string name="flow_card_net_secondary_format">Net %1$s</string>
+    <string name="flow_card_distance_secondary_format" translatable="false">%1$s mi</string>
+    <string name="flow_card_per_mile_secondary_format" translatable="false">%1$s/mi</string>
+    <string name="flow_card_badge_shop_and_deliver">Shop &amp; Deliver</string>
+    <string name="flow_card_badge_high_pay">High pay</string>
+    <string name="flow_card_badge_priority">Priority</string>
+    <string name="flow_card_badge_red_card">Red Card</string>
+    <string name="flow_card_badge_alcohol">Alcohol</string>
+    <string name="flow_card_badge_large_order">Large order</string>
+    <string name="flow_card_badge_pizza_bag">Pizza bag</string>
+    <string name="flow_card_badge_same_store">Same store</string>
+    <string name="flow_card_badge_same_customer">Same customer</string>
+    <string name="flow_card_badge_add_ons_ok">Add-ons OK</string>
+    <string name="flow_card_timer_dwell_label">Dwell</string>
+    <string name="flow_card_timer_at_door_sub">at door</string>
+    <string name="flow_card_timer_at_store_sub">at store</string>
+    <string name="flow_card_timer_overdue_label">Overdue</string>
+    <string name="flow_card_timer_to_go_label">To go</string>
+    <string name="flow_card_timer_elapsed_label">Elapsed</string>
+    <string name="flow_card_timer_en_route_sub">en route</string>
+    <string name="flow_card_running_at_label">Running at</string>
+    <string name="flow_card_running_at_overdue_format" translatable="false">%1$s/hr ↓</string>
+    <string name="flow_card_running_at_dropping_sub">dropping</string>
+    <string name="flow_card_running_at_on_track_sub">on track</string>
+    <string name="flow_card_arrived_margin_format">arrived %1$s %2$s · </string>
+    <string name="flow_card_margin_early">early</string>
+    <string name="flow_card_margin_late">late</string>
+    <string name="flow_card_at_stop">at stop</string>
+    <string name="flow_card_en_route">en route</string>
+    <string name="flow_card_past_deadline_format">%1$s past %2$s-by</string>
+    <string name="flow_card_by_deadline_format">%1$s by %2$s</string>
+    <string name="flow_card_verb_deliver">deliver</string>
+    <string name="flow_card_verb_pickup">pickup</string>
+    <string name="flow_card_below_floor_warning">Below your floor — no longer worth the wait.</string>
+    <string name="flow_card_shop_progress_format" translatable="false">shop %1$d/%2$d</string>
+    <string name="flow_card_shop_pace_format" translatable="false">%1$s/min</string>
+    <string name="flow_card_detail_arrived_format"> · arrived %1$s</string>
+    <string name="flow_card_detail_picked_up_format"> · picked up %1$s</string>
+    <string name="flow_card_post_task_delivery_total">delivery total</string>
+    <string name="flow_card_post_task_tip_format">tip · %1$s</string>
+    <string name="flow_card_post_task_session_format">session %1$s</string>
+    <string name="flow_card_action_decline">Decline</string>
+    <string name="flow_card_action_accept">Accept</string>
+    <string name="flow_card_outcome_accepted">Accepted</string>
+    <string name="flow_card_outcome_declined">Declined</string>
+    <string name="flow_card_outcome_timed_out">Timed out</string>
+
+    <!-- settings/EvidenceSettingsScreen.kt -->
+    <string name="evidence_settings_title">Evidence Locker</string>
+    <string name="evidence_settings_master_label">Master Record</string>
+    <string name="evidence_settings_master_subtitle">Global kill-switch for all data recording</string>
+    <string name="evidence_settings_section_granular">Granular Controls</string>
+    <string name="evidence_settings_offers_label">Save Offers</string>
+    <string name="evidence_settings_offers_subtitle">Keep full JSON/Screenshots of incoming offers</string>
+    <string name="evidence_settings_deliveries_label">Save Deliveries</string>
+    <string name="evidence_settings_deliveries_subtitle">Track completion stats</string>
+    <string name="evidence_settings_session_label">Save Session Summary</string>
+    <string name="evidence_settings_session_subtitle">End of session earnings report</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,7 +63,7 @@
 
     <string name="perm_title_location">Background Location</string>
     <string name="perm_pitch_location">DashBuddy tracks your miles while you are dashing so you can calculate your actual profit after gas and wear-and-tear.</string>
-    <string name="perm_hood_location">We only ping your GPS while an active Dash is running. Once you hit \'End Dash\', our Odometer shuts down completely to save your battery and protect your privacy.</string>
+    <string name="perm_hood_location">We only ping your GPS while an active session is running. Once you end the session, our Odometer shuts down completely to save your battery and protect your privacy.</string>
     <string name="perm_action_location">Grant Location</string>
 
     <string name="perm_title_post_notif">Bubble Alerts</string>
@@ -212,19 +212,19 @@
     <string name="data_export_title">Export Data</string>
     <string name="data_export_csv_heading">Export your mileage &amp; earnings to CSV</string>
     <string name="data_export_csv_desc">Pick a folder and DashBuddy writes three spreadsheet files into it:\n• deliveries.csv — one row per delivery\n• sessions.csv — one row per session\n• summary.csv — totals + estimated IRS mileage deduction\n\nThis is your own data, on-device — nothing is uploaded. Exports all history (a date-range picker is coming later).</string>
-    <string name="data_export_csv_button">  Choose folder &amp; export</string>
+    <string name="data_export_csv_button">"  Choose folder &amp; export"</string>
     <string name="data_export_csv_success_format">Exported %1$d files to the chosen folder.</string>
     <string name="data_export_csv_error_format">Export failed: %1$s</string>
     <string name="data_export_log_heading">Export a bug report</string>
     <string name="data_export_log_desc">Pick a folder and DashBuddy writes dashbuddy-log.txt into it — the log the developer needs to diagnose an issue.\n\nINFO+ milestones only — no raw store, customer, or address text. Every line is auto-scrubbed at the sink before it\'s written, so a leaked name can\'t reach the file. On-device, nothing is uploaded.</string>
-    <string name="data_export_log_button">  Choose folder &amp; export log</string>
+    <string name="data_export_log_button">"  Choose folder &amp; export log"</string>
     <string name="data_export_log_success_format">Exported dashbuddy-log.txt — %1$d line(s) were auto-scrubbed.</string>
     <string name="data_export_log_error_format">Log export failed: %1$s</string>
 
     <!-- settings/components/FakeOfferCard.kt -->
-    <string name="fake_offer_score_format" translatable="false">%1$s  ·  %2$dpts</string>
-    <string name="fake_offer_pay_line_format" translatable="false">%1$s gross  →  %2$s net</string>
-    <string name="fake_offer_pay_line_estimate_format" translatable="false">%1$s gross  →  %2$s net (est.)</string>
+    <string name="fake_offer_score_format" translatable="false">"%1$s  ·  %2$dpts"</string>
+    <string name="fake_offer_pay_line_format" translatable="false">"%1$s gross  →  %2$s net"</string>
+    <string name="fake_offer_pay_line_estimate_format" translatable="false">"%1$s gross  →  %2$s net (est.)"</string>
     <string name="fake_offer_fuel_cost_format" translatable="false">−%1$s fuel</string>
     <string name="fake_offer_nonfuel_cost_format">−%1$s wear &amp; fixed costs</string>
     <string name="fake_offer_metric_dollar_per_mile_label" translatable="false">$/mi</string>
@@ -297,7 +297,7 @@
     <string name="settings_home_item_strategy_title">Strategy Config</string>
     <string name="settings_home_item_strategy_subtitle">Rules, Pricing, and Simulation</string>
     <string name="settings_home_economy_true_cost_format" translatable="false">True cost: %1$s/mi</string>
-    <string name="settings_home_economy_defaults_suffix_format"> · %1$d defaults</string>
+    <string name="settings_home_economy_defaults_suffix_format">" · %1$d defaults"</string>
     <string name="settings_home_economy_fallback_subtitle">Tires, oil, depreciation, insurance, phone</string>
     <string name="settings_home_item_economy_title">Personal Economy</string>
     <string name="settings_home_group_data_privacy">Data &amp; Privacy</string>
@@ -428,7 +428,7 @@
     <string name="economy_editor_phone_title">Phone &amp; data</string>
     <string name="economy_editor_phone_plan_total_label">Plan total</string>
     <string name="economy_editor_phone_lines_label">Lines</string>
-    <string name="economy_editor_phone_business_percent_format">% for gig work: %1$d%%</string>
+    <string name="economy_editor_phone_business_percent_format">%% for gig work: %1$d%%</string>
     <string name="economy_editor_phone_per_line_format">Your line: %1$s/mo × %2$d%% = %3$s/mo for gig work</string>
     <string name="economy_editor_annual_miles_title">Expected gig miles / yr</string>
     <string name="economy_editor_annual_miles_summary_format" translatable="false">%1$s mi</string>
@@ -526,7 +526,7 @@
     <string name="flow_card_running_at_overdue_format" translatable="false">%1$s/hr ↓</string>
     <string name="flow_card_running_at_dropping_sub">dropping</string>
     <string name="flow_card_running_at_on_track_sub">on track</string>
-    <string name="flow_card_arrived_margin_format">arrived %1$s %2$s · </string>
+    <string name="flow_card_arrived_margin_format">"arrived %1$s %2$s · "</string>
     <string name="flow_card_margin_early">early</string>
     <string name="flow_card_margin_late">late</string>
     <string name="flow_card_at_stop">at stop</string>
@@ -538,8 +538,8 @@
     <string name="flow_card_below_floor_warning">Below your floor — no longer worth the wait.</string>
     <string name="flow_card_shop_progress_format" translatable="false">shop %1$d/%2$d</string>
     <string name="flow_card_shop_pace_format" translatable="false">%1$s/min</string>
-    <string name="flow_card_detail_arrived_format"> · arrived %1$s</string>
-    <string name="flow_card_detail_picked_up_format"> · picked up %1$s</string>
+    <string name="flow_card_detail_arrived_format">" · arrived %1$s"</string>
+    <string name="flow_card_detail_picked_up_format">" · picked up %1$s"</string>
     <string name="flow_card_post_task_delivery_total">delivery total</string>
     <string name="flow_card_post_task_tip_format">tip · %1$s</string>
     <string name="flow_card_post_task_session_format">session %1$s</string>

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardViewModelTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardViewModelTest.kt
@@ -160,13 +160,13 @@ class DashboardViewModelTest {
         assertEquals("Looking for offers...", onlineVm.uiState.value.statusText)
         onlineJob.cancel()
 
-        // Offline → not dashing + "ready to dash".
+        // Offline → not dashing + "ready to start a session".
         whenever(stateManager.state).thenReturn(MutableStateFlow(offlineState()))
         val offlineVm = buildViewModel()
         val offlineJob = launch { offlineVm.uiState.collect {} }
         testScheduler.advanceUntilIdle()
         assertFalse(offlineVm.uiState.value.isDashing)
-        assertEquals("Ready to Dash", offlineVm.uiState.value.statusText)
+        assertEquals("Ready to start a session", offlineVm.uiState.value.statusText)
         offlineJob.cancel()
     }
 }


### PR DESCRIPTION
## Summary

Three stacked mechanical passes for the `:app` UI copy arc, one commit each:

1. **#238 — split `BubbleScreen.kt`** (633 lines) into focused files, adapted to the
   *current* function list (the issue predates the mode-card→FlowCardItem migration, so
   only `ModeIdle` remained as a "Mode\*" composable, not the full set the issue described):
   - `BubbleScreen.kt` (kept): `BubbleScreen` scaffold + `findActivity` + `DashboardView`
   - `StatusBar.kt`: `StatusBadgeTitle`, `SessionMetricsActions`, `statusBadge`
   - `ChatViews.kt`: `FullChatView`, `ChatBubble`, `HtmlText`, `LatestMessageTicker`
   - `ModeCards.kt`: `ModeIdle`
   - `BubbleHelpers.kt`: `ModeRow`, `getPreviewText`
   Pure move; only cross-file call sites widened `private` → `internal`. **rememberNow
   note**: it already lives in `:core:designsystem` (`TimeKit.kt`) and BubbleScreen.kt had
   no local duplicate — the issue's SSOT caveat didn't apply.

2. **#694 — neutral session vocabulary.** Replaced DoorDash's own vocabulary
   (`dash`/`dashes`/`Dashing`) with **`session`/`sessions`** — chosen because it's already
   the code's own SSOT (`Session`, `SessionRecord`, `sessions.csv`, `saveSessionSummaries`).
   **Dev veto welcome** on this word choice at review. Full changed-string list is in the
   `cleanup(#694)` commit message; highlights: `RECENT DASHES`→`RECENT SESSIONS`,
   `Ready to Dash`→`Ready to start a session`, `Dash Complete`→`Session Complete`,
   `Dashing — tap for the bubble`→`Session active — tap for the bubble`, `Save Dash
   Summary`→`Save Session Summary`, wizard CTA `Let's Go Dash`→`Let's Go` (dropped the
   platform pun rather than force "session" into a verb slot). Left alone: the app name
   `DashBuddy`, `DashBuddyTheme`, genuine DoorDash-platform references, and the `dasher`
   term (CLAUDE.md itself uses it generically for the driver, not as a DoorDash word).

3. **#57 — strings.xml extraction.** Nearly every hardcoded literal in `:app`'s Compose UI
   (screens, cards, dialogs, bubble HUD — 33 files) now routes through `stringResource()`,
   using the `<screen>_<component>_<property>` convention from the issue (`common_*` for
   truly cross-screen strings: `common_content_desc_back`, `common_period_*`; `app_name`
   marked `translatable="false"` per the issue's blueprint). Format-arg lines use
   positional `%1$s`/`%1$d` templates. A few previously-non-composable helper functions
   (`offerSummary`/`postTaskSummary`/`badgeMeta` in `FlowCardItem.kt`, `periodOptions()` in
   `AnalyticsScreen.kt`/`DashboardScreen.kt`) picked up `@Composable` purely to reach
   `stringResource()` — no behavior change.

## Vocabulary decision (for dev veto)

`session`/`sessions` replaces `dash`/`dashes` everywhere in Pass 2. If a different word is
preferred, it's a find-and-replace across the strings enumerated in the `cleanup(#694)`
commit message (now also centralized in `strings.xml` after Pass 3, so a future rename is
one file instead of a UI sweep).

## Changed strings (Pass 2 vocabulary sweep) — full list

See the `cleanup(#694)` commit message for the complete before/after list (14 call sites
across `BubbleManager.kt`, `MoneyTab.kt`, `SessionDetailScreen.kt`, `TimeTab.kt`,
`DashboardScreen.kt`/`DashboardViewModel.kt`, `EvidenceSettingsScreen.kt`,
`GeneralSettingsScreen.kt`, `DataExportScreen.kt`, `WizardScreen.kt`, plus the matching
test-assertion fix in `DashboardViewModelTest.kt`).

## Deliberately NOT extracted in Pass 3 (and why)

- **Bare unit/currency tokens** (`"$"` prefix in `CurrencyInput.kt`, `"mi"`/`"/mo"`/`"/yr"`
  default suffixes) — formatting symbols, not sentence-level copy.
- **Compose animation debug `label = "..."` params** (`"chevron"`, `"container"`,
  `"progress"`) — internal to the animation inspector tooling, never rendered to the user.
- **`WaterfallModel` (`MoneyTab.kt`) and `MileageTaxModel` (`TimeTab.kt`)** — both are
  explicitly documented as "kept Compose-free so it's unit-testable in isolation from
  rendering." Routing their copy through `stringResource()` would require a
  `Context`/`@Composable` dependency, undoing that deliberate architecture choice. A real
  tradeoff, not an oversight — flagged for the adversarial reviewer.
- **Pre-existing `strings.xml` entries** (permission screens, wizard phase/step titles)
  predate the `<screen>_<component>_<property>` convention; left as-is rather than
  renamed, to avoid unrelated churn across their existing call sites (`PermissionCard`,
  `PermissionBottomSheet`, `PermissionType`, `WizardPhase`, `WizardStep`).

## #428 remainder (TTS + non-Compose copy — explicitly out of scope per the task)

Issue #57's scope is Compose UI; #428 already owns TTS/action-consent i18n. Residual
non-Compose hardcoded copy found while auditing (not touched in this PR):

- **`state/effects/TtsEffectHandler.kt`** (`formatEvaluation`) — the spoken-verdict
  template's connective words ("dollars an hour net.", "Net", "miles,", "score") and
  verdict words ("Accept"/"Decline"/"Review"/"Offer") — squarely #428's stated scope.
- **`ui/bubble/BubbleManager.kt`** (non-Compose, notification/channel plumbing) — channel
  names/descriptions ("DashBuddy Stream", "Offer Alerts", etc.), the dynamic-shortcut
  label, the MessagingStyle conversation title, session start/end chat messages, and the
  offer-card `RemoteViews` text templates.
- **`ui/main/dashboard/DashboardViewModel.kt`** — `statusText()`'s status labels and the
  welcome chat message are ViewModel-owned `String`s in `UiState`, not Compose; extracting
  them cleanly would mean re-plumbing `UiState` to carry string-resource IDs instead of
  formatted `String`s — a design change beyond this mechanical pass.
- **`state/effects/TipEffectHandler.kt`** — the tip chat message template.
- **`ui/main/analytics/AnalyticsUiState.kt`**'s `AnalyticsTab` enum `label` fields
  ("Money"/"Decisions"/"Time"/"Patterns") — same non-Compose-owned-copy category as the
  DashboardViewModel status text above.

None of these are TTS-adjacent in the #428 sense except the first bullet; the rest are a
distinct "ViewModel/non-Compose owns literal copy" residual — noted here rather than
silently left out, per the task's instruction to flag anything unclear.

## Test plan

- [x] `:app:compileDebugKotlin` green after every batch (checkpointed ~15 times through
      the extraction)
- [x] `:app:testDebugUnitTest` green after each pass and at the end
- [x] `:app:assembleDebug` succeeds (resource merge / string-arg formatting sanity)
- [x] `./gradlew testDebugUnitTest :domain:test` (full shared-machine suite) green
- [x] `DashboardViewModelTest.kt` updated for the Pass-2 status-text change
- [x] `strings.xml` validated as well-formed XML

### Design-goal review

1. **UDF** — no state-flow changes; this is copy/structure only.
2. **MAD** — Compose-idiomatic `stringResource()` usage throughout; no new architecture.
3. **Single responsibility** — Pass 1 is exactly this principle applied to
   `BubbleScreen.kt` (the #237 family goal): one concern per file.
4. **Kotlin/Android best practices** — positional format args (`%1$s`) throughout, not
   string concatenation, so args can reorder per-locale; no new stringly-typed values.
5. **SSOT** — Pass 3 turns previously-scattered inline copy into one owned resource per
   string (a future wording change is a one-line `strings.xml` edit instead of a
   file-by-file hunt); Pass 2's vocabulary decision is likewise now centralized. The
   documented `WaterfallModel`/`MileageTaxModel` exception is a real, flagged SSOT
   tradeoff (testability vs. resource-based i18n), not a silent gap.
6. **Security & privacy** — no capture/recognition/effect surfaces touched; copy-only.
7. **Semantic logging** — not touched.
8. **Platform-agnostic core** — Pass 2 directly remediates a P8 drift (DoorDash's own
   "dash" vocabulary leaking into generic UI copy, per #694) — this PR **is** the P8 fix
   for the analytics/dashboard/settings surfaces. No `:core:state`/`:core:pipeline`/
   `:domain`/rule-JSON edits in this diff.
- **Reactive UI rules** — untouched; no new time-derived values, no new ticker usage.

### Adversarial review

Not yet run — this PR is left OPEN per instructions (builder does not merge). Flagging for
the reviewer: (1) the `WaterfallModel`/`MileageTaxModel` extraction exception above, (2)
the `session` vocabulary word choice (dev veto point), (3) the #428-remainder scope
boundary (ViewModel-owned copy vs. Compose UI copy) — confirm the boundary is drawn in the
right place.



### Adversarial review

Fable adversarial reviewer ran commit-by-commit against head `76976608` — verdict **APPROVE-WITH-FIXES**, all applied in `38035501`. **HIGH-1 (a guaranteed runtime crash the green build masked):** extracting `"% for gig work: ${…}%"` manufactured `% f` — a valid-looking format specifier that consumes the Int arg and throws `IllegalFormatConversionException` the moment the economy editor renders (empirically confirmed on JVM 25; neither `assembleDebug` nor unit tests exercise resource formatting, which is why every checkpoint stayed green) — escaped to `%%`. **MED-2/3:** aapt strips unquoted leading/trailing spaces and collapses interior runs — nine concatenation-fragment/icon-gap strings (bubble HUD captions, settings suffix, export buttons, FakeOfferCard) verified stripped in the compiled APK via `aapt2 dump`, now quoted and re-verified compiled-correct. **LOW-4:** `perm_hood_location` was live pre-existing copy still reading "active Dash"/"End Dash" — neutralized. Everything else verified clean: **pass 1** is a line-set-identical pure move (4 justified visibility widenings; the `rememberNow` designsystem-SSOT claim confirmed true); **pass 2** touched zero identifiers/routes/prefs keys/channel IDs/wire strings (grep-verified — `isDashing`, `DashBuddy`, DoorDash-the-platform all survive) and reads as English ("Let's Go Dash"→"Let's Go" over forcing a verb); **pass 3**'s 314 removed literals cross-checked against 382 added resources with every miss explained, all 80 format strings arg-count/type-consistent (beyond HIGH-1), escaping correct, no `stringResource` outside composables. Recorded non-blocking: hand-rolled singular/plural pairs (fine for alpha, `<plurals>` for real i18n), dead legacy resources predating this PR (cleanup candidate), naming drift nits. Close verdicts adopted: #238 and #694 close on merge; #57 closes with translations/`<plurals>`/non-Compose copy routed to #428 (keeping it open only for translations would be scope-creep at alpha).
