### PR TITLE
cleanup(#715): strip dormant Expected/Unexpected outcomes classification

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,9 +107,14 @@ matchers (included build, not a :core module) ⇒ canonicalizes rules → :core:
 - **`:core:pipeline`** — Accessibility pipeline, notification pipeline, JSON rule engine
   (RuleCompiler, Ruleset, JsonRuleInterpreter), observation classifier. Reads third-party UI.
 - **`:core:state`** — Multi-region state machine (StateMachine, FlowRegionStepper,
-  PlatformRegionStepper, CrossPlatformRegionStepper), effect map, `TransitionPolicy` (the
-  expected/unexpected classification + commit graces; replaced the old `HealingPolicy`), crash
-  recovery (StateManagerV2). Defines `EffectExecutor` and `MetadataProvider` interfaces.
+  PlatformRegionStepper, CrossPlatformRegionStepper), effect map, `TransitionPolicy` (screen-
+  authoritative mode resolution + commit graces; replaced the old `HealingPolicy`), crash
+  recovery (StateManagerV2). Defines `EffectExecutor` and `MetadataProvider` interfaces. (#715
+  struck the former Expected/Unexpected `outcomes` classification — schema key, compiler support,
+  `TransitionPolicy.classify()`, `TransitionKind`, `PlatformRegion.lastTransitionKind` — as dormant:
+  no ruleset ever declared `outcomes`, so `Unexpected` was unreachable and its two "consumers"
+  (`SessionStartSource.RECOVERY`, the healing gate) always fell to their other arm. `#438`'s
+  Offline→Online healing edge is unaffected — it never depended on the classification.)
 - **`:core:database`** — Room entities, DAOs, and database setup. **Data-safety posture (#690):
   no `fallbackToDestructiveMigration`.** `app_events` is the analytics source of truth (the
   read-model tables are a rebuildable projection of it), so an upgrade that Room has no path for must

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/ObservationClassifier.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/ObservationClassifier.kt
@@ -134,7 +134,6 @@ class ObservationClassifier @Inject constructor(
             effects = DedupeTokens.resolve(result.effects, parsed),
             targets = result.targets,
             transitionOverrides = result.transitionOverrides,
-            expectedOutcomes = result.outcomes,
         )
 
         // Cache last non-sensitive screen for click enrichment, keyed by THIS
@@ -157,7 +156,6 @@ class ObservationClassifier @Inject constructor(
         effects: List<RequestedEffect> = emptyList(),
         targets: Map<String, NodeRef> = emptyMap(),
         transitionOverrides: Map<TransitionTrigger, List<RequestedEffect>> = emptyMap(),
-        expectedOutcomes: Set<Flow>? = null,
     ) = Observation.Screen(
         timestamp = now,
         captureId = null,
@@ -170,7 +168,6 @@ class ObservationClassifier @Inject constructor(
         effects = effects,
         targets = targets,
         transitionOverrides = transitionOverrides,
-        expectedOutcomes = expectedOutcomes,
     )
 
     // ── Click ───────────────────────────────────────────────────────────
@@ -198,7 +195,6 @@ class ObservationClassifier @Inject constructor(
                     target = result.intent,
                     effects = DedupeTokens.resolve(result.effects, parsed),
                     transitionOverrides = result.transitionOverrides,
-                    expectedOutcomes = result.outcomes,
                     screenTarget = screenTarget,
                 )
             }
@@ -247,7 +243,6 @@ class ObservationClassifier @Inject constructor(
                     target = result.intent,
                     effects = DedupeTokens.resolve(result.effects, parsed),
                     transitionOverrides = result.transitionOverrides,
-                    expectedOutcomes = result.outcomes,
                 )
             }
         }

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/CompiledRules.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/CompiledRules.kt
@@ -64,7 +64,6 @@ data class CompiledBranch<TInput>(
     val intent: String? = null,
     val flow: Flow? = null,
     val modeHint: Mode? = null,
-    val outcomes: Set<Flow>? = null,
     val screenIs: String? = null,
     val transitionOverrides: Map<String, List<CompiledEffect>> = emptyMap(),
 )
