### PR TITLE
docs(#247): per-platform recognition-strategy READMEs (doordash, uber)

### DIFF
--- a/matchers/rules/doordash/README.md
+++ b/matchers/rules/doordash/README.md
@@ -44,7 +44,12 @@ That said, several real surfaces blend into each other and need care:
 - **Shared anchors across adjacent screens.** The dropoff arrival card and the pickup arrival
   card both carry the text `"Delivery for"`; a dropoff-specific discriminator (`"Hand it to
   recipient"` / the `complete_delivery_steps_button` id) is required alongside it so the pickup
-  card doesn't get stolen (`dropoff.json5`, the `dropoff_navigation`/arrival-card rule).
+  card doesn't get stolen — that's `dropoff.json5`'s `dropoff_pre_arrival` rule, whose own comment
+  documents the three require branches (#462/#460/#549). `dropoff_navigation` (the earlier,
+  en-route rule) has the opposite relationship to that same CTA set: it `reject`s
+  `complete_delivery_steps_button`/"Continue"/"Complete Delivery"/"Mark as delivered" (the #603
+  arrival discriminator), so an at-the-door frame falls through to `dropoff_pre_arrival` instead of
+  being claimed early by the en-route rule.
 - **Priority ordering as a disambiguator, not just a tie-break.** Several `pickup.json5` rules
   are commented with explicit priority reasoning — e.g. the GoPuff zone-arrival rule's anchors
   (`go_to_store_action_view` + an "Arrived at store" label) also appear on every regular
@@ -81,9 +86,12 @@ the rules' job is just to recognize each screen and extract its fields.
 ## Field extraction notes
 
 - **Customer identity is hashed at the edge, never stored raw.** Where a rule parses customer
-  name/address, the field's `transform` is `sha256` (e.g. `dropoff.json5`'s handoff/receipt
-  parses) — this is how customers are differentiated for dedup/correlation without keeping their
-  actual info (the Pledges' "customers are hashed, not blocked").
+  name/address, the field hashes it via a `sha256`-terminated transform chain — e.g.
+  `dropoff.json5`'s `dropoff_navigation`, `dropoff_pre_arrival`, and
+  `dropoff_pre_arrival_completion` rules, the dropoff task-phase parses that actually extract
+  `customerNameHash`/`customerAddressHash` — this is how customers are differentiated for
+  dedup/correlation without keeping their actual info (the Pledges' "customers are hashed, not
+  blocked").
 - **The capture envelope is redacted independently of the parse.** Every rule that hashes PII in
   its `parse` also declares a `redact` block (compiler-enforced, #598) masking the same node text
   in the serialized capture, so a debug capture of a recognized screen never carries plaintext

--- a/matchers/rules/doordash/README.md
+++ b/matchers/rules/doordash/README.md
@@ -1,0 +1,125 @@
+# DoorDash recognition strategy
+
+This README explains **how recognition works for DoorDash** and why — context for a future
+contributor (in-tree today, community rule author once Pillar 2 / #192 lands) editing or adding
+rules under this directory. It does not restate the rule DSL (that's
+[ADR-0001](../../../docs/adr/ADR-0001-matcher-rule-format.md)) or the build/canonicalizer
+(that's [`matchers/README.md`](../../README.md)) — read those first if you haven't.
+
+## Surface map
+
+DoorDash's rules are split into surface sub-files (#639) instead of one flat file, because the
+DoorDash Driver app itself is organized as a sequence of **discrete, separable screens** — each
+sub-file owns one family of those screens:
+
+| File | Owns |
+|---|---|
+| `_manifest.json5` | Platform header only (`format_version`, `platform_id`) — no rules |
+| `sensitive.json5` | Dasher banking/identity + document-image capture surfaces — blocked, never parsed |
+| `offer.json5` | The incoming-offer popup and its accept/decline/confirm-decline actuation targets |
+| `dash-lifecycle.json5` | Start/pause/resume/end, scheduling, idle & waiting-for-offer, the end-of-dash summary |
+| `pickup.json5` | Pickup navigation, arrival, shopping, item verification, issue/resolution sub-screens (incl. GoPuff/Drive warehouse batch) |
+| `dropoff.json5` | Dropoff navigation, arrival/handoff, photo & PIN, delivery receipt/summary, alcohol-ID recognition |
+| `nav-comms.json5` | Generic navigation and in-app chat |
+| `ratings-feedback.json5` | Post-delivery ratings and safety feedback |
+| `chrome.json5` | App chrome — side menu, earnings, help, promos, notifications view, camera capture |
+| `notifications.json5` | System notifications (order/tip/earnings/weather/etc.) |
+
+The canonicalizer merges these (sorted by filename, `_manifest` excepted) into one
+`assets/rules/doordash.json`; splitting a screen family into its own file is purely an authoring
+convenience — see `matchers/README.md` for why the merge is behaviorally inert.
+
+## Recognition strategy: discrete screen matching
+
+DoorDash screens are largely **discrete and separable** — one screen, one purpose, a stable set
+of widget IDs and copy. The dominant matching style here is **exact tree match**: a rule anchors
+on a widget `hasIdSuffix` (an Android resource-id suffix, stable across the app's res-id
+prefix/version churn) or a small set of literal/regex text conditions unique to that screen, and
+often both together for precision. Contrast this with Uber's affordance-set strategy below —
+DoorDash rarely needs to reason about "what's currently visible" because each screen's tree shape
+is, on its own, close to unambiguous.
+
+That said, several real surfaces blend into each other and need care:
+
+- **Shared anchors across adjacent screens.** The dropoff arrival card and the pickup arrival
+  card both carry the text `"Delivery for"`; a dropoff-specific discriminator (`"Hand it to
+  recipient"` / the `complete_delivery_steps_button` id) is required alongside it so the pickup
+  card doesn't get stolen (`dropoff.json5`, the `dropoff_navigation`/arrival-card rule).
+- **Priority ordering as a disambiguator, not just a tie-break.** Several `pickup.json5` rules
+  are commented with explicit priority reasoning — e.g. the GoPuff zone-arrival rule's anchors
+  (`go_to_store_action_view` + an "Arrived at store" label) also appear on every regular
+  pre-arrival tree, so it only stays scoped to the GoPuff case because a more specific regular
+  pre-arrival rule is evaluated first (lower priority number) and the GoPuff rule's `reject`
+  clauses explicitly exclude a degraded regular frame from falling through to it.
+- **Recognize-only rules for transient interstitials.** Confirmation modals, surveys, and
+  issue-menu sub-screens that don't change the driver's actual task phase are recognized (so they
+  stop appearing as `UNKNOWN` captures) but declare no `state.flow` — they can't perturb the state
+  machine, only pull noise out of the capture pipeline. `pickup.json5`'s wait-survey and
+  `dropoff.json5`'s multi-order-confirm are both this shape.
+
+### GoPuff (DoorDash Drive) — warehouse batch is a branch, not a platform
+
+GoPuff orders route through the DoorDash app but present a **warehouse batch** flow instead of
+a normal single-store pickup: one store, a bin-scan step for N items, a single "complete pickup"
+action, then N customer dropoffs. This is handled as **branches of the existing pickup rules**,
+not a separate platform or a parallel rule tree — see `pickup.json5`'s bin-scan-steps and
+zone-arrival rules. The warehouse leg was previously almost entirely `UNKNOWN` (no arrival ever
+fired because the ordinary pickup-arrival anchors don't appear), so the bin-scan-steps branch
+declares the one `task:pickup:arrived` anchor for the whole batch; the zone-arrival screen that
+precedes it is recognize-only (nav is already established by that point, and its "Arrived at
+store" button label is an affordance, not the arrival anchor).
+
+### Offer attribution and multi-store/multi-order batches
+
+A DoorDash offer can bundle multiple stores and/or multiple orders (grocery batches, GoPuff).
+`dropoff.json5`'s multi-order-confirm screen exists specifically because mix-ups are common at
+drop-off when a dash carries more than one order — it is not GoPuff-specific, it's the generic
+DoorDash multi-order confirmation. Store/task attribution across a multi-drop batch is a state-
+machine concern (see CLAUDE.md's job-container model), not something the rules encode directly;
+the rules' job is just to recognize each screen and extract its fields.
+
+## Field extraction notes
+
+- **Customer identity is hashed at the edge, never stored raw.** Where a rule parses customer
+  name/address, the field's `transform` is `sha256` (e.g. `dropoff.json5`'s handoff/receipt
+  parses) — this is how customers are differentiated for dedup/correlation without keeping their
+  actual info (the Pledges' "customers are hashed, not blocked").
+- **The capture envelope is redacted independently of the parse.** Every rule that hashes PII in
+  its `parse` also declares a `redact` block (compiler-enforced, #598) masking the same node text
+  in the serialized capture, so a debug capture of a recognized screen never carries plaintext
+  customer text either. Some redacts are shape-based rather than id-based — e.g. the multi-order-
+  confirm card's customer line has no `viewId` and no `"Deliver to "`/`"Message from "` marker for
+  the cross-platform `CustomerTextMarkers` backstop to catch, so its `redact` matches the
+  first-name + last-initial name shape directly (the same regex `SnapshotRedactor` uses on the
+  test-corpus side, kept byte-equal by `CaptureRedactionCorpusTest` so the two can't drift).
+- **Merchant/store names are kept, not hashed.** They're driver-owned business information, not
+  customer PII — see any `dropoff.json5`/`pickup.json5` parse that reads a store name plainly.
+
+## Sensitive vs. hashed boundary
+
+Two different postures apply to two different kinds of screen, per the Pledges (CLAUDE.md):
+
+- **Blocked, never parsed or stored** — the dasher's own banking/identity screens (DasherDirect /
+  Crimson balance & transfers, card details, cash-out) and document-image capture surfaces (the
+  license-scan camera, the signature pad), regardless of whose ID/signature it is. These live in
+  `sensitive.json5`: `doordash.screen.sensitive.known` is priority 0, `overrideable: false` —
+  structurally first, so nothing else in the ruleset can pre-empt the block — plus a low-
+  confidence `sensitive.catchall` backstop (priority 999, `overrideable: true`) that only fires
+  when nothing more specific already recognized the screen.
+- **Recognized and hashed** — customer-facing delivery screens, including an alcohol delivery's
+  ID-CHECK instruction screen and arrival card (`dropoff.json5`'s
+  `dropoff_alcohol_id_intro`/`alcohol_id_check`/`alcohol_verify_*` rules). Only the literal
+  scanner/signature capture surfaces are sensitive; the surrounding instruction and confirmation
+  screens are ordinary recognized-and-hashed customer screens.
+
+A recognition change to either family must not blur this line — see CLAUDE.md's "Security &
+privacy first" principle and the load-time sensitive-coverage guard that fails closed if a
+platform ships screen rules without matching sensitive rules.
+
+## Framing note
+
+Everything above describes **empirical measurement of the visible offer/screen surface** the
+DoorDash Driver app already renders on the dasher's own device — the same information a sighted
+driver reads off their own screen. See `LEGAL.md` and `matchers/README.md`'s "Framing" section for
+the full posture; nothing here characterizes DoorDash's internal systems (routing, pricing,
+dispatch), only the screens a driver sees.

--- a/matchers/rules/uber.md
+++ b/matchers/rules/uber.md
@@ -85,11 +85,25 @@ Same two-tier posture as DoorDash, applied to Uber's own screens:
   identity screens. `uber.screen.sensitive.known` is priority 0, `overrideable: false`
   (structurally first); `sensitive.catchall` is the low-confidence backstop (priority 998,
   `overrideable: true`) for anything the specific rules miss.
-- **Recognized and hashed** — customer-facing delivery screens (`customer_chat`,
-  `delivery_confirmation`, the per-leg trip notifications). Customer name/address fields go through
-  `sha256` in the `parse`, with a matching `redact` block masking the same text in the capture
-  envelope (e.g. `trip_en_route_dropoff`/`trip_at_dropoff` redact their title with a `keepPrefix`
-  marker so recognition on replay is unchanged, per #598/#623).
+- **Recognized, not (yet) hashed — `customer_chat`/`delivery_confirmation` are recognize-only.**
+  `uber.screen.customer_chat` and `uber.screen.delivery_confirmation` are recognized (so they
+  graduate out of `UNKNOWN` capture) but declare no `parse` block at all — nothing is extracted
+  from either screen today, so there's no customer name/address field to hash. `uber.json5` has
+  zero `sha256` transforms; the file's only masking lives on the two per-leg trip
+  **notifications**, `trip_en_route_dropoff`/`trip_at_dropoff`, which `redact` their title
+  directly (not derived from any parsed/hashed field). The two differ in shape: `trip_at_dropoff`
+  masks with a `keepPrefix` (`"Leave the order at "`/`"Meet at door for "`) so its own require (a
+  literal-text match) still recognizes the redacted title on replay — the #598/#623 replay-
+  fidelity property. `trip_en_route_dropoff` instead masks the **whole title, no keepPrefix** —
+  deliberately, because its require is `titleMatchesRegex: "^Going to \\d"` (digit-anchored, to
+  distinguish a dropoff address from the pickup notification's `^Going to (?!\d)` store name); if
+  the mask kept the `"Going to "` prefix, the character right after it would be the
+  `[redacted:…]` marker rather than a digit, and the rule's own require could no longer re-match
+  the redacted envelope on replay — so whole-masking is the only replay-safe choice here, not an
+  oversight. If/when a customer field is ever parsed off a Uber screen, follow the DoorDash
+  hash+redact pattern (a `sha256`-terminated transform plus a matching `redact` block) — see
+  [`doordash/README.md`](doordash/README.md)'s "Field extraction notes" — rather than inventing a
+  second scheme.
 
 A recognition change to either family must not blur this line — see CLAUDE.md's "Security &
 privacy first" principle and the load-time sensitive-coverage guard that fails closed if a platform

--- a/matchers/rules/uber.md
+++ b/matchers/rules/uber.md
@@ -1,0 +1,124 @@
+# Uber recognition strategy
+
+This README explains **how recognition works for Uber** and why — context for a future
+contributor (in-tree today, community rule author once Pillar 2 / #192 lands) editing or adding
+rules in `uber.json5`. It does not restate the rule DSL (that's
+[ADR-0001](../../docs/adr/ADR-0001-matcher-rule-format.md)) or the build/canonicalizer (that's
+[`matchers/README.md`](../README.md)) — read those first if you haven't. Uber stays a **flat
+single file** rather than a directory of surface sub-files (contrast DoorDash) because its
+recognition strategy below doesn't decompose cleanly into separable screen families — see
+"Surface map" below for why.
+
+## Surface map
+
+`uber.json5` is one file, but its rules still group into families:
+
+| Group | Owns |
+|---|---|
+| `sensitive.known` / `sensitive.catchall` | Wallet / Instant Pay / cash-out / bank / identity — blocked, never parsed |
+| `offer` | The incoming-offer/match card and its accept target |
+| `splash` | App launch/splash |
+| `pickup_verification_*` | Pickup PIN/items/info verification sub-screens |
+| `customer_chat` | In-app customer chat |
+| `photo_capture` | Delivery photo capture |
+| `delivery_confirmation` | Dropoff confirmation |
+| `shop_and_pay_*` | Shop-and-deliver order list + checkout |
+| `post_trip` / `session_summary` | End-of-trip and end-of-session summaries |
+| `earnings_activity` | Earnings/activity screen |
+| `active_trip` / `awaiting_offer` / `idle_map` / `home_dashboard` | The online/offline + trip-active state surfaces (see below) |
+| `notifications.*` | System notifications, incl. the persistent "you're online" push and per-leg trip pushes |
+
+## Recognition strategy: affordance-set matching, not exact tree match
+
+Uber's screens **blend into each other** — shared chrome, a persistent map background, transient
+sheets and overlays — rather than DoorDash's discrete, separable screens (2026-05-09 field
+session). Recognizing a screen on Uber is less about "does this exact tree match" and more about
+**"what set of affordances is currently visible."** Concretely:
+
+- Rules anchor on stable `hasIdSuffix` widget ids (survives Uber's res-id churn) **combined with**
+  the presence/absence of specific text, because a single id often exists on more than one surface
+  in a given mode.
+- **The online/offline "two valid screens" problem is handled by branches, one per surface.**
+  Going online or offline is reachable from **two different surfaces** — the post-splash home
+  dashboard (`glide_bottom_nav_home` + a `go_online_button` id) and the full map screen
+  (`home_screen_overlay_container`) — and each surface's layout differs from the other. Instead of
+  one matcher keyed on a telltale that only exists on one surface (which is what caused the
+  online/offline flapping in the 2026-05-09 session), `uber.screen.home_dashboard` and
+  `uber.screen.idle_map`/`uber.screen.active_trip`/`uber.screen.awaiting_offer` are separate rules,
+  each keyed on ids specific to its own surface, all converging on the same `modeHint` (`online`/
+  `offline`) so downstream state doesn't care which surface the driver is looking at.
+- **Text presence/absence, not just presence, is a first-class signal.** `idle_map`'s `require`
+  includes `notExists: "You're online"` and `notExists: "Finding trips"` alongside its id anchor —
+  it has to actively rule out the online affordances, not just check for the offline one, because
+  the container id it anchors on isn't unique to the offline state.
+
+## Field extraction notes
+
+- **Uber gives offer duration as minutes directly; DoorDash gives a deadline timestamp.** The offer
+  rule's `timeToCompleteMinutes` field (`parseLeadingInt` off a `\d+\s*min` match) has no DoorDash
+  analog — DoorDash offers carry a due-time instead. Anything consuming offer timing across both
+  platforms needs to convert one representation to the other rather than assuming a shared raw
+  field (2026-05-09 field session, item 3 — the TTS bug that motivated this).
+- **Multi-order offers are parsed as a list within one offer, not multiple concurrent offers.** The
+  offer rule's `orders.each` extracts one `storeName`/entry per order card inside a single offer
+  (a shop-and-pay-style batch). This is a different thing from the **"match" screen** the
+  2026-05-09 session also observed, which can show more than one *separate* offer at once — that
+  screen is not yet a distinct recognized rule (open question #9 in the field log); the current
+  `offer` rule only accepts `"Accept"` or `"Match"` as the button label on a single offer card.
+- **The "Going to " prefix is store/address-ambiguous** — Uber's en-route pickup and en-route
+  dropoff notifications share the same `"Going to "` prefix, distinguished only by whether what
+  follows starts with a digit (a dropoff street address) or not (a store name):
+  `uber.notification.trip_en_route_pickup` requires `^Going to (?!\d)`, `trip_en_route_dropoff`
+  requires `^Going to \d`. This is a documented residual (CLAUDE.md) that a generic prefix-based PII
+  scrub can't own on its own — the rule-declared `redact` on the dropoff notification is the primary
+  control for that field, not the cross-platform text-marker backstop.
+- **Overlay-rendered offers are captured via `getWindows()`.** The 2026-05-09 session found some
+  Uber offers render as a `SYSTEM_ALERT_WINDOW`-style overlay that a normal single-window
+  accessibility read misses; `AccessibilitySource.getWindows()` (with `flagRetrieveInteractiveWindows`
+  in the service config) enumerates all windows so the overlay surface is captured like any other.
+
+## Sensitive vs. hashed boundary
+
+Same two-tier posture as DoorDash, applied to Uber's own screens:
+
+- **Blocked, never parsed or stored** — the dasher's wallet, Instant Pay, cash-out, bank, and
+  identity screens. `uber.screen.sensitive.known` is priority 0, `overrideable: false`
+  (structurally first); `sensitive.catchall` is the low-confidence backstop (priority 998,
+  `overrideable: true`) for anything the specific rules miss.
+- **Recognized and hashed** — customer-facing delivery screens (`customer_chat`,
+  `delivery_confirmation`, the per-leg trip notifications). Customer name/address fields go through
+  `sha256` in the `parse`, with a matching `redact` block masking the same text in the capture
+  envelope (e.g. `trip_en_route_dropoff`/`trip_at_dropoff` redact their title with a `keepPrefix`
+  marker so recognition on replay is unchanged, per #598/#623).
+
+A recognition change to either family must not blur this line — see CLAUDE.md's "Security &
+privacy first" principle and the load-time sensitive-coverage guard that fails closed if a platform
+ships screen rules without matching sensitive rules.
+
+## Known gotchas / open questions
+
+These are observed but not fully resolved in the rules yet — noted here so a future author doesn't
+have to rediscover them:
+
+- **Slide-to-confirm advance affordances** (pickup → dropoff → complete) may not surface as a
+  normal click event depending on how Uber implements the widget (SeekBar-style progress event,
+  a completion-triggered click, or a pure gesture with no accessibility action at all) — see the
+  2026-05-09 field log item 7 for the three candidate shapes; whichever one a given Uber build uses
+  determines whether a `click` rule can key on it directly or recognition has to infer the advance
+  from the screen transition that follows.
+- **The persistent "you're online" notification is still classified as noise**
+  (`uber.notification.online_status`, `parse.as: "noise"`), even though its body text changes with
+  the active leg (e.g. "picking up from …" vs. "going to …") and its action buttons change with leg
+  too. Given Uber's blended UI and overlay-style offers, this notification is a plausible richer
+  continuous signal of "what leg is the driver on right now" — but re-shaping it into a parsed,
+  leg-correlated rule hasn't been done (2026-05-09 field log item 6).
+- **The multi-offer "match" screen** (more than one offer visible at once) has no dedicated rule —
+  see "Field extraction notes" above.
+
+## Framing note
+
+Everything above describes **empirical measurement of the visible offer/screen surface** the Uber
+Driver app already renders on the dasher's own device — the same information a sighted driver reads
+off their own screen. See `LEGAL.md` and `matchers/README.md`'s "Framing" section for the full
+posture; nothing here characterizes Uber's internal systems (dispatch, pricing, matching), only the
+screens a driver sees.


### PR DESCRIPTION
[skip ci]

## Summary

Per the 2026-07-07 bounded spec on #247, adds a per-platform recognition-strategy README next to
each platform's rule source:

- `matchers/rules/doordash/README.md` — new file (sibling of the `doordash/` sub-file directory)
- `matchers/rules/uber.md` — new file (sibling of `uber.json5`; kept as a `.md` file rather than
  converting Uber into a directory, per the spec's hard boundary — `uber.json5` is untouched and
  stays flat)

Docs only. No `.json5`, `.kt`, or schema changes.

### What each README covers

Both READMEs cover the same four areas the spec asked for, without duplicating
`matchers/README.md` (build/canonicalizer) or the ADRs (format/distribution) — they link to those
instead:

1. **Surface map** — which sub-file (DoorDash) or rule group (Uber) owns which screen family.
2. **Recognition strategy** — DoorDash's discrete/separable "exact tree match" (widget id +
   literal/regex text) vs. Uber's "flowy" **affordance-set matching** (id + text
   presence/absence, branched per surface to fix the historical online/offline flapping described
   in the 2026-05-09 field session).
3. **Field extraction notes** — platform-specific parser quirks grounded in the current rule
   source and the field log: DoorDash's GoPuff warehouse-batch branch, multi-order attribution,
   sha256 hashing + redact pairing; Uber's minutes-vs-deadline offer field, the multi-order-within-
   one-offer (`orders.each`) vs. still-unbuilt multi-offer "match" screen, the `"Going to "`
   store/address-ambiguous notification prefix, and the `getWindows()` overlay-offer capture fix.
4. **Known gotchas** — DoorDash's sensitive/hashed boundary tied to the load-time coverage guard;
   Uber's still-open items (slide-to-confirm accessibility shape, the still-noise "you're online"
   notification, the unbuilt match screen).

Every claim was cross-checked against the actual `.json5` rule source (ids, priorities, `require`/
`redact` shapes) rather than restated from memory — grep receipts are in the PR discussion if
needed.

### Framing discipline check

Confirmed: `grep -in "reverse\|decompile\|model recovery\|characterize the platform"` over both new
files returns no matches. Both READMEs describe recognition as reading the driver's own on-screen
affordances (framed per LEGAL.md "Purpose"/§15.4 and `matchers/README.md`'s "Framing" section), and
the PII framing matches the Pledges: customers are hashed at the edge (`sha256` + rule `redact`),
the dasher's own sensitive screens (banking/identity/document-image capture) are blocked, never
parsed.

### Stale-premise note

The bounded spec was verified against master @ `f46a35b3`; master has since moved to `50da0874`
(through #241/#742/#743/#744). None of the intervening merges touched the doordash sub-file
layout, `uber.json5`'s flat-file shape, or the ADRs/matchers/README.md this doc links to, so the
spec's core premises held — no adaptation was needed beyond writing against current rule content.

## Design-goal review

- **Principle 5 (SSOT):** the READMEs deliberately don't restate the DSL (ADR-0001), the
  distribution architecture (ADR-0009), or the build/canonicalizer topology
  (`matchers/README.md`) — they link to each rather than creating a second, driftable copy.
- **Principle 6 (Security & privacy first):** both READMEs describe the sensitive-vs-hashed
  boundary exactly as implemented (priority-0 non-overrideable block vs. sha256+redact hashing)
  and reproduce no plaintext PII; framing language was self-checked against LEGAL.md/CLAUDE.md's
  reverse-engineering-avoidance rule (see above). No behavior changed — nothing to gate or scrub.
- **Principle 8 (Platform-agnostic core):** not touched — these are per-platform *docs*, not core
  logic; no `:core:state`/`:core:pipeline`/`:domain` edits, and the READMEs exist precisely to keep
  platform-specific reasoning out of the shared core (documenting the DoorDash/Uber divergence in
  data-adjacent docs rather than in code).

Other principles (UDF, MAD, Kotlin/Android practices, semantic logging, Reactive UI) aren't
touched by a docs-only diff.

## Security / privacy posture

No code, capture, network, or effect surface touched. The diff is two new Markdown files under
`matchers/rules/`; nothing here changes what's trusted, gated, or scrubbed.

## Adversarial review

Per the orchestration note on #247, this is routed for **light top-tier review** — a separate
fable-tier reviewer gates merge per CLAUDE.md's adversarial-review requirement; not self-attested
here.

Closes #247.


---

### Adversarial review (Fable-tier, 2026-07-10)

One verification finder (proportionate to a docs-only diff), three angles: **framing discipline** (the public-repo bar — these files are destined for the forkable matchers repo), **claims vs the live rule source** (~19 checked), and **privacy-boundary accuracy**.

**Framing: CLEAN.** Every sentence scanned adversarially — no reverse-engineering / model-recovery / algorithm-characterization / circumvention overtones; both framing notes hold the CLAUDE.md discipline; the `getWindows()` overlay paragraph attributes the gap to our own read, not to the platform hiding anything.

**Four claim errors found → all fixed in-branch (commit `2f793d86`):**
- *uber.md overstated the privacy pipeline* (pledge-communication defect): claimed customer fields are sha256-hashed in the parse — uber.json5 has ZERO sha256 transforms; the customer-bearing screens are recognize-only (nothing extracted). Rewritten to the true posture with a cross-reference to the DoorDash hash+redact pattern for future parses.
- *Wrong keepPrefix claim*: `trip_en_route_dropoff` is deliberately whole-masked (its digit-anchored `^Going to \d` require makes prefix-keeping replay-breaking); only `trip_at_dropoff` has the keepPrefix replay-fidelity property. Now distinguished and explained.
- *Wrong sha256 exemplars*: handoff is redact-only and receipts parse only money — replaced with the real three hash sites (dropoff_navigation / dropoff_pre_arrival / dropoff_pre_arrival_completion), phrased to stay true after #745's transform-chain change.
- *Discriminator attributed to the wrong rule*: the 'Delivery for'+CTA branches live in `dropoff_pre_arrival`; `dropoff_navigation` REJECTS that CTA set (#603) — attribution corrected with the reject relationship.

**Verified clean beyond the fixes:** the 10-file surface map, GoPuff branch/zone-arrival descriptions (incl. the load-bearing rejects), the priority-0 sensitive block + catchall, alcohol-flow rule ids, the Uber online/offline branch fix history, `orders.each` parsing, the "Going to " prefix split. Boundary posture accurate on the DoorDash side; the Uber side's overstatement was finding 1, now fixed.
