### PR TITLE
feat(#501): recognize-only GoPuff zone-arrival rule (item 3)

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/GoPuffRecognitionTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/GoPuffRecognitionTest.kt
@@ -50,4 +50,55 @@ class GoPuffRecognitionTest {
         assertEquals("pickup_barcode_scan_issue", r?.intent)
         assertNull("a mid-pickup sub-screen must not change phase", r?.flow)
     }
+
+    /**
+     * #501 item 3 — the GoPuff (Drive) zone-arrival CTA card, recognize-only (dev decision
+     * 2026-07-07): no parse, no state.flow — nav is already established before this frame
+     * appears, and its button is an affordance, not the arrival anchor (`pickup_steps`'s
+     * bin-scan branch owns the one PICKUP_ARRIVED). Unlike the other GoPuff #501 fixtures, no
+     * raw device capture for this screen made it into `snapshots/INBOX/` before this build —
+     * the anchors below (`go_to_store_action_view` id + the "Navigate to zone"/"Arrived at
+     * store" button-label text) are the grounded, verbatim-cited strings from issue #501's
+     * 2026-06-15 deep-dive over the real 2026-06-14 captures, not a fabricated screen. This
+     * hand-built minimal tree exercises the rule's actual predicate logic (same
+     * `Ruleset.matchFirst` entry point as a loaded snapshot); it is intentionally NOT filed
+     * under `snapshots/` since it isn't a captured device tree. `pickup_zone_arrival` is
+     * pinned in `ParseOutputGoldenTest.knownUncoveredIntents` until a real capture lands.
+     */
+    @Test
+    fun `the GoPuff zone-arrival CTA recognizes without changing phase (#501 item 3)`() {
+        val node = UiNode(
+            children = listOf(
+                UiNode(text = "2 orders • 3 items total"),
+                UiNode(
+                    viewIdResourceName = "com.doordash.driverapp:id/go_to_store_action_view",
+                    text = "Navigate to zone",
+                    isClickable = true,
+                    isEnabled = true,
+                ),
+            ),
+        ).restoreParents()
+
+        val r = rules.matchFirst(node)
+        assertEquals("pickup_zone_arrival", r?.intent)
+        assertNull("the zone-arrival CTA is recognize-only — it must not perturb the pickup phase", r?.flow)
+    }
+
+    @Test
+    fun `the GoPuff zone-arrival CTA also recognizes once its label flips to Arrived at store (#501 item 3)`() {
+        val node = UiNode(
+            children = listOf(
+                UiNode(
+                    viewIdResourceName = "com.doordash.driverapp:id/go_to_store_action_view",
+                    text = "Arrived at store",
+                    isClickable = true,
+                    isEnabled = true,
+                ),
+            ),
+        ).restoreParents()
+
+        val r = rules.matchFirst(node)
+        assertEquals("pickup_zone_arrival", r?.intent)
+        assertNull("the zone-arrival CTA is recognize-only — it must not perturb the pickup phase", r?.flow)
+    }
 }

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/GoPuffRecognitionTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/GoPuffRecognitionTest.kt
@@ -5,13 +5,16 @@ import cloud.trotter.dashbuddy.domain.state.Flow
 import cloud.trotter.dashbuddy.test.util.TestResourceLoader
 import cloud.trotter.dashbuddy.test.util.TestRulesetFactory
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 import java.io.File
 
 /**
- * #501 — the GoPuff (DoorDash Drive) warehouse batch-pickup screens, recognized as BRANCHES of the
- * existing pickup rules, run against the real (redacted) 2026-06-14 capture frames.
+ * #501 — the GoPuff (DoorDash Drive) warehouse batch-pickup screens. The original three (bin-scan
+ * steps, wait survey, barcode failure) are BRANCHES of existing pickup rules, run against the real
+ * (redacted) 2026-06-14 capture frames; the item-3 zone-arrival intent (below) is a STANDALONE
+ * recognize-only rule exercised via hand-built trees until a real capture lands in the corpus.
  *
  * The load-bearing assertion: the **bin-scan steps** screen mints the batch's single
  * `PICKUP_ARRIVED`. The whole warehouse leg was otherwise all-UNKNOWN, so no arrival ever fired and
@@ -57,48 +60,100 @@ class GoPuffRecognitionTest {
      * appears, and its button is an affordance, not the arrival anchor (`pickup_steps`'s
      * bin-scan branch owns the one PICKUP_ARRIVED). Unlike the other GoPuff #501 fixtures, no
      * raw device capture for this screen made it into `snapshots/INBOX/` before this build —
-     * the anchors below (`go_to_store_action_view` id + the "Navigate to zone"/"Arrived at
-     * store" button-label text) are the grounded, verbatim-cited strings from issue #501's
-     * 2026-06-15 deep-dive over the real 2026-06-14 captures, not a fabricated screen. This
-     * hand-built minimal tree exercises the rule's actual predicate logic (same
-     * `Ruleset.matchFirst` entry point as a loaded snapshot); it is intentionally NOT filed
-     * under `snapshots/` since it isn't a captured device tree. `pickup_zone_arrival` is
-     * pinned in `ParseOutputGoldenTest.knownUncoveredIntents` until a real capture lands.
+     * the anchor strings are the grounded, verbatim-cited strings from issue #501's 2026-06-15
+     * deep-dive over the real 2026-06-14 captures, not a fabricated screen. The fixture mirrors
+     * the REAL tree shape from the committed pre-arrival corpus (the same CTA widget): the
+     * `go_to_store_action_view` node is a text-less container and the label lives two levels
+     * down (`primary_action_button` > `textView_prism_button_title`) — which is why the rule's
+     * two require clauses are independent tree-wide exists, a property the fall-through tests
+     * below pin from the reject side. Hand-built trees exercise the rule's actual predicate
+     * logic (same `Ruleset.matchFirst` entry point as a loaded snapshot); they are intentionally
+     * NOT filed under `snapshots/` since they aren't captured device trees. `pickup_zone_arrival`
+     * is pinned in `ParseOutputGoldenTest.knownUncoveredIntents` until a real capture lands.
+     *
+     * NOTE the anchors are NOT GoPuff-unique (every regular pickup_pre_arrival tree carries the
+     * id + a descendant 'Arrived at store'): a full regular pre-arrival frame is kept out of
+     * this rule by priority order (71 first), and a DEGRADED regular frame — one that fails
+     * 71's 'Pickup from' conjunct — is kept out by the rule's rejects (customer-card ids,
+     * 'Return to dash'), so it falls to UNKNOWN instead of a redact-less recognized capture.
      */
