### PR TITLE
fix(#630): mid-stack under-attribution — final-shape gate, minted-set denominator, collapsed-downgrade guard, order-invariant cents

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/replay/TwoPickupStackReplayTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/replay/TwoPickupStackReplayTest.kt
@@ -1,6 +1,7 @@
 package cloud.trotter.dashbuddy.replay
 
 import cloud.trotter.dashbuddy.domain.model.event.AppEventType
+import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.PickupPayload
 import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.domain.state.TaskPhase
@@ -148,6 +149,29 @@ class TwoPickupStackReplayTest {
                 "no fresh mint)",
             placeholderDropoffIds.containsAll(activeDropIds),
         )
+    }
+
+    @Test
+    fun `receipted jobs' dropRealizedPay shares sum to their receipt total (#630 mainline pin)`() {
+        // The #630 no-regression invariant over the whole trace: for every job whose
+        // DELIVERY_COMPLETED rows observed a receipt (any row carries a non-null parsedPay), the
+        // stamped dropRealizedPay shares sum EXACTLY to that receipt's total in integer cents.
+        // (With THIS fixture the documented address-parse residual means no DELIVERY_COMPLETED is
+        // reached — the assertion is then vacuous — but it pins the mainline the moment the fixture
+        // or the machine closes the job cleanly.)
+        val steps = run()
+        val deliveries = steps.flatMap { it.events }
+            .filter { it.type == AppEventType.DELIVERY_COMPLETED }
+            .mapNotNull { it.payload as? DeliveryPayload }
+        deliveries.groupBy { it.jobId }.forEach { (jobId, rows) ->
+            val receiptTotal = rows.firstNotNullOfOrNull { it.parsedPay }?.total ?: return@forEach
+            val summed = rows.mapNotNull { it.dropRealizedPay }.sumOf { Math.round(it * 100.0) }
+            assertEquals(
+                "job $jobId: Σ dropRealizedPay must equal the observed receipt total (cents-exact)",
+                Math.round(receiptTotal * 100.0),
+                summed,
+            )
+        }
     }
 
     @Test

--- a/app/src/test/java/cloud/trotter/dashbuddy/replay/TwoPickupStackReplayTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/replay/TwoPickupStackReplayTest.kt
@@ -3,6 +3,8 @@ package cloud.trotter.dashbuddy.replay
 import cloud.trotter.dashbuddy.domain.model.event.AppEventType
 import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.PickupPayload
+import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.state.ParsedFields
 import cloud.trotter.dashbuddy.domain.state.Platform
 import cloud.trotter.dashbuddy.domain.state.TaskPhase
 import cloud.trotter.dashbuddy.test.util.SessionReplay
