### PR TITLE
fix(#588): per-platform shop-rate learning (no global rate)

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
@@ -321,15 +321,15 @@ class SideEffectEngine @Inject constructor(
             is AppEffect.ResumeOdometer -> odometerEffectHandler.resume()
 
             is AppEffect.RecordShopRate -> {
-                // #556: learn the dasher's shopping pace.
+                // #556/#588: learn the dasher's shopping pace for THIS platform.
                 val minutes = effect.shopDurationMs / 60_000.0
-                strategyRepository.recordShopRate(effect.itemsShopped, minutes)
+                strategyRepository.recordShopRate(effect.platform, effect.itemsShopped, minutes)
                 val perMin = if (minutes > 0) effect.itemsShopped / minutes else 0.0
-                // #551 P7: rate math is a shareable INFO milestone, but the merchant name
-                // (raw third-party UI text) stays on the DEBUG firehose only.
+                // #551 P7: rate math + the platform wire are shareable INFO milestones (the wire is a
+                // registry token, not PII); the merchant name (raw third-party UI text) stays DEBUG-only.
                 Timber.tag("ShopRate").i(
-                    "recorded %d items / %.1f min = %.2f/min",
-                    effect.itemsShopped, minutes, perMin,
+                    "recorded %d items / %.1f min = %.2f/min [%s]",
+                    effect.itemsShopped, minutes, perMin, effect.platform.wire,
                 )
                 Timber.tag("ShopRate").d(
                     "recorded %d items / %.1f min = %.2f/min (store=%s)",
@@ -351,7 +351,9 @@ class SideEffectEngine @Inject constructor(
                 // first load WAITS for real economics rather than scoring
                 // against a guessed default.
                 val config = strategyRepository.evaluationConfig.filterNotNull().first()
-                val result = offerEvaluator.evaluate(effect.parsedOffer, config)
+                // #588: resolve the offer's own platform's learned shop rate + seed into the economy
+                // before scoring — a DoorDash-learned pace never prices an Instacart/Uber shop.
+                val result = offerEvaluator.evaluate(effect.parsedOffer, config.forPlatform(effect.platform))
                 // Emit the loopback observation directly (#402): the old
                 // OfferEvaluationEvent was a 1:1 shim the bridge re-typed.
                 _events.emit(

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/SettingsViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/settings/SettingsViewModel.kt
@@ -79,9 +79,13 @@ class SettingsViewModel @Inject constructor(
             payAmount = pay,
             distanceMiles = miles,
             itemCount = 5, // Default average workload
-            orders = emptyList()
+            orders = emptyList() // non-shop by construction (no SHOP order) — never exercises shop pace
         )
 
+        // #588: intentionally NOT calling evaluationConfig.value.forPlatform(...) — this simulator has
+        // no platform to resolve against. Safe only because fakeOffer is never a shop offer (see
+        // EvaluationConfig.userEconomy KDoc); a shop-capable simulator would need to pick a platform
+        // and call forPlatform() first, or it would silently price off seed-only shop pace.
         val currentConfig = evaluationConfig.value
         return offerEvaluator.evaluate(fakeOffer, currentConfig)
     }

--- a/app/src/test/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngineTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngineTest.kt
@@ -781,6 +781,7 @@ class SideEffectEngineTest {
         try {
             engine.process(
                 AppEffect.RecordShopRate(
+                    platform = Platform.DoorDash,
                     itemsShopped = 24,
                     shopDurationMs = 18 * 60_000L,
                     storeName = "H-E-B",
@@ -793,6 +794,8 @@ class SideEffectEngineTest {
             // The shareable INFO stream carries the pace math but never the merchant name.
             tree.assertNoInfoPlusContains("H-E-B")
             tree.assertLevelContains(Log.INFO, "24 items")
+            // #588: the platform wire is a registry token (PII-safe) and rides the INFO milestone.
+            tree.assertLevelContains(Log.INFO, "doordash")
             // The DEBUG firehose still names the store.
             tree.assertLevelContains(Log.DEBUG, "H-E-B")
         } finally {

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/strategy/StrategyRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/strategy/StrategyRepository.kt
@@ -9,6 +9,7 @@ import cloud.trotter.dashbuddy.domain.evaluation.EvaluationConfig
 import cloud.trotter.dashbuddy.domain.evaluation.MerchantAction
 import cloud.trotter.dashbuddy.domain.evaluation.MetricType
 import cloud.trotter.dashbuddy.domain.evaluation.ScoringRule
+import cloud.trotter.dashbuddy.domain.state.Platform
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
@@ -174,24 +175,25 @@ class StrategyRepository @Inject constructor(
         protectStatsMode,
         allowShopping,
         appPreferencesRepository.userEconomy,
-        dataSource.learnedShopRate,
-    ) { rules, protect, shop, economy, shopRate ->
+        dataSource.learnedShopRates,
+    ) { rules, protect, shop, economy, shopRates ->
         EvaluationConfig(
             protectStatsMode = protect,
             rules = rules,
             allowShopping = shop,
-            // #556: fold the learned shopping pace into the economy here (it lives in the strategy
-            // store, not the user-economy store, so it's never reseeded by a vehicle-class change).
-            userEconomy = economy.copy(
-                learnedShopItemsPerMinute = shopRate.itemsPerMin,
-                shopRateSampleCount = shopRate.sampleCount,
-            ),
+            userEconomy = economy,
+            // #588: carry the per-platform learned pace; the offer's own platform selects its entry at
+            // eval time via EvaluationConfig.forPlatform (a DoorDash-learned pace can no longer price an
+            // Instacart shop). It lives in the strategy store, not the user-economy store, so it's never
+            // reseeded by a vehicle-class change (#556).
+            shopRates = shopRates,
         )
     }.stateIn(scope, SharingStarted.Eagerly, null)
 
 
-    /** #556: fold a completed shop's measured pace into the learned overall items/min (atomic). */
-    suspend fun recordShopRate(items: Int, minutes: Double) = dataSource.recordShopRate(items, minutes)
+    /** #556/#588: fold a completed shop's measured pace into [platform]'s learned items/min (atomic). */
+    suspend fun recordShopRate(platform: Platform, items: Int, minutes: Double) =
+        dataSource.recordShopRate(platform, items, minutes)
 
     suspend fun clearPreferences() {
         Timber.w("Clearing Strategy Preferences")

--- a/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/strategy/StrategyDataSource.kt
+++ b/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/strategy/StrategyDataSource.kt
@@ -60,6 +60,13 @@ class StrategyDataSource @Inject constructor(
     private fun shopSamplesKey(platform: Platform) =
         intPreferencesKey("shop_rate_sample_count:${platform.wire}")
 
+    // #588 FIX 3b: the pre-#588 GLOBAL un-suffixed keys (one shared mean before shop-rate learning
+    // went per-platform). Deliberately DROPPED, not migrated (#588 design decision — an old global
+    // mean isn't reliably any one platform's pace, so it's discarded rather than guessed onto one).
+    // Kept here only so [recordShopRate] can tidy them off disk; no reader ever consults them again.
+    private val legacyGlobalShopRateKey = doublePreferencesKey("learned_shop_items_per_min")
+    private val legacyGlobalShopSamplesKey = intPreferencesKey("shop_rate_sample_count")
+
     val evidenceMaster: Flow<Boolean> = ds.data.map { it[Keys.EVIDENCE_MASTER] ?: EvidenceConfig.DEFAULT_MASTER }
     val evidenceOffers: Flow<Boolean> = ds.data.map { it[Keys.EVIDENCE_OFFERS] ?: EvidenceConfig.DEFAULT_SAVE_OFFERS }
     val evidenceDelivery: Flow<Boolean> = ds.data.map { it[Keys.EVIDENCE_DELIVERY] ?: EvidenceConfig.DEFAULT_SAVE_DELIVERIES }
@@ -120,6 +127,11 @@ class StrategyDataSource @Inject constructor(
                 p[shopRateKey(platform)] = avg
                 p[shopSamplesKey(platform)] = n
             }
+            // #588 FIX 3b: one-time tidy — drop the old un-suffixed global keys now that shop-rate
+            // learning is per-platform. Idempotent (a no-op once they're gone); rides the next fold
+            // rather than a dedicated migration step since a fold happens on every real shop anyway.
+            p.remove(legacyGlobalShopRateKey)
+            p.remove(legacyGlobalShopSamplesKey)
         }
     }
 

--- a/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/strategy/StrategyDataSource.kt
+++ b/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/strategy/StrategyDataSource.kt
@@ -11,6 +11,7 @@ import cloud.trotter.dashbuddy.core.datastore.di.StrategyPreferences
 import cloud.trotter.dashbuddy.core.datastore.strategy.dto.ScoringRuleDto
 import cloud.trotter.dashbuddy.domain.evaluation.LearnedShopRate
 import cloud.trotter.dashbuddy.domain.evaluation.ShopRate
+import cloud.trotter.dashbuddy.domain.state.Platform
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.serialization.InternalSerializationApi
@@ -47,12 +48,17 @@ class StrategyDataSource @Inject constructor(
         val PROTECT_STATS_MODE = booleanPreferencesKey("protect_stats_mode")
         val ALLOW_SHOPPING = booleanPreferencesKey("allow_shopping")
 
-        // #556: learned overall shopping pace (running mean items/min + sample count). Not a
-        // user-set economy field — a measured value, kept here so a vehicle-class reseed never
-        // touches it; folded into the evaluator's UserEconomy by StrategyRepository.
-        val LEARNED_SHOP_RATE = doublePreferencesKey("learned_shop_items_per_min")
-        val SHOP_RATE_SAMPLES = intPreferencesKey("shop_rate_sample_count")
     }
+
+    // #588: learned shopping pace, now keyed **per platform** (was a single global pair — a
+    // DoorDash-learned pace could price an Instacart/Uber shop and pollute the shared mean). Not a
+    // user-set economy field — a measured value, kept in the strategy store so a vehicle-class reseed
+    // never touches it; folded into the evaluator's UserEconomy by StrategyRepository. The keys derive
+    // from the registry [Platform.wire], so a new platform needs zero datastore change (P8).
+    private fun shopRateKey(platform: Platform) =
+        doublePreferencesKey("learned_shop_items_per_min:${platform.wire}")
+    private fun shopSamplesKey(platform: Platform) =
+        intPreferencesKey("shop_rate_sample_count:${platform.wire}")
 
     val evidenceMaster: Flow<Boolean> = ds.data.map { it[Keys.EVIDENCE_MASTER] ?: EvidenceConfig.DEFAULT_MASTER }
     val evidenceOffers: Flow<Boolean> = ds.data.map { it[Keys.EVIDENCE_OFFERS] ?: EvidenceConfig.DEFAULT_SAVE_OFFERS }
@@ -88,22 +94,31 @@ class StrategyDataSource @Inject constructor(
     val protectStatsMode: Flow<Boolean> = ds.data.map { it[Keys.PROTECT_STATS_MODE] ?: false }
     val allowShopping: Flow<Boolean> = ds.data.map { it[Keys.ALLOW_SHOPPING] ?: true }
 
-    /** #556: the learned overall shopping pace + how many shops back it (null pace until first sample). */
-    val learnedShopRate: Flow<LearnedShopRate> = ds.data.map {
-        LearnedShopRate(it[Keys.LEARNED_SHOP_RATE], it[Keys.SHOP_RATE_SAMPLES] ?: 0)
+    /**
+     * #588: the learned shopping pace per platform (running mean items/min + sample count). A platform
+     * with no recorded shops is omitted from the map — the eval seam ([EvaluationConfig.forPlatform])
+     * owns the per-platform seed fallback, so a missing entry is the seed, never another platform's
+     * rate.
+     */
+    val learnedShopRates: Flow<Map<Platform, LearnedShopRate>> = ds.data.map { prefs ->
+        Platform.entries.mapNotNull { platform ->
+            val avg = prefs[shopRateKey(platform)]
+            val n = prefs[shopSamplesKey(platform)] ?: 0
+            if (avg == null && n == 0) null else platform to LearnedShopRate(avg, n)
+        }.toMap()
     }
 
     /**
-     * #556: fold one measured shop ([items] over [minutes] in-store) into the running mean, atomically
-     * (read-modify-write inside one edit, so back-to-back stacked shops can't race). Out-of-band
-     * samples (below the [ShopRate] floors) are no-ops.
+     * #556/#588: fold one measured shop ([items] over [minutes] in-store) into [platform]'s running
+     * mean, atomically (read-modify-write inside one edit, so back-to-back stacked shops can't race).
+     * Out-of-band samples (below the [ShopRate] floors) are no-ops. Only [platform]'s key pair moves.
      */
-    suspend fun recordShopRate(items: Int, minutes: Double) {
+    suspend fun recordShopRate(platform: Platform, items: Int, minutes: Double) {
         ds.edit { p ->
-            val (avg, n) = ShopRate.fold(p[Keys.LEARNED_SHOP_RATE], p[Keys.SHOP_RATE_SAMPLES] ?: 0, items, minutes)
+            val (avg, n) = ShopRate.fold(p[shopRateKey(platform)], p[shopSamplesKey(platform)] ?: 0, items, minutes)
             if (avg != null) {
-                p[Keys.LEARNED_SHOP_RATE] = avg
-                p[Keys.SHOP_RATE_SAMPLES] = n
+                p[shopRateKey(platform)] = avg
+                p[shopSamplesKey(platform)] = n
             }
         }
     }

--- a/core/datastore/src/test/java/cloud/trotter/dashbuddy/core/datastore/strategy/StrategyDataSourceShopRateTest.kt
+++ b/core/datastore/src/test/java/cloud/trotter/dashbuddy/core/datastore/strategy/StrategyDataSourceShopRateTest.kt
@@ -1,6 +1,9 @@
 package cloud.trotter.dashbuddy.core.datastore.strategy
 
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.doublePreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
 import cloud.trotter.dashbuddy.domain.evaluation.ShopRate
 import cloud.trotter.dashbuddy.domain.state.Platform
 import kotlinx.coroutines.CoroutineScope
@@ -79,5 +82,28 @@ class StrategyDataSourceShopRateTest {
         advanceUntilIdle()
 
         assertTrue("no entry from noise", src.learnedShopRates.first().isEmpty())
+    }
+
+    @Test
+    fun `the old un-suffixed GLOBAL keys are dropped, not migrated onto any platform (#588 FIX 3a)`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val ds = PreferenceDataStoreFactory.create(
+            scope = CoroutineScope(dispatcher + Job()),
+            produceFile = { File(tmp.root, "strategy3.preferences_pb") },
+        )
+        // Seed the pre-#588 GLOBAL pair directly — as if this datastore file predates the
+        // per-platform migration and still carries the old shared mean.
+        ds.edit { p ->
+            p[doublePreferencesKey("learned_shop_items_per_min")] = 0.8
+            p[intPreferencesKey("shop_rate_sample_count")] = 12
+        }
+        advanceUntilIdle()
+
+        val src = StrategyDataSource(ds)
+        assertTrue(
+            "the design decision is DROP, not migrate — the old global pair must not surface " +
+                "under DoorDash or any other platform",
+            src.learnedShopRates.first().isEmpty(),
+        )
     }
 }

--- a/core/datastore/src/test/java/cloud/trotter/dashbuddy/core/datastore/strategy/StrategyDataSourceShopRateTest.kt
+++ b/core/datastore/src/test/java/cloud/trotter/dashbuddy/core/datastore/strategy/StrategyDataSourceShopRateTest.kt
@@ -1,0 +1,83 @@
+package cloud.trotter.dashbuddy.core.datastore.strategy
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import cloud.trotter.dashbuddy.domain.evaluation.ShopRate
+import cloud.trotter.dashbuddy.domain.state.Platform
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+/**
+ * #588 — the learned shop pace is keyed per platform. A rate learned under one platform must never
+ * appear under another, and recording under A must not move B's entry (the un-unmixable global-mean
+ * pollution the issue describes).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class StrategyDataSourceShopRateTest {
+
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    @Test
+    fun `two platforms learn independent means and recording under one never moves the other (#588)`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val ds = PreferenceDataStoreFactory.create(
+            scope = CoroutineScope(dispatcher + Job()),
+            produceFile = { File(tmp.root, "strategy1.preferences_pb") },
+        )
+        val src = StrategyDataSource(ds)
+
+        // DoorDash: five 24-item / 30-min shops → 0.8/min, past the trust gate.
+        repeat(5) { src.recordShopRate(Platform.DoorDash, items = 24, minutes = 30.0) }
+        // Instacart: five 30-item / 20-min shops → 1.5/min.
+        repeat(5) { src.recordShopRate(Platform.Instacart, items = 30, minutes = 20.0) }
+        advanceUntilIdle()
+
+        val rates = src.learnedShopRates.first()
+        assertEquals(0.8, rates.getValue(Platform.DoorDash).itemsPerMin!!, 1e-9)
+        assertEquals(5, rates.getValue(Platform.DoorDash).sampleCount)
+        assertEquals(1.5, rates.getValue(Platform.Instacart).itemsPerMin!!, 1e-9)
+        assertEquals(5, rates.getValue(Platform.Instacart).sampleCount)
+
+        // A platform that never recorded is simply absent — the eval seam owns the seed fallback.
+        assertNull(rates[Platform.Uber])
+        assertNull(rates[Platform.WalmartSpark])
+
+        // Recording MORE DoorDash shops must not perturb Instacart's mean or count.
+        repeat(3) { src.recordShopRate(Platform.DoorDash, items = 12, minutes = 30.0) } // 0.4/min, drags DD down
+        advanceUntilIdle()
+        val after = src.learnedShopRates.first()
+        assertEquals("Instacart untouched", 1.5, after.getValue(Platform.Instacart).itemsPerMin!!, 1e-9)
+        assertEquals("Instacart untouched", 5, after.getValue(Platform.Instacart).sampleCount)
+        assertEquals(8, after.getValue(Platform.DoorDash).sampleCount)
+        assertTrue("DoorDash mean moved", after.getValue(Platform.DoorDash).itemsPerMin!! < 0.8)
+    }
+
+    @Test
+    fun `a below-floor sample is a no-op and does not create a map entry (#556)`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val ds = PreferenceDataStoreFactory.create(
+            scope = CoroutineScope(dispatcher + Job()),
+            produceFile = { File(tmp.root, "strategy2.preferences_pb") },
+        )
+        val src = StrategyDataSource(ds)
+
+        // Below ShopRate floors (items < MIN_ITEMS or minutes < MIN_MINUTES) — ignored.
+        src.recordShopRate(Platform.DoorDash, items = ShopRate.MIN_ITEMS - 1, minutes = 30.0)
+        src.recordShopRate(Platform.DoorDash, items = 24, minutes = ShopRate.MIN_MINUTES - 0.5)
+        advanceUntilIdle()
+
+        assertTrue("no entry from noise", src.learnedShopRates.first().isEmpty())
+    }
+}

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/AppEffect.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/AppEffect.kt
@@ -127,13 +127,16 @@ sealed class AppEffect {
      * re-observed confirm can't double-count (mirrors the #518 DELIVERY_COMPLETED keying).
      */
     data class RecordShopRate(
+        val platform: Platform,
         val itemsShopped: Int,
         val shopDurationMs: Long,
         val storeName: String?,
         val jobId: String,
         val taskId: String,
     ) : AppEffect() {
-        override val effectKey: String get() = "shop_rate:$taskId"
+        // #588: platform-namespaced dedup key — a per-platform learned rate; the taskId is
+        // per-platform-unique already, the wire prefix keeps the namespace disjoint (mirrors #438-B4).
+        override val effectKey: String get() = "shop_rate:${platform.wire}:$taskId"
     }
     /**
      * Evaluate the pending offer. [offerHash] rides the async round-trip so the result

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/TaskEffects.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/TaskEffects.kt
@@ -11,6 +11,7 @@ import cloud.trotter.dashbuddy.domain.pipeline.TransitionTrigger
 import cloud.trotter.dashbuddy.domain.state.Flow
 import cloud.trotter.dashbuddy.domain.state.ParsedFields
 import cloud.trotter.dashbuddy.domain.state.PickupActivity
+import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.domain.state.PlatformRegion
 import cloud.trotter.dashbuddy.domain.state.Task
 import cloud.trotter.dashbuddy.domain.state.TaskPhase
@@ -285,6 +286,9 @@ internal fun EffectMap.pickupConfirmSweepEffects(
         addAll(
             pickupConfirmedEffects(
                 sessionId, task, obs,
+                // #588: the region owns the platform — a shop's measured pace folds into THIS
+                // platform's learned rate, never a shared global.
+                platform = region.platform,
                 confirmedAt = task.completedAt ?: obs.timestamp,
                 jobOfferHashes = jobOfferHashes,
             ),
@@ -303,6 +307,7 @@ private fun EffectMap.pickupConfirmedEffects(
     sessionId: String?,
     prevTask: Task,
     obs: Observation,
+    platform: Platform,
     confirmedAt: Long = obs.timestamp,
     jobOfferHashes: List<String> = emptyList(),
 ): List<AppEffect> = buildList {
@@ -327,6 +332,7 @@ private fun EffectMap.pickupConfirmedEffects(
     if (prevTask.activity == PickupActivity.SHOPPING && shopItems > 0 && shopArrivedAt != null) {
         add(
             AppEffect.RecordShopRate(
+                platform = platform,
                 itemsShopped = shopItems,
                 shopDurationMs = confirmedAt - shopArrivedAt,
                 storeName = prevTask.storeName,

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/TaskEffects.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/TaskEffects.kt
@@ -327,6 +327,11 @@ private fun EffectMap.pickupConfirmedEffects(
     )
     // #556: a completed SHOP pickup feeds the learned items/min. In-store time is measured
     // arrived→confirmed (the 0.8/min seed basis); the handler floors out noise.
+    // Residual (pre-existing #556 exposure, traced during #588 review): a #736-style unassigned
+    // shop (a few items measured, then unassign) can still fold one garbage pace sample here once
+    // the close-out sweep (pickupConfirmSweepEffects, above) fires for a job that never reached
+    // dropoff. Mitigated today by MIN_SHOP_SAMPLES=5 diluting a single bad sample, and expected to
+    // tighten once #736's unassignedAt guard lands — see #736.
     val shopItems = prevTask.itemsShopped ?: 0
     val shopArrivedAt = prevTask.arrivedAt
     if (prevTask.activity == PickupActivity.SHOPPING && shopItems > 0 && shopArrivedAt != null) {

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
@@ -157,10 +157,15 @@ class EffectMapTest {
         sessionId: String? = "sess-1",
         activeTask: Task? = null,
         recentTasks: List<Task> = emptyList(),
+        // Defaults to DoorDash (matches every pre-existing call site); a non-default platform lets a
+        // test prove a platform value was genuinely THREADED from region.platform rather than
+        // hardcoded, since Platform.DoorDash can't distinguish "read from the region" from "hardcoded"
+        // (see the #588 shop-rate tests below).
+        platform: Platform = Platform.DoorDash,
     ): Pair<Platform, PlatformRegion> {
         val session = sessionId?.let { Session(it, startedAt = 100L) }
-        return Platform.DoorDash to PlatformRegion(
-            platform = Platform.DoorDash,
+        return platform to PlatformRegion(
+            platform = platform,
             mode = mode,
             session = session,
             activeTask = activeTask,
@@ -1043,8 +1048,12 @@ class EffectMapTest {
     }
 
     @Test
-    fun `a completed SHOP pickup emits RecordShopRate with measured items and duration (#556)`() {
-        val (platform, _) = stateWithPlatform()
+    fun `a completed SHOP pickup emits RecordShopRate with measured items and duration (#556, #588)`() {
+        // #588 review: this MUST be a non-DoorDash platform. `stateWithPlatform()`'s old DoorDash
+        // default made `rec.platform == DoorDash` an A==A tautology that stays green even if
+        // TaskEffects hardcoded Platform.DoorDash instead of reading region.platform — Instacart
+        // proves the value is genuinely threaded.
+        val (platform, _) = stateWithPlatform(platform = Platform.Instacart)
         val session = Session("sess-1", startedAt = 100L)
         val arrivedAt = 100_000L
         val confirmAt = arrivedAt + 30 * 60_000L  // 30 min in-store → 24 items = 0.8/min
@@ -1078,8 +1087,51 @@ class EffectMapTest {
         assertEquals(platform, rec.platform)
         assertEquals(
             "the sample is idempotent per platform-scoped pickup task",
-            "shop_rate:doordash:task-1", rec.effectKey,
+            "shop_rate:instacart:task-1", rec.effectKey,
         )
+    }
+
+    @Test
+    fun `a SHOP pickup that closes WITHOUT ever reaching a dropoff mints RecordShopRate via the #596 close-out sweep (#556, #588)`() {
+        // Coverage gap the #588 review flagged: the test above only drives the pickup→dropoff edge
+        // (TaskEffects.diffTask calling pickupConfirmSweepEffects). A pickup-only job that closes
+        // without ever reaching a dropoff — an unassign mid-shop is the #736 case this pattern
+        // shares — is instead confirmed by the SEPARATE close-out sweep in
+        // DeliveryCompletionEffects.diffDeliveryCompletion. Proves RecordShopRate fires from THAT
+        // site too, again on a non-DoorDash platform so platform threading is a real assertion.
+        val (platform, _) = stateWithPlatform(platform = Platform.Instacart)
+        val session = Session("sess-1", startedAt = 100L)
+        val arrivedAt = 100_000L
+        val closedAt = arrivedAt + 10 * 60_000L  // 10 min in-store → 5 items = 0.5/min
+        val job = Job("job-shop", offerStoreHint = emptyList(), parentOfferHash = null, startedAt = 900L)
+        val shopPickup = Task(
+            taskId = "task-shop-1", jobId = "job-shop", phase = TaskPhase.PICKUP, storeName = "Trader Joe's",
+            activity = PickupActivity.SHOPPING, itemsShopped = 5, arrivedAt = arrivedAt, startedAt = 900L,
+        )
+        val prev = AppState(regions = Regions(
+            flow = FlowRegion(flow = Flow.TaskPickupArrived),
+            platforms = mapOf(platform to PlatformRegion(
+                platform, mode = Mode.Online, session = session, activeJob = job, activeTask = shopPickup,
+            )),
+        ))
+        // The job closes WITHOUT ever reaching a dropoff — activeJob clears, the pickup is displaced
+        // into recentTasks (completed, never a dropoff task on this job at all).
+        val next = AppState(regions = Regions(
+            flow = FlowRegion(flow = Flow.Idle),
+            platforms = mapOf(platform to PlatformRegion(
+                platform, mode = Mode.Online, session = session, activeJob = null, activeTask = null,
+                recentTasks = listOf(shopPickup.copy(completedAt = closedAt)),
+            )),
+        ))
+
+        val effects = effectMap.diff(prev, next, screenObs(flow = Flow.Idle, timestamp = closedAt))
+
+        val rec = effects.filterIsInstance<AppEffect.RecordShopRate>().single()
+        assertEquals(5, rec.itemsShopped)
+        assertEquals(10 * 60_000L, rec.shopDurationMs)
+        assertEquals("task-shop-1", rec.taskId)
+        assertEquals("the close-out sweep threads THIS region's platform too (#588)", platform, rec.platform)
+        assertEquals("shop_rate:instacart:task-shop-1", rec.effectKey)
     }
 
     @Test

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
@@ -1074,7 +1074,12 @@ class EffectMapTest {
         assertEquals(24, rec.itemsShopped)
         assertEquals(30 * 60_000L, rec.shopDurationMs)
         assertEquals("task-1", rec.taskId)
-        assertEquals("the sample is idempotent per pickup task", "shop_rate:task-1", rec.effectKey)
+        // #588: the effect carries the region's platform so the pace folds into THAT platform's rate.
+        assertEquals(platform, rec.platform)
+        assertEquals(
+            "the sample is idempotent per platform-scoped pickup task",
+            "shop_rate:doordash:task-1", rec.effectKey,
+        )
     }
 
     @Test

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -76,9 +76,11 @@ was found **broken-in-part** (raw PII in capture envelopes) and moved to that en
 - **🆕 NEW — per-platform shop-rate learning; shop offers price sanely after the reset (#588 / PR).**
   The learned shopping pace (items/min) is now keyed per platform, and the old global learned value was
   **dropped** (restart-learning, no migration) — every platform relearns from its 0.8/min seed over ~5 shops.
-  **How to tell it's working (on a DoorDash dash):** a Shop & Deliver offer should still read a sane
-  handling time / $/hr immediately (the seed ≈ the discarded global, so no visible regression); after ~5
-  real shops the learned pace takes over again. **Desk-side after the dash:** the shareable INFO log's
+  **How to tell it's working (on a DoorDash dash):** shop pricing may shift toward the 0.8/min seed
+  until ~5 shops relearn the pace on this platform (the discarded value was the dev's own LEARNED mean,
+  not necessarily close to 0.8) — a Shop & Deliver offer's handling time / $/hr should still read sane,
+  not absurd, in the meantime; after ~5 real shops the learned pace takes back over. **Desk-side after
+  the dash:** the shareable INFO log's
   `ShopRate` lines now carry a `[doordash]` platform tag; there should be no cross-platform bleed if a
   second platform (Uber/Instacart) is ever shopped. Watch for any shop offer suddenly reading an absurd
   $/hr (would mean the seed/reset went wrong).

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -73,6 +73,17 @@ card's **mechanical** half, #577 (re-confirmed, 24/24, ~0.55 s — with a new po
 that entry's Bug #1), the #457 path, and #554 ShadowProjector (2/2). The #462/#460 dropoff item
 was found **broken-in-part** (raw PII in capture envelopes) and moved to that entry's Bug #7.)_
 
+- **🆕 NEW — per-platform shop-rate learning; shop offers price sanely after the reset (#588 / PR).**
+  The learned shopping pace (items/min) is now keyed per platform, and the old global learned value was
+  **dropped** (restart-learning, no migration) — every platform relearns from its 0.8/min seed over ~5 shops.
+  **How to tell it's working (on a DoorDash dash):** a Shop & Deliver offer should still read a sane
+  handling time / $/hr immediately (the seed ≈ the discarded global, so no visible regression); after ~5
+  real shops the learned pace takes over again. **Desk-side after the dash:** the shareable INFO log's
+  `ShopRate` lines now carry a `[doordash]` platform tag; there should be no cross-platform bleed if a
+  second platform (Uber/Instacart) is ever shopped. Watch for any shop offer suddenly reading an absurd
+  $/hr (would mean the seed/reset went wrong).
+  - Confirmed: 0/2
+
 - **🆕 NEW — store entity resolution keys real stores from live dashes (#159 / PR).**
   The read-model now resolves each job's stores (`stores` + `pickup_records` tables) from captured
   pickup/dropoff/payout surfaces. **How to tell it's working (desk-side, after a dash):** on a job with a

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/EvaluationConfig.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/EvaluationConfig.kt
@@ -9,6 +9,16 @@ data class EvaluationConfig(
     val protectStatsMode: Boolean = false,
     val rules: List<ScoringRule> = emptyList(),
     val allowShopping: Boolean = true,
+    /**
+     * #588: **unresolved** shop-pace fields until [forPlatform] runs. [shopRates] is per-platform, so
+     * a raw [EvaluationConfig] can't know which platform's learned pace/seed belongs in
+     * [UserEconomy.learnedShopItemsPerMinute] / [UserEconomy.shopSeedItemsPerMin] — those fields on
+     * THIS [userEconomy] are whatever the last [forPlatform] call (if any) stamped, which for a
+     * freshly-constructed/raw config is the domain default seed, not any platform's real pace. A
+     * consumer that scores a SHOP offer against the raw config (skipping [forPlatform]) silently gets
+     * seed-only pricing — see `SettingsViewModel.simulateOffer`, which is safe today only because its
+     * simulated offer is never a shop offer.
+     */
     val userEconomy: UserEconomy = UserEconomy(),
     /**
      * #588: the learned shopping pace **per platform** — an offer's own platform selects its entry at
@@ -25,6 +35,10 @@ data class EvaluationConfig(
      * the returned economy mean "the resolved pair for this offer's platform", which is exactly what the
      * single evaluator consumer already reads. A platform with no samples yields its seed, never
      * another platform's learned rate (even one past the trust gate).
+     *
+     * **Contract:** call this before scoring ANY shop offer. Skipping it (evaluating against the raw
+     * [userEconomy]) is not an error — it just means shop-pace fields are whatever they were on this
+     * config already (seed-only for a freshly-built one), never a platform's real learned pace.
      */
     fun forPlatform(platform: Platform): EvaluationConfig {
         val learned = shopRates[platform]

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/EvaluationConfig.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/EvaluationConfig.kt
@@ -1,5 +1,7 @@
 package cloud.trotter.dashbuddy.domain.evaluation
 
+import cloud.trotter.dashbuddy.domain.state.Platform
+
 /**
  * The Snapshot of all rules and Dasher economy settings needed to score an offer.
  */
@@ -8,4 +10,30 @@ data class EvaluationConfig(
     val rules: List<ScoringRule> = emptyList(),
     val allowShopping: Boolean = true,
     val userEconomy: UserEconomy = UserEconomy(),
-)
+    /**
+     * #588: the learned shopping pace **per platform** — an offer's own platform selects its entry at
+     * eval time via [forPlatform]. A platform absent from the map has no learned pace yet and resolves
+     * to its [ShopRateSeeds] seed. Keyed by [Platform] (never a global), so a DoorDash-learned pace can
+     * never price an Instacart / Uber shop.
+     */
+    val shopRates: Map<Platform, LearnedShopRate> = emptyMap(),
+) {
+    /**
+     * #588: resolve THIS offer's [platform]'s learned pace + seed into [userEconomy], producing the
+     * config the evaluator scores against. Keeps [OfferEvaluator.evaluate] and
+     * [UserEconomy.effectiveShopItemsPerMinute] signature-unchanged — the `learned*`/`seed` fields on
+     * the returned economy mean "the resolved pair for this offer's platform", which is exactly what the
+     * single evaluator consumer already reads. A platform with no samples yields its seed, never
+     * another platform's learned rate (even one past the trust gate).
+     */
+    fun forPlatform(platform: Platform): EvaluationConfig {
+        val learned = shopRates[platform]
+        return copy(
+            userEconomy = userEconomy.copy(
+                learnedShopItemsPerMinute = learned?.itemsPerMin,
+                shopRateSampleCount = learned?.sampleCount ?: 0,
+                shopSeedItemsPerMin = ShopRateSeeds.seedFor(platform),
+            ),
+        )
+    }
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/ShopRate.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/ShopRate.kt
@@ -11,7 +11,7 @@ data class LearnedShopRate(val itemsPerMin: Double?, val sampleCount: Int)
  * estimate falls back to that platform's seed here — a DoorDash-learned pace can never seed an
  * Instacart / Uber shop, and vice-versa.
  *
- * Today only DoorDash carries a bespoke corpus-derived entry (0.8/min, 48 real shops, 2026-06); every
+ * Today only DoorDash carries a bespoke corpus-derived entry ([DOORDASH_CORPUS_SEED]); every
  * other platform resolves to [DEFAULT]. The value is **data, not logic** — the shape is
  * `Map<Platform, Double>`, so a second platform's measured seed (Instacart bin-scan / staging overhead
  * differs) drops in as one map entry, never a `when (platform)`. This is the same `(platform, …)`
@@ -19,12 +19,24 @@ data class LearnedShopRate(val itemsPerMin: Double?, val sampleCount: Int)
  */
 object ShopRateSeeds {
 
-    /** Generic fallback pace for a platform with no bespoke seed; equals the DoorDash corpus median. */
-    const val DEFAULT: Double = UserEconomy.DEFAULT_SHOP_ITEMS_PER_MIN
+    /**
+     * DoorDash's own measured corpus seed — median 0.79 (rounded to 0.8), IQR 0.66–0.92, across 48
+     * real shops in the 2026-06 capture corpus (#556). This is the ONE anchor for that fact; every
+     * other constant/comment that wants "the DoorDash corpus seed" should point here, not
+     * re-declare the literal.
+     */
+    const val DOORDASH_CORPUS_SEED: Double = 0.8
+
+    /**
+     * Generic fallback pace for a platform with no bespoke seed of its own. Today this simply
+     * ADOPTS [DOORDASH_CORPUS_SEED] wholesale — the only measured corpus we have — not because a
+     * non-DoorDash shop is known to pace the same; it's a placeholder fallback until that platform
+     * earns its own bespoke, independently-measured entry (#588).
+     */
+    const val DEFAULT: Double = DOORDASH_CORPUS_SEED
 
     private val byPlatform: Map<Platform, Double> = mapOf(
-        // DoorDash: median 0.79 (IQR 0.66–0.92) across 48 real shops, 2026-06 capture corpus (#556).
-        Platform.DoorDash to UserEconomy.DEFAULT_SHOP_ITEMS_PER_MIN,
+        Platform.DoorDash to DOORDASH_CORPUS_SEED,
     )
 
     /** The seed pace for [platform] — its bespoke corpus entry, else the generic [DEFAULT]. */

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/ShopRate.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/ShopRate.kt
@@ -1,7 +1,35 @@
 package cloud.trotter.dashbuddy.domain.evaluation
 
+import cloud.trotter.dashbuddy.domain.state.Platform
+
 /** The persisted learned shopping pace: the running mean items/min and the shops behind it (#556). */
 data class LearnedShopRate(val itemsPerMin: Double?, val sampleCount: Int)
+
+/**
+ * The cold-start seed shopping pace (items/min) **per platform** (#588). Until a platform has crossed
+ * the [UserEconomy.MIN_SHOP_SAMPLES] trust gate on its OWN measured shops, the Shop & Deliver time
+ * estimate falls back to that platform's seed here — a DoorDash-learned pace can never seed an
+ * Instacart / Uber shop, and vice-versa.
+ *
+ * Today only DoorDash carries a bespoke corpus-derived entry (0.8/min, 48 real shops, 2026-06); every
+ * other platform resolves to [DEFAULT]. The value is **data, not logic** — the shape is
+ * `Map<Platform, Double>`, so a second platform's measured seed (Instacart bin-scan / staging overhead
+ * differs) drops in as one map entry, never a `when (platform)`. This is the same `(platform, …)`
+ * key-space #159's per-store/chain tier and #254's learned constants inherit (P8).
+ */
+object ShopRateSeeds {
+
+    /** Generic fallback pace for a platform with no bespoke seed; equals the DoorDash corpus median. */
+    const val DEFAULT: Double = UserEconomy.DEFAULT_SHOP_ITEMS_PER_MIN
+
+    private val byPlatform: Map<Platform, Double> = mapOf(
+        // DoorDash: median 0.79 (IQR 0.66–0.92) across 48 real shops, 2026-06 capture corpus (#556).
+        Platform.DoorDash to UserEconomy.DEFAULT_SHOP_ITEMS_PER_MIN,
+    )
+
+    /** The seed pace for [platform] — its bespoke corpus entry, else the generic [DEFAULT]. */
+    fun seedFor(platform: Platform): Double = byPlatform[platform] ?: DEFAULT
+}
 
 /**
  * Folds measured shops into the dasher's learned overall shopping pace (#556). Pure and

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/UserEconomy.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/UserEconomy.kt
@@ -43,6 +43,15 @@ data class UserEconomy(
     /** Number of measured shops behind [learnedShopItemsPerMinute]; gates trusting it (#556). */
     val shopRateSampleCount: Int = 0,
 
+    /**
+     * The cold-start seed pace (items/min) for the offer's platform (#588), used until this platform
+     * has its own [MIN_SHOP_SAMPLES] measured shops. Resolved from [ShopRateSeeds] by
+     * [EvaluationConfig.forPlatform] at eval time; defaults to the generic corpus median off-config so
+     * a hand-built economy (and every existing test) behaves exactly as before. Keeps the seed
+     * per-platform without widening [OfferEvaluator]'s signature.
+     */
+    val shopSeedItemsPerMin: Double = DEFAULT_SHOP_ITEMS_PER_MIN,
+
     // Maintenance (paired: cost + interval/lifetime). Defaults are zero so a
     // hand-constructed UserEconomy is cost-free for tests. Production paths
     // populate these from the VehicleClass preset via the repository.
@@ -106,13 +115,14 @@ data class UserEconomy(
     val operatingCostPerMile: Double get() = fuelCostPerMile + nonFuelCostPerMile
 
     /**
-     * Items/minute for the Shop & Deliver time estimate (#556): the learned overall pace once
-     * [MIN_SHOP_SAMPLES] shops have been measured, else the data-derived seed. Always > 0.
+     * Items/minute for the Shop & Deliver time estimate (#556): the learned pace once
+     * [MIN_SHOP_SAMPLES] shops have been measured for this platform, else this platform's
+     * [shopSeedItemsPerMin] seed (#588). Always > 0.
      */
     val effectiveShopItemsPerMinute: Double
         get() = learnedShopItemsPerMinute
             ?.takeIf { shopRateSampleCount >= MIN_SHOP_SAMPLES && it > 0.0 }
-            ?: DEFAULT_SHOP_ITEMS_PER_MIN
+            ?: shopSeedItemsPerMin
 
     fun isUserSet(field: EconomyField): Boolean = field in userSetFields
 

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/evaluation/ShopTimeModelTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/evaluation/ShopTimeModelTest.kt
@@ -4,6 +4,7 @@ import cloud.trotter.dashbuddy.domain.model.offer.ParsedOffer
 import cloud.trotter.dashbuddy.domain.model.order.OrderType
 import cloud.trotter.dashbuddy.domain.model.order.ParsedOrder
 import cloud.trotter.dashbuddy.domain.model.vehicle.VehicleClass
+import cloud.trotter.dashbuddy.domain.state.Platform
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -57,6 +58,36 @@ class ShopTimeModelTest {
         val cold = economy.copy(learnedShopItemsPerMinute = 1.0, shopRateSampleCount = 2) // below floor
         assertEquals(UserEconomy.DEFAULT_SHOP_ITEMS_PER_MIN, cold.effectiveShopItemsPerMinute, 0.0)
         assertEquals(UserEconomy.DEFAULT_SHOP_ITEMS_PER_MIN, economy.effectiveShopItemsPerMinute, 0.0)
+    }
+
+    @Test
+    fun `forPlatform resolves a platform with no samples to its seed, never another platform's learned rate (#588)`() {
+        // DoorDash is well past the trust gate at a fast learned pace; Instacart has no samples.
+        val cfg = config.copy(
+            shopRates = mapOf(
+                Platform.DoorDash to LearnedShopRate(itemsPerMin = 2.0, sampleCount = UserEconomy.MIN_SHOP_SAMPLES + 3),
+            ),
+        )
+
+        // DoorDash resolves to its own learned pace.
+        assertEquals(2.0, cfg.forPlatform(Platform.DoorDash).userEconomy.effectiveShopItemsPerMinute, 0.0)
+
+        // Instacart — absent from the map — resolves to the SEED, never DoorDash's 2.0/min.
+        val ic = cfg.forPlatform(Platform.Instacart).userEconomy
+        assertEquals(ShopRateSeeds.seedFor(Platform.Instacart), ic.effectiveShopItemsPerMinute, 0.0)
+        assertEquals(0, ic.shopRateSampleCount)
+    }
+
+    @Test
+    fun `forPlatform selects each platform's own learned mean independently (#588)`() {
+        val cfg = config.copy(
+            shopRates = mapOf(
+                Platform.DoorDash to LearnedShopRate(0.8, UserEconomy.MIN_SHOP_SAMPLES),
+                Platform.Instacart to LearnedShopRate(1.5, UserEconomy.MIN_SHOP_SAMPLES),
+            ),
+        )
+        assertEquals(0.8, cfg.forPlatform(Platform.DoorDash).userEconomy.effectiveShopItemsPerMinute, 0.0)
+        assertEquals(1.5, cfg.forPlatform(Platform.Instacart).userEconomy.effectiveShopItemsPerMinute, 0.0)
     }
 
     @Test


### PR DESCRIPTION
Closes #588.

Keys the #556 learned shop-rate model **per platform** end-to-end, following the dev-vetted build spec on the issue (2026-07-07 design pass). The single global items/min mean is gone: a DoorDash-learned pace can no longer price — or be polluted by — an Instacart / Uber shop.

## What changed (mapped to the issue's fix direction)

| Spec item | Change |
|---|---|
| 2. Per-platform DataStore keys (drop the global pair) | `StrategyDataSource`: global `learned_shop_items_per_min` / `shop_rate_sample_count` → **dynamic keys** `…:${platform.wire}`; `learnedShopRate: Flow<LearnedShopRate>` → `learnedShopRates: Flow<Map<Platform, LearnedShopRate>>` (enumerates `Platform.entries`, platforms with no samples omitted); `recordShopRate(platform, items, minutes)` folds only that platform's pair (same atomic `ds.edit`). |
| 1. Thread `platform` onto `RecordShopRate` + dedup key | `AppEffect.RecordShopRate` gains `platform: Platform`; `effectKey = "shop_rate:${platform.wire}:$taskId"`. `TaskEffects.pickupConfirmedEffects` threads `region.platform` from both sweep sites (pickup→dropoff edge + #596 close-out). |
| 3. `EvaluationConfig` carries rate per platform, selected at eval | `EvaluationConfig.shopRates: Map<Platform, LearnedShopRate>` + `forPlatform(platform)` seam that resolves the learned pair + seed into `userEconomy` — keeps `OfferEvaluator.evaluate` / `UserEconomy.effectiveShopItemsPerMinute` **signature-unchanged**. `SideEffectEngine.EvaluateOffer` calls `config.forPlatform(effect.platform)` (platform already on the effect, #438 8a). |
| 4. Seed becomes a `Platform`-keyed lookup; gate counted per platform | New `ShopRateSeeds` (`Map<Platform, Double>`, DoorDash corpus entry as **data**, `DEFAULT = 0.8` generic fallback); `UserEconomy.shopSeedItemsPerMin` fallback field; `MIN_SHOP_SAMPLES` unchanged (now reads a per-platform-resolved count). |
| 5. Key-space shape for #159 / #254 | The `…:<wire>` suffix + `Map<Platform, …>` + `forPlatform` seam are the shape `(platform, chain)` (#159) and #254's learned constants inherit. |

## Migration — restart-learning (no migration), per the design's dev-vetoable recommendation

The old global keys are **dropped**; every platform relearns from its seed and re-crosses the 5-sample trust gate independently. The loss is numerically negligible — the 0.8 seed **is** the median of the same 48-shop DoorDash corpus the global mean was trained on, so the fallback ≈ the discarded value. No migration code, no stale-key residue. (Accepted residual: pre-upgrade `effects_fired` rows hold the old `shop_rate:<taskId>` key format — a recovery replay spanning the upgrade could double-fold one shop; alpha, minutes-wide window, running-mean noise.)

## Tests

- **New** `StrategyDataSourceShopRateTest` (`:core:datastore`): two platforms learn independent means; recording under DoorDash never moves Instacart's entry; unrecorded platforms are absent (seed fallback owns them); below-floor samples are no-ops.
- **New** `ShopTimeModelTest` cases (`:domain`): `forPlatform(Instacart)` with 0 samples yields the seed, never DoorDash's learned rate even past the trust gate; each platform's learned mean resolves independently.
- **Updated** `EffectMapTest` (effect carries `region.platform`, `effectKey == "shop_rate:doordash:task-1"`) and `SideEffectEngineTest` (constructor + INFO carries the `doordash` wire tag, store name still DEBUG-only).
- Existing `ShopTimeModelTest` / `OfferEvaluator` / `UserEconomy` tests green unmodified (the seed defaults off-config to today's constant).
- `./gradlew :domain:test testDebugUnitTest` — **BUILD SUCCESSFUL**, all green.

No `ParsedOffer` / parse-golden / ruleset change (platform arrives via the effect/observation, ADR-0007/#245).

### Design-goal review

- **P8 platform-agnostic core (mandatory — touches `:domain`/`:core:state`):** platform threads from `region.platform` at the mint and `effect.platform` at eval — both registry-resolved upstream; no `Platform.fromPackage`/literal derivation added. DataStore keys derive from `Platform.wire`; rates are `Map<Platform, …>`; the gate counts per platform. The **only** DoorDash literal in the diff is **data, not logic** — the corpus-seed entry in `ShopRateSeeds.byPlatform` (the `GraceConfig.DEFAULT` defaults-as-data pattern). Acceptance test holds: enabling Instacart/WalmartSpark needs **zero** `:core:state`/`:core:pipeline`/`:domain` edits — dynamic keys enumerate the registry, absent platforms resolve to the seed.
- **P5 SSOT:** the learned pace has one owner (the strategy DataStore, now keyed); the seed is one `ShopRateSeeds` lookup consumed via `forPlatform`; `ShopRate.fold` (the running mean) is untouched and still shared. No second copy introduced.
- **P1 UDF:** pure reducer/stepper untouched — this is effect-mint plumbing (`region.platform` onto the effect) + a read-side config seam; resolution happens at the edge in `SideEffectEngine`, not in a reducer.
- **P7 semantic logging:** the `ShopRate` INFO milestone gains `effect.platform.wire` (a registry token, PII-safe); the raw store name stays DEBUG-only — asserted by the updated `SideEffectEngineTest`.
- **P3 SRP / P4 Kotlin:** small focused additions; `Map<Platform, T>` + enum-keyed lookup, immutability preserved.

### Security / privacy posture

On-device only; no new network, capture, or effect-actuation surface. The added INFO log token is the platform **wire** string (an enumerated registry constant), never customer/merchant PII. No change to the sensitive-block or customer-hash paths.

## Next field test

Added a `Confirmed: 0/2` checklist item to `docs/field-testing/README.md`: on a DoorDash shop offer, handling-time/$/hr should read sane immediately after the reset (seed ≈ old global), the learned pace takes over after ~5 real shops, and the shareable `ShopRate` INFO lines now carry a `[doordash]` tag with no cross-platform bleed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

### Adversarial review (Fable-tier, 2026-07-10)

Two finder agents (correctness + cross-file tracer; P8/principles + test quality) → 10 candidates, deduped to 6 actionable + 1 verified-informational. All actionable items **fixed in-branch** (commit `fce0b443`); suites green.

**Verified sound (the load-bearing properties, traced not trusted):**
- Both sweep sites route through the one `pickupConfirmSweepEffects` and pass their own region's platform; the eval loopback evaluates against the OFFER's own platform (`EvaluateOffer.platform`) — recording and evaluation are symmetric per platform.
- `Platform.Unknown` resolves to an isolated `_unknown` bucket/seed — it can never read or pollute another platform's rate.
- The effectKey format change (`shop_rate:<wire>:<taskId>`) is **bounded**: crash-recovery replay suppresses `RecordShopRate` entirely (external effect), so only a live re-observation within the 48h horizon can re-fire once — and it lands in the correct new per-platform bucket (the old global was discarded), so no double-count is possible.

**Fixed:**
- **A==A test vacuity (the P8 guard):** the platform-threading test hardcoded DoorDash on both sides — the exact regression #588 exists to prevent was undetectable. Now built on `Platform.Instacart`, plus a NEW close-out-sweep test (shop job closing pickup-only, non-DoorDash) covering the previously untested `RecordShopRate` path.
- **Seed provenance inversion:** the "DoorDash 48-shop corpus seed" and the generic default were two readings of one constant — now `DOORDASH_CORPUS_SEED` with provenance, `DEFAULT` explicitly derives from it.
- **"Dropped, not migrated" pinned by test:** legacy global keys seeded into the store are asserted ignored; `recordShopRate` now also tidies the two orphaned legacy keys.
- **Field-test item honesty:** "no visible regression" over-claimed (the discarded value was the dev's learned mean) — softened to "pricing may shift toward the 0.8/min seed until ~5 shops relearn."
- **API-shape hazard documented:** `EvaluationConfig.userEconomy` is unresolved until `forPlatform()` — KDoc contract added; the one raw consumer (`simulateOffer`) is non-shop by construction and now says so.
- **Abandoned-shop residual cross-linked:** a #736-style unassigned shop can fold one garbage pace sample (pre-existing #556 exposure, diluted by MIN_SHOP_SAMPLES=5); comment at the mint site references #736, whose unassign guard will close it at the source.

**Principles walk (review-verified):** P8 clean — no platform literals in logic, seeds are registry-keyed DATA, threading now falsifiably tested on a non-DoorDash platform; P5 seed SSOT fixed; P7 INFO carries wire tag only, store names stay DEBUG; P1 steppers pure, DataStore writes at the effect edge only.
