### PR TITLE
feat(#701): surface over-attribution (signed reported − Σ) instead of MAX-flooring

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/MoneyTab.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/MoneyTab.kt
@@ -75,6 +75,16 @@ fun MoneyTab(
                 modifier = Modifier.fillMaxWidth(),
             )
         }
+        // Mirror signal (#701): attributed pay exceeded the reported total — display-only, never
+        // folded into netProfit/unattributedPay. badBg (not warnBg) since an over-count is a stronger
+        // review flag than an unattributed bonus/adjustment.
+        if (economics.overAttributedPay > UNATTRIBUTED_EPSILON) {
+            AppCallout(
+                text = stringResource(R.string.money_tab_over_attributed_callout_format, Formats.money(economics.overAttributedPay)),
+                container = AppTheme.colors.badBg,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
         TopStoresCard(topStores)
         RecentDashesCard(recentSessions, onOpenSession)
     }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/SessionDetailScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/SessionDetailScreen.kt
@@ -132,6 +132,10 @@ private fun DashDetailContent(
     var adjustTarget by remember { mutableStateOf<DeliveryRecord?>(null) }
 
     val hasCallout = detail.unattributedPay > UNATTRIBUTED_EPSILON
+    // Mirror flag (#701): captured delivery pay exceeded the reported total — display-only, never
+    // folded into unattributedPay/net. Independent of [hasCallout] (a missed-delivery add doesn't
+    // apply here), so it doesn't affect the deliveries-card add-button placement below.
+    val hasOverAttributedCallout = detail.overAttributedPay > UNATTRIBUTED_EPSILON
 
     Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(16.dp)) {
         HeaderCard(detail)
@@ -144,6 +148,15 @@ private fun DashDetailContent(
                 )
                 TextButton(onClick = { showAddDialog = true }) { Text(stringResource(R.string.session_detail_add_missed_delivery)) }
             }
+        }
+        if (hasOverAttributedCallout) {
+            // badBg (not warnBg) — an over-count is a stronger review flag than an unattributed
+            // bonus/adjustment; no add-missed-delivery button (that entry point doesn't apply here).
+            AppCallout(
+                text = stringResource(R.string.session_detail_over_attributed_format, Formats.money(detail.overAttributedPay)),
+                container = AppTheme.colors.badBg,
+                modifier = Modifier.fillMaxWidth(),
+            )
         }
         // With no callout, the add entry point lives at the bottom of the deliveries card — a missed
         // delivery can exist without a reported excess.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -467,6 +467,7 @@
     <string name="money_tab_no_store_earnings_yet">No store earnings in this period yet.</string>
     <string name="money_tab_unknown_store">Unknown store</string>
     <string name="money_tab_unattributed_callout_format">%1$s not attributed to any delivery — bonuses/adjustments; review coming (#650)</string>
+    <string name="money_tab_over_attributed_callout_format">attributed exceeds reported by %1$s — review estimates/corrections</string>
     <string name="money_tab_recent_sessions_title">RECENT SESSIONS</string>
     <string name="money_tab_no_sessions_recorded_yet">No sessions recorded yet.</string>
     <string name="money_tab_cash_marker_format">+%1$s cash</string>
@@ -475,6 +476,7 @@
     <string name="session_detail_title">Session detail</string>
     <string name="session_detail_not_found">Session not found.</string>
     <string name="session_detail_unaccounted_format">%1$s unaccounted on this session — the platform reported more than the captured deliveries.</string>
+    <string name="session_detail_over_attributed_format">attributed exceeds reported by %1$s on this session — review estimates/corrections.</string>
     <string name="session_detail_add_missed_delivery">Add missed delivery</string>
     <string name="session_detail_deliveries_title">DELIVERIES</string>
     <string name="session_detail_no_deliveries_yet">No deliveries captured for this session.</string>

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
@@ -76,7 +76,7 @@ class AnalyticsRepository @Inject constructor(
                     assemble(
                         deliveredPay = d.pay, deliveryNet = d.net, deliveries = d.deliveries,
                         jobs = d.jobs, miles = s.miles, onlineMillis = s.onlineMillis,
-                        gross = g.gross, unattributed = g.unattributed,
+                        gross = g.gross, unattributed = g.unattributed, overAttributed = g.overAttributed,
                         fuelCost = d.fuelCost, nonFuelCost = d.nonFuelCost, cash = d.cash,
                     )
                 }
@@ -95,6 +95,7 @@ class AnalyticsRepository @Inject constructor(
                         deliveries = d?.deliveries ?: 0, jobs = d?.jobs ?: 0,
                         miles = s?.miles ?: 0.0, onlineMillis = s?.onlineMillis ?: 0L,
                         gross = g?.gross ?: 0.0, unattributed = g?.unattributed ?: 0.0,
+                        overAttributed = g?.overAttributed ?: 0.0,
                         fuelCost = d?.fuelCost, nonFuelCost = d?.nonFuelCost, cash = d?.cash ?: 0.0,
                     )
                 }