@@ -261,7 +260,6 @@ data class RuleMatchResult(
     val shape: String? = null,
     val flow: Flow? = null,
     val modeHint: Mode? = null,
-    val outcomes: Set<Flow>? = null,
     val fields: Map<String, Any?> = emptyMap(),
     val effects: List<RequestedEffect> = emptyList(),
     val targets: Map<String, cloud.trotter.dashbuddy.domain.pipeline.NodeRef> = emptyMap(),

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompiler.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompiler.kt
@@ -379,13 +379,11 @@ object RuleCompiler {
                 }
                 // #293 item 5: unknown branch keys are a typed reject naming them.
                 validateKnownKeys(branchObj, knownBranchKeys(context), scope = "branch", ruleId = id)
-                compileBranch(branchObj, context, ruleState.flow, ruleState.modeHint,
-                    ruleOutcomes = ruleState.outcomes, ruleId = id,
+                compileBranch(branchObj, context, ruleState.flow, ruleState.modeHint, ruleId = id,
                     ruleParseBlock = ruleParseObj, ruleParseAs = ruleParseAs, ruleBindObj = ruleBindObj)
             }
         } else {
-            listOf(compileBranch(obj, context, ruleState.flow, ruleState.modeHint,
-                ruleOutcomes = ruleState.outcomes, ruleId = id))
+            listOf(compileBranch(obj, context, ruleState.flow, ruleState.modeHint, ruleId = id))
         }
 
         // #419: bound the total effect count across all branches (own effects +
