### PR TITLE
chore(#428): route TTS/notification/ViewModel copy through strings.xml (Half A, no i18n)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -75,6 +75,10 @@ android {
     }
 
     testOptions {
+        // Robolectric needs the compiled app resources (not just the SDK's) to resolve a
+        // @StringRes id via a real Context — e.g. AnalyticsTabTest's resolved-label guard (#428).
+        // Without this, Context.getString() throws Resources.NotFoundException in a unit test.
+        unitTests.isIncludeAndroidResources = true
         unitTests.all { test ->
             test.jvmArgs("-XX:+EnableDynamicAgentLoading")
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/TipEffectHandler.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/TipEffectHandler.kt
@@ -1,9 +1,12 @@
 package cloud.trotter.dashbuddy.state.effects
 
+import android.content.Context
+import cloud.trotter.dashbuddy.R
 import cloud.trotter.dashbuddy.domain.model.chat.ChatPersona
 import cloud.trotter.dashbuddy.domain.format.Formats
 import cloud.trotter.dashbuddy.core.state.AppEffect
 import cloud.trotter.dashbuddy.ui.bubble.BubbleManager
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -13,7 +16,8 @@ import javax.inject.Singleton
 
 @Singleton
 class TipEffectHandler @Inject constructor(
-    private val bubbleManager: BubbleManager
+    private val bubbleManager: BubbleManager,
+    @param:ApplicationContext private val context: Context,
 ) {
 
     fun process(scope: CoroutineScope, effect: AppEffect.ProcessTipNotification) {
@@ -26,7 +30,11 @@ class TipEffectHandler @Inject constructor(
                     "Tip received: %s from %s", Formats.money(effect.amount), effect.storeName,
                 )
                 bubbleManager.postMessage(
-                    text = "Nice! ${Formats.money(effect.amount)} tip from ${effect.storeName}",
+                    text = context.getString(
+                        R.string.tip_effect_chat_message,
+                        Formats.money(effect.amount),
+                        effect.storeName,
+                    ),
                     persona = ChatPersona.Dispatcher
                 )
             } catch (e: Exception) {

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/TtsEffectHandler.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/TtsEffectHandler.kt
@@ -6,6 +6,7 @@ import android.media.AudioFocusRequest
 import android.media.AudioManager
 import android.speech.tts.TextToSpeech
 import android.speech.tts.UtteranceProgressListener
+import cloud.trotter.dashbuddy.R
 import cloud.trotter.dashbuddy.domain.evaluation.OfferAction
 import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -90,17 +91,27 @@ class TtsEffectHandler @Inject constructor(
     }
 
     private fun formatEvaluation(eval: OfferEvaluation): String {
-        val verdict = when (eval.action) {
-            OfferAction.ACCEPT -> "Accept"
-            OfferAction.DECLINE -> "Decline"
-            OfferAction.MANUAL_REVIEW -> "Review"
-            else -> "Offer"
-        }
-        return "$verdict. ${eval.merchantName.trim()}. " +
-            "${Formats.decimal(eval.dollarsPerHour, 0)} dollars an hour net. " +
-            "Net ${Formats.decimal(eval.netPayAmount, 2)}, " +
-            "${Formats.decimal(eval.distanceMiles)} miles, " +
-            "score ${eval.score.toInt()}."
+        // #428 Half A: the verdict word + template connectives moved to strings.xml (string
+        // ownership, NOT locale-selected TTS — the engine still speaks Locale.US regardless of
+        // device locale; per-language reading is a separate, out-of-scope design issue).
+        // Formats.decimal(...) numeric formatting is unchanged — only the literal words moved.
+        val verdict = context.getString(
+            when (eval.action) {
+                OfferAction.ACCEPT -> R.string.tts_verdict_accept
+                OfferAction.DECLINE -> R.string.tts_verdict_decline
+                OfferAction.MANUAL_REVIEW -> R.string.tts_verdict_review
+                else -> R.string.tts_verdict_offer
+            }
+        )
+        return context.getString(
+            R.string.tts_offer_evaluation_template,
+            verdict,
+            eval.merchantName.trim(),
+            Formats.decimal(eval.dollarsPerHour, 0),
+            Formats.decimal(eval.netPayAmount, 2),
+            Formats.decimal(eval.distanceMiles),
+            eval.score.toInt().toString(),
+        )
     }
 
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManager.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManager.kt
@@ -156,13 +156,26 @@ class BubbleManager @Inject constructor(
     /** Session chat copy only — the dash id derives from state (#437). */
     fun startSession(sessionId: String, platformName: String) {
         val verb = sessionVerb(platformName)
-        postMessage("Started $verb!", ChatPersona.Dispatcher)
+        postMessage(context.getString(R.string.bubble_chat_session_started, verb), ChatPersona.Dispatcher)
     }
 
     /** Session chat copy only — the dash id derives from state (#437). */
     fun endSession(platformName: String? = null) {
         val verb = sessionVerb(platformName)
-        postMessage("Done $verb!", ChatPersona.Dispatcher)
+        postMessage(context.getString(R.string.bubble_chat_session_done, verb), ChatPersona.Dispatcher)
+    }
+
+    /**
+     * The first-run/ready-to-dash welcome chat line (#428 Half A). Owned here (not
+     * [cloud.trotter.dashbuddy.ui.main.dashboard.DashboardViewModel]) because [BubbleManager] already
+     * carries a [Context] and a `@HiltViewModel` should not inject one.
+     */
+    fun postWelcomeMessage() {
+        postMessage(
+            text = context.getString(R.string.bubble_welcome_message),
+            persona = ChatPersona.Dispatcher,
+            expand = true,
+        )
     }
 
     /**
@@ -204,9 +217,9 @@ class BubbleManager @Inject constructor(
 
     private fun createChannel() {
         val channel = NotificationChannel(
-            channelId, "DashBuddy Stream", NotificationManager.IMPORTANCE_HIGH
+            channelId, context.getString(R.string.bubble_channel_stream_name), NotificationManager.IMPORTANCE_HIGH
         ).apply {
-            description = "Live updates from your session"
+            description = context.getString(R.string.bubble_channel_stream_description)
             setAllowBubbles(true)
         }
         notificationManager.createNotificationChannel(channel)
@@ -216,9 +229,9 @@ class BubbleManager @Inject constructor(
         // — forcing a shade-pull that breaks the Accept/Decline verified click. This channel never
         // bubbles, so an offer posts as a normal high-importance heads-up over DoorDash.
         val offerChannel = NotificationChannel(
-            offerChannelId, "Offer Alerts", NotificationManager.IMPORTANCE_HIGH
+            offerChannelId, context.getString(R.string.bubble_channel_offer_name), NotificationManager.IMPORTANCE_HIGH
         ).apply {
-            description = "Heads-up offer alerts with Accept / Decline"
+            description = context.getString(R.string.bubble_channel_offer_description)
             setAllowBubbles(false)
         }
         notificationManager.createNotificationChannel(offerChannel)
@@ -238,7 +251,7 @@ class BubbleManager @Inject constructor(
         val shortcut = ShortcutInfoCompat.Builder(context, shortcutId)
             .setLongLived(true)
             .setIntent(activityIntent)
-            .setShortLabel("DashBuddy")
+            .setShortLabel(context.getString(R.string.app_name))
             .setIcon(
                 IconCompat.createWithResource(
                     context,
@@ -291,7 +304,7 @@ class BubbleManager @Inject constructor(
         )
 
         val style = NotificationCompat.MessagingStyle(senderPerson)
-            .setConversationTitle("Current Session")
+            .setConversationTitle(context.getString(R.string.bubble_notification_conversation_title))
             .setGroupConversation(true)
             .addMessage(text, System.currentTimeMillis(), senderPerson)
 
@@ -401,11 +414,17 @@ class BubbleManager @Inject constructor(
             )
             rv.setInt(R.id.notif_offer_verdict, "setBackgroundColor", verdictArgb)
         }
-        rv.setTextViewText(R.id.notif_offer_rate, "${money0(offer.dollarsPerHour)}/hr")
+        rv.setTextViewText(
+            R.id.notif_offer_rate,
+            context.getString(R.string.bubble_offer_card_rate_per_hr, money0(offer.dollarsPerHour)),
+        )
         if (!expanded) {
             rv.setTextViewText(
                 R.id.notif_offer_sub,
-                "Net ${money(offer.netPayAmount)} · ${money(offer.dollarsPerMile)}/mi · ${miles(offer.distanceMiles)}",
+                context.getString(
+                    R.string.bubble_offer_card_sub_compact,
+                    money(offer.netPayAmount), money(offer.dollarsPerMile), miles(offer.distanceMiles),
+                ),
             )
         }
 
@@ -450,8 +469,11 @@ class BubbleManager @Inject constructor(
         if (expanded) {
             rv.setTextViewText(
                 R.id.notif_offer_metrics,
-                "Net ${money(offer.netPayAmount)} · Gross ${money(offer.payAmount)} · " +
-                    "${miles(offer.distanceMiles)} · ${money(offer.dollarsPerMile)}/mi",
+                context.getString(
+                    R.string.bubble_offer_card_metrics_expanded,
+                    money(offer.netPayAmount), money(offer.payAmount),
+                    miles(offer.distanceMiles), money(offer.dollarsPerMile),
+                ),
             )
             // Badges into fixed slots, tinted with the verdict color so they're visible on any
             // notification background (theme-attr fills don't resolve in the remote process).
@@ -471,7 +493,9 @@ class BubbleManager @Inject constructor(
                 }
             }
             val stores = offer.storeNames.joinToString(" + ")
-            val items = if (offer.itemCount > 1) " · ${offer.itemCount} items" else ""
+            val items = if (offer.itemCount > 1) {
+                context.getString(R.string.bubble_offer_card_items_suffix, offer.itemCount)
+            } else ""
             rv.setTextViewText(R.id.notif_offer_store, (stores + items).trim())
         }
         return rv

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManager.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/BubbleManager.kt
@@ -190,9 +190,9 @@ class BubbleManager @Inject constructor(
         val platform = Platform.fromName(platformName)
         return when {
             platform?.sessionVerb != null -> platform.sessionVerb!!
-            platform != null -> "driving for ${platform.displayName}"
-            platformName != null -> "driving for $platformName"
-            else -> "driving"
+            platform != null -> context.getString(R.string.bubble_session_verb_fallback_named, platform.displayName)
+            platformName != null -> context.getString(R.string.bubble_session_verb_fallback_named, platformName)
+            else -> context.getString(R.string.bubble_session_verb_fallback_unnamed)
         }
     }
 
@@ -389,10 +389,11 @@ class BubbleManager @Inject constructor(
      * `setImageViewBitmap` (RemoteViews can't draw an arc); countdown → a self-ticking
      * [Chronometer]; Accept/Decline → brand-styled `TextView`s wired with `setOnClickPendingIntent`.
      */
-    // Null-safe money/distance for the notification card — "—" when a metric didn't parse.
-    private fun money(d: Double?) = d?.let { Formats.money(it) } ?: "—"
-    private fun money0(d: Double?) = d?.let { Formats.money0(it) } ?: "—"
-    private fun miles(d: Double?) = d?.let { "${Formats.decimal(it)} mi" } ?: "—"
+    // Null-safe money/distance for the notification card — the placeholder when a metric didn't parse.
+    private fun money(d: Double?) = d?.let { Formats.money(it) } ?: context.getString(R.string.bubble_offer_card_metric_placeholder)
+    private fun money0(d: Double?) = d?.let { Formats.money0(it) } ?: context.getString(R.string.bubble_offer_card_metric_placeholder)
+    private fun miles(d: Double?) = d?.let { context.getString(R.string.bubble_offer_card_miles, Formats.decimal(it)) }
+        ?: context.getString(R.string.bubble_offer_card_metric_placeholder)
 
     private fun buildOfferCardView(
         offer: FlowCardSnapshot.Offer,

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsScreen.kt
@@ -78,11 +78,16 @@ fun AnalyticsScreen(
                 .padding(16.dp)
                 .fillMaxSize(),
         ) {
+            val tabOptions = tabOptions()
+            val selectedTabLabel = tabOptions.first { it.tab == uiState.selectedTab }.label
             AppSegmented(
-                options = AnalyticsTab.entries.map { it.label },
-                selected = uiState.selectedTab.label,
+                options = tabOptions.map { it.label },
+                selected = selectedTabLabel,
                 onSelect = { label ->
-                    AnalyticsTab.entries.firstOrNull { it.label == label }?.let(viewModel::setTab)
+                    // Lookup happens against this already-resolved pairs list (#428 Half A), so
+                    // selection stays keyed off the enum — not a raw resolved-string comparison
+                    // that could collide across locales/tabs.
+                    tabOptions.firstOrNull { it.label == label }?.let { viewModel.setTab(it.tab) }
                 },
                 modifier = Modifier.fillMaxWidth(),
             )
@@ -131,6 +136,13 @@ fun AnalyticsScreen(
         }
     }
 }
+
+/** The hub tabs paired with their resolved label (#428 Half A) — identity stays the enum. */
+private data class TabOption(val tab: AnalyticsTab, val label: String)
+
+@Composable
+private fun tabOptions(): List<TabOption> =
+    AnalyticsTab.entries.map { TabOption(it, stringResource(it.labelRes)) }
 
 /** The review windows offered by the Money period selector, in display order. */
 private data class PeriodOption(val period: AnalyticsPeriod, val label: String)

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsUiState.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsUiState.kt
@@ -1,5 +1,7 @@
 package cloud.trotter.dashbuddy.ui.main.analytics
 
+import androidx.annotation.StringRes
+import cloud.trotter.dashbuddy.R
 import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
 import cloud.trotter.dashbuddy.domain.analytics.DailyEarnings
 import cloud.trotter.dashbuddy.domain.analytics.DecisionEconomics
@@ -20,12 +22,16 @@ internal const val EMPTY_VALUE = "—"
 /**
  * The Analytics hub tabs (#315). [Money], [Decisions] (H3), [Time] (H4), and [Patterns] (H5) all
  * render real content.
+ *
+ * [labelRes] is a `@StringRes` id (#428 Half A), resolved at the Compose layer — see
+ * `AnalyticsScreen.tabOptions()`. The [AppSegmented][cloud.trotter.dashbuddy.core.designsystem.component.AppSegmented]
+ * selection there is keyed off the enum itself, never the resolved label string.
  */
-enum class AnalyticsTab(val label: String) {
-    Money("Money"),
-    Patterns("Patterns"),
-    Decisions("Decisions"),
-    Time("Time"),
+enum class AnalyticsTab(@StringRes val labelRes: Int) {
+    Money(R.string.analytics_tab_money),
+    Patterns(R.string.analytics_tab_patterns),
+    Decisions(R.string.analytics_tab_decisions),
+    Time(R.string.analytics_tab_time),
 }
 
 /**

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardScreen.kt
@@ -141,7 +141,7 @@ fun DashboardScreen(
                 // entry tiles, and a manual bubble trigger.
                 else -> {
                     StatusCard(
-                        title = uiState.statusText,
+                        title = stringResource(uiState.statusText),
                         subtitle = if (uiState.isDashing) stringResource(R.string.dashboard_screen_dashing_subtitle)
                         else stringResource(R.string.dashboard_screen_ready_subtitle),
                         containerColor = MaterialTheme.colorScheme.primaryContainer

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardUiState.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardUiState.kt
@@ -1,5 +1,7 @@
 package cloud.trotter.dashbuddy.ui.main.dashboard
 
+import androidx.annotation.StringRes
+import cloud.trotter.dashbuddy.R
 import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
 import cloud.trotter.dashbuddy.domain.analytics.PeriodEconomics
 
@@ -23,7 +25,13 @@ import cloud.trotter.dashbuddy.domain.analytics.PeriodEconomics
  */
 data class DashboardUiState(
     val isFirstRun: Boolean = true,
-    val statusText: String = "Offline",
+    /**
+     * The home status headline — a `@StringRes` id (#428 Half A), resolved with
+     * `stringResource(...)` at the Compose layer so this Context-free `@HiltViewModel` never
+     * carries resolved copy. Not i18n: the app still ships English-only; this is a string-
+     * ownership move (SSOT), not locale selection.
+     */
+    @StringRes val statusText: Int = R.string.dashboard_status_offline,
     /**
      * True while a dash session is active (focused region present, mode != Offline),
      * registry-resolved (never a `== DoorDash` literal). Drives the bubble pointer only.

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardViewModel.kt
@@ -1,11 +1,12 @@
 package cloud.trotter.dashbuddy.ui.main.dashboard
 
+import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import cloud.trotter.dashbuddy.R
 import cloud.trotter.dashbuddy.core.data.analytics.AnalyticsRepository
 import cloud.trotter.dashbuddy.core.data.state.AppStateRepository
 import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
-import cloud.trotter.dashbuddy.domain.model.chat.ChatPersona
 import cloud.trotter.dashbuddy.domain.state.AppState
 import cloud.trotter.dashbuddy.domain.state.Flow
 import cloud.trotter.dashbuddy.domain.state.Mode
@@ -82,11 +83,9 @@ class DashboardViewModel @Inject constructor(
     }
 
     fun showWelcomeBubble() {
-        bubbleManager.postMessage(
-            text = "DashBuddy is ready. Open your platform and start a session — I'll track everything from here.",
-            ChatPersona.Dispatcher,
-            expand = true
-        )
+        // #428 Half A: the copy itself is owned by BubbleManager (which has Context) — this
+        // ViewModel stays Context-free.
+        bubbleManager.postWelcomeMessage()
     }
 
     /** The platform the home status attributes to — registry-resolved, not a literal. */
@@ -96,22 +95,23 @@ class DashboardViewModel @Inject constructor(
         return platform?.let { state.regions.platforms[it] }
     }
 
-    private fun statusText(flow: Flow, mode: Mode?): String {
+    @StringRes
+    private fun statusText(flow: Flow, mode: Mode?): Int {
         if (mode == null || mode == Mode.Offline) {
             return when (flow) {
-                Flow.SessionEnded -> "Session Complete"
-                else -> "Ready to start a session"
+                Flow.SessionEnded -> R.string.dashboard_status_session_complete
+                else -> R.string.dashboard_status_ready
             }
         }
-        if (mode == Mode.Paused) return "Paused"
+        if (mode == Mode.Paused) return R.string.dashboard_status_paused
 
         return when (flow) {
-            Flow.Idle -> "Looking for offers..."
-            Flow.OfferPresented -> "Reviewing Offer"
-            Flow.TaskPickupNavigation, Flow.TaskPickupArrived -> "Heading to Pickup"
-            Flow.TaskDropoffNavigation, Flow.TaskDropoffArrived -> "Heading to Drop-off"
-            Flow.PostTask -> "Delivery Complete"
-            Flow.SessionEnded -> "Session Complete"
+            Flow.Idle -> R.string.dashboard_status_looking_for_offers
+            Flow.OfferPresented -> R.string.dashboard_status_reviewing_offer
+            Flow.TaskPickupNavigation, Flow.TaskPickupArrived -> R.string.dashboard_status_heading_to_pickup
+            Flow.TaskDropoffNavigation, Flow.TaskDropoffArrived -> R.string.dashboard_status_heading_to_dropoff
+            Flow.PostTask -> R.string.dashboard_status_delivery_complete
+            Flow.SessionEnded -> R.string.dashboard_status_session_complete
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -606,12 +606,14 @@
          separate, out-of-scope design issue). -->
 
     <!-- state/effects/TtsEffectHandler.kt -->
-    <string name="tts_verdict_accept">Accept</string>
-    <string name="tts_verdict_decline">Decline</string>
-    <string name="tts_verdict_review">Review</string>
-    <string name="tts_verdict_offer">Offer</string>
+    <!-- Locale-locked by design: the TTS engine speaks Locale.US regardless of device locale
+         (see the in-code comment on TtsEffectHandler), so these are NOT translation candidates. -->
+    <string name="tts_verdict_accept" translatable="false">Accept</string>
+    <string name="tts_verdict_decline" translatable="false">Decline</string>
+    <string name="tts_verdict_review" translatable="false">Review</string>
+    <string name="tts_verdict_offer" translatable="false">Offer</string>
     <!-- %1$s verdict word, %2$s merchant name, %3$s $/hr, %4$s net pay, %5$s miles, %6$s score -->
-    <string name="tts_offer_evaluation_template">%1$s. %2$s. %3$s dollars an hour net. Net %4$s, %5$s miles, score %6$s.</string>
+    <string name="tts_offer_evaluation_template" translatable="false">%1$s. %2$s. %3$s dollars an hour net. Net %4$s, %5$s miles, score %6$s.</string>
 
     <!-- state/effects/TipEffectHandler.kt -->
     <!-- %1$s tip amount, %2$s store name -->
@@ -626,11 +628,20 @@
     <!-- %1$s is Platform.sessionVerb (or its displayName fallback) — never a hardcoded platform word (Principle 8). -->
     <string name="bubble_chat_session_started">Started %1$s!</string>
     <string name="bubble_chat_session_done">Done %1$s!</string>
+    <!-- BubbleManager.sessionVerb() fallbacks when a Platform has no sessionVerb of its own —
+         %1$s is the platform's displayName (or the raw, unresolved platform id). -->
+    <string name="bubble_session_verb_fallback_named">driving for %1$s</string>
+    <string name="bubble_session_verb_fallback_unnamed">driving</string>
     <string name="bubble_welcome_message">DashBuddy is ready. Open your platform and start a session — I\'ll track everything from here.</string>
     <string name="bubble_offer_card_rate_per_hr">%1$s/hr</string>
     <string name="bubble_offer_card_sub_compact">Net %1$s · %2$s/mi · %3$s</string>
     <string name="bubble_offer_card_metrics_expanded">Net %1$s · Gross %2$s · %3$s · %4$s/mi</string>
     <string name="bubble_offer_card_items_suffix">" · %1$d items"</string>
+    <!-- BubbleManager.miles() — %1$s is the formatted distance. -->
+    <string name="bubble_offer_card_miles">%1$s mi</string>
+    <!-- Null-safe metric placeholder for the offer card's money()/money0()/miles() helpers when a
+         value didn't parse. -->
+    <string name="bubble_offer_card_metric_placeholder" translatable="false">—</string>
 
     <!-- ui/main/dashboard/DashboardViewModel.kt -->
     <string name="dashboard_status_offline">Offline</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -600,4 +600,52 @@
     <string name="evidence_settings_deliveries_subtitle">Track completion stats</string>
     <string name="evidence_settings_session_label">Save Session Summary</string>
     <string name="evidence_settings_session_subtitle">End of session earnings report</string>
+
+    <!-- #428 Half A: non-Compose copy routed through strings.xml (string ownership, NOT i18n —
+         the TTS engine still speaks the device-default voice; per-language reading is a
+         separate, out-of-scope design issue). -->
+
+    <!-- state/effects/TtsEffectHandler.kt -->
+    <string name="tts_verdict_accept">Accept</string>
+    <string name="tts_verdict_decline">Decline</string>
+    <string name="tts_verdict_review">Review</string>
+    <string name="tts_verdict_offer">Offer</string>
+    <!-- %1$s verdict word, %2$s merchant name, %3$s $/hr, %4$s net pay, %5$s miles, %6$s score -->
+    <string name="tts_offer_evaluation_template">%1$s. %2$s. %3$s dollars an hour net. Net %4$s, %5$s miles, score %6$s.</string>
+
+    <!-- state/effects/TipEffectHandler.kt -->
+    <!-- %1$s tip amount, %2$s store name -->
+    <string name="tip_effect_chat_message">Nice! %1$s tip from %2$s</string>
+
+    <!-- ui/bubble/BubbleManager.kt -->
+    <string name="bubble_channel_stream_name">DashBuddy Stream</string>
+    <string name="bubble_channel_stream_description">Live updates from your session</string>
+    <string name="bubble_channel_offer_name">Offer Alerts</string>
+    <string name="bubble_channel_offer_description">Heads-up offer alerts with Accept / Decline</string>
+    <string name="bubble_notification_conversation_title">Current Session</string>
+    <!-- %1$s is Platform.sessionVerb (or its displayName fallback) — never a hardcoded platform word (Principle 8). -->
+    <string name="bubble_chat_session_started">Started %1$s!</string>
+    <string name="bubble_chat_session_done">Done %1$s!</string>
+    <string name="bubble_welcome_message">DashBuddy is ready. Open your platform and start a session — I\'ll track everything from here.</string>
+    <string name="bubble_offer_card_rate_per_hr">%1$s/hr</string>
+    <string name="bubble_offer_card_sub_compact">Net %1$s · %2$s/mi · %3$s</string>
+    <string name="bubble_offer_card_metrics_expanded">Net %1$s · Gross %2$s · %3$s · %4$s/mi</string>
+    <string name="bubble_offer_card_items_suffix">" · %1$d items"</string>
+
+    <!-- ui/main/dashboard/DashboardViewModel.kt -->
+    <string name="dashboard_status_offline">Offline</string>
+    <string name="dashboard_status_session_complete">Session Complete</string>
+    <string name="dashboard_status_ready">Ready to start a session</string>
+    <string name="dashboard_status_paused">Paused</string>
+    <string name="dashboard_status_looking_for_offers">Looking for offers...</string>
+    <string name="dashboard_status_reviewing_offer">Reviewing Offer</string>
+    <string name="dashboard_status_heading_to_pickup">Heading to Pickup</string>
+    <string name="dashboard_status_heading_to_dropoff">Heading to Drop-off</string>
+    <string name="dashboard_status_delivery_complete">Delivery Complete</string>
+
+    <!-- ui/main/analytics/AnalyticsUiState.kt -->
+    <string name="analytics_tab_money">Money</string>
+    <string name="analytics_tab_patterns">Patterns</string>
+    <string name="analytics_tab_decisions">Decisions</string>
+    <string name="analytics_tab_time">Time</string>
 </resources>

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsTabTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsTabTest.kt
@@ -2,27 +2,36 @@ package cloud.trotter.dashbuddy.ui.main.analytics
 
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
 
 /**
  * #428 Half A: [AnalyticsTab]'s tab label moved from a hand-authored `String` field to a
  * `@StringRes` id ([AnalyticsTab.labelRes]) resolved at the Compose layer
  * (`AnalyticsScreen.tabOptions()`), which pairs each [AnalyticsTab] with its resolved label and
  * keys `AppSegmented` selection off the enum via that pairs list — never a raw string comparison
- * against the resolved label. This test guards the data half of that mechanism: every tab must
- * own a DISTINCT resource id, since a duplicate would make two entries in `tabOptions()` share a
- * label (harmless for the pairs-list lookup used here, but a smell worth catching before it masks
- * a real content bug — the `setTab switches to Decisions...` case in [AnalyticsViewModelTest]
- * already covers the ViewModel-level round-trip proof that `setTab` resolves by enum identity).
+ * against the resolved label. But `AppSegmented` itself is string-keyed (`opt == selected`,
+ * `onSelect(opt)`), and `tabOptions().firstOrNull { it.label == label }` does the reverse lookup
+ * by the RESOLVED label string, not by resource id — so the real invariant is that the RESOLVED
+ * labels are pairwise distinct; two distinct resource ids that happen to resolve to the same
+ * text would still mis-select. This test resolves each [AnalyticsTab.labelRes] through a real
+ * Android `Context` (Robolectric — this test module already runs it, see
+ * `MainActivityRouteIntentTest`) and asserts the resolved strings are distinct (the
+ * `setTab switches to Decisions...` case in [AnalyticsViewModelTest] already covers the
+ * ViewModel-level round-trip proof that `setTab` resolves by enum identity).
  */
+@RunWith(RobolectricTestRunner::class)
 class AnalyticsTabTest {
 
     @Test
-    fun `every tab has its own distinct label resource`() {
-        val labelResIds = AnalyticsTab.entries.map { it.labelRes }
+    fun `every tab resolves to its own distinct label`() {
+        val context = RuntimeEnvironment.getApplication()
+        val resolvedLabels = AnalyticsTab.entries.map { context.getString(it.labelRes) }
         assertEquals(
-            "each AnalyticsTab must own a distinct labelRes",
+            "each AnalyticsTab must resolve to a distinct label (AppSegmented is string-keyed)",
             AnalyticsTab.entries.size,
-            labelResIds.distinct().size,
+            resolvedLabels.distinct().size,
         )
     }
 }

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsTabTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsTabTest.kt
@@ -1,0 +1,28 @@
+package cloud.trotter.dashbuddy.ui.main.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * #428 Half A: [AnalyticsTab]'s tab label moved from a hand-authored `String` field to a
+ * `@StringRes` id ([AnalyticsTab.labelRes]) resolved at the Compose layer
+ * (`AnalyticsScreen.tabOptions()`), which pairs each [AnalyticsTab] with its resolved label and
+ * keys `AppSegmented` selection off the enum via that pairs list — never a raw string comparison
+ * against the resolved label. This test guards the data half of that mechanism: every tab must
+ * own a DISTINCT resource id, since a duplicate would make two entries in `tabOptions()` share a
+ * label (harmless for the pairs-list lookup used here, but a smell worth catching before it masks
+ * a real content bug — the `setTab switches to Decisions...` case in [AnalyticsViewModelTest]
+ * already covers the ViewModel-level round-trip proof that `setTab` resolves by enum identity).
+ */
+class AnalyticsTabTest {
+
+    @Test
+    fun `every tab has its own distinct label resource`() {
+        val labelResIds = AnalyticsTab.entries.map { it.labelRes }
+        assertEquals(
+            "each AnalyticsTab must own a distinct labelRes",
+            AnalyticsTab.entries.size,
+            labelResIds.distinct().size,
+        )
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardViewModelTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/main/dashboard/DashboardViewModelTest.kt
@@ -1,5 +1,6 @@
 package cloud.trotter.dashbuddy.ui.main.dashboard
 
+import cloud.trotter.dashbuddy.R
 import cloud.trotter.dashbuddy.core.data.analytics.AnalyticsRepository
 import cloud.trotter.dashbuddy.core.data.state.AppStateRepository
 import cloud.trotter.dashbuddy.core.state.StateManagerV2
@@ -157,7 +158,7 @@ class DashboardViewModelTest {
         val onlineJob = launch { onlineVm.uiState.collect {} }
         testScheduler.advanceUntilIdle()
         assertTrue(onlineVm.uiState.value.isDashing)
-        assertEquals("Looking for offers...", onlineVm.uiState.value.statusText)
+        assertEquals(R.string.dashboard_status_looking_for_offers, onlineVm.uiState.value.statusText)
         onlineJob.cancel()
 
         // Offline → not dashing + "ready to start a session".
@@ -166,7 +167,7 @@ class DashboardViewModelTest {
         val offlineJob = launch { offlineVm.uiState.collect {} }
         testScheduler.advanceUntilIdle()
         assertFalse(offlineVm.uiState.value.isDashing)
-        assertEquals("Ready to start a session", offlineVm.uiState.value.statusText)
+        assertEquals(R.string.dashboard_status_ready, offlineVm.uiState.value.statusText)
         offlineJob.cancel()
     }
 }

--- a/app/src/test/resources/robolectric.properties
+++ b/app/src/test/resources/robolectric.properties
@@ -1,0 +1,14 @@
+# Pin every Robolectric-run unit test to the plain android.app.Application rather than the
+# manifest-declared DashBuddyApplication (a @HiltAndroidApp entry point that boots the real
+# StateMachine/AnalyticsProjector/rule-load pipeline in its onCreate()).
+#
+# This became load-bearing when testOptions.unitTests.isIncludeAndroidResources was turned on
+# (#428, AnalyticsTabTest — Context.getString() needs the compiled app resources, not just the
+# SDK's, to resolve a real @StringRes id). With real resources present, Robolectric can fully
+# resolve the manifest's android:name and would otherwise instantiate DashBuddyApplication for
+# every test — e.g. LogRepositoryTest asserts EXACT firehose contents, and the real onCreate()'s
+# own INFO-level bootstrap logging (state machine init, rule compile) landed in the same log file
+# the test writes to, corrupting the assertion. Pinning the application here restores the
+# pre-existing behavior (no test depended on the real Application running) while keeping real
+# resource resolution available to tests that ask for it via a real Context.
+application=android.app.Application


### PR DESCRIPTION
## Summary

Piece A (bounded spec, dev-vetted 2026-07-07) of #428: routes the #57/#719 non-Compose copy
remainder — enumerated in the [bounded-spec comment](https://github.com/sjtrotter/DashBuddy/issues/428#issuecomment-4900410696) —
through `strings.xml`. **Half A only** (per the [orchestration note](https://github.com/sjtrotter/DashBuddy/issues/428#issuecomment-4900194082)):
this is a **string-ownership/SSOT move, NOT internationalization**. The TTS engine still
speaks `Locale.US` unconditionally — no `TextToSpeech` language/voice APIs touched, no
locale detection added. Actual multi-language offer reading (Half B) is a separate,
out-of-scope design issue. **#428 stays OPEN** for Half B.

### The five sites (verified against master @ `50da0874`; the spec's line numbers had drifted
from `f46a35b3` but every site's shape/behavior matched)

| # | Site | Context availability | What moved |
|---|------|----------------------|------------|
| 1 | `TtsEffectHandler.formatEvaluation()` | Already injected (`@param:ApplicationContext`) | Verdict words (`tts_verdict_*`) + one combined template (`tts_offer_evaluation_template`, `%1$s`…`%6$s`) — `Formats.decimal(...)` untouched |
| 2 | `BubbleManager` | Already injected | Channel names/descriptions, shortcut label (reuses `R.string.app_name`, not a new resource), `MessagingStyle` conversation title, session-chat connectives (`sessionVerb` stays the arg), offer-card `RemoteViews` templates (rate/hr, compact sub, expanded metrics, item-count suffix) |
| 3 | `TipEffectHandler` | **Added** `@param:ApplicationContext context: Context` (Hilt-provided, mechanical) | Tip chat template — `Formats.money(...)` + `storeName` stay args |
| 4 | `DashboardViewModel` / `DashboardUiState` | **Not injected — correctly stays Context-free.** `statusText` is now a `@StringRes Int`, resolved via `stringResource(...)` in `DashboardScreen`. `showWelcomeBubble()` now calls a new `BubbleManager.postWelcomeMessage()` (Context lives there) instead of building the string itself. | Status labels + the welcome-bubble line |
| 5 | `AnalyticsUiState.AnalyticsTab` | Compose-layer resolution | `label: String` → `@StringRes labelRes: Int`. `AnalyticsScreen` resolves via a new `tabOptions()` composable that pairs each `AnalyticsTab` with its resolved label; `AppSegmented` selection is keyed off **that pairs list** (looks up by label, returns the paired enum) — never a naive string-vs-resolved-string comparison. Reverse lookup preserved correctly (verified: `PatternsTab`/`coming_soon_title` from the old spec text no longer exists — all 4 tabs render real content post-#315, so that residual mentioned in the original spec text is moot). |

### Hard boundaries held
- No `TextToSpeech.setLanguage`/`Voice`/locale APIs touched.
- No runtime identifiers moved: channel ids (`bubble_channel`/`offer_channel`), `shortcutId`,
  `Platform.sessionVerb` values, wire strings, prefs keys are all untouched — only their
  display-facing name/description literals changed.
- `sessionVerb` / merchant name / store name / tip amount / offer economics all remain format
  **arguments**, never baked into the resource text (Principle 8 — no platform word hardcoded
  into a resource).
- `Formats.decimal`/`Formats.money`/`Formats.money0` numeric formatting is unchanged.

### `%`-escaping + aapt-space-quoting check
No new string contains a literal `%` character outside a `%N$s`/`%N$d` positional spec, so no
`%%` escaping was needed (the #719 HIGH-1 crash class). `bubble_offer_card_items_suffix` has a
meaningful leading space (`" · %1$d items"`) and is quoted per the existing
`flow_card_detail_arrived_format` convention. Verified structurally by a clean `:app:assembleDebug`
(resource merge + aapt format-string validation) — see Test plan.

## Test plan
- [x] `export JAVA_HOME=/usr/lib/jvm/java-25 && ./gradlew :domain:test testDebugUnitTest` — green
- [x] `./gradlew :app:assembleDebug` — green (resource merge + aapt string-arg sanity)
- [x] `DashboardViewModelTest` — updated (site 4's regression gate): asserts `R.string.dashboard_status_*`
  resource ids instead of literal strings
- [x] New `AnalyticsTabTest` — guards the site-5 reverse-lookup gotcha: every `AnalyticsTab` owns
  a distinct `labelRes` (the existing `AnalyticsViewModelTest`'s `setTab switches to Decisions...`
  test already proves `setTab` resolves by enum identity at the ViewModel level)
- [x] Manually eyeballed every new/changed format string for unescaped `%` — none found

### Design-goal review
- **Principle 5 (SSOT):** every extracted literal now has exactly one owner in `strings.xml`
  instead of being hand-authored inline at each call site; the Analytics-tab label and the
  Dashboard status text each had exactly one definition before and after — this PR only changes
  *where* that definition lives, and stops the DashboardViewModel/AnalyticsUiState from being a
  second, code-embedded copy of user-facing copy.
- **Principle 8 (platform-agnostic core):** `Platform.sessionVerb` (and the DoorDash/store/
  merchant/customer text baked into `RemoteViews` templates) remain format **arguments**, never
  literal text inside a resource — no platform word got hardcoded into a template.
- **Reactive UI:** no time-derived value touched; `statusText`/`AnalyticsTab.labelRes` are static
  per state, resolved once per recomposition via `stringResource`, same as every other resource
  read already in these screens.

### Security / privacy posture
No recognition, capture, network, or effect-firing logic changed — this is a pure copy-location
refactor. No PII or third-party UI text was moved into a resource; merchant name / store name /
tip amount / offer economics / `sessionVerb` all remain runtime arguments substituted into the
templates exactly as before, so nothing that was previously scrubbed/hashed/gated changes
posture.

### Deviations from the bounded spec
- The spec's exact line numbers (from master @ `f46a35b3`) had drifted by 46 commits by the time
  of this build (master @ `50da0874`); every site's *shape* still matched exactly, so I proceeded
  per the "verify against current master, adapt mechanically" instruction rather than stopping.
- The spec's site-5 note about `coming_soon_title, tab.label` at `AnalyticsScreen.kt:166` is
  **stale** — that code path no longer exists; `#315` shipped the Patterns tab with real content
  before this PR, so all 4 tabs render real content and there is no "coming soon" placeholder
  left to worry about. No action needed; noted for the record.
- Found but **intentionally out of scope** (not one of the five enumerated sites, and touching
  it would exceed the bounded spec): `ui/formatters/OfferFormatters.kt#offerVerdictLabel` still
  hardcodes `"ACCEPT"/"DECLINE"/"REVIEW"/"OFFER"`, and `DashboardScreen.kt`'s
  `DashingStatusRow` still hardcodes `"🟢 Session active — tap for the bubble"`. Both are
  Compose-adjacent literals PR #719 apparently missed but are not in this bounded spec's five
  sites — left untouched per "only the five non-Compose residual sites above."

## Next field test — things to look for
No on-device behavior changed (string-ownership only, same resolved text at every call site,
same TTS voice/locale) — no new field-test checklist item needed for this PR.

Related: #428 (Half B remains open — actual multi-language TTS is a separate design issue).


---

### Adversarial review (Fable-tier, 2026-07-10)

One finder (proportionate to a mechanical extraction), five angles. **Verified clean:** all 7 argument-bearing templates arg-checked against the old inline constructions — order, types, and joins byte-identical (incl. the TTS template's 6 slots and the one `%d` confirmed bound to the Int field, not the Double); statusText/labelRes flips have no stale consumers; TipEffectHandler's DI addition matches sibling handlers; P7 log content unchanged; the two disclosed out-of-scope literals genuinely untouched.

**Four findings → all fixed in-branch (commit `98495e74`):**
- Two half-extracted fragments in the BubbleManager site (the `sessionVerb()` fallback copy and `miles()`' " mi"/"—" unit suffix) — completed, with a shared metric-placeholder resource.
- The AnalyticsTab guard asserted distinct resource *ids*, but the real hazard is duplicate resolved *values* (AppSegmented is string-keyed; `firstOrNull { it.label == label }` mis-selects on duplicates) — the test now resolves through a Robolectric context and asserts pairwise-distinct strings. Enabling real test resources surfaced a genuine side effect (Robolectric booting the @HiltAndroidApp application corrupted LogRepositoryTest's exact-log assertions) — pinned to plain `android.app.Application` via robolectric.properties, verified by bisection.
- The locale-locked TTS strings are now `translatable="false"` per the file's convention, making the Locale.US contract enforceable.

#428 stays OPEN for Half B.
