### PR TITLE
feat(#315): Patterns tab — store report cards + hour×day net-$/hr heatmap (H5)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsScreen.kt
@@ -30,8 +30,8 @@ import cloud.trotter.dashbuddy.core.designsystem.component.AppSegmented
 import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
 
 /**
- * The Analytics hub (#315). Money / Decisions / Time all render real content; Patterns (H5) still
- * shows a "coming soon" card. A **review** surface: UDF state in, `setTab`/`setPeriod` intents out
+ * The Analytics hub (#315). Money / Decisions / Time / Patterns (H5) all render real content. A
+ * **review** surface: UDF state in, `setTab`/`setPeriod` intents out
  * (Principle 1); reactive-fresh via the read-model Flows, no `rememberNow()` tick (a historical
  * period's figures are fixed).
  *

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.material.icons.filled.FileDownload
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -27,9 +26,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import cloud.trotter.dashbuddy.R
-import cloud.trotter.dashbuddy.core.designsystem.component.AppCard
 import cloud.trotter.dashbuddy.core.designsystem.component.AppSegmented
-import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
 import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
 
 /**
@@ -125,7 +122,11 @@ fun AnalyticsScreen(
                     TimeTab(time = uiState.time, period = uiState.selectedPeriod)
                 }
 
-                AnalyticsTab.Patterns -> ComingSoonCard(uiState.selectedTab)
+                // Patterns (H5) is LIFETIME-scoped (rate/pattern-based) — deliberately NO period selector.
+                AnalyticsTab.Patterns -> PatternsTab(
+                    storeCards = uiState.storeReportCards,
+                    heatmap = uiState.earningsHeatmap,
+                )
             }
         }
     }
@@ -157,21 +158,4 @@ private fun PeriodSelector(
         },
         modifier = Modifier.fillMaxWidth(),
     )
-}
-
-@Composable
-private fun ComingSoonCard(tab: AnalyticsTab) {
-    AppCard(modifier = Modifier.fillMaxWidth()) {
-        Text(
-            text = stringResource(R.string.analytics_screen_coming_soon_title, tab.label),
-            style = MaterialTheme.typography.titleMedium,
-            color = AppTheme.colors.text,
-        )
-        Spacer(Modifier.height(4.dp))
-        Text(
-            text = stringResource(R.string.analytics_screen_coming_soon_desc),
-            style = MaterialTheme.typography.bodyMedium,
-            color = AppTheme.colors.text3,
-        )
-    }
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsUiState.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsUiState.kt
@@ -3,15 +3,16 @@ package cloud.trotter.dashbuddy.ui.main.analytics
 import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
 import cloud.trotter.dashbuddy.domain.analytics.DailyEarnings
 import cloud.trotter.dashbuddy.domain.analytics.DecisionEconomics
+import cloud.trotter.dashbuddy.domain.analytics.EarningsHeatmap
 import cloud.trotter.dashbuddy.domain.analytics.PeriodEconomics
 import cloud.trotter.dashbuddy.domain.analytics.SessionRecord
 import cloud.trotter.dashbuddy.domain.analytics.StoreEconomics
+import cloud.trotter.dashbuddy.domain.analytics.StoreReportCard
 import cloud.trotter.dashbuddy.domain.analytics.TimeEconomics
 
 /**
- * The Analytics hub tabs (#315). [Money], [Decisions] (H3), and [Time] (H4) render real content;
- * [Patterns] (H5) still ships as the real tab-bar structure with a "coming soon" placeholder so it
- * slots in without reshaping navigation.
+ * The Analytics hub tabs (#315). [Money], [Decisions] (H3), [Time] (H4), and [Patterns] (H5) all
+ * render real content.
  */
 enum class AnalyticsTab(val label: String) {
     Money("Money"),
@@ -50,4 +51,14 @@ data class AnalyticsUiState(
     val decisions: DecisionEconomics = DecisionEconomics.EMPTY,
     /** Time / mileage economics for [selectedPeriod] — the Time tab (#315 H4, measured). */
     val time: TimeEconomics = TimeEconomics.EMPTY,
+    /**
+     * Per-store report cards — the Patterns tab (#315 H5, #159), newest-visited first. **Lifetime-scoped**,
+     * NOT period-filtered: the Patterns tab hides the period selector (it is rate/pattern-based).
+     */
+    val storeReportCards: List<StoreReportCard> = emptyList(),
+    /**
+     * The driver's own realized net $/hr by hour-of-week — the Patterns tab heatmap (#315 H5).
+     * Lifetime-scoped (no period). Empty grid until data accrues.
+     */
+    val earningsHeatmap: EarningsHeatmap = EarningsHeatmap.EMPTY,
 )

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsUiState.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsUiState.kt
@@ -11,6 +11,13 @@ import cloud.trotter.dashbuddy.domain.analytics.StoreReportCard
 import cloud.trotter.dashbuddy.domain.analytics.TimeEconomics
 
 /**
+ * The placeholder shown for a stat with no measurable value yet — the em-dash. ONE owner across every
+ * analytics-hub tab (Money / Decisions / Time / Patterns / SessionDetail), Principle 5: a per-file copy
+ * is a divergence bug waiting to fire.
+ */
+internal const val EMPTY_VALUE = "—"
+
+/**
  * The Analytics hub tabs (#315). [Money], [Decisions] (H3), [Time] (H4), and [Patterns] (H5) all
  * render real content.
  */

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsViewModel.kt
@@ -25,7 +25,9 @@ import javax.inject.Inject
  * [AnalyticsUiState] (Principle 1 — UDF). Over the read-model repository surface:
  * `periodEconomics` (frozen-net totals), `perStoreEconomics` (top stores), `recentSessions`
  * (recent dashes), `decisionEconomics` (H3 funnel/verdicts), and `timeEconomics` (H4 time/mileage) —
- * every source session-anchored (#655) via the DAO join, which owns the bucketing.
+ * every *period* source session-anchored (#655) via the DAO join, which owns the bucketing. The
+ * Patterns tab's `storeReportCards` (#159) + `earningsHeatmap` (H5) are LIFETIME-scoped and sit
+ * outside the period `flatMapLatest`, so a period switch never re-queries them.
  *
  * Reactive by construction: every source is a Room-invalidation `Flow`, so the tiles re-emit
  * as the projector folds each delivery and at midnight/week/month rollover (the boundary
@@ -66,7 +68,11 @@ class AnalyticsViewModel @Inject constructor(
             }
         },
         analyticsRepository.recentSessions(RECENT_SESSIONS_LIMIT),
-    ) { tab, data, sessions ->
+        // The Patterns tab (H5, #159) is LIFETIME-scoped by design — its sources sit OUTSIDE the
+        // period flatMapLatest so switching the Money/Decisions/Time period never re-queries them.
+        analyticsRepository.storeReportCards(),
+        analyticsRepository.earningsHeatmap(),
+    ) { tab, data, sessions, storeCards, heatmap ->
         AnalyticsUiState(
             selectedTab = tab,
             selectedPeriod = data.period,
@@ -76,6 +82,8 @@ class AnalyticsViewModel @Inject constructor(
             decisions = data.decisions,
             time = data.time,
             dailyEarnings = data.dailyEarnings,
+            storeReportCards = storeCards,
+            earningsHeatmap = heatmap,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), AnalyticsUiState())
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/DecisionsTab.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/DecisionsTab.kt
@@ -26,8 +26,6 @@ import cloud.trotter.dashbuddy.domain.analytics.DecisionEconomics
 import cloud.trotter.dashbuddy.domain.format.Formats
 import kotlin.math.roundToInt
 
-/** Placeholder shown for a figure with no measurable input yet (Money-tab parity). */
-private const val EMPTY_VALUE = "—"
 
 /**
  * Decisions tab (#315 H3): the frozen-decision review for the selected period, top→bottom — the

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/MoneyTab.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/MoneyTab.kt
@@ -41,8 +41,6 @@ import cloud.trotter.dashbuddy.domain.format.formatShortDate
 import java.time.format.TextStyle
 import java.util.Locale
 
-/** Placeholder shown for a rate figure that has no measurable denominator yet (dashboard parity). */
-private const val EMPTY_VALUE = "—"
 
 /** Below this the unattributed pay is effectively zero — no callout (avoids a "$0.00" flag). */
 private const val UNATTRIBUTED_EPSILON = 0.005

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/PatternsTab.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/PatternsTab.kt
@@ -1,6 +1,7 @@
 package cloud.trotter.dashbuddy.ui.main.analytics
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -12,6 +13,7 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
@@ -25,7 +27,6 @@ import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import cloud.trotter.dashbuddy.R
 import cloud.trotter.dashbuddy.core.designsystem.component.AppCard
 import cloud.trotter.dashbuddy.core.designsystem.component.AppChip
@@ -37,6 +38,7 @@ import cloud.trotter.dashbuddy.domain.analytics.StoreReportCard
 import cloud.trotter.dashbuddy.domain.format.Formats
 import cloud.trotter.dashbuddy.domain.format.formatDuration
 import cloud.trotter.dashbuddy.domain.format.formatShortDate
+import cloud.trotter.dashbuddy.domain.format.hourOfDayLabel
 import java.time.DayOfWeek
 import java.time.format.TextStyle
 import java.util.Locale
@@ -118,12 +120,21 @@ private fun HeatmapCard(heatmap: EarningsHeatmap) {
                     ) {
                         for (hour in 0 until EarningsHeatmap.HOURS) {
                             val cell = heatmap.cell(day.value - 1, hour)
+                            val rate = cell.dollarsPerHour
+                            // A covered-but-≤$0 cell ("worked, no net") gets a `bad` border on its badBg
+                            // fill so it reads as a distinct third state, not a dim tint (legible in both
+                            // themes with the fixed palette).
+                            val zeroRate = rate != null && rate <= 0.0
                             Box(
                                 modifier = Modifier
                                     .weight(1f)
                                     .aspectRatio(1f)
                                     .clip(RoundedCornerShape(2.dp))
-                                    .background(cellColor(cell, maxRate, c)),
+                                    .background(cellColor(cell, maxRate, c))
+                                    .then(
+                                        if (zeroRate) Modifier.border(1.dp, c.bad, RoundedCornerShape(2.dp))
+                                        else Modifier,
+                                    ),
                             )
                         }
                     }
@@ -135,13 +146,14 @@ private fun HeatmapCard(heatmap: EarningsHeatmap) {
         Spacer(Modifier.height(12.dp))
         HeatmapLegend(maxRate)
 
-        // Best-hour callout — the single most-earning cell (driver's own experience).
-        heatmap.cells.filter { it.dollarsPerHour != null }.maxByOrNull { it.dollarsPerHour!! }?.let { best ->
+        // Best-hour callout — the single most-earning cell (driver's own experience). Reads the domain
+        // SSOT [EarningsHeatmap.bestCell], the same cell the color ramp is scaled to (Principle 5).
+        heatmap.bestCell?.let { best ->
             Spacer(Modifier.height(10.dp))
             Text(
                 text = stringResource(
                     R.string.patterns_tab_heatmap_best_format,
-                    "${DayOfWeek.of(best.dayIndex + 1).getDisplayName(TextStyle.SHORT, Locale.getDefault())} ${hourLabel12(best.hour)}",
+                    "${DayOfWeek.of(best.dayIndex + 1).getDisplayName(TextStyle.SHORT, Locale.getDefault())} ${hourOfDayLabel(best.hour)}",
                     Formats.money(best.dollarsPerHour!!),
                 ),
                 style = MaterialTheme.typography.bodyMedium,
@@ -164,15 +176,20 @@ private fun HourAxis() {
     Row(Modifier.fillMaxWidth()) {
         Spacer(Modifier.width(30.dp))
         Row(modifier = Modifier.weight(1f), horizontalArrangement = Arrangement.SpaceBetween) {
+            // labelSmall, no raw fontSize override — matches the sibling AppBarChart axis-label treatment.
             listOf(0, 6, 12, 18).forEach { h ->
-                Text(text = hourLabel12(h), style = MaterialTheme.typography.labelSmall, color = c.text3, fontSize = 9.sp)
+                Text(text = hourOfDayLabel(h), style = MaterialTheme.typography.labelSmall, color = c.text3)
             }
-            Text(text = hourLabel12(0), style = MaterialTheme.typography.labelSmall, color = c.text3, fontSize = 9.sp)
+            Text(text = hourOfDayLabel(0), style = MaterialTheme.typography.labelSmall, color = c.text3)
         }
     }
 }
 
-/** Color-scale legend: the insufficient swatch + a low→high ramp keyed to the driver's own best hour. */
+/**
+ * Color-scale legend, three states so the grid is readable: the *insufficient* swatch ("too little
+ * time"), the covered-but-≤$0 swatch ("worked, no net" — badBg + a `bad` border, matching the grid),
+ * and the low→high positive ramp keyed to the driver's own best hour.
+ */
 @Composable
 private fun HeatmapLegend(maxRate: Double) {
     val c = AppTheme.colors
@@ -180,49 +197,50 @@ private fun HeatmapLegend(maxRate: Double) {
         LegendSwatch(c.surface3)
         Text(text = stringResource(R.string.patterns_tab_heatmap_legend_insufficient), style = MaterialTheme.typography.labelSmall, color = c.text3)
         Spacer(Modifier.width(8.dp))
+        LegendSwatch(c.badBg, border = c.bad)
+        Text(text = stringResource(R.string.patterns_tab_heatmap_legend_zero), style = MaterialTheme.typography.labelSmall, color = c.text3)
+        Spacer(Modifier.width(8.dp))
         Text(text = stringResource(R.string.patterns_tab_heatmap_legend_low), style = MaterialTheme.typography.labelSmall, color = c.text3)
-        listOf(0.0, 0.5, 1.0).forEach { f -> LegendSwatch(lerp(c.goodBg, c.good, f.toFloat())) }
+        listOf(0.0, 0.5, 1.0).forEach { f -> LegendSwatch(positiveRamp(f.toFloat(), c)) }
         Text(text = stringResource(R.string.patterns_tab_heatmap_legend_high), style = MaterialTheme.typography.labelSmall, color = c.text3)
     }
 }
 
 @Composable
-private fun LegendSwatch(color: Color) {
+private fun LegendSwatch(color: Color, border: Color? = null) {
     Box(
         modifier = Modifier
-            .size12()
+            .size(12.dp)
             .clip(RoundedCornerShape(2.dp))
-            .background(color),
+            .background(color)
+            .then(if (border != null) Modifier.border(1.dp, border, RoundedCornerShape(2.dp)) else Modifier),
     )
 }
-
-private fun Modifier.size12(): Modifier = this.width(12.dp).height(12.dp)
 
 /**
  * The tint for one cell (pure — takes the palette in). Insufficient coverage ([EarningsHeatmapCell.dollarsPerHour]
  * null) → a dim `surface3` (reads as "no data"); a rate ≤ 0 with enough coverage → the cold `badBg`
- * ("worked, earned ~nothing"); a positive rate → a `goodBg`→`good` ramp scaled to [maxRate]. The
- * insufficient and genuinely-zero cells are deliberately different so a masked cell never reads as a
- * real zero.
+ * ("worked, earned ~nothing", paired with a `bad` border at the call site); a positive rate → the
+ * [positiveRamp] scaled to [maxRate]. The insufficient and genuinely-zero cells are deliberately
+ * different so a masked cell never reads as a real zero.
  */
 private fun cellColor(cell: EarningsHeatmapCell, maxRate: Double, c: AppColors): Color {
     val rate = cell.dollarsPerHour ?: return c.surface3
     if (rate <= 0.0) return c.badBg
     val fraction = if (maxRate > 0.0) (rate / maxRate).coerceIn(0.0, 1.0) else 1.0
-    return lerp(c.goodBg, c.good, fraction.toFloat())
+    return positiveRamp(fraction.toFloat(), c)
 }
 
-/** Compact 12-hour clock label: 0→"12a", 6→"6a", 12→"12p", 18→"6p". */
-private fun hourLabel12(hour: Int): String {
-    val suffix = if (hour < 12) "a" else "p"
-    val h = when (hour % 12) { 0 -> 12; else -> hour % 12 }
-    return "$h$suffix"
-}
+/**
+ * The positive-rate ramp `goodBg → good`, but starting at **0.3** of the way up rather than at the raw
+ * ~12–14%-alpha `goodBg` — otherwise a low-positive cell is an indistinguishable faint tint next to the
+ * `surface3`/`badBg` cells in light mode. The lowest positive rate is thus a clearly-green swatch, and
+ * the best hour is solid `good`.
+ */
+private fun positiveRamp(fraction: Float, c: AppColors): Color =
+    lerp(c.goodBg, c.good, 0.3f + 0.7f * fraction.coerceIn(0f, 1f))
 
 // ── Store report cards ──────────────────────────────────────────────────
-
-/** Placeholder for a stat with no measurable value yet (Money/Time-tab parity). */
-private const val EMPTY_VALUE = "—"
 
 /** The per-store report cards, newest-visited first (the repository already orders by last-seen). */
 @Composable
@@ -230,6 +248,15 @@ private fun StoresCard(cards: List<StoreReportCard>) {
     val c = AppTheme.colors
     AppCard(modifier = Modifier.fillMaxWidth()) {
         Text(text = stringResource(R.string.patterns_tab_stores_title), style = MaterialTheme.typography.labelMedium, color = c.text3)
+        Spacer(Modifier.height(4.dp))
+        // v1 asymmetry (Money vs Patterns): manually-added + unresolved deliveries are in the Money
+        // totals but don't surface as store cards here yet. State it plainly so the lists don't look
+        // inconsistent to the driver.
+        Text(
+            text = stringResource(R.string.patterns_tab_stores_manual_note),
+            style = MaterialTheme.typography.bodySmall,
+            color = c.text3,
+        )
         Spacer(Modifier.height(10.dp))
         if (cards.isEmpty()) {
             Text(

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/PatternsTab.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/PatternsTab.kt
@@ -1,0 +1,334 @@
+package cloud.trotter.dashbuddy.ui.main.analytics
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import cloud.trotter.dashbuddy.R
+import cloud.trotter.dashbuddy.core.designsystem.component.AppCard
+import cloud.trotter.dashbuddy.core.designsystem.component.AppChip
+import cloud.trotter.dashbuddy.core.designsystem.theme.AppColors
+import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
+import cloud.trotter.dashbuddy.domain.analytics.EarningsHeatmap
+import cloud.trotter.dashbuddy.domain.analytics.EarningsHeatmapCell
+import cloud.trotter.dashbuddy.domain.analytics.StoreReportCard
+import cloud.trotter.dashbuddy.domain.format.Formats
+import cloud.trotter.dashbuddy.domain.format.formatDuration
+import cloud.trotter.dashbuddy.domain.format.formatShortDate
+import java.time.DayOfWeek
+import java.time.format.TextStyle
+import java.util.Locale
+
+/**
+ * Patterns tab (#315 H5): the driver's own **lifetime** patterns — top→bottom, the net-$/hr
+ * hour×day heatmap ("when your time actually pays") and the per-store report cards ("where you go",
+ * #159). Pure data in ([EarningsHeatmap] + [StoreReportCard] list), no side effects (Principle 1 — UDF);
+ * lifetime-scoped, so the hub renders it with **no** period selector.
+ *
+ * **Framing discipline (Pledge-adjacent):** every figure is the driver's *own realized* net $/hr and
+ * *own* dwell — empirical measurement of their own experience, never a platform-pay characterization
+ * ("DoorDash pays more at…" is out of bounds; "you earn more at…" is in). Store/merchant names are
+ * merchant data — fine to render (Principle 7 governs logs, not this UI); customer PII is sha256'd
+ * upstream and never reaches here (Principle 6). No network, no new capture surface.
+ *
+ * Aggregate-historical, not a live surface — no `rememberNow()` ticker (Reactive UI: nothing here can
+ * go stale while looked at; the read-model Flows behind the ViewModel re-emit on projector commits).
+ */
+@Composable
+fun PatternsTab(
+    storeCards: List<StoreReportCard>,
+    heatmap: EarningsHeatmap,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        HeatmapCard(heatmap)
+        StoresCard(storeCards)
+    }
+}
+
+// ── Heatmap ─────────────────────────────────────────────────────────────
+
+/** Local day order: Monday-first, matching the app's Monday-anchored week (#655 / PeriodBounds). */
+private val DAY_ROWS = listOf(
+    DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY,
+    DayOfWeek.FRIDAY, DayOfWeek.SATURDAY, DayOfWeek.SUNDAY,
+)
+
+/**
+ * The net-$/hr hour×day heatmap: 7 day-rows × 24 hour-columns, each cell tinted by the driver's own
+ * realized net $/hr for that hour-of-week. A cell below the coverage floor renders as
+ * *insufficient* (near-empty), visually distinct from a genuinely-zero cell (worked, earned ~nothing).
+ * The color ramp is scaled to the driver's own best hour, so it reads as "your best/worst times",
+ * never an absolute-dollar claim.
+ */
+@Composable
+private fun HeatmapCard(heatmap: EarningsHeatmap) {
+    val c = AppTheme.colors
+    AppCard(modifier = Modifier.fillMaxWidth()) {
+        Text(text = stringResource(R.string.patterns_tab_heatmap_title), style = MaterialTheme.typography.labelMedium, color = c.text3)
+        Spacer(Modifier.height(10.dp))
+
+        if (!heatmap.hasData) {
+            Text(
+                text = stringResource(R.string.patterns_tab_heatmap_no_data),
+                style = MaterialTheme.typography.bodyMedium,
+                color = c.text3,
+                modifier = Modifier.padding(vertical = 4.dp),
+            )
+            return@AppCard
+        }
+
+        val maxRate = heatmap.maxDollarsPerHour ?: 0.0
+
+        // Grid: each day is a row of a fixed-width label + 24 weighted cells.
+        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            DAY_ROWS.forEach { day ->
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = day.getDisplayName(TextStyle.SHORT, Locale.getDefault()),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = c.text3,
+                        modifier = Modifier.width(30.dp),
+                    )
+                    Row(
+                        modifier = Modifier.weight(1f),
+                        horizontalArrangement = Arrangement.spacedBy(1.dp),
+                    ) {
+                        for (hour in 0 until EarningsHeatmap.HOURS) {
+                            val cell = heatmap.cell(day.value - 1, hour)
+                            Box(
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .aspectRatio(1f)
+                                    .clip(RoundedCornerShape(2.dp))
+                                    .background(cellColor(cell, maxRate, c)),
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        Spacer(Modifier.height(6.dp))
+        HourAxis()
+        Spacer(Modifier.height(12.dp))
+        HeatmapLegend(maxRate)
+
+        // Best-hour callout — the single most-earning cell (driver's own experience).
+        heatmap.cells.filter { it.dollarsPerHour != null }.maxByOrNull { it.dollarsPerHour!! }?.let { best ->
+            Spacer(Modifier.height(10.dp))
+            Text(
+                text = stringResource(
+                    R.string.patterns_tab_heatmap_best_format,
+                    "${DayOfWeek.of(best.dayIndex + 1).getDisplayName(TextStyle.SHORT, Locale.getDefault())} ${hourLabel12(best.hour)}",
+                    Formats.money(best.dollarsPerHour!!),
+                ),
+                style = MaterialTheme.typography.bodyMedium,
+                color = c.text,
+            )
+        }
+        Spacer(Modifier.height(6.dp))
+        Text(
+            text = stringResource(R.string.patterns_tab_heatmap_caption),
+            style = MaterialTheme.typography.bodySmall,
+            color = c.text3,
+        )
+    }
+}
+
+/** Four evenly-spaced clock ticks under the grid (offset past the day-label gutter). */
+@Composable
+private fun HourAxis() {
+    val c = AppTheme.colors
+    Row(Modifier.fillMaxWidth()) {
+        Spacer(Modifier.width(30.dp))
+        Row(modifier = Modifier.weight(1f), horizontalArrangement = Arrangement.SpaceBetween) {
+            listOf(0, 6, 12, 18).forEach { h ->
+                Text(text = hourLabel12(h), style = MaterialTheme.typography.labelSmall, color = c.text3, fontSize = 9.sp)
+            }
+            Text(text = hourLabel12(0), style = MaterialTheme.typography.labelSmall, color = c.text3, fontSize = 9.sp)
+        }
+    }
+}
+
+/** Color-scale legend: the insufficient swatch + a low→high ramp keyed to the driver's own best hour. */
+@Composable
+private fun HeatmapLegend(maxRate: Double) {
+    val c = AppTheme.colors
+    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+        LegendSwatch(c.surface3)
+        Text(text = stringResource(R.string.patterns_tab_heatmap_legend_insufficient), style = MaterialTheme.typography.labelSmall, color = c.text3)
+        Spacer(Modifier.width(8.dp))
+        Text(text = stringResource(R.string.patterns_tab_heatmap_legend_low), style = MaterialTheme.typography.labelSmall, color = c.text3)
+        listOf(0.0, 0.5, 1.0).forEach { f -> LegendSwatch(lerp(c.goodBg, c.good, f.toFloat())) }
+        Text(text = stringResource(R.string.patterns_tab_heatmap_legend_high), style = MaterialTheme.typography.labelSmall, color = c.text3)
+    }
+}
+
+@Composable
+private fun LegendSwatch(color: Color) {
+    Box(
+        modifier = Modifier
+            .size12()
+            .clip(RoundedCornerShape(2.dp))
+            .background(color),
+    )
+}
+
+private fun Modifier.size12(): Modifier = this.width(12.dp).height(12.dp)
+
+/**
+ * The tint for one cell (pure — takes the palette in). Insufficient coverage ([EarningsHeatmapCell.dollarsPerHour]
+ * null) → a dim `surface3` (reads as "no data"); a rate ≤ 0 with enough coverage → the cold `badBg`
+ * ("worked, earned ~nothing"); a positive rate → a `goodBg`→`good` ramp scaled to [maxRate]. The
+ * insufficient and genuinely-zero cells are deliberately different so a masked cell never reads as a
+ * real zero.
+ */
+private fun cellColor(cell: EarningsHeatmapCell, maxRate: Double, c: AppColors): Color {
+    val rate = cell.dollarsPerHour ?: return c.surface3
+    if (rate <= 0.0) return c.badBg
+    val fraction = if (maxRate > 0.0) (rate / maxRate).coerceIn(0.0, 1.0) else 1.0
+    return lerp(c.goodBg, c.good, fraction.toFloat())
+}
+
+/** Compact 12-hour clock label: 0→"12a", 6→"6a", 12→"12p", 18→"6p". */
+private fun hourLabel12(hour: Int): String {
+    val suffix = if (hour < 12) "a" else "p"
+    val h = when (hour % 12) { 0 -> 12; else -> hour % 12 }
+    return "$h$suffix"
+}
+
+// ── Store report cards ──────────────────────────────────────────────────
+
+/** Placeholder for a stat with no measurable value yet (Money/Time-tab parity). */
+private const val EMPTY_VALUE = "—"
+
+/** The per-store report cards, newest-visited first (the repository already orders by last-seen). */
+@Composable
+private fun StoresCard(cards: List<StoreReportCard>) {
+    val c = AppTheme.colors
+    AppCard(modifier = Modifier.fillMaxWidth()) {
+        Text(text = stringResource(R.string.patterns_tab_stores_title), style = MaterialTheme.typography.labelMedium, color = c.text3)
+        Spacer(Modifier.height(10.dp))
+        if (cards.isEmpty()) {
+            Text(
+                text = stringResource(R.string.patterns_tab_no_stores),
+                style = MaterialTheme.typography.bodyMedium,
+                color = c.text3,
+                modifier = Modifier.padding(vertical = 4.dp),
+            )
+        } else {
+            cards.forEachIndexed { index, card ->
+                if (index > 0) Spacer(Modifier.height(14.dp))
+                StoreRow(card)
+            }
+        }
+    }
+}
+
+/** One store: chain name + location discriminator, address, counts + gross/net, dwell, first/last seen. */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun StoreRow(card: StoreReportCard) {
+    val c = AppTheme.colors
+    Column(Modifier.fillMaxWidth()) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = card.chainDisplay,
+                style = MaterialTheme.typography.bodyLarge,
+                color = c.text,
+                modifier = Modifier.weight(1f),
+            )
+            if (card.locationKnown && card.runningKey != null) {
+                AppChip(text = card.runningKey!!, uppercase = false)
+            } else {
+                AppChip(
+                    text = stringResource(R.string.patterns_tab_location_unknown),
+                    color = c.warn,
+                    container = c.warnBg,
+                    uppercase = false,
+                )
+            }
+        }
+        card.address?.let {
+            Spacer(Modifier.height(2.dp))
+            Text(text = it, style = MaterialTheme.typography.bodySmall, color = c.text3)
+        }
+
+        Spacer(Modifier.height(8.dp))
+        FlowRow(horizontalArrangement = Arrangement.spacedBy(16.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            StoreStat(stringResource(R.string.patterns_tab_store_pickups_label), Formats.commaInt(card.pickups))
+            StoreStat(stringResource(R.string.patterns_tab_store_deliveries_label), Formats.commaInt(card.deliveries))
+            StoreStat(stringResource(R.string.patterns_tab_store_gross_label), Formats.money(card.gross))
+            StoreStat(
+                stringResource(R.string.patterns_tab_store_net_label),
+                Formats.money(card.net),
+                valueColor = if (card.net >= 0.0) c.good else c.bad,
+            )
+        }
+
+        Spacer(Modifier.height(6.dp))
+        val dwellText = card.avgDwellMillis?.let { avg ->
+            val base = stringResource(
+                R.string.patterns_tab_store_dwell_format,
+                formatDuration(avg.toLong()),
+                card.p50DwellMillis?.let { formatDuration(it) } ?: EMPTY_VALUE,
+                card.p95DwellMillis?.let { formatDuration(it) } ?: EMPTY_VALUE,
+            )
+            // A chain-only ("location unknown") card blends multiple physical stores (F6) — mark dwell partial.
+            if (card.locationKnown) base else base + stringResource(R.string.patterns_tab_store_dwell_partial_suffix)
+        } ?: stringResource(R.string.patterns_tab_store_dwell_none)
+        Text(text = dwellText, style = MaterialTheme.typography.bodySmall, color = c.text3)
+
+        Spacer(Modifier.height(2.dp))
+        Text(
+            text = stringResource(
+                R.string.patterns_tab_store_seen_format,
+                formatShortDate(card.firstSeenAt),
+                formatShortDate(card.lastSeenAt),
+            ),
+            style = MaterialTheme.typography.bodySmall,
+            color = c.text3,
+        )
+
+        // F6: for a chain-only entity, state that per-location stats are partial by construction.
+        if (!card.locationKnown) {
+            Spacer(Modifier.height(2.dp))
+            Text(
+                text = stringResource(R.string.patterns_tab_stats_partial, card.chainDisplay),
+                style = MaterialTheme.typography.labelSmall,
+                color = c.warn,
+            )
+        }
+    }
+}
+
+/** A compact label-over-value stat cell for the store row (not a bordered [AppStatTile] — inline). */
+@Composable
+private fun StoreStat(label: String, value: String, valueColor: Color = AppTheme.colors.text) {
+    Column {
+        Text(text = label.uppercase(), style = AppTheme.num.chip, color = AppTheme.colors.text3)
+        Text(text = value, style = AppTheme.num.smNum, color = valueColor, textAlign = TextAlign.Start)
+    }
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/SessionDetailScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/SessionDetailScreen.kt
@@ -57,8 +57,6 @@ import kotlin.math.roundToInt
 /** Below this the unattributed pay is effectively zero — no callout (avoids a "$0.00" flag). */
 private const val UNATTRIBUTED_EPSILON = 0.005
 
-/** Placeholder shown for a figure that has no measurable value yet (dashboard parity). */
-private const val EMPTY_VALUE = "—"
 
 /**
  * The read-only per-dash drill-down (#650 PR A): one dash expanded top→bottom — a header card

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/TimeTab.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/TimeTab.kt
@@ -32,8 +32,6 @@ import java.time.ZoneId
 import kotlin.math.roundToInt
 import kotlin.math.roundToLong
 
-/** Placeholder shown for a figure with no measurable input yet (Money/Decisions-tab parity). */
-private const val EMPTY_VALUE = "—"
 
 /**
  * Time tab (#315 H4): the measured time / mileage review for the selected period, top→bottom — the

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -218,8 +218,6 @@
     <!-- main/analytics/AnalyticsScreen.kt -->
     <string name="analytics_screen_title">Analytics</string>
     <string name="analytics_screen_content_desc_export_csv">Export data (CSV)</string>
-    <string name="analytics_screen_coming_soon_title">%1$s — coming soon</string>
-    <string name="analytics_screen_coming_soon_desc">This tab lands in a later Analytics phase.</string>
 
     <!-- setup/permissions/PermissionCard.kt -->
     <string name="permission_card_content_desc_privacy">Privacy</string>
@@ -370,6 +368,27 @@
     <string name="time_tab_margin_late_format">typically %1$s late</string>
     <string name="time_tab_mileage_tax_title">MILEAGE &amp; TAX</string>
     <string name="time_tab_mileage_tax_disclosure">standard-mileage method — not the app\'s operating-cost model; confirm with a tax preparer.</string>
+
+    <!-- main/analytics/PatternsTab.kt (#315 H5) -->
+    <string name="patterns_tab_heatmap_title">YOUR NET $/HR BY HOUR</string>
+    <string name="patterns_tab_heatmap_caption">your own realized net $/hr, by hour and day — where your time actually pays. Lifetime.</string>
+    <string name="patterns_tab_heatmap_no_data">Not enough dashing yet to show a pattern. Dash a few more hours and your best times will fill in here.</string>
+    <string name="patterns_tab_heatmap_best_format">Your best hour so far: %1$s — %2$s/hr</string>
+    <string name="patterns_tab_heatmap_legend_low">lower</string>
+    <string name="patterns_tab_heatmap_legend_high">higher</string>
+    <string name="patterns_tab_heatmap_legend_insufficient">too little time</string>
+    <string name="patterns_tab_stores_title">YOUR STORES</string>
+    <string name="patterns_tab_no_stores">No stores visited yet.</string>
+    <string name="patterns_tab_location_unknown">location unknown</string>
+    <string name="patterns_tab_stats_partial">per-location stats partial — blends every %1$s you\'ve visited on payout-less jobs</string>
+    <string name="patterns_tab_store_pickups_label">Pickups</string>
+    <string name="patterns_tab_store_deliveries_label">Deliveries</string>
+    <string name="patterns_tab_store_gross_label">Gross</string>
+    <string name="patterns_tab_store_net_label">Net</string>
+    <string name="patterns_tab_store_dwell_format">dwell avg %1$s · median %2$s · p95 %3$s</string>
+    <string name="patterns_tab_store_dwell_partial_suffix"> (partial)</string>
+    <string name="patterns_tab_store_dwell_none">no pickup dwell recorded yet</string>
+    <string name="patterns_tab_store_seen_format">first %1$s · last %2$s</string>
 
     <!-- setup/wizard/WizardScreen.kt -->
     <string name="wizard_screen_goal_option1_title">Cherry Picker</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -377,7 +377,9 @@
     <string name="patterns_tab_heatmap_legend_low">lower</string>
     <string name="patterns_tab_heatmap_legend_high">higher</string>
     <string name="patterns_tab_heatmap_legend_insufficient">too little time</string>
+    <string name="patterns_tab_heatmap_legend_zero">worked, no net</string>
     <string name="patterns_tab_stores_title">YOUR STORES</string>
+    <string name="patterns_tab_stores_manual_note">Manually-added deliveries and history we couldn\'t match to a store still count in your Money totals — they just don\'t show up as a store card here yet.</string>
     <string name="patterns_tab_no_stores">No stores visited yet.</string>
     <string name="patterns_tab_location_unknown">location unknown</string>
     <string name="patterns_tab_stats_partial">per-location stats partial — blends every %1$s you\'ve visited on payout-less jobs</string>

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsViewModelTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsViewModelTest.kt
@@ -102,6 +102,25 @@ class AnalyticsViewModelTest {
     private fun store(name: String, net: Double, deliveries: Int) =
         StoreEconomics(storeName = name, net = net, gross = net, deliveries = deliveries)
 
+    private fun storeReportCard(chainDisplay: String) = StoreReportCard(
+        storeKey = "doordash|${chainDisplay.lowercase()}|02426",
+        platform = "doordash",
+        normalizedChain = chainDisplay.lowercase(),
+        chainDisplay = chainDisplay,
+        runningKey = "02426",
+        address = "123 Main St",
+        locationKnown = true,
+        pickups = 4,
+        deliveries = 6,
+        gross = 88.0,
+        net = 61.0,
+        avgDwellMillis = 300_000.0,
+        p50DwellMillis = 280_000L,
+        p95DwellMillis = 540_000L,
+        firstSeenAt = 1_700_000_000_000L,
+        lastSeenAt = 1_700_100_000_000L,
+    )
+
     private fun session(id: String, reported: Double?) = SessionRecord(
         sessionId = id, platform = Platform.DoorDash, startedAt = 1_700_000_000_000L, endedAt = null,
         reportedEarnings = reported, reportedDurationMillis = null, miles = 10.0,
@@ -186,6 +205,28 @@ class AnalyticsViewModelTest {
         assertEquals(5, ui.decisions.declined)
         assertEquals(0.3, ui.decisions.acceptanceRate!!, 1e-9)
         assertEquals(12.5, ui.decisions.declinedEstNet, 1e-9)
+        job.cancel()
+    }
+
+    @Test
+    fun `patterns-tab sources (store cards + heatmap) are wired into state`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        stubPeriod(AnalyticsPeriod.THIS_WEEK, economics(net = 100.0, netPerHour = 20.0))
+        stubSessions(emptyList())
+        // Override the @Before defaults with NON-DEFAULT values so the assertion is falsifiable — an
+        // empty stub would equal the UiState defaults and prove nothing about the wiring.
+        val heatmap = EarningsHeatmap.EMPTY.copy(minCoverageHours = 0.75)
+        whenever(analyticsRepository.storeReportCards())
+            .thenReturn(flowOf(listOf(storeReportCard("Wendys"))))
+        whenever(analyticsRepository.earningsHeatmap(anyOrNull())).thenReturn(flowOf(heatmap))
+
+        val viewModel = buildViewModel()
+        val job = launch { viewModel.uiState.collect {} }
+        testScheduler.advanceUntilIdle()
+
+        val ui = viewModel.uiState.value
+        assertEquals("Wendys", ui.storeReportCards.single().chainDisplay)
+        assertEquals(0.75, ui.earningsHeatmap.minCoverageHours, 1e-9)
         job.cancel()
     }
 

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsViewModelTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsViewModelTest.kt
@@ -4,10 +4,12 @@ import cloud.trotter.dashbuddy.core.data.analytics.AnalyticsRepository
 import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
 import cloud.trotter.dashbuddy.domain.analytics.DailyEarnings
 import cloud.trotter.dashbuddy.domain.analytics.DecisionEconomics
+import cloud.trotter.dashbuddy.domain.analytics.EarningsHeatmap
 import cloud.trotter.dashbuddy.domain.analytics.PeriodEconomics
 import cloud.trotter.dashbuddy.domain.analytics.PeriodTotals
 import cloud.trotter.dashbuddy.domain.analytics.SessionRecord
 import cloud.trotter.dashbuddy.domain.analytics.StoreEconomics
+import cloud.trotter.dashbuddy.domain.analytics.StoreReportCard
 import cloud.trotter.dashbuddy.domain.analytics.TimeEconomics
 import cloud.trotter.dashbuddy.domain.state.Platform
 import kotlinx.coroutines.Dispatchers
@@ -21,6 +23,7 @@ import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
@@ -38,6 +41,18 @@ import org.mockito.kotlin.whenever
 class AnalyticsViewModelTest {
 
     private val analyticsRepository: AnalyticsRepository = mock()
+
+    /**
+     * The Patterns-tab sources (#315 H5) are LIFETIME-scoped and collected unconditionally in the
+     * combine, so every test must supply them or the combine folds a null Flow. They're period-
+     * independent, so a single default stub covers all tests (the Patterns behavior has its own
+     * repository/domain tests).
+     */
+    @Before
+    fun stubPatternsSources() {
+        whenever(analyticsRepository.storeReportCards()).thenReturn(flowOf(emptyList<StoreReportCard>()))
+        whenever(analyticsRepository.earningsHeatmap(anyOrNull())).thenReturn(flowOf(EarningsHeatmap.EMPTY))
+    }
 
     private fun stubPeriod(
         period: AnalyticsPeriod,

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
@@ -27,11 +27,14 @@ import cloud.trotter.dashbuddy.domain.state.StoreKeys
 import java.time.Instant
 import java.time.ZoneId
 import kotlin.math.ceil
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -208,12 +211,15 @@ class AnalyticsRepository @Inject constructor(
      * rate = Σnet ÷ Σhours with a coverage mask) — this repository stays DAO-only and holds no second
      * copy of that math (Principle 5).
      *
-     * **Lifetime-scoped** (no period): the tab is rate-based and hides the period. **Timezone:** cells
-     * are bucketed in [zone] (the device zone by default; injectable for a fixed-zone test) — a timezone
-     * move re-buckets history, acceptable since driver-local patterns are the point. No economy
-     * dependency (net is the frozen stored value); no new PII surface (aggregate net + time only).
+     * **Lifetime-scoped** (no period): the tab is rate-based and hides the period. **Timezone:**
+     * [zoneProvider] is evaluated **per emission** inside the combine (not captured once at flow
+     * construction), so a timezone move re-buckets history on the very next projector commit — the
+     * device zone by default; a fixed-zone supplier is injected in tests. The apportionment + union is
+     * off-main ([Dispatchers.Default]) since it iterates the 168-cell grid; [distinctUntilChanged]
+     * suppresses re-emitting an identical grid on an unrelated Room invalidation. No economy dependency
+     * (net is the frozen stored value); no new PII surface (aggregate net + time only).
      */
-    fun earningsHeatmap(zone: ZoneId = ZoneId.systemDefault()): Flow<EarningsHeatmap> =
+    fun earningsHeatmap(zoneProvider: () -> ZoneId = { ZoneId.systemDefault() }): Flow<EarningsHeatmap> =
         combine(
             analyticsDao.sessionSpans(),
             analyticsDao.deliveryNets(),
@@ -221,9 +227,9 @@ class AnalyticsRepository @Inject constructor(
             EarningsHeatmapCalculator.compute(
                 spans = spans.map { SessionSpan(it.startMillis, it.endMillis) },
                 deliveries = nets.map { DeliveryNet(it.completedAt, it.netDollars) },
-                zone = zone,
+                zone = zoneProvider(),
             )
-        }
+        }.flowOn(Dispatchers.Default).distinctUntilChanged()
 
     /**
      * Offer-decision economics for [period] (#315 H3, Decisions tab): the funnel counts, the frozen

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
@@ -8,11 +8,15 @@ import cloud.trotter.dashbuddy.core.database.analytics.SessionTotalsRow
 import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
 import cloud.trotter.dashbuddy.domain.analytics.DailyEarnings
 import cloud.trotter.dashbuddy.domain.analytics.DecisionEconomics
+import cloud.trotter.dashbuddy.domain.analytics.DeliveryNet
 import cloud.trotter.dashbuddy.domain.analytics.DeliveryRecord
+import cloud.trotter.dashbuddy.domain.analytics.EarningsHeatmap
+import cloud.trotter.dashbuddy.domain.analytics.EarningsHeatmapCalculator
 import cloud.trotter.dashbuddy.domain.analytics.PeriodEconomics
 import cloud.trotter.dashbuddy.domain.analytics.PeriodTotals
 import cloud.trotter.dashbuddy.domain.analytics.SessionDetail
 import cloud.trotter.dashbuddy.domain.analytics.SessionRecord
+import cloud.trotter.dashbuddy.domain.analytics.SessionSpan
 import cloud.trotter.dashbuddy.domain.analytics.StoreEconomics
 import cloud.trotter.dashbuddy.domain.analytics.StoreReportCard
 import cloud.trotter.dashbuddy.domain.analytics.TimeEconomics
@@ -193,6 +197,32 @@ class AnalyticsRepository @Inject constructor(
                     lastSeenAt = r.lastSeenAt,
                 )
             }
+        }
+
+    /**
+     * The driver's own realized net **$/hr by hour-of-week** (#159/#315 H5, Patterns heatmap) — a 7×24
+     * grid of *their own* earning experience, never a platform-pay claim. Combines the two lifetime DAO
+     * reads: session spans ([AnalyticsDao.sessionSpans], the coverage denominator) and delivery nets
+     * ([AnalyticsDao.deliveryNets], the numerator). The apportionment math is the pure `:domain`
+     * [EarningsHeatmapCalculator] (span → fractional hour cells, net → the cell of its `completedAt`,
+     * rate = Σnet ÷ Σhours with a coverage mask) — this repository stays DAO-only and holds no second
+     * copy of that math (Principle 5).
+     *
+     * **Lifetime-scoped** (no period): the tab is rate-based and hides the period. **Timezone:** cells
+     * are bucketed in [zone] (the device zone by default; injectable for a fixed-zone test) — a timezone
+     * move re-buckets history, acceptable since driver-local patterns are the point. No economy
+     * dependency (net is the frozen stored value); no new PII surface (aggregate net + time only).
+     */
+    fun earningsHeatmap(zone: ZoneId = ZoneId.systemDefault()): Flow<EarningsHeatmap> =
+        combine(
+            analyticsDao.sessionSpans(),
+            analyticsDao.deliveryNets(),
+        ) { spans, nets ->
+            EarningsHeatmapCalculator.compute(
+                spans = spans.map { SessionSpan(it.startMillis, it.endMillis) },
+                deliveries = nets.map { DeliveryNet(it.completedAt, it.netDollars) },
+                zone = zone,
+            )
         }
 
     /**

--- a/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsHeatmapTest.kt
+++ b/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsHeatmapTest.kt
@@ -113,7 +113,7 @@ class AnalyticsHeatmapTest {
         dao.upsertSession(session("A", mon0 + 10 * hour, endedAt = mon0 + 11 * hour, lastEventAt = mon0 + 11 * hour))
         dao.upsertDelivery(delivery(1, "A", completedAt = mon0 + 10 * hour + 30 * minute, netProfit = 20.0, cashTip = 5.0))
 
-        val h = repo.earningsHeatmap(utc).first()
+        val h = repo.earningsHeatmap { utc }.first()
         val cell = h.cell(0, 10)
         assertEquals(1.0, cell.coverageHours, 1e-9)
         assertEquals(25.0, cell.netDollars, 1e-9)   // 20 frozen net + 5 cash
@@ -129,7 +129,7 @@ class AnalyticsHeatmapTest {
         dao.upsertSession(session("B", mon0 + 24 * hour + 14 * hour, endedAt = null, lastEventAt = mon0 + 24 * hour + 15 * hour))
         dao.upsertDelivery(delivery(2, "B", completedAt = mon0 + 24 * hour + 14 * hour + 30 * minute, netProfit = null, cashTip = 3.0))
 
-        val h = repo.earningsHeatmap(utc).first()
+        val h = repo.earningsHeatmap { utc }.first()
         val cell = h.cell(1, 14) // Tuesday 14:00
         assertEquals(1.0, cell.coverageHours, 1e-9)   // fell back to lastEventAt, not 0
         assertEquals(3.0, cell.netDollars, 1e-9)       // cash only (null frozen net → 0)
@@ -140,7 +140,7 @@ class AnalyticsHeatmapTest {
     @Test
     fun `no session coverage masks every cell`() = runBlocking {
         dao.upsertDelivery(delivery(3, "Z", completedAt = mon0 + 3 * hour, netProfit = 9.0))
-        val h = repo.earningsHeatmap(utc).first()
+        val h = repo.earningsHeatmap { utc }.first()
         assertNull(h.cell(0, 3).dollarsPerHour)
         assertTrue(h.cells.none { it.dollarsPerHour != null })
     }

--- a/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsHeatmapTest.kt
+++ b/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsHeatmapTest.kt
@@ -1,0 +1,147 @@
+package cloud.trotter.dashbuddy.core.data.analytics
+
+import androidx.room.Room
+import cloud.trotter.dashbuddy.core.database.DashBuddyDatabase
+import cloud.trotter.dashbuddy.core.database.analytics.AnalyticsDao
+import cloud.trotter.dashbuddy.core.database.analytics.DeliveryRecordEntity
+import cloud.trotter.dashbuddy.core.database.analytics.SessionRecordEntity
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import java.time.ZoneOffset
+
+/**
+ * #315 H5 — the Patterns-tab heatmap read (`AnalyticsRepository.earningsHeatmap`) over an in-memory DB
+ * with the real DAO. Proves the two lifetime DAO reads feed the pure [EarningsHeatmapCalculator]
+ * correctly: session spans supply the coverage denominator (with the `COALESCE(endedAt, lastEventAt)`
+ * effective-end), and delivery net (`netProfit + cashTip`, cash-inclusive) supplies the numerator. Runs
+ * in `UTC` so cell indices are exact. `MON0` = Monday 1970-01-05 00:00 UTC (dayIndex 0).
+ */
+@RunWith(RobolectricTestRunner::class)
+class AnalyticsHeatmapTest {
+
+    private lateinit var db: DashBuddyDatabase
+    private lateinit var dao: AnalyticsDao
+    private lateinit var repo: AnalyticsRepository
+
+    private val utc = ZoneOffset.UTC
+    private val hour = 3_600_000L
+    private val minute = 60_000L
+    private val mon0 = 4L * 86_400_000L
+
+    @Before
+    fun setUp() {
+        val context = RuntimeEnvironment.getApplication()
+        db = Room.inMemoryDatabaseBuilder(context, DashBuddyDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = db.analyticsDao()
+        repo = AnalyticsRepository(dao)
+    }
+
+    @After
+    fun tearDown() = db.close()
+
+    private fun session(
+        id: String,
+        startedAt: Long,
+        endedAt: Long?,
+        lastEventAt: Long,
+    ) = SessionRecordEntity(
+        sessionId = id,
+        platform = "doordash",
+        startedAt = startedAt,
+        endedAt = endedAt,
+        lastEventAt = lastEventAt,
+        endSource = "summary_screen",
+        startOdometer = 0.0,
+        lastOdometer = 5.0,
+        reportedEarnings = null,
+        reportedDurationMillis = hour,
+        offersReceived = 0,
+        offersAccepted = 0,
+        offersDeclined = 0,
+        offersTimeout = 0,
+        deliveries = 1,
+        jobsCompleted = 1,
+    )
+
+    private fun delivery(
+        seq: Long,
+        sessionId: String?,
+        completedAt: Long,
+        netProfit: Double?,
+        cashTip: Double? = null,
+    ) = DeliveryRecordEntity(
+        eventSequenceId = seq,
+        sessionId = sessionId,
+        platform = "doordash",
+        jobId = "job-$seq",
+        taskId = "task-$seq",
+        storeName = "Wendys",
+        customerHash = null,
+        addressHash = null,
+        phaseStartedAt = completedAt - 600_000,
+        arrivedAt = null,
+        completedAt = completedAt,
+        deadlineMillis = null,
+        realizedPay = 10.0,
+        payBasis = "DROP_SHARE",
+        tip = null,
+        basePay = null,
+        odometerAtCompletion = null,
+        realizedMiles = null,
+        realizedMinutes = null,
+        frozenCostPerMile = null,
+        netProfit = netProfit,
+        costBasis = "NONE",
+        cashTip = cashTip,
+    )
+
+    /** Coverage from a full-hour session; net = frozen netProfit + cashTip; rate = net ÷ hours. */
+    @Test
+    fun `heatmap folds a full-hour session and its cash-inclusive delivery net into the right cell`() = runBlocking {
+        // Monday 10:00–11:00, delivery at 10:30 with net 20 + cash 5 = 25.
+        dao.upsertSession(session("A", mon0 + 10 * hour, endedAt = mon0 + 11 * hour, lastEventAt = mon0 + 11 * hour))
+        dao.upsertDelivery(delivery(1, "A", completedAt = mon0 + 10 * hour + 30 * minute, netProfit = 20.0, cashTip = 5.0))
+
+        val h = repo.earningsHeatmap(utc).first()
+        val cell = h.cell(0, 10)
+        assertEquals(1.0, cell.coverageHours, 1e-9)
+        assertEquals(25.0, cell.netDollars, 1e-9)   // 20 frozen net + 5 cash
+        assertEquals(25.0, cell.dollarsPerHour!!, 1e-9)
+        assertEquals(25.0, h.maxDollarsPerHour!!, 1e-9)
+        assertTrue(h.hasData)
+    }
+
+    /** A still-open session (endedAt null) uses `lastEventAt` for its span; a null-net delivery folds cash only. */
+    @Test
+    fun `open session uses lastEventAt and a null-net delivery contributes only its cash`() = runBlocking {
+        // Tuesday 14:00, endedAt null, last event at 15:00 → 1h coverage. Delivery net null, cash 3.
+        dao.upsertSession(session("B", mon0 + 24 * hour + 14 * hour, endedAt = null, lastEventAt = mon0 + 24 * hour + 15 * hour))
+        dao.upsertDelivery(delivery(2, "B", completedAt = mon0 + 24 * hour + 14 * hour + 30 * minute, netProfit = null, cashTip = 3.0))
+
+        val h = repo.earningsHeatmap(utc).first()
+        val cell = h.cell(1, 14) // Tuesday 14:00
+        assertEquals(1.0, cell.coverageHours, 1e-9)   // fell back to lastEventAt, not 0
+        assertEquals(3.0, cell.netDollars, 1e-9)       // cash only (null frozen net → 0)
+        assertEquals(3.0, cell.dollarsPerHour!!, 1e-9)
+    }
+
+    /** No sessions ⇒ every cell masked (no coverage), even if a stray delivery has net. */
+    @Test
+    fun `no session coverage masks every cell`() = runBlocking {
+        dao.upsertDelivery(delivery(3, "Z", completedAt = mon0 + 3 * hour, netProfit = 9.0))
+        val h = repo.earningsHeatmap(utc).first()
+        assertNull(h.cell(0, 3).dollarsPerHour)
+        assertTrue(h.cells.none { it.dollarsPerHour != null })
+    }
+}

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
@@ -516,6 +516,29 @@ interface AnalyticsDao {
     )
     fun deliveryTimeTotals(start: Long, end: Long): Flow<DeliveryTimeTotalsRow>
 
+    // ── Patterns-tab heatmap reads (#315 H5) ────────────────────────────
+
+    /**
+     * Every session's online span — the hour×day net-$/hr heatmap **coverage denominator** (#315 H5).
+     * [SessionSpanRow.startMillis] is `startedAt`; [SessionSpanRow.endMillis] is the effective end
+     * `COALESCE(endedAt, lastEventAt)` (a still-open session falls back to its last observed event, the
+     * same effective-end definition [sessionTotals] uses for online duration). **Lifetime-scoped** — the
+     * Patterns tab is rate-based and hides the period, so this is deliberately unbounded (no start/end
+     * predicate). The repository apportions each span across the wall-clock hour cells it overlaps.
+     */
+    @Query("SELECT startedAt AS startMillis, COALESCE(endedAt, lastEventAt) AS endMillis FROM session_records")
+    fun sessionSpans(): Flow<List<SessionSpanRow>>
+
+    /**
+     * Every completed delivery's net + completion instant — the heatmap **numerator** (#315 H5).
+     * [DeliveryNetRow.netDollars] = `COALESCE(netProfit, 0) + COALESCE(cashTip, 0)` (the frozen realized
+     * net plus the driver-entered cash tip; #688 keeps cash outside `netProfit`, added at the read site).
+     * Lifetime-scoped (unbounded) like [sessionSpans]. The repository lands each delivery's net whole in
+     * the cell of its `completedAt`.
+     */
+    @Query("SELECT completedAt AS completedAt, (COALESCE(netProfit, 0) + COALESCE(cashTip, 0)) AS netDollars FROM delivery_records")
+    fun deliveryNets(): Flow<List<DeliveryNetRow>>
+
     // ── Drill-down list reads (future hub / #650) ────────────────────────
 
     /**

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsTotals.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsTotals.kt
@@ -161,6 +161,28 @@ data class SessionTotalsRow(
     val sessions: Int,
 )
 
+/**
+ * One session's online span (#315 H5 Patterns heatmap) — [startMillis] = `startedAt`, [endMillis] =
+ * effective end `COALESCE(endedAt, lastEventAt)` (a still-open session uses its last event). The
+ * repository apportions this span across the hour-of-week grid's coverage denominator. Lifetime-scoped
+ * (the heatmap has no period selector), so the query is unbounded.
+ */
+data class SessionSpanRow(
+    val startMillis: Long,
+    val endMillis: Long,
+)
+
+/**
+ * One completed delivery's net + completion instant (#315 H5 Patterns heatmap numerator).
+ * [netDollars] = `COALESCE(netProfit, 0) + COALESCE(cashTip, 0)` — the frozen realized net plus the
+ * driver-entered cash tip (#688; cash lives outside `netProfit`, added at the read site). A null-net
+ * (no cost basis) row contributes its cash only — the frozen-net philosophy, never recomputed.
+ */
+data class DeliveryNetRow(
+    val completedAt: Long,
+    val netDollars: Double,
+)
+
 /** Per-platform session totals (GROUP BY platform). */
 data class PlatformSessionTotalsRow(
     val platform: String,

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -83,6 +83,19 @@ was found **broken-in-part** (raw PII in capture envelopes) and moved to that en
   And a payout-less close (`DASH_STOP` with no summary) must NOT downgrade an already-keyed store back to
   chain-only. No UI yet (the #315 Patterns tab is the consumer) — verify via the DB / a CSV-adjacent read.
   - Confirmed: 0/2
+- **🆕 NEW — Analytics → Patterns tab: store report cards + net-$/hr heatmap (#315 H5 / PR).**
+  The Patterns tab (Analytics hub, no period selector — it's lifetime/rate-based) now renders two real
+  sections: (A) **store report cards** newest-visited-first, one per resolved store — chain name + a
+  location chip (the running key, or a "location unknown" chip for chain-only entities), pickup/delivery
+  counts, cash-inclusive gross/net, avg/median/p95 pickup dwell, and first/last-seen; and (B) a **7×24
+  hour×day heatmap** of the driver's OWN realized net $/hr, best-hour callout on top. **How to tell it's
+  working (open Analytics → Patterns after a few dashes):** the store cards should list the actual stores
+  from recent dashes with running keys that match reality and **sane dwell numbers** (minutes, not
+  seconds/hours — dwell = confirm − arrive on real pickups); the heatmap's warmer cells should fall on the
+  hours/days you actually earn the most, cells you barely dashed should read as "too little time" (dim,
+  distinct from a worked-but-earned-nothing cell), and the "best hour so far" line should feel right.
+  Framing check: all copy is "YOUR net $/hr" — flag any wording that reads as a platform-pay claim.
+  - Confirmed: 0/2
 - **🆕 NEW — GoPuff zone-arrival screens recognized (recognize-only, no state effect) (#501 item 3 / PR #738).**
   The GoPuff "Navigate to zone" / "Arrived at store" screens (the `go_to_store_action_view` CTA card)
   are now recognized as `pickup_zone_arrival` instead of landing in UNKNOWN. **How to tell it's working

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/EarningsHeatmap.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/EarningsHeatmap.kt
@@ -9,15 +9,23 @@ import java.time.temporal.ChronoUnit
  * (day-of-week × hour-of-day) grid of *their own* earning experience, not any platform-pay claim.
  *
  * Semantics (locked at review tier):
- *  - **Denominator (coverage):** each session's `[startMillis, endMillis)` span is apportioned across
- *    the hour-of-week cells it overlaps in **fractional hours** (a dash 6:40–7:20pm contributes 1/3h to
- *    the 6pm cell and 1/3h to the 7pm cell). Summed over every session.
+ *  - **Denominator (coverage):** the sessions are first merged into a **wall-clock union** — overlapping
+ *    or adjacent `[startMillis, endMillis)` spans (concurrent platforms, or a crashed-open session that
+ *    overlaps its successor) collapse into one, so an hour the driver was online is counted **once**, never
+ *    double-billed into the denominator. The union spans are then apportioned across the hour-of-week
+ *    cells they overlap in **fractional hours** (a dash 6:40–7:20pm contributes 1/3h to the 6pm cell and
+ *    1/3h to the 7pm cell).
  *  - **Numerator (net):** each delivery's (frozen `netProfit` + `cashTip`) lands **whole** in the cell
  *    of its `completedAt`.
  *  - **Cell rate = Σnet ÷ ΣcoverageHours**, but only where coverage clears [minCoverageHours]
  *    ([EarningsHeatmapCell.dollarsPerHour] is null below it) — a single delivery over 3 minutes of
  *    coverage is a noisy 20×/hr artifact, not a pattern. A masked cell is visually distinct from a
- *    *genuinely-zero* cell (enough coverage, no earnings → rate `0.0`).
+ *    *genuinely-zero* cell (enough coverage, no earnings → rate `0.0`). This is deliberately a **rate**
+ *    surface: a delivery can land in a cell with zero/thin coverage (a `MANUAL` correction is stamped at
+ *    the session's *exclusive* endpoint, and an inverted-timestamp session — #732 — has its span dropped
+ *    while its deliveries survive), so such a cell's net is present but its rate is masked (the money is
+ *    invisible, never wrong — the rate is only ever computed where coverage clears the floor, so it can
+ *    never be `Infinity`/`NaN`).
  *
  * Lifetime-scoped (Patterns hides the period — it is rate-based, #315). Cells are in the **device-local
  * timezone at read time**: [EarningsHeatmapCalculator.compute] takes the [ZoneId] and buckets by
@@ -36,8 +44,15 @@ data class EarningsHeatmap(
     /** The cell at ([dayIndex] 0=Monday..6=Sunday, [hour] 0..23). */
     fun cell(dayIndex: Int, hour: Int): EarningsHeatmapCell = cells[dayIndex * HOURS + hour]
 
+    /**
+     * The single highest-rate non-masked cell (the driver's own best earning hour), or null when no cell
+     * has cleared coverage — the one owner for both the UI's best-hour callout AND the color-scale top
+     * (Principle 5: the callout and the ramp read the same cell, never two separate scans).
+     */
+    val bestCell: EarningsHeatmapCell? get() = cells.filter { it.dollarsPerHour != null }.maxByOrNull { it.dollarsPerHour!! }
+
     /** The largest non-masked cell rate, or null when no cell has cleared coverage — the UI's color-scale top. */
-    val maxDollarsPerHour: Double? get() = cells.mapNotNull { it.dollarsPerHour }.maxOrNull()
+    val maxDollarsPerHour: Double? get() = bestCell?.dollarsPerHour
 
     /** True once any cell has cleared the coverage floor — the UI shows an empty state otherwise. */
     val hasData: Boolean get() = cells.any { it.dollarsPerHour != null }
@@ -88,10 +103,21 @@ object EarningsHeatmapCalculator {
     private const val MILLIS_PER_HOUR = 3_600_000.0
 
     /**
-     * Build the grid. [spans] are apportioned across cells by wall-clock hour in [zone] (DST-safe:
-     * iteration advances one wall-clock hour at a time, so a 23h/25h DST day attributes each real
-     * millisecond to the cell of the hour it fell in); [deliveries]' net lands whole in the cell of
-     * each `completedAt`. A span with `endMillis <= startMillis` contributes nothing (guarded).
+     * Sanity cap on a single span (14 days). A corrupt row — a seconds-vs-millis mix-up, or an
+     * epoch-zero `startMillis` — would otherwise apportion ~490k `ZonedDateTime` iterations across the
+     * grid. No legitimate dash approaches this, so an over-cap span is dropped silently (it contributes
+     * zero coverage); dropping it *before* the union merge also stops one corrupt span from swallowing
+     * every real one.
+     */
+    private const val MAX_SPAN_MILLIS = 14L * 24L * 3_600_000L
+
+    /**
+     * Build the grid. [spans] are first merged into a **wall-clock union** (overlapping/adjacent spans
+     * collapse, so a concurrent-platform or crashed-open overlap is counted once, not twice), then
+     * apportioned across cells by wall-clock hour in [zone] (DST-safe: iteration advances one wall-clock
+     * hour at a time, so a 23h/25h DST day attributes each real millisecond to the cell of the hour it
+     * fell in); [deliveries]' net lands whole in the cell of each `completedAt`. A span with
+     * `endMillis <= startMillis`, or one longer than [MAX_SPAN_MILLIS], contributes nothing (guarded).
      */
     fun compute(
         spans: List<SessionSpan>,
@@ -102,7 +128,7 @@ object EarningsHeatmapCalculator {
         val coverage = DoubleArray(EarningsHeatmap.DAYS * EarningsHeatmap.HOURS)
         val net = DoubleArray(EarningsHeatmap.DAYS * EarningsHeatmap.HOURS)
 
-        for (span in spans) apportionSpan(span, zone, coverage)
+        for (span in unionOf(spans)) apportionSpan(span, zone, coverage)
         for (d in deliveries) {
             net[cellIndex(d.completedAtMillis, zone)] += d.netDollars
         }
@@ -114,10 +140,36 @@ object EarningsHeatmapCalculator {
                 hour = i % EarningsHeatmap.HOURS,
                 netDollars = net[i],
                 coverageHours = hours,
-                dollarsPerHour = if (hours >= minCoverageHours) net[i] / hours else null,
+                // Rate only where coverage clears the floor AND is strictly positive — so a net-in-a-
+                // zero-coverage cell (MANUAL correction / dropped inverted span) stays masked, never
+                // an Infinity/NaN division.
+                dollarsPerHour = if (hours >= minCoverageHours && hours > 0.0) net[i] / hours else null,
             )
         }
         return EarningsHeatmap(cells, minCoverageHours)
+    }
+
+    /**
+     * Merge [spans] into a wall-clock union: drop empty/malformed and over-[MAX_SPAN_MILLIS] spans, sort
+     * by start, and collapse each span whose start is `<=` the running span's end into it (overlapping or
+     * exactly-adjacent). The result is a set of disjoint spans whose total length is the real online
+     * wall-clock time — so two concurrent sessions never double-count an hour into the denominator.
+     */
+    private fun unionOf(spans: List<SessionSpan>): List<SessionSpan> {
+        val valid = spans
+            .filter { it.endMillis > it.startMillis && it.endMillis - it.startMillis <= MAX_SPAN_MILLIS }
+            .sortedBy { it.startMillis }
+        if (valid.isEmpty()) return emptyList()
+        val merged = ArrayList<SessionSpan>(valid.size)
+        for (s in valid) {
+            val last = merged.lastOrNull()
+            if (last != null && s.startMillis <= last.endMillis) {
+                merged[merged.lastIndex] = SessionSpan(last.startMillis, maxOf(last.endMillis, s.endMillis))
+            } else {
+                merged.add(s)
+            }
+        }
+        return merged
     }
 
     /** Split one span's milliseconds across the wall-clock hour cells it overlaps, in fractional hours. */

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/EarningsHeatmap.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/EarningsHeatmap.kt
@@ -1,0 +1,148 @@
+package cloud.trotter.dashbuddy.domain.analytics
+
+import java.time.Instant
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
+
+/**
+ * The driver's own realized net **$/hr by hour-of-week** (#315 H5, Patterns tab) — a 7×24
+ * (day-of-week × hour-of-day) grid of *their own* earning experience, not any platform-pay claim.
+ *
+ * Semantics (locked at review tier):
+ *  - **Denominator (coverage):** each session's `[startMillis, endMillis)` span is apportioned across
+ *    the hour-of-week cells it overlaps in **fractional hours** (a dash 6:40–7:20pm contributes 1/3h to
+ *    the 6pm cell and 1/3h to the 7pm cell). Summed over every session.
+ *  - **Numerator (net):** each delivery's (frozen `netProfit` + `cashTip`) lands **whole** in the cell
+ *    of its `completedAt`.
+ *  - **Cell rate = Σnet ÷ ΣcoverageHours**, but only where coverage clears [minCoverageHours]
+ *    ([EarningsHeatmapCell.dollarsPerHour] is null below it) — a single delivery over 3 minutes of
+ *    coverage is a noisy 20×/hr artifact, not a pattern. A masked cell is visually distinct from a
+ *    *genuinely-zero* cell (enough coverage, no earnings → rate `0.0`).
+ *
+ * Lifetime-scoped (Patterns hides the period — it is rate-based, #315). Cells are in the **device-local
+ * timezone at read time**: [EarningsHeatmapCalculator.compute] takes the [ZoneId] and buckets by
+ * wall-clock hour, so a timezone move re-buckets history — acceptable, driver-local patterns are the
+ * whole point.
+ *
+ * Pure `:domain` value type — no Android, no wall clock. The calculator derives everything from the
+ * passed obs-timestamp longs + zone (Principle 1).
+ */
+data class EarningsHeatmap(
+    /** Always [DAYS]×[HOURS] = 168 cells, row-major (`dayIndex * HOURS + hour`); empty cells present at 0. */
+    val cells: List<EarningsHeatmapCell>,
+    /** The coverage floor a cell must clear for a non-null [EarningsHeatmapCell.dollarsPerHour]. */
+    val minCoverageHours: Double,
+) {
+    /** The cell at ([dayIndex] 0=Monday..6=Sunday, [hour] 0..23). */
+    fun cell(dayIndex: Int, hour: Int): EarningsHeatmapCell = cells[dayIndex * HOURS + hour]
+
+    /** The largest non-masked cell rate, or null when no cell has cleared coverage — the UI's color-scale top. */
+    val maxDollarsPerHour: Double? get() = cells.mapNotNull { it.dollarsPerHour }.maxOrNull()
+
+    /** True once any cell has cleared the coverage floor — the UI shows an empty state otherwise. */
+    val hasData: Boolean get() = cells.any { it.dollarsPerHour != null }
+
+    companion object {
+        const val DAYS = 7
+        const val HOURS = 24
+
+        /** Empty grid (all cells zero, all masked) — the pre-data state. */
+        val EMPTY = EarningsHeatmap(
+            cells = List(DAYS * HOURS) { i ->
+                EarningsHeatmapCell(dayIndex = i / HOURS, hour = i % HOURS, netDollars = 0.0, coverageHours = 0.0, dollarsPerHour = null)
+            },
+            minCoverageHours = EarningsHeatmapCalculator.DEFAULT_MIN_COVERAGE_HOURS,
+        )
+    }
+}
+
+/**
+ * One hour-of-week cell of the [EarningsHeatmap]. [dayIndex] 0=Monday..6=Sunday, [hour] 0..23.
+ * [dollarsPerHour] is null when [coverageHours] is below the mask threshold (insufficient data,
+ * rendered distinctly from a `0.0` genuinely-zero cell).
+ */
+data class EarningsHeatmapCell(
+    val dayIndex: Int,
+    val hour: Int,
+    val netDollars: Double,
+    val coverageHours: Double,
+    val dollarsPerHour: Double?,
+)
+
+/** One session's online span for the heatmap denominator (repository maps a DAO row → this). */
+data class SessionSpan(val startMillis: Long, val endMillis: Long)
+
+/** One completed delivery's net (frozen `netProfit` + `cashTip`) + completion instant, for the numerator. */
+data class DeliveryNet(val completedAtMillis: Long, val netDollars: Double)
+
+/**
+ * Pure apportionment of session coverage + delivery net into the 7×24 hour-of-week grid (#315 H5).
+ * `obs.timestamp`-derived longs in, cell aggregates out — no Android, no wall clock (Principle 1), so
+ * it is exhaustively unit-testable (midnight/week-boundary/sub-hour/empty).
+ */
+object EarningsHeatmapCalculator {
+
+    /** Below this cumulative coverage a cell's rate is masked as insufficient (~30 min of presence). */
+    const val DEFAULT_MIN_COVERAGE_HOURS = 0.5
+
+    private const val MILLIS_PER_HOUR = 3_600_000.0
+
+    /**
+     * Build the grid. [spans] are apportioned across cells by wall-clock hour in [zone] (DST-safe:
+     * iteration advances one wall-clock hour at a time, so a 23h/25h DST day attributes each real
+     * millisecond to the cell of the hour it fell in); [deliveries]' net lands whole in the cell of
+     * each `completedAt`. A span with `endMillis <= startMillis` contributes nothing (guarded).
+     */
+    fun compute(
+        spans: List<SessionSpan>,
+        deliveries: List<DeliveryNet>,
+        zone: ZoneId,
+        minCoverageHours: Double = DEFAULT_MIN_COVERAGE_HOURS,
+    ): EarningsHeatmap {
+        val coverage = DoubleArray(EarningsHeatmap.DAYS * EarningsHeatmap.HOURS)
+        val net = DoubleArray(EarningsHeatmap.DAYS * EarningsHeatmap.HOURS)
+
+        for (span in spans) apportionSpan(span, zone, coverage)
+        for (d in deliveries) {
+            net[cellIndex(d.completedAtMillis, zone)] += d.netDollars
+        }
+
+        val cells = List(EarningsHeatmap.DAYS * EarningsHeatmap.HOURS) { i ->
+            val hours = coverage[i]
+            EarningsHeatmapCell(
+                dayIndex = i / EarningsHeatmap.HOURS,
+                hour = i % EarningsHeatmap.HOURS,
+                netDollars = net[i],
+                coverageHours = hours,
+                dollarsPerHour = if (hours >= minCoverageHours) net[i] / hours else null,
+            )
+        }
+        return EarningsHeatmap(cells, minCoverageHours)
+    }
+
+    /** Split one span's milliseconds across the wall-clock hour cells it overlaps, in fractional hours. */
+    private fun apportionSpan(span: SessionSpan, zone: ZoneId, coverage: DoubleArray) {
+        if (span.endMillis <= span.startMillis) return
+        // Start at the wall-clock hour boundary at or before the span start.
+        var cellStart = Instant.ofEpochMilli(span.startMillis).atZone(zone).truncatedTo(ChronoUnit.HOURS)
+        while (true) {
+            val cellStartMillis = cellStart.toInstant().toEpochMilli()
+            if (cellStartMillis >= span.endMillis) break
+            val nextCell = cellStart.plusHours(1)
+            val cellEndMillis = nextCell.toInstant().toEpochMilli()
+            val segStart = maxOf(span.startMillis, cellStartMillis)
+            val segEnd = minOf(span.endMillis, cellEndMillis)
+            if (segEnd > segStart) {
+                val idx = (cellStart.dayOfWeek.value - 1) * EarningsHeatmap.HOURS + cellStart.hour
+                coverage[idx] += (segEnd - segStart) / MILLIS_PER_HOUR
+            }
+            cellStart = nextCell
+        }
+    }
+
+    /** The row-major cell index (Monday=0..Sunday=6) for an instant's wall-clock day/hour in [zone]. */
+    private fun cellIndex(millis: Long, zone: ZoneId): Int {
+        val zdt = Instant.ofEpochMilli(millis).atZone(zone)
+        return (zdt.dayOfWeek.value - 1) * EarningsHeatmap.HOURS + zdt.hour
+    }
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/format/TimeFormats.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/format/TimeFormats.kt
@@ -64,6 +64,19 @@ fun formatShortDate(
         .format(Instant.ofEpochMilli(millis).atZone(zone))
 
 /**
+ * Compact 12-hour clock label for an **hour-of-day** (0..23): `0→"12a"`, `6→"6a"`, `12→"12p"`,
+ * `18→"6p"`. Not a timestamp — a fixed axis/label token for the hour-of-week heatmap (#315 H5), so it
+ * takes no zone/locale: the `a`/`p` suffix is a compact machine marker, not localized display copy. The
+ * one owner for this label (Principle 5) — the heatmap grid axis and its best-hour callout both call it.
+ */
+fun hourOfDayLabel(hour: Int): String {
+    val h24 = ((hour % 24) + 24) % 24
+    val suffix = if (h24 < 12) "a" else "p"
+    val h = (h24 % 12).let { if (it == 0) 12 else it }
+    return "$h$suffix"
+}
+
+/**
  * "5:42 PM" / "17:42" — a localized clock time for a review surface (the per-delivery rows of the
  * #650 drill-down). Same display policy as [formatShortDate]: the localized SHORT time in [locale],
  * resolved against the device [zone] — display copy the dasher reads in their own locale, not a

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/EarningsHeatmapCalculatorTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/EarningsHeatmapCalculatorTest.kt
@@ -1,0 +1,153 @@
+package cloud.trotter.dashbuddy.domain.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.ZoneOffset
+
+/**
+ * #315 H5 — the pure hour×day net-$/hr apportionment ([EarningsHeatmapCalculator]). All cases run in
+ * `UTC` so wall-clock == epoch and cell indices are exact and reproducible. epoch-day 0 is Thursday
+ * 1970-01-01; epoch-day 4 (`MON0`) is Monday 1970-01-05 00:00 UTC → dayIndex 0.
+ *
+ * Covers the review-mandated cases: sub-hour session, span crossing midnight, span crossing the
+ * week boundary (Sun→Mon), empty, the coverage mask threshold, and insufficient-vs-genuinely-zero.
+ */
+class EarningsHeatmapCalculatorTest {
+
+    private val utc = ZoneOffset.UTC
+    private val hour = 3_600_000L
+    private val minute = 60_000L
+
+    /** Monday 1970-01-05 00:00 UTC — the Monday-first grid's dayIndex-0 origin. */
+    private val mon0 = 4L * 86_400_000L
+
+    private fun idx(dayIndex: Int, hour: Int) = dayIndex * EarningsHeatmap.HOURS + hour
+
+    @Test
+    fun `empty inputs give a fully-masked zero grid`() {
+        val h = EarningsHeatmapCalculator.compute(emptyList(), emptyList(), utc)
+        assertEquals(EarningsHeatmap.DAYS * EarningsHeatmap.HOURS, h.cells.size)
+        assertFalse(h.hasData)
+        assertNull(h.maxDollarsPerHour)
+        assertTrue(h.cells.all { it.coverageHours == 0.0 && it.netDollars == 0.0 && it.dollarsPerHour == null })
+    }
+
+    @Test
+    fun `sub-hour session with a delivery yields a single rate cell`() {
+        // Monday 10:00–10:30 (0.5h) + a $15 net delivery completed at 10:15 → Mon/10 cell.
+        val h = EarningsHeatmapCalculator.compute(
+            spans = listOf(SessionSpan(mon0 + 10 * hour, mon0 + 10 * hour + 30 * minute)),
+            deliveries = listOf(DeliveryNet(mon0 + 10 * hour + 15 * minute, 15.0)),
+            zone = utc,
+        )
+        val cell = h.cell(0, 10)
+        assertEquals(0.5, cell.coverageHours, 1e-9)
+        assertEquals(15.0, cell.netDollars, 1e-9)
+        assertEquals(30.0, cell.dollarsPerHour!!, 1e-9) // 15 / 0.5h, and 0.5 clears the 0.5 floor
+        assertEquals(30.0, h.maxDollarsPerHour!!, 1e-9)
+        // No other cell has coverage.
+        assertEquals(0.5, h.cells.sumOf { it.coverageHours }, 1e-9)
+    }
+
+    @Test
+    fun `span crossing midnight splits coverage across two day cells`() {
+        // Monday 23:30 → Tuesday 00:30 : 0.5h to Mon/23, 0.5h to Tue/00.
+        val h = EarningsHeatmapCalculator.compute(
+            spans = listOf(SessionSpan(mon0 + 23 * hour + 30 * minute, mon0 + 24 * hour + 30 * minute)),
+            deliveries = emptyList(),
+            zone = utc,
+        )
+        assertEquals(0.5, h.cell(0, 23).coverageHours, 1e-9)  // Monday 23:00 cell
+        assertEquals(0.5, h.cell(1, 0).coverageHours, 1e-9)   // Tuesday 00:00 cell
+        assertEquals(1.0, h.cells.sumOf { it.coverageHours }, 1e-9)
+    }
+
+    @Test
+    fun `span crossing the week boundary splits Sunday into Monday`() {
+        // Sunday of this grid week = Mon + 6 days. Sun 23:30 → next Mon 00:30.
+        val sun0 = mon0 + 6L * 86_400_000L
+        val h = EarningsHeatmapCalculator.compute(
+            spans = listOf(SessionSpan(sun0 + 23 * hour + 30 * minute, sun0 + 24 * hour + 30 * minute)),
+            deliveries = emptyList(),
+            zone = utc,
+        )
+        assertEquals(0.5, h.cell(6, 23).coverageHours, 1e-9)  // Sunday 23:00
+        assertEquals(0.5, h.cell(0, 0).coverageHours, 1e-9)   // wraps to Monday 00:00
+    }
+
+    @Test
+    fun `coverage below the threshold masks the rate but keeps the raw net`() {
+        // 15-minute session (0.25h < 0.5 floor) with a $20 delivery → masked rate, raw net retained.
+        val h = EarningsHeatmapCalculator.compute(
+            spans = listOf(SessionSpan(mon0 + 14 * hour, mon0 + 14 * hour + 15 * minute)),
+            deliveries = listOf(DeliveryNet(mon0 + 14 * hour + 5 * minute, 20.0)),
+            zone = utc,
+        )
+        val cell = h.cell(0, 14)
+        assertEquals(0.25, cell.coverageHours, 1e-9)
+        assertEquals(20.0, cell.netDollars, 1e-9)
+        assertNull("below-threshold coverage must mask the noisy rate", cell.dollarsPerHour)
+        assertFalse(h.hasData)
+    }
+
+    @Test
+    fun `a covered but earning-less cell is genuinely zero, distinct from masked`() {
+        // A full 1h session with NO delivery → rate 0.0 (not null): worked, earned nothing.
+        val h = EarningsHeatmapCalculator.compute(
+            spans = listOf(SessionSpan(mon0 + 9 * hour, mon0 + 10 * hour)),
+            deliveries = emptyList(),
+            zone = utc,
+        )
+        val cell = h.cell(0, 9)
+        assertEquals(1.0, cell.coverageHours, 1e-9)
+        assertEquals(0.0, cell.dollarsPerHour!!, 1e-9) // genuinely zero, not masked
+        assertTrue(h.hasData)
+    }
+
+    @Test
+    fun `multiple sessions and deliveries in one cell accumulate`() {
+        val h = EarningsHeatmapCalculator.compute(
+            spans = listOf(
+                SessionSpan(mon0 + 18 * hour, mon0 + 18 * hour + 30 * minute),
+                SessionSpan(mon0 + 18 * hour + 30 * minute, mon0 + 19 * hour),
+            ),
+            deliveries = listOf(
+                DeliveryNet(mon0 + 18 * hour + 10 * minute, 12.0),
+                DeliveryNet(mon0 + 18 * hour + 40 * minute, 8.0),
+            ),
+            zone = utc,
+        )
+        val cell = h.cell(0, 18)
+        assertEquals(1.0, cell.coverageHours, 1e-9)
+        assertEquals(20.0, cell.netDollars, 1e-9)
+        assertEquals(20.0, cell.dollarsPerHour!!, 1e-9)
+    }
+
+    @Test
+    fun `a malformed span with end at-or-before start contributes nothing`() {
+        val h = EarningsHeatmapCalculator.compute(
+            spans = listOf(SessionSpan(mon0 + 5 * hour, mon0 + 5 * hour)),
+            deliveries = emptyList(),
+            zone = utc,
+        )
+        assertEquals(0.0, h.cells.sumOf { it.coverageHours }, 1e-9)
+    }
+
+    @Test
+    fun `a multi-hour span apportions whole hours to their own cells`() {
+        // Monday 08:00 → 11:00 : 1h each to 08, 09, 10.
+        val h = EarningsHeatmapCalculator.compute(
+            spans = listOf(SessionSpan(mon0 + 8 * hour, mon0 + 11 * hour)),
+            deliveries = emptyList(),
+            zone = utc,
+        )
+        assertEquals(1.0, h.cell(0, 8).coverageHours, 1e-9)
+        assertEquals(1.0, h.cell(0, 9).coverageHours, 1e-9)
+        assertEquals(1.0, h.cell(0, 10).coverageHours, 1e-9)
+        assertEquals(0.0, h.cell(0, 11).coverageHours, 1e-9) // end-exclusive
+        assertEquals(idx(0, 8) < idx(0, 9), true)
+    }
+}

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/EarningsHeatmapCalculatorTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/EarningsHeatmapCalculatorTest.kt
@@ -5,7 +5,9 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.time.ZoneId
 import java.time.ZoneOffset
+import java.time.ZonedDateTime
 
 /**
  * #315 H5 — the pure hour×day net-$/hr apportionment ([EarningsHeatmapCalculator]). All cases run in
@@ -148,6 +150,128 @@ class EarningsHeatmapCalculatorTest {
         assertEquals(1.0, h.cell(0, 9).coverageHours, 1e-9)
         assertEquals(1.0, h.cell(0, 10).coverageHours, 1e-9)
         assertEquals(0.0, h.cell(0, 11).coverageHours, 1e-9) // end-exclusive
-        assertEquals(idx(0, 8) < idx(0, 9), true)
+        // Real grid assertion (not a test-helper tautology): the produced cell at (dayIndex, hour) round-
+        // trips its own coordinates AND sits at the row-major index the grid promises.
+        val at = h.cell(0, 9)
+        assertEquals(0, at.dayIndex)
+        assertEquals(9, at.hour)
+        assertEquals(at, h.cells[idx(0, 9)])
+    }
+
+    @Test
+    fun `two fully-overlapping sessions count coverage once`() {
+        // Two identical Monday 12:00–14:00 spans (e.g. concurrent platforms) → 1h per cell, not 2h.
+        val one = SessionSpan(mon0 + 12 * hour, mon0 + 14 * hour)
+        val h = EarningsHeatmapCalculator.compute(
+            spans = listOf(one, one),
+            deliveries = listOf(DeliveryNet(mon0 + 12 * hour + 30 * minute, 30.0)),
+            zone = utc,
+        )
+        assertEquals(1.0, h.cell(0, 12).coverageHours, 1e-9)
+        assertEquals(1.0, h.cell(0, 13).coverageHours, 1e-9)
+        assertEquals(2.0, h.cells.sumOf { it.coverageHours }, 1e-9) // 2 cells × 1h, NOT 4h
+        // $30 over 1h of union coverage (not halved by the double-count) → $30/hr in the 12 cell.
+        assertEquals(30.0, h.cell(0, 12).dollarsPerHour!!, 1e-9)
+    }
+
+    @Test
+    fun `partially-overlapping sessions union their coverage`() {
+        // Monday 09:00–11:00 and 10:00–12:00 → union 09:00–12:00 = 3h total (the shared 10–11 counted once).
+        val h = EarningsHeatmapCalculator.compute(
+            spans = listOf(
+                SessionSpan(mon0 + 9 * hour, mon0 + 11 * hour),
+                SessionSpan(mon0 + 10 * hour, mon0 + 12 * hour),
+            ),
+            deliveries = emptyList(),
+            zone = utc,
+        )
+        assertEquals(1.0, h.cell(0, 9).coverageHours, 1e-9)
+        assertEquals(1.0, h.cell(0, 10).coverageHours, 1e-9) // union, not 2h
+        assertEquals(1.0, h.cell(0, 11).coverageHours, 1e-9)
+        assertEquals(3.0, h.cells.sumOf { it.coverageHours }, 1e-9)
+    }
+
+    @Test
+    fun `exactly-adjacent sessions merge without a seam`() {
+        // 08:00–09:00 then 09:00–10:00 → one 08:00–10:00 union, 1h each cell.
+        val h = EarningsHeatmapCalculator.compute(
+            spans = listOf(
+                SessionSpan(mon0 + 8 * hour, mon0 + 9 * hour),
+                SessionSpan(mon0 + 9 * hour, mon0 + 10 * hour),
+            ),
+            deliveries = emptyList(),
+            zone = utc,
+        )
+        assertEquals(2.0, h.cells.sumOf { it.coverageHours }, 1e-9)
+    }
+
+    @Test
+    fun `a wildly-oversized span is skipped and contributes zero coverage fast`() {
+        // A corrupt row: epoch 0 → +56 years. Without the cap this would iterate ~490k hour cells.
+        val fiftySixYears = 56L * 365L * 86_400_000L
+        val start = System.nanoTime()
+        val h = EarningsHeatmapCalculator.compute(
+            spans = listOf(SessionSpan(0L, fiftySixYears)),
+            deliveries = emptyList(),
+            zone = utc,
+        )
+        val elapsedMs = (System.nanoTime() - start) / 1_000_000
+        assertEquals(0.0, h.cells.sumOf { it.coverageHours }, 1e-9)
+        assertFalse(h.hasData)
+        assertTrue("oversized span must be skipped, not iterated (took ${elapsedMs}ms)", elapsedMs < 500)
+    }
+
+    @Test
+    fun `net in a zero-coverage cell is masked, never Infinity or NaN`() {
+        // A delivery with no session coverage in its cell (e.g. a MANUAL correction at an exclusive
+        // endpoint) → net present, rate masked, no exception, no non-finite value.
+        val h = EarningsHeatmapCalculator.compute(
+            spans = emptyList(),
+            deliveries = listOf(DeliveryNet(mon0 + 16 * hour, 25.0)),
+            zone = utc,
+        )
+        val cell = h.cell(0, 16)
+        assertEquals(0.0, cell.coverageHours, 1e-9)
+        assertEquals(25.0, cell.netDollars, 1e-9)
+        assertNull(cell.dollarsPerHour)
+        assertTrue(h.cells.all { it.dollarsPerHour?.isFinite() ?: true })
+    }
+
+    @Test
+    fun `DST spring-forward attributes real elapsed hours, skipping the missing 2am cell`() {
+        // America/Chicago 2026-03-08: clocks jump 02:00→03:00. Local 01:00→04:00 = 2 real hours.
+        val chicago = ZoneId.of("America/Chicago")
+        val start = ZonedDateTime.of(2026, 3, 8, 1, 0, 0, 0, chicago).toInstant().toEpochMilli()
+        val end = ZonedDateTime.of(2026, 3, 8, 4, 0, 0, 0, chicago).toInstant().toEpochMilli()
+        val h = EarningsHeatmapCalculator.compute(
+            spans = listOf(SessionSpan(start, end)),
+            deliveries = emptyList(),
+            zone = chicago,
+        )
+        // 2026-03-08 is a Sunday → dayIndex 6.
+        assertEquals(1.0, h.cell(6, 1).coverageHours, 1e-9)  // 1am cell: 1h
+        assertEquals(0.0, h.cell(6, 2).coverageHours, 1e-9)  // 2am does not exist that day
+        assertEquals(1.0, h.cell(6, 3).coverageHours, 1e-9)  // 3am cell: 1h
+        assertEquals(2.0, h.cells.sumOf { it.coverageHours }, 1e-9) // real elapsed = 2h
+    }
+
+    @Test
+    fun `DST fall-back attributes real elapsed hours across the repeated 1am`() {
+        // America/Chicago 2026-11-01: clocks fall 02:00→01:00. Local 00:30→02:30 = 3 real hours,
+        // the 1am cell lived twice so it gets ~2h.
+        val chicago = ZoneId.of("America/Chicago")
+        val start = ZonedDateTime.of(2026, 11, 1, 0, 30, 0, 0, chicago).toInstant().toEpochMilli()
+        // 02:30 is unambiguous (after the fall-back) — CST.
+        val end = ZonedDateTime.of(2026, 11, 1, 2, 30, 0, 0, chicago).toInstant().toEpochMilli()
+        val h = EarningsHeatmapCalculator.compute(
+            spans = listOf(SessionSpan(start, end)),
+            deliveries = emptyList(),
+            zone = chicago,
+        )
+        // 2026-11-01 is a Sunday → dayIndex 6.
+        assertEquals(0.5, h.cell(6, 0).coverageHours, 1e-9)  // 00:30–01:00
+        assertEquals(2.0, h.cell(6, 1).coverageHours, 1e-9)  // both 1am hours
+        assertEquals(0.5, h.cell(6, 2).coverageHours, 1e-9)  // 02:00–02:30
+        assertEquals(3.0, h.cells.sumOf { it.coverageHours }, 1e-9) // real elapsed = 3h
     }
 }


### PR DESCRIPTION
Closes the last unbuilt Analytics-hub phase (#315 H5 — Patterns tab). Money/Decisions/Time are already live; this replaces the Patterns "coming soon" placeholder with two real sections. The tab is **lifetime-scoped** (rate/pattern-based) so it renders with **no period selector**. Built on the just-merged #159 stores read-model.

## What was built (maps to H5 scope)

**A) Store report cards (#159 consumer).** One `AppCard`-styled row per resolved store entity from the existing `AnalyticsRepository.storeReportCards()`, newest-visited first: chain display name + a location chip (the `runningKey`, or a warn-toned **"location unknown"** chip for a chain-only entity, F6), address when present, pickup/delivery counts, cash-inclusive gross/net, avg/median/p95 pickup dwell (via `formatDuration`; marked **(partial)** + a "per-location stats partial" note for chain-only rows), and first/last-seen. Unresolved-history rows (storeKey NULL) intentionally don't appear here — they live in the Money tab's chain buckets. No read-model widening: the report-card read already existed from #159.

**B) Hour×day net-$/hr heatmap.** A 7×24 (day-of-week × hour) grid of the driver's **own** realized net $/hr, Monday-first, with a "best hour so far" callout and a color-scale legend.

## Heatmap semantics (as implemented)

- **Apportionment** is a pure `:domain` function, `EarningsHeatmapCalculator.compute(spans, deliveries, zone, minCoverageHours)`:
  - *Denominator (coverage):* each session's `[start, end)` span is apportioned across the wall-clock hour cells it overlaps in **fractional hours** (iterates one wall-clock hour at a time → DST-safe; a span with `end <= start` contributes nothing).
  - *Numerator:* each delivery's `(netProfit + cashTip)` lands **whole** in the cell of its `completedAt` (a null frozen net contributes cash only — frozen-net philosophy, never recomputed).
  - *Rate:* `Σnet ÷ Σhours`, but **masked** (`dollarsPerHour = null`) below the **0.5h coverage floor** — a masked cell renders visually distinct (dim `surface3`) from a *genuinely-zero* cell (enough coverage, `0.0` rate → cold `badBg`).
- **Mask threshold:** `DEFAULT_MIN_COVERAGE_HOURS = 0.5` (≈30 min of presence) — keeps a single delivery over 3 minutes of coverage from rendering a noisy 20×/hr artifact.
- **Timezone:** cells are bucketed in the **device-local zone at read time** (`zone` injectable for tests). Documented in KDoc: a timezone move re-buckets history — acceptable, driver-local patterns are the point.
- **Repository stays DAO-only.** Two minimal lifetime DAO reads — `sessionSpans()` (`startedAt` + `COALESCE(endedAt, lastEventAt)`) and `deliveryNets()` (`completedAt` + `COALESCE(netProfit,0)+COALESCE(cashTip,0)`) — are mapped to the domain input types and composed through the pure calculator. No economy dependency (net is the frozen stored value).

The heatmap composable is **feature-local** (`PatternsTab.kt`), not promoted to `:core:designsystem` — its cell semantics (null-mask vs genuine-zero, day/hour axis, best-hour callout) are Patterns-specific, not a generic data-in/lambdas-out primitive. Judgment call; stated here per the design-system rule.

## Security / privacy posture

- **Driver's own data only.** Every figure is the driver's own realized net / own dwell. No new capture surface, **no network**.
- **Merchant names in UI only** (store/chain names, addresses) — merchant data, fine to render (Principle 7 governs logs). No raw merchant/customer text is added to any INFO+ log site (this diff adds no log sites). Customer PII stays sha256'd upstream and never reaches this surface.
- **Framing discipline (Pledge-adjacent):** all copy is "YOUR net $/hr by hour/store" — empirical measurement of the driver's own experience. Never "DoorDash pays more at…"; no platform-pay characterization.

## Zone leaderboard — deferred

The zone leaderboard (H5's third possible section) remains **deferred: zone capture doesn't exist**, so there's nothing to render. Flagging for the dev's call on whether #315 closes with this PR or stays open for the zone work.

## Tests

`export JAVA_HOME=/usr/lib/jvm/java-25` — all green:
- `:domain:test` — `EarningsHeatmapCalculatorTest` (empty, sub-hour, midnight-crossing, week-boundary-crossing Sun→Mon, mask threshold, insufficient-vs-genuinely-zero, multi-session accumulation, malformed span, multi-hour).
- `:core:database:testDebugUnitTest` — full suite (DAO row types/queries compile + existing).
- `:core:data:testDebugUnitTest` — `AnalyticsHeatmapTest` (full-hour session + cash-inclusive net into the right cell; open-session `lastEventAt` fallback + null-net delivery folds cash only; no-coverage masks every cell) + full suite.
- `:app:testDebugUnitTest` — full suite (764 tests); `AnalyticsViewModelTest` updated with a `@Before` stub for the two lifetime Patterns sources.

## Design-goal review

- **P1 (UDF):** apportionment is a pure `:domain` function (obs-timestamp longs + zone in, cell aggregates out — no wall clock); the repository reads DAO Flows and the ViewModel exposes one immutable `AnalyticsUiState`; composables are stateless, data-in. The Patterns sources sit **outside** the period `flatMapLatest` (lifetime-scoped), so a period switch never re-queries them.
- **P5 (SSOT):** the apportionment math has one owner (`EarningsHeatmapCalculator`) — the repository holds no copy; money/duration/date route through the `Formats`/`formatDuration`/`formatShortDate` SSOTs; the report-card read is reused from #159, not re-derived.
- **P6 (security/privacy):** driver-own data, no network, no new capture; customer PII stays hashed upstream.
- **P7 (logging):** no log sites added; merchant names are UI-only.
- **P8 (platform-agnostic):** no platform literals — the heatmap/apportionment are platform-neutral (net + time); DAO reads are unbounded lifetime, no per-platform gating.
- **Reactive UI:** aggregate-historical surface — deliberately **no** `rememberNow()` ticker (nothing here goes stale while looked at; the read-model Flows re-emit on projector commits). Stated in KDoc.

Also removed the now-dead `ComingSoonCard` + its two unused string resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

### Adversarial review (Fable-tier, 2026-07-10)

Three finder agents (heatmap math + SQL correctness; cross-file + test quality; principles + Reactive UI + framing discipline) → ~15 deduped findings, all **fixed in-branch** (3 commits, head `bbe7f448`); suites re-run green. **No framing-discipline violations found** — all copy stayed driver-experience empirical.

**Fixed — correctness (HIGH):**
- **Multi-app coverage double-count:** overlapping session spans (concurrent platforms; a crashed-open session overlapping its successor) each added denominator hours, roughly halving the displayed $/hr for exactly the driver's most profitable hours — masked by single-platform field testing (the P8 pattern). Fixed: spans merge into a **wall-clock union** before apportionment; overlap/adjacency tests added.
- **Unbounded main-thread recompute:** the lifetime heatmap recomputed on every Room invalidation on `Dispatchers.Main`, and one corrupt span (seconds-vs-millis, epoch-zero) meant ~490k iterations — ANR-class. Fixed: 14-day span sanity cap (dropped before the union so it can't swallow real spans; 56-year-span test) + `flowOn(Dispatchers.Default)` + `distinctUntilChanged`.
- **Timezone captured at flow construction** (3× corroborated): contradicted the documented "a timezone move re-buckets history". Fixed: `zoneProvider: () -> ZoneId` evaluated per emission.
- **No-coverage money guard:** a delivery can land in a cell with zero coverage (MANUAL corrections stamp the session's exclusive endpoint; #732-inverted sessions drop their span but keep deliveries). Decided semantics: this is a *rate* surface — such cells stay masked (money invisible, never wrong); the rate guard now provably cannot produce Infinity/NaN (test added), residual documented on the KDoc.

**Fixed — test honesty:** the "DST-safe" claim had zero DST tests (all fixed-offset UTC) — added `America/Chicago` spring-forward + fall-back cases (**the implementation passed unchanged**: the instant-based hour advance was already correct); the ViewModel wiring for both new flows was unfalsifiable (stubs equaled state defaults) — now asserted with non-default values; one tautological assertion replaced with a real grid round-trip.

**Fixed — UI/SSOT:** missing third legend entry ("worked, no net", badBg + border) and a ramp floor (0.3+0.7·f) so low-positive / zero / masked cells are legible in both themes on the fixed palette; `bestCell` hoisted to `:domain` (callout + color-scale top read one owner); the hour-label formatter moved into `format.TimeFormats` (the documented SSOT); the fifth hand-copied `EMPTY_VALUE` constant consolidated across all five analytics tab files; `Modifier.size(12.dp)`; axis label matched to `AppCharts`' plain `labelSmall`.

**Named v1 asymmetry (documented + UI caption):** MANUAL/unresolved deliveries count in the Money tab's chain buckets but appear as no Patterns store card (resolution never stamps a job-less row) — a static caption under the stores header tells the driver; unification is #159-phase-2 territory.

**Principles walk (review-verified):** framing discipline clean; P1 pure `:domain` calculator (zone is a parameter, no wall clock); P5 one apportionment/bestCell/hour-label owner; P6 no new PII surface (aggregate net + time; merchant names UI-only); P7 no new log sites; Reactive UI — aggregate-historical tab, no stale time-derived strings, no gratuitous ticker.