@@ -276,6 +277,7 @@ class AnalyticsRepository @Inject constructor(
         onlineMillis: Long,
         gross: Double,
         unattributed: Double,
+        overAttributed: Double,
         fuelCost: Double?,
         nonFuelCost: Double?,
         cash: Double,
@@ -284,6 +286,7 @@ class AnalyticsRepository @Inject constructor(
         // cash sum (folded in the DAO's `grossAndUnattributed`); net adds it here (it is deliberately
         // OUTSIDE the frozen delivery `netProfit`, so it can't be lost to a null-net row). The
         // waterfall's cost = gross − net is unchanged (cash cancels), so the 4-step reconcile holds.
+        // [overAttributed] (#701) is deliberately NOT folded into [net] — display-only review signal.
         val net = deliveryNet + unattributed + cash
         val hours = onlineMillis / 3_600_000.0
         return PeriodEconomics(
@@ -303,6 +306,7 @@ class AnalyticsRepository @Inject constructor(
             // nullable SUMs (null = no frozen split coverage → the UI falls back to 3-step, #659).
             fuelCost = fuelCost,
             nonFuelCost = nonFuelCost,
+            overAttributedPay = overAttributed,
         )
     }
 

--- a/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepositoryTest.kt
+++ b/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepositoryTest.kt
@@ -384,4 +384,53 @@ class AnalyticsRepositoryTest {
         assertEquals(1, life.deliveries)
         assertEquals(12.0, life.pay, 1e-9)
     }
+
+    /**
+     * #701: a session whose reported total is LESS than its Σ delivered pay surfaces the excess as
+     * [PeriodEconomics.overAttributedPay] — never floored to zero, and never subtracted from
+     * `netProfit` (which stays Σ frozen delivery net + cash, with `unattributed` at 0 since reported
+     * did not exceed delivered).
+     */
+    @Test
+    fun `over-attributed session surfaces the positive delta without touching unattributed or net (#701)`() = runBlocking {
+        // Reported 30 < delivered 45 (25 + 20) → 15 over-attributed; unattributed stays 0.
+        dao.upsertSession(session("S1", base, reportedEarnings = 30.0, durationMillis = hour, startOdo = 0.0, lastOdo = 10.0, deliveries = 2, jobsCompleted = 1))
+        dao.upsertDelivery(delivery(1, "S1", "J1", "Wendys", pay = 25.0, net = 20.0, completedAt = base + hour))
+        dao.upsertDelivery(delivery(2, "S1", "J1", "Wendys", pay = 20.0, net = 16.0, completedAt = base + 2 * hour))
+
+        val eco = repo.periodEconomics(AnalyticsPeriod.LIFETIME).first()
+        assertEquals("over-attribution = delivered 45 − reported 30", 15.0, eco.overAttributedPay, 1e-9)
+        assertEquals("unattributed stays 0 — reported did not exceed delivered", 0.0, eco.unattributedPay, 1e-9)
+        // Net = Σ frozen delivery net (20 + 16) + unattributed (0) + cash (0) = 36 — the over-attribution
+        // is NOT subtracted.
+        assertEquals(36.0, eco.netProfit, 1e-9)
+    }
+
+    /**
+     * #701: a period mixing one over-attributed and one under-attributed session — `unattributed` and
+     * `overAttributed` are independent per-session SUMs; neither direction cancels the other.
+     */
+    @Test
+    fun `mixed period sums unattributed and overAttributed independently (#701)`() = runBlocking {
+        // S1: reported 50 > delivered 40 → 10 unattributed.
+        dao.upsertSession(session("S1", base, reportedEarnings = 50.0, durationMillis = hour, startOdo = 0.0, lastOdo = 10.0, deliveries = 1, jobsCompleted = 1))
+        dao.upsertDelivery(delivery(1, "S1", "J1", "Wendys", pay = 40.0, net = 35.0, completedAt = base + hour))
+        // S2: reported 10 < delivered 18 → 8 over-attributed.
+        dao.upsertSession(session("S2", base + 10 * hour, reportedEarnings = 10.0, durationMillis = hour, startOdo = 0.0, lastOdo = 5.0, deliveries = 1, jobsCompleted = 1))
+        dao.upsertDelivery(delivery(2, "S2", "J2", "Chipotle", pay = 18.0, net = 15.0, completedAt = base + 11 * hour))
+
+        val eco = repo.periodEconomics(AnalyticsPeriod.LIFETIME).first()
+        assertEquals("S1's 10 unattributed, unaffected by S2's over-attribution", 10.0, eco.unattributedPay, 1e-9)
+        assertEquals("S2's 8 over-attributed, unaffected by S1's unattributed", 8.0, eco.overAttributedPay, 1e-9)
+    }
+
+    /** #701 x #688: a cash tip on an over-attributed session does not shrink/grow overAttributedPay (cash-free comparison). */
+    @Test
+    fun `cash tip does not change overAttributedPay (#701, #688 cash-free invariant)`() = runBlocking {
+        dao.upsertSession(session("S1", base, reportedEarnings = 10.0, durationMillis = hour, startOdo = 0.0, lastOdo = 5.0, deliveries = 1, jobsCompleted = 1))
+        dao.upsertDelivery(delivery(1, "S1", "J1", "Wendys", pay = 18.0, net = 15.0, completedAt = base + hour, cashTip = 4.0))
+
+        val eco = repo.periodEconomics(AnalyticsPeriod.LIFETIME).first()
+        assertEquals("overAttributed compares cash-free delivered pay: 18 − 10 = 8, cash never counted", 8.0, eco.overAttributedPay, 1e-9)
+    }
 }

--- a/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsSessionDetailTest.kt
+++ b/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsSessionDetailTest.kt
@@ -161,4 +161,43 @@ class AnalyticsSessionDetailTest {
 
         assertEquals(0.0, repo.sessionDetail("S").first()!!.unattributedPay, 1e-9)
     }
+
+    /** #701: the mirror signal — delivered exceeds reported ⇒ overAttributedPay is the positive delta. */
+    @Test
+    fun `overAttributedPay is delivered minus reported when delivered exceeds reported (#701)`() = runBlocking {
+        dao.upsertSession(session("S", reportedEarnings = 5.0))
+        dao.upsertDelivery(delivery(1, "S", completedAt = base + hour, realizedPay = 8.0))
+
+        val detail = repo.sessionDetail("S").first()!!
+        assertEquals(3.0, detail.overAttributedPay, 1e-9)   // 8 − 5
+        assertEquals("unattributedPay stays 0 — reported did not exceed delivered", 0.0, detail.unattributedPay, 1e-9)
+    }
+
+    /** #701: overAttributedPay is 0 when reportedEarnings is null (nothing to compare against). */
+    @Test
+    fun `overAttributedPay is zero when reported is null (#701)`() = runBlocking {
+        dao.upsertSession(session("S", reportedEarnings = null))
+        dao.upsertDelivery(delivery(1, "S", completedAt = base + hour, realizedPay = 8.0))
+
+        assertEquals(0.0, repo.sessionDetail("S").first()!!.overAttributedPay, 1e-9)
+    }
+
+    /** #701: overAttributedPay never goes negative when reported exceeds delivered. */
+    @Test
+    fun `overAttributedPay never goes negative when reported exceeds delivered (#701)`() = runBlocking {
+        dao.upsertSession(session("S", reportedEarnings = 25.0))
+        dao.upsertDelivery(delivery(1, "S", completedAt = base + hour, realizedPay = 8.0))
+
+        assertEquals(0.0, repo.sessionDetail("S").first()!!.overAttributedPay, 1e-9)
+    }
+
+    /** #701 x #688: a cash tip does not shrink/grow overAttributedPay (cash-free comparison, mirrors unattributedPay). */
+    @Test
+    fun `cash tip does not change overAttributedPay (#701, #688 cash-free invariant)`() = runBlocking {
+        dao.upsertSession(session("S", reportedEarnings = 5.0))
+        dao.upsertDelivery(delivery(1, "S", completedAt = base + hour, realizedPay = 8.0, cashTip = 3.0))
+
+        val detail = repo.sessionDetail("S").first()!!
+        assertEquals("overAttributed compares cash-free deliveredPay: 8 − 5 = 3", 3.0, detail.overAttributedPay, 1e-9)
+    }
 }

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
@@ -178,6 +178,12 @@ interface AnalyticsDao {
      * [deliveryTotals]'s null-session-inclusive `cash`) and into `gross` here (session-join only) is
      * the same amount; a null-session cash row would leak into net but not gross, which the invariant
      * forbids.
+     *
+     * **`overAttributed` (#701):** the mirror signal `deliveredPay − reportedEarnings` for sessions
+     * where delivered exceeds reported (the opposite excess from `unattributed`) — surfaced as a
+     * **positive magnitude**, never folded into `netProfit`/`unattributed`. Same cash-free comparison
+     * (`d.deliveredPay`, never `+ d.cashTip`) as `unattributed`, so the #688 cash exclusion holds for
+     * both directions. `unattributed` is left byte-for-byte untouched.
      */
     @Query(
         """SELECT COALESCE(SUM(COALESCE(s.reportedEarnings, d.deliveredPay, 0) + COALESCE(d.cashTip, 0)), 0) AS gross,
@@ -185,7 +191,12 @@ interface AnalyticsDao {
                     CASE WHEN s.reportedEarnings IS NOT NULL
                               AND s.reportedEarnings > COALESCE(d.deliveredPay, 0)
                          THEN s.reportedEarnings - COALESCE(d.deliveredPay, 0)
-                         ELSE 0 END), 0) AS unattributed
+                         ELSE 0 END), 0) AS unattributed,
+                  COALESCE(SUM(
+                    CASE WHEN s.reportedEarnings IS NOT NULL
+                              AND s.reportedEarnings < COALESCE(d.deliveredPay, 0)
+                         THEN COALESCE(d.deliveredPay, 0) - s.reportedEarnings
+                         ELSE 0 END), 0) AS overAttributed
            FROM session_records s
            LEFT JOIN (
              SELECT sessionId, SUM(realizedPay) AS deliveredPay, SUM(cashTip) AS cashTip
@@ -195,6 +206,7 @@ interface AnalyticsDao {
     )
     fun grossAndUnattributed(start: Long, end: Long): Flow<GrossTotalsRow>
 
+    /** Per-platform variant of [grossAndUnattributed] — same `overAttributed` mirror aggregate (#701). */
     @Query(
         """SELECT s.platform AS platform,
                   COALESCE(SUM(COALESCE(s.reportedEarnings, d.deliveredPay, 0) + COALESCE(d.cashTip, 0)), 0) AS gross,
@@ -202,7 +214,12 @@ interface AnalyticsDao {
                     CASE WHEN s.reportedEarnings IS NOT NULL
                               AND s.reportedEarnings > COALESCE(d.deliveredPay, 0)
                          THEN s.reportedEarnings - COALESCE(d.deliveredPay, 0)
-                         ELSE 0 END), 0) AS unattributed
+                         ELSE 0 END), 0) AS unattributed,
+                  COALESCE(SUM(
+                    CASE WHEN s.reportedEarnings IS NOT NULL
+                              AND s.reportedEarnings < COALESCE(d.deliveredPay, 0)
+                         THEN COALESCE(d.deliveredPay, 0) - s.reportedEarnings
+                         ELSE 0 END), 0) AS overAttributed
            FROM session_records s
            LEFT JOIN (
              SELECT sessionId, SUM(realizedPay) AS deliveredPay, SUM(cashTip) AS cashTip

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsTotals.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsTotals.kt
@@ -79,18 +79,22 @@ data class StoreTotalsRow(
  * Reported-authoritative gross + the unattributed delta for a period (#314 PR3).
  * Computed per session (reported summary total when present, else that session's Σ
  * delivered pay), then summed. [unattributed] is the excess of reported over delivered
- * — bonuses/adjustments/a missed capture; a review flag (#650).
+ * — bonuses/adjustments/a missed capture; a review flag (#650). [overAttributed] is the
+ * mirror excess of delivered over reported (#701) — a **display-only** review signal, never
+ * folded into [unattributed]/`netProfit`.
  */
 data class GrossTotalsRow(
     val gross: Double,
     val unattributed: Double,
+    val overAttributed: Double,
 )
 
-/** Per-platform gross + unattributed (GROUP BY platform). */
+/** Per-platform gross + unattributed + overAttributed (GROUP BY platform, #701). */
 data class PlatformGrossTotalsRow(
     val platform: String,
     val gross: Double,
     val unattributed: Double,
+    val overAttributed: Double,
 )
 
 /**

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -87,6 +87,20 @@ was found **broken-in-part** (raw PII in capture envelopes) and moved to that en
   skipped, or a gas edit that doesn't stick is a regression — capture it.
   - Confirmed: 0/2
   - Desk replay fixture: `~/dashbuddy/logs/2026/07/06/` (the 07-05 $0 session `session-doordash-1783294721320-15`).
+- **🆕 NEW — over-attribution review flag on the Money tab + per-dash drill-down (#701).**
+  The Money tab's unattributed-pay callout ("$X not attributed…") now has a mirror: when a
+  session's **captured delivery pay exceeds** the platform's reported summary total (the
+  opposite direction — e.g. a phantom offer-pay estimate or a mixed-receipt over-stamp), a
+  second callout appears ("attributed exceeds reported by $X — review estimates/corrections"),
+  tinted with the stronger `badBg` (not the softer `warnBg` the unattributed one uses). The
+  per-dash drill-down (tap a session in Recent Dashes) shows the same mirror callout when that
+  ONE dash is over-attributed. **What to watch:** on a normal dash where reported ≈ delivered,
+  neither callout (or only the unattributed one) should appear — the new callout is a **display-only**
+  signal and must never move the True-Net waterfall's Net figure or the stat tiles. If you ever see
+  a dash where delivered pay looks higher than the platform's own reported total (rare — usually a
+  DoorDash shop/Drive job with an estimate involved), confirm the new callout fires with the correct
+  dollar amount and that Net/hr, Net/mi, and the waterfall are unaffected.
+  - Confirmed: 0/2
 - **🆕 NEW — per-region lifecycle edges hold single-platform behavior (#438 B1 / PR #707).** The
   state machine's job/task edges now fire off each platform's OWN last-acted flow instead of the
   global screen flow (a latent multi-platform fix — single-platform behavior should be **byte

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/PeriodEconomics.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/PeriodEconomics.kt
@@ -41,6 +41,14 @@ data class PeriodEconomics(
     val fuelCost: Double? = null,
     /** Σ frozen non-fuel dollars over the period's deliveries, or `null` when no frozen split exists (#659). */
     val nonFuelCost: Double? = null,
+    /**
+     * Σ (deliveredPay − reportedEarnings) where delivered exceeds reported (#701) — the mirror of
+     * [unattributedPay], surfaced as a positive magnitude so an over-count (a phantom offer-pay
+     * estimate, a mixed-receipt over-stamp) is never silently floored to zero. **Display-only**: this
+     * is NEVER added to/subtracted from [netProfit] or [unattributedPay] — it is a review flag the
+     * Money tab renders alongside the unattributed callout, nothing more.
+     */
+    val overAttributedPay: Double = 0.0,
 ) {
     companion object {
         val EMPTY = PeriodEconomics(
@@ -52,6 +60,7 @@ data class PeriodEconomics(
             netPerMile = null,
             fuelCost = null,
             nonFuelCost = null,
+            overAttributedPay = 0.0,
         )
     }
 }

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/SessionDetail.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/SessionDetail.kt
@@ -41,4 +41,17 @@ data class SessionDetail(
             val reported = session.reportedEarnings ?: return 0.0
             return (reported - deliveredPay).coerceAtLeast(0.0)
         }
+
+    /**
+     * `delivered − reported` when captured delivery pay exceeds the platform-reported total, else
+     * `0` (never negative) — the mirror of [unattributedPay] (#701), a **display-only** per-dash
+     * review signal for an over-count (never folded into [unattributedPay] or any net figure). Same
+     * cash-free [deliveredPay] comparison as [unattributedPay], so the #688 cash exclusion holds for
+     * both directions; `0` when [session] carries no `reportedEarnings` (nothing to compare against).
+     */
+    val overAttributedPay: Double
+        get() {
+            val reported = session.reportedEarnings ?: return 0.0
+            return (deliveredPay - reported).coerceAtLeast(0.0)
+        }
 }


### PR DESCRIPTION
## Summary

- Read-side-only change: adds a display-only mirror signal, `overAttributedPay`, alongside the existing `unattributedPay` on both the period-level Money tab and the per-dash drill-down. Where `unattributedPay` = `MAX(reported − Σ realizedPay, 0)`, `overAttributedPay` = `MAX(Σ realizedPay − reported, 0)` — the excess in the opposite direction, previously silently floored to zero with no visible signal anywhere (the #691 design-vet W1-d follow-up, per #689's never-silent precedent).
- **No reducer, no fold, no `netProfit` math change.** `overAttributedPay` is never added to or subtracted from `netProfit` or `unattributedPay` — it is a pure review flag.
- Period side: `AnalyticsDao.grossAndUnattributed`/`grossAndUnattributedByPlatform` gain a second CASE aggregate; `unattributed`'s existing CASE is byte-for-byte untouched. Threaded through `GrossTotalsRow`/`PlatformGrossTotalsRow` → `AnalyticsRepository.assemble` → `PeriodEconomics.overAttributedPay` (default `0.0`) → `MoneyTab` renders a second `AppCallout` (using `AppTheme.colors.badBg` — a stronger flag than the softer `warnBg` used for the unattributed case; no new palette color needed).
- Per-dash side: `SessionDetail.overAttributedPay` mirrors `unattributedPay`'s existing computed-property shape; `SessionDetailScreen` renders the mirror callout independently of the missed-delivery add-button flow (over-attribution isn't about a missed delivery).
- New string resources: `money_tab_over_attributed_callout_format`, `session_detail_over_attributed_format` — positional `%1$s` only, next to their existing counterparts.
- No `PROJECTOR_VERSION` bump, no schema/migration — pure query/read-model additions.

**#688 cash-free invariant preserved.** The new `overAttributed` CASE compares `reportedEarnings` against the same cash-free `d.deliveredPay` (`SUM(realizedPay)`) `unattributed` already uses — never `+ cashTip`. Same for `SessionDetail.overAttributedPay` (built on the existing cash-free `deliveredPay`). The pre-existing invariant test `cash tips add to net and gross but leave unattributed unchanged (#688)` in `AnalyticsRepositoryTest` is unchanged and green; new tests explicitly assert a cash tip does not move `overAttributedPay` on either surface.

## Test plan

- [x] `JAVA_HOME=/usr/lib/jvm/java-25 ./gradlew testDebugUnitTest :domain:test` — full suite green.
- [x] `AnalyticsRepositoryTest` (Robolectric, real in-memory Room DB) — 16/16 tests pass, including 3 new: over-attributed session surfaces the positive delta without moving `unattributed`/`netProfit`; a mixed period sums `unattributed`/`overAttributed` independently (neither cancels the other); a cash tip does not change `overAttributedPay` (#688 cash-free invariant).
- [x] `AnalyticsSessionDetailTest` — 10/10 tests pass, including 4 new: `overAttributedPay` = delivered − reported when positive; `0.0` when `reportedEarnings` is null; never negative when reported exceeds delivered; a cash tip does not change it.
- [x] `:app:compileDebugKotlin` / `:core:database:compileDebugKotlin` / `:domain:compileKotlin` all compile clean (Compose callouts, DAO/DTO field additions).

### Design-goal review

- **Principle 5 (SSOT).** One owner for the over-attribution delta at each layer: the DAO CASE aggregate is the sole definition (mirrored, not duplicated, into `SessionDetail.overAttributedPay` the same way `unattributedPay` already documents its own SQL-mirror relationship); both UI call sites read the same repository/domain field rather than recomputing.
- **Principle 6 (security & privacy).** No PII, no new network/capture surface — this is a pure economics-signal addition over already-derived numeric aggregates (store/customer identity untouched).
- **Principle 8 (platform-agnostic core).** No platform literals introduced; the new DAO queries use the same `Platform`-keyed `GROUP BY s.platform` shape as their existing siblings, and `PeriodEconomics`/`SessionDetail` remain pure read-model DTOs (no state-machine re-entry).
- **Reactive UI.** No new time-derived/ticking values — this is a static per-period/per-dash figure, refreshed the same way the sibling `unattributedPay` callout already is (Room-invalidation Flow), so no additional reactivity concern.

Closes #701.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Adversarial review

Reviewed at the session top tier (Fable) against the full diff, 2026-07-07.

**Correctness — verified clean:**
- The `overAttributed` CASE is an exact mirror of `unattributed` (strict inequalities both directions; equality yields 0 on both; `reportedEarnings IS NULL` yields 0 on both). The existing `unattributed` CASE and `gross` expression are byte-for-byte untouched — confirmed against the diff.
- The #688 cash-free invariant genuinely holds in both directions: the comparison quantity is the sub-select's `SUM(realizedPay)` (`deliveredPay`), never `+ cashTip`; `SessionDetail.overAttributedPay` builds on the existing cash-free `deliveredPay` property. New tests pin this on both surfaces.
- Display-only claim verified: `assemble()` folds `unattributed + cash` into net exactly as before; `overAttributed` is threaded but never enters `net`/`unattributedPay`. Tests assert net = 36.0 with a 15.0 over-attribution present.
- All constructors/consumers of `GrossTotalsRow`/`PlatformGrossTotalsRow` are the two DAO queries + the two `assemble` call sites — all threaded; no other construction site exists in the tree (Room maps by column name).
- The per-day chart query (`dailyGross`-family, AnalyticsRepository.kt:189 comment) deliberately does not gain the mirror aggregate — correct scope: it feeds the bar chart, not the reconciliation callouts.
- `SessionDetail.overAttributedPay` follows the already-documented SQL-mirror pattern `unattributedPay` established (DAO CASE is the definition owner) — consistent with the existing SSOT posture, not a new duplication.

**Design principles:** P5/P6/P8 walk in the author block checks out on inspection; no log sites added (P7 n/a); no reducer/fold/schema change; Reactive-UI n/a (Room-invalidation Flow, same as the sibling callout).

**Findings (both LOW, non-blocking):**
1. Copy style: the two new strings start lowercase ("attributed exceeds reported by …") while sibling callout strings lead with the amount — cosmetic inconsistency, fine to leave for the UI-copy arc.
2. `PeriodEconomics.EMPTY` explicitly sets `overAttributedPay = 0.0` which the default already supplies — harmless, matches EMPTY's list-all-fields style.

Verdict: **clean — approved for merge on green CI.**
