### PR TITLE
feat(#501): SnapshotRedactor id-less-name fix + GoPuff dropoff multi-order-confirm rule (items 1-2)

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/CaptureRedactionCorpusTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/CaptureRedactionCorpusTest.kt
@@ -3,6 +3,7 @@ package cloud.trotter.dashbuddy.core.pipeline.rules
 import cloud.trotter.dashbuddy.domain.capture.schema.UiNodeSchema
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
 import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData
+import cloud.trotter.dashbuddy.test.util.SnapshotRedactor
 import cloud.trotter.dashbuddy.test.util.TestResourceLoader
 import cloud.trotter.dashbuddy.test.util.TestRulesetFactory
 import kotlinx.serialization.json.Json
@@ -130,6 +131,126 @@ class CaptureRedactionCorpusTest {
             "marker kept, address masked",
             Regex("""Deliver to door of \[redacted:[0-9a-f]{4}\]""").containsMatchIn(masked),
         )
+    }
+
+    // =========================================================================
+    // #501 — the id-less first-name + last-initial customer-name shape. The
+    // adversarial-review pledge finding: the runtime redact fail-OPEN on common
+    // name shapes (accents, interior caps, hyphen/apostrophe, ALL-CAPS, trailing
+    // space), and the corpus was scrubbed by a DIVERGENT (case-sensitive, trimmed)
+    // masker. FIX 1c (SSOT parity), FIX 2 (injected-synthetic masking), FIX 4
+    // (committed-corpus bare-name guard).
+    // =========================================================================
+
+    /** Every `hasTextMatchesRegex` string value anywhere inside [element]. */
+    private fun collectRegexes(
+        element: kotlinx.serialization.json.JsonElement,
+        out: MutableList<String>,
+    ) {
+        when (element) {
+            is kotlinx.serialization.json.JsonObject -> element.forEach { (k, v) ->
+                if (k == "hasTextMatchesRegex" && v is kotlinx.serialization.json.JsonPrimitive && v.isString) {
+                    out += v.content
+                } else {
+                    collectRegexes(v, out)
+                }
+            }
+            is kotlinx.serialization.json.JsonArray -> element.forEach { collectRegexes(it, out) }
+            else -> {}
+        }
+    }
+
+    /** The `hasTextMatchesRegex` strings in a screen rule's `redact` block (generated asset). */
+    private fun ruleRedactRegexes(ruleId: String): List<String> {
+        val root = Json.parseToJsonElement(File(rulesDir, "doordash.json").readText()).jsonObject
+        val screen = root["screens"]!!.jsonArray.first {
+            it.jsonObject["id"]?.jsonPrimitive?.content == ruleId
+        }.jsonObject
+        val out = mutableListOf<String>()
+        screen["redact"]?.jsonArray?.forEach { collectRegexes(it, out) }
+        return out
+    }
+
+    @Test
+    fun `the id-less name-shape redact pattern is SSOT with SnapshotRedactor (FIX 1c, #362 class)`() {
+        // The canonical name-shape regex on the multi-order-confirm rule must be
+        // byte-identical to SnapshotRedactor's constant — the two copies scrub the
+        // same customer token (runtime envelope vs committed corpus) and must not
+        // drift silently (the #362 duplicated-sha256 class of bug).
+        assertTrue(
+            "multi_order_confirm must carry the canonical name-shape regex identical to " +
+                "SnapshotRedactor.FIRST_LAST_INITIAL_PATTERN; found " +
+                ruleRedactRegexes("doordash.screen.dropoff_multi_order_confirm"),
+            ruleRedactRegexes("doordash.screen.dropoff_multi_order_confirm")
+                .contains(SnapshotRedactor.FIRST_LAST_INITIAL_PATTERN),
+        )
+        // FIX 3 defense-in-depth: the two earlier-priority rules that could win a
+        // modal-over-handoff combined frame carry the SAME pattern.
+        for (id in listOf("doordash.screen.dropoff_navigation", "doordash.screen.dropoff_handoff")) {
+            assertTrue(
+                "$id must carry the canonical name-shape regex (FIX 3 defense-in-depth)",
+                ruleRedactRegexes(id).contains(SnapshotRedactor.FIRST_LAST_INITIAL_PATTERN),
+            )
+        }
+    }
+
+    @Test
+    fun `multi_order_confirm redact masks injected name shapes, keeps the require anchors (FIX 2)`() {
+        val rule = TestRulesetFactory.screenRuleset
+            .ruleById("doordash.screen.dropoff_multi_order_confirm")!!
+        // Accents, interior caps, hyphen/apostrophe, ALL-CAPS (runtime IGNORE_CASE),
+        // and a trailing space (the raw-text alignment) — every shape the pre-fix
+        // masker fell open on.
+        val names = listOf("Brandon C", "José R", "O'Brien M", "Mary-Jo K", "JOSE G", "Brandon C ", "McKenna B")
+        val maskShape = Regex("""\[redacted:[0-9a-f]{4}\]""")
+        for (name in names) {
+            val tree = UiNode(
+                children = listOf(
+                    UiNode(text = "Confirm you have the correct order before drop-off."),
+                    UiNode(text = "Mix-ups frequently occur at drop-off when there are multiple orders in a Dash."),
+                    UiNode(text = name), // the id-less customer-name line
+                    UiNode(text = "SPROUTS FARMERS MARKET #118"),
+                    UiNode(text = "2 items"),
+                ),
+            ).restoreParents()
+            val masked = serialize(rule.redact.apply(tree))
+
+            assertFalse("injected name '$name' must not persist", masked.contains(name.trim()))
+            assertTrue("name '$name' masked to [redacted:<4hex>]", maskShape.containsMatchIn(masked))
+            // Negative: the require anchors + merchant + count must survive untouched.
+            assertTrue("require anchor kept", masked.contains("correct order before drop-off"))
+            assertTrue("mix-ups anchor kept", masked.contains("Mix-ups frequently occur at drop-off"))
+            assertTrue("merchant (driver-owned) kept", masked.contains("SPROUTS FARMERS MARKET #118"))
+            assertTrue("count kept", masked.contains("2 items"))
+        }
+    }
+
+    @Test
+    fun `committed corpus carries no un-masked bare customer-name node (FIX 4)`() {
+        val nameShape = Regex(SnapshotRedactor.FIRST_LAST_INITIAL_PATTERN, RegexOption.IGNORE_CASE)
+        // Folders whose owning rule declares the name-shape redact (FIX 3 included).
+        val folders = listOf("dropoff_multi_order_confirm", "dropoff_navigation", "dropoff_handoff")
+        val leaks = mutableListOf<String>()
+        for (folder in folders) {
+            for ((filename, node, _) in TestResourceLoader.loadSnapshots("snapshots/$folder")) {
+                walkText(node) { text ->
+                    if (!text.contains("[redacted") && nameShape.matches(text)) {
+                        leaks += "$folder/$filename: \"$text\""
+                    }
+                }
+            }
+        }
+        assertTrue(
+            "committed corpus leaks an un-masked bare customer name (the masker's blind spot " +
+                "is now a test failure, not a permanent git leak): $leaks",
+            leaks.isEmpty(),
+        )
+    }
+
+    private fun walkText(node: UiNode, visit: (String) -> Unit) {
+        node.text?.let(visit)
+        node.contentDescription?.let(visit)
+        node.children.forEach { walkText(it, visit) }
     }
 
     @Test