@@ -153,21 +155,41 @@ class TwoPickupStackReplayTest {
 
     @Test
     fun `receipted jobs' dropRealizedPay shares sum to their receipt total (#630 mainline pin)`() {
-        // The #630 no-regression invariant over the whole trace: for every job whose
-        // DELIVERY_COMPLETED rows observed a receipt (any row carries a non-null parsedPay), the
-        // stamped dropRealizedPay shares sum EXACTLY to that receipt's total in integer cents.
+        // The #630 no-regression invariant over the whole trace. Two honesty fixes vs the naive pin:
+        //  (a) DEDUP-AWARE: SessionReplay has NO effects_fired dedup, so a taskId re-emitted (null at a
+        //      non-final PostTask exit, then its share at close) appears TWICE in the raw trace. The
+        //      live engine persists only the FIRST emission per taskId — mirror that here (first wins)
+        //      so the summed Σ matches what actually lands in app_events.
+        //  (b) OBSERVED-RECEIPT total: derive the expected total from the PostTask OBSERVATION's
+        //      parsedPay (the receipt the dasher actually saw), NOT from the row payloads — a #630
+        //      withheld receipt (mid-stack exit stamps parsedPay = null on the row) would otherwise
+        //      silently drop the whole job from the assertion, hiding the exact shape #630 defends.
         // (With THIS fixture the documented address-parse residual means no DELIVERY_COMPLETED is
-        // reached — the assertion is then vacuous — but it pins the mainline the moment the fixture
-        // or the machine closes the job cleanly.)
+        // reached — the assertion is then vacuous, driving it to close is #700 — but it pins the
+        // mainline the moment the fixture or the machine closes a job cleanly.)
         val steps = run()
-        val deliveries = steps.flatMap { it.events }
+
+        // Per job, the receipt total the dasher observed on a PostTask frame (max across the trace —
+        // the FINAL receipt is the largest; keyed on the active job at that step).
+        val observedReceiptByJob = HashMap<String, Double>()
+        steps.forEach { s ->
+            val fields = (s.observation as? Observation.Screen)?.parsed as? ParsedFields.PostTaskFields
+            val total = fields?.parsedPay?.total ?: return@forEach
+            val jobId = dd(s)?.activeJob?.jobId ?: return@forEach
+            observedReceiptByJob[jobId] = maxOf(observedReceiptByJob[jobId] ?: 0.0, total)
+        }
+
+        // DELIVERY_COMPLETED rows, deduped to the FIRST emission per taskId (live-engine persistence).
+        val persistedRows = steps.flatMap { it.events }
             .filter { it.type == AppEventType.DELIVERY_COMPLETED }
             .mapNotNull { it.payload as? DeliveryPayload }
-        deliveries.groupBy { it.jobId }.forEach { (jobId, rows) ->
-            val receiptTotal = rows.firstNotNullOfOrNull { it.parsedPay }?.total ?: return@forEach
+            .distinctBy { it.taskId }
+        persistedRows.groupBy { it.jobId }.forEach { (jobId, rows) ->
+            val receiptTotal = observedReceiptByJob[jobId] ?: return@forEach
             val summed = rows.mapNotNull { it.dropRealizedPay }.sumOf { Math.round(it * 100.0) }
             assertEquals(
-                "job $jobId: Σ dropRealizedPay must equal the observed receipt total (cents-exact)",
+                "job $jobId: Σ dropRealizedPay (first-emission-per-taskId) must equal the OBSERVED " +
+                    "receipt total (cents-exact)",
                 Math.round(receiptTotal * 100.0),
                 summed,
             )

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/DeliveryCompletionEffects.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/DeliveryCompletionEffects.kt
@@ -92,14 +92,45 @@ internal fun EffectMap.diffDeliveryCompletion(
             if (completedTask != null && completedTask.phase == TaskPhase.DROPOFF && !identityLess) {
                 val retireSince = p.pendingDestructive
                     ?.takeIf { it.kind == DestructiveKind.TASK_RETIRE }?.since
-                // #528: attribute this drop's share of the combined receipt. Read the
-                // receipt from the PREV region's lastPostTaskFields (the singular job
-                // receipt) directly — NOT the per-task pinning — so every drop of a stack
-                // gets a share, not just the announced one.
-                val dropShare = DropPayApportioner.apportion(
-                    parsedPay = p.lastPostTaskFields?.parsedPay,
-                    dropoffTasks = jobDropoffTasks(next, p.activeJob?.jobId),
-                )[completedTask.taskId]
+                // #630 R2: gate the receipt split on the job's FINAL shape (the SAME predicate
+                // #691's requireFinalShape uses — [OfferPayFallback.isFinalShape], one definition).
+                // At a mid-stack, non-final exit the job's `lastPostTaskFields` is only a PARTIAL
+                // receipt (covers the delivered-so-far drops) over a PROVISIONAL denominator, so
+                // splitting it would freeze a wrong share on this drop while later siblings mint
+                // against the FINAL receipt → Σ drifts below the real total (findings 1/3). A
+                // no-activeJob exit is trivially final (its jobId would be null anyway).
+                val finalShape =
+                    p.activeJob?.let { OfferPayFallback.isFinalShape(it, completedTask.taskId) } ?: true
+                // #528/#630 R1: attribute this drop's share of the combined receipt over the
+                // minting-qualified denominator (the exact rows that will ever mint), so the shares
+                // sum to the receipt total. Withhold entirely on a non-final exit (R2/R4).
+                val dropShare = if (finalShape) {
+                    DropPayApportioner.apportion(
+                        parsedPay = p.lastPostTaskFields?.parsedPay,
+                        dropoffTasks = mintingDropoffTasks(
+                            p, next, p.activeJob?.jobId,
+                            retirePending = retireSince != null,
+                            emittedThisStep = emittedThisStep + completedTask.taskId,
+                        ),
+                    )[completedTask.taskId]
+                } else {
+                    null
+                }
+                // #630 R2 (load-bearing): a non-final exit must NOT attach the partial receipt to the
+                // payload either — else the fold's RECEIPT_TOTAL arm stamps the WHOLE partial total on
+                // this row, turning the under-attribution into an OVER-count once siblings mint. With
+                // both nulled the row folds PayBasis.NONE and its dollars ride the unattributed bucket.
+                val receiptForPayload = if (finalShape) p.lastPostTaskFields else null
+                // #630 R4: the mid-stack partial-receipt seam is observable in the field. PII-safe —
+                // counts + jobId only, stable tag (Principle 7; the #691 FIX-6 / #699 D6 precedent).
+                if (!finalShape && p.lastPostTaskFields?.parsedPay != null) {
+                    Timber.tag("StateMachine").w(
+                        "#630 mid-stack non-final receipt exit: job %s, %d owed dropoffs — " +
+                            "dropRealizedPay withheld (partial receipt not split; rides unattributed)",
+                        p.activeJob?.jobId,
+                        p.activeJob?.tasks?.count { it.phase == TaskPhase.DROPOFF } ?: 0,
+                    )
+                }
                 // #691: when the whole job was receipt-less, stamp this drop's equal-split
                 // share of the accepted-offer pay so it folds a real net row (not $0-unattr).
                 // FIX 1: a PostTask-exit mint's job may still be OPEN — stamp only when this is
@@ -115,7 +146,7 @@ internal fun EffectMap.diffDeliveryCompletion(
                     task = completedTask,
                     jobId = p.activeJob?.jobId,
                     completedAt = completedTask.completedAt ?: retireSince ?: obs.timestamp,
-                    postTaskFields = p.lastPostTaskFields,
+                    postTaskFields = receiptForPayload,
                     sessionEarnings = next.session?.runningEarnings ?: p.session?.runningEarnings,
                     dropRealizedPay = dropShare,
                     offerPayShare = offerShare,
@@ -169,7 +200,11 @@ internal fun EffectMap.diffDeliveryCompletion(
         // one over-full row become per-drop shares that sum to the receipt total).
         val dropShares = DropPayApportioner.apportion(
             parsedPay = p.lastPostTaskFields?.parsedPay,
-            dropoffTasks = jobDropoffTasks(next, closedJob.jobId),
+            dropoffTasks = mintingDropoffTasks(
+                p, next, closedJob.jobId,
+                retirePending = retirePending,
+                emittedThisStep = emittedThisStep,
+            ),
         )
         for (task in next.recentTasks) {
             if (task.jobId != closedJob.jobId || task.phase != TaskPhase.DROPOFF) continue
@@ -326,19 +361,42 @@ private fun EffectMap.receiptSuppressesEstimate(region: PlatformRegion, job: Job
 }
 
 /**
- * The job's delivered dropoff tasks — the completion rows the [DropPayApportioner] splits the
- * receipt across (#528). Sourced from the region records at the mint step (`recentTasks` +
- * the active task, deduped by id), scoped to [jobId] and the DROPOFF phase, and restricted to
- * identity-bearing drops so it mirrors the close-out's #498 identity firewall — an identity-
- * less phantom that never mints a completion must not inflate the split denominator.
+ * #630 R1: the job's *minting-qualified* delivered dropoffs — the EXACT set of completion rows the
+ * [DropPayApportioner] splits the receipt across, so the denominator equals the minted-row set and
+ * `Σ dropRealizedPay` sums to the receipt total. Replaces the former `jobDropoffTasks`, which
+ * returned ALL identity-bearing dropoffs of the job (incl. an endSession-force-stamped or otherwise
+ * undelivered drop that entered the denominator but never MINTED → its share evaporated → Σ < total,
+ * findings 1/3).
+ *
+ * Sourced from the region records at the mint step (`recentTasks` + the active task, deduped by id),
+ * scoped to [jobId] + the DROPOFF phase, restricted to identity-bearing, non-unassigned drops (the
+ * #498 phantom + #736 unassign firewalls), then filtered to the rows that will actually mint — the
+ * SAME amdt#5 qualification the close-out loop applies: already completed before this step, OR the
+ * active task just retired under a TASK_RETIRE grace, OR minted by the PostTask-exit block this step
+ * ([emittedThisStep]). Both mint blocks call this with identical arguments so a co-firing step agrees
+ * on one denominator (and the [DropPayApportioner]'s canonical `taskId` sort makes the remainder cent
+ * order-invariant across the two calls, #630 finding 4).
  */
-private fun EffectMap.jobDropoffTasks(region: PlatformRegion, jobId: String?): List<Task> {
+private fun EffectMap.mintingDropoffTasks(
+    p: PlatformRegion,
+    next: PlatformRegion,
+    jobId: String?,
+    retirePending: Boolean,
+    emittedThisStep: Set<String>,
+): List<Task> {
     if (jobId == null) return emptyList()
-    return (region.recentTasks + listOfNotNull(region.activeTask))
+    return (next.recentTasks + listOfNotNull(next.activeTask))
         .filter {
             it.jobId == jobId &&
                 it.phase == TaskPhase.DROPOFF &&
+                it.unassignedAt == null &&
                 (it.customerNameHash != null || it.customerAddressHash != null)
         }
         .distinctBy { it.taskId }
+        .filter { t ->
+            val alreadyCompleted =
+                p.recentTasks.any { it.taskId == t.taskId && it.completedAt != null }
+            val justRetiredUnderGrace = retirePending && p.activeTask?.taskId == t.taskId
+            alreadyCompleted || justRetiredUnderGrace || t.taskId in emittedThisStep
+        }
 }

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/DeliveryCompletionEffects.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/DeliveryCompletionEffects.kt
@@ -13,6 +13,7 @@ import cloud.trotter.dashbuddy.domain.state.ParsedFields
 import cloud.trotter.dashbuddy.domain.state.PlatformRegion
 import cloud.trotter.dashbuddy.domain.state.Task
 import cloud.trotter.dashbuddy.domain.state.TaskPhase
+import cloud.trotter.dashbuddy.domain.state.isAccountableDropoff
 import timber.log.Timber
 
 /**
@@ -89,7 +90,15 @@ internal fun EffectMap.diffDeliveryCompletion(
             val identityLess = completedTask != null &&
                 completedTask.customerNameHash == null &&
                 completedTask.customerAddressHash == null
-            if (completedTask != null && completedTask.phase == TaskPhase.DROPOFF && !identityLess) {
+            // #736 belt: the `recentTasks.lastOrNull { jobId }` fallback above can select a drop the
+            // dasher UNASSIGNED (a null-completedAt abandon that the close-out sweep already filters) —
+            // it must never be the PostTask-exit mint target either, or it fabricates a
+            // DELIVERY_COMPLETED for a never-delivered order. Mirrors the close-out's `unassignedAt`
+            // firewall (below) at this second mint site.
+            val unassigned = completedTask?.unassignedAt != null
+            if (completedTask != null && completedTask.phase == TaskPhase.DROPOFF &&
+                !identityLess && !unassigned
+            ) {
                 val retireSince = p.pendingDestructive
                     ?.takeIf { it.kind == DestructiveKind.TASK_RETIRE }?.since
                 // #630 R2: gate the receipt split on the job's FINAL shape (the SAME predicate
@@ -123,7 +132,12 @@ internal fun EffectMap.diffDeliveryCompletion(
                 val receiptForPayload = if (finalShape) p.lastPostTaskFields else null
                 // #630 R4: the mid-stack partial-receipt seam is observable in the field. PII-safe —
                 // counts + jobId only, stable tag (Principle 7; the #691 FIX-6 / #699 D6 precedent).
-                if (!finalShape && p.lastPostTaskFields?.parsedPay != null) {
+                // Gate on the SAME pay-bearing predicate the fold/estimate use (parsedPay != null ||
+                // totalPay > 0.0) so a pay-bearing COLLAPSED receipt (a $X total with no itemized
+                // parsedPay) is not silently skipped by the WARN.
+                val payBearingReceipt = p.lastPostTaskFields
+                    ?.let { it.parsedPay != null || it.totalPay > 0.0 } == true
+                if (!finalShape && payBearingReceipt) {
                     Timber.tag("StateMachine").w(
                         "#630 mid-stack non-final receipt exit: job %s, %d owed dropoffs — " +
                             "dropRealizedPay withheld (partial receipt not split; rides unattributed)",
@@ -369,13 +383,14 @@ private fun EffectMap.receiptSuppressesEstimate(region: PlatformRegion, job: Job
  * findings 1/3).
  *
  * Sourced from the region records at the mint step (`recentTasks` + the active task, deduped by id),
- * scoped to [jobId] + the DROPOFF phase, restricted to identity-bearing, non-unassigned drops (the
- * #498 phantom + #736 unassign firewalls), then filtered to the rows that will actually mint — the
- * SAME amdt#5 qualification the close-out loop applies: already completed before this step, OR the
- * active task just retired under a TASK_RETIRE grace, OR minted by the PostTask-exit block this step
- * ([emittedThisStep]). Both mint blocks call this with identical arguments so a co-firing step agrees
- * on one denominator (and the [DropPayApportioner]'s canonical `taskId` sort makes the remainder cent
- * order-invariant across the two calls, #630 finding 4).
+ * scoped to [jobId] + the **accountable-dropoff** filter ([Task.isAccountableDropoff]: DROPOFF phase,
+ * identity-bearing, non-unassigned — the #498 phantom + #736 unassign firewalls), then filtered to the
+ * rows that will actually mint — the SAME amdt#5 qualification the close-out loop applies: already
+ * completed before this step, OR the active task just retired under a TASK_RETIRE grace, OR minted by
+ * the PostTask-exit block this step ([emittedThisStep]). Both mint blocks call this with identical
+ * arguments so a co-firing step agrees on one denominator (and the [DropPayApportioner]'s canonical
+ * `taskId` sort makes the remainder cent order-invariant across the two calls, #630 finding 4). The
+ * accountable-dropoff filter is the SSOT shared with [OfferPayFallback.isFinalShape] (Principle 5).
  */
 private fun EffectMap.mintingDropoffTasks(
     p: PlatformRegion,
@@ -386,12 +401,7 @@ private fun EffectMap.mintingDropoffTasks(
 ): List<Task> {
     if (jobId == null) return emptyList()
     return (next.recentTasks + listOfNotNull(next.activeTask))
-        .filter {
-            it.jobId == jobId &&
-                it.phase == TaskPhase.DROPOFF &&
-                it.unassignedAt == null &&
-                (it.customerNameHash != null || it.customerAddressHash != null)
-        }
+        .filter { it.jobId == jobId && it.isAccountableDropoff }
         .distinctBy { it.taskId }
         .filter { t ->
             val alreadyCompleted =

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
@@ -693,11 +693,24 @@ class PlatformRegionStepper @Inject constructor() {
                 // one frame and double-fired the receipt bubble on the
                 // expanded re-observation.
                 val postTaskTaskId = r.activeTask?.taskId ?: r.recentTasks.lastOrNull()?.taskId
-                r = r.copy(
-                    lastPostTaskPayHash = payHash,
-                    lastPostTaskFields = parsed,
-                    lastAnnouncedPostTaskTaskId = postTaskTaskId ?: r.lastAnnouncedPostTaskTaskId,
-                )
+                // #630 R3: never let a COLLAPSED re-render (parsedPay == null) clobber an already-
+                // captured EXPANDED receipt for the SAME announced task. A PostTask re-entry (e.g.
+                // after a chained-offer decline) can render collapsed first, and if the retire-grace
+                // close-out apportions off `lastPostTaskFields` before auto-expand restores the
+                // itemized receipt, `apportion(null)` nulls every not-yet-minted drop's share while an
+                // exit-minted drop kept its share → Σ < total. A DIFFERENT task's collapsed receipt is
+                // a genuinely new receipt and still overwrites. `sessionEarnings` still folds below.
+                val sameTaskCollapsedDowngrade = parsed.parsedPay == null &&
+                    r.lastPostTaskFields?.parsedPay != null &&
+                    postTaskTaskId != null &&
+                    postTaskTaskId == r.lastAnnouncedPostTaskTaskId
+                if (!sameTaskCollapsedDowngrade) {
+                    r = r.copy(
+                        lastPostTaskPayHash = payHash,
+                        lastPostTaskFields = parsed,
+                        lastAnnouncedPostTaskTaskId = postTaskTaskId ?: r.lastAnnouncedPostTaskTaskId,
+                    )
+                }
                 r.session?.let { session ->
                     val earnings = parsed.sessionEarnings
                     if (earnings != null) {

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
@@ -700,6 +700,9 @@ class PlatformRegionStepper @Inject constructor() {
                 // itemized receipt, `apportion(null)` nulls every not-yet-minted drop's share while an
                 // exit-minted drop kept its share → Σ < total. A DIFFERENT task's collapsed receipt is
                 // a genuinely new receipt and still overwrites. `sessionEarnings` still folds below.
+                // Accepted trade: on the same-task skip the collapsed frame's possibly-updated
+                // `totalPay` is DISCARDED (the itemized expanded receipt is authoritative); an EXPANDED
+                // re-render (`parsedPay != null`) is not a downgrade and refreshes both fields normally.
                 val sameTaskCollapsedDowngrade = parsed.parsedPay == null &&
                     r.lastPostTaskFields?.parsedPay != null &&
                     postTaskTaskId != null &&

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapDropPayTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapDropPayTest.kt
@@ -22,6 +22,7 @@ import cloud.trotter.dashbuddy.domain.state.TaskPhase
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -168,6 +169,181 @@ class EffectMapDropPayTest {
         val rows = completedRows(prev, next, screenObs(Flow.Idle, timestamp = 3000L))
         assertEquals(1, rows.size)
         assertNull("no receipt → null realized pay", rows.single().dropRealizedPay)
+    }
+
+    // =========================================================================
+    // #630 — mid-stack / multi-receipt hardening
+    // =========================================================================
+
+    /** A job whose owed-dropoff mirror ([Job.tasks]) drives the #630 final-shape gate. */
+    private fun jobWithTasks(tasks: List<Task>) = Job(
+        jobId = "J",
+        offerStoreHint = emptyList(),
+        parentOfferHash = null,
+        tasks = tasks,
+        startedAt = 50L,
+    )
+
+    @Test
+    fun `mid-stack non-final PostTask exit — no share of a partial receipt, receipt not attached (#630 R2)`() {
+        // 3-drop stack: A delivered, B exiting PostTask NOW with the PARTIAL receipt R_AB visible,
+        // C still owed. B's completion must carry NO dropRealizedPay and NO parsedPay/totalPay —
+        // attaching the partial receipt would make the fold stamp RECEIPT_TOTAL with R_AB.total,
+        // converting the under-attribution into an OVER-count once A/C mint their R_ABC shares.
+        val receiptAB = ParsedPay(
+            appPayComponents = listOf(ParsedPayItem("Base Pay", 6.0)),
+            customerTips = listOf(ParsedPayItem("Target", 4.0)),
+        ) // total $10 — covers A+B only
+        val postFieldsAB = ParsedFields.PostTaskFields(totalPay = 10.0, parsedPay = receiptAB, sessionEarnings = 30.0)
+        val dropA = dropoff("dA", "Target", "cA", completedAt = 350L)
+        val dropB = dropoff("dB", "Maple", "cB", completedAt = null)
+        val dropC = dropoff("dC", "Chili's", "cC", completedAt = null) // the still-owed sibling
+
+        val logged = mutableListOf<String>()
+        val tree = object : timber.log.Timber.Tree() {
+            override fun log(priority: Int, tag: String?, message: String, t: Throwable?) { logged += message }
+        }
+        timber.log.Timber.plant(tree)
+        try {
+            val regionPrev = PlatformRegion(
+                platform = Platform.DoorDash,
+                mode = Mode.Online,
+                session = Session("s1", startedAt = 100L, runningEarnings = 30.0),
+                activeJob = jobWithTasks(listOf(dropA, dropB, dropC)),
+                activeTask = dropB,
+                recentTasks = listOf(dropA),
+                lastPostTaskFields = postFieldsAB,
+                lastAnnouncedPostTaskTaskId = "dB",
+            )
+            val regionNext = regionPrev.copy()
+
+            val prev = appState(FlowRegion(flow = Flow.PostTask), mapOf(Platform.DoorDash to regionPrev))
+            val next = appState(FlowRegion(flow = Flow.TaskDropoffNavigation), mapOf(Platform.DoorDash to regionNext))
+
+            val rows = completedRows(prev, next, screenObs(Flow.TaskDropoffNavigation, timestamp = 3000L))
+            assertEquals("only B completes on this exit", 1, rows.size)
+            val b = rows.single()
+            assertEquals("dB", b.taskId)
+            assertNull("no share of a partial receipt (R2)", b.dropRealizedPay)
+            assertNull("the partial receipt must NOT ride the payload (fold RECEIPT_TOTAL over-count)", b.parsedPay)
+            assertNull(b.totalPay)
+            assertNull("estimate independently withheld (requireFinalShape + pay-bearing receipt)", b.offerPayShare)
+            assertTrue(
+                "the non-final receipt exit emits ONE observability WARN (R4)",
+                logged.any { it.contains("#630 mid-stack non-final receipt exit") },
+            )
+        } finally {
+            timber.log.Timber.uproot(tree)
+        }
+    }
+
+    @Test
+    fun `mid-stack shape at close — final receipt splits over the FULL denominator, shortfall visible (#630 R4)`() {
+        // The same stack later closes with the FINAL receipt R_ABC. The close-out splits R_ABC over
+        // the full minted denominator INCLUDING the early-minted B (DD-2: per-row honesty) — B's
+        // re-emission is swallowed live by effects_fired, so its computed share is intentionally NOT
+        // redistributed to A/C: the persisted rows sum to (total − B's share) and the difference
+        // surfaces read-side as unattributed.
+        val receiptABC = ParsedPay(
+            appPayComponents = listOf(ParsedPayItem("Base Pay", 9.0)),
+            customerTips = listOf(
+                ParsedPayItem("Target", 4.0),
+                ParsedPayItem("Maple", 2.0),
+                ParsedPayItem("Chili's", 3.0),
+            ),
+        ) // total $18
+        val postFieldsABC = ParsedFields.PostTaskFields(totalPay = 18.0, parsedPay = receiptABC, sessionEarnings = 48.0)
+        val dropA = dropoff("dA", "Target", "cA", completedAt = 350L)
+        val dropB = dropoff("dB", "Maple", "cB", completedAt = 400L)
+        val dropC = dropoff("dC", "Chili's", "cC", completedAt = 450L)
+
+        val regionPrev = PlatformRegion(
+            platform = Platform.DoorDash,
+            mode = Mode.Online,
+            session = Session("s1", startedAt = 100L, runningEarnings = 48.0),
+            activeJob = jobWithTasks(listOf(dropA, dropB, dropC)),
+            recentTasks = listOf(dropA, dropB, dropC),
+            lastPostTaskFields = postFieldsABC,
+            lastAnnouncedPostTaskTaskId = "dC",
+        )
+        val regionNext = regionPrev.copy(activeJob = null)
+
+        val prev = appState(FlowRegion(flow = Flow.Idle), mapOf(Platform.DoorDash to regionPrev))
+        val next = appState(FlowRegion(flow = Flow.Idle), mapOf(Platform.DoorDash to regionNext))
+
+        val rows = completedRows(prev, next, screenObs(Flow.Idle, timestamp = 5000L))
+        assertEquals("close-out emits all three (B's re-emission dedups live)", 3, rows.size)
+
+        // Tip-exact shares over the FULL 3-drop denominator: base $9/3 = $3 each.
+        val a = rows.single { it.taskId == "dA" }
+        val b = rows.single { it.taskId == "dB" }
+        val c = rows.single { it.taskId == "dC" }
+        assertEquals(7.0, a.dropRealizedPay!!, 0.001)
+        assertEquals(5.0, b.dropRealizedPay!!, 0.001)
+        assertEquals(6.0, c.dropRealizedPay!!, 0.001)
+        assertEquals(
+            "Σ(all computed shares) == final receipt total in cents",
+            cents(receiptABC.total),
+            rows.sumOf { cents(it.dropRealizedPay!!) },
+        )
+        // The persisted invariant: B minted null at the non-final exit (previous test), so the rows
+        // that actually persist sum to total − share(B) — the visible, never-redistributed shortfall.
+        assertEquals(
+            cents(receiptABC.total) - cents(b.dropRealizedPay!!),
+            cents(a.dropRealizedPay!!) + cents(c.dropRealizedPay!!),
+        )
+    }
+
+    @Test
+    fun `endSession force-stamp — the undelivered drop is excluded, shares sum to the receipt (#630 R1)`() {
+        // 3-drop job with a receipt visible; drops 1-2 delivered, drop 3 UNDELIVERED when the dash
+        // ends. endSession force-stamps drop 3's completedAt into recentTasks (T3), but the amdt#5
+        // guard keeps it from MINTING — so the denominator must exclude it too, or its share would
+        // evaporate (Σ < total). The receipt splits fully across the two rows that mint.
+        val receipt = ParsedPay(
+            appPayComponents = listOf(ParsedPayItem("Base Pay", 12.0)),
+            customerTips = emptyList(),
+        ) // total $12, no tips → equal split
+        val postFields = ParsedFields.PostTaskFields(totalPay = 12.0, parsedPay = receipt, sessionEarnings = 40.0)
+        val d1 = dropoff("d1", "Target", "c1", completedAt = 350L)
+        val d2 = dropoff("d2", "Maple", "c2", completedAt = 400L)
+        val d3 = dropoff("d3", "Chili's", "c3", completedAt = null) // active, undelivered
+
+        val regionPrev = PlatformRegion(
+            platform = Platform.DoorDash,
+            mode = Mode.Online,
+            session = Session("s1", startedAt = 100L, runningEarnings = 40.0),
+            activeJob = jobWithTasks(listOf(d1, d2, d3)),
+            activeTask = d3,
+            recentTasks = listOf(d1, d2),
+            lastPostTaskFields = postFields,
+            lastAnnouncedPostTaskTaskId = "d2",
+        )
+        // The endSession shape: session/job/task cleared, d3 force-stamped into recentTasks.
+        val regionNext = regionPrev.copy(
+            session = null,
+            activeJob = null,
+            activeTask = null,
+            recentTasks = listOf(d1, d2, d3.copy(completedAt = 5000L)),
+            lastPostTaskFields = null,
+            lastPostTaskPayHash = null,
+        )
+
+        val prev = appState(FlowRegion(flow = Flow.Idle), mapOf(Platform.DoorDash to regionPrev))
+        val next = appState(FlowRegion(flow = Flow.Idle), mapOf(Platform.DoorDash to regionNext))
+
+        val rows = completedRows(prev, next, screenObs(Flow.Idle, timestamp = 5000L))
+        assertEquals("exactly the two DELIVERED drops mint (amdt#5 excludes the force-stamp)", 2, rows.size)
+        assertTrue(rows.none { it.taskId == "d3" })
+        val r1 = rows.single { it.taskId == "d1" }
+        val r2 = rows.single { it.taskId == "d2" }
+        assertEquals("denominator = 2 (not 3): \$12 / 2", 6.0, r1.dropRealizedPay!!, 0.001)
+        assertEquals(6.0, r2.dropRealizedPay!!, 0.001)
+        assertEquals(
+            "Σ minted shares == the receipt total to the cent (finding 3 fixed)",
+            cents(receipt.total),
+            rows.sumOf { cents(it.dropRealizedPay!!) },
+        )
     }
 
     @Test

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapDropPayTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapDropPayTest.kt
@@ -346,6 +346,122 @@ class EffectMapDropPayTest {
         )
     }
 
+    // =========================================================================
+    // #630 review — the isFinalShape gate must not be WEDGED by an un-mintable sibling
+    // (a never-activated customer-TBD placeholder, #749; or an unassigned drop, #736).
+    // On cd348221 (pre-fix) both wedge the gate shut → the delivered drop mints
+    // dropRealizedPay = null AND postTaskFields = null → the whole receipt folds NONE.
+    // =========================================================================
+
+    /** A never-activated dropoff placeholder — customer-TBD, both identity hashes null (#749). */
+    private fun placeholderDrop(id: String) = Task(
+        taskId = id,
+        jobId = "J",
+        phase = TaskPhase.DROPOFF,
+        customerNameHash = null,
+        customerAddressHash = null,
+        startedAt = 300L,
+        completedAt = null,
+    )
+
+    @Test
+    fun `dangling placeholder sibling does not wedge the gate — delivered drop gets the FULL receipt (#630 review, #749)`() {
+        // Job: one identity-RESOLVED delivered drop + one customer-TBD dangling placeholder that never
+        // activated (both hashes null). The delivered drop exits PostTask with the receipt. The
+        // placeholder can never mint, so it must NOT hold the final-shape gate shut — the delivered
+        // drop is the sole accountable dropoff and takes the whole receipt.
+        val receipt = ParsedPay(appPayComponents = listOf(ParsedPayItem("Base Pay", 12.0)), customerTips = emptyList())
+        val postFields = ParsedFields.PostTaskFields(totalPay = 12.0, parsedPay = receipt, sessionEarnings = 40.0)
+        val delivered = dropoff("dDelivered", "Wendy's", "cW", completedAt = 400L)
+        val placeholder = placeholderDrop("dPlaceholder")
+
+        val regionPrev = PlatformRegion(
+            platform = Platform.DoorDash,
+            mode = Mode.Online,
+            session = Session("s1", startedAt = 100L, runningEarnings = 40.0),
+            activeJob = jobWithTasks(listOf(delivered, placeholder)),
+            activeTask = delivered,
+            recentTasks = listOf(delivered),
+            lastPostTaskFields = postFields,
+            lastAnnouncedPostTaskTaskId = "dDelivered",
+        )
+        val regionNext = regionPrev.copy() // job stays open → only the PostTask-exit mint fires
+
+        val prev = appState(FlowRegion(flow = Flow.PostTask), mapOf(Platform.DoorDash to regionPrev))
+        val next = appState(FlowRegion(flow = Flow.Idle), mapOf(Platform.DoorDash to regionNext))
+
+        val rows = completedRows(prev, next, screenObs(Flow.Idle, timestamp = 3000L))
+        assertEquals("only the delivered drop mints", 1, rows.size)
+        val r = rows.single()
+        assertEquals("dDelivered", r.taskId)
+        assertEquals("the delivered drop takes the WHOLE receipt (placeholder didn't wedge the gate)", 12.0, r.dropRealizedPay!!, 0.001)
+        assertNotNull("the receipt IS attached (final shape restored)", r.parsedPay)
+        assertNotNull(r.totalPay)
+    }
+
+    @Test
+    fun `unassigned sibling does not wedge the gate — survivor gets the FULL receipt (#630 review, #736)`() {
+        // 2-order job: an identity-bearing sibling was UNASSIGNED (unassignedAt set, completedAt null —
+        // the reconcile re-add shape) and sits in recentTasks + job.tasks. The survivor delivers with a
+        // receipt. The abandoned drop can never mint, so it must NOT hold the gate shut — the survivor
+        // is the sole accountable dropoff and takes the whole receipt.
+        val receipt = ParsedPay(appPayComponents = listOf(ParsedPayItem("Base Pay", 9.0)), customerTips = emptyList())
+        val postFields = ParsedFields.PostTaskFields(totalPay = 9.0, parsedPay = receipt, sessionEarnings = 30.0)
+        val survivor = dropoff("dSurvivor", "Chipotle", "cS", completedAt = 400L)
+        val abandoned = dropoff("dAbandoned", "Taco Bell", "cA", completedAt = null).copy(unassignedAt = 500L)
+
+        val regionPrev = PlatformRegion(
+            platform = Platform.DoorDash,
+            mode = Mode.Online,
+            session = Session("s1", startedAt = 100L, runningEarnings = 30.0),
+            activeJob = jobWithTasks(listOf(survivor, abandoned)),
+            activeTask = survivor,
+            recentTasks = listOf(abandoned),
+            lastPostTaskFields = postFields,
+            lastAnnouncedPostTaskTaskId = "dSurvivor",
+        )
+        val regionNext = regionPrev.copy() // job stays open → only the PostTask-exit mint fires
+
+        val prev = appState(FlowRegion(flow = Flow.PostTask), mapOf(Platform.DoorDash to regionPrev))
+        val next = appState(FlowRegion(flow = Flow.Idle), mapOf(Platform.DoorDash to regionNext))
+
+        val rows = completedRows(prev, next, screenObs(Flow.Idle, timestamp = 3000L))
+        assertEquals("only the survivor mints (the abandoned drop is not a target)", 1, rows.size)
+        val r = rows.single()
+        assertEquals("dSurvivor", r.taskId)
+        assertEquals("the survivor takes the WHOLE receipt (unassigned sibling didn't wedge the gate)", 9.0, r.dropRealizedPay!!, 0.001)
+        assertNotNull("the receipt IS attached (final shape restored)", r.parsedPay)
+        assertNotNull(r.totalPay)
+    }
+
+    @Test
+    fun `an abandoned drop as the most-recent recentTask is never a PostTask-exit mint target (#630 review Fix B, #736)`() {
+        // The `recentTasks.lastOrNull { jobId }` fallback selects an UNASSIGNED drop (identity-bearing,
+        // completedAt null). The #736 belt must stop it from minting a fabricated DELIVERY_COMPLETED for
+        // a never-delivered order. On cd348221 (no unassigned guard on this fallback) it mints one.
+        val receipt = ParsedPay(appPayComponents = listOf(ParsedPayItem("Base Pay", 7.0)), customerTips = emptyList())
+        val postFields = ParsedFields.PostTaskFields(totalPay = 7.0, parsedPay = receipt, sessionEarnings = 20.0)
+        val abandoned = dropoff("dAbandoned", "Taco Bell", "cA", completedAt = null).copy(unassignedAt = 500L)
+
+        val regionPrev = PlatformRegion(
+            platform = Platform.DoorDash,
+            mode = Mode.Online,
+            session = Session("s1", startedAt = 100L, runningEarnings = 20.0),
+            activeJob = jobWithTasks(listOf(abandoned)),
+            activeTask = null, // force the recentTasks fallback to resolve the completed task
+            recentTasks = listOf(abandoned),
+            lastPostTaskFields = postFields,
+            lastAnnouncedPostTaskTaskId = "dAbandoned",
+        )
+        val regionNext = regionPrev.copy() // job stays open → close-out doesn't fire; isolate the exit mint
+
+        val prev = appState(FlowRegion(flow = Flow.PostTask), mapOf(Platform.DoorDash to regionPrev))
+        val next = appState(FlowRegion(flow = Flow.Idle), mapOf(Platform.DoorDash to regionNext))
+
+        val rows = completedRows(prev, next, screenObs(Flow.Idle, timestamp = 3000L))
+        assertTrue("no DELIVERY_COMPLETED for an abandoned drop (master: one fabricated row)", rows.isEmpty())
+    }
+
     @Test
     fun `PostTask exit — single delivery carries dropRealizedPay`() {
         val receipt = ParsedPay(

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/OfferPayFallbackEffectMapTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/OfferPayFallbackEffectMapTest.kt
@@ -152,20 +152,25 @@ class OfferPayFallbackEffectMapTest {
 
     @Test
     fun `FIX1 — a mid-stack PostTask exit does NOT stamp (not the last open owed drop)`() {
-        // A receipt-less mid-stack completion: d1 completes while its sibling d2 is still owed (an
-        // unresolved, identity-less placeholder, completedAt == null). FIX 1's final-shape gate stamps
-        // a PostTask-exit drop ONLY when it is the LAST OPEN owed dropoff. d2 is not yet done → d1 is
-        // mid-stack → NO stamp (the traded class: its dollars ride unattributed; it got nothing
-        // pre-#691 too). This kills the estimate-then-late-receipt / cents-drift-across-mints over-count.
+        // A receipt-less mid-stack completion: d1 completes while its sibling d2 is still owed. FIX 1's
+        // final-shape gate stamps a PostTask-exit drop ONLY when it is the LAST OPEN owed dropoff. d2 is
+        // an identity-RESOLVED, undelivered drop (customer hash present, completedAt == null) → it is an
+        // ACCOUNTABLE sibling → it holds the shape non-final → d1 is mid-stack → NO stamp (the traded
+        // class: its dollars ride unattributed; it got nothing pre-#691 too). This kills the
+        // estimate-then-late-receipt / cents-drift-across-mints over-count.
+        // NOTE (PR #754): the blocker MUST now be identity-RESOLVED — an identity-less placeholder no
+        // longer holds the gate shut (see the companion test below); that narrowing is the intended
+        // #630-review side effect on the #691 estimate gate.
         val d1 = dropoff("d1", "H-E-B", "cA", completedAt = null)
-        val placeholder = dropoff("d2", null, cust = null, completedAt = null) // identity-less, owed
-        val activeJob = job(offerPay = 12.95, tasks = listOf(d1, placeholder))
+        val d2 = dropoff("d2", "H-E-B", "cB", completedAt = null) // identity-resolved, still owed
+        val activeJob = job(offerPay = 12.95, tasks = listOf(d1, d2))
         val regionPrev = PlatformRegion(
             platform = Platform.DoorDash,
             mode = Mode.Online,
             session = Session("s1", startedAt = 100L, runningEarnings = 40.0),
             activeJob = activeJob,
-            recentTasks = listOf(d1),
+            activeTask = d1,
+            recentTasks = emptyList(),
             lastPostTaskFields = null,
         )
         val regionNext = regionPrev.copy() // job stays open (mid-stack)
@@ -176,6 +181,39 @@ class OfferPayFallbackEffectMapTest {
         val rows = completedRows(prev, next, screenObs(Flow.Idle, timestamp = 3000L))
         assertEquals("only d1 completes at the mid-stack exit", 1, rows.size)
         assertNull("mid-stack exit → no offer stamp (final-shape gate)", rows.single().offerPayShare)
+    }
+
+    @Test
+    fun `FIX1 companion (PR #754) — an identity-less placeholder sibling no longer blocks the estimate`() {
+        // The #630-review narrowing: an unresolved, customer-TBD placeholder (both identity hashes null)
+        // can NEVER mint, so it must not wedge the final-shape gate shut. d1 completes at a receipt-less
+        // PostTask exit while only such a placeholder is "owed" → d1 IS the last open ACCOUNTABLE drop →
+        // it gets its equal-split offer share (pre-#754 the placeholder wrongly held the shape non-final
+        // → d1 rode unattributed forever). The split denominator still KEEPS the placeholder (per-owed-
+        // order), so d1's share is total/2, not the whole offer.
+        val d1 = dropoff("d1", "H-E-B", "cA", completedAt = null)
+        val placeholder = dropoff("d2", null, cust = null, completedAt = null) // identity-less, owed
+        val activeJob = job(offerPay = 12.95, tasks = listOf(d1, placeholder))
+        val regionPrev = PlatformRegion(
+            platform = Platform.DoorDash,
+            mode = Mode.Online,
+            session = Session("s1", startedAt = 100L, runningEarnings = 40.0),
+            activeJob = activeJob,
+            activeTask = d1,
+            recentTasks = emptyList(),
+            lastPostTaskFields = null,
+        )
+        val regionNext = regionPrev.copy() // job stays open
+
+        val prev = appState(FlowRegion(flow = Flow.PostTask), mapOf(Platform.DoorDash to regionPrev))
+        val next = appState(FlowRegion(flow = Flow.Idle), mapOf(Platform.DoorDash to regionNext))
+
+        val rows = completedRows(prev, next, screenObs(Flow.Idle, timestamp = 3000L))
+        assertEquals("only d1 completes", 1, rows.size)
+        assertEquals(
+            "the placeholder no longer wedges the gate → d1 gets its equal split (12.95 / 2 owed orders)",
+            6.48, rows.single().offerPayShare!!, 0.001,
+        )
     }
 
     @Test

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepperTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepperTest.kt
@@ -1,6 +1,8 @@
 package cloud.trotter.dashbuddy.core.state
 
 import cloud.trotter.dashbuddy.domain.capture.ReplayMetadata
+import cloud.trotter.dashbuddy.domain.model.pay.ParsedPay
+import cloud.trotter.dashbuddy.domain.model.pay.ParsedPayItem
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
 import cloud.trotter.dashbuddy.domain.state.Flow
 import cloud.trotter.dashbuddy.domain.state.FlowRegion
@@ -331,6 +333,102 @@ class PlatformRegionStepperTest {
             next.activeTask?.taskId,
         )
         assertEquals(TaskPhase.DROPOFF, next.activeTask?.phase)
+    }
+
+    // =========================================================================
+    // #630 R3 — no expanded→collapsed receipt downgrade for the SAME announced task
+    // =========================================================================
+
+    private fun postTaskObs(
+        parsedPay: ParsedPay?,
+        totalPay: Double,
+        sessionEarnings: Double?,
+        timestamp: Long,
+    ): Observation.Screen = Observation.Screen(
+        timestamp = timestamp,
+        captureId = "cap-$timestamp",
+        ruleId = "doordash.screen.test",
+        metadata = ReplayMetadata.EMPTY,
+        flow = Flow.PostTask,
+        modeHint = Mode.Online,
+        parsed = ParsedFields.PostTaskFields(
+            totalPay = totalPay,
+            parsedPay = parsedPay,
+            sessionEarnings = sessionEarnings,
+        ),
+    )
+
+    private val expandedReceipt = ParsedPay(
+        appPayComponents = listOf(ParsedPayItem("Base Pay", 4.5)),
+        customerTips = listOf(ParsedPayItem("Wendy's", 3.0)),
+    )
+
+    @Test
+    fun `same-task collapsed PostTask re-render does not clobber the captured expanded receipt (#630 R3)`() {
+        val task = pickupTask("task-D", "Wendy's")
+        val prev = region(activeTask = task)
+
+        // Frame 1: EXPANDED receipt for task-D.
+        val afterExpanded = stepper.step(
+            prev = prev,
+            prevFlow = FlowRegion(flow = Flow.PostTask),
+            nextFlow = FlowRegion(flow = Flow.PostTask),
+            obs = postTaskObs(expandedReceipt, totalPay = 7.5, sessionEarnings = 50.0, timestamp = 1_000L),
+            policy = policy,
+        )
+        assertNotNull("expanded receipt captured", afterExpanded.lastPostTaskFields?.parsedPay)
+        assertEquals("task-D", afterExpanded.lastAnnouncedPostTaskTaskId)
+
+        // Frame 2: a COLLAPSED re-render (parsedPay = null) for the SAME announced task — e.g. a
+        // PostTask re-entry after a chained-offer decline renders collapsed first.
+        val afterCollapsed = stepper.step(
+            prev = afterExpanded,
+            prevFlow = FlowRegion(flow = Flow.PostTask),
+            nextFlow = FlowRegion(flow = Flow.PostTask),
+            obs = postTaskObs(parsedPay = null, totalPay = 7.5, sessionEarnings = 51.0, timestamp = 2_000L),
+            policy = policy,
+        )
+
+        assertNotNull(
+            "the itemized (expanded) receipt survives a same-task collapsed re-render — the retire-" +
+                "grace close-out must apportion off the EXPANDED parsedPay, never apportion(null)",
+            afterCollapsed.lastPostTaskFields?.parsedPay,
+        )
+        assertEquals(
+            "sessionEarnings still folds from the collapsed frame",
+            51.0,
+            afterCollapsed.session?.runningEarnings,
+        )
+    }
+
+    @Test
+    fun `different-task collapsed PostTask frame DOES overwrite (a new receipt, not a downgrade)`() {
+        val taskD = pickupTask("task-D", "Wendy's")
+        val prev = region(activeTask = taskD).copy(
+            // An expanded receipt already held for a PRIOR task.
+            lastPostTaskFields = ParsedFields.PostTaskFields(
+                totalPay = 12.0,
+                parsedPay = expandedReceipt,
+                sessionEarnings = 40.0,
+            ),
+            lastAnnouncedPostTaskTaskId = "task-C",
+        )
+
+        val next = stepper.step(
+            prev = prev,
+            prevFlow = FlowRegion(flow = Flow.PostTask),
+            nextFlow = FlowRegion(flow = Flow.PostTask),
+            obs = postTaskObs(parsedPay = null, totalPay = 7.5, sessionEarnings = 51.0, timestamp = 2_000L),
+            policy = policy,
+        )
+
+        assertNull(
+            "a DIFFERENT task's collapsed receipt is a genuinely NEW receipt and overwrites",
+            next.lastPostTaskFields?.parsedPay,
+        )
+        assertEquals(7.5, next.lastPostTaskFields?.totalPay)
+        assertEquals("task-D", next.lastAnnouncedPostTaskTaskId)
+        assertEquals("sessionEarnings still folds", 51.0, next.session?.runningEarnings)
     }
 
 }

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -80,8 +80,13 @@ was found **broken-in-part** (raw PII in capture envelopes) and moved to that en
   **How to tell it's working (desk-side, after a dash with ≥1 stacked job):** in the per-dash
   drill-down, each stacked job's delivery rows sum EXACTLY to its receipt total (no missing-pay row
   where a receipt existed, no ±1¢ mismatch); the Money tab's unattributed callout doesn't grow from
-  stacked jobs. A `#630 mid-stack non-final receipt exit` WARN in the exported log would be the
-  first-ever field sighting of the mid-stack receipt shape — grab the capture session if you see it.
+  stacked jobs. A `#630 mid-stack non-final receipt exit` WARN in the exported log (now also tripped
+  by a pay-bearing *collapsed* receipt, not only an itemized one) would be a genuine field sighting of
+  the mid-stack receipt shape — grab the capture session if you see it. NOTE (PR #754 review): the
+  final-shape gate no longer wedges shut on a never-activated placeholder (#749) or an unassigned
+  sibling (#736), so a normal single-delivered-drop stacked job must attach its full receipt (not fold
+  a $0/NONE row) — watch that a receipted delivery never shows $0 when a placeholder/unassigned
+  sibling exists.
   - Confirmed: 0/2
 
 - **🆕 NEW — unassign an order mid-dash produces NO paid/confirmed artifacts (#736).**

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -73,6 +73,17 @@ card's **mechanical** half, #577 (re-confirmed, 24/24, ~0.55 s — with a new po
 that entry's Bug #1), the #457 path, and #554 ShadowProjector (2/2). The #462/#460 dropoff item
 was found **broken-in-part** (raw PII in capture envelopes) and moved to that entry's Bug #7.)_
 
+- **🆕 NEW — stacked receipts still split exactly; ±1¢ drift and collapsed-receipt nulls gone (#630).**
+  The per-drop receipt split is hardened for mid-stack/multi-receipt shapes: a collapsed PostTask
+  re-render can no longer wipe an already-captured itemized receipt (the field-reachable break), the
+  split denominator now equals exactly the rows that mint, and the rounding cent is order-invariant.
+  **How to tell it's working (desk-side, after a dash with ≥1 stacked job):** in the per-dash
+  drill-down, each stacked job's delivery rows sum EXACTLY to its receipt total (no missing-pay row
+  where a receipt existed, no ±1¢ mismatch); the Money tab's unattributed callout doesn't grow from
+  stacked jobs. A `#630 mid-stack non-final receipt exit` WARN in the exported log would be the
+  first-ever field sighting of the mid-stack receipt shape — grab the capture session if you see it.
+  - Confirmed: 0/2
+
 - **🆕 NEW — unassign an order mid-dash produces NO paid/confirmed artifacts (#736).**
   When you unassign an active order via the pickup help / resolution flow ("Unassign order" survey →
   "You've been unassigned from this order" confirmation), the app now recognizes the unassign and

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/DropPayApportioner.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/DropPayApportioner.kt
@@ -25,7 +25,10 @@ import cloud.trotter.dashbuddy.domain.model.pay.ParsedPayItem
  * The load-bearing property is the **no-double-count invariant**: the shares sum EXACTLY to
  * [ParsedPay.total] (the *receipt* total — tips adjust post-delivery, so this is authoritative over
  * the offer-time [Job.totalPayAmount]). Computed in integer cents, the rounding remainder to the
- * last drop, so summing the emitted shares reproduces the receipt to the cent.
+ * last drop in **canonical `taskId` order** (drops are sorted by `taskId` after dedup, #630 finding
+ * 4), so the remainder assignment is invariant across resume/replay input reorderings — the two mint
+ * sites of a stack can no longer disagree by a cent because they saw the denominator in a different
+ * iteration order.
  *
  * Pure and side-effect-free (no PII: store names are not PII; customer identity is already hashed
  * upstream). Reused from `:core:state` at the DELIVERY_COMPLETED mint sites.
@@ -47,7 +50,7 @@ object DropPayApportioner {
      */
     fun apportion(parsedPay: ParsedPay?, dropoffTasks: List<Task>): Map<String, Double> {
         if (parsedPay == null) return emptyMap()
-        val drops = dropoffTasks.distinctBy { it.taskId }
+        val drops = dropoffTasks.distinctBy { it.taskId }.sortedBy { it.taskId }
         if (drops.isEmpty()) return emptyMap()
 
         val totalCents = toCents(parsedPay.total)
@@ -89,7 +92,7 @@ object DropPayApportioner {
      */
     fun equalSplit(total: Double?, dropoffTasks: List<Task>): Map<String, Double> {
         if (total == null || total <= 0.0) return emptyMap()
-        val drops = dropoffTasks.distinctBy { it.taskId }
+        val drops = dropoffTasks.distinctBy { it.taskId }.sortedBy { it.taskId }
         if (drops.isEmpty()) return emptyMap()
 
         val totalCents = toCents(total)

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/OfferPayFallback.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/OfferPayFallback.kt
@@ -57,8 +57,11 @@ object OfferPayFallback {
             return NONE // mid-stack exit — not the last open owed drop
         }
 
-        // The denominator is the job's OWN owed dropoff set (deduped) — NOT the identity-filtered
-        // mint denominator, which shrinks at a mid-stack exit and would hand one drop the full total.
+        // The denominator is the job's OWN owed dropoff set (deduped) — every owed order, so this
+        // DELIBERATELY KEEPS placeholders and unassigned drops (it is a per-owed-order equal split
+        // over the offer's order count, NOT the mint set). This is the intentional asymmetry with
+        // [isFinalShape] / `mintingDropoffTasks`, which filter to accountable drops via
+        // [Task.isAccountableDropoff] — do NOT collapse the two chains onto one filter.
         val ownDropoffs = job.tasks
             .filter { it.phase == TaskPhase.DROPOFF }
             .distinctBy { it.taskId }
@@ -70,18 +73,32 @@ object OfferPayFallback {
 
     /**
      * The **final-shape** predicate shared by #691 (the offer-pay estimate gate above) and #630 (the
-     * receipt-split gate at the PostTask-exit mint): is [mintingTaskId] the LAST OPEN owed dropoff of
-     * [job] — has every OTHER owed dropoff already completed (`completedAt != null`)?
+     * receipt-split gate at the PostTask-exit mint): is [mintingTaskId] the LAST OPEN **accountable**
+     * dropoff of [job] — has every OTHER accountable dropoff already completed (`completedAt != null`)?
      *
-     * The denominator is the job's OWN owed dropoff set (`job.tasks`, deduped) — placeholders
-     * included — so an un-visited or resolved-but-undelivered sibling keeps the shape NON-final and
-     * blocks a mid-stack partial-receipt / partial-estimate split. Excluding [mintingTaskId] sidesteps
-     * the amdt#6 mirror staleness of the just-finishing drop's own `completedAt`. ONE definition so
-     * both mint gates read the same "final shape" (Principle 5).
+     * The sibling scan is filtered through [Task.isAccountableDropoff] — the SAME identity+unassign
+     * filter the mint denominator (`DeliveryCompletionEffects.mintingDropoffTasks`) uses (Principle 5,
+     * SSOT), so the two chains cannot drift. Excluding [mintingTaskId] sidesteps the amdt#6 mirror
+     * staleness of the just-finishing drop's own `completedAt`.
+     *
+     * The trade this filter restores (the #630 review fix — the prior "placeholders included" scan
+     * wedged the gate shut forever):
+     * - An identity-**RESOLVED** but still-undelivered sibling (a real, activated drop with a customer
+     *   hash and null `completedAt`) STILL holds the shape NON-final and blocks a mid-stack split —
+     *   that is the gate's whole purpose, unchanged.
+     * - An **unresolved placeholder** sibling (customer-TBD, both hashes null — e.g. the #749
+     *   same-customer double-order that never activates) or an **unassigned** sibling (#736) now reads
+     *   the shape as final, because such a drop can never mint. This reverts that sub-shape to the
+     *   pre-PR partial-split behaviour — the spec's accepted, not-DoorDash-fielded residual — rather
+     *   than letting an un-mintable sibling under-attribute the receipt (mint `dropRealizedPay`/
+     *   `postTaskFields` = null → the whole receipt folds `PayBasis.NONE`, a money-loss regression).
+     *
+     * Side effect on #691 (both reviewers agreed, correct direction): narrowing the sibling set lets
+     * an OFFER_PAY estimate stamp in a dangling-placeholder shape that the old scan blocked.
      */
     fun isFinalShape(job: Job, mintingTaskId: String): Boolean =
         job.tasks
-            .filter { it.phase == TaskPhase.DROPOFF }
+            .filter { it.isAccountableDropoff }
             .distinctBy { it.taskId }
             .filter { it.taskId != mintingTaskId }
             .all { it.completedAt != null }

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/OfferPayFallback.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/OfferPayFallback.kt
@@ -53,22 +53,36 @@ object OfferPayFallback {
     ): Result {
         if (suppressedByReceipt) return NONE
 
+        if (requireFinalShape && !isFinalShape(job, mintingTaskId)) {
+            return NONE // mid-stack exit — not the last open owed drop
+        }
+
         // The denominator is the job's OWN owed dropoff set (deduped) — NOT the identity-filtered
         // mint denominator, which shrinks at a mid-stack exit and would hand one drop the full total.
         val ownDropoffs = job.tasks
             .filter { it.phase == TaskPhase.DROPOFF }
             .distinctBy { it.taskId }
-
-        if (requireFinalShape) {
-            val everyOtherDropDone = ownDropoffs
-                .filter { it.taskId != mintingTaskId }
-                .all { it.completedAt != null }
-            if (!everyOtherDropDone) return NONE // mid-stack exit — not the last open owed drop
-        }
-
         val share = DropPayApportioner.equalSplit(job.offerPayTotal, ownDropoffs)[mintingTaskId]
         // Eligible (all gates passed) but the split yielded nothing: pay-less offer or a minting task
         // outside the owed set. Surface it (FIX 6) rather than silently dropping the estimate.
         return Result(share = share, eligibleButUnsplit = share == null)
     }
+
+    /**
+     * The **final-shape** predicate shared by #691 (the offer-pay estimate gate above) and #630 (the
+     * receipt-split gate at the PostTask-exit mint): is [mintingTaskId] the LAST OPEN owed dropoff of
+     * [job] — has every OTHER owed dropoff already completed (`completedAt != null`)?
+     *
+     * The denominator is the job's OWN owed dropoff set (`job.tasks`, deduped) — placeholders
+     * included — so an un-visited or resolved-but-undelivered sibling keeps the shape NON-final and
+     * blocks a mid-stack partial-receipt / partial-estimate split. Excluding [mintingTaskId] sidesteps
+     * the amdt#6 mirror staleness of the just-finishing drop's own `completedAt`. ONE definition so
+     * both mint gates read the same "final shape" (Principle 5).
+     */
+    fun isFinalShape(job: Job, mintingTaskId: String): Boolean =
+        job.tasks
+            .filter { it.phase == TaskPhase.DROPOFF }
+            .distinctBy { it.taskId }
+            .filter { it.taskId != mintingTaskId }
+            .all { it.completedAt != null }
 }

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/Task.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/Task.kt
@@ -53,3 +53,23 @@ data class Task(
     val unassignedAt: Long? = null,
     val recovered: Boolean = false,
 )
+
+/**
+ * The **accountable-dropoff** predicate — a dropoff that may be attributed pay and may hold a job's
+ * final shape open: it is a [TaskPhase.DROPOFF] the dasher did NOT unassign ([unassignedAt] null,
+ * the #736 firewall) AND it bears a customer identity ([customerNameHash] or [customerAddressHash]
+ * non-null, the #498 phantom firewall — a never-activated, customer-TBD placeholder has neither).
+ *
+ * SSOT (Principle 5): both the receipt-split denominator
+ * (`DeliveryCompletionEffects.mintingDropoffTasks`) and the final-shape gate
+ * ([OfferPayFallback.isFinalShape]) filter siblings through THIS one predicate, so the two chains
+ * cannot drift (the #630 review wedge: `isFinalShape` used to include placeholders/unassigned drops
+ * the mint set already excluded, so an un-mintable sibling could hold the gate shut forever — the
+ * mid-stack under-attribution regression). Note the deliberate asymmetry the split still owns: the
+ * #691 estimate's equal-split denominator (`OfferPayFallback.shareFor`) KEEPS placeholders (it is a
+ * per-owed-order split), so it does NOT use this predicate.
+ */
+val Task.isAccountableDropoff: Boolean
+    get() = phase == TaskPhase.DROPOFF &&
+        unassignedAt == null &&
+        (customerNameHash != null || customerAddressHash != null)

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/state/DropPayApportionerTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/state/DropPayApportionerTest.kt
@@ -149,6 +149,69 @@ class DropPayApportionerTest {
         assertSumsToReceipt(shares, receipt)
     }
 
+    // ── #630 finding 4: order invariance (canonical taskId sort inside the apportioner) ──
+
+    /** All permutations of a list (small n only — test helper). */
+    private fun <T> permutations(items: List<T>): List<List<T>> {
+        if (items.size <= 1) return listOf(items)
+        return items.flatMap { head ->
+            permutations(items - head).map { rest -> listOf(head) + rest }
+        }
+    }
+
+    @Test
+    fun `apportion — identical map (incl the remainder cent) for every input-order permutation`() {
+        // Equal-split path with a rounding remainder: $10.01 across 3 drops.
+        val receipt = ParsedPay(
+            appPayComponents = listOf(ParsedPayItem("Base Pay", 10.01)),
+            customerTips = emptyList(),
+        )
+        val drops = listOf(drop("d1", null), drop("d2", null), drop("d3", null))
+
+        val canonical = DropPayApportioner.apportion(receipt, drops)
+        permutations(drops).forEach { perm ->
+            assertEquals(
+                "apportion must be input-order invariant (a resume between a stack's two mint " +
+                    "steps can reorder the denominator, #630 finding 4)",
+                canonical,
+                DropPayApportioner.apportion(receipt, perm),
+            )
+        }
+        assertSumsToReceipt(canonical, receipt)
+    }
+
+    @Test
+    fun `apportion — two half-cent shares pin the extra cent to the FIRST taskId in canonical order`() {
+        // $10.01 across 2 drops = $5.005 each. toCents rounds half-up → the first drop in canonical
+        // (taskId-sorted) order takes 501c, the LAST takes the remainder 500c — regardless of the
+        // caller's input order.
+        val receipt = ParsedPay(
+            appPayComponents = listOf(ParsedPayItem("Base Pay", 10.01)),
+            customerTips = emptyList(),
+        )
+        val forward = DropPayApportioner.apportion(receipt, listOf(drop("d-a", null), drop("d-b", null)))
+        val reversed = DropPayApportioner.apportion(receipt, listOf(drop("d-b", null), drop("d-a", null)))
+
+        assertEquals(5.01, forward.getValue("d-a"), 0.0001)
+        assertEquals(5.00, forward.getValue("d-b"), 0.0001)
+        assertEquals("reversed input order yields the identical assignment", forward, reversed)
+        assertSumsToReceipt(forward, receipt)
+    }
+
+    @Test
+    fun `equalSplit — identical map for every input-order permutation`() {
+        val drops = listOf(drop("d1", null), drop("d2", null), drop("d3", null))
+        val canonical = DropPayApportioner.equalSplit(10.01, drops)
+        permutations(drops).forEach { perm ->
+            assertEquals(
+                "equalSplit must be input-order invariant (#630 finding 4)",
+                canonical,
+                DropPayApportioner.equalSplit(10.01, perm),
+            )
+        }
+        assertEquals(1001L, canonical.values.sumOf { cents(it) })
+    }
+
     // ── #691 equalSplit: the offer-pay fallback for a wholly receipt-less job ──
 
     @Test


### PR DESCRIPTION
Fixes #630 — the #528 Slice A mid-stack / multi-receipt under-attribution family (+ the P8 one-receipt-per-job platform seam).

## Summary

All four findings share one root: **the apportion denominator and the minted-row set were computed at different times against a mutable receipt (`lastPostTaskFields`), so `Σ dropRealizedPay` could drift below `parsedPay.total`.** Per the design pass posted on #630 (the routing SSOT), all changes are **write-side only** — `RecordFolds` untouched, `PROJECTOR_VERSION` still 4, existing history folds byte-identically.

- **R1 — minted-set denominator** (`DeliveryCompletionEffects.mintingDropoffTasks`, replacing `jobDropoffTasks`): the receipt split now runs over exactly the amdt#5-qualified rows that will ever mint (already-completed ∪ just-retired-under-grace ∪ emitted-this-step), shared by BOTH mint blocks so a co-firing step agrees on one denominator. Fixes finding 3 (`endSession` force-stamped undelivered drop diluted every share → its slice evaporated → Σ < total); DD-3 as recommended: the receipt total is authoritative, the undelivered drop's slice lands on the delivered rows.
- **R2 — final-shape gate on the receipt split** (PostTask-exit mint): a mid-stack, non-final exit mints `dropRealizedPay = null` **and** `postTaskFields = null`. The payload-null is load-bearing — attaching the partial receipt would fold `RECEIPT_TOTAL` with the whole partial total and flip the under-attribution into an **over**-count once siblings mint. The gate is the SAME predicate #691 uses, extracted as the SSOT (`OfferPayFallback.isFinalShape`). Fixes finding 1's over-count risk; DD-1 Option B (no settlement event — filed as platform-#2 work if/when a per-drop-receipt platform lands).
- **R3 — no expanded→collapsed downgrade** (`PlatformRegionStepper.updateSessionFields`): a collapsed PostTask re-render (`parsedPay == null`) no longer overwrites an already-captured expanded receipt for the SAME announced task (the one field-reachable break, finding 2). A different task's collapsed receipt still overwrites; `sessionEarnings` still folds either way. Pure, stepper-only, no new state.
- **Finding 4 — order-invariant cents** (`DropPayApportioner`): drops are sorted by `taskId` after dedup in both `apportion` and `equalSplit`, so the remainder-cent assignment is invariant across resume/replay input reorderings.
- **R4 — visible shortfall**: the close-out splits the final receipt over the FULL denominator including an early-minted drop (DD-2: include — per-row honesty, #438 item-9 doctrine); its re-emission dedups via `effects_fired`, so the shortfall surfaces read-side (unattributed) instead of being silently redistributed. One PII-safe `Timber.tag("StateMachine").w` at the non-final receipt exit (jobId + count only) makes the seam field-observable.

## Tests (the spec's acceptance criteria)

1. **Mid-stack expanded receipt** (`EffectMapDropPayTest`): B's non-final exit row carries null `dropRealizedPay`/`parsedPay`/`totalPay`/`offerPayShare` (folds `NONE`); the close splits `R_ABC` over the full 3-drop denominator, Σ(computed shares) == total, persisted Σ == total − share(B); the WARN is asserted via a Timber capture tree.
2. **Collapsed re-entry downgrade** (`PlatformRegionStepperTest`): same-task collapsed frame preserves the expanded `parsedPay`; different-task collapsed frame overwrites; `sessionEarnings` updates in both.
3. **endSession force-stamp** (`EffectMapDropPayTest`): exactly 2 rows mint, denominator = 2, Σ == receipt total in cents.
4. **Order invariance** (`DropPayApportionerTest`): identical maps (incl. the remainder cent) for every permutation; a two-half-cent case pins the extra cent to the first canonical taskId.
5. **Replay guard**: `TwoPickupStackReplayTest` green (7/7) + a new per-job `Σ dropRealizedPay == parsedPay.total` invariant over the trace (vacuous on this fixture per its documented residual; pins the mainline).
6. **Fold stability**: `RecordFolds` untouched, `RecordFoldsTest` unchanged and green, `PROJECTOR_VERSION` still 4. `ParseOutputGoldenTest` untouched (no rule changes).

Full gate green: `./gradlew testDebugUnitTest :domain:test`.

## Security / privacy posture

No recognition, capture, network, or PII-handling changes. The one new log site is a WARN under the stable `StateMachine` tag carrying **jobId + dropoff count only** — no store/customer text (Principle 7; the #691 FIX-6 precedent). Money history is untouched: pre-fix under-attributed rows live in immutable event payloads and are NOT refolded (a refold could not repair them anyway); they stay visible in unattributed and correctable via #688.

### Design-goal review

- **P1 (UDF):** all logic stays in the pure diff/stepper layer (`obs.timestamp` only, no wall clock); the WARN is emitted at the EffectMap edge, not inside a reducer's state computation.
- **P3 (single responsibility):** the mint-denominator policy lives in one helper (`mintingDropoffTasks`); the final-shape predicate lives in `:domain` next to its consumers.
- **P5 (SSOT):** `OfferPayFallback.isFinalShape` is now the ONE final-shape definition shared by the #691 estimate gate and the #630 receipt gate — previously the same predicate was inlined in `shareFor`. The amdt#5 qualification is applied identically at both mint sites through the shared helper instead of being duplicated-and-divergent (the old exit-mint denominator disagreed with the close-out's minted set — exactly the class of drift this principle targets).
- **P7 (semantic logging):** one new WARN (a defended invariant fired — the mid-stack receipt seam), PII-safe by construction (ids/counts), stable tag.
- **P8 (platform-agnostic core):** no platform literals; the rules key off job/task/receipt shape only. This PR *closes* a P8 seam: correctness no longer leans on DoorDash's one-receipt-per-job-at-end behavior — a platform with routine mid-job receipts now under-attributes visibly (unattributed bucket) instead of corrupting rows, and the DD-1 settlement event is the recorded follow-up for full Σ==total on such a platform.

### Adversarial review

_Appended before merge (fable-tier `/code-review`; the spec flags R2's payload-nulling and the no-fold-change claim for specific re-verification)._


---

#### Post-review fixes (two fable adversarial reviews)

- **Fix A (HIGH) — `OfferPayFallback.isFinalShape` no longer wedges on an un-mintable sibling.** The sibling scan now filters through a new SSOT predicate `Task.isAccountableDropoff` (DROPOFF + identity-bearing + non-unassigned) — the SAME filter `mintingDropoffTasks` uses — so a never-activated customer-TBD **placeholder** (#749, fielded) or an **unassigned** sibling (#736, merged after the spec) can no longer hold the gate shut forever. Pre-fix, such a sibling forced every mid-stack exit non-final → the delivered drop minted `dropRealizedPay = null` AND `postTaskFields = null` under the frozen `log:DELIVERY_COMPLETED:<taskId>` key → the close-out's re-emission deduped → the whole receipt folded `PayBasis.NONE` (a money-loss regression vs master's diluted share). The trade the filter restores (documented in the `isFinalShape` KDoc): an identity-**RESOLVED** undelivered sibling still holds the gate shut (the gate's purpose); an **unresolved-placeholder** sibling now reads final — reverting that sub-shape to the pre-PR partial-split, the spec's accepted, not-DoorDash-fielded residual.
  - **#691 estimate-gate side effect (both reviewers agreed, correct direction):** narrowing `isFinalShape` lets an `OFFER_PAY` estimate stamp in a dangling-placeholder shape the old scan blocked. The existing `FIX1 — mid-stack does NOT stamp` test was updated to use an identity-RESOLVED blocker (still correctly blocks); a companion test pins the placeholder-no-longer-blocks flip.
  - `shareFor`'s `ownDropoffs` denominator DELIBERATELY keeps placeholders (per-owed-order equal split) — a comment now distinguishes it from the gate so the two filter chains can't drift silently (reviewer NIT 7).
- **Fix B (MED) — unassign belt on the PostTask-exit mint fallback.** The `next.recentTasks.lastOrNull { jobId }` fallback could select an unassigned drop and fabricate a `DELIVERY_COMPLETED` for a never-delivered order; it now also requires `completedTask.unassignedAt == null` (mirroring the close-out firewall). New unit test.
- **Fix C (MED) — honest replay Σ-pin.** `TwoPickupStackReplayTest`'s Σ-invariant now (a) dedups DELIVERY_COMPLETED rows to the FIRST emission per taskId (SessionReplay has no `effects_fired` dedup, so it now mirrors live persistence) and (b) derives the expected total from the trace's PostTask **observation** `parsedPay`, not the row payloads — so a #630-withheld receipt can no longer silently drop the job from the assertion. Vacuous on this fixture per its documented address-parse residual (close = #700).
- **Fix D (LOW) — WARN predicate.** The R4 mid-stack WARN now gates on the fold's `payBearingReceipt` predicate (`parsedPay != null || totalPay > 0.0`), so a pay-bearing **collapsed** receipt is no longer silently skipped. (Per-taskId edge-gating deferred — the `EffectMap` diff can't write region state; that needs stepper plumbing beyond a field.)
- **Fix E (docs) — corrections to the claims above:**
  - The Summary/Tests "**PROJECTOR_VERSION still 4**" is stale — master is at **5** (#159 store-resolution refold). The actual constraint holds unchanged: this PR is write-side only, does NOT bump `PROJECTOR_VERSION`, and touches no `RecordFolds` — history folds identically.
  - **DD-1** (the per-drop-receipt platform settlement event) is now filed as **#756** — replaces the "filed as platform-#2 work" wording. DD-1/DD-2/DD-3 remain flagged for dev ack.
  - **payoutStoreForms-null collateral:** a non-final exit row folds with null `postTaskFields`, so `#159` store resolution falls back to `normalizedChain(storeName)` for that (not-fielded) shape — no store downgrade of a fielded row.
  - **R3 same-task collapsed-skip:** documented as a code comment at the skip site — a collapsed re-render's possibly-updated `totalPay` is discarded (the itemized expanded receipt is authoritative); an expanded re-render refreshes both fields.
- **P3 (explicit violation):** the R3 guard lives in `PlatformRegionStepper.updateSessionFields` (~1489 lines, past the ceiling). Splitting a money-critical stepper mid-fix is riskier than the added lines — deferred to the #237 family / #718 extraction precedent, not done in this fix PR. (This PR adds only comment lines to that file.)
- **P8:** this PR does not "close the seam" outright — named residuals persist: the unparsed-offer `dropoffCount=1`-fallback sub-shape, and full Σ==total on a routine-mid-job-receipt platform (DD-1 → #756).

**Discriminator proof:** all three new `EffectMapDropPayTest` cases were run against a targeted revert of the Fix A/B production hunks (`git checkout HEAD -- OfferPayFallback.kt Task.kt DeliveryCompletionEffects.kt`, tests retained) — all three FAILED (tests 1/2 NPE on null `dropRealizedPay` from the wedged gate; test 3 AssertionError on the fabricated abandoned-drop row), then passed once the fixes were restored. Full gate green: `testDebugUnitTest :domain:test`.


### Adversarial review

Loop: 2 independent fable finders (money/state correctness; design-principles/P8) → opus fixer (cd348221 → d55fc480) → fable re-verification. **Final verdict: APPROVE.**

**Fixed in-PR:**
1. **HIGH (both finders, converged independently):** `isFinalShape` required every `job.tasks` dropoff sibling completed, with no identity scoping (an explicit deviation from the #630 spec's R2) and no `unassignedAt` filter (#736 merged after the spec) — a never-activated customer-TBD placeholder (the FIELDED #749 same-customer double-order shape) or an unassigned sibling wedged the gate shut, and the frozen `log:DELIVERY_COMPLETED:<taskId>` key made the close-out's correct re-emission dedup away → **total receipt loss** where master attributed at least a diluted share. Fixed via a new `:domain` SSOT predicate `Task.isAccountableDropoff` shared by the gate and `mintingDropoffTasks` (structurally cannot drift; the collapse verified a semantic no-op). Re-verify proved: an identity-RESOLVED undelivered sibling still blocks (the fix's intent); double-attribution on late-resolving placeholders is structurally impossible (per-taskId effects_fired + transactional insert-and-mark); the #691 estimate-gate flip is coherent (gate vs per-owed-order split asymmetry documented at both sites). 3 discriminator tests, each proven failing on cd348221.
2. **MED:** the exit-mint `recentTasks` fallback could mint a fabricated `DELIVERY_COMPLETED` for an unassigned drop — `unassignedAt == null` belt added (re-verify confirmed the #736 retro-mark is pickup-only, so no legitimate mint is starved).
3. **MED:** the replay Σ-pin folded pre-dedup emissions and derived its expected total from row payloads (blind to withheld receipts) — now first-emission-per-taskId (mirrors live `effects_fired` semantics) with the expected total taken from the trace's observed PostTask receipt.
4. **LOW:** withheld-receipt WARN widened to the pay-bearing predicate; checklist wording aligned; trailing newline; stale PR-body claims corrected (PROJECTOR_VERSION is 5; DD-1 follow-up now actually filed → #756).

**Verified-safe:** no over-attribution path (minted ⊆ denominator, Σ ≤ receipt structurally); order-invariant cents proven (canonical sort + remainder-to-last, permutation tests discriminate); no projector/fold impact; R2 payload-nulling prevents the under→over flip; endSession force-stamp exclusion correct; 769 tests green incl. all six replay suites.

**Residuals (documented, non-blocking):** Σ-drift across taskIds in the not-DoorDash-fielded mid-stack-receipt shape (frozen early mints vs later cumulative receipt) — the full fix is the settlement event, filed as **#756**; the dropoffCount=1-fallback sub-shape keeps pre-PR behavior; a genuine mid-stack exit with an unresolved-placeholder sibling reverts to the spec's accepted partial-split residual; WARN "%d owed dropoffs" counts all dropoffs (cosmetic). **For dev ack at merge: the #630 DD-1/DD-2/DD-3 Option-B decisions ride this PR; DD-1's full fix is #756.**