@@ -498,7 +496,6 @@ object RuleCompiler {
         context: RuleContext,
         ruleFlow: Flow? = null,
         ruleModeHint: Mode? = null,
-        ruleOutcomes: Set<Flow>? = null,
         ruleId: String? = null,
         ruleParseBlock: JsonObject? = null,
         ruleParseAs: String? = null,
@@ -599,7 +596,6 @@ object RuleCompiler {
             intent = intent,
             flow = branchState.flow ?: ruleFlow,
             modeHint = branchState.modeHint ?: ruleModeHint,
-            outcomes = branchState.outcomes ?: ruleOutcomes,
             screenIs = screenIs,
             transitionOverrides = transitionOverrides,
         )
@@ -653,7 +649,6 @@ object RuleCompiler {
     data class ParsedStateBlock(
         val flow: Flow? = null,
         val modeHint: Mode? = null,
-        val outcomes: Set<Flow>? = null,
     )
 
     fun parseStateBlock(stateObj: JsonObject?, ruleId: String): ParsedStateBlock {
@@ -671,13 +666,8 @@ object RuleCompiler {
             Mode.fromWire(it)
                 ?: throw RuleCompileException("Rule '$ruleId': unknown mode value '$it'")
         }
-        val outcomes = stateObj["outcomes"]?.jsonArray?.map { elem ->
-            val wire = elem.jsonPrimitive.content
-            Flow.fromWire(wire)
-                ?: throw RuleCompileException("Rule '$ruleId': unknown outcome flow '$wire'")
-        }?.toSet()
 
-        return ParsedStateBlock(flow, modeHint, outcomes)
+        return ParsedStateBlock(flow, modeHint)
     }
 
     // ==========================================================================

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/Ruleset.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/Ruleset.kt
@@ -157,7 +157,6 @@ class Ruleset<TInput>(rules: List<CompiledRule<TInput>>) {
                     shape = branch.shape,
                     flow = branch.flow,
                     modeHint = branch.modeHint,
-                    outcomes = branch.outcomes,
                     fields = fieldsWithIntent,
                     effects = resolvedEffects,
                     targets = targets,

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -33,7 +33,6 @@ import cloud.trotter.dashbuddy.domain.state.FlowRegion
 import cloud.trotter.dashbuddy.domain.state.Job
 import cloud.trotter.dashbuddy.domain.state.Mode
 import cloud.trotter.dashbuddy.domain.state.OfferPayFallback
-import cloud.trotter.dashbuddy.domain.state.TransitionKind
 import cloud.trotter.dashbuddy.domain.state.ParsedFields
 import cloud.trotter.dashbuddy.domain.state.PickupActivity
 import cloud.trotter.dashbuddy.domain.state.PendingOffer

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/ModeEffects.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/ModeEffects.kt
@@ -15,7 +15,6 @@ import cloud.trotter.dashbuddy.domain.state.DestructiveKind
 import cloud.trotter.dashbuddy.domain.state.Mode
 import cloud.trotter.dashbuddy.domain.state.ParsedFields
 import cloud.trotter.dashbuddy.domain.state.PlatformRegion
-import cloud.trotter.dashbuddy.domain.state.TransitionKind
 import timber.log.Timber
 
 /**
@@ -138,11 +137,12 @@ internal fun EffectMap.diffMode(
                         sessionId = nextSession.sessionId,
                         platform = next.platform.name,
                         startedAt = nextSession.startedAt,
-                        source = if (next.lastTransitionKind == TransitionKind.Unexpected) {
-                            SessionStartSource.RECOVERY
-                        } else {
-                            SessionStartSource.INTERACTION
-                        },
+                        // #715: this used to branch on `lastTransitionKind == Unexpected` to
+                        // distinguish a crash-recovery start from a normal one, but that kind
+                        // was unreachable (no ruleset ever declared `outcomes`) — the branch
+                        // always evaluated to INTERACTION. Struck along with the rest of the
+                        // dormant Expected/Unexpected classification machinery.
+                        source = SessionStartSource.INTERACTION,
                         startScreen = "WaitingForOffer",
                     )
                     add(logEffect(nextSession.sessionId, AppEventType.DASH_START, obs.timestamp, payload))

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
@@ -21,7 +21,6 @@ import cloud.trotter.dashbuddy.domain.state.StoreNameMatch
 import cloud.trotter.dashbuddy.domain.state.Task
 import cloud.trotter.dashbuddy.domain.state.TaskPhase
 import cloud.trotter.dashbuddy.domain.state.TaskSubFlow
-import cloud.trotter.dashbuddy.domain.state.TransitionKind
 import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -280,7 +279,6 @@ class PlatformRegionStepper @Inject constructor() {
             // resume grace (#605): the modal is still up, the online flap was noise.
             impliedMode == current.mode -> current.copy(
                 lastObservedAt = obs.timestamp,
-                lastTransitionKind = TransitionKind.Confirmed,
                 pendingModeResume = if (impliedMode == Mode.Paused) null else current.pendingModeResume,
             )
 
@@ -312,16 +310,13 @@ class PlatformRegionStepper @Inject constructor() {
 
             // Screen or Notification — authoritative, apply immediately
             else -> {
-                val kind = policy.classify(
-                    current.mode, impliedMode, flowObs.expectedOutcomes, flowObs,
-                )
-                val transitioned = applyModeTransition(current, impliedMode, obs, kind, policy)
+                val transitioned = applyModeTransition(current, impliedMode, obs, policy)
                 // Heal lifecycle when coming Online from Offline (app restart
-                // mid-task) or on any Unexpected transition. healActiveLifecycle
-                // self-guards: only acts if the flow is a task flow with no
-                // active job, so it's safe to call broadly.
-                if (kind == TransitionKind.Unexpected ||
-                    (current.mode == Mode.Offline && impliedMode == Mode.Online)) {
+                // mid-task) — the live path (#715 struck the former Unexpected-
+                // transition gate: no ruleset ever declared `outcomes`, so that arm
+                // never fired). healActiveLifecycle self-guards: only acts if the
+                // flow is a task flow with no active job, so it's safe to call broadly.
+                if (current.mode == Mode.Offline && impliedMode == Mode.Online) {
                     healActiveLifecycle(transitioned, obs)
                 } else {
                     transitioned
@@ -341,13 +336,11 @@ class PlatformRegionStepper @Inject constructor() {
         prev: PlatformRegion,
         newMode: Mode,
         obs: Observation,
-        kind: TransitionKind,
         policy: TransitionPolicy,
     ): PlatformRegion {
         var region = prev.copy(
             mode = newMode,
             lastObservedAt = obs.timestamp,
-            lastTransitionKind = kind,
         )
 
         // Session lifecycle on mode transitions. An authoritative `session:ended`
@@ -418,10 +411,10 @@ class PlatformRegionStepper @Inject constructor() {
         obs: Observation,
         policy: TransitionPolicy,
     ): PlatformRegion =
-        applyModeTransition(region, Mode.Online, obs, TransitionKind.Expected, policy)
+        applyModeTransition(region, Mode.Online, obs, policy)
 
     /**
-     * When an unexpected transition fires (e.g., app launched mid-pickup),
+     * When the app comes Online from Offline (e.g., launched mid-pickup),
      * synthesize missing lifecycle entities so the state is consistent.
      */
     private fun healActiveLifecycle(region: PlatformRegion, obs: Observation): PlatformRegion {
@@ -474,9 +467,7 @@ class PlatformRegionStepper @Inject constructor() {
                 // Pause timer expired — transition to offline via applyModeTransition
                 // so it gets grace treatment
                 if (prev.mode == Mode.Paused) {
-                    applyModeTransition(
-                        prev, Mode.Offline, obs, TransitionKind.Expected, policy,
-                    )
+                    applyModeTransition(prev, Mode.Offline, obs, policy)
                 } else prev
             }
             else -> prev // Automation timeouts handled by EffectMap

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/TransitionPolicy.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/TransitionPolicy.kt
@@ -1,12 +1,10 @@
 package cloud.trotter.dashbuddy.core.state
 
-import cloud.trotter.dashbuddy.domain.pipeline.Observation
 import cloud.trotter.dashbuddy.domain.settings.GraceConfig
 import cloud.trotter.dashbuddy.domain.settings.GraceConfigProvider
 import cloud.trotter.dashbuddy.domain.state.Flow
 import cloud.trotter.dashbuddy.domain.state.Mode
 import cloud.trotter.dashbuddy.domain.state.Platform
-import cloud.trotter.dashbuddy.domain.state.TransitionKind
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -16,7 +14,6 @@ import javax.inject.Singleton
  * Replaces [HealingPolicy]. Key differences:
  * - Screens apply mode **immediately** — no threshold counting.
  * - Clicks record user intent — they do NOT drive mode.
- * - [classify] is diagnostic only — it never blocks a transition.
  * - Session grace period protects sessions from brief offline blips.
  */
 @Singleton
@@ -97,27 +94,5 @@ class TransitionPolicy @Inject constructor(
             Flow.Idle -> null // Idle is ambiguous — could be offline or between offers
             null -> null
         }
-    }
-
-    /**
-     * Classify a transition for logging and lifecycle decisions.
-     *
-     * When [prevOutcomes] is null (rule declared no outcomes), mode changes
-     * default to [TransitionKind.Expected] for backward compatibility.
-     */
-    fun classify(
-        prevMode: Mode,
-        impliedMode: Mode?,
-        prevOutcomes: Set<Flow>?,
-        obs: Observation.FlowObservation,
-    ): TransitionKind {
-        if (impliedMode == null) return TransitionKind.NoSignal
-        if (impliedMode == prevMode) return TransitionKind.Confirmed
-
-        // Mode is changing. Check if the new flow was expected.
-        if (prevOutcomes == null) return TransitionKind.Expected // no outcomes declared — compat
-
-        val obsFlow = obs.flow ?: return TransitionKind.Expected // no flow to check against
-        return if (obsFlow in prevOutcomes) TransitionKind.Expected else TransitionKind.Unexpected
     }
 }

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/StateMachineTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/StateMachineTest.kt
@@ -19,7 +19,6 @@ import cloud.trotter.dashbuddy.domain.state.ParsedFields
 import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.domain.state.TaskPhase
 import cloud.trotter.dashbuddy.domain.state.TaskSubFlow
-import cloud.trotter.dashbuddy.domain.state.TransitionKind
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -69,7 +68,6 @@ class StateMachineTest {
         parsed: ParsedFields = ParsedFields.None,
         ruleId: String = "doordash.screen.test",
         timestamp: Long = tick(),
-        expectedOutcomes: Set<Flow>? = null,
     ) = Observation.Screen(
         timestamp = timestamp,
         captureId = "cap-$timestamp",
@@ -78,7 +76,6 @@ class StateMachineTest {
         flow = flow,
         modeHint = modeHint,
         parsed = parsed,
-        expectedOutcomes = expectedOutcomes,
     )
 
     private fun clickObs(
@@ -867,12 +864,13 @@ class StateMachineTest {
     // =========================================================================
 
     @Test
-    fun `unexpected transition — app restart mid-task synthesizes lifecycle`() {
+    fun `app restart mid-task synthesizes lifecycle on the Offline to Online edge`() {
         var state = AppState()
 
-        // Cold start: first screen is a pickup navigation (app launched mid-delivery)
-        // This is Offline→Online which is an unexpected transition when outcomes
-        // don't include the observed flow
+        // Cold start: first screen is a pickup navigation (app launched mid-delivery).
+        // healActiveLifecycle fires on the Offline→Online edge (#715 struck the former
+        // Unexpected-transition gate — no ruleset ever declared `outcomes`, so that arm
+        // never fired; this edge alone is the live path).
         state = machine.step(state, screenObs(
             flow = Flow.TaskPickupNavigation,
             parsed = taskFields(),
@@ -884,25 +882,6 @@ class StateMachineTest {
         assertNotNull(dd.activeJob)
         assertNotNull(dd.activeTask)
         assertTrue(dd.activeTask!!.recovered)
-    }
-
-    @Test
-    fun `transition kind is Confirmed when mode stays the same`() {
-        var state = AppState()
-
-        // Get Online
-        state = machine.step(state, screenObs(
-            flow = Flow.OfferPresented, parsed = offerFields(),
-        )).newState
-
-        // Another Online screen — confirms mode
-        state = machine.step(state, screenObs(
-            flow = Flow.OfferPresented, parsed = offerFields(),
-        )).newState
-
-        val dd = state.regions.platforms[Platform.DoorDash]!!
-        assertEquals(Mode.Online, dd.mode)
-        assertEquals(TransitionKind.Confirmed, dd.lastTransitionKind)
     }
 
     // =========================================================================

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/TransitionPolicyTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/TransitionPolicyTest.kt
@@ -1,12 +1,8 @@
 package cloud.trotter.dashbuddy.core.state
 
-import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
-import cloud.trotter.dashbuddy.domain.pipeline.Observation
 import cloud.trotter.dashbuddy.domain.state.Flow
 import cloud.trotter.dashbuddy.domain.state.Mode
-import cloud.trotter.dashbuddy.domain.state.ParsedFields
 import cloud.trotter.dashbuddy.domain.state.Platform
-import cloud.trotter.dashbuddy.domain.state.TransitionKind
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
@@ -58,77 +54,6 @@ class TransitionPolicyTest {
         for (flow in taskFlows) {
             assertEquals("$flow should imply Online", Mode.Online, policy.resolveMode(flow, null))
         }
-    }
-
-    // =========================================================================
-    // classify — transition kind determination
-    // =========================================================================
-
-    private fun screenObs(
-        flow: Flow? = null,
-        modeHint: Mode? = null,
-        expectedOutcomes: Set<Flow>? = null,
-    ) = Observation.Screen(
-        timestamp = 1000L,
-        captureId = null,
-        ruleId = "test.screen.test",
-        metadata = ReplayMetadata.EMPTY,
-        flow = flow,
-        modeHint = modeHint,
-        parsed = ParsedFields.None,
-        expectedOutcomes = expectedOutcomes,
-    )
-
-    @Test
-    fun `classify — null impliedMode returns NoSignal`() {
-        val kind = policy.classify(
-            Mode.Online, null, null, screenObs(flow = Flow.Idle),
-        )
-        assertEquals(TransitionKind.NoSignal, kind)
-    }
-
-    @Test
-    fun `classify — same mode returns Confirmed`() {
-        val kind = policy.classify(
-            Mode.Online, Mode.Online, null, screenObs(flow = Flow.OfferPresented),
-        )
-        assertEquals(TransitionKind.Confirmed, kind)
-    }
-
-    @Test
-    fun `classify — mode change with no outcomes defaults to Expected`() {
-        val kind = policy.classify(
-            Mode.Online, Mode.Offline, null, screenObs(flow = Flow.SessionEnded),
-        )
-        assertEquals(TransitionKind.Expected, kind)
-    }
-
-    @Test
-    fun `classify — mode change with flow in outcomes is Expected`() {
-        val outcomes = setOf(Flow.SessionEnded, Flow.Idle)
-        val kind = policy.classify(
-            Mode.Online, Mode.Offline, outcomes, screenObs(flow = Flow.SessionEnded),
-        )
-        assertEquals(TransitionKind.Expected, kind)
-    }
-
-    @Test
-    fun `classify — mode change with flow NOT in outcomes is Unexpected`() {
-        val outcomes = setOf(Flow.OfferPresented, Flow.Idle)
-        val kind = policy.classify(
-            Mode.Online, Mode.Offline, outcomes,
-            screenObs(flow = Flow.SessionEnded),
-        )
-        assertEquals(TransitionKind.Unexpected, kind)
-    }
-
-    @Test
-    fun `classify — mode change with null flow defaults to Expected`() {
-        val outcomes = setOf(Flow.Idle)
-        val kind = policy.classify(
-            Mode.Offline, Mode.Online, outcomes, screenObs(flow = null),
-        )
-        assertEquals(TransitionKind.Expected, kind)
     }
 
     // =========================================================================

--- a/docs/adr/ADR-0005-pipeline-driven-multi-region-state-architecture.md
+++ b/docs/adr/ADR-0005-pipeline-driven-multi-region-state-architecture.md
@@ -12,11 +12,13 @@
 > **Amendment (2026-06-13, #440).** Two parts of the original design were not built as
 > written — the as-implemented system diverges as follows:
 > - **Lifecycle healing is `TransitionPolicy`, not `ModeConfidence` thresholds.** The
->   confidence-threshold healing in §5.5/§5.8 was abandoned. Healing is now an
->   expected/unexpected transition classification plus commit graces (`TransitionPolicy`),
->   and in practice rides on the Offline→Online edge — there is no `ModeConfidence`
->   accumulator. (The expected/unexpected `outcomes` machinery is itself currently dormant —
->   no ruleset declares `outcomes` — see #439.)
+>   confidence-threshold healing in §5.5/§5.8 was abandoned. Healing rides on the
+>   Offline→Online edge plus commit graces (`TransitionPolicy`) — there is no `ModeConfidence`
+>   accumulator. (The expected/unexpected `outcomes` machinery once layered on top of this was
+>   flagged dormant — no ruleset ever declared `outcomes` — see #439, and **struck entirely by
+>   #715 (2026-07-07)**: `TransitionPolicy.classify()`, `TransitionKind`, and
+>   `PlatformRegion.lastTransitionKind` are gone. The Offline→Online healing edge itself never
+>   depended on that classification and is unaffected.)
 > - **A single set of steppers, not a per-platform stepper map.** `FlowRegionStepper` /
 >   `PlatformRegionStepper` / `CrossPlatformRegionStepper` are pure functions applied per
 >   region; the per-platform map of stepper instances described here was never built.

--- a/docs/rules.schema.json
+++ b/docs/rules.schema.json
@@ -307,12 +307,6 @@
         "mode": {
           "$ref": "#/$defs/modeEnum",
           "description": "v1 compat alias for 'modeHint'."
-        },
-        "outcomes": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/flowEnum" },
-          "uniqueItems": true,
-          "description": "Plausible next flows from this screen. Used for transition classification (expected vs. unexpected)."
         }
       }
     },

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/Observation.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/Observation.kt
@@ -46,8 +46,6 @@ sealed interface Observation : cloud.trotter.dashbuddy.domain.model.state.StateE
         val targets: Map<String, NodeRef>
         /** Per-trigger overrides that replace built-in transition defaults. */
         val transitionOverrides: Map<TransitionTrigger, List<RequestedEffect>>
-        /** Plausible next flows declared by the matched rule's `outcomes` field. */
-        val expectedOutcomes: Set<Flow>?
     }
 
     /** A screen classification from the accessibility window pipeline. */
@@ -63,7 +61,6 @@ sealed interface Observation : cloud.trotter.dashbuddy.domain.model.state.StateE
         override val effects: List<RequestedEffect> = emptyList(),
         override val targets: Map<String, NodeRef> = emptyMap(),
         override val transitionOverrides: Map<TransitionTrigger, List<RequestedEffect>> = emptyMap(),
-        override val expectedOutcomes: Set<Flow>? = null,
     ) : FlowObservation
 
     /** A click/tap event classified by the click pipeline. */
@@ -79,7 +76,6 @@ sealed interface Observation : cloud.trotter.dashbuddy.domain.model.state.StateE
         override val effects: List<RequestedEffect> = emptyList(),
         override val targets: Map<String, NodeRef> = emptyMap(),
         override val transitionOverrides: Map<TransitionTrigger, List<RequestedEffect>> = emptyMap(),
-        override val expectedOutcomes: Set<Flow>? = null,
         /** The last classified screen target when this click occurred. */
         val screenTarget: String? = null,
     ) : FlowObservation
@@ -97,7 +93,6 @@ sealed interface Observation : cloud.trotter.dashbuddy.domain.model.state.StateE
         override val effects: List<RequestedEffect> = emptyList(),
         override val targets: Map<String, NodeRef> = emptyMap(),
         override val transitionOverrides: Map<TransitionTrigger, List<RequestedEffect>> = emptyMap(),
-        override val expectedOutcomes: Set<Flow>? = null,
     ) : FlowObservation
 
     /** A timeout fired by the state machine's internal timer system. */

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/PlatformRegion.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/PlatformRegion.kt
@@ -32,7 +32,6 @@ data class PlatformRegion(
      * Replaces the former separate sessionGraceDeadline / taskClearGraceDeadline.
      */
     val pendingDestructive: PendingDestructive? = null,
-    val lastTransitionKind: TransitionKind? = null,
     val zoneName: String? = null,
     val sessionType: SessionType? = null,
     val ratings: RatingsSnapshot? = null,
@@ -190,24 +189,4 @@ enum class DestructiveKind {
 
     /** Retire the active task — a task flow gave way to idle/offer mid-delivery. */
     TASK_RETIRE,
-}
-
-/**
- * Classification of a mode transition for logging and lifecycle decisions.
- * Stored on [PlatformRegion.lastTransitionKind] so downstream (EffectMap)
- * can distinguish recovery starts from normal starts.
- *
- * This type lives in :domain so PlatformRegion can reference it without
- * depending on :core:state. The policy logic that produces these values
- * lives in TransitionPolicy (:core:state).
- */
-enum class TransitionKind {
-    /** Observation carries no mode signal. */
-    NoSignal,
-    /** Observation confirms the current mode — no change. */
-    Confirmed,
-    /** Mode change to a flow that was in the declared outcomes (or no outcomes). */
-    Expected,
-    /** Mode change to a flow NOT in the declared outcomes. */
-    Unexpected,
 }


### PR DESCRIPTION
Closes #715.

## Decision (already made on the issue)

Per #715's posted decision (dev + fable, 2026-07-07): **STRIP**. The `TransitionPolicy`
Expected/Unexpected classification was fully wired end-to-end (schema key → compiler →
`classify()` → two "live" consumers) but structurally dead: **zero rulesets in
`matchers/rules/` ever declared `outcomes`** (verified again on this branch), so
`TransitionKind.Unexpected` was unreachable in production and both of its downstream
readers always fell to their other arm.

## What changed

Using PR #713's evidence trail (item 3) as the site map:

- **`domain/.../pipeline/Observation.kt`** — removed `FlowObservation.expectedOutcomes`
  (+ the `Screen`/`Click`/`Notification` constructors).
- **`domain/.../state/PlatformRegion.kt`** — removed `lastTransitionKind` and the
  `TransitionKind` enum. No live consumer remained once the `ModeEffects` read (below)
  was struck, so per the bounded spec ("survives only if a live consumer remains") it's
  deleted rather than kept unused. `StateJson`'s existing `ignoreUnknownKeys = true` gives
  snapshot decode-compat for free — no explicit default-plumbing needed for old snapshots
  that still carry the field.
- **`core/pipeline/.../rules/RuleCompiler.kt`, `CompiledRules.kt`, `Ruleset.kt`,
  `ObservationClassifier.kt`** — removed the `outcomes` schema key parsing
  (`ParsedStateBlock.outcomes`), `CompiledBranch.outcomes`, `RuleMatchResult.outcomes`,
  and the `expectedOutcomes = result.outcomes` wiring at all three classify sites
  (screen/click/notification).
- **`docs/rules.schema.json`** — removed the `outcomes` property from `stateBlock`.
- **`core/state/.../TransitionPolicy.kt`** — removed `classify()` entirely (its only
  purpose was producing `TransitionKind`, which no longer exists).
- **`core/state/.../PlatformRegionStepper.kt`** — `applyModeTransition`/`commitModeResume`/
  `handleTimeout` no longer thread a `kind` param. The `else` branch's healing-lifecycle
  gate drops its now-redundant `kind == TransitionKind.Unexpected ||` disjunct — **the
  Offline→Online edge (the one live healing path) is untouched**, only the
  never-true disjunct is gone.
- **`core/state/.../ModeEffects.kt`** — the `SessionStartSource.RECOVERY` read
  (`next.lastTransitionKind == TransitionKind.Unexpected ? RECOVERY : INTERACTION`)
  always evaluated to `INTERACTION` in practice; replaced with the unconditional value.
  `SessionStartSource.RECOVERY` itself (the wire-value constant, and the generic
  "duplicate DASH_START must not clobber" fold logic in `RecordFolds`/`AnalyticsProjector`
  that the constant's doc-comments illustrate) is **out of scope** — it's not what the
  bounded spec named, and it's still a legitimate general-purpose wire value with no
  dependency on the struck classification.
- Test updates: `TransitionPolicyTest` drops the whole `classify` test section (the
  method it tested is gone); `StateMachineTest` drops the `lastTransitionKind`-specific
  test and re-titles the "unexpected transition" test to describe what it actually now
  exercises (the Offline→Online healing edge, still green, unaffected by the strip).
- **`CLAUDE.md`** (`:core:state` bullet) and **`docs/adr/ADR-0005-...md`** (the
  2026-06-13 amendment note) updated to drop the stale "expected/unexpected
  classification" framing and record the strike-out.

## Hard boundaries respected

- `pendingDestructive`/grace machinery: untouched.
- No rule JSON edits: confirmed zero rules anywhere declare `outcomes`.
- No new platform literals or logic changes to the live Offline→Online healing edge.

## Deviations / notes

- Per the bounded spec's conditional ("`lastTransitionKind` survives ONLY if a live
  consumer remains"), I deleted the field rather than keeping it dormant — confirmed via
  grep that its one production reader (the `ModeEffects` RECOVERY ternary) was the only
  one, and that reader is itself being struck. This is the more thorough of the two
  readings the spec allowed for; flagging in case the intent was to keep the field/enum
  shell for a future re-use.
- Left `SessionStartSource.RECOVERY` (the domain wire-value constant) and the
  `RecordFolds`/`SessionFoldContext`/`AnalyticsProjector` "duplicate DASH_START" fold
  logic untouched — that logic doesn't gate on the literal `RECOVERY` value (it handles
  ANY duplicate DASH_START for an already-started session, regardless of source), so it's
  a general mechanism, not a dependent of the struck classification. Not named in the
  bounded spec's strip list, so treated as out of scope.

### Design-goal review

- **P5 (SSOT)** — this is a pure deletion of a hand-maintained-but-unreachable second
  classification path; nothing is now derived from two places. `TransitionPolicy` still
  owns mode resolution (`resolveMode`) and grace timing exclusively.
- **P4 (Kotlin/Android practices)** — deletions keep named-argument construction
  idiomatic; no behavior change for any reachable path (`Unexpected` was never reachable),
  confirmed by the full green test run below.
- **P3 (single responsibility)** — `TransitionPolicy`/`PlatformRegionStepper` both get
  smaller and lose a branch that could never fire.
- **P8 (platform-agnostic core)** — this diff touches `:core:state`/`:core:pipeline`/
  `:domain`. No new platform literals introduced; nothing here was ever platform-keyed
  (the classification was global-per-region), and its removal doesn't change that.
- No UDF/Reactive-UI/security-relevant surface touched (no new I/O, no rule/capture
  behavior change — the schema key removal only prevents authoring a field that was
  already inert; existing rule JSON never used it).

### Test results

`JAVA_HOME=/usr/lib/jvm/java-25 ./gradlew testDebugUnitTest :domain:test` —
**BUILD SUCCESSFUL**, all modules (domain, core:pipeline, core:state, core:data,
core:database, core:datastore, core:network, app). No test disabled/skipped; the
tests that exercised the struck `classify()` method were removed along with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Adversarial review

Reviewed at the session top tier (Fable) against the full diff, 2026-07-07. This PR touches `:core:state`/`:domain`/rule schema, so the P8 walk is mandatory — done below.

**Dormancy premises independently re-verified (not taken from the author):**
- `grep` of `matchers/rules/` for `outcomes`: **zero declarations** in any JSON5 source — `classify()` could only return `Unexpected` when a matched rule declared `outcomes`, so `Unexpected` was structurally unreachable. Both struck consumers were therefore dead: the healing-gate disjunct (`kind == Unexpected ||`) never fired, and the `ModeEffects` ternary always evaluated to `INTERACTION`.
- The one behavior-adjacent judgment call — deleting the `SessionStartSource.RECOVERY` producer — is safe: every `startSource` read site (`RecordFolds` 294/311/325, `AnalyticsProjector` 454/494) only null-checks or passes it through; nothing compares against the `RECOVERY` literal. The constant stays defined for the read side; historical rows keep whatever they recorded (which was always `interaction` anyway).
- Snapshot decode compat for the deleted `PlatformRegion.lastTransitionKind` field: `StateJson` sets `ignoreUnknownKeys = true`, so pre-#715 persisted snapshots decode cleanly. The outright deletion (vs a dormant shell) is the right call.
- The Offline→Online healing edge is intact — the surviving `if (current.mode == Mode.Offline && impliedMode == Mode.Online)` is byte-equivalent to the old gate given premise 1, and the retained `app restart mid-task synthesizes lifecycle` test still pins it.
- Schema: `outcomes` removed from the main schema's state block; the fragment schema `$ref`s the main `$defs`, so editors inherit the removal with no second edit (SSOT). A future rule declaring `outcomes` now fails loud at compile rather than silently no-oping — the correct posture for a struck feature.

**Design principles:** P5 (SSOT) — net improvement: a dead parallel vocabulary (schema key → compiler → observation field → region field → two readers) is removed end-to-end rather than left half-wired. P8 — no platform literals introduced; the diff is platform-neutral deletions. Docs updated in-PR (CLAUDE.md `:core:state` blurb + ADR-0005 amendment) per the context-update rule. No log-site changes (P7 n/a); no recognition/capture/network surface (P6 n/a).

**Findings:** none blocking; nothing worth a follow-up issue.

Verdict: **clean — approved for merge on green CI.**