--- a/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/GoPuffRecognitionTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/GoPuffRecognitionTest.kt
@@ -55,6 +55,30 @@ class GoPuffRecognitionTest {
     }
 
     /**
+     * #501 item 2 — the multi-order drop-off confirmation card. Recognize-only (dev decision
+     * 2026-07-07): no state.flow — the dropoff-navigation phase is already established before this
+     * transient modal appears, so recognizing it only graduates the frame out of UNKNOWN. Both
+     * committed corpus frames are REAL redacted 2026-06-14 captures: a GoPuff (Drive) warehouse
+     * drop AND an ordinary Sprouts multi-merchant drop — proving the card is NOT GoPuff-specific
+     * (it's the generic DoorDash multi-order confirm). The id-less customer-name line was masked
+     * by SnapshotRedactor's FIRST_LAST_INITIAL masker (#501 item 1), which is why these frames
+     * could be committed at all; the rule's own `redact` masks the same node at runtime.
+     */
+    @Test
+    fun `the GoPuff multi-order drop-off confirm recognizes without changing phase (#501 item 2)`() {
+        val r = rules.matchFirst(load("dropoff_multi_order_confirm/gopuff_multi_order_confirm.json"))
+        assertEquals("dropoff_multi_order_confirm", r?.intent)
+        assertNull("the multi-order confirm card is recognize-only — it must not perturb the dropoff phase", r?.flow)
+    }
+
+    @Test
+    fun `a regular multi-merchant drop-off confirm recognizes the same intent (#501 item 2, not GoPuff-specific)`() {
+        val r = rules.matchFirst(load("dropoff_multi_order_confirm/sprouts_multi_order_confirm.json"))
+        assertEquals("dropoff_multi_order_confirm", r?.intent)
+        assertNull("the multi-order confirm card is recognize-only — it must not perturb the dropoff phase", r?.flow)
+    }
+
+    /**
      * #501 item 3 — the GoPuff (Drive) zone-arrival CTA card, recognize-only (dev decision
      * 2026-07-07): no parse, no state.flow — nav is already established before this frame
      * appears, and its button is an affordance, not the arrival anchor (`pickup_steps`'s

--- a/app/src/test/java/cloud/trotter/dashbuddy/test/util/SnapshotRedactor.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/test/util/SnapshotRedactor.kt
@@ -77,6 +77,19 @@ object SnapshotRedactor {
      * or "$15.15 Guaranteed"; requires a capitalized street word, not a unit/count.
      */
     private val BARE_STREET = Regex("""^\d{2,6}\s+[A-Z][A-Za-z.'-]+(?:\s+[A-Z][A-Za-z0-9.'-]+){0,3}$""")
