### PR TITLE
feat(#159): stores table + store entity resolution in the read-model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -321,7 +321,19 @@ payBasis)` so a re-priced `USER_CORRECTED` row keeps its original receipt eviden
 additive-only (five nullable columns — delivery +2, offer +2, session +1); the v10→v11 migration is likewise
 additive-only (delivery +2 — `cashTip`/`originalPayBasis`; `PROJECTOR_VERSION` 3→4 refolds them from the log,
 populating `originalPayBasis` for all history — the bump is #703's requirement, not a corrections one, and it
-also re-stamps `CURRENT_FALLBACK` rows against today's economy). `NetProfit`
+also re-stamps `CURRENT_FALLBACK` rows against today's economy). **Store entity resolution (#159, Room
+v11→v12 additive):** two new tables `stores` (identity/resolution only — deterministic `storeKey =
+platform|normalizedChain|runningKey`, D2/F5/F7) + `pickup_records` (the per-`PICKUP_CONFIRMED` visits table;
+dwell = `confirmedAt−arrivedAt` derived at read) plus `delivery_records.{storeKey,payoutStoreForms,
+storeKeyPinned}` + `offer_records.{storeKey,linkedJobId}`. Recognition is one pure `:domain` resolver core
+(`StoreResolver`/`StoreKeys`, shared with the field-verified shadow `StoreChainProjector` via a `Job` adapter);
+the projector runs it **resolve-from-rows** inside the batch transaction (`StoreResolutionRunner`, the row
+adapter) — a `DELIVERY_COMPLETED` persists the FULL receipt store-form set to `payoutStoreForms` (B1/B2), and
+resolution reads that from the committed rows so a payout-less `DASH_STOP` re-run recomputes the SAME keys, never
+a downgrade. A driver `newStoreName` correction sets a sticky `storeKeyPinned` (H1, never re-keyed). Per-store
+reads group on the resolved key, unresolved rows fall back to `normalizedChain(storeName)` (F9); the #315
+Patterns tab (store report card + dwell percentiles) is the consumer. `PROJECTOR_VERSION` 4→5 refolds all
+history and (F8) the version-bump wipe now also clears `stores`/`pickup_records`. `NetProfit`
 (`:domain`) is the one shared cost-math SSOT for both the offer estimate and the frozen realized net.
 `AnalyticsRepository` (`:core:data`, **DAO-only — no economy dependency**, so historical net is structurally
 immutable) serves period economics (`SUM(netProfit)` frozen + `unattributedPay`; all-pay gross =

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjector.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjector.kt
@@ -459,19 +459,28 @@ class AnalyticsProjector @Inject constructor(
         resolutions: ArrayList<ResolutionTask>,
         triggerSequenceId: Long,
     ) {
+        // Collect the newly inferred-closed sessions from both sources, then emit their resolutions in a
+        // deterministic order (FIX 10): all these tasks share the DASH_START's triggerSequenceId, so the
+        // transaction's stable `sortedBy { sequenceId }` would otherwise preserve HashMap/query iteration
+        // order among them — non-deterministic between incremental fold and refold. Sorting by sessionId
+        // pins it.
+        val inferred = ArrayList<Pair<String, String>>() // sessionId → platformWire
         // In-batch open contexts on the same platform.
         for (ctx in contexts.values.toList()) {
             if (ctx.sessionId == fresh.sessionId || ctx.platform != fresh.platform || ctx.endedAt != null) continue
             contexts[ctx.sessionId] = ctx.copy(endedAt = ctx.lastEventAt, endSource = INFERRED)
             touched += ctx.sessionId
-            resolutions += inferredResolution(ctx.sessionId, ctx.platform.wire, ctx.lastEventAt, triggerSequenceId)
+            inferred += ctx.sessionId to ctx.platform.wire
         }
         // DB rows still open for this platform, not already handled in this batch.
         for (row in analyticsDao.openSessions(fresh.platform.wire)) {
             if (row.sessionId == fresh.sessionId || contexts.containsKey(row.sessionId)) continue
             contexts[row.sessionId] = row.toContext().copy(endedAt = row.lastEventAt, endSource = INFERRED)
             touched += row.sessionId
-            resolutions += inferredResolution(row.sessionId, fresh.platform.wire, row.lastEventAt, triggerSequenceId)
+            inferred += row.sessionId to fresh.platform.wire
+        }
+        inferred.sortedBy { it.first }.forEach { (sessionId, platformWire) ->
+            resolutions += inferredResolution(sessionId, platformWire, triggerSequenceId)
         }
     }
 
@@ -480,11 +489,10 @@ class AnalyticsProjector @Inject constructor(
     private fun inferredResolution(
         sessionId: String,
         platformWire: String,
-        at: Long,
         triggerSequenceId: Long,
     ) = ResolutionTask(
         triggerSequenceId,
-        StoreResolution(sessionId = sessionId, platform = platformWire, jobId = null, offerHashes = emptyList(), at = at),
+        StoreResolution(sessionId = sessionId, platform = platformWire, jobId = null, offerHashes = emptyList()),
     )
 
     // ── Entity ↔ domain mapping (the storage boundary; :domain cannot see :core:database) ──

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjector.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjector.kt
@@ -8,6 +8,7 @@ import cloud.trotter.dashbuddy.core.database.analytics.AnalyticsDao
 import cloud.trotter.dashbuddy.core.database.analytics.AnalyticsProjectionStateEntity
 import cloud.trotter.dashbuddy.core.database.analytics.DeliveryRecordEntity
 import cloud.trotter.dashbuddy.core.database.analytics.OfferRecordEntity
+import cloud.trotter.dashbuddy.core.database.analytics.PickupRecordEntity
 import cloud.trotter.dashbuddy.core.database.analytics.SessionRecordEntity
 import cloud.trotter.dashbuddy.core.database.event.AppEventDao
 import cloud.trotter.dashbuddy.domain.analytics.DeliveryAdjustmentFold
@@ -15,8 +16,10 @@ import cloud.trotter.dashbuddy.domain.analytics.DeliveryFold
 import cloud.trotter.dashbuddy.domain.analytics.OfferFold
 import cloud.trotter.dashbuddy.domain.analytics.PayAdjustmentFold
 import cloud.trotter.dashbuddy.domain.analytics.PayBasis
+import cloud.trotter.dashbuddy.domain.analytics.PickupFold
 import cloud.trotter.dashbuddy.domain.analytics.RecordFolds
 import cloud.trotter.dashbuddy.domain.analytics.SessionFoldContext
+import cloud.trotter.dashbuddy.domain.analytics.StoreResolution
 import cloud.trotter.dashbuddy.domain.evaluation.NetProfit
 import cloud.trotter.dashbuddy.domain.state.Platform
 import kotlinx.coroutines.CancellationException
@@ -64,6 +67,10 @@ class AnalyticsProjector @Inject constructor(
     private val analyticsDao: AnalyticsDao,
     private val appPreferencesRepository: AppPreferencesRepository,
 ) {
+
+    /** #159 store-resolution runner (row adapter over the pure `StoreResolver` core), run inside the
+     *  batch transaction against the job's committed rows. */
+    private val storeResolutionRunner = StoreResolutionRunner(analyticsDao)
 
     /** Started from `DashBuddyApplication.onCreate` (NOT debug-gated). */
     fun start(scope: CoroutineScope) {
@@ -165,6 +172,8 @@ class AnalyticsProjector @Inject constructor(
         val touched = LinkedHashSet<String>()
         val deliveries = ArrayList<DeliveryFold>()
         val offers = ArrayList<OfferFold>()
+        val pickups = ArrayList<PickupFold>()          // #159 visits rows
+        val resolutions = ArrayList<ResolutionTask>()  // #159 store-resolution triggers (seq-ordered)
         // FIX 1: one event-sequence-ordered stream of adjustment decisions (PAY_ADJUSTMENT +
         // DELIVERY_ADJUSTMENT interleaved), NOT two type-partitioned lists. Type-order apply mis-ordered
         // a PA sequenced after a DA on the same row when they shared a batch (incremental ≠ refold).
@@ -179,6 +188,8 @@ class AnalyticsProjector @Inject constructor(
             if (outcome.skip != null) skips++
             outcome.delivery?.let { deliveries += it }
             outcome.offer?.let { offers += it }
+            outcome.pickup?.let { pickups += it }
+            outcome.resolution?.let { resolutions += ResolutionTask(ev.sequenceId, it) }
             outcome.payAdjustment?.let { adjustments += Adjustment.Pay(ev.sequenceId, it) }
             outcome.deliveryAdjustment?.let { adjustments += Adjustment.Delivery(ev.sequenceId, it) }
             outcome.context?.let { ctx ->
@@ -188,16 +199,22 @@ class AnalyticsProjector @Inject constructor(
             // A fresh DASH_START infers the close of any still-open session on the same platform —
             // a crash-orphaned dash the next one ends. (freshSession is false for a RECOVERY
             // re-start of an already-started session, so that path does not re-close anything.)
+            // #159 F3: each inferred-closed session is also a store-resolution trigger.
             if (outcome.freshSession) {
-                outcome.context?.let { inferredCloseOpenSessions(it, contexts, touched) }
+                outcome.context?.let { inferredCloseOpenSessions(it, contexts, touched, resolutions, ev.sequenceId) }
             }
         }
 
         val lastSeq = events.last().sequenceId
         var adjustmentSkips = 0
         db.withTransaction {
+            // #159 transaction order (M1/M2): deliveries → offers → pickups → sessions → adjustments →
+            // resolutions → watermark. Pickups + offers + adjustments are strictly BEFORE resolutions,
+            // so a same-batch pickup is an available anchor, the same-batch offer is linkable, and a
+            // same-batch store correction is already pinned when resolution runs.
             deliveries.forEach { analyticsDao.upsertDelivery(it.toEntity()) }
             offers.forEach { analyticsDao.upsertOffer(it.toEntity()) }
+            pickups.forEach { analyticsDao.upsertPickup(it.toEntity()) }
             touched.forEach { sid -> contexts[sid]?.let { analyticsDao.upsertSession(it.toEntity()) } }
             // Apply the driver corrections AFTER the batch's own delivery upserts (so a same-batch
             // target is already written) and before the watermark, in ONE event-sequence order (FIX 1).
@@ -211,6 +228,10 @@ class AnalyticsProjector @Inject constructor(
                 }
                 if (skipped) adjustmentSkips++
             }
+            // #159: store resolution reads the just-committed rows for each triggered job and stamps the
+            // storeKey back onto them (resolve-from-rows, F1). sequenceId-ordered (M1) so incremental
+            // fold ≡ from-zero refold.
+            resolutions.sortedBy { it.sequenceId }.forEach { storeResolutionRunner.resolve(it.resolution) }
             analyticsDao.setWatermark(
                 AnalyticsProjectionStateEntity(watermarkSequenceId = lastSeq, projectorVersion = PROJECTOR_VERSION),
             )
@@ -236,6 +257,10 @@ class AnalyticsProjector @Inject constructor(
         data class Pay(override val sequenceId: Long, val fold: PayAdjustmentFold) : Adjustment
         data class Delivery(override val sequenceId: Long, val fold: DeliveryAdjustmentFold) : Adjustment
     }
+
+    /** A #159 store-resolution trigger carrying its source event's [sequenceId] for the seq-ordered
+     *  in-transaction apply (M1). */
+    private data class ResolutionTask(val sequenceId: Long, val resolution: StoreResolution)
 
     /**
      * Apply one legacy PAY_ADJUSTMENT re-price by-PK. Returns true iff the target row was missing (a
@@ -337,6 +362,13 @@ class AnalyticsProjector @Inject constructor(
                 NetProfit.net(newPay, newMiles, row.frozenCostPerMile!!)
             else -> null
         }
+        // #159 H1: a driver-supplied newStoreName NULLS the resolved storeKey AND sets the pin, so the
+        // driver's fix wins the report-card grouping (its grouping becomes read-side
+        // normalizedChain(newStoreName), F9) and store resolution NEVER re-keys it back to the pickup
+        // anchor (every resolution UPDATE carries `WHERE storeKeyPinned = 0`). The pin is derived from
+        // this event, so a from-zero refold re-derives it (F8 wipe clears it, the replayed event resets
+        // it) — rebuild-deterministic. A store-name-less edit leaves storeKey/pin untouched.
+        val storeChanged = adj.newStoreName != null
         analyticsDao.upsertDelivery(
             // originalPayBasis (+ every unmentioned column) is preserved by `row.copy`.
             row.copy(
@@ -347,6 +379,8 @@ class AnalyticsProjector @Inject constructor(
                 realizedMiles = newMiles,
                 payBasis = newBasis,
                 netProfit = net,
+                storeKey = if (storeChanged) null else row.storeKey,
+                storeKeyPinned = if (storeChanged) 1 else row.storeKeyPinned,
             ),
         )
         return false
@@ -365,6 +399,11 @@ class AnalyticsProjector @Inject constructor(
             analyticsDao.deleteAllDeliveries()
             analyticsDao.deleteAllSessions()
             analyticsDao.deleteAllOffers()
+            // #159 F8: the wipe MUST also clear the store tables, or stale `stores` first-observed fields
+            // survive the refold and become permanently wrong (the forgotten-edge class the data-safety
+            // posture exists to catch). The refold repopulates both from the immutable log.
+            analyticsDao.deleteAllStores()
+            analyticsDao.deleteAllPickupRecords()
             analyticsDao.setWatermark(
                 AnalyticsProjectionStateEntity(watermarkSequenceId = 0, projectorVersion = PROJECTOR_VERSION),
             )
@@ -417,20 +456,36 @@ class AnalyticsProjector @Inject constructor(
         fresh: SessionFoldContext,
         contexts: HashMap<String, SessionFoldContext>,
         touched: LinkedHashSet<String>,
+        resolutions: ArrayList<ResolutionTask>,
+        triggerSequenceId: Long,
     ) {
         // In-batch open contexts on the same platform.
         for (ctx in contexts.values.toList()) {
             if (ctx.sessionId == fresh.sessionId || ctx.platform != fresh.platform || ctx.endedAt != null) continue
             contexts[ctx.sessionId] = ctx.copy(endedAt = ctx.lastEventAt, endSource = INFERRED)
             touched += ctx.sessionId
+            resolutions += inferredResolution(ctx.sessionId, ctx.platform.wire, ctx.lastEventAt, triggerSequenceId)
         }
         // DB rows still open for this platform, not already handled in this batch.
         for (row in analyticsDao.openSessions(fresh.platform.wire)) {
             if (row.sessionId == fresh.sessionId || contexts.containsKey(row.sessionId)) continue
             contexts[row.sessionId] = row.toContext().copy(endedAt = row.lastEventAt, endSource = INFERRED)
             touched += row.sessionId
+            resolutions += inferredResolution(row.sessionId, fresh.platform.wire, row.lastEventAt, triggerSequenceId)
         }
     }
+
+    /** #159 F3: an inferred session close is a store-resolution trigger too (session-level, jobId null),
+     *  carried under the triggering DASH_START's sequenceId for the seq-ordered in-transaction apply. */
+    private fun inferredResolution(
+        sessionId: String,
+        platformWire: String,
+        at: Long,
+        triggerSequenceId: Long,
+    ) = ResolutionTask(
+        triggerSequenceId,
+        StoreResolution(sessionId = sessionId, platform = platformWire, jobId = null, offerHashes = emptyList(), at = at),
+    )
 
     // ── Entity ↔ domain mapping (the storage boundary; :domain cannot see :core:database) ──
 
@@ -525,6 +580,27 @@ class AnalyticsProjector @Inject constructor(
         // preserves it via `row.copy`, so a re-priced row keeps its original receipt-evidence basis
         // for the #691 hydration COALESCE.
         originalPayBasis = payBasis,
+        // #159: storeKey is null at fold time (stamped later by resolution, in the same transaction);
+        // the full receipt store-form set is persisted here (serialized) as the row-sourced evidence.
+        storeKey = null,
+        payoutStoreForms = StoreResolutionRunner.encodeForms(payoutStoreForms),
+        storeKeyPinned = 0,
+    )
+
+    private fun PickupFold.toEntity() = PickupRecordEntity(
+        eventSequenceId = eventSequenceId,
+        sessionId = sessionId,
+        platform = platform,
+        jobId = jobId,
+        taskId = taskId,
+        storeName = storeName,
+        storeKey = null, // stamped later by resolution
+        phaseStartedAt = phaseStartedAt,
+        arrivedAt = arrivedAt,
+        confirmedAt = confirmedAt,
+        deadlineMillis = deadlineMillis,
+        activity = activity,
+        storeAddress = storeAddress,
     )
 
     private fun OfferFold.toEntity() = OfferRecordEntity(
@@ -579,7 +655,11 @@ class AnalyticsProjector @Inject constructor(
          * `CURRENT_FALLBACK` rows against today's economy (`CostBasis` is not rebuild-stable), so those
          * rows' fallback net shifts on the bump — the same behaviour as the v2/v3 bumps. `cashTip`
          * stays null in history (no cash events exist yet).
+         * v5 (#159): the from-zero refold populates the new `stores` + `pickup_records` tables and the
+         * `delivery_records.storeKey`/`payoutStoreForms` + `offer_records.storeKey`/`linkedJobId`
+         * columns for ALL history (rebuild ≡ backfill — the backfill is the first drain). The F8 wipe
+         * clears `stores`/`pickup_records` so the refold's first-observed store fields are correct.
          */
-        private const val PROJECTOR_VERSION = 4
+        private const val PROJECTOR_VERSION = 5
     }
 }

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
@@ -106,33 +106,40 @@ class AnalyticsRepository @Inject constructor(
         }
 
     /**
-     * Per-store economics for [period], highest-**gross** store first — frozen net + realized gross.
-     * Cash tips (#688 F5) are added to BOTH gross and net (`gross = realized pay + cash`, `net =
-     * frozen net + cash`) — explicit adds here, mirroring the period-level locked accounting.
+     * Per-store economics for [period], highest-**gross** store first — frozen net + realized gross,
+     * rolled up to CHAIN level (#159 F9). Both a resolved keyed location (`…|target|02426`) and an
+     * unresolved/MANUAL raw row (`Target`) on the same platform fold into ONE bucket keyed
+     * `platform + "|" + normalizedChain` (chain from the storeKey's middle segment when keyed, else the
+     * shared `:domain` normalizer over `storeName`). This is the F9 sentence — "Target" (unresolved) and
+     * "doordash|target|02426" share a bucket — the cross-platform parity (F5), and the fix for multiple
+     * identical-"Target" rows fragmenting the list. Per-LOCATION detail stays the report card's job
+     * ([storeReportCards], grouped by `storeKey`).
      *
-     * **Cash-inclusive ordering (F8):** the DAO's `ORDER BY pay DESC` is a cash-free **stable
-     * pre-sort**; the final rank is re-sorted here by the cash-inclusive [StoreEconomics.gross] so a
-     * cash-heavy store isn't ranked below a lower-gross one whose cash the SQL sort key ignored. The
-     * repository owns the mapped-value ordering because cash is added here, not in SQL (Principle 5 —
-     * one owner for the gross number, one owner for the sort that uses it).
+     * Display name prefers the chain's first-observed `stores.chainDisplay` (a single extra reactive DAO
+     * read), else the first row's raw `storeName`.
      *
-     * **Null-net + cash presentation:** a store whose only row has a null frozen `net` (no cost basis)
-     * but a recorded `cashTip` surfaces as `net = 0 + cash` — i.e. "net = cash". Accepted: cash has no
-     * cost term to net out, so the driver-attested cash IS the honest net contribution of that row.
+     * Cash tips (#688 F5) add to BOTH gross and net (explicit adds here, per the locked accounting). The
+     * DAO's `ORDER BY pay DESC` is a cash-free pre-sort; the final rank is re-sorted here by the
+     * cash-inclusive [StoreEconomics.gross].
+     *
+     * **Null-net + cash presentation:** a bucket whose rows all have a null frozen `net` (no cost basis)
+     * but a recorded `cashTip` surfaces as `net = 0 + cash`. Accepted: cash has no cost term to net out.
      */
     fun perStoreEconomics(period: AnalyticsPeriod): Flow<List<StoreEconomics>> =
         periodBoundariesFlow(period).flatMapLatest { (start, end) ->
-            analyticsDao.deliveryTotalsByStore(start, end).map { rows ->
-                // #159 F9: fold the DAO's (storeKey, storeName) groups onto ONE entity per resolved
-                // storeKey; an unresolved row (storeKey null) folds by the shared
-                // `normalizedChain(storeName)` so `"Target"` and `"…|target|02426"` don't fragment as a
-                // raw-text entry. The representative storeName is the group's first row.
-                rows.groupBy { it.storeKey ?: StoreKeys.normalizedChain(it.storeName.orEmpty()) }
-                    .map { (_, group) ->
+            combine(
+                analyticsDao.deliveryTotalsByStore(start, end),
+                analyticsDao.storeChainDisplays(),
+            ) { rows, displays ->
+                val displayByBucket = displays.associate {
+                    (it.platform + "|" + it.normalizedChain) to it.chainDisplay
+                }
+                rows.groupBy { chainBucket(it) }
+                    .map { (bucket, group) ->
                         val first = group.first()
                         StoreEconomics(
-                            storeKey = first.storeKey,
-                            storeName = first.storeName,
+                            storeKey = bucket, // chain-level bucket identity (not a per-location storeKey)
+                            storeName = displayByBucket[bucket] ?: first.storeName,
                             net = group.sumOf { it.net + it.cash },
                             gross = group.sumOf { it.pay + it.cash },
                             deliveries = group.sumOf { it.deliveries },
@@ -140,6 +147,14 @@ class AnalyticsRepository @Inject constructor(
                     }.sortedByDescending { it.gross }
             }
         }
+
+    /** The F9 chain bucket for a store totals row: `platform + "|" + normalizedChain`, chain taken from
+     *  the storeKey's middle segment when keyed, else the shared `:domain` normalizer over storeName. */
+    private fun chainBucket(row: cloud.trotter.dashbuddy.core.database.analytics.StoreTotalsRow): String {
+        val chain = row.storeKey?.split("|")?.getOrNull(1)?.takeIf { it.isNotEmpty() }
+            ?: StoreKeys.normalizedChain(row.storeName.orEmpty())
+        return row.platform + "|" + chain
+    }
 
     /**
      * The store report cards (#159, the #315 Patterns tab) — one per **referenced** resolved store

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
@@ -14,12 +14,15 @@ import cloud.trotter.dashbuddy.domain.analytics.PeriodTotals
 import cloud.trotter.dashbuddy.domain.analytics.SessionDetail
 import cloud.trotter.dashbuddy.domain.analytics.SessionRecord
 import cloud.trotter.dashbuddy.domain.analytics.StoreEconomics
+import cloud.trotter.dashbuddy.domain.analytics.StoreReportCard
 import cloud.trotter.dashbuddy.domain.analytics.TimeEconomics
 import cloud.trotter.dashbuddy.domain.evaluation.NetProfit
 import cloud.trotter.dashbuddy.domain.model.event.AppEventType
 import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.domain.state.StoreKeys
 import java.time.Instant
 import java.time.ZoneId
+import kotlin.math.ceil
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
@@ -120,14 +123,60 @@ class AnalyticsRepository @Inject constructor(
     fun perStoreEconomics(period: AnalyticsPeriod): Flow<List<StoreEconomics>> =
         periodBoundariesFlow(period).flatMapLatest { (start, end) ->
             analyticsDao.deliveryTotalsByStore(start, end).map { rows ->
-                rows.map {
-                    StoreEconomics(
-                        storeName = it.storeName,
-                        net = it.net + it.cash,
-                        gross = it.pay + it.cash,
-                        deliveries = it.deliveries,
-                    )
-                }.sortedByDescending { it.gross }
+                // #159 F9: fold the DAO's (storeKey, storeName) groups onto ONE entity per resolved
+                // storeKey; an unresolved row (storeKey null) folds by the shared
+                // `normalizedChain(storeName)` so `"Target"` and `"…|target|02426"` don't fragment as a
+                // raw-text entry. The representative storeName is the group's first row.
+                rows.groupBy { it.storeKey ?: StoreKeys.normalizedChain(it.storeName.orEmpty()) }
+                    .map { (_, group) ->
+                        val first = group.first()
+                        StoreEconomics(
+                            storeKey = first.storeKey,
+                            storeName = first.storeName,
+                            net = group.sumOf { it.net + it.cash },
+                            gross = group.sumOf { it.pay + it.cash },
+                            deliveries = group.sumOf { it.deliveries },
+                        )
+                    }.sortedByDescending { it.gross }
+            }
+        }
+
+    /**
+     * The store report cards (#159, the #315 Patterns tab) — one per **referenced** resolved store
+     * entity (M4, no phantom orphan rows), lifetime-scoped, newest-visited first. Combines the DAO
+     * rollup ([AnalyticsDao.storeReportRows] — metadata + pickup/delivery counts + gross/net) with the
+     * dwell samples ([AnalyticsDao.storeDwellSamples]); avg/p50/p95 dwell are computed HERE (SQLite has
+     * no native percentile; store visit counts are small). A chain-only row surfaces as
+     * `locationKnown = false` ("location unknown", F6). Reactive by construction (both sources are
+     * Room-invalidation Flows). No economy dependency (net is the frozen stored value); no new PII
+     * surface (merchant metadata + counts only).
+     */
+    fun storeReportCards(): Flow<List<StoreReportCard>> =
+        combine(
+            analyticsDao.storeReportRows(),
+            analyticsDao.storeDwellSamples(),
+        ) { rows, dwells ->
+            val dwellsByKey = dwells.groupBy { it.storeKey }
+            rows.map { r ->
+                val sorted = dwellsByKey[r.storeKey].orEmpty().map { it.dwellMillis }.sorted()
+                StoreReportCard(
+                    storeKey = r.storeKey,
+                    platform = r.platform,
+                    normalizedChain = r.normalizedChain,
+                    chainDisplay = r.chainDisplay,
+                    runningKey = r.runningKey,
+                    address = r.address,
+                    locationKnown = r.runningKey != null,
+                    pickups = r.pickups,
+                    deliveries = r.deliveries,
+                    gross = r.gross,
+                    net = r.net,
+                    avgDwellMillis = sorted.takeIf { it.isNotEmpty() }?.average(),
+                    p50DwellMillis = percentile(sorted, 0.50),
+                    p95DwellMillis = percentile(sorted, 0.95),
+                    firstSeenAt = r.firstSeenAt,
+                    lastSeenAt = r.lastSeenAt,
+                )
             }
         }
 
@@ -352,6 +401,17 @@ class AnalyticsRepository @Inject constructor(
      * derived split ([TimeEconomics.unattributedMillis]/[TimeEconomics.unattributedMiles] etc.) is the
      * DTO's own coerce-≥0 helper, so this repository stores no second copy of that math (Principle 5).
      */
+    /**
+     * The [p]-th percentile of an ASCENDING-sorted dwell list (#159 store report card) — nearest-rank
+     * (SQLite has no native percentile and store visit counts are small, so an exact in-Kotlin nearest-
+     * rank is honest and cheap). Null on an empty list. `p ∈ [0,1]`.
+     */
+    private fun percentile(sorted: List<Long>, p: Double): Long? {
+        if (sorted.isEmpty()) return null
+        val rank = ceil(p * sorted.size).toInt().coerceIn(1, sorted.size)
+        return sorted[rank - 1]
+    }
+
     private fun assembleTime(
         session: SessionTotalsRow,
         delivery: DeliveryTimeTotalsRow,

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/StoreResolutionRunner.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/StoreResolutionRunner.kt
@@ -1,0 +1,164 @@
+package cloud.trotter.dashbuddy.core.data.analytics
+
+import cloud.trotter.dashbuddy.core.database.analytics.AnalyticsDao
+import cloud.trotter.dashbuddy.core.database.analytics.OfferRecordEntity
+import cloud.trotter.dashbuddy.core.database.analytics.PickupRecordEntity
+import cloud.trotter.dashbuddy.core.database.analytics.StoreEntity
+import cloud.trotter.dashbuddy.domain.analytics.StoreResolution
+import cloud.trotter.dashbuddy.domain.model.event.AppEventType
+import cloud.trotter.dashbuddy.domain.state.StoreKeys
+import cloud.trotter.dashbuddy.domain.state.StoreNameMatch
+import cloud.trotter.dashbuddy.domain.state.StoreResolver
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
+
+/**
+ * The #159 read-model store-resolution runner — the **row adapter** over the pure
+ * [StoreResolver.resolveAnchors] core (M5; the shadow `StoreChainProjector` is the sibling `Job`
+ * adapter). Runs INSIDE the projector's batch transaction (resolve-from-rows, F1): for each triggered
+ * job it reads the job's committed `pickup_records` (anchors + address) and `delivery_records`
+ * (dropoff names + the row-persisted `payoutStoreForms` receipt evidence), resolves every anchor,
+ * upserts the `stores` identity rows, and stamps the deterministic `storeKey` back onto the visit rows
+ * (+ the offer↔job link). Because it reads committed rows only and the key is row-sourced + monotonic,
+ * incremental fold ≡ from-zero refold (B1) and a re-run is a byte-identical no-op (L1).
+ *
+ * **Privacy:** store names/addresses are MERCHANT data — fine at rest, never logged at INFO+ (P7). No
+ * network, no new capture. Customer hashes are never read here.
+ */
+internal class StoreResolutionRunner(private val dao: AnalyticsDao) {
+
+    private val acceptedOutcome = AppEventType.OFFER_ACCEPTED.name
+
+    /** Resolve one trigger: a job-scoped task ([StoreResolution.jobId] set) or a session-level task
+     *  (jobId null ⇒ enumerate the session's jobs, L2). */
+    suspend fun resolve(task: StoreResolution) {
+        val sessionId = task.sessionId
+        val taskJobId = task.jobId
+        val jobIds: List<String> = when {
+            taskJobId != null -> listOf(taskJobId)
+            sessionId != null -> dao.jobIdsForSession(sessionId)
+            else -> emptyList()
+        }
+        for (jobId in jobIds) resolveJob(jobId, task)
+    }
+
+    private suspend fun resolveJob(jobId: String, task: StoreResolution) {
+        val pickups = dao.pickupRecordsForJob(jobId)
+        // v1 (matches the field-verified shadow): anchors come from pickup rows; a job with delivery
+        // rows but no pickup rows produces no store link.
+        if (pickups.isEmpty()) return
+        val anchors = pickups.map { it.storeName }.filter { it.isNotBlank() }.distinct()
+        if (anchors.isEmpty()) return
+        val deliveries = dao.deliveryRecordsForJob(jobId)
+
+        val dropoffForms = deliveries.mapNotNull { it.storeName }
+        // Union of the receipt store forms across the job's delivery rows, ORDER BY eventSequenceId
+        // (the DAO orders them) — on the fielded single-receipt shape exactly one row is non-null (B2).
+        val payoutForms = deliveries
+            .flatMap { decodeForms(it.payoutStoreForms) }
+            .map { StoreResolver.PayoutForm(it) }
+
+        // Candidate offer(s) for the offer form + the offer↔job link (below). Exact via jobOfferHashes,
+        // else the temporal nominee (F4). Their merchantName feeds the resolver's offerNameForm.
+        val jobFirstAt = pickups.minOf { it.phaseStartedAt }
+        val offerRows = candidateOffers(task, jobId, jobFirstAt)
+        val offerForms = offerRows.mapNotNull { it.merchantName }
+
+        val resolved = StoreResolver.resolveAnchors(anchors, offerForms, dropoffForms, payoutForms)
+        val platform = pickups.first().platform
+
+        // Build each anchor's deterministic storeKey + upsert the identity row (first-observed forms
+        // preserved). No-op re-stamps are value-compared to avoid Room invalidation churn.
+        val anchorKey = HashMap<String, String>()
+        for (r in resolved) {
+            val normChain = StoreKeys.normalizedChain(r.canonical)
+            val runKey = StoreKeys.normalizeRunningKey(r.runningKey)
+            val key = StoreKeys.storeKey(platform, normChain, runKey)
+            anchorKey[r.canonical] = key
+            upsertStore(key, platform, normChain, runKey, r, task.at, pickups)
+        }
+
+        // Stamp pickup rows by their own anchor (storeName == the anchor).
+        for (pu in pickups) {
+            val key = anchorKey[pu.storeName] ?: continue
+            dao.stampPickupStoreKey(pu.eventSequenceId, key)
+        }
+        // Stamp delivery rows by best-matching their dropoff form to an anchor (the dropoff form differs
+        // from the pickup form). The SQL carries the pin predicate (H1) + value guard.
+        for (d in deliveries) {
+            val store = d.storeName ?: continue
+            val anchor = StoreNameMatch.bestMatch(anchors, store) ?: continue
+            val key = anchorKey[anchor] ?: continue
+            dao.stampDeliveryStoreKey(d.eventSequenceId, key)
+        }
+
+        // Offer↔job link (F4). Exact (hash) matches ARE this job's offers → stamp unconditionally.
+        // The temporal nominee stamps ONLY on brand-token agreement (else it is a queued next-job
+        // offer). storeKey = the anchor its merchantName best-matches (null for a no-match / multi-store).
+        val exact = task.offerHashes.isNotEmpty()
+        for (offer in offerRows) {
+            val anchor = offer.merchantName?.let { StoreNameMatch.bestMatch(anchors, it) }
+            if (!exact && anchor == null) continue
+            dao.stampOfferLink(offer.eventSequenceId, anchor?.let { anchorKey[it] }, jobId)
+        }
+    }
+
+    private suspend fun candidateOffers(
+        task: StoreResolution,
+        jobId: String,
+        jobFirstAt: Long,
+    ): List<OfferRecordEntity> {
+        if (task.offerHashes.isNotEmpty()) return dao.offerRecordsByHashes(task.offerHashes)
+        val sessionId = task.sessionId ?: return emptyList()
+        return listOfNotNull(dao.nominateOfferForJob(sessionId, jobFirstAt, jobId, acceptedOutcome))
+    }
+
+    private suspend fun upsertStore(
+        storeKey: String,
+        platform: String,
+        normalizedChain: String,
+        runningKey: String?,
+        r: StoreResolver.AnchorResolution,
+        at: Long,
+        pickups: List<PickupRecordEntity>,
+    ) {
+        val prior = dao.store(storeKey)
+        val address = prior?.address
+            ?: pickups.firstOrNull { it.storeName == r.canonical && it.storeAddress != null }?.storeAddress
+        val store = StoreEntity(
+            storeKey = storeKey,
+            platform = platform,
+            normalizedChain = normalizedChain,
+            chainDisplay = prior?.chainDisplay ?: r.canonical,
+            runningKey = runningKey, // consistent with the key by construction
+            offerNameForm = prior?.offerNameForm ?: r.offerForm,
+            pickupNameForm = prior?.pickupNameForm ?: r.canonical,
+            payoutNameForm = prior?.payoutNameForm ?: r.payoutForm,
+            address = address,
+            firstSeenAt = prior?.firstSeenAt ?: at,
+            lastSeenAt = maxOf(prior?.lastSeenAt ?: at, at),
+        )
+        // Value-compare so an idempotent re-run (same `at`) doesn't churn Room invalidation (L1).
+        if (store != prior) dao.upsertStore(store)
+    }
+
+    companion object {
+        private val json = Json { encodeDefaults = true }
+        private val formsSerializer = ListSerializer(String.serializer())
+
+        /** Serialize the full receipt store-form set for `delivery_records.payoutStoreForms` (B1/B2). */
+        fun encodeForms(forms: List<String>?): String? =
+            forms?.takeIf { it.isNotEmpty() }?.let { json.encodeToString(formsSerializer, it) }
+
+        /** Decode the persisted receipt store-form set; empty on null/blank/malformed (fail-soft). */
+        fun decodeForms(raw: String?): List<String> {
+            if (raw.isNullOrBlank()) return emptyList()
+            return try {
+                json.decodeFromString(formsSerializer, raw)
+            } catch (_: Exception) {
+                emptyList()
+            }
+        }
+    }
+}

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/StoreResolutionRunner.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/StoreResolutionRunner.kt
@@ -6,12 +6,15 @@ import cloud.trotter.dashbuddy.core.database.analytics.PickupRecordEntity
 import cloud.trotter.dashbuddy.core.database.analytics.StoreEntity
 import cloud.trotter.dashbuddy.domain.analytics.StoreResolution
 import cloud.trotter.dashbuddy.domain.model.event.AppEventType
+import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.domain.state.StoreKeys
 import cloud.trotter.dashbuddy.domain.state.StoreNameMatch
 import cloud.trotter.dashbuddy.domain.state.StoreResolver
+import cloud.trotter.dashbuddy.domain.state.UNKNOWN_STORE
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
+import timber.log.Timber
 
 /**
  * The #159 read-model store-resolution runner — the **row adapter** over the pure
@@ -48,11 +51,16 @@ internal class StoreResolutionRunner(private val dao: AnalyticsDao) {
         // v1 (matches the field-verified shadow): anchors come from pickup rows; a job with delivery
         // rows but no pickup rows produces no store link.
         if (pickups.isEmpty()) return
-        val anchors = pickups.map { it.storeName }.filter { it.isNotBlank() }.distinct()
+        // FIX 2: exclude the UNKNOWN_STORE sentinel — a null-store pickup must not mint a
+        // `platform|unknown|` entity (the fielded #733 NULL-store shape). Same idiom as :domain's
+        // DisplayNames (import the constant, don't re-literal it).
+        val anchors = pickups.map { it.storeName }
+            .filter { it.isNotBlank() && it != UNKNOWN_STORE }.distinct()
         if (anchors.isEmpty()) return
         val deliveries = dao.deliveryRecordsForJob(jobId)
 
         val dropoffForms = deliveries.mapNotNull { it.storeName }
+            .filter { it.isNotBlank() && it != UNKNOWN_STORE } // FIX 2: never feed the sentinel to the resolver
         // Union of the receipt store forms across the job's delivery rows, ORDER BY eventSequenceId
         // (the DAO orders them) — on the fielded single-receipt shape exactly one row is non-null (B2).
         val payoutForms = deliveries
@@ -66,7 +74,11 @@ internal class StoreResolutionRunner(private val dao: AnalyticsDao) {
         val offerForms = offerRows.mapNotNull { it.merchantName }
 
         val resolved = StoreResolver.resolveAnchors(anchors, offerForms, dropoffForms, payoutForms)
-        val platform = pickups.first().platform
+        // FIX 7: key platform = the trigger's own platform when it is REAL, else the pickup row's
+        // platform. This makes `StoreResolution.platform` load-bearing: a DASH_STOP re-resolution of an
+        // `_unknown`-started session (its DASH_STOP carried the corrected platform) upgrades the key to
+        // the real platform and re-stamps, instead of keying under the stale `_unknown` pickup rows.
+        val platform = task.platform.takeIf { it != Platform.Unknown.wire } ?: pickups.first().platform
 
         // Build each anchor's deterministic storeKey + upsert the identity row (first-observed forms
         // preserved). No-op re-stamps are value-compared to avoid Room invalidation churn.
@@ -76,20 +88,23 @@ internal class StoreResolutionRunner(private val dao: AnalyticsDao) {
             val runKey = StoreKeys.normalizeRunningKey(r.runningKey)
             val key = StoreKeys.storeKey(platform, normChain, runKey)
             anchorKey[r.canonical] = key
-            upsertStore(key, platform, normChain, runKey, r, task.at, pickups)
+            upsertStore(key, platform, normChain, runKey, r, pickups)
         }
 
-        // Stamp pickup rows by their own anchor (storeName == the anchor).
+        // Stamp pickup rows by their own anchor (storeName == the anchor). FIX 6 monotonic backstop:
+        // never re-stamp a keyed row down to a chain-only key of the same platform+chain.
         for (pu in pickups) {
             val key = anchorKey[pu.storeName] ?: continue
+            if (isMonotonicDowngrade(pu.storeKey, key)) continue
             dao.stampPickupStoreKey(pu.eventSequenceId, key)
         }
         // Stamp delivery rows by best-matching their dropoff form to an anchor (the dropoff form differs
         // from the pickup form). The SQL carries the pin predicate (H1) + value guard.
         for (d in deliveries) {
-            val store = d.storeName ?: continue
+            val store = d.storeName?.takeIf { it != UNKNOWN_STORE } ?: continue
             val anchor = StoreNameMatch.bestMatch(anchors, store) ?: continue
             val key = anchorKey[anchor] ?: continue
+            if (isMonotonicDowngrade(d.storeKey, key)) continue
             dao.stampDeliveryStoreKey(d.eventSequenceId, key)
         }
 
@@ -104,13 +119,37 @@ internal class StoreResolutionRunner(private val dao: AnalyticsDao) {
         }
     }
 
+    /**
+     * FIX 6 monotonic-key backstop: true iff [newKey] is CHAIN-ONLY (empty running-key segment) and the
+     * row's [current] key is a KEYED variant of the same platform+chain — i.e. this would downgrade an
+     * already-keyed row. Resolution is row-sourced and monotonic by design, so this only fires on a rare
+     * evidence loss; keeping the keyed value guards against a silent regression. The storeKey strings
+     * are merchant-derived, so the observability note is DEBUG (keys) + a merchant-free WARN counter (P7).
+     */
+    private fun isMonotonicDowngrade(current: String?, newKey: String): Boolean {
+        if (current == null || !newKey.endsWith("|")) return false
+        val downgrade = current != newKey && current.startsWith(newKey)
+        if (downgrade) {
+            Timber.tag(TAG).d("store-key: kept keyed %s over chain-only recompute %s", current, newKey)
+            Timber.tag(TAG).w("store-key downgrade averted (monotonic backstop)")
+        }
+        return downgrade
+    }
+
     private suspend fun candidateOffers(
         task: StoreResolution,
         jobId: String,
         jobFirstAt: Long,
     ): List<OfferRecordEntity> {
-        if (task.offerHashes.isNotEmpty()) return dao.offerRecordsByHashes(task.offerHashes)
         val sessionId = task.sessionId ?: return emptyList()
+        // Exact path: the job's OWN accepted offer rows, scoped to session + accepted outcome (FIX 1a).
+        if (task.offerHashes.isNotEmpty()) {
+            return dao.offerRecordsByHashes(task.offerHashes, sessionId, acceptedOutcome)
+        }
+        // FIX 1b: if the job already holds a claim (from an earlier trigger), don't nominate a second
+        // offer — the exact path stays convergent because its scoped lookup returns the same rows, but a
+        // DASH_STOP re-run of a temporal-linked job must not claim a different nearby offer.
+        if (dao.offerLinkCountForJob(jobId) > 0) return emptyList()
         return listOfNotNull(dao.nominateOfferForJob(sessionId, jobFirstAt, jobId, acceptedOutcome))
     }
 
@@ -120,7 +159,6 @@ internal class StoreResolutionRunner(private val dao: AnalyticsDao) {
         normalizedChain: String,
         runningKey: String?,
         r: StoreResolver.AnchorResolution,
-        at: Long,
         pickups: List<PickupRecordEntity>,
     ) {
         val prior = dao.store(storeKey)
@@ -136,14 +174,15 @@ internal class StoreResolutionRunner(private val dao: AnalyticsDao) {
             pickupNameForm = prior?.pickupNameForm ?: r.canonical,
             payoutNameForm = prior?.payoutNameForm ?: r.payoutForm,
             address = address,
-            firstSeenAt = prior?.firstSeenAt ?: at,
-            lastSeenAt = maxOf(prior?.lastSeenAt ?: at, at),
         )
-        // Value-compare so an idempotent re-run (same `at`) doesn't churn Room invalidation (L1).
+        // Value-compare so an idempotent re-run doesn't churn Room invalidation (L1). first/last-seen are
+        // no longer row columns (FIX 3) — they derive at read — so the store row is now truly stable
+        // across per-trigger re-resolutions (no `lastSeenAt` bump on every trigger).
         if (store != prior) dao.upsertStore(store)
     }
 
     companion object {
+        private const val TAG = "Analytics"
         private val json = Json { encodeDefaults = true }
         private val formsSerializer = ListSerializer(String.serializer())
 
@@ -151,12 +190,17 @@ internal class StoreResolutionRunner(private val dao: AnalyticsDao) {
         fun encodeForms(forms: List<String>?): String? =
             forms?.takeIf { it.isNotEmpty() }?.let { json.encodeToString(formsSerializer, it) }
 
-        /** Decode the persisted receipt store-form set; empty on null/blank/malformed (fail-soft). */
+        /**
+         * Decode the persisted receipt store-form set; empty on null/blank/malformed (fail-soft). A
+         * malformed payload is WARN'd (FIX 6) instead of silently swallowed — the raw string is
+         * merchant-derived, so the WARN carries the failure class only, never the payload (P7).
+         */
         fun decodeForms(raw: String?): List<String> {
             if (raw.isNullOrBlank()) return emptyList()
             return try {
                 json.decodeFromString(formsSerializer, raw)
             } catch (_: Exception) {
+                Timber.tag(TAG).w("payoutStoreForms decode failed; treating this row as no receipt evidence")
                 emptyList()
             }
         }

--- a/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/StoreReadsTest.kt
+++ b/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/StoreReadsTest.kt
@@ -1,0 +1,170 @@
+package cloud.trotter.dashbuddy.core.data.analytics
+
+import androidx.room.Room
+import cloud.trotter.dashbuddy.core.database.DashBuddyDatabase
+import cloud.trotter.dashbuddy.core.database.analytics.AnalyticsDao
+import cloud.trotter.dashbuddy.core.database.analytics.DeliveryRecordEntity
+import cloud.trotter.dashbuddy.core.database.analytics.PickupRecordEntity
+import cloud.trotter.dashbuddy.core.database.analytics.StoreEntity
+import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+/**
+ * #159 read-side guards for the store report card + F9 grouping (the #315 Patterns tab consumer):
+ * unresolved rows fold by `normalizedChain(storeName)` not raw text (F9), dwell percentiles are
+ * computed in the repository, and a chain-only store surfaces as "location unknown" (F6).
+ */
+@RunWith(RobolectricTestRunner::class)
+class StoreReadsTest {
+
+    private lateinit var db: DashBuddyDatabase
+    private lateinit var dao: AnalyticsDao
+    private lateinit var repo: AnalyticsRepository
+
+    @Before
+    fun setUp() {
+        val context = RuntimeEnvironment.getApplication()
+        db = Room.inMemoryDatabaseBuilder(context, DashBuddyDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = db.analyticsDao()
+        repo = AnalyticsRepository(dao)
+    }
+
+    @After
+    fun tearDown() = db.close()
+
+    private fun deliveryRow(
+        seq: Long,
+        storeName: String?,
+        storeKey: String?,
+        pay: Double,
+        net: Double,
+        completedAt: Long = 1_000L,
+    ) = DeliveryRecordEntity(
+        eventSequenceId = seq,
+        sessionId = null, // null-session rows fold by their own completedAt (in-window for LIFETIME)
+        platform = "doordash",
+        jobId = "J$seq",
+        taskId = "T$seq",
+        storeName = storeName,
+        customerHash = null,
+        addressHash = null,
+        phaseStartedAt = completedAt - 1000,
+        arrivedAt = completedAt - 500,
+        completedAt = completedAt,
+        deadlineMillis = null,
+        realizedPay = pay,
+        payBasis = "RECEIPT_TOTAL",
+        tip = null,
+        basePay = null,
+        odometerAtCompletion = null,
+        realizedMiles = 1.0,
+        realizedMinutes = 10.0,
+        frozenCostPerMile = 0.25,
+        netProfit = net,
+        costBasis = "OFFER_FROZEN",
+        storeKey = storeKey,
+    )
+
+    private fun pickupRow(seq: Long, storeKey: String?, arrivedAt: Long, confirmedAt: Long) =
+        PickupRecordEntity(
+            eventSequenceId = seq,
+            sessionId = "S1",
+            platform = "doordash",
+            jobId = "J$seq",
+            taskId = "PT$seq",
+            storeName = "Target",
+            storeKey = storeKey,
+            phaseStartedAt = arrivedAt - 100,
+            arrivedAt = arrivedAt,
+            confirmedAt = confirmedAt,
+            deadlineMillis = null,
+            activity = "PICKUP",
+        )
+
+    private fun storeRow(storeKey: String, chain: String, runningKey: String?) = StoreEntity(
+        storeKey = storeKey, platform = "doordash", normalizedChain = chain, chainDisplay = "Target",
+        runningKey = runningKey, offerNameForm = null, pickupNameForm = "Target", payoutNameForm = null,
+        address = null, firstSeenAt = 100, lastSeenAt = 200,
+    )
+
+    @Test
+    fun `F9 — unresolved rows fold by normalizedChain, not raw text`() = runBlocking {
+        // Two unresolved (storeKey null) rows differing only in casing/whitespace → ONE chain bucket.
+        dao.upsertDelivery(deliveryRow(1, "Target", null, pay = 10.0, net = 8.0))
+        dao.upsertDelivery(deliveryRow(2, "  target ", null, pay = 5.0, net = 4.0))
+
+        val stores = repo.perStoreEconomics(AnalyticsPeriod.LIFETIME).first()
+        assertEquals("casing/whitespace variants fold into one bucket (F9)", 1, stores.size)
+        assertEquals(15.0, stores.single().gross, 0.001)
+        assertEquals(12.0, stores.single().net, 0.001)
+    }
+
+    @Test
+    fun `F9 — a resolved keyed store and an unresolved chain bucket are distinct per-location entries`() = runBlocking {
+        dao.upsertDelivery(deliveryRow(1, "Target (02426)", "doordash|target|02426", pay = 10.0, net = 8.0))
+        dao.upsertDelivery(deliveryRow(2, "Target", null, pay = 5.0, net = 4.0))
+
+        val stores = repo.perStoreEconomics(AnalyticsPeriod.LIFETIME).first()
+        assertEquals(2, stores.size)
+        assertTrue(stores.any { it.storeKey == "doordash|target|02426" })
+        assertTrue(stores.any { it.storeKey == null })
+    }
+
+    @Test
+    fun `report card computes dwell percentiles and surfaces a keyed location`() = runBlocking {
+        val key = "doordash|target|02426"
+        dao.upsertStore(storeRow(key, "target", "02426"))
+        // dwells: 10s, 20s, 30s, 40s, 100s (ms).
+        val dwells = listOf(10_000L, 20_000L, 30_000L, 40_000L, 100_000L)
+        dwells.forEachIndexed { i, d -> dao.upsertPickup(pickupRow(i + 1L, key, arrivedAt = 0, confirmedAt = d)) }
+        dao.upsertDelivery(deliveryRow(100, "Target (02426)", key, pay = 12.0, net = 9.0))
+
+        val card = repo.storeReportCards().first().single()
+        assertEquals(key, card.storeKey)
+        assertTrue("keyed location known (F6)", card.locationKnown)
+        assertEquals(5, card.pickups)
+        assertEquals(1, card.deliveries)
+        assertEquals(40_000.0, card.avgDwellMillis!!, 0.001)
+        // nearest-rank: p50 of 5 samples = index ceil(0.5*5)=3 → 30_000; p95 = ceil(0.95*5)=5 → 100_000.
+        assertEquals(30_000L, card.p50DwellMillis)
+        assertEquals(100_000L, card.p95DwellMillis)
+    }
+
+    @Test
+    fun `F6 — a chain-only store surfaces as location unknown`() = runBlocking {
+        val chainOnly = "doordash|chipotle|"
+        dao.upsertStore(
+            StoreEntity(
+                storeKey = chainOnly, platform = "doordash", normalizedChain = "chipotle",
+                chainDisplay = "Chipotle", runningKey = null, offerNameForm = null,
+                pickupNameForm = "Chipotle", payoutNameForm = null, address = null,
+                firstSeenAt = 1, lastSeenAt = 2,
+            ),
+        )
+        dao.upsertPickup(pickupRow(1, chainOnly, arrivedAt = 0, confirmedAt = 15_000))
+
+        val card = repo.storeReportCards().first().single()
+        assertEquals(chainOnly, card.storeKey)
+        assertFalse("no running key ⇒ location unknown (F6)", card.locationKnown)
+    }
+
+    @Test
+    fun `M4 — an unreferenced store row shows no phantom report entry`() = runBlocking {
+        // A chain-only provisional key that was upgraded away (no visit references it) must not appear.
+        dao.upsertStore(storeRow("doordash|orphan|", "orphan", null))
+        val cards = repo.storeReportCards().first()
+        assertTrue("orphan store with zero visits is absent (M4)", cards.none { it.storeKey == "doordash|orphan|" })
+    }
+}

--- a/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/StoreReadsTest.kt
+++ b/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/StoreReadsTest.kt
@@ -51,6 +51,7 @@ class StoreReadsTest {
         pay: Double,
         net: Double,
         completedAt: Long = 1_000L,
+        cashTip: Double? = null,
     ) = DeliveryRecordEntity(
         eventSequenceId = seq,
         sessionId = null, // null-session rows fold by their own completedAt (in-window for LIFETIME)
@@ -74,10 +75,11 @@ class StoreReadsTest {
         frozenCostPerMile = 0.25,
         netProfit = net,
         costBasis = "OFFER_FROZEN",
+        cashTip = cashTip,
         storeKey = storeKey,
     )
 
-    private fun pickupRow(seq: Long, storeKey: String?, arrivedAt: Long, confirmedAt: Long) =
+    private fun pickupRow(seq: Long, storeKey: String?, arrivedAt: Long?, confirmedAt: Long?) =
         PickupRecordEntity(
             eventSequenceId = seq,
             sessionId = "S1",
@@ -86,7 +88,7 @@ class StoreReadsTest {
             taskId = "PT$seq",
             storeName = "Target",
             storeKey = storeKey,
-            phaseStartedAt = arrivedAt - 100,
+            phaseStartedAt = (arrivedAt ?: 0) - 100,
             arrivedAt = arrivedAt,
             confirmedAt = confirmedAt,
             deadlineMillis = null,
@@ -96,7 +98,7 @@ class StoreReadsTest {
     private fun storeRow(storeKey: String, chain: String, runningKey: String?) = StoreEntity(
         storeKey = storeKey, platform = "doordash", normalizedChain = chain, chainDisplay = "Target",
         runningKey = runningKey, offerNameForm = null, pickupNameForm = "Target", payoutNameForm = null,
-        address = null, firstSeenAt = 100, lastSeenAt = 200,
+        address = null,
     )
 
     @Test
@@ -112,14 +114,56 @@ class StoreReadsTest {
     }
 
     @Test
-    fun `F9 — a resolved keyed store and an unresolved chain bucket are distinct per-location entries`() = runBlocking {
+    fun `F9 — a resolved keyed store and its unresolved chain form MERGE into one chain bucket (FIX 8)`() = runBlocking {
         dao.upsertDelivery(deliveryRow(1, "Target (02426)", "doordash|target|02426", pay = 10.0, net = 8.0))
         dao.upsertDelivery(deliveryRow(2, "Target", null, pay = 5.0, net = 4.0))
 
         val stores = repo.perStoreEconomics(AnalyticsPeriod.LIFETIME).first()
-        assertEquals(2, stores.size)
-        assertTrue(stores.any { it.storeKey == "doordash|target|02426" })
-        assertTrue(stores.any { it.storeKey == null })
+        assertEquals("keyed + unresolved fold to ONE chain bucket (F9/FIX 8)", 1, stores.size)
+        assertEquals("doordash|target", stores.single().storeKey)
+        assertEquals(15.0, stores.single().gross, 0.001)
+        assertEquals(12.0, stores.single().net, 0.001)
+    }
+
+    @Test
+    fun `F9 — two keyed locations of one chain roll up to a single chain bucket (FIX 8)`() = runBlocking {
+        dao.upsertDelivery(deliveryRow(1, "Target (02426)", "doordash|target|02426", pay = 10.0, net = 8.0))
+        dao.upsertDelivery(deliveryRow(2, "Target (99999)", "doordash|target|99999", pay = 6.0, net = 5.0))
+        // A chainDisplay for the chain feeds the bucket's display name.
+        dao.upsertStore(storeRow("doordash|target|02426", "target", "02426"))
+
+        val stores = repo.perStoreEconomics(AnalyticsPeriod.LIFETIME).first()
+        assertEquals(1, stores.size)
+        assertEquals("doordash|target", stores.single().storeKey)
+        assertEquals("Target", stores.single().storeName) // chainDisplay preferred
+        assertEquals(16.0, stores.single().gross, 0.001)
+    }
+
+    @Test
+    fun `FIX 4 — the report card gross and net include cash tips`() = runBlocking {
+        val key = "doordash|target|02426"
+        dao.upsertStore(storeRow(key, "target", "02426"))
+        dao.upsertPickup(pickupRow(1, key, arrivedAt = 0, confirmedAt = 10_000))
+        dao.upsertDelivery(deliveryRow(100, "Target (02426)", key, pay = 12.0, net = 9.0, cashTip = 3.0))
+
+        val card = repo.storeReportCards().first().single()
+        assertEquals("gross includes cash (#688)", 15.0, card.gross, 0.001)
+        assertEquals("net includes cash (#688)", 12.0, card.net, 0.001)
+    }
+
+    @Test
+    fun `FIX 11 — a negative-dwell pickup row is excluded from the dwell samples`() = runBlocking {
+        val key = "doordash|target|02426"
+        dao.upsertStore(storeRow(key, "target", "02426"))
+        // One valid dwell (20s) and one inverted row (confirmed BEFORE arrived, #732 class).
+        dao.upsertPickup(pickupRow(1, key, arrivedAt = 0, confirmedAt = 20_000))
+        dao.upsertPickup(pickupRow(2, key, arrivedAt = 50_000, confirmedAt = 10_000))
+        dao.upsertDelivery(deliveryRow(100, "Target (02426)", key, pay = 12.0, net = 9.0))
+
+        val card = repo.storeReportCards().first().single()
+        // Only the valid 20s sample survives — the inverted row is filtered out (no negative dwell).
+        assertEquals(20_000.0, card.avgDwellMillis!!, 0.001)
+        assertEquals(20_000L, card.p50DwellMillis)
     }
 
     @Test
@@ -150,7 +194,6 @@ class StoreReadsTest {
                 storeKey = chainOnly, platform = "doordash", normalizedChain = "chipotle",
                 chainDisplay = "Chipotle", runningKey = null, offerNameForm = null,
                 pickupNameForm = "Chipotle", payoutNameForm = null, address = null,
-                firstSeenAt = 1, lastSeenAt = 2,
             ),
         )
         dao.upsertPickup(pickupRow(1, chainOnly, arrivedAt = 0, confirmedAt = 15_000))

--- a/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/StoreResolutionProjectorTest.kt
+++ b/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/StoreResolutionProjectorTest.kt
@@ -6,22 +6,30 @@ import cloud.trotter.dashbuddy.core.data.settings.AppPreferencesRepository
 import cloud.trotter.dashbuddy.core.database.DashBuddyDatabase
 import cloud.trotter.dashbuddy.core.database.analytics.AnalyticsDao
 import cloud.trotter.dashbuddy.core.database.analytics.AnalyticsProjectionStateEntity
+import cloud.trotter.dashbuddy.core.database.analytics.PickupRecordEntity
 import cloud.trotter.dashbuddy.core.database.analytics.StoreEntity
 import cloud.trotter.dashbuddy.core.database.event.AppEventDao
 import cloud.trotter.dashbuddy.core.database.event.AppEventEntity
+import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
+import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
+import cloud.trotter.dashbuddy.domain.evaluation.OfferQuality
 import cloud.trotter.dashbuddy.domain.evaluation.UserEconomy
 import cloud.trotter.dashbuddy.domain.model.event.AppEventCodec
 import cloud.trotter.dashbuddy.domain.model.event.AppEventType
 import cloud.trotter.dashbuddy.domain.model.event.payload.AppEventPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryAdjustmentPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.OfferPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.PickupPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionEndSource
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStartPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStartSource
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStopPayload
+import cloud.trotter.dashbuddy.domain.model.offer.ParsedOffer
 import cloud.trotter.dashbuddy.domain.model.pay.ParsedPay
 import cloud.trotter.dashbuddy.domain.model.pay.ParsedPayItem
+import cloud.trotter.dashbuddy.domain.state.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import org.junit.After
@@ -202,62 +210,83 @@ class StoreResolutionProjectorTest {
     // ── F1: incremental fold with a batch boundary splitting the job ≡ from-zero refold ──
 
     @Test
-    fun `F1 — incremental fold split across batches equals a from-zero refold`() = runBlocking {
+    fun `F1 — incremental fold with the batch boundary BETWEEN the two drops equals a from-zero refold`() = runBlocking {
+        // FIX 12b: the receipt rides the SECOND drop, with the batch boundary between the drops — the
+        // divergence-prone shape (drop1's early resolution keys chain-only; drop2's receipt upgrades it).
         insert(AppEventType.DASH_START, "S1", 1000, start("S1", 1000))
         insert(AppEventType.PICKUP_CONFIRMED, "S1", 1100, pickup("J1", "pT", "Target", 1100))
         insert(AppEventType.PICKUP_CONFIRMED, "S1", 1150, pickup("J1", "pM", "Maple Street Biscuit Company", 1150))
+        insert(AppEventType.DELIVERY_COMPLETED, "S1", 1200, delivery("J1", "dT", "Target", 1200, dropRealizedPay = 4.5))
         insert(
-            AppEventType.DELIVERY_COMPLETED, "S1", 1200,
+            AppEventType.DELIVERY_COMPLETED, "S1", 1250,
             delivery(
-                "J1", "dT", "Target", 1200,
+                "J1", "dM", "Maple Street Biscuit Company", 1250,
                 parsedPay = receipt("Target (02426)" to 2.25, "Maple Street Biscuit - Alamo Ranch" to 6.50),
-                dropRealizedPay = 4.5,
+                dropRealizedPay = 4.25,
             ),
         )
-        insert(AppEventType.DELIVERY_COMPLETED, "S1", 1250, delivery("J1", "dM", "Maple Street Biscuit Company", 1250, dropRealizedPay = 4.25))
         insert(AppEventType.DASH_STOP, "S1", 1300, stop("S1", 1300))
 
-        // Incremental: force multi-batch (limit 2) so pickups, the receipt, and the close land in
-        // different batches (the exact case the accumulator design failed).
+        // Incremental: limit 2 lands DASH_START+pT in b1, pM+dT in b2, dM+DASH_STOP in b3 — so dT and dM
+        // (and their resolutions) fall in DIFFERENT batches.
         val p = projector()
         while (p.processBatch(limit = 2) != null) { /* drain */ }
-        val incrementalStores = dao.allStores()
-        val incrementalKeys = listOf("dT", "dM").associateWith { dao.deliveryRecordByTask(it)?.storeKey }
+        val incrementalVisible = dao.storeReportRows().first().map { it.storeKey }.toSet()
+        val incrementalDeliveryKeys = listOf("dT", "dM").associateWith { dao.deliveryRecordByTask(it)?.storeKey }
+        val incrementalPickupKeys = dao.pickupRecordsForJob("J1").associate { it.taskId to it.storeKey }
 
         // From-zero refold in ONE drain.
         wipeAndResetWatermark()
         projector().catchUp()
-        val refoldStores = dao.allStores()
-        val refoldKeys = listOf("dT", "dM").associateWith { dao.deliveryRecordByTask(it)?.storeKey }
+        val refoldVisible = dao.storeReportRows().first().map { it.storeKey }.toSet()
+        val refoldDeliveryKeys = listOf("dT", "dM").associateWith { dao.deliveryRecordByTask(it)?.storeKey }
+        val refoldPickupKeys = dao.pickupRecordsForJob("J1").associate { it.taskId to it.storeKey }
 
-        assertEquals("stores identical incremental vs refold", incrementalStores, refoldStores)
-        assertEquals("delivery storeKeys identical incremental vs refold", incrementalKeys, refoldKeys)
-        assertEquals(targetKey, incrementalKeys["dT"])
-        assertEquals(mapleKey, incrementalKeys["dM"])
+        // The READ-VISIBLE store set (M4 EXISTS-filtered) + ALL delivery + ALL pickup stamps converge.
+        // NOTE: the raw `stores` table can differ — the incremental path leaves an unreferenced chain-only
+        // orphan row (dT's early resolution before dM's receipt landed); that orphan is an ACCEPTED,
+        // read-invisible residual (M4 filters it out of every read), not a divergence that surfaces.
+        assertEquals("read-visible store set identical incremental vs refold", refoldVisible, incrementalVisible)
+        assertEquals("delivery storeKeys identical", refoldDeliveryKeys, incrementalDeliveryKeys)
+        assertEquals("pickup storeKeys identical", refoldPickupKeys, incrementalPickupKeys)
+        assertEquals(targetKey, incrementalDeliveryKeys["dT"])
+        assertEquals(mapleKey, incrementalDeliveryKeys["dM"])
+        assertEquals(setOf(targetKey, mapleKey), incrementalVisible)
     }
 
     // ── H1: a disagreeing driver correction pins the row; resolution never re-keys it ──
 
     @Test
-    fun `H1 — a store-name correction pins the row and resolution does not re-key it`() = runBlocking {
+    fun `H1 — a store-name correction pins the row and resolution does not re-key it (pin is load-bearing)`() = runBlocking {
         insert(AppEventType.DASH_START, "S1", 1000, start("S1", 1000))
         insert(AppEventType.PICKUP_CONFIRMED, "S1", 1100, pickup("J1", "pT", "Target", 1100))
         val d = insert(
             AppEventType.DELIVERY_COMPLETED, "S1", 1200,
             delivery("J1", "dT", "Target", 1200, receipt("Target (02426)" to 3.0), totalPay = 8.0),
         )
-        // Driver corrects the store to a DIFFERENT chain — pins it.
+        // FIX 12a: correct to a name that STILL brand-matches the pickup anchor ("Target Cafe" shares the
+        // leading "target" token). Without the pin, resolution WOULD re-key it back to the Target entity —
+        // so the pin is genuinely load-bearing here (a disagreeing name would have stayed null regardless).
         insert(
             AppEventType.DELIVERY_ADJUSTMENT, "S1", 1250,
-            DeliveryAdjustmentPayload(targetEventSequenceId = d, sessionId = "S1", newStoreName = "Panda Express"),
+            DeliveryAdjustmentPayload(targetEventSequenceId = d, sessionId = "S1", newStoreName = "Target Cafe"),
         )
         insert(AppEventType.DASH_STOP, "S1", 1300, stop("S1", 1300)) // session-level re-resolution
         projector().catchUp()
 
         val row = dao.deliveryRecord(d)!!
-        assertEquals("driver name honored", "Panda Express", row.storeName)
+        assertEquals("driver name honored", "Target Cafe", row.storeName)
         assertEquals("pinned", 1, row.storeKeyPinned)
-        assertNull("storeKey stays null — resolution did NOT re-key it back to Target", row.storeKey)
+        assertNull("storeKey stays null — the pin blocks the brand-matching re-key", row.storeKey)
+
+        // FIX 12a refold half: a from-zero refold re-derives the pin (the DELIVERY_ADJUSTMENT replays
+        // after its target) → the pinned row's final state is identical to the incremental path.
+        wipeAndResetWatermark()
+        projector().catchUp()
+        val refold = dao.deliveryRecord(d)!!
+        assertEquals("Target Cafe", refold.storeName)
+        assertEquals(1, refold.storeKeyPinned)
+        assertNull(refold.storeKey)
     }
 
     // ── F8: a PROJECTOR_VERSION bump wipes stores + pickup_records ──
@@ -277,9 +306,18 @@ class StoreResolutionProjectorTest {
         val bogus = StoreEntity(
             storeKey = "doordash|ghost|999", platform = "doordash", normalizedChain = "ghost",
             chainDisplay = "Ghost", runningKey = "999", offerNameForm = null, pickupNameForm = "Ghost",
-            payoutNameForm = null, address = null, firstSeenAt = 1, lastSeenAt = 1,
+            payoutNameForm = null, address = null,
         )
         dao.upsertStore(bogus)
+        // FIX 12c: also seed a POISONED pickup_records row (a fake PK no refold recreates) to prove the
+        // F8 wipe clears pickup_records, not only stores.
+        dao.upsertPickup(
+            PickupRecordEntity(
+                eventSequenceId = 99_999, sessionId = "S1", platform = "doordash", jobId = "JGHOST",
+                taskId = "PTGHOST", storeName = "Ghost", storeKey = "doordash|ghost|999",
+                phaseStartedAt = 1, arrivedAt = 1, confirmedAt = 2, deadlineMillis = null, activity = "PICKUP",
+            ),
+        )
         // Force the version-mismatch rebuild by writing an OLD projectorVersion watermark.
         dao.setWatermark(AnalyticsProjectionStateEntity(watermarkSequenceId = 999, projectorVersion = 4))
 
@@ -287,5 +325,74 @@ class StoreResolutionProjectorTest {
 
         assertNull("stale bogus store wiped", dao.store("doordash|ghost|999"))
         assertNotNull("real store re-created by the refold", dao.store(targetKey))
+        assertEquals("poisoned pickup row gone after rebuild (F8)", 0, dao.pickupRecordsForJob("JGHOST").size)
     }
+
+    // ── FIX 12d: F4 offer-link guards ──
+
+    private fun offerAccepted(offerHash: String, merchant: String, at: Long) =
+        OfferPayload(
+            offerHash = offerHash,
+            parsedOffer = ParsedOffer(offerHash = offerHash),
+            evaluation = OfferEvaluation(
+                action = OfferAction.ACCEPT, score = 80.0, qualityLevel = OfferQuality.GOOD,
+                payAmount = 10.0, fuelCostEstimate = 0.0, nonFuelCostEstimate = 0.75,
+                operatingCostPerMile = 0.25, netPayAmount = 9.25, distanceMiles = 3.0,
+                dollarsPerMile = 3.0, dollarsPerHour = 20.0, estimatedTimeMinutes = 15.0,
+                itemCount = 1.0, merchantName = merchant,
+            ),
+            outcome = AppEventType.OFFER_ACCEPTED, presentedAt = at - 10, decidedAt = at,
+            returnFlow = Flow.Idle,
+        )
+
+    @Test
+    fun `F4 — a queued next-job offer that brand-DISAGREES is not linked by the temporal fallback`() = runBlocking {
+        insert(AppEventType.DASH_START, "S1", 1000, start("S1", 1000))
+        // A queued NEXT-job offer accepted mid-job for a DIFFERENT brand (Whataburger), no offer hashes
+        // on the job → temporal fallback only. It must NOT be linked to the Target job.
+        val offSeq = insert(AppEventType.OFFER_ACCEPTED, "S1", 1050, offerAccepted("HASHW", "Whataburger", 1050))
+        insert(AppEventType.PICKUP_CONFIRMED, "S1", 1100, pickup("J1", "pT", "Target", 1100))
+        insert(
+            AppEventType.DELIVERY_COMPLETED, "S1", 1200,
+            delivery("J1", "dT", "Target", 1200, receipt("Target (02426)" to 3.0), totalPay = 8.0),
+        )
+        insert(AppEventType.DASH_STOP, "S1", 1300, stop("S1", 1300))
+        projector().catchUp()
+
+        val offer = dao.offerRecord(offSeq)!!
+        assertNull("a brand-disagreeing queued offer is not linked (F4)", offer.linkedJobId)
+    }
+
+    @Test
+    fun `FIX 1b — a job already exactly-linked does not claim a second offer on the DASH_STOP re-run`() = runBlocking {
+        insert(AppEventType.DASH_START, "S1", 1000, start("S1", 1000))
+        // The job's OWN accepted offer (hash carried onto the job's events → exact link).
+        val ownSeq = insert(AppEventType.OFFER_ACCEPTED, "S1", 1040, offerAccepted("HASH1", "Target", 1040))
+        // A SECOND accepted Target offer (a next job's), same brand → would temporally agree.
+        val nextSeq = insert(AppEventType.OFFER_ACCEPTED, "S1", 1060, offerAccepted("HASH2", "Target", 1060))
+        insert(AppEventType.PICKUP_CONFIRMED, "S1", 1100, pickupWithHashes("J1", "pT", "Target", 1100, listOf("HASH1")))
+        insert(
+            AppEventType.DELIVERY_COMPLETED, "S1", 1200,
+            deliveryWithHashes("J1", "dT", "Target", 1200, receipt("Target (02426)" to 3.0), 8.0, listOf("HASH1")),
+        )
+        insert(AppEventType.DASH_STOP, "S1", 1300, stop("S1", 1300)) // session-level re-run, no hashes → temporal
+        projector().catchUp()
+
+        assertEquals("the exact-linked own offer is claimed", "J1", dao.offerRecord(ownSeq)!!.linkedJobId)
+        assertNull("the second Target offer is NOT claimed on the DASH_STOP re-run (FIX 1b)", dao.offerRecord(nextSeq)!!.linkedJobId)
+    }
+
+    private fun pickupWithHashes(jobId: String, taskId: String, store: String, at: Long, hashes: List<String>) =
+        PickupPayload(
+            jobId = jobId, taskId = taskId, storeName = store, phaseStartedAt = at - 100,
+            arrivedAt = at - 60, confirmedAt = at, activity = "PICKUP", jobOfferHashes = hashes,
+        )
+
+    private fun deliveryWithHashes(
+        jobId: String, taskId: String, store: String, at: Long, parsedPay: ParsedPay, totalPay: Double, hashes: List<String>,
+    ) = DeliveryPayload(
+        jobId = jobId, taskId = taskId, storeName = store, customerHash = "cust-$taskId",
+        addressHash = "addr-$taskId", phaseStartedAt = at - 200, arrivedAt = at - 30,
+        completedAt = at, totalPay = totalPay, parsedPay = parsedPay, jobOfferHashes = hashes,
+    )
 }

--- a/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/StoreResolutionProjectorTest.kt
+++ b/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/StoreResolutionProjectorTest.kt
@@ -1,0 +1,291 @@
+package cloud.trotter.dashbuddy.core.data.analytics
+
+import androidx.room.Room
+import cloud.trotter.dashbuddy.core.data.event.AppEventRepo
+import cloud.trotter.dashbuddy.core.data.settings.AppPreferencesRepository
+import cloud.trotter.dashbuddy.core.database.DashBuddyDatabase
+import cloud.trotter.dashbuddy.core.database.analytics.AnalyticsDao
+import cloud.trotter.dashbuddy.core.database.analytics.AnalyticsProjectionStateEntity
+import cloud.trotter.dashbuddy.core.database.analytics.StoreEntity
+import cloud.trotter.dashbuddy.core.database.event.AppEventDao
+import cloud.trotter.dashbuddy.core.database.event.AppEventEntity
+import cloud.trotter.dashbuddy.domain.evaluation.UserEconomy
+import cloud.trotter.dashbuddy.domain.model.event.AppEventCodec
+import cloud.trotter.dashbuddy.domain.model.event.AppEventType
+import cloud.trotter.dashbuddy.domain.model.event.payload.AppEventPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryAdjustmentPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.PickupPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.SessionEndSource
+import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStartPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStartSource
+import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStopPayload
+import cloud.trotter.dashbuddy.domain.model.pay.ParsedPay
+import cloud.trotter.dashbuddy.domain.model.pay.ParsedPayItem
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+/**
+ * #159 — the store-resolution edges of [AnalyticsProjector] against an in-memory Room DB: fresh
+ * resolution, the B1 no-downgrade + re-run-no-op guards, the B2 multi-store stack, the F1 batch-
+ * boundary incremental ≡ refold guard, the H1 correction pin, and the F8 version-wipe. The pure
+ * resolver/normalizer are covered in `:domain`.
+ */
+@RunWith(RobolectricTestRunner::class)
+class StoreResolutionProjectorTest {
+
+    private lateinit var db: DashBuddyDatabase
+    private lateinit var dao: AnalyticsDao
+    private lateinit var eventDao: AppEventDao
+    private lateinit var repo: AppEventRepo
+    private lateinit var prefs: AppPreferencesRepository
+
+    @Before
+    fun setUp() {
+        val context = RuntimeEnvironment.getApplication()
+        db = Room.inMemoryDatabaseBuilder(context, DashBuddyDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = db.analyticsDao()
+        eventDao = db.appEventDao()
+        repo = AppEventRepo(db, eventDao, db.effectsFiredDao())
+        prefs = mock { on { userEconomy } doReturn flowOf(UserEconomy()) }
+    }
+
+    @After
+    fun tearDown() = db.close()
+
+    private fun projector() = AnalyticsProjector(db, repo, eventDao, dao, prefs)
+
+    private suspend fun insert(type: AppEventType, sessionId: String?, at: Long, payload: AppEventPayload?): Long =
+        eventDao.insert(
+            AppEventEntity(
+                aggregateId = sessionId,
+                eventType = type,
+                eventPayload = payload?.let(AppEventCodec::encodePayload) ?: "{}",
+                occurredAt = at,
+            ),
+        )
+
+    private fun start(sid: String, at: Long) =
+        SessionStartPayload(sid, "DoorDash", at, SessionStartSource.INTERACTION, "start")
+
+    private fun stop(sid: String, at: Long) =
+        SessionStopPayload(sid, at, SessionEndSource.EARLY_OFFLINE, platform = "DoorDash")
+
+    private fun pickup(jobId: String, taskId: String, store: String, at: Long, address: String? = null) =
+        PickupPayload(
+            jobId = jobId, taskId = taskId, storeName = store, phaseStartedAt = at - 100,
+            arrivedAt = at - 60, confirmedAt = at, activity = "PICKUP", storeAddress = address,
+        )
+
+    private fun delivery(
+        jobId: String,
+        taskId: String,
+        store: String,
+        at: Long,
+        parsedPay: ParsedPay? = null,
+        totalPay: Double? = null,
+        dropRealizedPay: Double? = null,
+        customerHash: String? = "cust-$taskId",
+    ) = DeliveryPayload(
+        jobId = jobId, taskId = taskId, storeName = store, customerHash = customerHash,
+        addressHash = "addr-$taskId", phaseStartedAt = at - 200, arrivedAt = at - 30,
+        completedAt = at, totalPay = totalPay, parsedPay = parsedPay, dropRealizedPay = dropRealizedPay,
+    )
+
+    private fun receipt(vararg tips: Pair<String, Double>) =
+        ParsedPay(
+            appPayComponents = listOf(ParsedPayItem("Base Pay", 5.0)),
+            customerTips = tips.map { ParsedPayItem(it.first, it.second) },
+        )
+
+    private val targetKey = "doordash|target|02426"
+    private val mapleKey = "doordash|maple street biscuit company|alamo ranch"
+
+    // ── Basics: fresh fold stamps stores + pickup_records + delivery storeKey ──
+
+    @Test
+    fun `fresh fold resolves a single-store job — stores row, pickup + delivery keyed`() = runBlocking {
+        insert(AppEventType.DASH_START, "S1", 1000, start("S1", 1000))
+        val pu = insert(AppEventType.PICKUP_CONFIRMED, "S1", 1100, pickup("J1", "pT", "Target", 1100, "123 Main St"))
+        val d = insert(
+            AppEventType.DELIVERY_COMPLETED, "S1", 1200,
+            delivery("J1", "dT", "Target", 1200, receipt("Target (02426)" to 3.0), totalPay = 8.0),
+        )
+        insert(AppEventType.DASH_STOP, "S1", 1300, stop("S1", 1300))
+        projector().catchUp()
+
+        val store = dao.store(targetKey)
+        assertNotNull("Target keyed store exists", store)
+        assertEquals("target", store!!.normalizedChain)
+        assertEquals("02426", store.runningKey)
+        assertEquals("123 Main St", store.address)
+        assertEquals("Target", store.pickupNameForm)
+        assertEquals(targetKey, dao.pickupRecordsForJob("J1").single { it.eventSequenceId == pu }.storeKey)
+        assertEquals(targetKey, dao.deliveryRecord(d)!!.storeKey)
+        // pay/net untouched by resolution.
+        assertEquals(8.0, dao.deliveryRecord(d)!!.realizedPay!!, 0.001)
+    }
+
+    // ── B1: keyed drop then payout-less DASH_STOP → no downgrade; re-run is a no-op ──
+
+    @Test
+    fun `B1 — payout-less DASH_STOP does not downgrade a keyed store, and a re-run is a no-op`() = runBlocking {
+        insert(AppEventType.DASH_START, "S1", 1000, start("S1", 1000))
+        insert(AppEventType.PICKUP_CONFIRMED, "S1", 1100, pickup("J1", "pT", "Target", 1100))
+        val d = insert(
+            AppEventType.DELIVERY_COMPLETED, "S1", 1200,
+            delivery("J1", "dT", "Target", 1200, receipt("Target (02426)" to 3.0), totalPay = 8.0),
+        )
+        insert(AppEventType.DASH_STOP, "S1", 1300, stop("S1", 1300))
+        projector().catchUp()
+
+        // Still keyed after the payout-less DASH_STOP resolution ran (session-level, no receipt).
+        assertEquals(targetKey, dao.deliveryRecord(d)!!.storeKey)
+        val storeBefore = dao.store(targetKey)!!
+
+        // A from-zero refold re-runs every resolution over the row set: byte-identical (L1) — the key
+        // is row-sourced, so the payout-less close recomputes the SAME key, no downgrade.
+        wipeAndResetWatermark()
+        projector().catchUp()
+        assertEquals("store row byte-identical on refold", storeBefore, dao.store(targetKey))
+        assertEquals(targetKey, dao.deliveryRecord(d)!!.storeKey)
+    }
+
+    private suspend fun wipeAndResetWatermark() {
+        dao.deleteAllDeliveries(); dao.deleteAllSessions(); dao.deleteAllOffers()
+        dao.deleteAllStores(); dao.deleteAllPickupRecords()
+        dao.setWatermark(AnalyticsProjectionStateEntity(watermarkSequenceId = 0, projectorVersion = 5))
+    }
+
+    // ── B2: Target+Maple stack, one receipt on drop1, drop2 receipt-less, closed by DASH_STOP ──
+
+    @Test
+    fun `B2 — a multi-store stack keys BOTH stores from the single receipt`() = runBlocking {
+        insert(AppEventType.DASH_START, "S1", 1000, start("S1", 1000))
+        insert(AppEventType.PICKUP_CONFIRMED, "S1", 1100, pickup("J1", "pT", "Target", 1100))
+        insert(AppEventType.PICKUP_CONFIRMED, "S1", 1150, pickup("J1", "pM", "Maple Street Biscuit Company", 1150))
+        // drop1 carries the FULL receipt (both store lines); drop2 is receipt-less.
+        val d1 = insert(
+            AppEventType.DELIVERY_COMPLETED, "S1", 1200,
+            delivery(
+                "J1", "dT", "Target", 1200,
+                parsedPay = receipt("Target (02426)" to 2.25, "Maple Street Biscuit - Alamo Ranch" to 6.50),
+                dropRealizedPay = 4.5,
+            ),
+        )
+        val d2 = insert(
+            AppEventType.DELIVERY_COMPLETED, "S1", 1250,
+            delivery("J1", "dM", "Maple Street Biscuit Company", 1250, dropRealizedPay = 4.25),
+        )
+        insert(AppEventType.DASH_STOP, "S1", 1300, stop("S1", 1300))
+        projector().catchUp()
+
+        assertNotNull("Target keyed", dao.store(targetKey))
+        assertNotNull("Maple keyed (NOT chain-only) — both stores of the stack keyed from one receipt", dao.store(mapleKey))
+        assertEquals(targetKey, dao.deliveryRecord(d1)!!.storeKey)
+        assertEquals(mapleKey, dao.deliveryRecord(d2)!!.storeKey)
+    }
+
+    // ── F1: incremental fold with a batch boundary splitting the job ≡ from-zero refold ──
+
+    @Test
+    fun `F1 — incremental fold split across batches equals a from-zero refold`() = runBlocking {
+        insert(AppEventType.DASH_START, "S1", 1000, start("S1", 1000))
+        insert(AppEventType.PICKUP_CONFIRMED, "S1", 1100, pickup("J1", "pT", "Target", 1100))
+        insert(AppEventType.PICKUP_CONFIRMED, "S1", 1150, pickup("J1", "pM", "Maple Street Biscuit Company", 1150))
+        insert(
+            AppEventType.DELIVERY_COMPLETED, "S1", 1200,
+            delivery(
+                "J1", "dT", "Target", 1200,
+                parsedPay = receipt("Target (02426)" to 2.25, "Maple Street Biscuit - Alamo Ranch" to 6.50),
+                dropRealizedPay = 4.5,
+            ),
+        )
+        insert(AppEventType.DELIVERY_COMPLETED, "S1", 1250, delivery("J1", "dM", "Maple Street Biscuit Company", 1250, dropRealizedPay = 4.25))
+        insert(AppEventType.DASH_STOP, "S1", 1300, stop("S1", 1300))
+
+        // Incremental: force multi-batch (limit 2) so pickups, the receipt, and the close land in
+        // different batches (the exact case the accumulator design failed).
+        val p = projector()
+        while (p.processBatch(limit = 2) != null) { /* drain */ }
+        val incrementalStores = dao.allStores()
+        val incrementalKeys = listOf("dT", "dM").associateWith { dao.deliveryRecordByTask(it)?.storeKey }
+
+        // From-zero refold in ONE drain.
+        wipeAndResetWatermark()
+        projector().catchUp()
+        val refoldStores = dao.allStores()
+        val refoldKeys = listOf("dT", "dM").associateWith { dao.deliveryRecordByTask(it)?.storeKey }
+
+        assertEquals("stores identical incremental vs refold", incrementalStores, refoldStores)
+        assertEquals("delivery storeKeys identical incremental vs refold", incrementalKeys, refoldKeys)
+        assertEquals(targetKey, incrementalKeys["dT"])
+        assertEquals(mapleKey, incrementalKeys["dM"])
+    }
+
+    // ── H1: a disagreeing driver correction pins the row; resolution never re-keys it ──
+
+    @Test
+    fun `H1 — a store-name correction pins the row and resolution does not re-key it`() = runBlocking {
+        insert(AppEventType.DASH_START, "S1", 1000, start("S1", 1000))
+        insert(AppEventType.PICKUP_CONFIRMED, "S1", 1100, pickup("J1", "pT", "Target", 1100))
+        val d = insert(
+            AppEventType.DELIVERY_COMPLETED, "S1", 1200,
+            delivery("J1", "dT", "Target", 1200, receipt("Target (02426)" to 3.0), totalPay = 8.0),
+        )
+        // Driver corrects the store to a DIFFERENT chain — pins it.
+        insert(
+            AppEventType.DELIVERY_ADJUSTMENT, "S1", 1250,
+            DeliveryAdjustmentPayload(targetEventSequenceId = d, sessionId = "S1", newStoreName = "Panda Express"),
+        )
+        insert(AppEventType.DASH_STOP, "S1", 1300, stop("S1", 1300)) // session-level re-resolution
+        projector().catchUp()
+
+        val row = dao.deliveryRecord(d)!!
+        assertEquals("driver name honored", "Panda Express", row.storeName)
+        assertEquals("pinned", 1, row.storeKeyPinned)
+        assertNull("storeKey stays null — resolution did NOT re-key it back to Target", row.storeKey)
+    }
+
+    // ── F8: a PROJECTOR_VERSION bump wipes stores + pickup_records ──
+
+    @Test
+    fun `F8 — a version bump wipes stale stores and pickup_records`() = runBlocking {
+        // Seed a real store + one bogus stale store, and a bogus pickup row, at an OLD projector version.
+        insert(AppEventType.DASH_START, "S1", 1000, start("S1", 1000))
+        insert(AppEventType.PICKUP_CONFIRMED, "S1", 1100, pickup("J1", "pT", "Target", 1100))
+        insert(
+            AppEventType.DELIVERY_COMPLETED, "S1", 1200,
+            delivery("J1", "dT", "Target", 1200, receipt("Target (02426)" to 3.0), totalPay = 8.0),
+        )
+        insert(AppEventType.DASH_STOP, "S1", 1300, stop("S1", 1300))
+        projector().catchUp() // version 5, real store created
+
+        val bogus = StoreEntity(
+            storeKey = "doordash|ghost|999", platform = "doordash", normalizedChain = "ghost",
+            chainDisplay = "Ghost", runningKey = "999", offerNameForm = null, pickupNameForm = "Ghost",
+            payoutNameForm = null, address = null, firstSeenAt = 1, lastSeenAt = 1,
+        )
+        dao.upsertStore(bogus)
+        // Force the version-mismatch rebuild by writing an OLD projectorVersion watermark.
+        dao.setWatermark(AnalyticsProjectionStateEntity(watermarkSequenceId = 999, projectorVersion = 4))
+
+        projector().catchUp() // triggers rebuildIfVersionChanged → F8 wipe + refold
+
+        assertNull("stale bogus store wiped", dao.store("doordash|ghost|999"))
+        assertNotNull("real store re-created by the refold", dao.store(targetKey))
+    }
+}

--- a/core/database/schemas/cloud.trotter.dashbuddy.core.database.DashBuddyDatabase/12.json
+++ b/core/database/schemas/cloud.trotter.dashbuddy.core.database.DashBuddyDatabase/12.json
@@ -1,0 +1,1115 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 12,
+    "identityHash": "9721699725291acd1b698dc5916b3c4f",
+    "entities": [
+      {
+        "tableName": "app_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sequenceId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `aggregateId` TEXT, `eventType` TEXT NOT NULL, `eventPayload` TEXT NOT NULL, `occurredAt` INTEGER NOT NULL, `metadata` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "sequenceId",
+            "columnName": "sequenceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "aggregateId",
+            "columnName": "aggregateId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "eventType",
+            "columnName": "eventType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventPayload",
+            "columnName": "eventPayload",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "occurredAt",
+            "columnName": "occurredAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadata",
+            "columnName": "metadata",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "sequenceId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_app_events_aggregateId",
+            "unique": false,
+            "columnNames": [
+              "aggregateId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_app_events_aggregateId` ON `${TABLE_NAME}` (`aggregateId`)"
+          },
+          {
+            "name": "index_app_events_eventType",
+            "unique": false,
+            "columnNames": [
+              "eventType"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_app_events_eventType` ON `${TABLE_NAME}` (`eventType`)"
+          },
+          {
+            "name": "index_app_events_occurredAt",
+            "unique": false,
+            "columnNames": [
+              "occurredAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_app_events_occurredAt` ON `${TABLE_NAME}` (`occurredAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "app_state_snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`correlationVersion` INTEGER NOT NULL, `capturedAt` INTEGER NOT NULL, `sessionId` TEXT, `stateJson` TEXT NOT NULL, PRIMARY KEY(`correlationVersion`))",
+        "fields": [
+          {
+            "fieldPath": "correlationVersion",
+            "columnName": "correlationVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "capturedAt",
+            "columnName": "capturedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "stateJson",
+            "columnName": "stateJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "correlationVersion"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `dashId` TEXT, `text` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `personaType` TEXT NOT NULL, `personaName` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dashId",
+            "columnName": "dashId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personaType",
+            "columnName": "personaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personaName",
+            "columnName": "personaName",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_messages_dashId",
+            "unique": false,
+            "columnNames": [
+              "dashId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_messages_dashId` ON `${TABLE_NAME}` (`dashId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "effects_fired",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `effectKey` TEXT NOT NULL, `firedAt` INTEGER NOT NULL, `correlationVersion` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "effectKey",
+            "columnName": "effectKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firedAt",
+            "columnName": "firedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "correlationVersion",
+            "columnName": "correlationVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_effects_fired_effectKey",
+            "unique": true,
+            "columnNames": [
+              "effectKey"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_effects_fired_effectKey` ON `${TABLE_NAME}` (`effectKey`)"
+          }
+        ]
+      },
+      {
+        "tableName": "observations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sequenceId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `occurredAt` INTEGER NOT NULL, `sessionId` TEXT, `pipelineId` TEXT NOT NULL, `ruleId` TEXT, `platform` TEXT, `flow` TEXT, `modeHint` TEXT, `parsedJson` TEXT NOT NULL, `captureId` TEXT, `metadataJson` TEXT NOT NULL, `correlationVersion` INTEGER NOT NULL, `timeoutType` TEXT, `payloadJson` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "sequenceId",
+            "columnName": "sequenceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "occurredAt",
+            "columnName": "occurredAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pipelineId",
+            "columnName": "pipelineId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ruleId",
+            "columnName": "ruleId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "flow",
+            "columnName": "flow",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "modeHint",
+            "columnName": "modeHint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "parsedJson",
+            "columnName": "parsedJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "captureId",
+            "columnName": "captureId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "metadataJson",
+            "columnName": "metadataJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "correlationVersion",
+            "columnName": "correlationVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeoutType",
+            "columnName": "timeoutType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "payloadJson",
+            "columnName": "payloadJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "sequenceId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_observations_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_observations_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          },
+          {
+            "name": "index_observations_occurredAt",
+            "unique": false,
+            "columnNames": [
+              "occurredAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_observations_occurredAt` ON `${TABLE_NAME}` (`occurredAt`)"
+          },
+          {
+            "name": "index_observations_correlationVersion",
+            "unique": false,
+            "columnNames": [
+              "correlationVersion"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_observations_correlationVersion` ON `${TABLE_NAME}` (`correlationVersion`)"
+          }
+        ]
+      },
+      {
+        "tableName": "delivery_records",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`eventSequenceId` INTEGER NOT NULL, `sessionId` TEXT, `platform` TEXT NOT NULL, `jobId` TEXT NOT NULL, `taskId` TEXT NOT NULL, `storeName` TEXT, `customerHash` TEXT, `addressHash` TEXT, `phaseStartedAt` INTEGER NOT NULL, `arrivedAt` INTEGER, `completedAt` INTEGER NOT NULL, `deadlineMillis` INTEGER, `realizedPay` REAL, `payBasis` TEXT NOT NULL, `tip` REAL, `basePay` REAL, `odometerAtCompletion` REAL, `realizedMiles` REAL, `realizedMinutes` REAL, `frozenCostPerMile` REAL, `frozenFuelPerMile` REAL, `frozenNonFuelPerMile` REAL, `netProfit` REAL, `costBasis` TEXT NOT NULL, `cashTip` REAL, `originalPayBasis` TEXT, `storeKey` TEXT, `payoutStoreForms` TEXT, `storeKeyPinned` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`eventSequenceId`))",
+        "fields": [
+          {
+            "fieldPath": "eventSequenceId",
+            "columnName": "eventSequenceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jobId",
+            "columnName": "jobId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "taskId",
+            "columnName": "taskId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storeName",
+            "columnName": "storeName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customerHash",
+            "columnName": "customerHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addressHash",
+            "columnName": "addressHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "phaseStartedAt",
+            "columnName": "phaseStartedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "arrivedAt",
+            "columnName": "arrivedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deadlineMillis",
+            "columnName": "deadlineMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "realizedPay",
+            "columnName": "realizedPay",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "payBasis",
+            "columnName": "payBasis",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tip",
+            "columnName": "tip",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "basePay",
+            "columnName": "basePay",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "odometerAtCompletion",
+            "columnName": "odometerAtCompletion",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "realizedMiles",
+            "columnName": "realizedMiles",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "realizedMinutes",
+            "columnName": "realizedMinutes",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "frozenCostPerMile",
+            "columnName": "frozenCostPerMile",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "frozenFuelPerMile",
+            "columnName": "frozenFuelPerMile",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "frozenNonFuelPerMile",
+            "columnName": "frozenNonFuelPerMile",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "netProfit",
+            "columnName": "netProfit",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "costBasis",
+            "columnName": "costBasis",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cashTip",
+            "columnName": "cashTip",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "originalPayBasis",
+            "columnName": "originalPayBasis",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "storeKey",
+            "columnName": "storeKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "payoutStoreForms",
+            "columnName": "payoutStoreForms",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "storeKeyPinned",
+            "columnName": "storeKeyPinned",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "eventSequenceId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_delivery_records_completedAt",
+            "unique": false,
+            "columnNames": [
+              "completedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_delivery_records_completedAt` ON `${TABLE_NAME}` (`completedAt`)"
+          },
+          {
+            "name": "index_delivery_records_platform_completedAt",
+            "unique": false,
+            "columnNames": [
+              "platform",
+              "completedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_delivery_records_platform_completedAt` ON `${TABLE_NAME}` (`platform`, `completedAt`)"
+          },
+          {
+            "name": "index_delivery_records_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_delivery_records_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          },
+          {
+            "name": "index_delivery_records_sessionId_jobId",
+            "unique": false,
+            "columnNames": [
+              "sessionId",
+              "jobId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_delivery_records_sessionId_jobId` ON `${TABLE_NAME}` (`sessionId`, `jobId`)"
+          },
+          {
+            "name": "index_delivery_records_jobId",
+            "unique": false,
+            "columnNames": [
+              "jobId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_delivery_records_jobId` ON `${TABLE_NAME}` (`jobId`)"
+          },
+          {
+            "name": "index_delivery_records_storeName",
+            "unique": false,
+            "columnNames": [
+              "storeName"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_delivery_records_storeName` ON `${TABLE_NAME}` (`storeName`)"
+          },
+          {
+            "name": "index_delivery_records_storeKey",
+            "unique": false,
+            "columnNames": [
+              "storeKey"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_delivery_records_storeKey` ON `${TABLE_NAME}` (`storeKey`)"
+          }
+        ]
+      },
+      {
+        "tableName": "session_records",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sessionId` TEXT NOT NULL, `platform` TEXT NOT NULL, `startedAt` INTEGER NOT NULL, `endedAt` INTEGER, `lastEventAt` INTEGER NOT NULL, `endSource` TEXT, `startSource` TEXT, `startOdometer` REAL, `lastOdometer` REAL, `reportedEarnings` REAL, `reportedDurationMillis` INTEGER, `offersReceived` INTEGER NOT NULL, `offersAccepted` INTEGER NOT NULL, `offersDeclined` INTEGER NOT NULL, `offersTimeout` INTEGER NOT NULL, `deliveries` INTEGER NOT NULL, `jobsCompleted` INTEGER NOT NULL, PRIMARY KEY(`sessionId`))",
+        "fields": [
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "startedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endedAt",
+            "columnName": "endedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastEventAt",
+            "columnName": "lastEventAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endSource",
+            "columnName": "endSource",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "startSource",
+            "columnName": "startSource",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "startOdometer",
+            "columnName": "startOdometer",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "lastOdometer",
+            "columnName": "lastOdometer",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "reportedEarnings",
+            "columnName": "reportedEarnings",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "reportedDurationMillis",
+            "columnName": "reportedDurationMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "offersReceived",
+            "columnName": "offersReceived",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "offersAccepted",
+            "columnName": "offersAccepted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "offersDeclined",
+            "columnName": "offersDeclined",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "offersTimeout",
+            "columnName": "offersTimeout",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deliveries",
+            "columnName": "deliveries",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jobsCompleted",
+            "columnName": "jobsCompleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sessionId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_session_records_startedAt",
+            "unique": false,
+            "columnNames": [
+              "startedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_session_records_startedAt` ON `${TABLE_NAME}` (`startedAt`)"
+          },
+          {
+            "name": "index_session_records_platform_startedAt",
+            "unique": false,
+            "columnNames": [
+              "platform",
+              "startedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_session_records_platform_startedAt` ON `${TABLE_NAME}` (`platform`, `startedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "offer_records",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`eventSequenceId` INTEGER NOT NULL, `sessionId` TEXT, `platform` TEXT NOT NULL, `offerHash` TEXT NOT NULL, `outcome` TEXT NOT NULL, `presentedAt` INTEGER NOT NULL, `decidedAt` INTEGER NOT NULL, `payAmount` REAL, `distanceMiles` REAL, `itemCount` INTEGER NOT NULL, `merchantName` TEXT, `score` REAL, `action` TEXT, `quality` TEXT, `estNetPay` REAL, `estDollarsPerHour` REAL, `estDollarsPerMile` REAL, `estTimeMinutes` REAL, `estOperatingCostPerMile` REAL, `estFuelPerMile` REAL, `estNonFuelPerMile` REAL, `storeKey` TEXT, `linkedJobId` TEXT, PRIMARY KEY(`eventSequenceId`))",
+        "fields": [
+          {
+            "fieldPath": "eventSequenceId",
+            "columnName": "eventSequenceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "offerHash",
+            "columnName": "offerHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "outcome",
+            "columnName": "outcome",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "presentedAt",
+            "columnName": "presentedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "decidedAt",
+            "columnName": "decidedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payAmount",
+            "columnName": "payAmount",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "distanceMiles",
+            "columnName": "distanceMiles",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "itemCount",
+            "columnName": "itemCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchantName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "action",
+            "columnName": "action",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "quality",
+            "columnName": "quality",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "estNetPay",
+            "columnName": "estNetPay",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "estDollarsPerHour",
+            "columnName": "estDollarsPerHour",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "estDollarsPerMile",
+            "columnName": "estDollarsPerMile",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "estTimeMinutes",
+            "columnName": "estTimeMinutes",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "estOperatingCostPerMile",
+            "columnName": "estOperatingCostPerMile",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "estFuelPerMile",
+            "columnName": "estFuelPerMile",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "estNonFuelPerMile",
+            "columnName": "estNonFuelPerMile",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "storeKey",
+            "columnName": "storeKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "linkedJobId",
+            "columnName": "linkedJobId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "eventSequenceId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_offer_records_decidedAt",
+            "unique": false,
+            "columnNames": [
+              "decidedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offer_records_decidedAt` ON `${TABLE_NAME}` (`decidedAt`)"
+          },
+          {
+            "name": "index_offer_records_platform_decidedAt",
+            "unique": false,
+            "columnNames": [
+              "platform",
+              "decidedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offer_records_platform_decidedAt` ON `${TABLE_NAME}` (`platform`, `decidedAt`)"
+          },
+          {
+            "name": "index_offer_records_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offer_records_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          },
+          {
+            "name": "index_offer_records_offerHash",
+            "unique": false,
+            "columnNames": [
+              "offerHash"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offer_records_offerHash` ON `${TABLE_NAME}` (`offerHash`)"
+          },
+          {
+            "name": "index_offer_records_linkedJobId",
+            "unique": false,
+            "columnNames": [
+              "linkedJobId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offer_records_linkedJobId` ON `${TABLE_NAME}` (`linkedJobId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "analytics_projection_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `watermarkSequenceId` INTEGER NOT NULL, `projectorVersion` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "watermarkSequenceId",
+            "columnName": "watermarkSequenceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "projectorVersion",
+            "columnName": "projectorVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "stores",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storeKey` TEXT NOT NULL, `platform` TEXT NOT NULL, `normalizedChain` TEXT NOT NULL, `chainDisplay` TEXT NOT NULL, `runningKey` TEXT, `offerNameForm` TEXT, `pickupNameForm` TEXT, `payoutNameForm` TEXT, `address` TEXT, `firstSeenAt` INTEGER NOT NULL, `lastSeenAt` INTEGER NOT NULL, PRIMARY KEY(`storeKey`))",
+        "fields": [
+          {
+            "fieldPath": "storeKey",
+            "columnName": "storeKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "normalizedChain",
+            "columnName": "normalizedChain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chainDisplay",
+            "columnName": "chainDisplay",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "runningKey",
+            "columnName": "runningKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "offerNameForm",
+            "columnName": "offerNameForm",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pickupNameForm",
+            "columnName": "pickupNameForm",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "payoutNameForm",
+            "columnName": "payoutNameForm",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "firstSeenAt",
+            "columnName": "firstSeenAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenAt",
+            "columnName": "lastSeenAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storeKey"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_stores_normalizedChain",
+            "unique": false,
+            "columnNames": [
+              "normalizedChain"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_stores_normalizedChain` ON `${TABLE_NAME}` (`normalizedChain`)"
+          }
+        ]
+      },
+      {
+        "tableName": "pickup_records",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`eventSequenceId` INTEGER NOT NULL, `sessionId` TEXT, `platform` TEXT NOT NULL, `jobId` TEXT NOT NULL, `taskId` TEXT NOT NULL, `storeName` TEXT NOT NULL, `storeKey` TEXT, `phaseStartedAt` INTEGER NOT NULL, `arrivedAt` INTEGER, `confirmedAt` INTEGER, `deadlineMillis` INTEGER, `activity` TEXT, `storeAddress` TEXT, PRIMARY KEY(`eventSequenceId`))",
+        "fields": [
+          {
+            "fieldPath": "eventSequenceId",
+            "columnName": "eventSequenceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jobId",
+            "columnName": "jobId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "taskId",
+            "columnName": "taskId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storeName",
+            "columnName": "storeName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storeKey",
+            "columnName": "storeKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "phaseStartedAt",
+            "columnName": "phaseStartedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "arrivedAt",
+            "columnName": "arrivedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "confirmedAt",
+            "columnName": "confirmedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "deadlineMillis",
+            "columnName": "deadlineMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "activity",
+            "columnName": "activity",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "storeAddress",
+            "columnName": "storeAddress",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "eventSequenceId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_pickup_records_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_pickup_records_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          },
+          {
+            "name": "index_pickup_records_jobId",
+            "unique": false,
+            "columnNames": [
+              "jobId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_pickup_records_jobId` ON `${TABLE_NAME}` (`jobId`)"
+          },
+          {
+            "name": "index_pickup_records_storeKey",
+            "unique": false,
+            "columnNames": [
+              "storeKey"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_pickup_records_storeKey` ON `${TABLE_NAME}` (`storeKey`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '9721699725291acd1b698dc5916b3c4f')"
+    ]
+  }
+}

--- a/core/database/schemas/cloud.trotter.dashbuddy.core.database.DashBuddyDatabase/12.json
+++ b/core/database/schemas/cloud.trotter.dashbuddy.core.database.DashBuddyDatabase/12.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 12,
-    "identityHash": "9721699725291acd1b698dc5916b3c4f",
+    "identityHash": "ef72ae74f079bf1e63ce89b439fb2343",
     "entities": [
       {
         "tableName": "app_events",
@@ -912,7 +912,7 @@
       },
       {
         "tableName": "stores",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storeKey` TEXT NOT NULL, `platform` TEXT NOT NULL, `normalizedChain` TEXT NOT NULL, `chainDisplay` TEXT NOT NULL, `runningKey` TEXT, `offerNameForm` TEXT, `pickupNameForm` TEXT, `payoutNameForm` TEXT, `address` TEXT, `firstSeenAt` INTEGER NOT NULL, `lastSeenAt` INTEGER NOT NULL, PRIMARY KEY(`storeKey`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storeKey` TEXT NOT NULL, `platform` TEXT NOT NULL, `normalizedChain` TEXT NOT NULL, `chainDisplay` TEXT NOT NULL, `runningKey` TEXT, `offerNameForm` TEXT, `pickupNameForm` TEXT, `payoutNameForm` TEXT, `address` TEXT, PRIMARY KEY(`storeKey`))",
         "fields": [
           {
             "fieldPath": "storeKey",
@@ -962,18 +962,6 @@
             "fieldPath": "address",
             "columnName": "address",
             "affinity": "TEXT"
-          },
-          {
-            "fieldPath": "firstSeenAt",
-            "columnName": "firstSeenAt",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "lastSeenAt",
-            "columnName": "lastSeenAt",
-            "affinity": "INTEGER",
-            "notNull": true
           }
         ],
         "primaryKey": {
@@ -1109,7 +1097,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '9721699725291acd1b698dc5916b3c4f')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'ef72ae74f079bf1e63ce89b439fb2343')"
     ]
   }
 }

--- a/core/database/src/androidTest/java/cloud/trotter/dashbuddy/core/database/AnalyticsMigration11to12Test.kt
+++ b/core/database/src/androidTest/java/cloud/trotter/dashbuddy/core/database/AnalyticsMigration11to12Test.kt
@@ -1,0 +1,102 @@
+package cloud.trotter.dashbuddy.core.database
+
+import androidx.room.testing.MigrationTestHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * #159 — execute the REAL committed `AutoMigration(11→12)` against a **populated** v11 database and
+ * prove it is additive-only: the pre-existing analytics rows survive, the two new tables
+ * (`stores` + `pickup_records`) exist, and the new nullable/defaulted columns are present
+ * (delivery_records.{storeKey, payoutStoreForms, storeKeyPinned}, offer_records.{storeKey,
+ * linkedJobId}) — left NULL / defaulted by the ADD COLUMN (the `PROJECTOR_VERSION` 4→5 refold
+ * repopulates them from the immutable log).
+ *
+ * Instrumented (androidTest) because [MigrationTestHelper] opens an on-disk SQLite DB via the
+ * framework factory and replays the exported schema JSONs. Runs under
+ * `:core:database:connectedAndroidTest`.
+ */
+@RunWith(AndroidJUnit4::class)
+class AnalyticsMigration11to12Test {
+
+    private val dbName = "migration-11-to-12-test"
+
+    @get:Rule
+    val helper = MigrationTestHelper(
+        InstrumentationRegistry.getInstrumentation(),
+        DashBuddyDatabase::class.java,
+        emptyList(),
+        FrameworkSQLiteOpenHelperFactory(),
+    )
+
+    @Test
+    fun migrate11To12_preservesRows_addsStoreTablesAndColumns() {
+        helper.createDatabase(dbName, 11).use { db ->
+            db.execSQL(
+                """INSERT INTO delivery_records
+                   (eventSequenceId, sessionId, platform, jobId, taskId, storeName, customerHash,
+                    addressHash, phaseStartedAt, arrivedAt, completedAt, deadlineMillis, realizedPay,
+                    payBasis, tip, basePay, odometerAtCompletion, realizedMiles, realizedMinutes,
+                    frozenCostPerMile, frozenFuelPerMile, frozenNonFuelPerMile, netProfit, costBasis,
+                    cashTip, originalPayBasis)
+                   VALUES (1, 'S1', 'doordash', 'J1', 'T1', 'Target', 'ch', 'ah', 100, NULL, 3000,
+                           NULL, 10.0, 'RECEIPT_TOTAL', NULL, NULL, 105.0, 5.0, 1.0, 0.25, 0.10, 0.15,
+                           8.75, 'OFFER_FROZEN', NULL, 'RECEIPT_TOTAL')""",
+            )
+            db.execSQL(
+                """INSERT INTO offer_records
+                   (eventSequenceId, sessionId, platform, offerHash, outcome, presentedAt, decidedAt,
+                    payAmount, distanceMiles, itemCount, merchantName, score, action, quality,
+                    estNetPay, estDollarsPerHour, estDollarsPerMile, estTimeMinutes,
+                    estOperatingCostPerMile, estFuelPerMile, estNonFuelPerMile)
+                   VALUES (2, 'S1', 'doordash', 'HASH1', 'OFFER_ACCEPTED', 900, 950, 12.0, 3.0, 1,
+                           'Target', 80.0, 'ACCEPT', 'GOOD', 9.0, 20.0, 3.0, 15.0, 0.25, 0.10, 0.15)""",
+            )
+            db.execSQL(
+                """INSERT INTO session_records
+                   (sessionId, platform, startedAt, endedAt, lastEventAt, endSource, startOdometer,
+                    lastOdometer, reportedEarnings, reportedDurationMillis, offersReceived,
+                    offersAccepted, offersDeclined, offersTimeout, deliveries, jobsCompleted, startSource)
+                   VALUES ('S1', 'doordash', 1000, 5000, 5000, 'summary_screen', 100.0, 110.0, 25.0,
+                           4000, 1, 1, 0, 0, 1, 1, 'interaction')""",
+            )
+        }
+
+        val db = helper.runMigrationsAndValidate(dbName, 12, true)
+
+        // Pre-existing rows survived (additive-only).
+        db.query("SELECT COUNT(*) FROM delivery_records").use { c ->
+            c.moveToFirst(); assertEquals(1, c.getInt(0))
+        }
+        db.query("SELECT COUNT(*) FROM offer_records").use { c ->
+            c.moveToFirst(); assertEquals(1, c.getInt(0))
+        }
+        // New delivery columns exist; storeKey/payoutStoreForms NULL, storeKeyPinned defaults 0.
+        db.query("SELECT storeKey, payoutStoreForms, storeKeyPinned FROM delivery_records WHERE eventSequenceId = 1").use { c ->
+            c.moveToFirst()
+            assertTrue("storeKey NULL post-migration", c.isNull(0))
+            assertTrue("payoutStoreForms NULL post-migration", c.isNull(1))
+            assertEquals("storeKeyPinned defaults 0", 0, c.getInt(2))
+        }
+        // New offer columns exist and are NULL.
+        db.query("SELECT storeKey, linkedJobId FROM offer_records WHERE eventSequenceId = 2").use { c ->
+            c.moveToFirst()
+            assertTrue("offer storeKey NULL post-migration", c.isNull(0))
+            assertTrue("linkedJobId NULL post-migration", c.isNull(1))
+        }
+        // New tables exist and are empty (repopulated by the refold).
+        db.query("SELECT COUNT(*) FROM stores").use { c ->
+            c.moveToFirst(); assertEquals(0, c.getInt(0))
+        }
+        db.query("SELECT COUNT(*) FROM pickup_records").use { c ->
+            c.moveToFirst(); assertEquals(0, c.getInt(0))
+        }
+        db.close()
+    }
+}

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/DashBuddyDatabase.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/DashBuddyDatabase.kt
@@ -8,7 +8,9 @@ import cloud.trotter.dashbuddy.core.database.analytics.AnalyticsDao
 import cloud.trotter.dashbuddy.core.database.analytics.AnalyticsProjectionStateEntity
 import cloud.trotter.dashbuddy.core.database.analytics.DeliveryRecordEntity
 import cloud.trotter.dashbuddy.core.database.analytics.OfferRecordEntity
+import cloud.trotter.dashbuddy.core.database.analytics.PickupRecordEntity
 import cloud.trotter.dashbuddy.core.database.analytics.SessionRecordEntity
+import cloud.trotter.dashbuddy.core.database.analytics.StoreEntity
 import cloud.trotter.dashbuddy.core.database.chat.ChatDao
 import cloud.trotter.dashbuddy.core.database.chat.ChatMessageEntity
 import cloud.trotter.dashbuddy.core.database.effects.EffectsFiredDao
@@ -32,6 +34,9 @@ import cloud.trotter.dashbuddy.core.database.snapshot.AppStateSnapshotEntity
         SessionRecordEntity::class,
         OfferRecordEntity::class,
         AnalyticsProjectionStateEntity::class,
+        // Store entity resolution (#159) — additive: identity table + per-pickup visits table.
+        StoreEntity::class,
+        PickupRecordEntity::class,
     ],
     version = DashBuddyDatabase.VERSION,
     exportSchema = true,
@@ -53,10 +58,17 @@ import cloud.trotter.dashbuddy.core.database.snapshot.AppStateSnapshotEntity
     // the PROJECTOR_VERSION 3→4 refold this bump triggers (cashTip stays null in history —
     // no cash events exist; originalPayBasis is stamped for every row). Additive ⇒ never
     // wipes app_events or the existing analytics rows.
+    // v11→v12 (#159) is additive-only: two new tables (`stores` + `pickup_records`) plus new
+    // nullable/defaulted columns — delivery_records.{storeKey, payoutStoreForms, storeKeyPinned},
+    // offer_records.{storeKey, linkedJobId} — and new indices (delivery_records.jobId/storeKey,
+    // offer_records.linkedJobId). The `PROJECTOR_VERSION` 4→5 refold this bump triggers populates the
+    // two new tables + the storeKey columns for ALL history (rebuild ≡ backfill; the backfill is just
+    // the first drain). Additive ⇒ never wipes app_events or the existing analytics rows.
     autoMigrations = [
         AutoMigration(from = 8, to = 9),
         AutoMigration(from = 9, to = 10),
         AutoMigration(from = 10, to = 11),
+        AutoMigration(from = 11, to = 12),
     ],
 )
 @TypeConverters(DataTypeConverters::class)
@@ -84,7 +96,7 @@ abstract class DashBuddyDatabase : RoomDatabase() {
          * this in lockstep with a new `schemas/**/<N>.json`, an `AutoMigration(N-1 → N)`, and its
          * `MigrationTestHelper` case — see the release checklist in CLAUDE.md.
          */
-        const val VERSION = 11
+        const val VERSION = 12
     }
 
 }

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
@@ -42,6 +42,14 @@ interface AnalyticsDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsertOffer(record: OfferRecordEntity)
 
+    /** Upsert one resolved store entity (#159) — REPLACE-idempotent on the deterministic storeKey. */
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertStore(record: StoreEntity)
+
+    /** Upsert one completed-pickup visit row (#159) — REPLACE-idempotent on the source event PK. */
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertPickup(record: PickupRecordEntity)
+
     /** Read the singleton watermark row, or null before the first fold. */
     @Query("SELECT * FROM analytics_projection_state WHERE id = 1")
     suspend fun getWatermark(): AnalyticsProjectionStateEntity?
@@ -59,6 +67,85 @@ interface AnalyticsDao {
 
     @Query("DELETE FROM offer_records")
     suspend fun deleteAllOffers()
+
+    /** #159 F8: the `PROJECTOR_VERSION` wipe MUST also clear these, or stale `stores` first-observed
+     *  fields survive and become permanently wrong. */
+    @Query("DELETE FROM stores")
+    suspend fun deleteAllStores()
+
+    @Query("DELETE FROM pickup_records")
+    suspend fun deleteAllPickupRecords()
+
+    // ── Store resolution: reads (#159, run inside the batch transaction) ──
+
+    /** A job's committed pickup rows — the resolution anchors + dwell, ordered for a stable union. */
+    @Query("SELECT * FROM pickup_records WHERE jobId = :jobId ORDER BY eventSequenceId ASC")
+    suspend fun pickupRecordsForJob(jobId: String): List<PickupRecordEntity>
+
+    /** A job's committed delivery rows — dropoff names, `payoutStoreForms`, `storeKeyPinned`. Ordered
+     *  by `eventSequenceId` so the union of `payoutStoreForms` is stable (M2). */
+    @Query("SELECT * FROM delivery_records WHERE jobId = :jobId ORDER BY eventSequenceId ASC")
+    suspend fun deliveryRecordsForJob(jobId: String): List<DeliveryRecordEntity>
+
+    /** One store entity by key (resolution reads the prior row to keep first-observed forms). */
+    @Query("SELECT * FROM stores WHERE storeKey = :storeKey")
+    suspend fun store(storeKey: String): StoreEntity?
+
+    /** Distinct jobIds referenced by a session's pickup OR delivery rows — a session-level trigger
+     *  (DASH_STOP / inferred close) enumerates its jobs to re-resolve each (#159 L2). */
+    @Query(
+        """SELECT DISTINCT jobId FROM (
+              SELECT jobId FROM pickup_records WHERE sessionId = :sessionId
+              UNION SELECT jobId FROM delivery_records WHERE sessionId = :sessionId)"""
+    )
+    suspend fun jobIdsForSession(sessionId: String): List<String>
+
+    // ── Store resolution: writes (#159, value-guarded to avoid Room invalidation churn) ──
+
+    /** Stamp/re-stamp a pickup row's storeKey. Value-compare guard (no-op re-run doesn't churn Room). */
+    @Query(
+        "UPDATE pickup_records SET storeKey = :storeKey " +
+            "WHERE eventSequenceId = :eventSequenceId AND (storeKey IS NULL OR storeKey != :storeKey)"
+    )
+    suspend fun stampPickupStoreKey(eventSequenceId: Long, storeKey: String)
+
+    /** Stamp/re-stamp a delivery row's storeKey — pin predicate (H1) + value guard. A pinned row
+     *  (driver correction) is never re-keyed; an identical re-stamp is a no-op. */
+    @Query(
+        "UPDATE delivery_records SET storeKey = :storeKey " +
+            "WHERE eventSequenceId = :eventSequenceId AND storeKeyPinned = 0 " +
+            "AND (storeKey IS NULL OR storeKey != :storeKey)"
+    )
+    suspend fun stampDeliveryStoreKey(eventSequenceId: Long, storeKey: String)
+
+    /** The offer rows for a job's exact offer hashes (#159 F4 exact link). */
+    @Query("SELECT * FROM offer_records WHERE offerHash IN (:offerHashes)")
+    suspend fun offerRecordsByHashes(offerHashes: List<String>): List<OfferRecordEntity>
+
+    /** Nominate the most recent accepted, not-already-claimed offer at-or-before [atOrBefore] in a
+     *  session — the temporal fallback (#159 F4). Nomination is NOT a link; the projector stamps only
+     *  on brand-token agreement. [acceptedOutcome] is `AppEventType.OFFER_ACCEPTED.name` (bound, not a
+     *  magic literal). */
+    @Query(
+        """SELECT * FROM offer_records
+           WHERE sessionId = :sessionId AND outcome = :acceptedOutcome AND decidedAt <= :atOrBefore
+             AND (linkedJobId IS NULL OR linkedJobId = :jobId)
+           ORDER BY decidedAt DESC LIMIT 1"""
+    )
+    suspend fun nominateOfferForJob(
+        sessionId: String,
+        atOrBefore: Long,
+        jobId: String,
+        acceptedOutcome: String,
+    ): OfferRecordEntity?
+
+    /** Stamp an offer's storeKey + linkedJobId (the claimed-offer set, #159 F4). Idempotent guard so a
+     *  re-run over the same claim is a no-op. */
+    @Query(
+        "UPDATE offer_records SET storeKey = :storeKey, linkedJobId = :jobId " +
+            "WHERE eventSequenceId = :eventSequenceId AND (linkedJobId IS NULL OR linkedJobId = :jobId)"
+    )
+    suspend fun stampOfferLink(eventSequenceId: Long, storeKey: String?, jobId: String)
 
     // ── Read-side aggregates (Flow ⇒ reactive via Room invalidation) ─────
 
@@ -119,8 +206,17 @@ interface AnalyticsDao {
      * pay only) on purpose — cash is added to the store's gross/net in the repository mapper (#688
      * F5), not used as the sort key.
      */
+    /**
+     * Per-store delivery totals grouped on the **resolved** `storeKey` (#159 — the fragmentation fix
+     * this issue exists for), not the raw `storeName`. An unresolved row (`storeKey IS NULL` — a MANUAL
+     * delivery never in a job, or a not-yet-resolved row) groups by its raw `storeName` HERE, then the
+     * repository re-folds those null-key buckets by the shared `:domain` `normalizedChain(storeName)`
+     * (F9) so `"Target"` and `"…|target|02426"` at least share a chain bucket. Each group carries a
+     * representative [StoreTotalsRow.storeKey] (null for the unresolved buckets) + `storeName`.
+     */
     @Query(
-        """SELECT storeName,
+        """SELECT storeKey,
+                  storeName,
                   COALESCE(SUM(realizedPay), 0) AS pay,
                   COALESCE(SUM(netProfit), 0) AS net,
                   COUNT(*) AS deliveries,
@@ -129,10 +225,43 @@ interface AnalyticsDao {
            WHERE sessionId IN (SELECT sessionId FROM session_records
                                WHERE startedAt >= :start AND startedAt < :end)
               OR (sessionId IS NULL AND completedAt >= :start AND completedAt < :end)
-           GROUP BY storeName
+           GROUP BY storeKey, storeName
            ORDER BY pay DESC"""
     )
     fun deliveryTotalsByStore(start: Long, end: Long): Flow<List<StoreTotalsRow>>
+
+    // ── Store report card reads (#159, the #315 Patterns tab consumer) ───
+
+    /**
+     * One rollup row per **referenced** store entity (M4 — DISTINCT over the visit tables, so an
+     * upgraded-away chain-only provisional key with zero referencing visits never appears as a phantom
+     * entry). Joined to `stores` metadata; pickup/delivery counts + realized gross/net derived at read.
+     * Dwell percentiles are computed in the repository from [storeDwellSamples]. Lifetime-scoped (the
+     * report card's default); a period-scoped variant can wrap the same shape later.
+     */
+    @Query(
+        """SELECT s.storeKey AS storeKey, s.platform AS platform, s.normalizedChain AS normalizedChain,
+                  s.chainDisplay AS chainDisplay, s.runningKey AS runningKey, s.address AS address,
+                  s.firstSeenAt AS firstSeenAt, s.lastSeenAt AS lastSeenAt,
+                  (SELECT COUNT(*) FROM pickup_records p WHERE p.storeKey = s.storeKey) AS pickups,
+                  (SELECT COUNT(*) FROM delivery_records d WHERE d.storeKey = s.storeKey) AS deliveries,
+                  (SELECT COALESCE(SUM(realizedPay), 0) FROM delivery_records d WHERE d.storeKey = s.storeKey) AS gross,
+                  (SELECT COALESCE(SUM(netProfit), 0) FROM delivery_records d WHERE d.storeKey = s.storeKey) AS net
+           FROM stores s
+           WHERE EXISTS (SELECT 1 FROM pickup_records p WHERE p.storeKey = s.storeKey)
+              OR EXISTS (SELECT 1 FROM delivery_records d WHERE d.storeKey = s.storeKey)
+           ORDER BY s.lastSeenAt DESC"""
+    )
+    fun storeReportRows(): Flow<List<StoreReportRow>>
+
+    /** Every pickup dwell sample (`confirmedAt − arrivedAt`) keyed by storeKey — the repository computes
+     *  per-store avg/p50/p95 (SQLite has no percentile; store visit counts are small). */
+    @Query(
+        """SELECT storeKey, (confirmedAt - arrivedAt) AS dwellMillis
+           FROM pickup_records
+           WHERE storeKey IS NOT NULL AND arrivedAt IS NOT NULL AND confirmedAt IS NOT NULL"""
+    )
+    fun storeDwellSamples(): Flow<List<StoreDwellSample>>
 
     @Query(
         """SELECT COALESCE(SUM(MAX(lastOdometer - startOdometer, 0)), 0) AS miles,

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
@@ -91,6 +91,10 @@ interface AnalyticsDao {
     @Query("SELECT * FROM stores WHERE storeKey = :storeKey")
     suspend fun store(storeKey: String): StoreEntity?
 
+    /** One offer row by its source-event PK — offer↔job link assertions (#159). */
+    @Query("SELECT * FROM offer_records WHERE eventSequenceId = :eventSequenceId")
+    suspend fun offerRecord(eventSequenceId: Long): OfferRecordEntity?
+
     /** All store entities (resolution debug / rebuild-equivalence assertions). */
     @Query("SELECT * FROM stores ORDER BY storeKey ASC")
     suspend fun allStores(): List<StoreEntity>
@@ -108,7 +112,8 @@ interface AnalyticsDao {
     @Query(
         """SELECT DISTINCT jobId FROM (
               SELECT jobId FROM pickup_records WHERE sessionId = :sessionId
-              UNION SELECT jobId FROM delivery_records WHERE sessionId = :sessionId)"""
+              UNION SELECT jobId FROM delivery_records WHERE sessionId = :sessionId)
+           ORDER BY jobId ASC"""
     )
     suspend fun jobIdsForSession(sessionId: String): List<String>
 
@@ -130,9 +135,27 @@ interface AnalyticsDao {
     )
     suspend fun stampDeliveryStoreKey(eventSequenceId: Long, storeKey: String)
 
-    /** The offer rows for a job's exact offer hashes (#159 F4 exact link). */
-    @Query("SELECT * FROM offer_records WHERE offerHash IN (:offerHashes)")
-    suspend fun offerRecordsByHashes(offerHashes: List<String>): List<OfferRecordEntity>
+    /**
+     * The job's own ACCEPTED offer rows for the exact offer↔job link (#159 F4 exact path). Scoped to
+     * the job's [sessionId] AND the accepted [acceptedOutcome] (FIX 1a): a content `offerHash` recurs
+     * across sessions and on declined-then-re-presented twins, so only THIS session's accepted row(s)
+     * are this job's offers — an unscoped `offerHash IN (…)` would pull a foreign-session or declined
+     * twin. [acceptedOutcome] is `AppEventType.OFFER_ACCEPTED.name` (bound, not a magic literal).
+     */
+    @Query(
+        "SELECT * FROM offer_records WHERE offerHash IN (:offerHashes) " +
+            "AND sessionId = :sessionId AND outcome = :acceptedOutcome"
+    )
+    suspend fun offerRecordsByHashes(
+        offerHashes: List<String>,
+        sessionId: String,
+        acceptedOutcome: String,
+    ): List<OfferRecordEntity>
+
+    /** Count of offers already claimed by [jobId] (#159 FIX 1b) — the nomination guard: a job that
+     *  already holds a claim never nominates a second temporal offer (the DASH_STOP re-run defect). */
+    @Query("SELECT COUNT(*) FROM offer_records WHERE linkedJobId = :jobId")
+    suspend fun offerLinkCountForJob(jobId: String): Int
 
     /** Nominate the most recent accepted, not-already-claimed offer at-or-before [atOrBefore] in a
      *  session — the temporal fallback (#159 F4). Nomination is NOT a link; the projector stamps only
@@ -142,7 +165,7 @@ interface AnalyticsDao {
         """SELECT * FROM offer_records
            WHERE sessionId = :sessionId AND outcome = :acceptedOutcome AND decidedAt <= :atOrBefore
              AND (linkedJobId IS NULL OR linkedJobId = :jobId)
-           ORDER BY decidedAt DESC LIMIT 1"""
+           ORDER BY decidedAt DESC, eventSequenceId DESC LIMIT 1"""
     )
     suspend fun nominateOfferForJob(
         sessionId: String,
@@ -151,11 +174,13 @@ interface AnalyticsDao {
         acceptedOutcome: String,
     ): OfferRecordEntity?
 
-    /** Stamp an offer's storeKey + linkedJobId (the claimed-offer set, #159 F4). Idempotent guard so a
-     *  re-run over the same claim is a no-op. */
+    /** Stamp an offer's storeKey + linkedJobId (the claimed-offer set, #159 F4). Two guards: the claim
+     *  guard (only an unclaimed row or THIS job's) + a VALUE guard (FIX 1d) so an identical re-stamp
+     *  matches ZERO rows (no Room invalidation churn) — `IS NOT` handles the nullable [storeKey]. */
     @Query(
         "UPDATE offer_records SET storeKey = :storeKey, linkedJobId = :jobId " +
-            "WHERE eventSequenceId = :eventSequenceId AND (linkedJobId IS NULL OR linkedJobId = :jobId)"
+            "WHERE eventSequenceId = :eventSequenceId AND (linkedJobId IS NULL OR linkedJobId = :jobId) " +
+            "AND (storeKey IS NOT :storeKey OR linkedJobId IS NOT :jobId)"
     )
     suspend fun stampOfferLink(eventSequenceId: Long, storeKey: String?, jobId: String)
 
@@ -219,16 +244,19 @@ interface AnalyticsDao {
      * F5), not used as the sort key.
      */
     /**
-     * Per-store delivery totals grouped on the **resolved** `storeKey` (#159 — the fragmentation fix
-     * this issue exists for), not the raw `storeName`. An unresolved row (`storeKey IS NULL` — a MANUAL
-     * delivery never in a job, or a not-yet-resolved row) groups by its raw `storeName` HERE, then the
-     * repository re-folds those null-key buckets by the shared `:domain` `normalizedChain(storeName)`
-     * (F9) so `"Target"` and `"…|target|02426"` at least share a chain bucket. Each group carries a
-     * representative [StoreTotalsRow.storeKey] (null for the unresolved buckets) + `storeName`.
+     * Per-(storeKey, storeName, platform) delivery totals for a period — the raw input the repository
+     * folds to CHAIN level (#159 F9). It does NOT itself produce the final per-store buckets: the
+     * repository groups these rows by `platform + "|" + normalizedChain` (chain from the storeKey's
+     * middle segment when keyed, else the shared `:domain` normalizer over `storeName`), so a resolved
+     * `"…|target|02426"` and an unresolved `"Target"` on the same platform collapse into ONE chain
+     * bucket. Each row carries its [StoreTotalsRow.storeKey] (null when unresolved), `storeName`, and
+     * `platform` so the repository can compute that bucket. `ORDER BY pay DESC` is a cash-free stable
+     * pre-sort; the final cash-inclusive rank is the repository's.
      */
     @Query(
         """SELECT storeKey,
                   storeName,
+                  platform,
                   COALESCE(SUM(realizedPay), 0) AS pay,
                   COALESCE(SUM(netProfit), 0) AS net,
                   COUNT(*) AS deliveries,
@@ -237,10 +265,16 @@ interface AnalyticsDao {
            WHERE sessionId IN (SELECT sessionId FROM session_records
                                WHERE startedAt >= :start AND startedAt < :end)
               OR (sessionId IS NULL AND completedAt >= :start AND completedAt < :end)
-           GROUP BY storeKey, storeName
+           GROUP BY storeKey, storeName, platform
            ORDER BY pay DESC"""
     )
     fun deliveryTotalsByStore(start: Long, end: Long): Flow<List<StoreTotalsRow>>
+
+    /** Chain-display metadata for the F9 chain-level rollup (#159): the first-observed capitalization
+     *  per (platform, normalizedChain). Combined reactively into `perStoreEconomics` for the bucket's
+     *  display name (else the first row's raw storeName). */
+    @Query("SELECT platform, normalizedChain, chainDisplay FROM stores")
+    fun storeChainDisplays(): Flow<List<StoreChainDisplayRow>>
 
     // ── Store report card reads (#159, the #315 Patterns tab consumer) ───
 
@@ -250,19 +284,36 @@ interface AnalyticsDao {
      * entry). Joined to `stores` metadata; pickup/delivery counts + realized gross/net derived at read.
      * Dwell percentiles are computed in the repository from [storeDwellSamples]. Lifetime-scoped (the
      * report card's default); a period-scoped variant can wrap the same shape later.
+     *
+     * **first/last seen derived at read (FIX 3):** `firstSeenAt`/`lastSeenAt` are MIN/MAX over the
+     * store's visit rows (pickup `phaseStartedAt`/`confirmedAt` UNION delivery `completedAt`), NOT
+     * denormalized `stores` columns — the removed columns rewrote every store row of a job on every
+     * per-trigger resolution (churning observers + diverging between incremental fold and refold at a
+     * batch boundary). The read-time derivation is refold-stable by construction.
+     *
+     * **cash-inclusive gross/net (FIX 4):** `gross = Σ realizedPay + Σ cashTip` and `net = Σ netProfit +
+     * Σ cashTip`, per the #688 rule that cash lives outside `realizedPay`/`netProfit` and is added at
+     * every read site (mirrors `deliveryTotalsByStore` + the repository mapper).
      */
     @Query(
         """SELECT s.storeKey AS storeKey, s.platform AS platform, s.normalizedChain AS normalizedChain,
                   s.chainDisplay AS chainDisplay, s.runningKey AS runningKey, s.address AS address,
-                  s.firstSeenAt AS firstSeenAt, s.lastSeenAt AS lastSeenAt,
+                  (SELECT MIN(x) FROM (
+                     SELECT phaseStartedAt AS x FROM pickup_records WHERE storeKey = s.storeKey
+                     UNION ALL SELECT completedAt FROM delivery_records WHERE storeKey = s.storeKey)) AS firstSeenAt,
+                  (SELECT MAX(x) FROM (
+                     SELECT confirmedAt AS x FROM pickup_records WHERE storeKey = s.storeKey
+                     UNION ALL SELECT completedAt FROM delivery_records WHERE storeKey = s.storeKey)) AS lastSeenAt,
                   (SELECT COUNT(*) FROM pickup_records p WHERE p.storeKey = s.storeKey) AS pickups,
                   (SELECT COUNT(*) FROM delivery_records d WHERE d.storeKey = s.storeKey) AS deliveries,
-                  (SELECT COALESCE(SUM(realizedPay), 0) FROM delivery_records d WHERE d.storeKey = s.storeKey) AS gross,
-                  (SELECT COALESCE(SUM(netProfit), 0) FROM delivery_records d WHERE d.storeKey = s.storeKey) AS net
+                  (SELECT COALESCE(SUM(realizedPay), 0) + COALESCE(SUM(cashTip), 0)
+                     FROM delivery_records d WHERE d.storeKey = s.storeKey) AS gross,
+                  (SELECT COALESCE(SUM(netProfit), 0) + COALESCE(SUM(cashTip), 0)
+                     FROM delivery_records d WHERE d.storeKey = s.storeKey) AS net
            FROM stores s
            WHERE EXISTS (SELECT 1 FROM pickup_records p WHERE p.storeKey = s.storeKey)
               OR EXISTS (SELECT 1 FROM delivery_records d WHERE d.storeKey = s.storeKey)
-           ORDER BY s.lastSeenAt DESC"""
+           ORDER BY lastSeenAt DESC"""
     )
     fun storeReportRows(): Flow<List<StoreReportRow>>
 
@@ -271,7 +322,8 @@ interface AnalyticsDao {
     @Query(
         """SELECT storeKey, (confirmedAt - arrivedAt) AS dwellMillis
            FROM pickup_records
-           WHERE storeKey IS NOT NULL AND arrivedAt IS NOT NULL AND confirmedAt IS NOT NULL"""
+           WHERE storeKey IS NOT NULL AND arrivedAt IS NOT NULL AND confirmedAt IS NOT NULL
+             AND confirmedAt >= arrivedAt"""
     )
     fun storeDwellSamples(): Flow<List<StoreDwellSample>>
 

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
@@ -91,6 +91,18 @@ interface AnalyticsDao {
     @Query("SELECT * FROM stores WHERE storeKey = :storeKey")
     suspend fun store(storeKey: String): StoreEntity?
 
+    /** All store entities (resolution debug / rebuild-equivalence assertions). */
+    @Query("SELECT * FROM stores ORDER BY storeKey ASC")
+    suspend fun allStores(): List<StoreEntity>
+
+    /** Count of `stores` rows — F8 wipe verification. */
+    @Query("SELECT COUNT(*) FROM stores")
+    suspend fun storeCount(): Int
+
+    /** Count of `pickup_records` rows — F8 wipe verification. */
+    @Query("SELECT COUNT(*) FROM pickup_records")
+    suspend fun pickupRecordCount(): Int
+
     /** Distinct jobIds referenced by a session's pickup OR delivery rows — a session-level trigger
      *  (DASH_STOP / inferred close) enumerates its jobs to re-resolve each (#159 L2). */
     @Query(
@@ -511,6 +523,10 @@ interface AnalyticsDao {
      */
     @Query("SELECT * FROM delivery_records WHERE eventSequenceId = :eventSequenceId")
     suspend fun deliveryRecord(eventSequenceId: Long): DeliveryRecordEntity?
+
+    /** One delivery row by taskId (resolution/rebuild-equivalence assertions). */
+    @Query("SELECT * FROM delivery_records WHERE taskId = :taskId LIMIT 1")
+    suspend fun deliveryRecordByTask(taskId: String): DeliveryRecordEntity?
 
     /** Still-live sessions for a platform — the next DASH_START infers their close. */
     @Query("SELECT * FROM session_records WHERE platform = :platform AND endedAt IS NULL")

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsTotals.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsTotals.kt
@@ -66,19 +66,29 @@ data class PlatformDeliveryTotalsRow(
 )
 
 /**
- * Per-store delivery totals grouped on the resolved `storeKey` (#159 — was raw `storeName`). One row
- * per (storeKey, storeName) group; [storeKey] is null for an unresolved row, which the repository
- * re-folds by the shared `normalizedChain(storeName)` (F9). [storeName] is a representative raw form
- * of the group (arbitrary for a keyed multi-form group — the display name comes from `stores`).
+ * Per-(storeKey, storeName, platform) delivery totals (#159 F9 raw input). [storeKey] is null for an
+ * unresolved row; [platform] lets the repository fold every row to `platform + "|" + normalizedChain`
+ * (chain from the storeKey's middle segment when keyed, else the normalizer over [storeName]), merging
+ * a resolved keyed location and its unresolved chain form into ONE bucket. [storeName] is a
+ * representative raw form of the group (the display name prefers `stores.chainDisplay`).
  */
 data class StoreTotalsRow(
     val storeKey: String?,
     val storeName: String?,
+    val platform: String,
     val pay: Double,
     val net: Double,
     val deliveries: Int,
     /** Σ driver-entered cash tips for the store's period rows (#688) — see [DeliveryTotalsRow.cash]. */
     val cash: Double,
+)
+
+/** First-observed chain-display capitalization per (platform, normalizedChain) — the F9 rollup's
+ *  display-name source (#159). */
+data class StoreChainDisplayRow(
+    val platform: String,
+    val normalizedChain: String,
+    val chainDisplay: String,
 )
 
 /**

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsTotals.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsTotals.kt
@@ -65,14 +65,49 @@ data class PlatformDeliveryTotalsRow(
     val nonFuelCost: Double?,
 )
 
-/** Per-store delivery totals (GROUP BY storeName) — per-store + future chain resolution (#159). */
+/**
+ * Per-store delivery totals grouped on the resolved `storeKey` (#159 — was raw `storeName`). One row
+ * per (storeKey, storeName) group; [storeKey] is null for an unresolved row, which the repository
+ * re-folds by the shared `normalizedChain(storeName)` (F9). [storeName] is a representative raw form
+ * of the group (arbitrary for a keyed multi-form group — the display name comes from `stores`).
+ */
 data class StoreTotalsRow(
+    val storeKey: String?,
     val storeName: String?,
     val pay: Double,
     val net: Double,
     val deliveries: Int,
     /** Σ driver-entered cash tips for the store's period rows (#688) — see [DeliveryTotalsRow.cash]. */
     val cash: Double,
+)
+
+/**
+ * One store's report-card rollup (#159, the #315 Patterns tab) — the `stores` metadata plus
+ * derived-at-read pickup/delivery counts and realized gross/net. Dwell percentiles are computed in the
+ * repository from [StoreDwellSample]. A [runningKey] of null is a **chain-only ("location unknown")**
+ * bucket (F6): its dwell population blends multiple physical locations, so per-location stats are
+ * partial by construction.
+ */
+data class StoreReportRow(
+    val storeKey: String,
+    val platform: String,
+    val normalizedChain: String,
+    val chainDisplay: String,
+    val runningKey: String?,
+    val address: String?,
+    val firstSeenAt: Long,
+    val lastSeenAt: Long,
+    val pickups: Int,
+    val deliveries: Int,
+    val gross: Double,
+    val net: Double,
+)
+
+/** One pickup dwell sample (`confirmedAt − arrivedAt`) keyed by storeKey — the raw input the repository
+ *  folds into per-store avg/p50/p95 (#159; SQLite has no native percentile). */
+data class StoreDwellSample(
+    val storeKey: String?,
+    val dwellMillis: Long,
 )
 
 /**

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/DeliveryRecordEntity.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/DeliveryRecordEntity.kt
@@ -1,5 +1,6 @@
 package cloud.trotter.dashbuddy.core.database.analytics
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
@@ -38,7 +39,9 @@ import androidx.room.PrimaryKey
         Index(value = ["platform", "completedAt"]), // per-platform ordering/charts (period bucketing is session-anchored, #655)
         Index("sessionId"),                         // per-dash drilldown + fold hydration
         Index(value = ["sessionId", "jobId"]),      // incremental distinct-job counting
+        Index("jobId"),                             // store resolution reads a job's rows by jobId (#159)
         Index("storeName"),                         // per-store aggregation + chain resolution (#159)
+        Index("storeKey"),                          // resolved per-store economics grouping (#159)
     ]
 )
 data class DeliveryRecordEntity(
@@ -115,4 +118,31 @@ data class DeliveryRecordEntity(
      * on legacy rows until the `PROJECTOR_VERSION` 3→4 refold populates it from the immutable log.
      */
     val originalPayBasis: String? = null,
+
+    // ── Store entity resolution (#159, v12) ─────────────────────────────────
+    /**
+     * The resolved store entity key (`StoreKeys.storeKey`, #159), stamped/re-stamped by store
+     * resolution against the pickup anchor; null until resolved (a MANUAL row never in a job, or a
+     * not-yet-resolved row). The per-store economics query groups on it, falling back to the read-side
+     * `normalizedChain(storeName)` for unresolved rows (F9). Refold-deterministic (row-sourced key).
+     */
+    val storeKey: String? = null,
+    /**
+     * The FULL receipt store-form set (#159 B1/B2) — every `parsedPay.customerTips[].type` on the ONE
+     * completion that carried `parsedPay`, serialized as a JSON string array (null on the sibling
+     * drops that carried no receipt). Persists ALL the receipt's store lines (not just this drop's),
+     * because a stacked job settles on one end-of-job receipt riding a single completion — so resolution
+     * reads the running keys from ROWS (never a trigger event), keeping every store keyed and the key
+     * monotonic across a payout-less re-run. Merchant strings — fine at rest, never an INFO+ log
+     * surface (P7).
+     */
+    val payoutStoreForms: String? = null,
+    /**
+     * Driver-correction sticky bit (#159 H1). Set to 1 when a `DELIVERY_ADJUSTMENT` supplies a
+     * `newStoreName`; resolution SKIPS re-stamping any pinned row (`WHERE storeKeyPinned = 0`), so a
+     * correction that disagrees with the pickup anchor is never re-keyed back. Derived from the
+     * `DELIVERY_ADJUSTMENT` event ⇒ a from-zero refold re-derives it. Default 0 (SQL column default so
+     * the additive AutoMigration back-fills existing rows).
+     */
+    @ColumnInfo(defaultValue = "0") val storeKeyPinned: Int = 0,
 )

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/DeliveryRecordEntity.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/DeliveryRecordEntity.kt
@@ -135,6 +135,12 @@ data class DeliveryRecordEntity(
      * reads the running keys from ROWS (never a trigger event), keeping every store keyed and the key
      * monotonic across a payout-less re-run. Merchant strings — fine at rest, never an INFO+ log
      * surface (P7).
+     *
+     * **Named residual (FIX 13):** these strings come from the receipt-partition heuristic
+     * (`parsedPay.customerTips[].type`) and are merchant-shaped ONLY under the fielded DoorDash receipt.
+     * A future/unfielded platform that itemizes tips *per customer* would land customer-shaped text here,
+     * so any consumer that ever surfaces this column (a CSV/UI export) MUST scrub it — it is not
+     * guaranteed to be merchant-only for every platform. No consumer exports it today.
      */
     val payoutStoreForms: String? = null,
     /**

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/OfferRecordEntity.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/OfferRecordEntity.kt
@@ -23,6 +23,7 @@ import androidx.room.PrimaryKey
         Index(value = ["platform", "decidedAt"]), // per-platform periods
         Index("sessionId"),
         Index("offerHash"),
+        Index("linkedJobId"),   // resolution's persistent claimed-offer set (#159 F4)
     ]
 )
 data class OfferRecordEntity(
@@ -60,4 +61,20 @@ data class OfferRecordEntity(
     val estFuelPerMile: Double? = null,
     /** Non-fuel component of [estOperatingCostPerMile] (per-mile) = `nonFuelCostEstimate ÷ distanceMiles` (#659). */
     val estNonFuelPerMile: Double? = null,
+
+    // ── Store entity resolution (#159, v12) ─────────────────────────────────
+    /**
+     * The PRIMARY store of the offer (first order's hint) for single-store offers; null for multi-store
+     * offers in v1 (a per-order offer↔store bridge is phase 2). Stamped by resolution when the offer is
+     * linked to a job AND its `merchantName` agrees by brand token with a resolved pickup anchor (F4).
+     */
+    val storeKey: String? = null,
+    /**
+     * The persistent claimed-offer set (#159 F4). Stamped at resolution when this offer is linked to a
+     * job (exact via `jobOfferHashes`, or the brand-token-guarded temporal fallback). Survives batch
+     * boundaries and is refold-deterministic, so the temporal fallback's "not already claimed" test is a
+     * durable `linkedJobId IS NULL OR = thisJob` predicate, not an ephemeral in-memory set. Never used
+     * for money.
+     */
+    val linkedJobId: String? = null,
 )

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/PickupRecordEntity.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/PickupRecordEntity.kt
@@ -1,0 +1,54 @@
+package cloud.trotter.dashbuddy.core.database.analytics
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * Durable analytics read-model row — one per completed pickup (#159, the visits table, D1). Folded
+ * from `PICKUP_CONFIRMED` (the closing event of the pickup phase, carrying the full
+ * `phaseStartedAt/arrivedAt/confirmedAt` progression). A pickup that never confirms folds no row (no
+ * dwell to report — a known v1 gap, F10).
+ *
+ * Dwell (`confirmedAt − arrivedAt`) is DERIVED in SQL, never stored (D1/SSOT). [storeKey] is null at
+ * write time and stamped/re-stamped by store resolution (see `AnalyticsProjector`).
+ *
+ * `storeName` is MERCHANT data, not customer PII — fine at rest, never in INFO+ logs (P7).
+ */
+@Entity(
+    tableName = "pickup_records",
+    indices = [
+        Index("sessionId"),   // per-dash / per-session enumeration
+        Index("jobId"),       // resolution reads a job's committed pickups by jobId
+        Index("storeKey"),    // per-store dwell aggregation
+    ],
+)
+data class PickupRecordEntity(
+    /** sequenceId of the source PICKUP_CONFIRMED row in app_events — provenance AND idempotency. */
+    @PrimaryKey val eventSequenceId: Long,
+    /** app_events.aggregateId (nullable there → nullable here). */
+    val sessionId: String?,
+    /** Platform.wire, resolved from session context — NEVER id-parsed. */
+    val platform: String,
+    val jobId: String,
+    val taskId: String,
+    /** Raw pickup-surface form (the canonical anchor). Merchant data, never in INFO logs. */
+    val storeName: String,
+    /** Resolved entity key — null at write, stamped/re-stamped by resolution. */
+    val storeKey: String?,
+    val phaseStartedAt: Long,
+    /** dwell = confirmedAt − arrivedAt is DERIVED in SQL, never stored. */
+    val arrivedAt: Long?,
+    val confirmedAt: Long?,
+    val deadlineMillis: Long?,
+    /** Shop vs pickup — dwell populations differ; the report card can segment. */
+    val activity: String?,
+    /**
+     * The parsed store address from the enriched `PickupPayload` (#159 D4), when present. Resolution
+     * seeds `stores.address` from the first non-null value across a store's pickup rows — so the
+     * enrichment must land on a queryable row (resolution reads rows, never a trigger event). Null on
+     * all historical rows. MERCHANT data, never in INFO+ logs (P7). (Spec deviation: the spec's
+     * pickup_records table omitted this column; it is the only row source for `stores.address`.)
+     */
+    val storeAddress: String? = null,
+)

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/StoreEntity.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/StoreEntity.kt
@@ -10,10 +10,12 @@ import androidx.room.PrimaryKey
  * has been observed and coexists with keyed rows once one is learned. Reads that want chain-level
  * rollups group by [normalizedChain]; reads that want per-location detail group by [storeKey].
  *
- * No stats columns (D1): pickup/delivery counts, dwell, p50/p95 are all **derived at read time** by
- * `GROUP BY` over `pickup_records` / `delivery_records` (SSOT — and percentiles can't be folded
- * incrementally anyway). The one denormalization kept is [firstSeenAt]/[lastSeenAt] (cheap,
- * deterministic, saves a MIN/MAX join on every list read).
+ * No stats columns (D1): pickup/delivery counts, dwell, p50/p95 — AND first/last-seen (FIX 3) — are all
+ * **derived at read time** by `GROUP BY` / `MIN`/`MAX` over `pickup_records` / `delivery_records` (SSOT;
+ * percentiles can't be folded incrementally anyway). first/last-seen were briefly denormalized columns
+ * here, but per-trigger resolution rewrote every store row of a job on every trigger (churning Room
+ * observers mid-dash) and the values diverged between an incremental fold and a batch-split refold, so
+ * they were removed — the report-card query derives them with a read-time MIN/MAX over the visit rows.
  *
  * Store names/addresses are **MERCHANT** data, not customer PII — fine at rest, never in INFO+ logs
  * (P7). No customer hashes live here.
@@ -46,7 +48,4 @@ data class StoreEntity(
     val payoutNameForm: String?,
     /** First-observed non-null store address (enriched `PickupPayload`; null for all historical rows). */
     val address: String?,
-    /** Maintained by the fold from `obs`-derived event timestamps (never wall clock). */
-    val firstSeenAt: Long,
-    val lastSeenAt: Long,
 )

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/StoreEntity.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/StoreEntity.kt
@@ -1,0 +1,52 @@
+package cloud.trotter.dashbuddy.core.database.analytics
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * Durable store-entity row (#159) — identity / resolution ONLY (D1). One row per resolved store
+ * entity; a **chain-only provisional** row (`storeKey = "doordash|heb|"`) exists while no running key
+ * has been observed and coexists with keyed rows once one is learned. Reads that want chain-level
+ * rollups group by [normalizedChain]; reads that want per-location detail group by [storeKey].
+ *
+ * No stats columns (D1): pickup/delivery counts, dwell, p50/p95 are all **derived at read time** by
+ * `GROUP BY` over `pickup_records` / `delivery_records` (SSOT — and percentiles can't be folded
+ * incrementally anyway). The one denormalization kept is [firstSeenAt]/[lastSeenAt] (cheap,
+ * deterministic, saves a MIN/MAX join on every list read).
+ *
+ * Store names/addresses are **MERCHANT** data, not customer PII — fine at rest, never in INFO+ logs
+ * (P7). No customer hashes live here.
+ */
+@Entity(
+    tableName = "stores",
+    indices = [Index("normalizedChain")],
+)
+data class StoreEntity(
+    /**
+     * `platform + "|" + normalizedChain + "|" + runningKey` (D2, `StoreKeys.storeKey`). The
+     * `runningKey` segment is empty while unknown (chain-only provisional); the `platform` segment
+     * prevents a cross-platform chain collision (F5). Deterministic — a refold reproduces it byte-for-
+     * byte.
+     */
+    @PrimaryKey val storeKey: String,
+    /** `Platform.wire` from session context (P8: never id-parsed, never a literal); also key segment 1. */
+    val platform: String,
+    /** Lowercased, whitespace-collapsed, qualifier-stripped chain bucket — one `:domain` normalizer (F7). */
+    val normalizedChain: String,
+    /** First-observed capitalization of the chain form (the issue's `chain_name`). */
+    val chainDisplay: String,
+    /** The platform's location discriminator (`02426`, `alamo ranch`, `0164-0045`); null while unknown. */
+    val runningKey: String?,
+    /** First-observed offer-surface form (`Target`). */
+    val offerNameForm: String?,
+    /** First-observed pickup/canonical form. */
+    val pickupNameForm: String?,
+    /** First-observed payout form (`Target (02426)`) — the key carrier, kept for audit/re-resolution. */
+    val payoutNameForm: String?,
+    /** First-observed non-null store address (enriched `PickupPayload`; null for all historical rows). */
+    val address: String?,
+    /** Maintained by the fold from `obs`-derived event timestamps (never wall clock). */
+    val firstSeenAt: Long,
+    val lastSeenAt: Long,
+)

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/DeliveryCompletionEffects.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/DeliveryCompletionEffects.kt
@@ -119,6 +119,7 @@ internal fun EffectMap.diffDeliveryCompletion(
                     sessionEarnings = next.session?.runningEarnings ?: p.session?.runningEarnings,
                     dropRealizedPay = dropShare,
                     offerPayShare = offerShare,
+                    jobOfferHashes = p.activeJob?.parentOfferHashes ?: emptyList(),
                 )
                 // #518: scope idempotency to the completed task, not obs.timestamp, so a
                 // re-entered PostTask receipt can't re-fire (and double-count) the same
@@ -155,7 +156,12 @@ internal fun EffectMap.diffDeliveryCompletion(
         val jobHadDropoff = (next.recentTasks + listOfNotNull(next.activeTask))
             .any { it.jobId == closedJob.jobId && it.phase == TaskPhase.DROPOFF }
         if (!jobHadDropoff) {
-            addAll(pickupConfirmSweepEffects(sessionId, next, closedJob.jobId, obs))
+            addAll(
+                pickupConfirmSweepEffects(
+                    sessionId, next, closedJob.jobId, obs,
+                    jobOfferHashes = closedJob.parentOfferHashes,
+                ),
+            )
         }
         val retirePending = p.pendingDestructive?.kind == DestructiveKind.TASK_RETIRE
         // #528: split the combined receipt across the job's delivered drops once, so each
@@ -204,6 +210,7 @@ internal fun EffectMap.diffDeliveryCompletion(
                 sessionEarnings = next.session?.runningEarnings ?: p.session?.runningEarnings,
                 dropRealizedPay = dropShares[task.taskId],
                 offerPayShare = offerShare,
+                jobOfferHashes = closedJob.parentOfferHashes,
             )
             add(
                 logEffect(
@@ -224,6 +231,7 @@ private fun EffectMap.deliveryCompletedPayload(
     sessionEarnings: Double?,
     dropRealizedPay: Double? = null,
     offerPayShare: Double? = null,
+    jobOfferHashes: List<String> = emptyList(),
 ): DeliveryPayload = DeliveryPayload(
     jobId = jobId ?: task?.jobId ?: "unknown",
     taskId = task?.taskId ?: "unknown",
@@ -241,6 +249,7 @@ private fun EffectMap.deliveryCompletedPayload(
     dropRealizedPay = dropRealizedPay,
     offerPayShare = offerPayShare,
     sessionEarningsAtCompletion = sessionEarnings,
+    jobOfferHashes = jobOfferHashes,
 )
 
 /**

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/TaskEffects.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/TaskEffects.kt
@@ -106,7 +106,13 @@ internal fun EffectMap.diffTask(
             // displaced prevTask + any earlier displaced pickups), each at its own completion
             // time, BEFORE the dropoff's DELIVERY_NAV_STARTED (CONFIRMED-before-NAV). Per-task
             // keys make this idempotent with the close-out sweep below.
-            addAll(pickupConfirmSweepEffects(sessionId, next, prevTask.jobId, obs))
+            addAll(
+                pickupConfirmSweepEffects(
+                    sessionId, next, prevTask.jobId, obs,
+                    jobOfferHashes = next.activeJob
+                        ?.takeIf { it.jobId == prevTask.jobId }?.parentOfferHashes ?: emptyList(),
+                ),
+            )
             addAll(deliveryNavStartedEffects(sessionId, nextTask, obs))
         }
 
@@ -261,13 +267,22 @@ internal fun EffectMap.pickupConfirmSweepEffects(
     region: PlatformRegion,
     jobId: String?,
     obs: Observation,
+    // #159 D3: the job's contributing offer hashes, carried onto each PICKUP_CONFIRMED payload for the
+    // offer↔job link. Passed by the caller (the job is in scope there); empty ⇒ temporal fallback (F12).
+    jobOfferHashes: List<String> = emptyList(),
 ): List<AppEffect> = buildList {
     if (jobId == null) return@buildList
     val lineage = (region.recentTasks + listOfNotNull(region.activeTask))
         .filter { it.jobId == jobId && it.phase == TaskPhase.PICKUP && it.arrivedAt != null }
         .distinctBy { it.taskId }
     for (task in lineage) {
-        addAll(pickupConfirmedEffects(sessionId, task, obs, confirmedAt = task.completedAt ?: obs.timestamp))
+        addAll(
+            pickupConfirmedEffects(
+                sessionId, task, obs,
+                confirmedAt = task.completedAt ?: obs.timestamp,
+                jobOfferHashes = jobOfferHashes,
+            ),
+        )
     }
 }
 
@@ -283,13 +298,19 @@ private fun EffectMap.pickupConfirmedEffects(
     prevTask: Task,
     obs: Observation,
     confirmedAt: Long = obs.timestamp,
+    jobOfferHashes: List<String> = emptyList(),
 ): List<AppEffect> = buildList {
     add(
         logEffect(
             sessionId,
             AppEventType.PICKUP_CONFIRMED,
             confirmedAt,
-            pickupPayload(task = prevTask, storeName = prevTask.storeName ?: UNKNOWN_STORE, confirmedAt = confirmedAt),
+            pickupPayload(
+                task = prevTask,
+                storeName = prevTask.storeName ?: UNKNOWN_STORE,
+                confirmedAt = confirmedAt,
+                jobOfferHashes = jobOfferHashes,
+            ),
             effectKeyOverride = "log:${AppEventType.PICKUP_CONFIRMED}:${prevTask.taskId}",
         ),
     )
@@ -383,6 +404,7 @@ private fun EffectMap.pickupPayload(
     task: Task,
     storeName: String,
     confirmedAt: Long? = null,
+    jobOfferHashes: List<String> = emptyList(),
 ): PickupPayload = PickupPayload(
     jobId = task.jobId,
     taskId = task.taskId,
@@ -397,6 +419,9 @@ private fun EffectMap.pickupPayload(
     itemsShopped = task.itemsShopped,
     redCardTotal = task.redCardTotal,
     activity = task.activity,
+    // #159 D4/D3: the parsed store address + the job's offer hashes for entity resolution.
+    storeAddress = task.storeAddress,
+    jobOfferHashes = jobOfferHashes,
 )
 
 private fun EffectMap.deliveryPhasePayload(

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/TaskEffects.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/TaskEffects.kt
@@ -109,8 +109,14 @@ internal fun EffectMap.diffTask(
             addAll(
                 pickupConfirmSweepEffects(
                     sessionId, next, prevTask.jobId, obs,
-                    jobOfferHashes = next.activeJob
-                        ?.takeIf { it.jobId == prevTask.jobId }?.parentOfferHashes ?: emptyList(),
+                    // #159 FIX 9: source the job's offer hashes from the job matching prevTask.jobId in
+                    // PREV state first (next's active job may have already swapped to a stacked next job on
+                    // this edge, which would drop the hashes to empty); fall back to next's, then empty
+                    // only when the job is truly gone from both.
+                    jobOfferHashes = (
+                        prev.activeJob?.takeIf { it.jobId == prevTask.jobId }
+                            ?: next.activeJob?.takeIf { it.jobId == prevTask.jobId }
+                        )?.parentOfferHashes ?: emptyList(),
                 ),
             )
             addAll(deliveryNavStartedEffects(sessionId, nextTask, obs))

--- a/docs/design/stores-read-model.md
+++ b/docs/design/stores-read-model.md
@@ -85,7 +85,7 @@ keyed rows once one is learned — reads that want chain-level rollups group by
 | `pickupNameForm` | TEXT nullable | First-observed pickup/canonical form. |
 | `payoutNameForm` | TEXT nullable | First-observed payout form (`Target (02426)`) — the key carrier, kept for audit/re-resolution. |
 | `address` | TEXT nullable | First observed non-null `storeAddress` (from the enriched `PickupPayload`; null for all historical rows). Merchant data, not customer PII — fine at rest, never in INFO+ logs (P7). |
-| `firstSeenAt` / `lastSeenAt` | INTEGER | Maintained by the fold from `obs`-derived event timestamps (never wall clock). The one denormalization kept on the row (cheap, deterministic, saves a MIN/MAX join on every list read). |
+| ~~`firstSeenAt` / `lastSeenAt`~~ | — | **REMOVED (PR adversarial-review FIX 3).** The "cheap, deterministic" premise was falsified: per-trigger resolution rewrote every store row of a job on every trigger (churning Room observers mid-dash) and the values diverged between an incremental fold and a batch-split refold. They are now **derived at read** — a `MIN`/`MAX` over the store's `pickup_records` (`phaseStartedAt`/`confirmedAt`) UNION its `delivery_records` (`completedAt`) inside the report-card query. Refold-stable by construction; the `stores` row is now truly immutable across re-resolutions. |
 
 No stats columns (D1): `match_count`, `pickup_count`, `avg/p50/p95_wait_ms` from the issue's
 original schema are all **derived at read time**.

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -73,6 +73,17 @@ card's **mechanical** half, #577 (re-confirmed, 24/24, ~0.55 s — with a new po
 that entry's Bug #1), the #457 path, and #554 ShadowProjector (2/2). The #462/#460 dropoff item
 was found **broken-in-part** (raw PII in capture envelopes) and moved to that entry's Bug #7.)_
 
+- **🆕 NEW — store entity resolution keys real stores from live dashes (#159 / PR).**
+  The read-model now resolves each job's stores (`stores` + `pickup_records` tables) from captured
+  pickup/dropoff/payout surfaces. **How to tell it's working (desk-side, after a dash):** on a job with a
+  payout receipt, the `stores` table should hold one keyed row per store (`storeKey` ending in a real
+  running key like `…|target|02426`, not an empty `…|target|` segment) and the delivery/pickup rows for
+  that job should carry that `storeKey`. **Watch especially the multi-store stack** (e.g. the Target+Maple
+  case): BOTH stores should be keyed from the single end-of-job receipt, not one keyed + one chain-only.
+  And a payout-less close (`DASH_STOP` with no summary) must NOT downgrade an already-keyed store back to
+  chain-only. No UI yet (the #315 Patterns tab is the consumer) — verify via the DB / a CSV-adjacent read.
+  - Confirmed: 0/2
+
 - **🆕 NEW — bubble post-dash card shows the TRUE last session + gas/vehicle quick actions (#693 / PR).**
   The idle bubble card now reads the analytics read-model (`recentSessions(1)`) instead of an in-memory
   capture that could miss a dash. **Primary check — the $0 repro:** end a dash that earned nothing (accept

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/PeriodEconomics.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/PeriodEconomics.kt
@@ -66,15 +66,44 @@ data class PeriodEconomics(
 }
 
 /**
- * Per-store economics for a period (#314) — GROUP BY store over the delivery
- * records. [gross] is Σ realized delivery pay for the store; [net] is Σ frozen
- * delivery net. Chain/entity resolution (folding "H-E-B #472" and "H-E-B #018"
- * into one merchant) is deferred to #159 — [storeName] is the raw captured name,
- * nullable when a delivery record carried none.
+ * Per-store economics for a period (#314/#159) — grouped on the resolved [storeKey], falling back to
+ * the shared `normalizedChain(storeName)` for unresolved rows (#159 F9). [gross] is Σ realized delivery
+ * pay (+ cash) for the store; [net] is Σ frozen delivery net (+ cash). [storeName] is a representative
+ * raw form of the group (the richer chain/location display lives on [StoreReportCard]); [storeKey] is
+ * null for an unresolved (chain-folded) bucket.
  */
 data class StoreEconomics(
     val storeName: String?,
     val net: Double,
     val gross: Double,
     val deliveries: Int,
+    /** The resolved entity key (#159); null for an unresolved row folded by normalizedChain (F9). */
+    val storeKey: String? = null,
+)
+
+/**
+ * One store's report card (#159, the #315 Patterns tab consumer) — the resolved store entity plus its
+ * derived-at-read visit stats. A [runningKey] of null makes [locationKnown] false: this is a chain-only
+ * ("location unknown") bucket whose dwell population blends multiple physical locations, so its
+ * per-location [p50DwellMillis]/[p95DwellMillis] are partial by construction (F6). Store names /
+ * addresses are MERCHANT data — never customer PII.
+ */
+data class StoreReportCard(
+    val storeKey: String,
+    val platform: String,
+    val normalizedChain: String,
+    val chainDisplay: String,
+    val runningKey: String?,
+    val address: String?,
+    /** True when a running key has been observed — a real per-location entity (else "location unknown"). */
+    val locationKnown: Boolean,
+    val pickups: Int,
+    val deliveries: Int,
+    val gross: Double,
+    val net: Double,
+    val avgDwellMillis: Double?,
+    val p50DwellMillis: Long?,
+    val p95DwellMillis: Long?,
+    val firstSeenAt: Long,
+    val lastSeenAt: Long,
 )

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/PeriodEconomics.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/PeriodEconomics.kt
@@ -66,18 +66,19 @@ data class PeriodEconomics(
 }
 
 /**
- * Per-store economics for a period (#314/#159) — grouped on the resolved [storeKey], falling back to
- * the shared `normalizedChain(storeName)` for unresolved rows (#159 F9). [gross] is Σ realized delivery
- * pay (+ cash) for the store; [net] is Σ frozen delivery net (+ cash). [storeName] is a representative
- * raw form of the group (the richer chain/location display lives on [StoreReportCard]); [storeKey] is
- * null for an unresolved (chain-folded) bucket.
+ * Per-**chain** economics for a period (#314/#159 F9) — the top-stores list, rolled up to the chain
+ * level: both a resolved keyed location and its unresolved/MANUAL raw form on the same platform fold
+ * into one bucket. [gross] is Σ realized delivery pay (+ cash) for the chain; [net] is Σ frozen delivery
+ * net (+ cash). [storeName] is the chain's display name (first-observed `stores.chainDisplay`, else a
+ * representative raw form). Per-LOCATION detail lives on [StoreReportCard]; this is the chain rollup.
  */
 data class StoreEconomics(
     val storeName: String?,
     val net: Double,
     val gross: Double,
     val deliveries: Int,
-    /** The resolved entity key (#159); null for an unresolved row folded by normalizedChain (F9). */
+    /** The chain-level bucket identity `platform + "|" + normalizedChain` (#159 F9) — NOT a
+     *  per-location storeKey (that granularity is [StoreReportCard]). */
     val storeKey: String? = null,
 )
 

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/RecordFolds.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/RecordFolds.kt
@@ -143,8 +143,6 @@ data class DeliveryFold(
      * ROWS (never a trigger event), keeping every store of a multi-store stack keyed and monotonic.
      */
     val payoutStoreForms: List<String>? = null,
-    /** The job's contributing offer hashes (#159 D3) — the offer↔job link for resolution; never money. */
-    val jobOfferHashes: List<String> = emptyList(),
 )
 
 /**
@@ -166,8 +164,6 @@ data class PickupFold(
     val activity: String?,
     /** Enriched store address (#159 D4) — the only row source for `stores.address`. */
     val storeAddress: String?,
-    /** The job's contributing offer hashes (#159 D3) — carried for the offer↔job link at resolution. */
-    val jobOfferHashes: List<String> = emptyList(),
 )
 
 /**
@@ -185,8 +181,6 @@ data class StoreResolution(
     val jobId: String?,
     /** The job's offer hashes for the exact offer↔job link; empty ⇒ temporal fallback (F4/F12). */
     val offerHashes: List<String>,
-    /** The triggering event's timestamp — advances `stores.lastSeenAt` (never a wall clock). */
-    val at: Long,
 )
 
 /** An offer read-model row as produced by the pure fold — mapped 1:1 onto `OfferRecordEntity`. */
@@ -589,7 +583,6 @@ object RecordFolds {
             payoutStoreForms = p.parsedPay?.customerTips
                 ?.mapNotNull { it.type.takeIf { t -> t.isNotBlank() } }
                 ?.takeIf { it.isNotEmpty() },
-            jobOfferHashes = p.jobOfferHashes,
         )
 
         // #691: mark the job receipted once any drop folds RECEIPT EVIDENCE, so a later receipt-less
@@ -616,7 +609,6 @@ object RecordFolds {
             platform = platformWire,
             jobId = p.jobId,
             offerHashes = p.jobOfferHashes,
-            at = e.occurredAt,
         )
         return FoldOutcome(context = newCtx, delivery = delivery, resolution = resolution)
     }
@@ -646,7 +638,6 @@ object RecordFolds {
             deadlineMillis = p.deadlineMillis,
             activity = p.activity,
             storeAddress = p.storeAddress,
-            jobOfferHashes = p.jobOfferHashes,
         )
         val newCtx = ctx?.advance(e.occurredAt, event.metadata?.odometer)
         return FoldOutcome(context = newCtx, pickup = pickup)
@@ -805,7 +796,6 @@ object RecordFolds {
             platform = newCtx.platform.wire,
             jobId = null,
             offerHashes = emptyList(),
-            at = e.occurredAt,
         )
         return FoldOutcome(context = newCtx, resolution = resolution)
     }

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/RecordFolds.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/RecordFolds.kt
@@ -8,6 +8,7 @@ import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.ManualDeliveryPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.OfferPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.PayAdjustmentPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.PickupPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStartPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStopPayload
 import cloud.trotter.dashbuddy.domain.state.Platform
@@ -135,6 +136,57 @@ data class DeliveryFold(
     val frozenNonFuelPerMile: Double?,
     val netProfit: Double?,
     val costBasis: String,
+    /**
+     * The FULL receipt store-form set (#159 B1/B2) — every `parsedPay.customerTips[].type` on the ONE
+     * completion that carried `parsedPay`; null on receipt-less drops. Persisted to
+     * `delivery_records.payoutStoreForms` (serialized), so store resolution reads the running keys from
+     * ROWS (never a trigger event), keeping every store of a multi-store stack keyed and monotonic.
+     */
+    val payoutStoreForms: List<String>? = null,
+    /** The job's contributing offer hashes (#159 D3) — the offer↔job link for resolution; never money. */
+    val jobOfferHashes: List<String> = emptyList(),
+)
+
+/**
+ * A completed-pickup read-model row as produced by the pure fold (#159) — mapped 1:1 onto
+ * `PickupRecordEntity`. Folded from `PICKUP_CONFIRMED` (the closing event of the pickup phase);
+ * `storeKey` is stamped later by store resolution, so it is not on this fold shape.
+ */
+data class PickupFold(
+    val eventSequenceId: Long,
+    val sessionId: String?,
+    val platform: String,
+    val jobId: String,
+    val taskId: String,
+    val storeName: String,
+    val phaseStartedAt: Long,
+    val arrivedAt: Long?,
+    val confirmedAt: Long?,
+    val deadlineMillis: Long?,
+    val activity: String?,
+    /** Enriched store address (#159 D4) — the only row source for `stores.address`. */
+    val storeAddress: String?,
+    /** The job's contributing offer hashes (#159 D3) — carried for the offer↔job link at resolution. */
+    val jobOfferHashes: List<String> = emptyList(),
+)
+
+/**
+ * A store-resolution trigger (#159) the pure fold emits for the orchestrator to run INSIDE the batch
+ * transaction against the job's committed rows (resolve-from-rows — there is NO per-job accumulator,
+ * F1). Emitted on every `DELIVERY_COMPLETED` (job-scoped) and `DASH_STOP` (session-scoped: [jobId]
+ * null ⇒ enumerate the session's jobs, L2); the projector also emits one for each inferred-closed
+ * session. Re-runnable and convergent: because resolution reads committed rows (never a single-event
+ * payout), a later trigger recomputes the SAME keys (B1).
+ */
+data class StoreResolution(
+    val sessionId: String?,
+    val platform: String,
+    /** null ⇒ session-level: enumerate the session's jobs and resolve each. */
+    val jobId: String?,
+    /** The job's offer hashes for the exact offer↔job link; empty ⇒ temporal fallback (F4/F12). */
+    val offerHashes: List<String>,
+    /** The triggering event's timestamp — advances `stores.lastSeenAt` (never a wall clock). */
+    val at: Long,
 )
 
 /** An offer read-model row as produced by the pure fold — mapped 1:1 onto `OfferRecordEntity`. */
@@ -189,6 +241,10 @@ data class FoldOutcome(
      * applies it by-PK inside the batch transaction after the upserts.
      */
     val deliveryAdjustment: DeliveryAdjustmentFold? = null,
+    /** A completed-pickup visit row (#159), from `PICKUP_CONFIRMED`. */
+    val pickup: PickupFold? = null,
+    /** A store-resolution trigger (#159) the orchestrator runs against the job's committed rows. */
+    val resolution: StoreResolution? = null,
 )
 
 /**
@@ -254,6 +310,7 @@ object RecordFolds {
             AppEventType.OFFER_DECLINED,
             AppEventType.OFFER_TIMEOUT -> foldOffer(event, context)
             AppEventType.DELIVERY_COMPLETED -> foldDeliveryCompleted(event, context, currentCostPerMile)
+            AppEventType.PICKUP_CONFIRMED -> foldPickupConfirmed(event, context)
             AppEventType.MANUAL_DELIVERY -> foldManualDelivery(event, context, currentCostPerMile)
             AppEventType.PAY_ADJUSTMENT -> foldPayAdjustment(event, context)
             AppEventType.DELIVERY_ADJUSTMENT -> foldDeliveryAdjustment(event, context)
@@ -526,6 +583,13 @@ object RecordFolds {
             frozenNonFuelPerMile = frozenNonFuelPerMile,
             netProfit = netProfit,
             costBasis = costBasis,
+            // #159 B1/B2: persist the FULL receipt store-form set on the one completion that carries
+            // parsedPay (null on receipt-less sibling drops), so resolution reads running keys from
+            // ROWS — every store of a multi-store stack stays keyed even after a payout-less re-run.
+            payoutStoreForms = p.parsedPay?.customerTips
+                ?.mapNotNull { it.type.takeIf { t -> t.isNotBlank() } }
+                ?.takeIf { it.isNotEmpty() },
+            jobOfferHashes = p.jobOfferHashes,
         )
 
         // #691: mark the job receipted once any drop folds RECEIPT EVIDENCE, so a later receipt-less
@@ -545,7 +609,47 @@ object RecordFolds {
             lastEventAt = maxOf(ctx.lastEventAt, e.occurredAt),
             lastOdometer = odo ?: ctx.lastOdometer,
         )
-        return FoldOutcome(context = newCtx, delivery = delivery)
+        // #159: every DELIVERY_COMPLETED re-triggers store resolution for its job (job-scoped). The
+        // payout is NOT threaded — resolution reads payoutStoreForms from the committed rows (B1).
+        val resolution = StoreResolution(
+            sessionId = sid,
+            platform = platformWire,
+            jobId = p.jobId,
+            offerHashes = p.jobOfferHashes,
+            at = e.occurredAt,
+        )
+        return FoldOutcome(context = newCtx, delivery = delivery, resolution = resolution)
+    }
+
+    /**
+     * A completed pickup (#159) → one [PickupFold] visits row. `PICKUP_CONFIRMED` carries the full
+     * `phaseStartedAt/arrivedAt/confirmedAt` progression; `storeKey` is stamped later by resolution.
+     * Advances liveness like any session-attributed event (the pre-#159 `else` branch behaviour).
+     */
+    private fun foldPickupConfirmed(event: SequencedAppEvent, context: SessionFoldContext?): FoldOutcome {
+        val e = event.event
+        val p = e.payload as? PickupPayload
+            ?: return FoldOutcome(context = context, skip = "PICKUP_CONFIRMED: missing/malformed payload")
+        val sid = e.sessionId
+        val ctx = sid?.let { resolveContext(context, it, e.occurredAt) }
+        val platformWire = ctx?.platform?.wire ?: Platform.Unknown.wire
+        val pickup = PickupFold(
+            eventSequenceId = event.sequenceId,
+            sessionId = sid,
+            platform = platformWire,
+            jobId = p.jobId,
+            taskId = p.taskId,
+            storeName = p.storeName,
+            phaseStartedAt = p.phaseStartedAt,
+            arrivedAt = p.arrivedAt,
+            confirmedAt = p.confirmedAt ?: e.occurredAt,
+            deadlineMillis = p.deadlineMillis,
+            activity = p.activity,
+            storeAddress = p.storeAddress,
+            jobOfferHashes = p.jobOfferHashes,
+        )
+        val newCtx = ctx?.advance(e.occurredAt, event.metadata?.odometer)
+        return FoldOutcome(context = newCtx, pickup = pickup)
     }
 
     /**
@@ -685,16 +789,25 @@ object RecordFolds {
             ?: return FoldOutcome(context = context, skip = "DASH_STOP: no sessionId")
         val ctx = resolveContext(context, sid, e.occurredAt, platformName = p.platform)
         val odo = event.metadata?.odometer
-        return FoldOutcome(
-            context = ctx.copy(
-                endedAt = p.endedAt,
-                endSource = p.source,
-                reportedEarnings = p.totalEarnings ?: ctx.reportedEarnings,
-                reportedDurationMillis = p.sessionDurationMillis ?: ctx.reportedDurationMillis,
-                lastEventAt = maxOf(ctx.lastEventAt, e.occurredAt),
-                lastOdometer = odo ?: ctx.lastOdometer,
-            ),
+        val newCtx = ctx.copy(
+            endedAt = p.endedAt,
+            endSource = p.source,
+            reportedEarnings = p.totalEarnings ?: ctx.reportedEarnings,
+            reportedDurationMillis = p.sessionDurationMillis ?: ctx.reportedDurationMillis,
+            lastEventAt = maxOf(ctx.lastEventAt, e.occurredAt),
+            lastOdometer = odo ?: ctx.lastOdometer,
         )
+        // #159 F3: a session close re-resolves every job of the session (jobId null ⇒ session-level).
+        // Row-sourced resolution makes this payout-less trigger recompute the SAME keys, never a
+        // downgrade (B1). The offer link uses the temporal fallback here (no offer hashes on the stop).
+        val resolution = StoreResolution(
+            sessionId = sid,
+            platform = newCtx.platform.wire,
+            jobId = null,
+            offerHashes = emptyList(),
+            at = e.occurredAt,
+        )
+        return FoldOutcome(context = newCtx, resolution = resolution)
     }
 
     /**

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/payload/AppEventPayloads.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/payload/AppEventPayloads.kt
@@ -84,6 +84,22 @@ data class PickupPayload(
     val itemsShopped: Int? = null,
     val redCardTotal: Double? = null,
     val activity: String? = null,
+    /**
+     * The parsed store address (#159 D4), when the pickup screen surfaced one. First-observed
+     * non-null value seeds `stores.address` on the resolved entity — MERCHANT data, not customer
+     * PII (fine at rest, never in INFO+ logs, P7). Null on all historical events (nullable-with-
+     * default → old rows deserialize identically → no forced projector bump from this field).
+     */
+    val storeAddress: String? = null,
+    /**
+     * The job's contributing offer hashes (#159 D3, `Job.parentOfferHashes`) — the offer↔job link
+     * the log otherwise lacks (`OFFER_ACCEPTED` fires before the job is minted). Enables the resolver
+     * to stamp `offer_records.storeKey`/`linkedJobId` for the exact offer(s) of this job; degrades to
+     * the session-scoped temporal fallback when empty (a site that can't reach the job, or a historical
+     * event). NEVER used for money — the delivery `storeKey` comes from the pickup anchor, not the
+     * offer. Nullable-with-default ⇒ old events deserialize identically (F12).
+     */
+    val jobOfferHashes: List<String> = emptyList(),
 ) : AppEventPayload
 
 /**
@@ -142,6 +158,14 @@ data class DeliveryPayload(
     val offerPayShare: Double? = null,
     /** Session running total at the moment of completion. */
     val sessionEarningsAtCompletion: Double? = null,
+    /**
+     * The job's contributing offer hashes (#159 D3, `Job.parentOfferHashes`) — the offer↔job link the
+     * log otherwise lacks (`OFFER_ACCEPTED` fires before the job is minted). The resolver stamps
+     * `offer_records.storeKey`/`linkedJobId` for the exact offer(s) of this job; degrades to the
+     * temporal fallback when empty (F12). NEVER used for money. Nullable-with-default ⇒ old events
+     * deserialize identically.
+     */
+    val jobOfferHashes: List<String> = emptyList(),
 ) : AppEventPayload
 
 /**

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/StoreChainProjection.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/StoreChainProjection.kt
@@ -16,7 +16,7 @@ data class StoreChainLink(
     val offerName: String?,
     /** The dropoff-card form, if any dropoff resolved to this store. */
     val dropoffName: String?,
-    /** The payout-line form — the running-key representation (`Target (02426)`), the #159 doordash_key carrier. */
+    /** The payout-line form — the running-key representation (`Target (02426)`), the #159 runningKey carrier. */
     val payoutName: String?,
     /** The running key teased out of [payoutName]: the store number (`02426`) or area (`Alamo Ranch`). */
     val runningKey: String?,
@@ -33,60 +33,113 @@ data class JobStoreChain(
 )
 
 /**
+ * The pure #159 store-resolution CORE (M5) — the one resolver logic shared by the read-model
+ * projector (`AnalyticsProjector`, over committed DB rows) and the field-verified shadow projector
+ * ([StoreChainProjector], over a live [Job]). It takes **neutral surface inputs** (no [Job], no DB
+ * row), anchors on the pickup store names, and attaches each other surface form (offer / dropoff /
+ * payout) to the anchor whose brand tokens it best matches ([StoreNameMatch]).
+ *
+ * Because it is one function of its inputs, the read-model resolve-from-rows path and the shadow
+ * `Job` path produce identical resolutions from identical surfaces — that is what makes the
+ * shadow log a valid field oracle for the persisted path.
+ */
+object StoreResolver {
+
+    /** One payout store line — the store form ([type]) and its realized amount ([amount], shadow-only). */
+    data class PayoutForm(val type: String, val amount: Double? = null)
+
+    /** One anchor's resolved cross-surface forms. Running key is the RAW extracted token ([StoreKeys]). */
+    data class AnchorResolution(
+        val canonical: String,
+        val offerForm: String?,
+        val dropoffForm: String?,
+        val payoutForm: String?,
+        val runningKey: String?,
+        val realizedTip: Double?,
+    )
+
+    /**
+     * Resolve every distinct pickup anchor against the offer / dropoff / payout surfaces. Each payout
+     * line is assigned to its single best-matching anchor, so a store's [AnchorResolution.realizedTip]
+     * sums ALL its matched lines (D4) and every store in a multi-store stack keys off its own line
+     * (B2). A line matching no anchor is dropped (never mis-attributed). The running key is the first
+     * non-null extraction across the store's matched lines; the store's [payoutForm] surfaces the line
+     * that key came from.
+     */
+    fun resolveAnchors(
+        anchors: List<String>,
+        offerForms: List<String>,
+        dropoffForms: List<String>,
+        payoutForms: List<PayoutForm>,
+    ): List<AnchorResolution> {
+        val cleanAnchors = anchors.filter { it.isNotBlank() }.distinct()
+        if (cleanAnchors.isEmpty()) return emptyList()
+        val cleanOffers = offerForms.filter { it.isNotBlank() }
+        val cleanDropoffs = dropoffForms.filter { it.isNotBlank() }
+        // Assign each payout line to its single best-matching anchor (≥1 shared leading token).
+        val payoutByAnchor: Map<String, List<PayoutForm>> = payoutForms
+            .filter { it.type.isNotBlank() }
+            .mapNotNull { form -> StoreNameMatch.bestMatch(cleanAnchors, form.type)?.let { it to form } }
+            .groupBy({ it.first }, { it.second })
+        return cleanAnchors.map { canonical ->
+            val matched = payoutByAnchor[canonical].orEmpty()
+            // The key comes from the first matched line that yields one; the payout form surfaces that
+            // line (or, when none extracts a key, the first matched line — kept for audit).
+            val keyForm = matched.firstOrNull { StoreKeys.extractRunningKey(it.type) != null }
+                ?: matched.firstOrNull()
+            AnchorResolution(
+                canonical = canonical,
+                offerForm = StoreNameMatch.bestMatch(cleanOffers, canonical),
+                dropoffForm = StoreNameMatch.bestMatch(cleanDropoffs, canonical),
+                payoutForm = keyForm?.type,
+                runningKey = keyForm?.type?.let { StoreKeys.extractRunningKey(it) },
+                realizedTip = matched.mapNotNull { it.amount }.takeIf { it.isNotEmpty() }?.sum(),
+            )
+        }
+    }
+}
+
+/**
  * Projects a completed (or in-flight) [Job] + its payout into the per-store [JobStoreChain] (#159 /
  * #526 Step 3 — order attribution). Pure and side-effect-free: it is *shadow* projection input —
  * the caller logs it for verification / corpus and does NOT mutate authoritative state during a dash.
  *
- * Anchors on the job's **pickups** (the authoritative store names) and attaches each other surface
- * form to the pickup whose brand tokens it best matches, so the offer/dropoff/payout running-key
- * forms (which don't string-match) line up with the right order. A surface form that matches no
- * pickup is dropped rather than mis-attributed.
+ * The [Job] adapter over [StoreResolver] (M5): it flattens the job's pickup/dropoff/offer surfaces +
+ * the payout into the neutral resolver inputs, then re-attaches the job-only [StoreChainLink] field
+ * (the per-store customer hashes). The read-model projector is the sibling row adapter over the SAME
+ * [StoreResolver.resolveAnchors] core, so the persisted keys match this field-verified log.
  */
 object StoreChainProjector {
 
     fun project(job: Job, payout: ParsedPay?): JobStoreChain {
-        // The pickups are the anchors — one store-entity link per distinct pickup store.
         val pickupStores = job.tasks
             .filter { it.phase == TaskPhase.PICKUP && !it.storeName.isNullOrBlank() }
             .map { it.storeName!! }
             .distinct()
-
-        val offerHints = job.offerStoreHint.filter { it.isNotBlank() }
+        val offerHints = job.offerStoreHint
         val dropoffStores = job.tasks
             .filter { it.phase == TaskPhase.DROPOFF && !it.storeName.isNullOrBlank() }
             .map { it.storeName!! }
-        val payoutItems = payout?.customerTips.orEmpty().filter { it.type.isNotBlank() }
+        val payoutForms = payout?.customerTips.orEmpty()
+            .filter { it.type.isNotBlank() }
+            .map { StoreResolver.PayoutForm(it.type, it.amount) }
 
-        val links = pickupStores.map { canonical ->
-            val offerName = StoreNameMatch.bestMatch(offerHints, canonical)
-            val dropoffName = StoreNameMatch.bestMatch(dropoffStores, canonical)
-            val payoutItem = payoutItems
-                .map { it to StoreNameMatch.sharedLeadingTokens(it.type, canonical) }
-                .filter { it.second >= 1 }
-                .maxByOrNull { it.second }
-                ?.first
-            val customerHashes = job.tasks
-                .filter { it.phase == TaskPhase.DROPOFF && it.storeName == canonical && it.customerNameHash != null }
-                .mapNotNull { it.customerNameHash }
-                .distinct()
-            StoreChainLink(
-                canonicalStore = canonical,
-                offerName = offerName,
-                dropoffName = dropoffName,
-                payoutName = payoutItem?.type,
-                runningKey = payoutItem?.type?.let { extractRunningKey(it) },
-                customerHashes = customerHashes,
-                realizedTip = payoutItem?.amount,
-            )
-        }
+        val links = StoreResolver.resolveAnchors(pickupStores, offerHints, dropoffStores, payoutForms)
+            .map { r ->
+                val customerHashes = job.tasks
+                    .filter { it.phase == TaskPhase.DROPOFF && it.storeName == r.canonical && it.customerNameHash != null }
+                    .mapNotNull { it.customerNameHash }
+                    .distinct()
+                StoreChainLink(
+                    canonicalStore = r.canonical,
+                    offerName = r.offerForm,
+                    dropoffName = r.dropoffForm,
+                    payoutName = r.payoutForm,
+                    runningKey = r.runningKey,
+                    customerHashes = customerHashes,
+                    realizedTip = r.realizedTip,
+                )
+            }
         return JobStoreChain(jobId = job.jobId, links = links)
-    }
-
-    /** Tease the DoorDash running key out of a payout store form: the `(02426)` number or the ` - Area` suffix. */
-    private fun extractRunningKey(payoutName: String): String? {
-        Regex("""\((\d{2,6})\)\s*$""").find(payoutName)?.let { return it.groupValues[1] }
-        val dash = payoutName.indexOf(" - ")
-        if (dash >= 0) return payoutName.substring(dash + 3).trim().ifEmpty { null }
-        return null
     }
 }

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/StoreChainProjection.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/StoreChainProjection.kt
@@ -65,6 +65,14 @@ object StoreResolver {
      * (B2). A line matching no anchor is dropped (never mis-attributed). The running key is the first
      * non-null extraction across the store's matched lines; the store's [payoutForm] surfaces the line
      * that key came from.
+     *
+     * **Semantics note (FIX 13):** this per-line assignment + per-store tip-summing SUPERSEDES the older
+     * per-anchor best-line semantics (the spec's D4 intent), so the pre-PR shadow logs are NOT
+     * line-for-line comparable to this output.
+     *
+     * TODO(#159 phase-2): the unimplemented D4 bullet — match a payout line to a store by address / running
+     *  key when brand tokens share ZERO overlap (grocery payout lines that are bare order numbers). Today
+     *  such a line matches no anchor and is dropped; phase-2 adds the address/key fallback join.
      */
     fun resolveAnchors(
         anchors: List<String>,

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/StoreKeys.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/StoreKeys.kt
@@ -1,0 +1,80 @@
+package cloud.trotter.dashbuddy.domain.state
+
+import java.util.Locale
+
+/**
+ * The #159 store-identity SSOT: the one `:domain` normalizer + running-key extractor + deterministic
+ * `storeKey` builder shared by the read-model resolver (`AnalyticsProjector`) AND the field-verified
+ * shadow projector ([StoreChainProjector]). Every place `normalizedChain` / `runningKey` / `storeKey`
+ * appears derives from here, so a refold reproduces the same key byte-for-byte (F7) and no second copy
+ * of the normalization rule can drift (Principle 5).
+ *
+ * **Platform-agnostic (P8):** the extraction patterns are surface-SHAPE heuristics (parenthetical
+ * codes, ` - Area` suffixes, `#NNN` franchise numbers) — documented as such, never a `when` on a
+ * platform literal. A platform that needs different shapes extends the *data* (the phase-2 OTA
+ * lookup), not a branch here.
+ *
+ * **Privacy:** store names/keys are MERCHANT data — fine at rest, never an INFO+ log surface (P7).
+ */
+object StoreKeys {
+
+    /**
+     * The chain bucket for a store name — the issue's `offer_name_normalized`. Lowercased,
+     * whitespace-collapsed, and stripped of the per-location qualifiers a payout/dropoff form adds:
+     * a trailing `(…)` parenthetical, a ` - Location` suffix, and a `#NNN` franchise number. Always
+     * computed from the **pickup canonical anchor** at resolution (F7) — never the payout form, which
+     * carries the qualifier the anchor doesn't. `Locale.ROOT` so `İ`-style locales can't fork a chain.
+     */
+    fun normalizedChain(name: String): String {
+        var s = name.trim()
+        // Strip a trailing parenthetical qualifier: "CAVA (Sonterra Village)" → "CAVA".
+        s = s.replace(TRAILING_PAREN, "")
+        // Strip a trailing " - Location" suffix: "Maple Street Biscuit - Alamo Ranch" → "Maple …".
+        val dash = s.indexOf(" - ")
+        if (dash >= 0) s = s.substring(0, dash)
+        // Strip a trailing "#NNN" franchise number: "SPROUTS FARMERS MARKET #161" → "SPROUTS …".
+        s = s.replace(TRAILING_HASH, "")
+        return s.lowercase(Locale.ROOT).replace(WHITESPACE, " ").trim()
+    }
+
+    /**
+     * The platform's location discriminator inside a payout/dropoff store form — the `(02426)` code,
+     * the ` - Alamo Ranch` area, the `#161` franchise number, the `(0164-0045)` hyphenated code, or a
+     * `(Sonterra Village)` place name. Returns the RAW extracted token (the shadow projector surfaces
+     * it verbatim); [normalizeRunningKey] canonicalizes it for the key. Null when the form carries no
+     * discriminator. **Precedence (F7): a parenthetical wins** over a ` - Area` suffix.
+     */
+    fun extractRunningKey(payoutName: String): String? {
+        // Parenthetical wins (F7): any (...) content — digit code, hyphenated code, or place name.
+        TRAILING_PAREN_CAPTURE.find(payoutName)?.let { return it.groupValues[1].trim().ifEmpty { null } }
+        // "#NNN" franchise suffix (digits or a hyphenated code after the hash).
+        TRAILING_HASH_CAPTURE.find(payoutName)?.let { return it.groupValues[1].trim().ifEmpty { null } }
+        // " - Area" suffix.
+        val dash = payoutName.indexOf(" - ")
+        if (dash >= 0) return payoutName.substring(dash + 3).trim().ifEmpty { null }
+        return null
+    }
+
+    /**
+     * Canonicalize a running key for the [storeKey]: `Locale.ROOT` lowercase + whitespace-collapse so
+     * "Alamo Ranch" and "alamo ranch" don't fork one store into two entities (F7). Null/blank → null
+     * (an empty key segment, the chain-only provisional form).
+     */
+    fun normalizeRunningKey(raw: String?): String? =
+        raw?.lowercase(Locale.ROOT)?.replace(WHITESPACE, " ")?.trim()?.ifEmpty { null }
+
+    /**
+     * The deterministic entity key: `platform + "|" + normalizedChain + "|" + runningKey`
+     * (D2). The `runningKey` segment is empty while unknown (a chain-only provisional key). The
+     * `platform` segment prevents a cross-platform chain collision (F5). Pure ⇒ a refold reproduces
+     * it byte-for-byte. [runningKey] is expected already-normalized ([normalizeRunningKey]).
+     */
+    fun storeKey(platform: String, normalizedChain: String, runningKey: String?): String =
+        platform + "|" + normalizedChain + "|" + (runningKey ?: "")
+
+    private val TRAILING_PAREN = Regex("""\s*\([^)]*\)\s*$""")
+    private val TRAILING_PAREN_CAPTURE = Regex("""\(([^)]+)\)\s*$""")
+    private val TRAILING_HASH = Regex("""\s*#\s*[\w-]+\s*$""")
+    private val TRAILING_HASH_CAPTURE = Regex("""#\s*([\w-]+)\s*$""")
+    private val WHITESPACE = Regex("""\s+""")
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/StoreKeys.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/StoreKeys.kt
@@ -21,21 +21,53 @@ object StoreKeys {
     /**
      * The chain bucket for a store name — the issue's `offer_name_normalized`. Lowercased,
      * whitespace-collapsed, and stripped of the per-location qualifiers a payout/dropoff form adds:
-     * a trailing `(…)` parenthetical, a ` - Location` suffix, and a `#NNN` franchise number. Always
-     * computed from the **pickup canonical anchor** at resolution (F7) — never the payout form, which
-     * carries the qualifier the anchor doesn't. `Locale.ROOT` so `İ`-style locales can't fork a chain.
+     * a trailing `(…)` parenthetical, a trailing ` - Location` suffix, and a `#NNN` franchise number.
+     * Always computed from the **pickup canonical anchor** at resolution (F7) — never the payout form,
+     * which carries the qualifier the anchor doesn't. `Locale.ROOT` so `İ`-style locales can't fork a
+     * chain.
+     *
+     * Hardening (adversarial review):
+     * - **Trailing-only dash strip (FIX 5a):** the ` - Location` strip removes only the LAST
+     *   ` - <qualifier>` suffix (regex `\s-\s[^-]*$`) and is applied AT MOST ONCE, never splits at the
+     *   FIRST ` - `, so a brand whose name itself contains ` - ` ("Roli - Poli - Alamo Ranch" →
+     *   "roli - poli") keeps its brand core instead of collapsing to "roli".
+     * - **Strip-to-stable (FIX 5b):** the paren / hash strips run in a loop, and the single dash strip is
+     *   interleaved between two paren/hash passes, so a stacked qualifier ("Panda Express (Loop 410) -
+     *   San Antonio" → "panda express") fully reduces without the dash strip ever running twice.
+     * - **Delimiter defence (FIX 5c):** the key delimiter `|` is replaced with a space (then whitespace
+     *   collapses), so a merchant string containing `|` can't forge a [storeKey] segment collision.
+     * - **Degenerate-empty guard (FIX 5d):** an all-qualifier input ("(0164-0045)", "#161") whose strip
+     *   would leave nothing falls back to the lowered/collapsed UNstripped form, so two distinct
+     *   qualifier-only names don't both collapse into an empty `platform||` bucket.
      */
     fun normalizedChain(name: String): String {
-        var s = name.trim()
-        // Strip a trailing parenthetical qualifier: "CAVA (Sonterra Village)" → "CAVA".
-        s = s.replace(TRAILING_PAREN, "")
-        // Strip a trailing " - Location" suffix: "Maple Street Biscuit - Alamo Ranch" → "Maple …".
-        val dash = s.indexOf(" - ")
-        if (dash >= 0) s = s.substring(0, dash)
-        // Strip a trailing "#NNN" franchise number: "SPROUTS FARMERS MARKET #161" → "SPROUTS …".
-        s = s.replace(TRAILING_HASH, "")
-        return s.lowercase(Locale.ROOT).replace(WHITESPACE, " ").trim()
+        val raw = name.trim()
+        // Paren/hash strips loop to stability; the dash strip runs ONCE between two paren/hash passes so
+        // a paren exposed by the dash strip ("… (Loop 410) - San Antonio") still reduces, WITHOUT ever
+        // eating a brand's own internal " - " on a second dash pass (FIX 5a/5b).
+        var s = stripParenHash(raw)
+        s = s.replace(TRAILING_DASH_SUFFIX, "").trim().ifEmpty { s }
+        s = stripParenHash(s)
+        val stripped = collapse(s)
+        // FIX 5d: an all-qualifier input strips to empty — fall back to the UNstripped lowered form so
+        // distinct qualifier-only names stay distinct instead of merging into `platform||`.
+        return stripped.ifEmpty { collapse(raw) }
     }
+
+    /** Strip trailing `(…)` and `#NNN` qualifiers until stable (never below empty). */
+    private fun stripParenHash(name: String): String {
+        var s = name
+        var prev: String
+        do {
+            prev = s
+            s = s.replace(TRAILING_PAREN, "").replace(TRAILING_HASH, "").trim()
+        } while (s != prev && s.isNotEmpty())
+        return s
+    }
+
+    /** `Locale.ROOT` lower + replace the key delimiter `|` with a space (FIX 5c) + collapse whitespace. */
+    private fun collapse(s: String): String =
+        s.lowercase(Locale.ROOT).replace('|', ' ').replace(WHITESPACE, " ").trim()
 
     /**
      * The platform's location discriminator inside a payout/dropoff store form — the `(02426)` code,
@@ -49,8 +81,9 @@ object StoreKeys {
         TRAILING_PAREN_CAPTURE.find(payoutName)?.let { return it.groupValues[1].trim().ifEmpty { null } }
         // "#NNN" franchise suffix (digits or a hyphenated code after the hash).
         TRAILING_HASH_CAPTURE.find(payoutName)?.let { return it.groupValues[1].trim().ifEmpty { null } }
-        // " - Area" suffix.
-        val dash = payoutName.indexOf(" - ")
+        // " - Area" suffix — LAST occurrence, symmetric with normalizedChain's trailing-only strip (FIX
+        // 5a) so a brand whose name contains " - " yields the location tail, not the second brand token.
+        val dash = payoutName.lastIndexOf(" - ")
         if (dash >= 0) return payoutName.substring(dash + 3).trim().ifEmpty { null }
         return null
     }
@@ -61,7 +94,7 @@ object StoreKeys {
      * (an empty key segment, the chain-only provisional form).
      */
     fun normalizeRunningKey(raw: String?): String? =
-        raw?.lowercase(Locale.ROOT)?.replace(WHITESPACE, " ")?.trim()?.ifEmpty { null }
+        raw?.let { collapse(it) }?.ifEmpty { null }
 
     /**
      * The deterministic entity key: `platform + "|" + normalizedChain + "|" + runningKey`
@@ -74,6 +107,8 @@ object StoreKeys {
 
     private val TRAILING_PAREN = Regex("""\s*\([^)]*\)\s*$""")
     private val TRAILING_PAREN_CAPTURE = Regex("""\(([^)]+)\)\s*$""")
+    /** Trailing " - Location" only — LAST occurrence, no internal hyphen after it (FIX 5a). */
+    private val TRAILING_DASH_SUFFIX = Regex("""\s-\s[^-]*$""")
     private val TRAILING_HASH = Regex("""\s*#\s*[\w-]+\s*$""")
     private val TRAILING_HASH_CAPTURE = Regex("""#\s*([\w-]+)\s*$""")
     private val WHITESPACE = Regex("""\s+""")

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/state/StoreChainProjectorTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/state/StoreChainProjectorTest.kt
@@ -104,6 +104,43 @@ class StoreChainProjectorTest {
     }
 
     @Test
+    fun `M5 — the Job adapter and the row adapter produce identical resolutions over the same surfaces`() {
+        // The pure StoreResolver core is reached two ways: the Job adapter (StoreChainProjector, the
+        // shadow logger's path) and the row adapter (StoreResolutionRunner, over DB rows). Given the SAME
+        // surfaces, both MUST resolve identically — that parity is what makes the shadow log a valid field
+        // oracle for the persisted path. This test pins it.
+        val tasks = listOf(
+            pickup("p-target", "Target"),
+            pickup("p-maple", "Maple Street Biscuit Company"),
+            dropoff("d-target", "Target", "cust-A"),
+            dropoff("d-maple", "Maple Street Biscuit Company", "cust-B"),
+        )
+        val offerHints = listOf("Target", "Maple Street Biscuit Company")
+        val payout = ParsedPay(
+            appPayComponents = emptyList(),
+            customerTips = listOf(
+                ParsedPayItem("Maple Street Biscuit - Alamo Ranch", 6.50),
+                ParsedPayItem("Target (02426)", 2.25),
+            ),
+        )
+        // Job adapter.
+        val jobResolved = StoreChainProjector.project(job(tasks, offerHints), payout).links
+            .associate { it.canonicalStore to Triple(it.offerName, it.payoutName, it.runningKey) }
+        // Row adapter: the SAME surfaces flattened to neutral lists (what StoreResolutionRunner passes).
+        val rowResolved = StoreResolver.resolveAnchors(
+            anchors = listOf("Target", "Maple Street Biscuit Company"),
+            offerForms = offerHints,
+            dropoffForms = listOf("Target", "Maple Street Biscuit Company"),
+            payoutForms = listOf(
+                StoreResolver.PayoutForm("Maple Street Biscuit - Alamo Ranch", 6.50),
+                StoreResolver.PayoutForm("Target (02426)", 2.25),
+            ),
+        ).associate { it.canonical to Triple(it.offerForm, it.payoutForm, it.runningKey) }
+
+        assertEquals("row adapter ≡ Job adapter resolutions (M5 parity)", jobResolved, rowResolved)
+    }
+
+    @Test
     fun `null payout still yields the pickup-anchored links`() {
         val j = job(
             tasks = listOf(pickup("p1", "Chipotle"), dropoff("d1", "Chipotle", "cust-1")),

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/state/StoreKeysTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/state/StoreKeysTest.kt
@@ -1,0 +1,103 @@
+package cloud.trotter.dashbuddy.domain.state
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * #159 — the store-identity SSOT ([StoreKeys]): the chain normalizer, the running-key extraction
+ * hardening (D4 shapes), and the deterministic `storeKey` (F7 case/whitespace + parenthetical-wins).
+ */
+class StoreKeysTest {
+
+    // ── normalizedChain ─────────────────────────────────────────────────
+
+    @Test
+    fun `normalizedChain lowercases and collapses whitespace`() {
+        assertEquals("target", StoreKeys.normalizedChain("Target"))
+        assertEquals("maple street biscuit company", StoreKeys.normalizedChain("  Maple   Street Biscuit Company  "))
+    }
+
+    @Test
+    fun `normalizedChain strips the trailing parenthetical qualifier`() {
+        assertEquals("target", StoreKeys.normalizedChain("Target (02426)"))
+        assertEquals("cava", StoreKeys.normalizedChain("CAVA (Sonterra Village)"))
+    }
+
+    @Test
+    fun `normalizedChain strips the trailing dash-location suffix`() {
+        assertEquals("maple street biscuit", StoreKeys.normalizedChain("Maple Street Biscuit - Alamo Ranch"))
+    }
+
+    @Test
+    fun `normalizedChain strips the trailing franchise number`() {
+        assertEquals("sprouts farmers market", StoreKeys.normalizedChain("SPROUTS FARMERS MARKET #161"))
+    }
+
+    @Test
+    fun `normalizedChain keeps internal hyphens`() {
+        assertEquals("h-e-b", StoreKeys.normalizedChain("H-E-B"))
+    }
+
+    // ── extractRunningKey (D4 hardening + F7 precedence) ────────────────
+
+    @Test
+    fun `extractRunningKey pulls a parenthetical digit code`() {
+        assertEquals("02426", StoreKeys.extractRunningKey("Target (02426)"))
+        assertEquals("799", StoreKeys.extractRunningKey("H-E-B (799)"))
+    }
+
+    @Test
+    fun `extractRunningKey pulls a dash-area suffix`() {
+        assertEquals("Alamo Ranch", StoreKeys.extractRunningKey("Maple Street Biscuit - Alamo Ranch"))
+    }
+
+    @Test
+    fun `extractRunningKey pulls a franchise number suffix`() {
+        assertEquals("161", StoreKeys.extractRunningKey("SPROUTS FARMERS MARKET #161"))
+    }
+
+    @Test
+    fun `extractRunningKey pulls a place-name parenthetical`() {
+        assertEquals("Sonterra Village", StoreKeys.extractRunningKey("CAVA (Sonterra Village)"))
+        assertEquals("Stone Oak", StoreKeys.extractRunningKey("Chipotle (Stone Oak)"))
+    }
+
+    @Test
+    fun `extractRunningKey pulls a hyphenated store code`() {
+        assertEquals("0164-0045", StoreKeys.extractRunningKey("Little Caesars (0164-0045)"))
+    }
+
+    @Test
+    fun `extractRunningKey precedence — parenthetical wins over dash suffix (F7)`() {
+        assertEquals("123", StoreKeys.extractRunningKey("Foo - Bar (123)"))
+    }
+
+    @Test
+    fun `extractRunningKey is null when no discriminator`() {
+        assertNull(StoreKeys.extractRunningKey("Chipotle"))
+    }
+
+    // ── runningKey normalization + storeKey (F7) ────────────────────────
+
+    @Test
+    fun `normalizeRunningKey lowercases and collapses so casing does not fork a store`() {
+        assertEquals("alamo ranch", StoreKeys.normalizeRunningKey("Alamo Ranch"))
+        assertEquals("alamo ranch", StoreKeys.normalizeRunningKey("  alamo   ranch "))
+        assertNull(StoreKeys.normalizeRunningKey(""))
+        assertNull(StoreKeys.normalizeRunningKey(null))
+    }
+
+    @Test
+    fun `storeKey composes platform, chain, and running key with empty segment while unknown`() {
+        assertEquals("doordash|target|02426", StoreKeys.storeKey("doordash", "target", "02426"))
+        assertEquals("doordash|heb|", StoreKeys.storeKey("doordash", "heb", null))
+    }
+
+    @Test
+    fun `storeKey embeds platform so a cross-platform chain does not collide (F5)`() {
+        val dd = StoreKeys.storeKey("doordash", "mcdonalds", "123")
+        val uber = StoreKeys.storeKey("uber", "mcdonalds", "123")
+        assert(dd != uber)
+    }
+}

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/state/StoreKeysTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/state/StoreKeysTest.kt
@@ -39,6 +39,38 @@ class StoreKeysTest {
         assertEquals("h-e-b", StoreKeys.normalizedChain("H-E-B"))
     }
 
+    @Test
+    fun `normalizedChain strips only the LAST dash suffix, keeping a brand's internal dash (FIX 5a)`() {
+        // A brand whose name contains " - " keeps its brand core when a location is appended — the strip
+        // is trailing-only (last occurrence), never a split at the FIRST " - ".
+        assertEquals("roli - poli", StoreKeys.normalizedChain("Roli - Poli - Alamo Ranch"))
+        // The single-dash location case still reduces to the brand.
+        assertEquals("maple street biscuit", StoreKeys.normalizedChain("Maple Street Biscuit - Alamo Ranch"))
+    }
+
+    @Test
+    fun `normalizedChain strips stacked qualifiers to stability (FIX 5b)`() {
+        assertEquals("panda express", StoreKeys.normalizedChain("Panda Express (Loop 410) - San Antonio"))
+    }
+
+    @Test
+    fun `normalizedChain strips the pipe delimiter so a merchant string cannot forge a key segment (FIX 5c)`() {
+        assertEquals("foo bar", StoreKeys.normalizedChain("foo|bar"))
+        // Forgery is impossible: a chain carrying the delimiter can't collide with a chain+key split.
+        val forged = StoreKeys.storeKey("p", StoreKeys.normalizedChain("foo|bar"), StoreKeys.normalizeRunningKey(null))
+        val real = StoreKeys.storeKey("p", StoreKeys.normalizedChain("foo"), StoreKeys.normalizeRunningKey("bar|"))
+        assert(forged != real) { "delimiter-stripped chains/keys cannot forge a colliding storeKey" }
+    }
+
+    @Test
+    fun `normalizedChain falls back to the unstripped form for an all-qualifier input (FIX 5d)`() {
+        // An all-qualifier name would strip to empty; the fallback keeps distinct names distinct instead
+        // of merging them into an empty `platform||` bucket.
+        assertEquals("(0164-0045)", StoreKeys.normalizedChain("(0164-0045)"))
+        assertEquals("#161", StoreKeys.normalizedChain("#161"))
+        assert(StoreKeys.normalizedChain("(0164-0045)") != StoreKeys.normalizedChain("#161"))
+    }
+
     // ── extractRunningKey (D4 hardening + F7 precedence) ────────────────
 
     @Test

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/state/StoreResolverTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/state/StoreResolverTest.kt
@@ -1,0 +1,75 @@
+package cloud.trotter.dashbuddy.domain.state
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * #159 — the pure resolver core ([StoreResolver.resolveAnchors]) shared by the read-model projector
+ * and the shadow logger (M5). Covers the D4 hardening shapes and the realizedTip-sums-all-matched rule.
+ */
+class StoreResolverTest {
+
+    private fun payout(vararg forms: Pair<String, Double>) =
+        forms.map { StoreResolver.PayoutForm(it.first, it.second) }
+
+    @Test
+    fun `franchise-number and place-name payout forms resolve their running keys`() {
+        val r = StoreResolver.resolveAnchors(
+            anchors = listOf("Sprouts Farmers Market", "CAVA"),
+            offerForms = listOf("Sprouts Farmers Market", "CAVA"),
+            dropoffForms = emptyList(),
+            payoutForms = payout(
+                "SPROUTS FARMERS MARKET #161" to 4.0,
+                "CAVA (Sonterra Village)" to 3.0,
+            ),
+        )
+        assertEquals("161", r.single { it.canonical == "Sprouts Farmers Market" }.runningKey)
+        assertEquals("Sonterra Village", r.single { it.canonical == "CAVA" }.runningKey)
+    }
+
+    @Test
+    fun `realizedTip sums all payout lines matched to one store (D4)`() {
+        val r = StoreResolver.resolveAnchors(
+            anchors = listOf("Target"),
+            offerForms = emptyList(),
+            dropoffForms = emptyList(),
+            payoutForms = payout("Target (02426)" to 2.25, "Target Tip Adjustment" to 1.00),
+        )
+        assertEquals(3.25, r.single().realizedTip!!, 0.001)
+        assertEquals("02426", r.single().runningKey)
+    }
+
+    @Test
+    fun `each store in a multi-store stack keys off its own line (B2)`() {
+        val r = StoreResolver.resolveAnchors(
+            anchors = listOf("Target", "Maple Street Biscuit Company"),
+            offerForms = emptyList(),
+            dropoffForms = emptyList(),
+            payoutForms = payout(
+                "Target (02426)" to 2.25,
+                "Maple Street Biscuit - Alamo Ranch" to 6.50,
+            ),
+        )
+        assertEquals("02426", r.single { it.canonical == "Target" }.runningKey)
+        assertEquals("Alamo Ranch", r.single { it.canonical == "Maple Street Biscuit Company" }.runningKey)
+    }
+
+    @Test
+    fun `a payout line matching no anchor is dropped`() {
+        val r = StoreResolver.resolveAnchors(
+            anchors = listOf("Target"),
+            offerForms = emptyList(),
+            dropoffForms = emptyList(),
+            payoutForms = payout("Whataburger (123)" to 3.0),
+        )
+        assertNull(r.single().runningKey)
+        assertNull(r.single().realizedTip)
+    }
+
+    @Test
+    fun `no anchors yields no resolutions`() {
+        val r = StoreResolver.resolveAnchors(emptyList(), emptyList(), emptyList(), emptyList())
+        assertEquals(0, r.size)
+    }
+}


### PR DESCRIPTION
Implements #159 (stores table + store entity resolution in the read-model) per the binding, Fable-confirmed spec `docs/design/stores-read-model.md`. Blocks #315's Patterns tab.

## What was built (mapped to the spec)

**§M5 — `:domain` resolver rebuild.** One pure resolution core `StoreResolver.resolveAnchors` over neutral surface inputs, plus `StoreKeys` (the shared `normalizedChain` normalizer + running-key extraction hardening + deterministic `storeKey = platform|normalizedChain|runningKey`). `StoreChainProjector` is now the thin **`Job` adapter** over that core, so `ShadowStoreChainLogger` still compiles and runs as the field mirror. Running-key hardening (§D4): `#NNN` franchise suffixes, place-name/hyphenated parentheticals, ` - Area` suffixes, parenthetical-wins precedence (§F7), case/whitespace-normalized keys, realizedTip sums all matched lines.

**Schema (Room v11→v12, additive-only).** New tables `stores` + `pickup_records`; new nullable/defaulted columns `delivery_records.{storeKey, payoutStoreForms, storeKeyPinned}`, `offer_records.{storeKey, linkedJobId}`; new indices. `DashBuddyDatabase.VERSION` 11→12, `AutoMigration(11,12)`, exported `12.json` committed, `MigrationTestHelper` case added, `SchemaVersionGuardTest` chain v8→12 green.

**Fold + resolve-from-rows (§Fold design).** `RecordFolds` folds `PICKUP_CONFIRMED → PickupFold` and persists the **full receipt store-form set** to `payoutStoreForms` on `DELIVERY_COMPLETED` (B1/B2); it emits `StoreResolution` triggers (every completion, `DASH_STOP`, inferred-close). `StoreResolutionRunner` (the **row adapter**) runs inside the one `db.withTransaction` in the fixed order deliveries→offers→pickups→sessions→adjustments→resolutions→watermark (M1/M2): it reads the job's committed rows, resolves each anchor against the union of `payoutStoreForms` (ORDER BY eventSequenceId), upserts `stores`, and stamps `storeKey` back onto the visit rows with value-compare guards + the pin predicate (delivery UPDATE only, H1). `PROJECTOR_VERSION` 4→5; the version-wipe now also clears `stores`/`pickup_records` (F8).

**Offer↔job link (§D3/F4).** `jobOfferHashes` added to `PickupPayload`/`DeliveryPayload`, populated at the emit sites from `Job.parentOfferHashes` (degrades to `emptyList()`). Exact link via `offerHash IN jobOfferHashes`; the temporal fallback only *nominates* and stamps `offer_records.storeKey`/`linkedJobId` on brand-token agreement. Never used for money.

**Correction interplay (§H1/F2).** `applyDeliveryAdjustment(newStoreName)` nulls `storeKey` AND sets `storeKeyPinned = 1`; pinned rows are never re-stamped; pinned/unresolved rows group read-side by `normalizedChain(storeName)` (F9).

**Reads.** `deliveryTotalsByStore`/`perStoreEconomics` migrated to the resolved key with the F9 `normalizedChain` fallback; new `storeReportCards()` (per-store pickup/delivery counts + gross/net + avg/p50/p95 dwell computed in the repository), chain-only rows surfaced as "location unknown" (F6), store list is DISTINCT over referenced visits (M4). No UI (that's #315).

## Security / privacy posture

Store names/addresses are **merchant** data — fine at rest, **never** emitted at INFO+ (P7; no log site added carries them). Customer data stays `sha256`-hashed as before; no customer hash is read or written by resolution. No network, no new capture surface, no new untrusted-input boundary. Migration is additive-only (no destructive fallback, #690 posture intact).

## Spec deviations / notes for the reviewer

- **`pickup_records.storeAddress` column added** (not in the spec's `pickup_records` table). Resolution is resolve-from-rows, so `stores.address` (spec: "from the enriched PickupPayload") needs a queryable row source — the pickup row is the natural home. Additive, nullable. This is the only structural deviation.
- **`perStoreEconomics` per-location vs chain rollup:** the migrated query groups on the resolved `storeKey` (per-location, the #159 fix); unresolved rows fold by `normalizedChain(storeName)` (F9). A keyed store and an unresolved same-chain bucket remain distinct per-location entries (a chain-level rollup is the report card's job).
- **SessionReplay Level-B (Target+Maple 06-19):** not added — those captures are not in the unit test corpus. The B2 multi-store stack is covered by a synthetic end-to-end projector test instead.
- **Instrumented migration test needs a device.** `AnalyticsMigration11to12Test` compiles (`:core:database:compileDebugAndroidTestKotlin` green) but runs only under `connectedAndroidTest` — please run it on a device before/at merge.

## Test results (all green, JDK 25 → target 21)

- `:domain:test` — incl. `StoreKeysTest`, `StoreResolverTest`, `StoreChainProjectorTest` (unchanged, green).
- `:core:database:testDebugUnitTest` — incl. `SchemaVersionGuardTest` (v8→12 chain).
- `:core:data:testDebugUnitTest` — incl. `StoreResolutionProjectorTest` (6/6: fresh fold, B1, B2, F1 batch-boundary, H1, F8) and `StoreReadsTest` (5/5: F9, dwell percentiles, F6, M4).
- `:core:state:testDebugUnitTest`, `:app:testDebugUnitTest` — full suites green (emit-site + payload changes safe; recognition/SessionReplay unaffected).

### Design-goal review

1. **UDF** — resolver + normalizer are pure `:domain` (`obs.timestamp` only); resolution reads committed rows and writes stay at the projector transaction edge, never inside a reducer. No cross-event in-memory accumulation (F1).
2. **MAD** — Room/Kotlin/Flow idioms; additive AutoMigration; version catalog untouched.
3. **Single responsibility** — the row adapter is its own file (`StoreResolutionRunner`), the identity SSOT its own file (`StoreKeys`); no oversized file grown.
4. **Kotlin/Android** — `Locale.ROOT` machine string ops throughout; immutable data classes; value-guarded UPDATEs.
5. **SSOT** — one `StoreKeys.normalizedChain`/`storeKey` used by both the projector and the shadow logger; one `StoreResolver` core with two adapters; stats derived at read, never stored.
6. **Security/privacy (P6)** — merchant data only at rest, customers stay hashed, no network, no capture; additive migration, fail-loud posture intact.
7. **Logging (P7)** — no new INFO+ site carries store/customer text; the one WARN reused is counts/jobId only.
8. **Platform-agnostic** — `platform` comes from `Platform.wire` (session context), is the first `storeKey` segment (F5), and no literal/`when`-on-platform gates logic; extraction patterns are documented surface-shape heuristics, extended via data (phase-2 OTA), not code. The `OFFER_ACCEPTED` outcome match is bound as `AppEventType.OFFER_ACCEPTED.name`, not a magic literal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

### Adversarial review (Fable-tier, 2026-07-10)

Five parallel finder agents (spec-compliance vs `docs/design/stores-read-model.md`, production correctness, read-model invariants, test quality + cross-file tracing, principles/security) produced 42 candidates → ~14 deduped real findings, all **fixed in-branch** (4 commits, tip `2922eb56`) except the named residuals. All five unit suites re-run green after fixes.

**Fixed — correctness (HIGH):**
- **Offer-link over-claiming:** the exact path stamped every `offer_records` row sharing a content `offerHash` (declined-then-re-presented twins, identical offers from other sessions). Now scoped to the job's session + accepted outcome; the temporal fallback no longer nominates a second offer for an already-claimed job (the DASH_STOP re-run defect); `nominateOfferForJob` got a deterministic `eventSequenceId` tiebreaker; `stampOfferLink` got a value guard (no Room-invalidation churn on identical re-stamps).
- **"Unknown" sentinel store entity:** a null-store pickup folds `storeName="Unknown"` (the fielded #733 shape), which was minting a phantom `platform|unknown|` entity blending unrelated stores. Anchors/dropoff forms now exclude the `UNKNOWN_STORE` sentinel (the `:domain` DisplayNames idiom, imported constant).
- **rebuild ≡ backfill breaks:** `stores.firstSeenAt/lastSeenAt` denormalization was both nondeterministic across batch splits (receipt-on-a-later-drop diverged incremental vs refold) and churn-generating (every trigger rewrote every store row of the job, defeating all value-compare guards). **Columns removed** (pre-ship schema edit; `12.json` regenerated); first/last-seen now derive at read (MIN/MAX over visit rows). Plus: `jobIdsForSession` ORDER BY; inferred-close resolutions deterministically sorted; store row now truly immutable across re-resolutions.
- **Money display:** the report-card read omitted `cashTip` (the #688 add-at-every-read-site rule) — same store showed different gross/net on Money tab vs report card. Fixed + regression test.
- **Normalizer/key defects:** first-`' - '` stripping over-merged brands with embedded dashes; paren-before-dash ordering fragmented `Name (Code) - Area` forms; the `|` delimiter was strippable into key forgery; all-qualifier names collapsed into a degenerate shared `platform||` key. All fixed (trailing-only last-occurrence dash strip, strip-to-stable interleave, delimiter defence, degenerate-empty fallback) with per-shape unit cases.
- **Monotonic-key backstop:** a malformed `payoutStoreForms` decode (silent `emptyList`) could downgrade a keyed row to chain-only via the value-compare guard. Now: keyed-over-chain-only backstop at both stamp sites + WARN on decode failure (merchant-free, P7).
- **Platform fork:** pickups folded under an `_unknown`-started session keyed stores as `unknown|…` forever; the trigger's corrected platform now wins (makes `StoreResolution.platform` load-bearing; dead `jobOfferHashes` fold fields deleted).
- **Add-on edge:** the pickup-confirm sweep sourced `jobOfferHashes` from `next.activeJob`, which is the NEW job when the edge also swaps jobs — now prev-state-first.
- **F9 grouping:** keyed and unresolved rows never actually shared a chain bucket (contradicting the spec sentence and fragmenting the top-stores list; the fallback bucket also merged across platforms). `perStoreEconomics` now rolls up to `platform|normalizedChain` buckets with `stores.chainDisplay` preferred for the label; per-location detail stays on the report card. Negative dwell samples (fielded #732 timestamp-inversion class) filtered in SQL.

**Fixed — vacuous tests:** H1's pin guard passed even with the pin deleted (correction shared zero brand tokens — now `Target Cafe`, brand-matching, + the refold half); F1's receipt sat on the first drop where the divergence can't occur (now second drop with the batch boundary between, comparing the read-visible store set + all stamps); F8 never seeded a pickup row (now a poisoned row a refold can't recreate); the specced F4 guard didn't exist (added: brand-disagreeing queued offer not linked; no second claim on re-run); new M5 adapter-parity test (row adapter ≡ Job adapter).

**Named residuals (documented, not fixed):** unreferenced chain-only orphan `stores` rows can exist on the incremental path only — read-invisible by the M4 EXISTS filter (test comment + accepted); `payoutStoreForms` sources from the receipt-partition heuristic (`customerTips[].type`) — merchant-shaped only under the fielded DoorDash receipt; KDoc warns future consumers (CSV/UI) not to export unscrubbed; the D4 zero-token-overlap payout↔store matching bullet is a `TODO(#159 phase-2)`; a bare single-dash brand name (`Roli - Poli` with no location suffix) is structurally indistinguishable from `Brand - Location` and strips to its first token — multi-dash and location-suffixed forms are handled.

**Principles walk (review-verified):** P1 resolver/normalizer pure `:domain`, no wall clock; P5 one normalizer everywhere incl. the read-side bucket, `NetProfit` untouched; P6 customer data hash-only, merchant data at rest, no network; P7 new log sites are DEBUG-for-merchant-text / merchant-free WARN under a stable tag; P8 no platform literals — `platform` from session wire via the enumerated registry, extraction is surface-shape data. Frozen economics: the storeKey stamps never touch money columns; `netProfit`/cpm recompute paths unchanged.
