### PR TITLE
fix(#660): "(No session)" bucket (piece 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -339,7 +339,16 @@ history and (F8) the version-bump wipe now also clears `stores`/`pickup_records`
 immutable) serves period economics (`SUM(netProfit)` frozen + `unattributedPay`; all-pay gross =
 reported-total authoritative + the unattributed review flag; per-store; Monday-week boundaries via
 `PeriodBounds`, midnight-reactive) as Room-invalidation Flows to the home glance + the future Analytics hub
-(#315). Period totals are **read-side only** — they never re-enter the pure state machine (the dead
+(#315). **The "(No session)" bucket (#660 piece 1):** `delivery_records` rows whose source event carried
+NO `sessionId` at all were already counted in net (`deliveryTotals`'s own-`completedAt` fallback, #655)
+but invisible to gross (`grossAndUnattributed`/`sessionGrossRows` iterate `session_records` only, so a
+null-session row joined to nothing) — a seam that could let displayed net exceed gross. Fixed by folding
+the same null-session population (`AnalyticsDao.noSessionTotals`/`noSessionTotalsByPlatform`/
+`noSessionDailyRows`) into `PeriodEconomics.grossEarnings` and the per-day chart (bucketed on the
+delivery's own `completedAt` day, since there's no session start to anchor on), and surfacing it as its
+own `noSessionPay`/`noSessionDeliveries` review signal (Money tab callout, same pattern as
+unattributed/over-attributed). Piece 2 (deferred, #660) lets the driver categorize an orphan delivery
+into a real session via a new correction event. Period totals are **read-side only** — they never re-enter the pure state machine (the dead
 `CrossPlatformRegion.PeriodTotals` fields were deleted). The free-tier **CSV export** (#319) is a second
 read-side consumer: `AnalyticsRepository.buildCsvExport` reads raw `deliveriesBetween`/`sessionsBetween`
 rows (row-level, bucketing-free — the driver's own records dumped, not session-anchored periods) and the

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/MoneyTab.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/MoneyTab.kt
@@ -138,7 +138,9 @@ private fun EarningsHero(economics: PeriodEconomics) {
 /**
  * Earnings-by-day bar chart (#315 H6): one bar per local calendar day of the period, gap days at
  * zero, the best day highlighted. Session-anchored (#655) — a dash's whole gross sits on its start
- * day. Only rendered when [days] is non-empty (Today/Lifetime pass an empty list; see [MoneyTab]).
+ * day. **Exception (#660):** a "(No session)" delivery has no session start to anchor on, so it
+ * counts on its own completion day instead (the caption states this). Only rendered when [days] is
+ * non-empty (Today/Lifetime pass an empty list; see [MoneyTab]).
  */
 @Composable
 private fun EarningsByDayCard(days: List<DailyEarnings>) {

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/MoneyTab.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/MoneyTab.kt
@@ -83,6 +83,27 @@ fun MoneyTab(
                 modifier = Modifier.fillMaxWidth(),
             )
         }
+        // "(No session)" bucket (#660 piece 1): deliveries whose source event carried no sessionId at
+        // all. Already folded into [economics.grossEarnings]/[netProfit] above (so gross can't read
+        // below net from this seam) — this callout is the visible data-quality signal, same pattern as
+        // the unattributed/over-attributed flags. Categorizing the bucket into a session is #660 piece 2.
+        if (economics.noSessionPay > UNATTRIBUTED_EPSILON) {
+            val deliveryWord = if (economics.noSessionDeliveries == 1) {
+                stringResource(R.string.time_tab_delivery_singular)
+            } else {
+                stringResource(R.string.time_tab_delivery_plural)
+            }
+            AppCallout(
+                text = stringResource(
+                    R.string.money_tab_no_session_callout_format,
+                    Formats.money(economics.noSessionPay),
+                    Formats.commaInt(economics.noSessionDeliveries),
+                    deliveryWord,
+                ),
+                container = AppTheme.colors.warnBg,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
         TopStoresCard(topStores)
         RecentDashesCard(recentSessions, onOpenSession)
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -493,6 +493,7 @@
     <string name="money_tab_unknown_store">Unknown store</string>
     <string name="money_tab_unattributed_callout_format">%1$s not attributed to any delivery — bonuses/adjustments; review coming (#650)</string>
     <string name="money_tab_over_attributed_callout_format">attributed exceeds reported by %1$s — review estimates/corrections</string>
+    <string name="money_tab_no_session_callout_format">(No session): %1$s across %2$s %3$s not tied to a dash — data-quality flag (#660)</string>
     <string name="money_tab_recent_sessions_title">RECENT SESSIONS</string>
     <string name="money_tab_no_sessions_recorded_yet">No sessions recorded yet.</string>
     <string name="money_tab_cash_marker_format">+%1$s cash</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -482,7 +482,7 @@
     <string name="money_tab_net_per_hour_chip_format">Net/hr %1$s</string>
     <string name="money_tab_earnings_by_day_title">EARNINGS BY DAY</string>
     <string name="money_tab_no_earnings_yet">No earnings in this period yet.</string>
-    <string name="money_tab_earnings_by_day_caption">gross per day · sessions count on their start day</string>
+    <string name="money_tab_earnings_by_day_caption">gross per day · sessions count on their start day · (No session) deliveries count on their own completion day</string>
     <string name="money_tab_true_net_title">TRUE NET</string>
     <string name="money_tab_stat_net_per_hour">Net/hr</string>
     <string name="money_tab_stat_net_per_mile">Net/mi</string>

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
@@ -82,12 +82,14 @@ class AnalyticsRepository @Inject constructor(
                     analyticsDao.deliveryTotals(start, end),
                     analyticsDao.sessionTotals(start, end),
                     analyticsDao.grossAndUnattributed(start, end),
-                ) { d, s, g ->
+                    analyticsDao.noSessionTotals(start, end),
+                ) { d, s, g, ns ->
                     assemble(
                         deliveredPay = d.pay, deliveryNet = d.net, deliveries = d.deliveries,
                         jobs = d.jobs, miles = s.miles, onlineMillis = s.onlineMillis,
                         gross = g.gross, unattributed = g.unattributed, overAttributed = g.overAttributed,
                         fuelCost = d.fuelCost, nonFuelCost = d.nonFuelCost, cash = d.cash,
+                        noSessionPay = ns.pay + ns.cash, noSessionDeliveries = ns.deliveries,
                     )
                 }
             } else {
@@ -96,10 +98,12 @@ class AnalyticsRepository @Inject constructor(
                     analyticsDao.deliveryTotalsByPlatform(start, end),
                     analyticsDao.sessionTotalsByPlatform(start, end),
                     analyticsDao.grossAndUnattributedByPlatform(start, end),
-                ) { dl, sl, gl ->
+                    analyticsDao.noSessionTotalsByPlatform(start, end),
+                ) { dl, sl, gl, nsl ->
                     val d = dl.find { it.platform == wire }
                     val s = sl.find { it.platform == wire }
                     val g = gl.find { it.platform == wire }
+                    val ns = nsl.find { it.platform == wire }
                     assemble(
                         deliveredPay = d?.pay ?: 0.0, deliveryNet = d?.net ?: 0.0,
                         deliveries = d?.deliveries ?: 0, jobs = d?.jobs ?: 0,
@@ -107,6 +111,8 @@ class AnalyticsRepository @Inject constructor(
                         gross = g?.gross ?: 0.0, unattributed = g?.unattributed ?: 0.0,
                         overAttributed = g?.overAttributed ?: 0.0,
                         fuelCost = d?.fuelCost, nonFuelCost = d?.nonFuelCost, cash = d?.cash ?: 0.0,
+                        noSessionPay = (ns?.pay ?: 0.0) + (ns?.cash ?: 0.0),
+                        noSessionDeliveries = ns?.deliveries ?: 0,
                     )
                 }
             }
@@ -287,7 +293,10 @@ class AnalyticsRepository @Inject constructor(
      * [DailyEarnings] per local calendar day of the window, in order, with gap days present at `0.0`
      * gross (a driver who skipped Tuesday still gets a Tuesday bar). Gross per day = Σ of the
      * reported-authoritative per-session gross ([AnalyticsDao.sessionGrossRows], the same definition as
-     * [grossAndUnattributed]) for the sessions that *started* that day.
+     * [grossAndUnattributed]) for the sessions that *started* that day, **plus** any "(No session)"
+     * bucket pay ([AnalyticsDao.noSessionDailyRows], #660) whose own `completedAt` falls on that day —
+     * the #675 review's flagged follow-up site: a null-session delivery has no session start to anchor
+     * on, so it buckets by its own completion day instead (mirrors [periodEconomics]'s null-session fold).
      *
      * **Session-anchored (#655):** a session's whole gross lands on its start instant's local day, so a
      * midnight-spanning dash counts entirely on its start day — never split across two bars. [zone] is
@@ -297,21 +306,28 @@ class AnalyticsRepository @Inject constructor(
      * one-bar chart adds nothing, and LIFETIME's window is unbounded (its days can't be enumerated). The
      * UI hides the card on an empty list.
      *
-     * Re-emits on new session records (Room invalidation) and at week/month rollover (the boundary flow).
+     * Re-emits on new session/delivery records (Room invalidation) and at week/month rollover (the
+     * boundary flow).
      */
     fun dailyEarnings(period: AnalyticsPeriod, zone: ZoneId = ZoneId.systemDefault()): Flow<List<DailyEarnings>> {
         if (period == AnalyticsPeriod.TODAY || period == AnalyticsPeriod.LIFETIME) return flowOf(emptyList())
         return periodBoundariesFlow(period, zone).flatMapLatest { (start, end) ->
-            analyticsDao.sessionGrossRows(start, end).map { rows ->
+            combine(
+                analyticsDao.sessionGrossRows(start, end),
+                analyticsDao.noSessionDailyRows(start, end),
+            ) { rows, noSessionRows ->
                 // The end bound is exactly the next period's local midnight (PeriodBounds), so iterate
                 // day-by-day up to (but excluding) the end instant's date — a complete, gap-filled axis.
                 val startDate = Instant.ofEpochMilli(start).atZone(zone).toLocalDate()
                 val endDate = Instant.ofEpochMilli(end).atZone(zone).toLocalDate()
                 val byDay = rows.groupBy { Instant.ofEpochMilli(it.startedAt).atZone(zone).toLocalDate() }
+                val noSessionByDay = noSessionRows.groupBy { Instant.ofEpochMilli(it.completedAt).atZone(zone).toLocalDate() }
                 buildList {
                     var date = startDate
                     while (date < endDate) {
-                        add(DailyEarnings(date, byDay[date]?.sumOf { it.gross } ?: 0.0))
+                        val sessionGross = byDay[date]?.sumOf { it.gross } ?: 0.0
+                        val noSessionGross = noSessionByDay[date]?.sumOf { it.gross } ?: 0.0
+                        add(DailyEarnings(date, sessionGross + noSessionGross))
                         date = date.plusDays(1)
                     }
                 }
@@ -381,12 +397,18 @@ class AnalyticsRepository @Inject constructor(
         fuelCost: Double?,
         nonFuelCost: Double?,
         cash: Double,
+        noSessionPay: Double = 0.0,
+        noSessionDeliveries: Int = 0,
     ): PeriodEconomics {
         // Locked accounting (#688): cash tips add to BOTH net and gross. [gross] already includes the
         // cash sum (folded in the DAO's `grossAndUnattributed`); net adds it here (it is deliberately
         // OUTSIDE the frozen delivery `netProfit`, so it can't be lost to a null-net row). The
         // waterfall's cost = gross − net is unchanged (cash cancels), so the 4-step reconcile holds.
         // [overAttributed] (#701) is deliberately NOT folded into [net] — display-only review signal.
+        // [noSessionPay] (#660) is a delivery-side pay/cash sum ALREADY inside [deliveryNet]/[cash]
+        // (deliveryTotals counts a null-session row by its own completedAt, #655) — it is folded into
+        // [gross] here (which was otherwise purely session-anchored and never saw it) so gross can no
+        // longer read below net purely from this seam; it is NOT added a second time to net.
         val net = deliveryNet + unattributed + cash
         val hours = onlineMillis / 3_600_000.0
         return PeriodEconomics(
@@ -397,7 +419,7 @@ class AnalyticsRepository @Inject constructor(
                 jobs = jobs,
                 onlineDuration = onlineMillis,
             ),
-            grossEarnings = gross,
+            grossEarnings = gross + noSessionPay,
             netProfit = net,
             unattributedPay = unattributed,
             netPerHour = NetProfit.perHour(net, hours),
@@ -407,6 +429,8 @@ class AnalyticsRepository @Inject constructor(
             fuelCost = fuelCost,
             nonFuelCost = nonFuelCost,
             overAttributedPay = overAttributed,
+            noSessionPay = noSessionPay,
+            noSessionDeliveries = noSessionDeliveries,
         )
     }
 

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
@@ -409,6 +409,20 @@ class AnalyticsRepository @Inject constructor(
         // (deliveryTotals counts a null-session row by its own completedAt, #655) — it is folded into
         // [gross] here (which was otherwise purely session-anchored and never saw it) so gross can no
         // longer read below net purely from this seam; it is NOT added a second time to net.
+        //
+        // KNOWN OVERSTATEMENT (#660 piece 1, adjudicated): this fold assumes the orphan delivery's pay
+        // is genuinely NOT already inside any surviving session's `reportedEarnings`. That assumption can
+        // be wrong — e.g. a mid-dash accessibility-service/app restart that loses this one delivery's
+        // `sessionId` while the dash's summary screen still gets captured afterward: the summary's
+        // `reportedEarnings` (folded via [grossAndUnattributed]) already reflects that delivery's pay, so
+        // adding [noSessionPay] on top double-counts those dollars into [PeriodEconomics.grossEarnings],
+        // and the SAME dollars surface in both the unattributed-review callout AND the "(No session)"
+        // callout on the Money tab. This mirrors the pre-existing net-side overlap (an orphan's frozen net
+        // was always folded via [deliveryTotals], with the identical correlated-restart caveat) — it is
+        // not a new class of bug, just newly visible on the gross side now that this bucket folds in. The
+        // real fix is #660 piece 2 (categorize an orphan delivery into its real session via a correction
+        // event), which removes the row from this bucket entirely rather than trying to detect the overlap
+        // here; until then this is a documented, desk-verifiable edge, not a defect to patch in piece 1.
         val net = deliveryNet + unattributed + cash
         val hours = onlineMillis / 3_600_000.0
         return PeriodEconomics(

--- a/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsDailyEarningsTest.kt
+++ b/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsDailyEarningsTest.kt
@@ -191,4 +191,25 @@ class AnalyticsDailyEarningsTest {
         assertTrue(repo.dailyEarnings(AnalyticsPeriod.TODAY, zone).first().isEmpty())
         assertTrue(repo.dailyEarnings(AnalyticsPeriod.LIFETIME, zone).first().isEmpty())
     }
+
+    /**
+     * #660 piece 1 (the #675 review's flagged follow-up site): a `sessionId IS NULL` delivery has no
+     * session start to bucket the per-day chart on, so it lands on the LOCAL DAY of its own
+     * `completedAt` and ADDS to that day's bar alongside any real session gross — never silently
+     * dropped from the chart the way it used to be.
+     */
+    @Test
+    fun `a null-session delivery adds to its own completedAt day's bar (#660)`() = runBlocking {
+        val base = weekStart()
+        // A real dash on Monday (day 0), reported 20.
+        dao.upsertSession(session("M", base, reportedEarnings = 20.0))
+        // An orphan delivery (no session at all) completing on Wednesday (day 2), pay 8.
+        val wednesday = Instant.ofEpochMilli(base).atZone(zone).toLocalDate().plusDays(2)
+        val wednesdayNoon = wednesday.atTime(12, 0).atZone(zone).toInstant().toEpochMilli()
+        dao.upsertDelivery(delivery(99, sessionId = null, completedAt = wednesdayNoon, pay = 8.0))
+
+        val days = repo.dailyEarnings(AnalyticsPeriod.THIS_WEEK, zone).first()
+        assertEquals("Monday keeps its session gross", 20.0, days[0].gross, 1e-9)
+        assertEquals("Wednesday gets the orphan delivery's own-day gross", 8.0, days[2].gross, 1e-9)
+    }
 }

--- a/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepositoryTest.kt
+++ b/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepositoryTest.kt
@@ -436,6 +436,60 @@ class AnalyticsRepositoryTest {
     }
 
     /**
+     * #660 piece 1 guard: a mixed population — one normal sessionful dash (reported 50, no orphan
+     * overlap) plus one unrelated null-session orphan (pay 8) in the SAME period — must sum EXACTLY
+     * to `50 + 8 = 58`, and the orphan's own bucket must report EXACTLY its own 8. This pins the two
+     * source queries ([AnalyticsDao.grossAndUnattributed] and [AnalyticsDao.noSessionTotals]) as
+     * disjoint populations that only ever ADD, never merge — a future rewrite of either query into a
+     * single JOIN/COALESCE (to "simplify" the two-query split) could accidentally let the null-session
+     * group get swept into a session's own SUM (or vice versa), which this exact assertion would catch
+     * immediately (a 58/8 split collapsing into e.g. 58/0 or 50/8-double-counted-elsewhere).
+     */
+    @Test
+    fun `mixed session plus unrelated orphan sums exactly, no cross-population leakage (#660)`() = runBlocking {
+        // S1: reported 50, no delivered-pay overlap with the orphan below (unrelated dash).
+        dao.upsertSession(session("S1", base, reportedEarnings = 50.0, durationMillis = hour, startOdo = 0.0, lastOdo = 10.0, deliveries = 1, jobsCompleted = 1))
+        dao.upsertDelivery(delivery(1, "S1", "J1", "Wendys", pay = 50.0, net = 45.0, completedAt = base + hour))
+        // An unrelated orphan delivery — no session at all, pay 8, elsewhere in the same period.
+        dao.upsertDelivery(delivery(2, sessionId = null, jobId = "J2", storeName = "Chipotle", pay = 8.0, net = 6.0, completedAt = base + 2 * hour))
+
+        val eco = repo.periodEconomics(AnalyticsPeriod.LIFETIME).first()
+        assertEquals("gross = S1's reported 50 + the orphan's own 8, exactly", 58.0, eco.grossEarnings, 1e-9)
+        assertEquals("the (No session) bucket reports exactly its own 8, not merged into S1's 50", 8.0, eco.noSessionPay, 1e-9)
+    }
+
+    /**
+     * #660 piece 1 CHARACTERIZATION (adjudicated, documented in [AnalyticsRepository.assemble]'s
+     * KDoc/comment): when the orphan's pay is semantically ALREADY INSIDE a surviving session's
+     * captured `reportedEarnings` — e.g. a mid-dash accessibility-service restart drops this one
+     * delivery's `sessionId`, but the dash's summary screen still gets captured afterward and its
+     * `reportedEarnings` already reflects that delivery's pay — piece 1 has no way to detect the
+     * overlap (the two source queries are structurally disjoint, by design, per the test above) and
+     * so it double-counts: those same 8 dollars land in BOTH the session's own gross-vs-delivered
+     * unattributed delta AND the "(No session)" bucket. This pins that CURRENT, KNOWN behavior
+     * on purpose — it is the seam #660 piece 2 (categorize an orphan into its real session) is
+     * scoped to close. When piece 2 lands, this exact test SHOULD go red (gross should drop to
+     * 100.0 once the orphan is categorized away rather than double-added) — that failure is the
+     * signal piece 2 shipped correctly, not a regression to chase.
+     */
+    @Test
+    fun `CHARACTERIZATION - correlated orphan double-counts into gross until piece 2 lands (#660)`() = runBlocking {
+        // S1 reported 100, but only 92 of that is captured as session-tied delivered pay (unattributed
+        // = 8) — the missing 8 is semantically the SAME delivery re-appearing below as a null-session
+        // orphan (a restart mid-dash lost its sessionId after the summary screen already saw its pay).
+        dao.upsertSession(session("S1", base, reportedEarnings = 100.0, durationMillis = hour, startOdo = 0.0, lastOdo = 10.0, deliveries = 1, jobsCompleted = 1))
+        dao.upsertDelivery(delivery(1, "S1", "J1", "Wendys", pay = 92.0, net = 80.0, completedAt = base + hour))
+        // The correlated orphan: pay 8, no sessionId — its dollars are ALREADY inside S1's reported 100.
+        dao.upsertDelivery(delivery(2, sessionId = null, jobId = "J1", storeName = "Wendys", pay = 8.0, net = 6.0, completedAt = base + 90 * 60_000))
+
+        val eco = repo.periodEconomics(AnalyticsPeriod.LIFETIME).first()
+        // CURRENT (documented) behavior: gross = reported 100 + the orphan's own 8 = 108 (double-counted).
+        assertEquals("pins the documented double-count: 100 (reported, already incl. the 8) + 8 (orphan) = 108", 108.0, eco.grossEarnings, 1e-9)
+        assertEquals("unattributed = reported 100 minus session-tied delivered 92", 8.0, eco.unattributedPay, 1e-9)
+        assertEquals("the (No session) bucket still surfaces its own 8, as designed", 8.0, eco.noSessionPay, 1e-9)
+    }
+
+    /**
      * #701: a session whose reported total is LESS than its Σ delivered pay surfaces the excess as
      * [PeriodEconomics.overAttributedPay] — never floored to zero, and never subtracted from
      * `netProfit` (which stays Σ frozen delivery net + cash, with `unattributed` at 0 since reported

--- a/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepositoryTest.kt
+++ b/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepositoryTest.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -383,6 +384,55 @@ class AnalyticsRepositoryTest {
         val life = dao.deliveryTotals(0, Long.MAX_VALUE).first()
         assertEquals(1, life.deliveries)
         assertEquals(12.0, life.pay, 1e-9)
+    }
+
+    /**
+     * #660 piece 1: a `sessionId IS NULL` delivery's pay used to be invisible to [grossAndUnattributed]
+     * (session-anchored, iterates `session_records`) while still counting in net (via [deliveryTotals]'s
+     * own-`completedAt` fallback, #655) — the seam that let displayed net exceed gross. Proves the fix:
+     * the orphan pay is folded into [PeriodEconomics.grossEarnings] and surfaced as its own
+     * [PeriodEconomics.noSessionPay]/[PeriodEconomics.noSessionDeliveries] "(No session)" bucket.
+     */
+    @Test
+    fun `a null-session delivery's pay is folded into gross as the (No session) bucket (#660)`() = runBlocking {
+        // No session at all — an orphan delivery, pay 12 + cash 3, net 9.
+        dao.upsertDelivery(delivery(1, sessionId = null, jobId = "J1", storeName = "Wendys", pay = 12.0, net = 9.0, completedAt = base + hour, cashTip = 3.0))
+
+        val eco = repo.periodEconomics(AnalyticsPeriod.LIFETIME).first()
+        // Before the fix: gross = 0 (no sessions), net = 9 (deliveryNet) + 3 (cash) = 12 — net > gross.
+        // After the fix: gross also includes the orphan's pay + cash (12 + 3 = 15) ⇒ gross ≥ net.
+        assertEquals("gross folds in the orphan pay + cash", 15.0, eco.grossEarnings, 1e-9)
+        assertEquals("net unchanged: frozen 9 + cash 3", 12.0, eco.netProfit, 1e-9)
+        assertTrue("gross can no longer read below net from this seam", eco.grossEarnings >= eco.netProfit)
+        assertEquals("the bucket surfaces its own pay+cash total", 15.0, eco.noSessionPay, 1e-9)
+        assertEquals("the bucket surfaces its own delivery count", 1, eco.noSessionDeliveries)
+    }
+
+    /** A period with no session-less deliveries reports a zero "(No session)" bucket. */
+    @Test
+    fun `noSessionPay and noSessionDeliveries are zero when every delivery has a session (#660)`() = runBlocking {
+        dao.upsertSession(session("S1", base, reportedEarnings = null, durationMillis = hour, startOdo = 0.0, lastOdo = 5.0, deliveries = 1, jobsCompleted = 1))
+        dao.upsertDelivery(delivery(1, "S1", "J1", "Wendys", pay = 10.0, net = 8.0, completedAt = base + hour))
+
+        val eco = repo.periodEconomics(AnalyticsPeriod.LIFETIME).first()
+        assertEquals(0.0, eco.noSessionPay, 1e-9)
+        assertEquals(0, eco.noSessionDeliveries)
+        assertEquals(10.0, eco.grossEarnings, 1e-9)
+    }
+
+    /** The per-platform periodEconomics variant folds the "(No session)" bucket for that platform only. */
+    @Test
+    fun `per-platform periodEconomics folds the (No session) bucket for its own platform (#660)`() = runBlocking {
+        dao.upsertDelivery(delivery(1, sessionId = null, jobId = "J1", storeName = "Wendys", pay = 10.0, net = 8.0, completedAt = base + hour, platform = "doordash"))
+        dao.upsertDelivery(delivery(2, sessionId = null, jobId = "J2", storeName = "McD", pay = 20.0, net = 15.0, completedAt = base + hour, platform = "uber"))
+
+        val dd = repo.periodEconomics(AnalyticsPeriod.LIFETIME, cloud.trotter.dashbuddy.domain.state.Platform.DoorDash).first()
+        assertEquals(10.0, dd.grossEarnings, 1e-9)
+        assertEquals(1, dd.noSessionDeliveries)
+
+        val uber = repo.periodEconomics(AnalyticsPeriod.LIFETIME, cloud.trotter.dashbuddy.domain.state.Platform.Uber).first()
+        assertEquals(20.0, uber.grossEarnings, 1e-9)
+        assertEquals(1, uber.noSessionDeliveries)
     }
 
     /**

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
@@ -424,6 +424,51 @@ interface AnalyticsDao {
     fun grossAndUnattributedByPlatform(start: Long, end: Long): Flow<List<PlatformGrossTotalsRow>>
 
     /**
+     * The "(No session)" bucket (#660 piece 1): Σ realized pay + Σ cash tip + count for deliveries
+     * whose source event carried NO `sessionId` at all, in the window of their own `completedAt` —
+     * the exact null-session population [deliveryTotals] already folds into net (#655's documented
+     * edge), but that [grossAndUnattributed] never sees (it iterates `session_records`, and a
+     * null-session row joins to nothing there). The repository adds this into `grossEarnings` so a
+     * session-less completion can no longer make displayed net exceed gross, and surfaces the same
+     * totals as an explicit data-quality signal.
+     */
+    @Query(
+        """SELECT COALESCE(SUM(realizedPay), 0) AS pay,
+                  COALESCE(SUM(cashTip), 0) AS cash,
+                  COUNT(*) AS deliveries
+           FROM delivery_records
+           WHERE sessionId IS NULL AND completedAt >= :start AND completedAt < :end"""
+    )
+    fun noSessionTotals(start: Long, end: Long): Flow<NoSessionTotalsRow>
+
+    /** Per-platform variant of [noSessionTotals] — same null-session `completedAt` window, grouped on
+     *  the delivery's own denormalized `platform` column. */
+    @Query(
+        """SELECT platform,
+                  COALESCE(SUM(realizedPay), 0) AS pay,
+                  COALESCE(SUM(cashTip), 0) AS cash,
+                  COUNT(*) AS deliveries
+           FROM delivery_records
+           WHERE sessionId IS NULL AND completedAt >= :start AND completedAt < :end
+           GROUP BY platform"""
+    )
+    fun noSessionTotalsByPlatform(start: Long, end: Long): Flow<List<PlatformNoSessionTotalsRow>>
+
+    /**
+     * Every session-less delivery's own completion instant + gross (pay + cash) in a period — the
+     * "(No session)" bucket's per-day chart input (#660), mirroring [sessionGrossRows] for rows that
+     * join to no session at all. The repository buckets each onto the LOCAL DAY of its own
+     * `completedAt` (there is no session start to anchor on).
+     */
+    @Query(
+        """SELECT completedAt,
+                  (COALESCE(realizedPay, 0) + COALESCE(cashTip, 0)) AS gross
+           FROM delivery_records
+           WHERE sessionId IS NULL AND completedAt >= :start AND completedAt < :end"""
+    )
+    fun noSessionDailyRows(start: Long, end: Long): Flow<List<NoSessionDailyRow>>
+
+    /**
      * Per-session start + reported-authoritative gross for the sessions started in `[start, end)` — the
      * per-day earnings chart input (#315 H6). Gross per session = `reportedEarnings` when present else
      * that session's Σ delivered pay (same definition as [grossAndUnattributed]; the LEFT JOIN is onto a

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
@@ -366,11 +366,17 @@ interface AnalyticsDao {
      * `cashTip` alias) — cash is real earnings, so it belongs in gross. The `unattributed` CASE stays
      * **untouched** (it still compares `reportedEarnings` against the cash-free `deliveredPay`), so a
      * recorded cash tip raises gross/net without shrinking the reported-vs-captured reconciliation.
-     * **Invariant (#688 F3):** every cash-bearing row is sessionful (the drill-down writes only
-     * sessionful targets, MANUAL carries a sessionId) — so the cash counted into `net` (via
-     * [deliveryTotals]'s null-session-inclusive `cash`) and into `gross` here (session-join only) is
-     * the same amount; a null-session cash row would leak into net but not gross, which the invariant
-     * forbids.
+     * **Composition with the "(No session)" bucket (#660 piece 1):** this query is deliberately
+     * session-anchored ONLY — a `sessionId IS NULL` delivery joins to no `session_records` row here and
+     * contributes nothing to `gross`/`unattributed`/`overAttributed`, even though it already reaches
+     * `net` via [deliveryTotals]'s own-`completedAt` fallback (#655). That used to be an asymmetry
+     * (#688 F3 called the null-session-cash case "forbidden" back when nothing folded a null-session row
+     * into gross at all); it no longer is — [AnalyticsRepository.periodEconomics] separately reads
+     * [noSessionTotals] and adds its pay+cash on top of this query's `gross`, so the null-session
+     * population reaches gross too, just via a different query. This query's own cash sum
+     * (`d.cashTip`) therefore only ever covers **sessionful** cash-bearing rows (the drill-down writes
+     * only sessionful targets, MANUAL carries a sessionId) — a null-session cash row is picked up by
+     * [noSessionTotals]'s own `cashTip` sum instead, not by this one.
      *
      * **`overAttributed` (#701):** the mirror signal `deliveredPay − reportedEarnings` for sessions
      * where delivered exceeds reported (the opposite excess from `unattributed`) — surfaced as a

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsTotals.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsTotals.kt
@@ -153,6 +153,41 @@ data class SessionGrossRow(
     val gross: Double,
 )
 
+/**
+ * The "(No session)" bucket (#660 piece 1): Σ realized pay + Σ cash tip + count for deliveries whose
+ * source event carried NO `sessionId` at all — the same null-session population [DeliveryTotalsRow]
+ * already folds into net via its own `completedAt` (#655), but that [GrossTotalsRow]/[SessionGrossRow]
+ * never see because those iterate `session_records` and a null-session row joins to nothing. The
+ * repository adds [pay] + [cash] into `grossEarnings` so gross can no longer read below the net that
+ * already counts this pay, and exposes the same totals as an explicit review signal so an orphaned
+ * delivery is a visible data-quality flag, never a silent inconsistency.
+ */
+data class NoSessionTotalsRow(
+    val pay: Double,
+    val cash: Double,
+    val deliveries: Int,
+)
+
+/** Per-platform variant of [NoSessionTotalsRow] (GROUP BY platform) — grouped on the delivery's own
+ *  denormalized `platform` column, since there is no session to derive it from. */
+data class PlatformNoSessionTotalsRow(
+    val platform: String,
+    val pay: Double,
+    val cash: Double,
+    val deliveries: Int,
+)
+
+/**
+ * One session-less delivery's own completion instant + gross (pay + cash) — the "(No session)"
+ * bucket's per-day chart input (#660), mirroring [SessionGrossRow] for rows that join to no session.
+ * The repository buckets each onto the LOCAL DAY of its own [completedAt] (there is no session start
+ * to anchor on, so this mirrors [DeliveryTotalsRow]'s null-session `completedAt` fallback).
+ */
+data class NoSessionDailyRow(
+    val completedAt: Long,
+    val gross: Double,
+)
+
 /** Cross-platform session totals for a period: miles = Σ odo delta, onlineMillis = Σ duration, sessions = COUNT. */
 data class SessionTotalsRow(
     val miles: Double,

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -1572,6 +1572,18 @@ Accept and Decline registered on DoorDash — and moved to that session's entry 
   empty, check logcat for "Capture persistence disabled (release build)" — that means a release
   build got dashed by mistake.
   - Confirmed: 0/2.
+- **"(No session)" bucket keeps gross ≥ net when a delivery lands without a session (#660 piece
+  1).** Only reproducible if a dash produces a `sessionId IS NULL` delivery row (e.g. a straggler
+  DELIVERY_COMPLETED after the app/service restarted mid-dash, or any other path that loses
+  session context) — may not fire on a normal dash. If it does happen: on the Money tab for the
+  period containing that delivery, a new **"(No session): $X across N deliveries not tied to a
+  dash"** callout should appear (same style/placement as the existing unattributed/over-attributed
+  flags), the hero **Gross Earnings** figure should include that delivery's pay (no longer
+  possible for the True-Net chip to show more than Gross), and the per-day chart's bar for that
+  delivery's own completion day should include its pay. If you can't force this edge case, this
+  item can be validated desk-side by inspecting `delivery_records` for any `sessionId IS NULL` row
+  after a dash and confirming the Money tab reflects it as above.
+  - Confirmed: 0/2.
 
 ---
 

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -1583,6 +1583,13 @@ Accept and Decline registered on DoorDash — and moved to that session's entry 
   delivery's own completion day should include its pay. If you can't force this edge case, this
   item can be validated desk-side by inspecting `delivery_records` for any `sessionId IS NULL` row
   after a dash and confirming the Money tab reflects it as above.
+  - **Known caveat (desk-verifiable, not a bug to report):** if the orphan delivery's pay was
+    ALSO already inside a surviving session's captured `reportedEarnings` (e.g. the restart
+    happened mid-dash and the dash's summary screen still got captured afterward), gross will
+    double-count those dollars — expect to see them flagged in BOTH the unattributed callout
+    and the "(No session)" callout at once. This is a known, documented overstatement (mirrors
+    the pre-existing net-side overlap) that piece 2 (categorizing an orphan into its real
+    session) is the actual fix for — no action needed beyond noting it if seen.
   - Confirmed: 0/2.
 
 ---

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/PeriodEconomics.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/PeriodEconomics.kt
@@ -49,6 +49,18 @@ data class PeriodEconomics(
      * Money tab renders alongside the unattributed callout, nothing more.
      */
     val overAttributedPay: Double = 0.0,
+    /**
+     * The "(No session)" bucket (#660 piece 1): Σ (realizedPay + cashTip) for deliveries whose source
+     * event carried NO `sessionId` at all — an orphan population [netProfit] already counted (via the
+     * frozen delivery net + cash, both null-session-inclusive) but that [grossEarnings] historically
+     * never saw (it was purely session-anchored), so a session-less completion could make displayed net
+     * exceed gross. **Folded INTO [grossEarnings]** here so that can no longer happen, and kept as its
+     * own field so the UI can still surface it as an explicit review/data-quality flag alongside
+     * [unattributedPay]/[overAttributedPay]. Zero when every delivery in the period belongs to a session.
+     */
+    val noSessionPay: Double = 0.0,
+    /** Count of the deliveries behind [noSessionPay] — the "(No session)" bucket's delivery count. */
+    val noSessionDeliveries: Int = 0,
 ) {
     companion object {
         val EMPTY = PeriodEconomics(
@@ -61,6 +73,8 @@ data class PeriodEconomics(
             fuelCost = null,
             nonFuelCost = null,
             overAttributedPay = 0.0,
+            noSessionPay = 0.0,
+            noSessionDeliveries = 0,
         )
     }
 }


### PR DESCRIPTION
## Summary

Fixes the #660 seam (Fable retro-review Finding 4, 2026-07-05): a `delivery_records` row whose
source event carried NO `sessionId` at all was already counted in **net** (`deliveryTotals`'s
own-`completedAt` fallback, #655's documented null-session edge) but was **invisible to gross**
(`grossAndUnattributed` / `sessionGrossRows` iterate `session_records` only, so a null-session row
joins to nothing) — a session-less `DELIVERY_COMPLETED` could make displayed net exceed gross.

Per the dev's 2026-07-07 decision on #660, this is **piece 1 only** — the bucket. Piece 2
(categorizing an orphan delivery into a real session via a new correction event) is a separate,
corrections-family design pass and is **not** in this PR; #660 stays **open** for it.

- `AnalyticsDao`: three new reads — `noSessionTotals`/`noSessionTotalsByPlatform` (Σ pay + Σ cash +
  count for `sessionId IS NULL` rows in a period, same WHERE shape as `deliveryTotals`'s null-session
  fallback) and `noSessionDailyRows` (per-row completedAt + gross, for the per-day chart).
- `AnalyticsRepository.periodEconomics`: folds that pay+cash into `PeriodEconomics.grossEarnings` (so
  gross can no longer read below net from this seam) and exposes it as its own
  `noSessionPay`/`noSessionDeliveries` fields — both period-level and per-platform.
- `AnalyticsRepository.dailyEarnings`: folds the same null-session population into the per-day chart,
  bucketed on **the delivery's own completion day** (there's no session start to anchor on) — this is
  the exact follow-up site flagged in the #675 (H6 per-day chart) review comment on #660.
- `MoneyTab`: a new "(No session): $X across N deliveries not tied to a dash" callout, same
  pattern/placement as the existing unattributed/over-attributed review flags — the bucket doubles as
  a visible data-quality signal, not a silent fold into the totals.
- `CLAUDE.md` + `docs/field-testing/README.md`: context update + a field-test checklist item
  (`Confirmed: 0/2`) — this is a data-quality edge case that may not reproduce on every dash.

## Stale premises checked

Verified against current master (post #740/#739/#688-cashTip-at-every-read-site): the gross/net
seam described in the issue is unchanged in shape — `grossAndUnattributed`/`sessionGrossRows` are
still purely session-anchored, `deliveryTotals` still has the documented null-session `completedAt`
fallback (#655). The #688 cash-tip-at-every-read-site rule and #655 session-anchored bucketing are
followed for the new queries (cash is summed alongside pay, never folded into a frozen column).

## Test plan

- [x] `AnalyticsRepositoryTest`: 3 new tests — orphan delivery's pay+cash folds into
      `grossEarnings` and `gross >= net` holds; a session-only period reports a zero bucket;
      the per-platform variant folds only its own platform's orphan rows.
- [x] `AnalyticsDailyEarningsTest`: 1 new test — an orphan delivery adds to its own completion
      day's chart bar (the #675-flagged follow-up site) without disturbing a real session's day.
- [x] `./gradlew :domain:test testDebugUnitTest` — full suite green across all modules.
- [x] `./gradlew :app:compileDebugKotlin` — MoneyTab/strings compile clean.

### Design-goal review

1. **UDF** — read-side only; no reducer/state-machine changes. `MoneyTab` stays pure data-in
   (new `PeriodEconomics` fields flow down through the existing `AnalyticsViewModel` → `uiState`
   pipeline unchanged); the callout is a stateless composable.
2. **MAD** — Kotlin/Flow/Room idioms consistent with the surrounding DAO; no new deps.
3. **Single responsibility** — 3 small, focused DAO queries + 3 small DTOs, mirroring existing
   sibling shapes (`DeliveryTotalsRow`/`SessionGrossRow`); no file grew unreasonably.
4. **Kotlin/Android practices** — data classes, named/default params so all existing
   `PeriodEconomics(...)` call sites (tests) compile unchanged.
5. **SSOT** — the null-session `WHERE sessionId IS NULL AND completedAt >= :start AND completedAt
   < :end` shape is copy-consistent with `deliveryTotals`'s existing documented edge (not a new
   competing definition); `noSessionPay` is folded into `grossEarnings` in exactly one place
   (`assemble`).
6. **Security & privacy** — no new PII surface: economics/counts only (pay, cash, delivery count).
   No new capture, network, or storage path — pure aggregation over already-persisted, already-PII-
   hashed `delivery_records`.
7. **Semantic logging** — not touched; no new log sites.
8. **Platform-agnostic core** — the per-platform variant is keyed by the existing `Platform.wire`
   match pattern already used by `deliveryTotalsByPlatform`/`grossAndUnattributedByPlatform`, no new
   platform literal. Diff doesn't touch `:core:state`/`:core:pipeline`/`:domain` reducer logic (only
   a data-class field addition in `:domain`'s `PeriodEconomics`).
- **Reactive UI** — the new callout renders from the same reactive `PeriodEconomics` Flow the rest
  of `MoneyTab` already observes (Room invalidation on delivery upserts); no new manual-refresh path.

### Adversarial review

Not yet run — this PR is opened by the builder agent per the #660 dev-vetted bounded spec (piece 1
only); the adversarial `/code-review` + design-principles + security pass happens before merge, per
CLAUDE.md's Git Workflow. **This PR is not to be merged by the builder.**

## Field validation

Added to `docs/field-testing/README.md` § Next field test: the "(No session)" bucket is only
reproducible if a dash actually produces a `sessionId IS NULL` delivery row (rare edge case —
e.g. a straggler completion after an app/service restart mid-dash), so it's flagged as
desk-verifiable via `delivery_records` inspection if it doesn't naturally occur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

### Adversarial review (Fable-tier, 2026-07-10)

One finder, single mandate: trace the gross composition end-to-end for double-count paths. **Verdict: no SQL-level double-count** — the `sessionId IS NULL` population provably never joins any session-anchored gross read (NULL never joins; `NULL IN (…)` never true); net's composition is byte-identical pre/post; the three new WHERE shapes are token-identical to the #655 fallback disjunct (no period-boundary divergence between callout, hero, chart, and net); the #688 cash lanes stay structurally cash-free; the waterfall's `cost = gross − net` now reconciles *better* (orphan frozen costs were already in the cost sums while their pay was missing from gross); the exact-value tests would catch a structural double-count.

**One semantic seam found → documented + pinned (fixed in commit `c01eb012`):** when an orphan's pay is ALSO inside a surviving session's `reportedEarnings` (mid-dash restart with the summary captured), gross overstates by that amount and the same dollars flag in BOTH the unattributed and (No session) callouts. This mirrors the pre-existing net-side overlap; **#660 piece 2 (categorize-into-session) is the real fix.** Now: KDoc on the fold names the seam + piece 2; the checklist item carries the desk caveat; a mixed-population exact test (58.0) guards the disjointness; and a **deliberate characterization test pins the current 108.0 behavior with a comment that it goes red when piece 2 lands** — piece 2 inherits a red/green anchor.

**Also fixed:** the stale `grossAndUnattributed` "invariant forbids" KDoc (defused by this PR — rewritten to the current composition); the per-day chart caption now discloses the completion-day exception for (No session) deliveries.

#660 stays OPEN for piece 2.