-    @Test
-    fun `the GoPuff zone-arrival CTA recognizes without changing phase (#501 item 3)`() {
-        val node = UiNode(
+    private fun zoneArrivalCta(label: String): UiNode =
+        UiNode(
+            viewIdResourceName = "com.doordash.driverapp:id/go_to_store_action_view",
             children = listOf(
-                UiNode(text = "2 orders • 3 items total"),
                 UiNode(
-                    viewIdResourceName = "com.doordash.driverapp:id/go_to_store_action_view",
-                    text = "Navigate to zone",
+                    viewIdResourceName = "com.doordash.driverapp:id/primary_action_button",
                     isClickable = true,
                     isEnabled = true,
+                    children = listOf(
+                        UiNode(
+                            viewIdResourceName = "com.doordash.driverapp:id/textView_prism_button_title",
+                            text = label,
+                        ),
+                    ),
                 ),
             ),
+        )
+
+    private fun zoneArrivalTree(label: String, vararg siblings: UiNode): UiNode =
+        UiNode(
+            children = listOf(UiNode(text = "2 orders • 3 items total")) + siblings + zoneArrivalCta(label),
         ).restoreParents()
 
-        val r = rules.matchFirst(node)
+    @Test
+    fun `the GoPuff zone-arrival CTA recognizes without changing phase (#501 item 3)`() {
+        val r = rules.matchFirst(zoneArrivalTree("Navigate to zone"))
         assertEquals("pickup_zone_arrival", r?.intent)
         assertNull("the zone-arrival CTA is recognize-only — it must not perturb the pickup phase", r?.flow)
     }
 
     @Test
     fun `the GoPuff zone-arrival CTA also recognizes once its label flips to Arrived at store (#501 item 3)`() {
-        val node = UiNode(
+        val r = rules.matchFirst(zoneArrivalTree("Arrived at store"))
+        assertEquals("pickup_zone_arrival", r?.intent)
+        assertNull("the zone-arrival CTA is recognize-only — it must not perturb the pickup phase", r?.flow)
+    }
+
+    @Test
+    fun `a degraded regular pickup frame with a customer card must NOT fall through to the zone rule (#501 item 3)`() {
+        // A regular pre-arrival tree whose 'Pickup from' header drifted (fails rule 71's
+        // conjunct) but whose CTA + customer card survive. Without the reject this would land
+        // on the redact-less zone rule and a raw customer name could persist in a recognized
+        // capture (the split-node shape CustomerTextMarkers documents as rule-redact-only).
+        val degraded = UiNode(
             children = listOf(
                 UiNode(
-                    viewIdResourceName = "com.doordash.driverapp:id/go_to_store_action_view",
-                    text = "Arrived at store",
-                    isClickable = true,
-                    isEnabled = true,
+                    viewIdResourceName = "com.doordash.driverapp:id/user_name_label",
+                    text = "Heading to Walgreens",
                 ),
+                UiNode(
+                    viewIdResourceName = "com.doordash.driverapp:id/user_name",
+                    text = "Jane D",
+                ),
+                zoneArrivalCta("Arrived at store"),
             ),
         ).restoreParents()
 
-        val r = rules.matchFirst(node)
-        assertEquals("pickup_zone_arrival", r?.intent)
-        assertNull("the zone-arrival CTA is recognize-only — it must not perturb the pickup phase", r?.flow)
+        val r = rules.matchFirst(degraded)
+        assertNotEquals(
+            "a frame carrying a customer card must never classify as the redact-less zone rule",
+            "pickup_zone_arrival",
+            r?.intent,
+        )
+    }
+
+    @Test
+    fun `an expanded mid-pickup map keeps on_dash_map and its online modeHint (#501 item 3)`() {
+        // 106 evaluates before on_dash_map (110); the 'Return to dash' reject keeps a map frame
+        // that still mounts the pickup CTA sheet with the mode-hint-bearing rule.
+        val mapWithCta = UiNode(
+            children = listOf(
+                UiNode(text = "Return to dash"),
+                zoneArrivalCta("Arrived at store"),
+            ),
+        ).restoreParents()
+
+        val r = rules.matchFirst(mapWithCta)
+        assertEquals("on_dash_map", r?.intent)
     }
 }

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/ParseOutputGoldenTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/ParseOutputGoldenTest.kt
@@ -188,6 +188,12 @@ class ParseOutputGoldenTest {
         "pickup_verification_items",
         "pickup_verification_pin",
         "pickup_verify",
+        // #501 item 3 — GoPuff (Drive) zone-arrival, recognize-only (dev decision 2026-07-07).
+        // Anchors are grounded (verbatim from issue #501's 2026-06-15 deep-dive over the real
+        // 06-14 captures), but the raw capture JSON itself was never committed to
+        // snapshots/INBOX before this build — only GoPuffRecognitionTest's hand-built UiNode
+        // covers it today. Shrink this when a real device capture lands in the corpus.
+        "pickup_zone_arrival",
         "safety",
         "shop_and_pay_checkout",
         "shop_and_pay_list",

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/ParseOutputGoldenTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/ParseOutputGoldenTest.kt
@@ -189,10 +189,12 @@ class ParseOutputGoldenTest {
         "pickup_verification_pin",
         "pickup_verify",
         // #501 item 3 — GoPuff (Drive) zone-arrival, recognize-only (dev decision 2026-07-07).
-        // Anchors are grounded (verbatim from issue #501's 2026-06-15 deep-dive over the real
-        // 06-14 captures), but the raw capture JSON itself was never committed to
+        // Anchor strings are grounded (verbatim from issue #501's 2026-06-15 deep-dive over the
+        // real 06-14 captures), but the raw capture JSON itself was never committed to
         // snapshots/INBOX before this build — only GoPuffRecognitionTest's hand-built UiNode
-        // covers it today. Shrink this when a real device capture lands in the corpus.
+        // covers it today. NOTE the anchors are NOT GoPuff-unique (every regular
+        // pickup_pre_arrival tree carries them); the rule leans on priority order + its rejects,
+        // so a real capture matters doubly here. Shrink this when one lands in the corpus.
         "pickup_zone_arrival",
         "safety",
         "shop_and_pay_checkout",

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -73,6 +73,19 @@ card's **mechanical** half, #577 (re-confirmed, 24/24, ~0.55 s — with a new po
 that entry's Bug #1), the #457 path, and #554 ShadowProjector (2/2). The #462/#460 dropoff item
 was found **broken-in-part** (raw PII in capture envelopes) and moved to that entry's Bug #7.)_
 
+- **🆕 NEW — GoPuff zone-arrival screens recognized (recognize-only, no state effect) (#501 item 3 / PR #738).**
+  The GoPuff "Navigate to zone" / "Arrived at store" screens (the `go_to_store_action_view` CTA card)
+  are now recognized as `pickup_zone_arrival` instead of landing in UNKNOWN. **How to tell it's working
+  on a GoPuff (DoorDash Drive) run:** after the dash, the zone-arrival frames should NOT appear in the
+  UNKNOWN capture folder (they were ~15 frames/session of UNKNOWN noise on 06-14), AND the bin-scan
+  "Pickup steps" screen must still be the one-and-only `PICKUP_ARRIVED` anchor (exactly one arrival per
+  warehouse visit — the new rule is recognize-only and must not steal or duplicate it). A zone-arrival
+  frame still hitting UNKNOWN, or a second/missing pickup arrival, is a regression. Rule was built from
+  hand-cited anchors (the 06-14 captures were never committed), so a live GoPuff sighting doubles as the
+  first real-frame validation — grab a capture either way. **Also spot-check the captures LABELED
+  `pickup_zone_arrival` are actually zone screens** (the anchors are shared with regular pickups; a
+  regular pre-arrival or map frame tagged as zone-arrival is the over-match regression, not a pass).
+  - Confirmed: 0/2
 - **🆕 NEW — bubble post-dash card shows the TRUE last session + gas/vehicle quick actions (#693 / PR).**
   The idle bubble card now reads the analytics read-model (`recentSessions(1)`) instead of an in-memory
   capture that could miss a dash. **Primary check — the $0 repro:** end a dash that earned nothing (accept

--- a/matchers/rules/doordash/pickup.json5
+++ b/matchers/rules/doordash/pickup.json5
@@ -695,6 +695,32 @@
       }
     },
     {
+      "comment": "#501 item 3 — GoPuff (Drive) zone-arrival screen (the CTA card between pickup-nav and the bin-scan steps; its button label reads 'Navigate to zone' before entry and 'Arrived at store' once in range). Dev decision 2026-07-07: RECOGNIZE-ONLY, no parse, no state.flow — nav is already established by pickup_navigation/pickup_pre_arrival before this frame appears, and 'Arrived at store' here is an affordance, not the arrival anchor (pickup_steps' bin-scan branch owns the one PICKUP_ARRIVED). This rule's only job is pulling the recurring zone-arrival UNKNOWN captures into a named intent. Keyed on the GoPuff-specific CTA id (`go_to_store_action_view`, not shared with any other DoorDash screen — the unrelated idle `dash_along_the_way` card also carries 'Navigate to zone' text but never this id) plus either button-label text. No PII: the CTA and its label are not customer data.",
+      "id": "doordash.screen.pickup_zone_arrival",
+      "priority": 106,
+      "require": {
+        "all": [
+          {
+            "exists": {
+              "hasIdSuffix": "go_to_store_action_view"
+            }
+          },
+          {
+            "exists": {
+              "any": [
+                {
+                  "hasTextContaining": "Navigate to zone"
+                },
+                {
+                  "hasTextContaining": "Arrived at store"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
       "id": "doordash.screen.pickup_qr_confirm",
       "priority": 53,
       "require": {

--- a/matchers/rules/doordash/pickup.json5
+++ b/matchers/rules/doordash/pickup.json5
@@ -695,9 +695,26 @@
       }
     },
     {
-      "comment": "#501 item 3 — GoPuff (Drive) zone-arrival screen (the CTA card between pickup-nav and the bin-scan steps; its button label reads 'Navigate to zone' before entry and 'Arrived at store' once in range). Dev decision 2026-07-07: RECOGNIZE-ONLY, no parse, no state.flow — nav is already established by pickup_navigation/pickup_pre_arrival before this frame appears, and 'Arrived at store' here is an affordance, not the arrival anchor (pickup_steps' bin-scan branch owns the one PICKUP_ARRIVED). This rule's only job is pulling the recurring zone-arrival UNKNOWN captures into a named intent. Keyed on the GoPuff-specific CTA id (`go_to_store_action_view`, not shared with any other DoorDash screen — the unrelated idle `dash_along_the_way` card also carries 'Navigate to zone' text but never this id) plus either button-label text. No PII: the CTA and its label are not customer data.",
+      "comment": "#501 item 3 — GoPuff (Drive) zone-arrival screen (the CTA card between pickup-nav and the bin-scan steps; its button label reads 'Navigate to zone' before entry and 'Arrived at store' once in range). Dev decision 2026-07-07: RECOGNIZE-ONLY, no parse, no state.flow — nav is already established before this frame appears, and 'Arrived at store' here is an affordance, not the arrival anchor (pickup_steps' bin-scan branch owns the one PICKUP_ARRIVED). This rule's only job is pulling the recurring zone-arrival UNKNOWN captures into a named intent. CAUTION — the anchors are NOT GoPuff-unique: `go_to_store_action_view` (+ a descendant 'Arrived at store' label) is on EVERY regular pickup_pre_arrival tree in the corpus, so a full regular pre-arrival frame is kept out of this rule only by priority order (71 evaluates first). The rejects are therefore load-bearing: a degraded/partial regular pickup frame that fails 71's 'Pickup from' conjunct must NOT fall through to this redact-less rule (its customer card — user_name_label/customer_name_label with a raw-name sibling — is exactly the split-node shape the CustomerTextMarkers backstop documents as rule-redact-only), and a mid-pickup expanded map must stay with on_dash_map (110, modeHint online) rather than be stolen by 106. The two require clauses are deliberately independent tree-wide exists — on the real tree the id node is a text-less ViewGroup and the label lives two levels down (primary_action_button > textView_prism_button_title), so a same-node compound would never match a device frame. The idle dash_along_the_way card shares 'Navigate to zone' text but never this id (corpus-verified).",
       "id": "doordash.screen.pickup_zone_arrival",
       "priority": 106,
+      "reject": [
+        {
+          "exists": {
+            "hasIdSuffix": "user_name_label"
+          }
+        },
+        {
+          "exists": {
+            "hasIdSuffix": "customer_name_label"
+          }
+        },
+        {
+          "exists": {
+            "hasText": "Return to dash"
+          }
+        }
+      ],
       "require": {
         "all": [
           {


### PR DESCRIPTION
Implements **item 3 of #501** — the recognize-only GoPuff (Drive) zone-arrival rule, per the dev decision of 2026-07-07 on the issue ("re-scoped to RECOGNIZE-ONLY … a cheap structural match (the `pickup_wait_survey` precedent) whose only job is silencing the recurring UNKNOWN captures"). **#501 stays OPEN** — items 1–2 (the SnapshotRedactor id-less-name fix and the dropoff multi-order-confirm rule) are a separate, higher-tier build.

## What was added

- **`doordash.screen.pickup_zone_arrival`** (priority 106, screens section) in `matchers/rules/doordash/pickup.json5` — the GoPuff zone-arrival CTA card that sits between pickup-nav and the bin-scan steps. `require`: the GoPuff-specific `go_to_store_action_view` id **AND** either button label (`Navigate to zone` / `Arrived at store`). The id anchor is load-bearing for disambiguation: the unrelated **idle** `dash_along_the_way` card (priority 111) also carries "Navigate to zone" text but ships no viewIds / never this id, so the two rules cannot collide.
- **Recognize-only, structurally:** no `parse`, no `state` block, no `bind`, no effects. It cannot steal or emit `task:pickup:arrived` — the `pickup_steps` bin-scan branch (PR #530) remains the batch's single arrival anchor, and nav is already established by `pickup_navigation`/`pickup_pre_arrival` before this frame appears. The "Arrived at store" label here is an affordance, not the arrival.
- **Tests:** two new cases in `GoPuffRecognitionTest` (one per button-label state) assert `intent == "pickup_zone_arrival"` and `flow == null` through the production ruleset (`TestRulesetFactory.screenRuleset.matchFirst`).
- **`ParseOutputGoldenTest.knownUncoveredIntents`** gains `pickup_zone_arrival` (with a shrink-me comment) — see snapshot coverage below.

## Snapshot coverage (honest accounting)

The 06-14 GoPuff session's zone-arrival UNKNOWN captures were **never committed to the repo** (`snapshots/INBOX/` and `UNKNOWN/` are gitignored staging, and no zone-arrival frame graduated into a golden folder — verified across all git refs). Rather than fabricate a fake "captured" fixture, coverage is:

- Two **hand-built minimal `UiNode` trees** in `GoPuffRecognitionTest` (the existing `ScreenRulesetTest`/`TriageRulesTest` pattern), built from the **grounded, verbatim-cited anchors** in #501's 2026-06-15 deep-dive over the real 06-14 captures (`go_to_store_action_view` · `Navigate to zone` · `Arrived at store` · `N orders/M items total`). They exercise the same `Ruleset.matchFirst` entry point a loaded snapshot does.
- The intent is pinned in `knownUncoveredIntents` (the ratchet the corpus workflow already uses for exactly this situation) so the gap is visible and may only shrink — when the developer drops a real zone-arrival capture into `INBOX/`, `InboxProcessorTest` will sort it into `pickup_zone_arrival/`, and the pin gets deleted.
- `InboxProcessorTest` was not run: `INBOX/` does not exist in this worktree (no new raw captures were added), so there is nothing to sort.

## Security / privacy posture (principle 6)

- **Untrusted input:** the rule is pure data through the existing bounded `RuleCompiler` path; no engine/loader changes.
- **No PII surface:** the matched anchors are a widget id and two CTA labels — no customer name/address, no parse, so nothing is read into typed fields and nothing needs `redact` (compile-time rule: `redact` is only mandated when a rule `sha256`-hashes PII; this rule parses nothing).
- **No sensitive downgrade:** priority 106 is `overrideable` (default) and sits far above the priority-0 non-overrideable `sensitive.known` partition; the zone-arrival CTA is a pickup-logistics surface, not a dasher-sensitive or document-image capture surface.
- **No actuation:** no target bindings, no effects, no clicks.
- **Net effect on capture volume:** frames that previously hit disk as UNKNOWN captures (debug builds) now recognize and stop being captured — a strict reduction in what's persisted.

## Test results

`JAVA_HOME=/usr/lib/jvm/java-25 ./gradlew :app:testDebugUnitTest --tests "*AllMatchersSuite*" --tests "*GoPuffRecognitionTest*"` — **BUILD SUCCESSFUL, 606 tests, 0 failures** across the suite (GoldenSnapshotRegressionTest, ParseOutputGoldenTest, ScreenRulesetTest, TriageRulesTest, CaptureRedactionCorpusTest, CaptureBackstopCorpusTest, …) plus all 5 GoPuffRecognitionTest cases. **Parse-output golden unchanged** (expected: recognize-only, no parse, no corpus snapshot) — no regeneration needed. Canonicalizer (`:core:pipeline:importMatchersRules`) merges the sub-file cleanly; the generated `assets/rules/doordash.json` carries the new rule with no duplicate id/priority (screen-section priorities verified unique).

## Design-goal review

- **P5 (SSOT):** recognition change is one rule in the JSON5 source of truth — no Kotlin matcher, no duplicated anchor strings (the test cites the same literals the rule declares, which is the corpus-test pattern, not a divergence).
- **P6 (security & privacy):** see posture above — recognize-only, parse-less, PII-less, actuation-less; strictly reduces UNKNOWN capture volume.
- **P8 (platform-agnostic core):** zero `:core:state`/`:core:pipeline`/`:domain` logic edits — the change is ruleset data plus tests. No new platform literals in logic; no new rule↔state vocabulary (the rule declares none). The only non-data edits are test files (a corpus-ratchet pin and rule-level tests).
- **P1/P2/Reactive UI:** untouched (no state machine, UI, or async changes).
- Honest deviation, stated per CLAUDE.md: the "golden-corpus folder == intent" convention is not satisfied for this intent because the raw captures were never committed; covered instead by hand-built-tree tests + the `knownUncoveredIntents` ratchet (the mechanism that exists for exactly this). No fixture was fabricated to fake a device capture.

## Field-test note

The reviewer/merger should add a `## Next field test — things to look for` item (Confirmed: 0/2): on the next GoPuff (Drive) batch, the zone-arrival card ("Navigate to zone" → "Arrived at store") should stop producing UNKNOWN captures and log as `pickup_zone_arrival`, while the bin-scan steps screen still mints exactly one PICKUP_ARRIVED. Ideally also drop one real zone-arrival capture into `INBOX/` so the corpus pin can be retired.

#501 remains open for items 1–2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

### Adversarial review (Fable-tier, 2026-07-09)

8 finder angles (correctness ×3, cleanup ×3, altitude, conventions) + verify pass over the deduped candidates. One real defect cluster found and **fixed in-branch** (commit `602f7ff4`); remaining candidates triaged below.

**CONFIRMED — anchors not GoPuff-unique (corpus-proven).** All 15 committed regular `pickup_pre_arrival` snapshots carry `go_to_store_action_view` with a descendant "Arrived at store" label, contradicting the rule comment's uniqueness claim (repeated in the test KDoc + golden pin). Consequences fixed:
- *Drift-masking / silent absorption:* a regular pre-arrival frame failing rule 71's `Pickup from` conjunct (label drift, partial content-changed tree) would classify as the zone intent instead of surfacing in UNKNOWN triage.
- *PLAUSIBLE, pledge-class — redaction downgrade:* such a fall-through frame can carry the split-node customer card (`user_name_label` label + bare-name sibling), which the CustomerTextMarkers SSOT documents as **rule-redact-only** — and this rule declares no `redact`. A raw customer name could persist in a recognized debug capture (#598 defect class).
- *PLAUSIBLE — `on_dash_map` preemption:* at 106 < 110, a mid-pickup expanded map still mounting the CTA sheet would lose its screen-authoritative `modeHint: online`.

**Fix:** three `reject` predicates (`user_name_label`, `customer_name_label`, `Return to dash`) — degraded pickup frames now fall to UNKNOWN (where the UNKNOWN scrub path governs), map frames keep `on_dash_map`. Truthful comments at all three claim sites. Two new reject-guard regression tests.

**CONFIRMED — test fixtures modeled the wrong tree shape.** The real CTA node is a text-less ViewGroup; the label lives at `primary_action_button > textView_prism_button_title`. The original same-node fixtures would stay green under a predicate-merge edit that never matches a device frame. **Fix:** fixtures rebuilt to the corpus shape via a shared `zoneArrivalCta()` helper (also collapses the copy-paste the cleanup angle flagged); class KDoc corrected (zone rule is standalone + hand-built, not a branch + capture).

**Process fix:** the required field-test checklist item was stranded uncommitted in the working tree — now committed on the branch, extended with a spot-check that `pickup_zone_arrival`-labeled captures are actually zone screens (the original criterion was satisfiable by the over-match failure mode).

**Triaged, no action:**
- *FrameGate identity churn / click-context flip on recognized-vs-UNKNOWN interludes:* inherent to recognizing a previously-UNKNOWN surface at all (the issue's purpose); the zone screen is one continuous surface between nav and bin-scan, and the recognize-only dev decision explicitly declines state/click semantics for it. If field data shows the `arrived_at_store` click being swallowed on GoPuff runs, that's a follow-up click-rule scope question, not a defect in this rule.
- *Ship a real capture instead of the golden pin:* the raw 06-14 frames live on-disk outside the repo (`~/dashbuddy/logs`); redacting + committing one via the Inbox workflow is the right follow-up and is called out in the golden pin comment + the field-test item. The pin is the test's own sanctioned escape hatch, used deliberately in review.
- *Predicate efficiency (two tree-wide `exists` scans):* the cross-node form is load-bearing on the real tree shape (see fixture finding) — a same-node compound would be wrong, not faster.

Recognition suite + GoPuffRecognitionTest green post-fix (606+ tests, 0 failures).

**Security/privacy posture (post-review):** strictly improved — the rejects close a plausible recognized-capture redaction downgrade; the rule still parses nothing, stores nothing, declares no actuation, and network is untouched.
