### PR TITLE
fix(#722/#693): idle card (gas quick-edit) reachable when offline with a prior session

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleScreen.kt
@@ -211,7 +211,14 @@ fun DashboardView(
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
         when {
-            cardStack.isEmpty && (region == null || region.mode == Mode.Offline) -> {
+            // Idle/offline with no ACTIVE dash → the idle dashboard card (gas/vehicle
+            // just-in-time actions + last-session summary). Keyed on `active == null`, NOT
+            // `cardStack.isEmpty`: a completed session's timeline (non-active cards) must not
+            // suppress the idle card, or the gas quick-edit becomes unreachable after the first
+            // dash — `displayedSessionId` falls back to the most-recent session forever, so the
+            // stack is never empty again (#722/#693 reachability). The full completed timeline
+            // still shows while actively dashing and via the analytics drill-down.
+            (region == null || region.mode == Mode.Offline) && cardStack.active == null -> {
                 Card(
                     modifier = Modifier.fillMaxWidth(),
                     colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -87,6 +87,9 @@ was found **broken-in-part** (raw PII in capture envelopes) and moved to that en
   - Confirmed: 0/2
   - Desk replay fixture: `~/dashbuddy/logs/2026/07/06/` (the 07-05 $0 session `session-doordash-1783294721320-15`).
 - **🆕 NEW — bubble gas quick-edit is mode-adaptive: refresh (AUTO) vs. Resume auto (MANUAL) (#722 / PR).**
+  **Where to find it:** the idle dashboard card, shown whenever OFFLINE with no active dash (the
+  #722/#693 reachability fix — a completed session's timeline no longer hides it; the full timeline
+  now appears only while actively dashing, plus in the analytics drill-down).
   The idle card's gas control now shows ONE control set per mode instead of a stepper+refresh combo, because
   each action's meaning flips with mode. **AUTO mode:** price + "AUTO" caption + a refresh icon (no stepper
   visible) — tapping refresh fetches today's EIA price and stays auto (price updates in place, no mode


### PR DESCRIPTION
## Summary

The bubble's gas quick-edit (#722) lives in `ModeIdle → JustInTimeActions`, but `DashboardView` only rendered `ModeIdle` when `cardStack.isEmpty`. Since `displayedSessionId` falls back to the most-recent session forever (`BubbleViewModel`), the card stack is never empty again after the first-ever dash — so the idle card, and the gas control with it, was **unreachable** on any real device (found on-device 07-07: the expanded offline bubble showed only the completed session's timeline). Pre-existing from #693's most-recent-session fallback, exposed by #722.

**Fix (dev-chosen direction: "idle card wins when not actively dashing"):** key the idle branch on `(region == null || mode == Offline) && cardStack.active == null` instead of `cardStack.isEmpty`. Offline with no active dash → idle card (gas/vehicle just-in-time actions + last-session summary, which `ModeIdle` already carries). The full completed timeline still renders while actively dashing (any active card, or online with history) and in the analytics drill-down. An active job restored by crash recovery while screens read offline still takes the timeline branch (active card visible) — correct.

Verified on-device 07-07 (screenshot: idle card + AUTO-mode gas control render offline with a prior session present). Also points the #722 field-testing checklist item at where the control now lives.

### Design-goal review

- **Reactive UI:** pure state-derived branch condition; no new time-derived values; the idle card's contents were already reactive (#693).
- **P1 UDF:** display-only gating; no writes, no state-machine change.
- **P8:** no platform literals; `region.mode` is the platform-agnostic mode enum.

### Adversarial review

Reviewed at the session top tier (Fable), 2026-07-09. Branch-reachability walk: offline+no-active → idle card (the fix); online+empty stack → waiting text; active card present (incl. crash-recovery-restored job under offline screens) → timeline — all correct. The accepted tradeoff (completed timeline not visible while offline) is the dev's explicit choice, recorded here. No tests added: Compose-branch condition with no UI-test infra in repo (known, #726); logic is a single boolean predicate, device-verified. Verdict: **clean — merge on green CI.**