+    /**
+     * An **id-less first-name + last-initial** customer name line, e.g. "Brandon C" / "Gilberto U."
+     * — the shape on the multi-order drop-off confirm card (#501), whose name node ships **no
+     * viewId** so it escapes [PII_ID_SUFFIXES] and carries **no** "Deliver to "/"Message from "
+     * marker so the [NAME_PREFIXES] pass and the runtime CustomerTextMarkers backstop both miss it
+     * (the documented split-node residual). Whole-value anchored so it can't eat a multi-word
+     * merchant anchor ("SPROUTS FARMERS MARKET #118"), a warehouse zone code ("SAT_San-Antonio_187"),
+     * or a count ("2 items"): first name(s) are `Capitalized` words, the last token is a single
+     * capital letter (optionally with a period). Masking a shape this specific is the privacy-safe
+     * direction — a rare over-mask (a "Word X" UI label) is caught by the diff review + the
+     * [GoldenSnapshotRegressionTest] anchor guard; leaking a customer name is the dangerous one.
+     */
+    private val FIRST_LAST_INITIAL = Regex("""^[A-Z][a-z]{1,20}(?: [A-Z][a-z]{1,20}){0,3} [A-Z]\.?$""")
     private val APT = Regex("""(?i)\b(apt|suite|ste|unit|bldg|building|gate code|gate)\b[:#\s]*[A-Za-z0-9\-]+""")
     /** A quoted free-text customer note, e.g. "Corner House, please leave at door." — customer-entered, mask whole. */
     private val QUOTED_NOTE = Regex(""""[^"]{6,}"""")
@@ -149,6 +162,10 @@ object SnapshotRedactor {
         // A whole-value bare street line ("7610 Flecthers") with no recognized suffix — mask outright
         // before the token-level passes, so a residual unsuffixed street can't leak.
         if (BARE_STREET.matches(text.trim())) return "[address]"
+        // A whole-value id-less first-name + last-initial customer name ("Brandon C") — the
+        // multi-order drop-off confirm card residual (#501). Whole-value, so it fires only on a
+        // node that IS just the name, never on a longer line that merely contains one.
+        if (FIRST_LAST_INITIAL.matches(text.trim())) return MASK
         var t = text
         t = EMAIL.replace(t, "[email]")
         t = PHONE.replace(t, "[phone]")

--- a/app/src/test/java/cloud/trotter/dashbuddy/test/util/SnapshotRedactor.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/test/util/SnapshotRedactor.kt
@@ -78,18 +78,40 @@ object SnapshotRedactor {
      */
     private val BARE_STREET = Regex("""^\d{2,6}\s+[A-Z][A-Za-z.'-]+(?:\s+[A-Z][A-Za-z0-9.'-]+){0,3}$""")
     /**
-     * An **id-less first-name + last-initial** customer name line, e.g. "Brandon C" / "Gilberto U."
-     * — the shape on the multi-order drop-off confirm card (#501), whose name node ships **no
-     * viewId** so it escapes [PII_ID_SUFFIXES] and carries **no** "Deliver to "/"Message from "
-     * marker so the [NAME_PREFIXES] pass and the runtime CustomerTextMarkers backstop both miss it
-     * (the documented split-node residual). Whole-value anchored so it can't eat a multi-word
-     * merchant anchor ("SPROUTS FARMERS MARKET #118"), a warehouse zone code ("SAT_San-Antonio_187"),
-     * or a count ("2 items"): first name(s) are `Capitalized` words, the last token is a single
-     * capital letter (optionally with a period). Masking a shape this specific is the privacy-safe
-     * direction — a rare over-mask (a "Word X" UI label) is caught by the diff review + the
-     * [GoldenSnapshotRegressionTest] anchor guard; leaking a customer name is the dangerous one.
+     * The canonical **id-less first-name + last-initial** customer-name shape, e.g. "Brandon C" /
+     * "Gilberto U." / "José R" / "O'Brien M" / "Mary-Jo K" / "McKenna B" — the line on the
+     * multi-order drop-off confirm card (#501), whose name node ships **no viewId** so it escapes
+     * [PII_ID_SUFFIXES] and carries **no** "Deliver to "/"Message from " marker so the
+     * [NAME_PREFIXES] pass and the runtime CustomerTextMarkers backstop both miss it (the
+     * documented split-node residual).
+     *
+     * **SSOT (#362 class):** [FIRST_LAST_INITIAL_PATTERN] is byte-identical to the rule-side
+     * `hasTextMatchesRegex` in `doordash.screen.dropoff_multi_order_confirm` (+ the FIX-3
+     * defense-in-depth copies on `dropoff_navigation`/`dropoff_handoff`), and BOTH compile
+     * `IGNORE_CASE` — so the committed corpus is scrubbed the SAME way the runtime redacts the live
+     * envelope. `CaptureRedactionCorpusTest` asserts the two pattern strings are equal so they
+     * can't drift.
+     *
+     * Whole-value anchored (`^…$`, whitespace-tolerant via `\s{0,8}` so a trailing space still
+     * matches — the runtime `containsMatchIn` on raw text and this `matches` then agree on
+     * "Brandon C "), so it can't eat a multi-word merchant anchor ("SPROUTS FARMERS MARKET #118"),
+     * a warehouse zone code ("SAT_San-Antonio_187"), or a count ("2 items"). Character classes are
+     * `\p{L}` (accented/Unicode letters — José, Muñoz; interior capitals — McKenna) plus `'` and
+     * `-` (O'Brien, D'Angelo, Mary-Jo); the last token is a single letter with an optional trailing
+     * period. Every quantifier is bounded ({0,20}/{0,3}/{0,8}) so it passes RegexSafety's ReDoS
+     * guard when the identical string is compiled on the rule side.
+     *
+     * **Accepted over-mask trade-off (privacy-first):** because it is case-insensitive and
+     * shape-only, a two-token UI label that happens to end in a single letter — "Vitamin C",
+     * "Terminal B", "Plan B" — would also be masked. That is deliberate: a rare over-mask of a
+     * non-PII label is caught by the snapshot diff review + the [GoldenSnapshotRegressionTest]
+     * anchor guard (a masked anchor a rule needs turns the test red), whereas leaking a real
+     * customer name is the dangerous, silent failure. The `hasNoId` conjunct on the rule side and
+     * the whole-value anchoring here keep the surface small.
      */
-    private val FIRST_LAST_INITIAL = Regex("""^[A-Z][a-z]{1,20}(?: [A-Z][a-z]{1,20}){0,3} [A-Z]\.?$""")
+    const val FIRST_LAST_INITIAL_PATTERN =
+        "^\\s{0,8}[\\p{L}][\\p{L}'-]{0,20}( [\\p{L}][\\p{L}'-]{0,20}){0,3} [A-Z]\\.?\\s{0,8}$"
+    private val FIRST_LAST_INITIAL = Regex(FIRST_LAST_INITIAL_PATTERN, RegexOption.IGNORE_CASE)
     private val APT = Regex("""(?i)\b(apt|suite|ste|unit|bldg|building|gate code|gate)\b[:#\s]*[A-Za-z0-9\-]+""")
     /** A quoted free-text customer note, e.g. "Corner House, please leave at door." — customer-entered, mask whole. */
     private val QUOTED_NOTE = Regex(""""[^"]{6,}"""")
@@ -163,9 +185,10 @@ object SnapshotRedactor {
         // before the token-level passes, so a residual unsuffixed street can't leak.
         if (BARE_STREET.matches(text.trim())) return "[address]"
         // A whole-value id-less first-name + last-initial customer name ("Brandon C") — the
-        // multi-order drop-off confirm card residual (#501). Whole-value, so it fires only on a
-        // node that IS just the name, never on a longer line that merely contains one.
-        if (FIRST_LAST_INITIAL.matches(text.trim())) return MASK
+        // multi-order drop-off confirm card residual (#501). Matched on RAW text (the pattern is
+        // whitespace-tolerant) so this agrees byte-for-byte with the runtime redact's
+        // containsMatchIn; whole-value anchored, so it fires only on a node that IS just the name.
+        if (FIRST_LAST_INITIAL.matches(text)) return MASK
         var t = text
         t = EMAIL.replace(t, "[email]")
         t = PHONE.replace(t, "[phone]")

--- a/app/src/test/resources/snapshots/approved-parse-output.json
+++ b/app/src/test/resources/snapshots/approved-parse-output.json
@@ -1181,6 +1181,18 @@
         "shape": null,
         "fields": {}
     },
+    "dropoff_multi_order_confirm/gopuff_multi_order_confirm.json": {
+        "ruleId": "doordash.screen.dropoff_multi_order_confirm",
+        "intent": "dropoff_multi_order_confirm",
+        "shape": null,
+        "fields": {}
+    },
+    "dropoff_multi_order_confirm/sprouts_multi_order_confirm.json": {
+        "ruleId": "doordash.screen.dropoff_multi_order_confirm",
+        "intent": "dropoff_multi_order_confirm",
+        "shape": null,
+        "fields": {}
+    },
     "dropoff_navigation/20260128_201025_438_NAVIGATION_VIEW_TO_DROP_OFF.json": {
         "ruleId": "doordash.screen.dropoff_navigation",
         "intent": "dropoff_navigation",

--- a/app/src/test/resources/snapshots/dropoff_multi_order_confirm/gopuff_multi_order_confirm.json
+++ b/app/src/test/resources/snapshots/dropoff_multi_order_confirm/gopuff_multi_order_confirm.json
@@ -1,0 +1,431 @@
+{
+    "captureId": "04c39313-d8ef-4abb-93d6-0641007cc253",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1781452737924,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": 0,
+            "top": 2400,
+            "right": 1080,
+            "bottom": 4800
+        },
+        "children": [
+            {
+                "class": "android.widget.LinearLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 2400,
+                    "right": 1080,
+                    "bottom": 4747
+                },
+                "children": [
+                    {
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": 0,
+                            "top": 2536,
+                            "right": 1080,
+                            "bottom": 4747
+                        },
+                        "children": [
+                            {
+                                "id": "com.doordash.driverapp:id/action_bar_root",
+                                "class": "android.widget.FrameLayout",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": 0,
+                                    "top": 2536,
+                                    "right": 1080,
+                                    "bottom": 4747
+                                },
+                                "children": [
+                                    {
+                                        "id": "android:id/content",
+                                        "class": "android.widget.FrameLayout",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": 0,
+                                            "top": 2536,
+                                            "right": 1080,
+                                            "bottom": 4747
+                                        },
+                                        "children": [
+                                            {
+                                                "id": "com.doordash.driverapp:id/layout_bottom_sheet",
+                                                "class": "android.view.ViewGroup",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": 0,
+                                                    "top": 2536,
+                                                    "right": 1080,
+                                                    "bottom": 4747
+                                                },
+                                                "children": [
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/overlay_view",
+                                                        "class": "android.view.View",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 2536,
+                                                            "right": 1080,
+                                                            "bottom": 4747
+                                                        }
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/prism_sheet",
+                                                        "class": "android.view.ViewGroup",
+                                                        "isClickable": true,
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 3300,
+                                                            "right": 1080,
+                                                            "bottom": 4747
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/prism_sheet_collar_view",
+                                                                "class": "android.widget.FrameLayout",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 3300,
+                                                                    "right": 1080,
+                                                                    "bottom": 3336
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/handle_overlay",
+                                                                        "class": "android.widget.FrameLayout",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 3300,
+                                                                            "right": 1080,
+                                                                            "bottom": 3336
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/handle_overlay_image",
+                                                                                "class": "android.widget.ImageView",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 3318,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 3327
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            },
+                                                            {
+                                                                "id": "com.doordash.driverapp:id/prism_sheet_content_parent_container",
+                                                                "class": "android.view.ViewGroup",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": 0,
+                                                                    "top": 3336,
+                                                                    "right": 1080,
+                                                                    "bottom": 4711
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "id": "com.doordash.driverapp:id/nested_scroll_view",
+                                                                        "class": "android.widget.ScrollView",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": 0,
+                                                                            "top": 3336,
+                                                                            "right": 1080,
+                                                                            "bottom": 4711
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "id": "com.doordash.driverapp:id/prism_content_container",
+                                                                                "class": "android.widget.LinearLayout",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 0,
+                                                                                    "top": 3336,
+                                                                                    "right": 1080,
+                                                                                    "bottom": 4711
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "id": "com.doordash.driverapp:id/bottomsheet_content_container",
+                                                                                        "class": "android.widget.FrameLayout",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 0,
+                                                                                            "top": 3336,
+                                                                                            "right": 1080,
+                                                                                            "bottom": 4711
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "class": "androidx.compose.ui.platform.ComposeView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 0,
+                                                                                                    "top": 3336,
+                                                                                                    "right": 1080,
+                                                                                                    "bottom": 4711
+                                                                                                },
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "class": "android.view.View",
+                                                                                                        "isEnabled": true,
+                                                                                                        "bounds": {
+                                                                                                            "left": 0,
+                                                                                                            "top": 3336,
+                                                                                                            "right": 1080,
+                                                                                                            "bottom": 4711
+                                                                                                        },
+                                                                                                        "children": [
+                                                                                                            {
+                                                                                                                "desc": "",
+                                                                                                                "class": "android.widget.ImageView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 232,
+                                                                                                                    "top": 3336,
+                                                                                                                    "right": 849,
+                                                                                                                    "bottom": 3799
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "Confirm you have the correct order before drop-off.",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 36,
+                                                                                                                    "top": 3835,
+                                                                                                                    "right": 1044,
+                                                                                                                    "bottom": 3967
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "Mix-ups frequently occur at drop-off when there are multiple orders in a Dash.",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 36,
+                                                                                                                    "top": 4003,
+                                                                                                                    "right": 1044,
+                                                                                                                    "bottom": 4106
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 36,
+                                                                                                                    "top": 4090,
+                                                                                                                    "right": 1044,
+                                                                                                                    "bottom": 4196
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "text": "[redacted]",
+                                                                                                                "class": "android.widget.TextView",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 36,
+                                                                                                                    "top": 4198,
+                                                                                                                    "right": 1044,
+                                                                                                                    "bottom": 4264
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 36,
+                                                                                                                    "top": 4282,
+                                                                                                                    "right": 1044,
+                                                                                                                    "bottom": 4407
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "id": "Artwork Image",
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 4318,
+                                                                                                                            "right": 89,
+                                                                                                                            "bottom": 4371
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "text": "SAT_San-Antonio_187",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 125,
+                                                                                                                            "top": 4321,
+                                                                                                                            "right": 518,
+                                                                                                                            "bottom": 4368
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "android.view.View",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 36,
+                                                                                                                    "top": 4407,
+                                                                                                                    "right": 1044,
+                                                                                                                    "bottom": 4532
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "id": "Artwork Image",
+                                                                                                                        "class": "android.view.View",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 4443,
+                                                                                                                            "right": 89,
+                                                                                                                            "bottom": 4496
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "text": "2 items",
+                                                                                                                        "class": "android.widget.TextView",
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 125,
+                                                                                                                            "top": 4446,
+                                                                                                                            "right": 257,
+                                                                                                                            "bottom": 4493
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "class": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+                                                                                                                "isEnabled": true,
+                                                                                                                "bounds": {
+                                                                                                                    "left": 36,
+                                                                                                                    "top": 4568,
+                                                                                                                    "right": 1044,
+                                                                                                                    "bottom": 4675
+                                                                                                                },
+                                                                                                                "children": [
+                                                                                                                    {
+                                                                                                                        "class": "android.widget.Button",
+                                                                                                                        "isClickable": true,
+                                                                                                                        "isEnabled": true,
+                                                                                                                        "bounds": {
+                                                                                                                            "left": 36,
+                                                                                                                            "top": 4568,
+                                                                                                                            "right": 1044,
+                                                                                                                            "bottom": 4675
+                                                                                                                        },
+                                                                                                                        "children": [
+                                                                                                                            {
+                                                                                                                                "text": "Continue",
+                                                                                                                                "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                                                                "class": "android.widget.TextView",
+                                                                                                                                "isEnabled": true,
+                                                                                                                                "bounds": {
+                                                                                                                                    "left": 445,
+                                                                                                                                    "top": 4589,
+                                                                                                                                    "right": 635,
+                                                                                                                                    "bottom": 4655
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ]
+                                                                                                                    }
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/prism_sheet_footer_divider",
+                                                        "class": "android.view.View",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 4743,
+                                                            "right": 1080,
+                                                            "bottom": 4747
+                                                        }
+                                                    },
+                                                    {
+                                                        "id": "com.doordash.driverapp:id/prism_sheet_footer_container",
+                                                        "class": "android.widget.LinearLayout",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": 0,
+                                                            "top": 4747,
+                                                            "right": 1080,
+                                                            "bottom": 4747
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "id": "android:id/navigationBarBackground",
+                "class": "android.view.View",
+                "isEnabled": true,
+                "bounds": {
+                    "left": 0,
+                    "top": 4747,
+                    "right": 1080,
+                    "bottom": 4800
+                }
+            }
+        ]
+    }
+}

--- a/app/src/test/resources/snapshots/dropoff_multi_order_confirm/sprouts_multi_order_confirm.json
+++ b/app/src/test/resources/snapshots/dropoff_multi_order_confirm/sprouts_multi_order_confirm.json
@@ -1,0 +1,353 @@
+{
+    "captureId": "5ceb34e4-9241-4ca4-ad74-de4c3fa7efc4",
+    "pipelineId": "accessibility.window",
+    "schemaId": "uinode.v1",
+    "timestamp": 1781459281000,
+    "platform": "doordash",
+    "ruleId": null,
+    "classificationName": "UNKNOWN",
+    "metadata": {
+        "engineVersion": 1,
+        "rulesetFormatVersion": 2,
+        "pipelineVersions": {
+            "accessibility": 1,
+            "accessibility.window": 1,
+            "accessibility.click": 1,
+            "accessibility.long_click": 1,
+            "accessibility.scroll": 1,
+            "accessibility.focus": 1,
+            "notification": 1
+        },
+        "stateMachineApiVersion": "1.0",
+        "appVersion": "0.230.0",
+        "deviceFingerprint": "google/panther/panther:16/CP1A.260405.005/15001963:user/release-keys"
+    },
+    "payload": {
+        "class": "android.widget.FrameLayout",
+        "isEnabled": true,
+        "bounds": {
+            "left": -1,
+            "top": 0,
+            "right": 1078,
+            "bottom": 2400
+        },
+        "children": [
+            {
+                "class": "android.widget.FrameLayout",
+                "isEnabled": true,
+                "bounds": {
+                    "left": -1,
+                    "top": 0,
+                    "right": 1078,
+                    "bottom": 2400
+                },
+                "children": [
+                    {
+                        "id": "android:id/content",
+                        "class": "android.widget.FrameLayout",
+                        "isEnabled": true,
+                        "bounds": {
+                            "left": -1,
+                            "top": 0,
+                            "right": 1078,
+                            "bottom": 2400
+                        },
+                        "children": [
+                            {
+                                "class": "android.view.ViewGroup",
+                                "isEnabled": true,
+                                "bounds": {
+                                    "left": -1,
+                                    "top": 0,
+                                    "right": 1078,
+                                    "bottom": 2400
+                                },
+                                "children": [
+                                    {
+                                        "class": "android.view.View",
+                                        "isEnabled": true,
+                                        "bounds": {
+                                            "left": -1,
+                                            "top": 0,
+                                            "right": 1078,
+                                            "bottom": 2400
+                                        },
+                                        "children": [
+                                            {
+                                                "class": "android.view.View",
+                                                "isEnabled": true,
+                                                "bounds": {
+                                                    "left": -1,
+                                                    "top": 0,
+                                                    "right": 1078,
+                                                    "bottom": 2400
+                                                },
+                                                "children": [
+                                                    {
+                                                        "class": "android.view.View",
+                                                        "isEnabled": true,
+                                                        "bounds": {
+                                                            "left": -1,
+                                                            "top": 0,
+                                                            "right": 1078,
+                                                            "bottom": 2400
+                                                        },
+                                                        "children": [
+                                                            {
+                                                                "desc": "Close sheet",
+                                                                "class": "android.view.View",
+                                                                "isClickable": true,
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": -1,
+                                                                    "top": 0,
+                                                                    "right": 1078,
+                                                                    "bottom": 869
+                                                                }
+                                                            },
+                                                            {
+                                                                "class": "android.view.View",
+                                                                "isEnabled": true,
+                                                                "bounds": {
+                                                                    "left": -1,
+                                                                    "top": 869,
+                                                                    "right": 1078,
+                                                                    "bottom": 2400
+                                                                },
+                                                                "children": [
+                                                                    {
+                                                                        "class": "android.view.View",
+                                                                        "isEnabled": true,
+                                                                        "bounds": {
+                                                                            "left": -1,
+                                                                            "top": 869,
+                                                                            "right": 1078,
+                                                                            "bottom": 2351
+                                                                        },
+                                                                        "children": [
+                                                                            {
+                                                                                "class": "android.view.View",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 503,
+                                                                                    "top": 869,
+                                                                                    "right": 574,
+                                                                                    "bottom": 976
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isClickable": true,
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 485,
+                                                                                            "top": 869,
+                                                                                            "right": 592,
+                                                                                            "bottom": 976
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "desc": "Drag handle",
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 503,
+                                                                                                    "top": 918,
+                                                                                                    "right": 574,
+                                                                                                    "bottom": 927
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "class": "android.view.View",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": -1,
+                                                                                    "top": 976,
+                                                                                    "right": 1078,
+                                                                                    "bottom": 2351
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "desc": "",
+                                                                                        "class": "android.widget.ImageView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 230,
+                                                                                            "top": 976,
+                                                                                            "right": 847,
+                                                                                            "bottom": 1439
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "text": "Confirm you have the correct order before drop-off.",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 34,
+                                                                                            "top": 1475,
+                                                                                            "right": 1042,
+                                                                                            "bottom": 1607
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "text": "Mix-ups frequently occur at drop-off when there are multiple orders in a Dash.",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 34,
+                                                                                            "top": 1643,
+                                                                                            "right": 1042,
+                                                                                            "bottom": 1746
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 34,
+                                                                                            "top": 1730,
+                                                                                            "right": 1042,
+                                                                                            "bottom": 1836
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "text": "[redacted]",
+                                                                                        "class": "android.widget.TextView",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 34,
+                                                                                            "top": 1838,
+                                                                                            "right": 1042,
+                                                                                            "bottom": 1904
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 34,
+                                                                                            "top": 1922,
+                                                                                            "right": 1042,
+                                                                                            "bottom": 2047
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "Artwork Image",
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 34,
+                                                                                                    "top": 1958,
+                                                                                                    "right": 87,
+                                                                                                    "bottom": 2011
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "SPROUTS FARMERS MARKET #118",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 123,
+                                                                                                    "top": 1961,
+                                                                                                    "right": 789,
+                                                                                                    "bottom": 2008
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    {
+                                                                                        "class": "android.view.View",
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 34,
+                                                                                            "top": 2047,
+                                                                                            "right": 1042,
+                                                                                            "bottom": 2172
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "id": "Artwork Image",
+                                                                                                "class": "android.view.View",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 34,
+                                                                                                    "top": 2083,
+                                                                                                    "right": 87,
+                                                                                                    "bottom": 2136
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "text": "4 items",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 123,
+                                                                                                    "top": 2086,
+                                                                                                    "right": 257,
+                                                                                                    "bottom": 2133
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "class": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+                                                                                "isEnabled": true,
+                                                                                "bounds": {
+                                                                                    "left": 34,
+                                                                                    "top": 2202,
+                                                                                    "right": 1042,
+                                                                                    "bottom": 2309
+                                                                                },
+                                                                                "children": [
+                                                                                    {
+                                                                                        "class": "android.widget.Button",
+                                                                                        "isClickable": true,
+                                                                                        "isEnabled": true,
+                                                                                        "bounds": {
+                                                                                            "left": 34,
+                                                                                            "top": 2203,
+                                                                                            "right": 1042,
+                                                                                            "bottom": 2310
+                                                                                        },
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "text": "Continue",
+                                                                                                "id": "com.doordash.driverapp:id/textView_prism_button_title",
+                                                                                                "class": "android.widget.TextView",
+                                                                                                "isEnabled": true,
+                                                                                                "bounds": {
+                                                                                                    "left": 443,
+                                                                                                    "top": 2224,
+                                                                                                    "right": 633,
+                                                                                                    "bottom": 2290
+                                                                                                }
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -73,6 +73,19 @@ card's **mechanical** half, #577 (re-confirmed, 24/24, ~0.55 s — with a new po
 that entry's Bug #1), the #457 path, and #554 ShadowProjector (2/2). The #462/#460 dropoff item
 was found **broken-in-part** (raw PII in capture envelopes) and moved to that entry's Bug #7.)_
 
+- **🆕 NEW — GoPuff / multi-order drop-off confirm card recognized (#501 items 1-2 / this PR).**
+  The "Confirm you have the correct order before drop-off / Mix-ups frequently occur…" card that
+  appears before a drop on a **multi-order Dash** (GoPuff Drive batches AND ordinary multi-merchant
+  grocery batches) is now a recognized screen (`dropoff_multi_order_confirm`) instead of falling to
+  UNKNOWN. It's recognize-only (no state change) — its only job is to stop hitting the UNKNOWN
+  capture folder. **How to tell it's working (desk-side, after a multi-order dash):** the
+  `Confirm…correct order before drop-off` frames should NO LONGER appear under
+  `captures/.../accessibility.window/UNKNOWN/`; they should sort into
+  `accessibility.window/dropoff_multi_order_confirm/`, and the redacted capture must show the
+  customer name line masked (`[redacted:...]`), with the store name + item count kept. Completes
+  #501 (all 3 items). This is the last recognition piece of #501; watch that it doesn't perturb the
+  dropoff flow (no phantom re-mint around the confirm card).
+  - Confirmed: 0/2
 - **🆕 NEW — store entity resolution keys real stores from live dashes (#159 / PR).**
   The read-model now resolves each job's stores (`stores` + `pickup_records` tables) from captured
   pickup/dropoff/payout surfaces. **How to tell it's working (desk-side, after a dash):** on a job with a

--- a/matchers/rules/doordash/dropoff.json5
+++ b/matchers/rules/doordash/dropoff.json5
@@ -389,6 +389,40 @@
       }
     },
     {
+      "comment": "#501 item 2 — the DoorDash multi-order drop-off CONFIRMATION card ('Confirm you have the correct order before drop-off' / 'Mix-ups frequently occur at drop-off when there are multiple orders in a Dash.'), shown before a drop when a Dash carries multiple orders. It appears for BOTH a GoPuff (Drive) warehouse batch AND an ordinary multi-merchant grocery batch — the two committed corpus frames are a GoPuff drop and a Sprouts drop, so this is NOT GoPuff-specific (it's the generic DoorDash multi-order confirm). RECOGNIZE-ONLY (dev decision 2026-07-07, same posture as pickup_wait_survey / the item-3 pickup_zone_arrival rule): no state.flow, no parse — the task:dropoff:navigation flow is already established before this transient modal appears and the card is a confirmation, not a lifecycle anchor, so recognizing it only graduates the frame out of UNKNOWN (silencing the recurring capture) without any risk of a double-mint or phase perturbation. Anchors are unique to this card (grep of the corpus shows no other snapshot carries them), so priority is behaviorally inert. PRIVACY: the card carries an id-LESS customer-name line (first-name + last-initial, e.g. 'Brandon C') that no other control covers — it has no viewId (so the by-id redact misses it) and no 'Deliver to '/'Message from ' marker (so CustomerTextMarkers misses it, the documented split-node residual). The redact below masks it by SHAPE so the recognized capture envelope is PII-clean at the edge (#598); the store name (merchant, driver-owned) and warehouse zone code are kept. The two committed corpus frames were redacted the SAME way by SnapshotRedactor's matching FIRST_LAST_INITIAL masker (#501 item 1).",
+      "id": "doordash.screen.dropoff_multi_order_confirm",
+      "priority": 77,
+      "redact": [
+        {
+          "comment": "The id-less first-name + last-initial customer name. Whole-value anchored (^...$) so it masks ONLY the bare name node, never the multi-word merchant anchor, the zone code, a count, or the 'Confirm ...'/'Mix-ups ...' copy.",
+          "find": {
+            "all": [
+              {
+                "hasTextMatchesRegex": "^[A-Z][a-z]{1,20}( [A-Z][a-z]{1,20}){0,3} [A-Z]\\.?$"
+              },
+              {
+                "hasNoId": true
+              }
+            ]
+          }
+        }
+      ],
+      "require": {
+        "all": [
+          {
+            "exists": {
+              "hasTextContaining": "correct order before drop-off"
+            }
+          },
+          {
+            "exists": {
+              "hasTextContaining": "Mix-ups frequently occur at drop-off"
+            }
+          }
+        ]
+      }
+    },
+    {
       "id": "doordash.screen.dropoff_pre_arrival",
       "priority": 73,
       "redact": [

--- a/matchers/rules/doordash/dropoff.json5
+++ b/matchers/rules/doordash/dropoff.json5
@@ -66,6 +66,19 @@
           "find": {
             "hasIdSuffix": "bottom_sheet_instructions"
           }
+        },
+        {
+          "comment": "Defense-in-depth (FIX 3): a modal-over-handoff combined frame that carries the multi-order-confirm's id-less first-name+last-initial line could be claimed by THIS earlier-priority rule instead of dropoff_multi_order_confirm, whose id-keyed redacts wouldn't cover the id-less name node. Same canonical name-shape SSOT as SnapshotRedactor.FIRST_LAST_INITIAL_PATTERN so the leak closes regardless of which rule wins the frame; hasNoId keeps it off id-bearing nav anchors.",
+          "find": {
+            "all": [
+              {
+                "hasTextMatchesRegex": "^\\s{0,8}[\\p{L}][\\p{L}'-]{0,20}( [\\p{L}][\\p{L}'-]{0,20}){0,3} [A-Z]\\.?\\s{0,8}$"
+              },
+              {
+                "hasNoId": true
+              }
+            ]
+          }
         }
       ],
       "state": {
@@ -328,6 +341,19 @@
               }
             ]
           }
+        },
+        {
+          "comment": "Defense-in-depth (FIX 3): a modal-over-handoff combined frame carrying the multi-order-confirm's id-less first-name+last-initial line could be claimed by THIS earlier-priority rule instead of dropoff_multi_order_confirm. Same canonical name-shape SSOT as SnapshotRedactor.FIRST_LAST_INITIAL_PATTERN so the leak closes regardless of which rule wins the frame; hasNoId keeps it off id-bearing handoff anchors.",
+          "find": {
+            "all": [
+              {
+                "hasTextMatchesRegex": "^\\s{0,8}[\\p{L}][\\p{L}'-]{0,20}( [\\p{L}][\\p{L}'-]{0,20}){0,3} [A-Z]\\.?\\s{0,8}$"
+              },
+              {
+                "hasNoId": true
+              }
+            ]
+          }
         }
       ],
       "state": {
@@ -389,16 +415,16 @@
       }
     },
     {
-      "comment": "#501 item 2 — the DoorDash multi-order drop-off CONFIRMATION card ('Confirm you have the correct order before drop-off' / 'Mix-ups frequently occur at drop-off when there are multiple orders in a Dash.'), shown before a drop when a Dash carries multiple orders. It appears for BOTH a GoPuff (Drive) warehouse batch AND an ordinary multi-merchant grocery batch — the two committed corpus frames are a GoPuff drop and a Sprouts drop, so this is NOT GoPuff-specific (it's the generic DoorDash multi-order confirm). RECOGNIZE-ONLY (dev decision 2026-07-07, same posture as pickup_wait_survey / the item-3 pickup_zone_arrival rule): no state.flow, no parse — the task:dropoff:navigation flow is already established before this transient modal appears and the card is a confirmation, not a lifecycle anchor, so recognizing it only graduates the frame out of UNKNOWN (silencing the recurring capture) without any risk of a double-mint or phase perturbation. Anchors are unique to this card (grep of the corpus shows no other snapshot carries them), so priority is behaviorally inert. PRIVACY: the card carries an id-LESS customer-name line (first-name + last-initial, e.g. 'Brandon C') that no other control covers — it has no viewId (so the by-id redact misses it) and no 'Deliver to '/'Message from ' marker (so CustomerTextMarkers misses it, the documented split-node residual). The redact below masks it by SHAPE so the recognized capture envelope is PII-clean at the edge (#598); the store name (merchant, driver-owned) and warehouse zone code are kept. The two committed corpus frames were redacted the SAME way by SnapshotRedactor's matching FIRST_LAST_INITIAL masker (#501 item 1).",
+      "comment": "#501 item 2 — the DoorDash multi-order drop-off CONFIRMATION card ('Confirm you have the correct order before drop-off' / 'Mix-ups frequently occur at drop-off when there are multiple orders in a Dash.'), shown before a drop when a Dash carries multiple orders. It appears for BOTH a GoPuff (Drive) warehouse batch AND an ordinary multi-merchant grocery batch — the two committed corpus frames are a GoPuff drop and a Sprouts drop, so this is NOT GoPuff-specific (it's the generic DoorDash multi-order confirm). RECOGNIZE-ONLY (dev decision 2026-07-07, same posture as pickup_wait_survey / the item-3 pickup_zone_arrival rule): no state.flow, no parse — the task:dropoff:navigation flow is already established before this transient modal appears and the card is a confirmation, not a lifecycle anchor, so recognizing it only graduates the frame out of UNKNOWN (silencing the recurring capture) without any risk of a double-mint or phase perturbation. Anchors are unique to this card (grep of the corpus shows no other snapshot carries them), so priority is behaviorally inert. PRIVACY: the card carries an id-LESS customer-name line (first-name + last-initial, e.g. 'Brandon C') that no other control covers — it has no viewId (so the by-id redact misses it) and no 'Deliver to '/'Message from ' marker (so CustomerTextMarkers misses it, the documented split-node residual). The redact below masks it by SHAPE so the recognized capture envelope is PII-clean at the edge (#598); the store name (merchant, driver-owned) and warehouse zone code are kept. The name-shape regex is the SSOT shared with SnapshotRedactor.FIRST_LAST_INITIAL_PATTERN — CaptureRedactionCorpusTest asserts the two pattern strings are byte-equal AND both compile IGNORE_CASE (so 'JOSE G'/'Brandon C ' redact identically at runtime and in the committed corpus), so the two copies can't drift (#362 class). RESIDUAL (FIX 5): the runtime redact `find` matches node.text only (there is no hasDescMatchesRegex predicate in the engine — deliberately not built); a name surfaced ONLY via contentDescription would escape this rule at runtime, but SnapshotRedactor already scrubs the desc field on the commit path, so the committed corpus stays clean regardless.",
       "id": "doordash.screen.dropoff_multi_order_confirm",
       "priority": 77,
       "redact": [
         {
-          "comment": "The id-less first-name + last-initial customer name. Whole-value anchored (^...$) so it masks ONLY the bare name node, never the multi-word merchant anchor, the zone code, a count, or the 'Confirm ...'/'Mix-ups ...' copy.",
+          "comment": "The id-less first-name + last-initial customer name. Whole-value anchored (^...$, whitespace-tolerant so a trailing space still masks) so it masks ONLY the bare name node, never the multi-word merchant anchor, the zone code, a count, or the 'Confirm ...'/'Mix-ups ...' copy. Char classes cover accented/Unicode letters (José, Muñoz), interior capitals (McKenna), hyphenated first names (Mary-Jo), and apostrophes (O'Brien, D'Angelo); every quantifier is bounded ({0,20}/{0,3}/{0,8}) so RegexSafety's ReDoS guard accepts it. Compiled IGNORE_CASE (all rule regexes are), so 'JOSE G' masks too. SSOT with SnapshotRedactor.FIRST_LAST_INITIAL_PATTERN.",
           "find": {
             "all": [
               {
-                "hasTextMatchesRegex": "^[A-Z][a-z]{1,20}( [A-Z][a-z]{1,20}){0,3} [A-Z]\\.?$"
+                "hasTextMatchesRegex": "^\\s{0,8}[\\p{L}][\\p{L}'-]{0,20}( [\\p{L}][\\p{L}'-]{0,20}){0,3} [A-Z]\\.?\\s{0,8}$"
               },
               {
                 "hasNoId": true


### PR DESCRIPTION
Completes **#501** — items 1-2 (the two remaining pieces; item 3 zone-arrival shipped in PR #738). On merge the reviewer can **close #501** (all 3 items landed).

## What was built

### Item 1 — SnapshotRedactor: mask the id-less customer-name line
The multi-order drop-off confirm card carries the customer name as a **bare text node with no viewId** (`"Brandon C"`, `"Gilberto U."`). It escaped every existing control:
- no viewId → misses `PII_ID_SUFFIXES`
- no `"Deliver to "`/`"Message from "` marker → misses `NAME_PREFIXES` **and** the runtime `CustomerTextMarkers` backstop (the documented split-node residual)

New `FIRST_LAST_INITIAL` whole-value masker (`^[A-Z][a-z]{1,20}(?: [A-Z][a-z]{1,20}){0,3} [A-Z]\.?$`, bounded quantifiers), fired before the token-level passes. This is the tooling blocker the 2026-07-07 orchestration note called out — without it the dropoff corpus frames could not be committed clean.

### Item 2 — `doordash.screen.dropoff_multi_order_confirm` (recognize-only rule)
Keyed on the two unique anchor strings (`"correct order before drop-off"` + `"Mix-ups frequently occur at drop-off"`). **Recognize-only** (no `state.flow`, no `parse`) — dev decision 2026-07-07, same posture as `pickup_zone_arrival`: the `task:dropoff:navigation` flow is already established before this transient modal appears, so recognizing it only graduates the frame out of UNKNOWN (silencing the recurring capture) with **zero** risk of a double-mint or phase perturbation. Priority **77** (globally free among doordash screen rules); anchors verified unique across the committed corpus (no collision), so priority is behaviorally inert.

The rule declares a **shape-based `redact`** masking the same id-less name, so the recognized **runtime capture envelope** is PII-clean at the edge (#598) even though the name is never parsed.

> Deviation from the 2026-06-15 deep-dive's "recognize + parse (per-drop `customerNameHash`/`dropoffZoneCode`)" table: that was superseded by the 2026-06-18 grounded re-assessment (branch of `dropoff_pre_arrival`, parse-empty) and again by the 2026-07-07 recognize-only re-scope of these secondary GoPuff surfaces. Recognize-only is the lowest-risk, dev-consistent choice and avoids per-drop hashing on a transient confirm modal. I also chose a **standalone** rule over a `dropoff_pre_arrival` branch: a branch would inherit the parent's parse (spuriously hashing `"2 items"` into `customerAddressHash`) and its rule-level redact doesn't cover the id-less name anyway.

## Corpus coverage
Two **REAL redacted 2026-06-14 capture frames** (not hand-built):
- `gopuff_multi_order_confirm.json` — a GoPuff (Drive) warehouse drop (zone code `SAT_San-Antonio_187`)
- `sprouts_multi_order_confirm.json` — an ordinary Sprouts multi-merchant drop (store `SPROUTS FARMERS MARKET #118`)

Committing both proves the card is **not GoPuff-specific** — it's the generic DoorDash multi-order confirm. `GoPuffRecognitionTest` asserts both recognize as `dropoff_multi_order_confirm` with `flow=null`. `approved-parse-output.json` regenerated (both entries `shape:null, fields:{}` — the recognize-only signature).

## Privacy posture
Customer name is the **hash-not-block** class (Pledge). It is masked in **both** privacy surfaces: the committed corpus (SnapshotRedactor) and the runtime capture envelope (rule `redact`). It is **never parsed/sha256'd** (recognize-only), so no `sha256`-requires-redact constraint applies; the redact is declared defensively regardless. Store name (merchant, driver-owned) + item count + warehouse zone code are kept. No new actuation, no network, no state-machine change.

## Test results
`AllMatchersSuite` + `GoPuffRecognitionTest` + `InboxProcessorTest`: **BUILD SUCCESSFUL** (612 tests, 0 failures). Notable green gates: `CaptureBackstopCorpusTest`, `CaptureRedactionCorpusTest`, `GoldenSnapshotRegressionTest`, `ParseOutputGoldenTest` (post-regen). The rule's regex passed `RegexSafety` (initial `+`-nested-in-`*` ReDoS reject was fixed by bounding the quantifiers).

Field-test checklist item added (GoPuff/multi-order dropoff confirm recognized on a live run; `Confirmed: 0/2`).

### Design-goal review
- **P6 (security & privacy)** — the load-bearing goal. The id-less customer name is masked at both the corpus-commit edge (SnapshotRedactor, item 1) and the runtime-capture edge (rule `redact`, item 2). Over-masking is the privacy-safe direction and is guarded by `GoldenSnapshotRegressionTest` (a masked rule-anchor fails it). Recognition can't downgrade the block side (this is a customer-hash surface, not a dasher-block one) and doesn't store raw PII. Regex is `RegexSafety`-bounded (untrusted-input posture holds). What's trusted: nothing new. What's gated: n/a. What's scrubbed: the id-less name, both edges.
- **P8 (platform-agnostic core)** — recognition is **data** (a rule in `matchers/rules/doordash/dropoff.json5`) + a corpus, with **zero** `:core:state`/`:core:pipeline`/`:domain` edits. No new platform literal, no `== Platform.DoorDash`, no new state vocabulary (recognize-only ⇒ no flow). SnapshotRedactor is a test utility. Adding this recognition needed only ruleset + corpus, satisfying the acceptance test.
- **P5 (SSOT)** — the rule `redact` regex and SnapshotRedactor's `FIRST_LAST_INITIAL` are kept semantically identical (same bounded pattern) across the two independent modules that can't share code (rule JSON vs test util).
- Other principles untouched (no UI, no logging site, no reducer, no schema/DB).

### Adversarial review
Not yet run — a separate same-tier reviewer gates this PR (per the #589/#591 loop). Deferring `/code-review` + `/security-review` (P6 + untrusted-input boundary) to that pass.


---

### Adversarial review (Fable-tier, 2026-07-10)

Two finder agents (recognition-rule correctness with the PR #738 anchor-skepticism lesson; a zero-charity privacy/pledge pass over the committed device fixtures and redaction machinery) → ~11 candidates, deduped to 6 fixed + 2 accepted residuals. All fixes in-branch (head `ea2f6a48`); full suite green.

**Fixed — pledge-class (the headline cluster):**
- **Fail-open name shapes:** both the runtime redact regex and the test-side masker were ASCII-only — José R, Núñez, McKenna B, Mary-Jo K, O'Brien M, D'Angelo all escaped BOTH layers, and this card's id-less name node has NO backstop (no CustomerTextMarkers marker) — a raw-name-to-disk leak on common names in the field market. **Fixed:** one canonical Unicode-letter pattern (`\p{L}` classes + apostrophe/hyphen + optional initial period, all quantifiers bounded per the ReDoS guard).
- **"Mirrored" regexes that weren't:** runtime compiled IGNORE_CASE + `containsMatchIn` on raw text; the masker was case-sensitive `matches` on trimmed text — leaks in both directions ('JOSE G' committed raw to corpus; 'Brandon C ' shipped raw in envelopes). **Fixed:** byte-identical pattern string on both sides (whitespace-tolerant ends, IGNORE_CASE both), enforced by an **SSOT drift test** that reads the generated asset and asserts the rule's pattern == the masker constant (#362 class, now impossible to silently diverge).
- **Redact block was attested, not verified** (fixtures pre-masked, so replay never exercised it): injected-synthetic tests now drive all seven name shapes through the rule's redact → `[redacted:<4hex>]`, plus negatives proving the require anchors survive.
- **Combined-frame defense-in-depth:** a modal-over-handoff tree would be claimed by dropoff_navigation (61) / dropoff_handoff (64), whose redacts didn't cover the modal's name node — the same canonical redact entry now rides all three rules, so the leak closes regardless of which rule wins the frame.
- **Commit-path gate:** a new corpus test scans the name-redact folders (text + contentDescription) for unmasked bare-name nodes — masker blind spots are now a red test, not a permanent git leak.

**Accepted residuals (documented in-code):** no `hasDescMatchesRegex` predicate exists in the engine, so a Compose semantics change moving the name into contentDescription is out of the runtime redact's reach (SnapshotRedactor covers desc on the commit path; engine-vocabulary work deliberately out of scope); the masker's whole-corpus false-positive surface ("Vitamin C" / "Terminal B" shapes) is an accepted privacy-first trade-off with its guards named.

**Rule-correctness verdicts:** priority 77 globally unique; both fixtures are sheet-only window trees so the priority shield is structural for the fielded shape (the combined-frame case handled above); recognize-only integrity confirmed (no state/parse; golden entries are the recognize-only signature); the fixtures prove the card is NOT GoPuff-specific (Sprouts multi-merchant frame committed alongside).

This PR completes #501 (items 1–3 all shipped) — close on merge.
