### PR TITLE
feat(#693): bubble last-session summary from the read-model + just-in-time actions

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleScreen.kt
@@ -38,11 +38,15 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import cloud.trotter.dashbuddy.R
+import cloud.trotter.dashbuddy.domain.analytics.SessionRecord
 import cloud.trotter.dashbuddy.domain.model.cards.CardStack
 import cloud.trotter.dashbuddy.domain.model.chat.ChatMessage
 import cloud.trotter.dashbuddy.domain.state.Mode
+import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.domain.state.PlatformRegion
 import cloud.trotter.dashbuddy.ui.bubble.cards.FlowCardItem
+import cloud.trotter.dashbuddy.ui.main.MainActivity
+import cloud.trotter.dashbuddy.ui.main.navigation.Screen
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -58,7 +62,9 @@ fun BubbleScreen(
     val focusedRegion by viewModel.focusedRegion.collectAsStateWithLifecycle()
     val sessionMiles by viewModel.sessionMiles.collectAsStateWithLifecycle()
     val sessionEarnings by viewModel.sessionEarnings.collectAsStateWithLifecycle()
-    val lastSessionSummary by viewModel.lastSessionSummary.collectAsStateWithLifecycle()
+    val lastSession by viewModel.lastSession.collectAsStateWithLifecycle()
+    val gasPrice by viewModel.gasPrice.collectAsStateWithLifecycle()
+    val isGasPriceAuto by viewModel.isGasPriceAuto.collectAsStateWithLifecycle()
     val cardStack by viewModel.cardStack.collectAsStateWithLifecycle()
     var showFullChat by remember { mutableStateOf(false) }
 
@@ -66,6 +72,11 @@ fun BubbleScreen(
     val context = LocalContext.current
     LaunchedEffect(Unit) {
         viewModel.collapse.collect { context.findActivity()?.finish() }
+    }
+
+    // Vehicle just-in-time action (#693): deep-link into the main app's economy/vehicle settings.
+    val onOpenVehicleSettings: () -> Unit = {
+        context.startActivity(MainActivity.routeIntent(context, Screen.EconomySettings.route))
     }
 
     val flow = appState.regions.flow
@@ -102,7 +113,7 @@ fun BubbleScreen(
                             region = focusedRegion,
                             earnings = sessionEarnings,
                             miles = sessionMiles,
-                            lastSessionSummary = lastSessionSummary
+                            lastSession = lastSession
                         )
                     }
                 }
@@ -117,7 +128,12 @@ fun BubbleScreen(
                     cardStack = cardStack,
                     region = focusedRegion,
                     messages = messages,
-                    lastSessionSummary = lastSessionSummary,
+                    lastSession = lastSession,
+                    focusedPlatform = focusedPlatform,
+                    gasPrice = gasPrice,
+                    isGasPriceAuto = isGasPriceAuto,
+                    onSetGasPrice = viewModel::setGasPrice,
+                    onOpenVehicleSettings = onOpenVehicleSettings,
                     onOpenChat = { showFullChat = true },
                     onAccept = { viewModel.acceptOffer() },
                     onDecline = { viewModel.declineOffer() },
@@ -146,7 +162,12 @@ fun DashboardView(
     cardStack: CardStack,
     region: PlatformRegion?,
     messages: List<ChatMessage>,
-    lastSessionSummary: SessionSummary?,
+    lastSession: SessionRecord?,
+    focusedPlatform: Platform?,
+    gasPrice: Float?,
+    isGasPriceAuto: Boolean,
+    onSetGasPrice: (Float) -> Unit,
+    onOpenVehicleSettings: () -> Unit,
     onOpenChat: () -> Unit,
     onAccept: () -> Unit = {},
     onDecline: () -> Unit = {},
@@ -174,7 +195,14 @@ fun DashboardView(
                     elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
                 ) {
                     Box(modifier = Modifier.padding(16.dp)) {
-                        ModeIdle(lastSessionSummary)
+                        ModeIdle(
+                            session = lastSession,
+                            focusedPlatform = focusedPlatform,
+                            gasPrice = gasPrice,
+                            isGasPriceAuto = isGasPriceAuto,
+                            onSetGasPrice = onSetGasPrice,
+                            onOpenVehicleSettings = onOpenVehicleSettings,
+                        )
                     }
                 }
                 Spacer(modifier = Modifier.weight(1f))

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleViewModel.kt
@@ -2,19 +2,18 @@ package cloud.trotter.dashbuddy.ui.bubble
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import cloud.trotter.dashbuddy.core.data.analytics.AnalyticsRepository
 import cloud.trotter.dashbuddy.core.data.chat.ChatRepository
 import cloud.trotter.dashbuddy.core.data.event.AppEventRepo
 import cloud.trotter.dashbuddy.core.data.location.OdometerRepository
 import cloud.trotter.dashbuddy.core.data.settings.AppPreferencesRepository
 import cloud.trotter.dashbuddy.core.designsystem.theme.DRIVING_GLANCE_MULTIPLIER
+import cloud.trotter.dashbuddy.domain.analytics.SessionRecord
 import cloud.trotter.dashbuddy.domain.model.cards.CardStack
 import cloud.trotter.dashbuddy.domain.state.AppState
-import cloud.trotter.dashbuddy.domain.state.Flow
-import cloud.trotter.dashbuddy.domain.state.FlowRegion
 import cloud.trotter.dashbuddy.domain.state.Mode
 import cloud.trotter.dashbuddy.domain.state.OfferIntent
 import cloud.trotter.dashbuddy.domain.state.Platform
-import cloud.trotter.dashbuddy.domain.state.PlatformRegion
 import cloud.trotter.dashbuddy.core.state.StateManagerV2
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
 import cloud.trotter.dashbuddy.ui.bubble.cards.FlowCardMapper
@@ -31,16 +30,8 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.scan
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 import javax.inject.Inject
-
-data class SessionSummary(
-    val sessionId: String,
-    val earnings: Double,
-    val miles: Double,
-    /** Anchors (#367): the UI derives duration — the frozen summary can't drift. */
-    val startedAt: Long,
-    val endedAt: Long,
-)
 
 @HiltViewModel
 class BubbleViewModel @Inject constructor(
@@ -49,7 +40,8 @@ class BubbleViewModel @Inject constructor(
     odometerRepository: OdometerRepository,
     private val stateManager: StateManagerV2,
     appEventRepo: AppEventRepo,
-    appPreferencesRepository: AppPreferencesRepository,
+    private val appPreferencesRepository: AppPreferencesRepository,
+    analyticsRepository: AnalyticsRepository,
 ) : ViewModel() {
 
     // Current app state — drives the mode card in the HUD
@@ -152,35 +144,34 @@ class BubbleViewModel @Inject constructor(
     val sessionMiles = odometerRepository.sessionMilesFlow
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 0.0)
 
-    // Snapshot of the last completed dash — populated when session ends,
-    // persists through idle.
-    val lastSessionSummary = combine(
-        stateManager.state, focusedPlatform, odometerRepository.sessionMilesFlow
-    ) { state, platform, miles ->
-        Triple(state, platform, miles)
-    }
-        .scan(null as SessionSummary?) { last, (state, platform, miles) ->
-            val region = platform?.let { state.regions.platforms[it] }
-            val session = region?.session
-            // Capture summary when flow is SessionEnded
-            if (state.regions.flow.flow == Flow.SessionEnded && session != null &&
-                last?.sessionId != session.sessionId
-            ) {
-                // Captured ONCE per session (#367): the old scan re-stamped a
-                // wall-clock duration on every upstream emission, so the
-                // "frozen" summary grew while idle.
-                SessionSummary(
-                    sessionId = session.sessionId,
-                    earnings = session.runningEarnings,
-                    miles = miles,
-                    startedAt = session.startedAt,
-                    endedAt = state.timestamp,
-                )
-            } else {
-                last
-            }
-        }
+    // The most-recent dash, straight off the analytics read-model (#693). This REPLACED the old
+    // in-memory `SessionSummary` scan whose liveness-gated capture (SharingStarted.WhileSubscribed +
+    // the transient Flow.SessionEnded frame) silently missed any dash that ended while the bubble was
+    // collapsed — the post-dash HUD then showed the last dash it happened to catch (the stale
+    // "last dash with money"), not the true last one. `recentSessions(1)` is a Room-invalidation Flow
+    // over `session_records`: the row exists from DASH_START's fold and finalizes when DASH_STOP folds,
+    // survives process restart, and is the TRUE most-recent session — the $0 unassign dash included.
+    // Cross-platform by construction (P8): whichever platform dashed last, labeled by its own chip.
+    val lastSession = analyticsRepository.recentSessions(1)
+        .map { it.firstOrNull() }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+
+    // Gas price for the idle-card quick edit (#693) — read straight off the economy SSOT the settings
+    // screen owns; the write path (setGasPrice) flips auto OFF so the daily EIA worker won't clobber it.
+    val gasPrice = appPreferencesRepository.gasPrice
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+
+    val isGasPriceAuto = appPreferencesRepository.isGasPriceAuto
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), true)
+
+    /**
+     * Persist a driver override of the pump price from the bubble quick-edit (#693). Writes the SAME
+     * economy store the settings wizard owns (no second copy) and disables auto so the value sticks.
+     * Frozen-economics invariant (#314): this changes only FUTURE offer evaluations.
+     */
+    fun setGasPrice(price: Float) {
+        viewModelScope.launch { appPreferencesRepository.updateGasPriceManual(price) }
+    }
 
     // --- Offer actions (bubble Accept/Decline) ---
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/ModeCards.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/ModeCards.kt
@@ -2,44 +2,255 @@ package cloud.trotter.dashbuddy.ui.bubble
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.DirectionsCar
+import androidx.compose.material.icons.filled.LocalGasStation
+import androidx.compose.material.icons.filled.Remove
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import cloud.trotter.dashbuddy.R
+import cloud.trotter.dashbuddy.core.designsystem.time.rememberNow
+import cloud.trotter.dashbuddy.domain.analytics.SessionRecord
+import cloud.trotter.dashbuddy.domain.evaluation.UserEconomy
 import cloud.trotter.dashbuddy.domain.format.Formats
 import cloud.trotter.dashbuddy.domain.format.formatDuration
+import cloud.trotter.dashbuddy.domain.state.Platform
+
+/** $0.05 per tap on the gas quick-edit stepper. */
+private const val GAS_STEP = 0.05f
+
+/**
+ * The bubble's post-dash idle card (#693): a frozen summary of the last dash straight off the
+ * analytics read-model ([SessionRecord]), plus between-dash "just-in-time" actions (gas quick-edit,
+ * vehicle deep-link) shown while offline. Only the "ended Xm ago" caption ticks (Reactive-UI rule 2:
+ * anchor `endedAt`, derive live) — the summary numbers are immutable facts of a completed session.
+ *
+ * @param focusedPlatform the platform the HUD is currently showing; the session's own platform chip
+ *   is rendered only when it differs (a cross-platform last dash, P8).
+ */
+@Composable
+internal fun ModeIdle(
+    session: SessionRecord?,
+    focusedPlatform: Platform?,
+    gasPrice: Float?,
+    isGasPriceAuto: Boolean,
+    onSetGasPrice: (Float) -> Unit,
+    onOpenVehicleSettings: () -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        if (session != null) {
+            LastSessionSummary(session = session, focusedPlatform = focusedPlatform)
+        } else {
+            Text(
+                text = stringResource(R.string.bubble_mode_idle_no_session),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        JustInTimeActions(
+            gasPrice = gasPrice,
+            isGasPriceAuto = isGasPriceAuto,
+            onSetGasPrice = onSetGasPrice,
+            onOpenVehicleSettings = onOpenVehicleSettings,
+        )
+    }
+}
 
 @Composable
-internal fun ModeIdle(lastSessionSummary: SessionSummary?) {
-    if (lastSessionSummary != null) {
-        Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+private fun LastSessionSummary(session: SessionRecord, focusedPlatform: Platform?) {
+    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
             Text(
                 text = stringResource(R.string.bubble_mode_idle_last_session_label),
                 style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
             )
-            Text(
-                text = Formats.money(lastSessionSummary.earnings),
-                style = MaterialTheme.typography.headlineMedium,
-                fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.primary
-            )
+            // Platform chip only when the last dash was on a platform other than the one in focus (P8).
+            if (session.platform != Platform.Unknown && session.platform != focusedPlatform) {
+                Surface(
+                    shape = RoundedCornerShape(4.dp),
+                    color = MaterialTheme.colorScheme.secondaryContainer,
+                ) {
+                    Text(
+                        text = session.platform.shortName,
+                        style = MaterialTheme.typography.labelSmall,
+                        fontWeight = FontWeight.Medium,
+                        color = MaterialTheme.colorScheme.onSecondaryContainer,
+                        modifier = Modifier.padding(horizontal = 5.dp, vertical = 1.dp),
+                    )
+                }
+            }
+        }
+
+        Text(
+            text = Formats.money(session.reportedEarnings ?: 0.0),
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.primary,
+        )
+
+        session.miles?.let { miles ->
             ModeRow(
                 label = stringResource(R.string.bubble_mode_idle_miles_label),
-                value = "${Formats.decimal(lastSessionSummary.miles)} mi",
-            )
-            ModeRow(
-                label = stringResource(R.string.bubble_mode_idle_duration_label),
-                value = formatDuration(lastSessionSummary.endedAt - lastSessionSummary.startedAt),
+                value = "${Formats.decimal(miles)} mi",
             )
         }
-    } else {
+
+        session.endedAt?.let { endedAt ->
+            ModeRow(
+                label = stringResource(R.string.bubble_mode_idle_duration_label),
+                value = formatDuration(endedAt - session.startedAt),
+            )
+        }
+
+        if (session.offersReceived > 0) {
+            val pct = session.offersAccepted * 100 / session.offersReceived
+            ModeRow(
+                label = stringResource(R.string.bubble_mode_idle_acceptance_label),
+                value = "$pct%",
+            )
+        }
+
         ModeRow(
-            label = stringResource(R.string.bubble_mode_idle_status_label),
-            value = stringResource(R.string.bubble_mode_idle_offline_value),
+            label = stringResource(R.string.bubble_mode_idle_deliveries_label),
+            value = session.deliveries.toString(),
         )
+
+        // The one live value: how long ago the dash ended (anchor endedAt + 1-Hz ticker).
+        session.endedAt?.let { endedAt ->
+            val now by rememberNow()
+            Text(
+                text = stringResource(
+                    R.string.bubble_mode_idle_ended_ago,
+                    formatDuration((now - endedAt).coerceAtLeast(0L)),
+                ),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+            )
+        }
+    }
+}
+
+@Composable
+private fun JustInTimeActions(
+    gasPrice: Float?,
+    isGasPriceAuto: Boolean,
+    onSetGasPrice: (Float) -> Unit,
+    onOpenVehicleSettings: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        GasQuickEdit(
+            gasPrice = gasPrice,
+            isGasPriceAuto = isGasPriceAuto,
+            onSetGasPrice = onSetGasPrice,
+        )
+        Spacer(modifier = Modifier.width(4.dp))
+        VehicleAction(onClick = onOpenVehicleSettings)
+    }
+}
+
+@Composable
+private fun GasQuickEdit(
+    gasPrice: Float?,
+    isGasPriceAuto: Boolean,
+    onSetGasPrice: (Float) -> Unit,
+) {
+    // The store IS the source of truth — the displayed value is the flow, never a local shadow copy.
+    val current = gasPrice ?: UserEconomy.DEFAULT_GAS_PRICE_PER_GALLON.toFloat()
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Icon(
+            imageVector = Icons.Filled.LocalGasStation,
+            contentDescription = stringResource(R.string.bubble_mode_idle_gas_content_desc),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(18.dp),
+        )
+        IconButton(
+            onClick = { onSetGasPrice((current - GAS_STEP).coerceAtLeast(0f)) },
+            modifier = Modifier.size(28.dp),
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Remove,
+                contentDescription = stringResource(R.string.bubble_mode_idle_gas_decrease),
+                modifier = Modifier.size(16.dp),
+            )
+        }
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = Formats.money(current.toDouble()),
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                text = stringResource(
+                    if (isGasPriceAuto) R.string.bubble_mode_idle_gas_auto
+                    else R.string.bubble_mode_idle_gas_manual
+                ),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+            )
+        }
+        IconButton(
+            onClick = { onSetGasPrice(current + GAS_STEP) },
+            modifier = Modifier.size(28.dp),
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Add,
+                contentDescription = stringResource(R.string.bubble_mode_idle_gas_increase),
+                modifier = Modifier.size(16.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun VehicleAction(onClick: () -> Unit) {
+    Surface(
+        onClick = onClick,
+        shape = RoundedCornerShape(6.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant,
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 5.dp),
+        ) {
+            Icon(
+                imageVector = Icons.Filled.DirectionsCar,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(16.dp),
+            )
+            Text(
+                text = stringResource(R.string.bubble_mode_idle_vehicle_action),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
     }
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/StatusBar.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/StatusBar.kt
@@ -1,6 +1,7 @@
 package cloud.trotter.dashbuddy.ui.bubble
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -11,9 +12,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import cloud.trotter.dashbuddy.R
 import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
+import cloud.trotter.dashbuddy.domain.analytics.SessionRecord
 import cloud.trotter.dashbuddy.domain.format.Formats
 import cloud.trotter.dashbuddy.domain.state.Flow
 import cloud.trotter.dashbuddy.domain.state.FlowRegion
@@ -68,53 +72,64 @@ internal fun SessionMetricsActions(
     region: PlatformRegion?,
     earnings: Double,
     miles: Double,
-    lastSessionSummary: SessionSummary?
+    lastSession: SessionRecord?
 ) {
     val isActive = region?.mode == Mode.Online || region?.mode == Mode.Paused
 
-    val displayEarnings: Double?
-    val displayMiles: Double?
+    val displayEarnings: Double
+    val displayMiles: Double
     val dimmed: Boolean
+    val captionRes: Int
 
     when {
         isActive -> {
             displayEarnings = earnings
             displayMiles = miles
             dimmed = false
+            captionRes = R.string.bubble_status_this_session
         }
-        region?.mode == Mode.Offline && lastSessionSummary != null -> {
-            displayEarnings = lastSessionSummary.earnings
-            displayMiles = lastSessionSummary.miles
+        region?.mode == Mode.Offline && lastSession != null -> {
+            // Last-dash review: dimmed to signal it's history, not a live session (#693).
+            displayEarnings = lastSession.reportedEarnings ?: 0.0
+            displayMiles = lastSession.miles ?: 0.0
             dimmed = true
+            captionRes = R.string.bubble_status_last_session
         }
         else -> return
     }
 
-    Row(
-        modifier = Modifier.padding(end = 12.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        val textColor = if (dimmed)
-            MaterialTheme.colorScheme.onSurface.copy(alpha = 0.45f)
-        else
-            MaterialTheme.colorScheme.onSurface
+    val textColor = if (dimmed)
+        MaterialTheme.colorScheme.onSurface.copy(alpha = 0.45f)
+    else
+        MaterialTheme.colorScheme.onSurface
 
+    Column(
+        modifier = Modifier.padding(end = 12.dp),
+        horizontalAlignment = Alignment.End,
+    ) {
         Text(
-            text = Formats.money(displayEarnings),
-            style = MaterialTheme.typography.titleSmall,
-            fontWeight = FontWeight.Bold,
-            color = textColor
+            text = stringResource(captionRes),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
         )
-        Text(
-            text = "  ·  ",
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.25f)
-        )
-        Text(
-            text = "${Formats.decimal(displayMiles)} mi",
-            style = MaterialTheme.typography.titleSmall,
-            color = textColor
-        )
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = Formats.money(displayEarnings),
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+                color = textColor
+            )
+            Text(
+                text = "  ·  ",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.25f)
+            )
+            Text(
+                text = "${Formats.decimal(displayMiles)} mi",
+                style = MaterialTheme.typography.titleSmall,
+                color = textColor
+            )
+        }
     }
 }
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/MainActivity.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/MainActivity.kt
@@ -35,6 +35,7 @@ import cloud.trotter.dashbuddy.ui.main.analytics.AnalyticsScreen
 import cloud.trotter.dashbuddy.ui.main.analytics.SessionDetailScreen
 import cloud.trotter.dashbuddy.ui.main.dashboard.DashboardScreen
 import cloud.trotter.dashbuddy.ui.main.navigation.Screen
+import timber.log.Timber
 import cloud.trotter.dashbuddy.ui.main.ratings.RatingsScreen
 import cloud.trotter.dashbuddy.ui.main.settings.AboutScreen
 import cloud.trotter.dashbuddy.ui.main.settings.EconomySettingsScreen
@@ -63,7 +64,11 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+        // Consume-once (#693 review F2b): getIntent() is sticky across recreation — without
+        // removing the extra, a rotation re-reads it in the new instance's onCreate and pushes a
+        // duplicate destination onto the restored back stack.
         pendingRoute.value = intent?.getStringExtra(EXTRA_ROUTE)
+        intent?.removeExtra(EXTRA_ROUTE)
 
         setContent {
             DashBuddyTheme {
@@ -73,7 +78,11 @@ class MainActivity : ComponentActivity() {
                 val route by pendingRoute.collectAsStateWithLifecycle()
                 LaunchedEffect(route) {
                     route?.let {
-                        navController.navigate(it)
+                        // #693 review F3: MainActivity is exported (launcher) — a forged extra
+                        // carrying a non-route string would crash navigate() with
+                        // IllegalArgumentException. Fail closed: navigate only to known routes.
+                        if (it in Screen.allRoutes) navController.navigate(it)
+                        else Timber.tag("Main").w("Dropped unknown deep-link route (#693)")
                         pendingRoute.value = null
                     }
                 }
@@ -215,6 +224,7 @@ class MainActivity : ComponentActivity() {
         super.onNewIntent(intent)
         setIntent(intent)
         pendingRoute.value = intent.getStringExtra(EXTRA_ROUTE)
+        intent.removeExtra(EXTRA_ROUTE)
     }
 
     companion object {
@@ -227,7 +237,15 @@ class MainActivity : ComponentActivity() {
          */
         fun routeIntent(context: Context, route: String): Intent =
             Intent(context, MainActivity::class.java).apply {
-                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                // SINGLE_TOP (#693 review F2a): without it, standard-launchMode + CLEAR_TOP
+                // DESTROYS an open MainActivity and delivers to a fresh instance's onCreate —
+                // onNewIntent never fires and the user's back stack is lost on every Vehicle tap.
+                // With it, the single-activity app's task-top instance receives onNewIntent live.
+                addFlags(
+                    Intent.FLAG_ACTIVITY_NEW_TASK or
+                        Intent.FLAG_ACTIVITY_CLEAR_TOP or
+                        Intent.FLAG_ACTIVITY_SINGLE_TOP,
+                )
                 putExtra(EXTRA_ROUTE, route)
             }
     }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/MainActivity.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/MainActivity.kt
@@ -1,5 +1,7 @@
 package cloud.trotter.dashbuddy.ui.main
 
+import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -17,9 +19,13 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.flow.MutableStateFlow
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -45,13 +51,32 @@ import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
+    /**
+     * Deep-link target route pushed by an external launcher (the bubble's "Vehicle" just-in-time
+     * action, #693). Held as a one-shot: the NavHost consumes it once and clears it, so a
+     * config-change recomposition doesn't re-navigate. `onNewIntent` re-arms it when an already-open
+     * instance is brought forward.
+     */
+    private val pendingRoute = MutableStateFlow<String?>(null)
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+        pendingRoute.value = intent?.getStringExtra(EXTRA_ROUTE)
 
         setContent {
             DashBuddyTheme {
                 val navController = rememberNavController()
+
+                // Consume a deep-link route once, then clear it (#693 vehicle action).
+                val route by pendingRoute.collectAsStateWithLifecycle()
+                LaunchedEffect(route) {
+                    route?.let {
+                        navController.navigate(it)
+                        pendingRoute.value = null
+                    }
+                }
 
                 Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
                     NavHost(
@@ -184,6 +209,27 @@ class MainActivity : ComponentActivity() {
                 }
             }
         }
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        pendingRoute.value = intent.getStringExtra(EXTRA_ROUTE)
+    }
+
+    companion object {
+        /** Extra carrying a [Screen.route] to open on launch (the bubble's deep-link actions, #693). */
+        const val EXTRA_ROUTE = "cloud.trotter.dashbuddy.extra.ROUTE"
+
+        /**
+         * Build an [Intent] that opens [MainActivity] on [route]. Used by the bubble overlay (a
+         * separate task) to deep-link into settings, so it carries [Intent.FLAG_ACTIVITY_NEW_TASK].
+         */
+        fun routeIntent(context: Context, route: String): Intent =
+            Intent(context, MainActivity::class.java).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                putExtra(EXTRA_ROUTE, route)
+            }
     }
 }
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/navigation/DashBuddyRoutes.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/navigation/DashBuddyRoutes.kt
@@ -42,11 +42,13 @@ sealed class Screen(val route: String) {
          * the fail-closed allowlist for the exported-activity seam. Parameterized routes
          * (e.g. [SessionDetail]) are deliberately excluded: deep links carry no args.
          */
-        val allRoutes: Set<String> = setOf(
+        // lazy: a plain initializer runs during Screen's class-init, BEFORE the nested data
+        // objects exist (touching any Screen.X triggers it) → ExceptionInInitializerError.
+        val allRoutes: Set<String> by lazy { setOf(
             Dashboard.route, Analytics.route, SettingsHome.route, AboutSettings.route,
             StrategySettings.route, EvidenceSettings.route, DataExport.route,
             EconomySettings.route, GeneralSettings.route, DeveloperSettings.route,
             PlatformSettings.route,
-        )
+        ) }
     }
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/navigation/DashBuddyRoutes.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/navigation/DashBuddyRoutes.kt
@@ -35,4 +35,18 @@ sealed class Screen(val route: String) {
     data object GeneralSettings : Screen("settings/general")
     data object DeveloperSettings : Screen("settings/developer")
     data object PlatformSettings : Screen("settings/platforms")
+
+    companion object {
+        /**
+         * The static routes an external deep link (MainActivity.EXTRA_ROUTE, #693) may target —
+         * the fail-closed allowlist for the exported-activity seam. Parameterized routes
+         * (e.g. [SessionDetail]) are deliberately excluded: deep links carry no args.
+         */
+        val allRoutes: Set<String> = setOf(
+            Dashboard.route, Analytics.route, SettingsHome.route, AboutSettings.route,
+            StrategySettings.route, EvidenceSettings.route, DataExport.route,
+            EconomySettings.route, GeneralSettings.route, DeveloperSettings.route,
+            PlatformSettings.route,
+        )
+    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -136,8 +136,21 @@
     <string name="bubble_mode_idle_last_session_label">Last session</string>
     <string name="bubble_mode_idle_miles_label">Miles</string>
     <string name="bubble_mode_idle_duration_label">Duration</string>
-    <string name="bubble_mode_idle_status_label">Status</string>
-    <string name="bubble_mode_idle_offline_value">Offline</string>
+    <string name="bubble_mode_idle_acceptance_label">Acceptance</string>
+    <string name="bubble_mode_idle_deliveries_label">Deliveries</string>
+    <string name="bubble_mode_idle_no_session">No dashes yet</string>
+    <!-- %1$s is a duration, e.g. "12m" -->
+    <string name="bubble_mode_idle_ended_ago">ended %1$s ago</string>
+    <string name="bubble_mode_idle_gas_content_desc">Gas price</string>
+    <string name="bubble_mode_idle_gas_decrease">Lower gas price</string>
+    <string name="bubble_mode_idle_gas_increase">Raise gas price</string>
+    <string name="bubble_mode_idle_gas_auto">AUTO</string>
+    <string name="bubble_mode_idle_gas_manual">MANUAL</string>
+    <string name="bubble_mode_idle_vehicle_action">Vehicle</string>
+
+    <!-- bubble/StatusBar.kt -->
+    <string name="bubble_status_this_session">THIS SESSION</string>
+    <string name="bubble_status_last_session">LAST SESSION</string>
 
     <!-- setup/wizard/components/WizardBottomBar.kt -->
     <string name="wizard_bottom_bar_back">Back</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -138,7 +138,7 @@
     <string name="bubble_mode_idle_duration_label">Duration</string>
     <string name="bubble_mode_idle_acceptance_label">Acceptance</string>
     <string name="bubble_mode_idle_deliveries_label">Deliveries</string>
-    <string name="bubble_mode_idle_no_session">No dashes yet</string>
+    <string name="bubble_mode_idle_no_session">No sessions yet</string>
     <!-- %1$s is a duration, e.g. "12m" -->
     <string name="bubble_mode_idle_ended_ago">ended %1$s ago</string>
     <string name="bubble_mode_idle_gas_content_desc">Gas price</string>

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/bubble/BubbleViewModelTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/bubble/BubbleViewModelTest.kt
@@ -1,0 +1,137 @@
+package cloud.trotter.dashbuddy.ui.bubble
+
+import cloud.trotter.dashbuddy.core.data.analytics.AnalyticsRepository
+import cloud.trotter.dashbuddy.core.data.chat.ChatRepository
+import cloud.trotter.dashbuddy.core.data.event.AppEventRepo
+import cloud.trotter.dashbuddy.core.data.location.OdometerRepository
+import cloud.trotter.dashbuddy.core.data.settings.AppPreferencesRepository
+import cloud.trotter.dashbuddy.core.state.StateManagerV2
+import cloud.trotter.dashbuddy.domain.analytics.SessionRecord
+import cloud.trotter.dashbuddy.domain.state.AppState
+import cloud.trotter.dashbuddy.domain.state.Platform
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+/**
+ * #693 — the bubble's post-dash idle surface reads the analytics read-model, not an in-memory
+ * capture. The regression: the OLD `SessionSummary` scan was liveness-gated and silently dropped a
+ * dash that ended while the bubble was collapsed, so the HUD showed the last dash it happened to
+ * catch (the stale "last dash with money"). These prove the ViewModel now surfaces whatever
+ * `recentSessions(1)` returns as the true last session — a $0/zero-delivery dash included — with no
+ * `hasEarnings`-style filter, plus the gas quick-edit write path.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class BubbleViewModelTest {
+
+    private val bubbleManager: BubbleManager = mock()
+    private val chatRepository: ChatRepository = mock()
+    private val odometerRepository: OdometerRepository = mock()
+    private val stateManager: StateManagerV2 = mock()
+    private val appEventRepo: AppEventRepo = mock()
+    private val appPreferencesRepository: AppPreferencesRepository = mock()
+    private val analyticsRepository: AnalyticsRepository = mock()
+
+    private val dispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        // Init-time flow accessors — the VM builds several stateIn() flows in its property initializers.
+        whenever(stateManager.state).thenReturn(MutableStateFlow(AppState()))
+        whenever(bubbleManager.activeSessionId).thenReturn(MutableStateFlow(null))
+        whenever(appEventRepo.getMostRecentSessionId()).thenReturn(flowOf(null))
+        whenever(odometerRepository.sessionMilesFlow).thenReturn(flowOf(0.0))
+        whenever(appPreferencesRepository.glanceMode).thenReturn(flowOf(false))
+        whenever(appPreferencesRepository.gasPrice).thenReturn(flowOf(3.50f))
+        whenever(appPreferencesRepository.isGasPriceAuto).thenReturn(flowOf(true))
+    }
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun viewModel() = BubbleViewModel(
+        bubbleManager = bubbleManager,
+        chatRepository = chatRepository,
+        odometerRepository = odometerRepository,
+        stateManager = stateManager,
+        appEventRepo = appEventRepo,
+        appPreferencesRepository = appPreferencesRepository,
+        analyticsRepository = analyticsRepository,
+    )
+
+    private fun session(
+        id: String,
+        earnings: Double?,
+        deliveries: Int,
+        endedAt: Long? = 1_000L,
+    ) = SessionRecord(
+        sessionId = id,
+        platform = Platform.DoorDash,
+        startedAt = 0L,
+        endedAt = endedAt,
+        reportedEarnings = earnings,
+        reportedDurationMillis = endedAt,
+        miles = 4.2,
+        deliveries = deliveries,
+        jobsCompleted = deliveries,
+        offersReceived = 3,
+        offersAccepted = 1,
+        offersDeclined = 2,
+        offersTimeout = 0,
+    )
+
+    @Test
+    fun `lastSession surfaces the most recent dash even when it earned zero`() = runTest {
+        // The repro shape: the newest dash is a $0, zero-delivery unassign session.
+        val zero = session(id = "session-doordash-1783294721320-15", earnings = 0.0, deliveries = 0)
+        whenever(analyticsRepository.recentSessions(any())).thenReturn(flowOf(listOf(zero)))
+
+        val vm = viewModel()
+        val job = launch { vm.lastSession.collect {} }
+        advanceUntilIdle()
+
+        assertEquals(zero, vm.lastSession.value)
+        job.cancel()
+    }
+
+    @Test
+    fun `lastSession is null when there are no dashes yet`() = runTest {
+        whenever(analyticsRepository.recentSessions(any())).thenReturn(flowOf(emptyList()))
+
+        val vm = viewModel()
+        val job = launch { vm.lastSession.collect {} }
+        advanceUntilIdle()
+
+        assertNull(vm.lastSession.value)
+        job.cancel()
+    }
+
+    @Test
+    fun `setGasPrice writes a manual override to the economy settings store`() = runTest {
+        whenever(analyticsRepository.recentSessions(any())).thenReturn(flowOf(emptyList()))
+        val vm = viewModel()
+
+        vm.setGasPrice(3.49f)
+        advanceUntilIdle()
+
+        verify(appPreferencesRepository).updateGasPriceManual(eq(3.49f))
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/main/MainActivityRouteIntentTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/main/MainActivityRouteIntentTest.kt
@@ -1,0 +1,33 @@
+package cloud.trotter.dashbuddy.ui.main
+
+import android.content.Intent
+import cloud.trotter.dashbuddy.ui.main.navigation.Screen
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+/**
+ * #693 — the bubble's "Vehicle" just-in-time action deep-links into the main app via
+ * [MainActivity.routeIntent]. Proves the intent targets [MainActivity], carries the requested route
+ * in [MainActivity.EXTRA_ROUTE], and sets NEW_TASK (the bubble overlay lives in a separate task).
+ */
+@RunWith(RobolectricTestRunner::class)
+class MainActivityRouteIntentTest {
+
+    @Test
+    fun `routeIntent targets MainActivity with the route extra and NEW_TASK`() {
+        val context = RuntimeEnvironment.getApplication()
+
+        val intent = MainActivity.routeIntent(context, Screen.EconomySettings.route)
+
+        assertEquals(MainActivity::class.java.name, intent.component?.className)
+        assertEquals(Screen.EconomySettings.route, intent.getStringExtra(MainActivity.EXTRA_ROUTE))
+        assertTrue(
+            "expected FLAG_ACTIVITY_NEW_TASK",
+            intent.flags and Intent.FLAG_ACTIVITY_NEW_TASK != 0,
+        )
+    }
+}

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/settings/AppPreferencesRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/settings/AppPreferencesRepository.kt
@@ -183,6 +183,14 @@ class AppPreferencesRepository @Inject constructor(
     // WRITE ACTIONS
     // ============================================================================================
     suspend fun updateGasPrice(price: Float) = dataSource.updateGasPrice(price)
+
+    /**
+     * Manual pump-price override that also disables auto (EIA) fetching (#693) — the bubble's
+     * between-dash quick edit routes here so the value survives the daily worker. Frozen-economics
+     * invariant (#314): this only affects FUTURE evaluations; already-recorded deliveries keep their
+     * frozen cost basis.
+     */
+    suspend fun updateGasPriceManual(price: Float) = dataSource.updateGasPriceManual(price)
     suspend fun updateFuelType(type: FuelType) = dataSource.updateFuelType(type.name)
     suspend fun updateVehicleClass(type: VehicleClass) = dataSource.updateVehicleClass(type.name)
     suspend fun setProMode(enabled: Boolean) = dataSource.setProMode(enabled)

--- a/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/settings/AppPreferencesDataSource.kt
+++ b/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/settings/AppPreferencesDataSource.kt
@@ -151,6 +151,18 @@ class AppPreferencesDataSource @Inject constructor(
         ds.edit { it[Keys.GAS_PRICE] = price }
     }
 
+    /**
+     * Driver override of the pump price (e.g. the bubble's between-dash quick edit, #693): writes the
+     * price AND flips auto OFF in one edit, so the daily EIA worker won't clobber the manual value on
+     * its next run. Same store / same keys the economy wizard owns — no second gas-price copy.
+     */
+    suspend fun updateGasPriceManual(price: Float) {
+        ds.edit {
+            it[Keys.GAS_PRICE] = price
+            it[Keys.IS_GAS_PRICE_AUTO] = false
+        }
+    }
+
     suspend fun updateFuelType(type: String) {
         ds.edit { it[Keys.FUEL_TYPE] = type }
     }

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -73,6 +73,20 @@ card's **mechanical** half, #577 (re-confirmed, 24/24, ~0.55 s — with a new po
 that entry's Bug #1), the #457 path, and #554 ShadowProjector (2/2). The #462/#460 dropoff item
 was found **broken-in-part** (raw PII in capture envelopes) and moved to that entry's Bug #7.)_
 
+- **🆕 NEW — bubble post-dash card shows the TRUE last session + gas/vehicle quick actions (#693 / PR).**
+  The idle bubble card now reads the analytics read-model (`recentSessions(1)`) instead of an in-memory
+  capture that could miss a dash. **Primary check — the $0 repro:** end a dash that earned nothing (accept
+  one order then unassign, or just go online→offline with no completions), collapse the bubble, then reopen
+  it. The idle card AND the dimmed top-bar "LAST SESSION" must reflect **that** dash (earnings, miles,
+  duration, deliveries, acceptance %), **not** an older moneyed dash. The "ended Xm ago" caption should tick
+  up live. A live dash shows full-opacity "THIS SESSION". **Gas quick-edit:** tap −/+ on the card's gas
+  stepper → the value changes, the caption flips AUTO→MANUAL, and reopening **Settings → Personal Economy**
+  shows the same price (it persisted to the real store; the daily EIA worker won't clobber it). **Vehicle:**
+  tap Vehicle → the main app opens directly on the Personal Economy screen. Frozen-economics: a gas edit must
+  only change FUTURE offer $/hr, never a past delivery's recorded net. Anything stale, a $0 dash getting
+  skipped, or a gas edit that doesn't stick is a regression — capture it.
+  - Confirmed: 0/2
+  - Desk replay fixture: `~/dashbuddy/logs/2026/07/06/` (the 07-05 $0 session `session-doordash-1783294721320-15`).
 - **🆕 NEW — per-region lifecycle edges hold single-platform behavior (#438 B1 / PR #707).** The
   state machine's job/task edges now fire off each platform's OWN last-acted flow instead of the
   global screen flow (a latent multi-platform fix — single-platform behavior should be **byte


### PR DESCRIPTION
Closes #693. Builds on #719 (BubbleScreen split + strings extraction + neutral session vocabulary).

Design spec: [fable design pass, 2026-07-06](https://github.com/sjtrotter/DashBuddy/issues/693#issuecomment-4899720963).

## Root cause
`BubbleViewModel.lastSessionSummary` was an in-memory `scan` gated by `SharingStarted.WhileSubscribed(5000)` + the transient `Flow.SessionEnded` frame. A dash that ended while the bubble was collapsed (no subscriber → upstream not running), or across process death, was **never captured** — re-subscription restarted the scan from `null`. The HUD then rendered whatever summary it last happened to catch, i.e. the stale "last dash **with money**". It was never an earnings filter; it was a liveness-gated capture, and the $0 07-05 unassign session (`session-doordash-1783294721320-15`) was simply never latched.

## Fix
Delete the scan + the `SessionSummary` class. The idle card and the dimmed top-bar both read **`AnalyticsRepository.recentSessions(1)`** — a Room-invalidation Flow over `session_records` that is the **true** most-recent session (the $0 dash included), survives process restart and collapsed-bubble windows structurally, and finalizes reactively as the projector folds `DASH_STOP`.

### Idle card (`ModeCards.ModeIdle`)
"Last session" header, earnings hero, rows **Miles / Duration / Acceptance% (hidden at 0 offers) / Deliveries**, and a ticking **"ended Xm ago"** caption via `rememberNow` (anchor `endedAt`, derive live). Platform chip shown only when the last dash was on a platform other than the focused one (P8). Empty state ("No dashes yet") on first launch.

### Top bar (`StatusBar.SessionMetricsActions`)
Offline → metrics dimmed (~45%) + **"LAST SESSION"**; live → full opacity + **"THIS SESSION"**. Same `recentSessions(1)` source.

### Just-in-time actions (offline only)
- **Gas quick-edit** — a compact −/+ stepper writing the **same** economy store the settings wizard owns via a new `AppPreferencesRepository.updateGasPriceManual` (writes `GAS_PRICE` + flips `IS_GAS_PRICE_AUTO` off in one edit, so the daily EIA worker won't clobber the manual override). **Frozen-economics invariant (#314): a gas edit changes only FUTURE offer evaluations — a recorded delivery keeps its frozen cost basis.**
- **Vehicle** — deep-links into Personal Economy via a new minimal `MainActivity.EXTRA_ROUTE` / `routeIntent` seam (bubble overlay is a separate task → `FLAG_ACTIVITY_NEW_TASK`).

### Tests
- `BubbleViewModelTest` — the $0-session regression (latest = $0 dash → card shows the $0 dash, no `hasEarnings` filter), empty-state, and the gas manual-write path.
- `MainActivityRouteIntentTest` — the vehicle deep-link intent construction (target / extra / NEW_TASK).
- Field-test checklist item added (post-dash card shows the true last dash incl. a $0 one; gas edit persists into settings; vehicle deep-link lands).

Full unit suite (`testDebugUnitTest :domain:test`) green.

### Design-goal review
- **P1 UDF** — UI observes `StateFlow`s and dispatches up (`setGasPrice` → repo write on `viewModelScope`); no repo writes from composables; the read-model never re-enters the pure machine.
- **P5 SSOT** — the defining move: the hand-maintained in-memory `SessionSummary` mirror is **deleted**; the bubble becomes a second read-side consumer of the analytics SSOT. Gas price stays single-owned (the economy store) — the quick-edit routes through it, no second copy. Duration/"ended ago" are derived from anchors, not stored strings.
- **P3 single responsibility** — the idle card is decomposed into small private composables (`LastSessionSummary`, `JustInTimeActions`, `GasQuickEdit`, `VehicleAction`).
- **P6 privacy** — session aggregates only (earnings/miles/counts); no customer/store PII surfaced; no new network surface (EIA stays behind its existing opt-in).
- **P8 platform-agnostic** — `recentSessions(1)` is cross-platform by construction; the card labels the session by its own `Platform.shortName` (registry SSOT), no platform literal in logic.
- **Reactive UI** — only the "ended Xm ago" caption ticks (rule 2: anchor + `rememberNow`); the frozen summary numbers don't churn; the gas display reads the flow directly (no local shadow copy).

### Adversarial review
Pending — fable `/code-review` (+ `/security-review` for the settings-write path) to follow before merge.

### Adversarial review

Fable adversarial reviewer ran against head `0329e5d9` — verdict **APPROVE-WITH-FIXES**; all applied (`921adcb9` + `ecdcead1`). **F1:** the empty-state copy said "No dashes yet" — a vocabulary regression landing one PR after the #694 sweep (the resource was even named `_no_session`) → "No sessions yet". **F2:** the deep-link seam — `routeIntent` lacked `SINGLE_TOP`, so standard-launchMode + `CLEAR_TOP` destroyed an open MainActivity and delivered to a fresh `onCreate` (making `onNewIntent` dead code and killing the user's back stack on every Vehicle tap), and the sticky intent extra re-navigated after rotation → `SINGLE_TOP` added + consume-once `removeExtra` at both read sites. **F3 (defense-in-depth):** MainActivity is exported — a forged `EXTRA_ROUTE` would crash `navigate()`; now fail-closed against a new `Screen.allRoutes` allowlist (lazy-initialized — a plain companion initializer runs before the nested objects exist). **All three builder deviations adjudicated:** the gas auto-flip **APPROVED as the right semantic** (the EIA worker would clobber a non-flipped manual edit next morning; the wizard's explicit-toggle flow is deliberately different; the existing `updateGasPrice` is the worker's own write path and could not be reused; the dual-key write is atomic in one `ds.edit{}`), the deep-link mechanism approved with F2, the "THIS SESSION" live caption approved per the handoff. Core verifications: the regression pin structurally cannot compile against pre-PR code and the old scan/`SessionSummary` are grep-confirmed gone; no stale-previous-session window at dash end (the row exists from DASH_START; only finalization lags by ms–s with the duration rows gracefully hidden); reactive rules honored ("ended Xm ago" = anchor + `rememberNow`); P5 (the mirror is deleted — the defining move), P8 (registry-only platform chip), DI, and the frozen-economics restatement all clean.
