### PR TITLE
feature(#688): per-leg mileage (phase B)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -370,8 +370,22 @@ dialog (store/pay/tip/cash-tip/miles/note) writing a single all-optional-fields 
 applies each non-null field by-PK (payBasis flips to `USER_CORRECTED` **iff pay changes** so a store/tip/cash
 edit never drops an "est. offer pay" disclosure; a MANUAL row stays MANUAL; net recomputes only when pay/miles
 change, against the row's OWN frozen cpm; `originalPayBasis` preserved via `row.copy`). Legacy `PAY_ADJUSTMENT`
-stays fully readable for history; new UI writes only `DELIVERY_ADJUSTMENT`. Phase B (per-leg mileage, #688) is
-deferred. Session-categorize of an unattributed remainder is deferred (#650 follow-up). Related: #653/#655/#703.
+stays fully readable for history; new UI writes only `DELIVERY_ADJUSTMENT`. **Per-leg mileage (#688 phase B,
+Room v12→v13 additive, `PROJECTOR_VERSION` 5→6):** the fold now consumes the lifecycle `metadata.odometer`
+stamps (PICKUP_ARRIVED closes a to-store leg; DELIVERY_ARRIVED closes a to-dropoff leg keyed by the drop's own
+taskId, re-arrivals accumulate; PICKUP_CONFIRMED/DELIVERY_CONFIRMED/DELIVERY_COMPLETED advance the anchor;
+null-odometer anchors don't advance — miles roll forward; per-leg floor at 0) into `delivery_records.
+{milesToStore,milesToDropoff}`; a drop's `milesToStore` claims one store leg of its job (exact store-form match,
+else FIFO; claim-once — a shared-store sibling gets null, no fabricated split) and `realizedMiles` becomes the
+leg SUM only when `milesToDropoff != null` (a lone store leg never replaces the legacy partition delta), so
+per-drop net redistributes within a stack while session/period/IRS/CSV mileage totals stay odometer-span-anchored
+(unchanged). Pending legs describe not-yet-completed drops, so the accumulator persists as
+`session_records.legStateJson` (`LegState`/`LegStateCodec` in `:domain`, fail-closed decode → legacy delta,
+`MAX_PENDING` 32 bounded) — that persistence is what keeps incremental ≡ from-zero refold across the projector's
+500-event page boundaries. A driver `newMiles` edit wins `realizedMiles`/net (log-order precedence); the machine
+leg columns are provenance and are never rewritten, so leg-sum ≠ realizedMiles IS the visible edit trail.
+CSV gains `miles_to_store`/`miles_to_dropoff`. `newCompletedAt` stays banned on `DELIVERY_ADJUSTMENT`.
+Session-categorize of an unattributed remainder is deferred (#650 follow-up). Related: #653/#655/#703.
 
 ## Development Principles
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/SessionDetailScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/SessionDetailScreen.kt
@@ -370,10 +370,22 @@ private fun DeliveryRow(delivery: DeliveryRecord, onAdjust: () -> Unit) {
     }
 }
 
-/** "3.2 mi · 14 min" — only the parts actually measured; null when neither is present. */
+/**
+ * "3.2 mi (→ store 0.5 · → door 2.4) · 14 min" — only the parts actually measured; null when
+ * neither is present. The per-leg parenthetical (#688 phase B) renders only when the fold measured
+ * legs; a driver miles edit keeps the machine legs, so the parenthetical may disagree with the
+ * total on a corrected row — that IS the visible edit trail, glance-only.
+ */
 private fun travelLine(delivery: DeliveryRecord): String? {
     val parts = buildList {
-        delivery.realizedMiles?.let { add("${Formats.decimal(it)} mi") }
+        delivery.realizedMiles?.let { miles ->
+            val legs = buildList {
+                delivery.milesToStore?.let { add("→ store ${Formats.decimal(it)}") }
+                delivery.milesToDropoff?.let { add("→ door ${Formats.decimal(it)}") }
+            }
+            val legSuffix = legs.takeIf { it.isNotEmpty() }?.joinToString(" · ", " (", ")") ?: ""
+            add("${Formats.decimal(miles)} mi$legSuffix")
+        }
         delivery.realizedMinutes?.let { add("${it.roundToInt()} min") }
     }
     return parts.takeIf { it.isNotEmpty() }?.joinToString(" · ")

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsMappers.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsMappers.kt
@@ -30,6 +30,8 @@ internal fun DeliveryRecordEntity.toDomain(): DeliveryRecord = DeliveryRecord(
     tip = tip,
     basePay = basePay,
     cashTip = cashTip,
+    milesToStore = milesToStore,
+    milesToDropoff = milesToDropoff,
 )
 
 internal fun SessionRecordEntity.toDomain(): SessionRecord = SessionRecord(

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjector.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjector.kt
@@ -13,6 +13,7 @@ import cloud.trotter.dashbuddy.core.database.analytics.SessionRecordEntity
 import cloud.trotter.dashbuddy.core.database.event.AppEventDao
 import cloud.trotter.dashbuddy.domain.analytics.DeliveryAdjustmentFold
 import cloud.trotter.dashbuddy.domain.analytics.DeliveryFold
+import cloud.trotter.dashbuddy.domain.analytics.LegStateCodec
 import cloud.trotter.dashbuddy.domain.analytics.OfferFold
 import cloud.trotter.dashbuddy.domain.analytics.PayAdjustmentFold
 import cloud.trotter.dashbuddy.domain.analytics.PayBasis
@@ -515,6 +516,8 @@ class AnalyticsProjector @Inject constructor(
         deliveries = deliveries,
         jobsCompleted = jobsCompleted,
         startSource = startSource,
+        // #688 phase B: persist the per-leg accumulator so it survives a batch-boundary rehydration.
+        legStateJson = LegStateCodec.encode(legState),
     )
 
     private fun SessionRecordEntity.toContext(
@@ -556,6 +559,8 @@ class AnalyticsProjector @Inject constructor(
         // DASH_START that lands in a later batch upgrades it with the real platform/startedAt (F1).
         started = startSource != null,
         startSource = startSource,
+        // #688 phase B: rehydrate the per-leg accumulator; fail-closed to empty on a garbage/null blob.
+        legState = LegStateCodec.decode(legStateJson),
     )
 
     private fun DeliveryFold.toEntity() = DeliveryRecordEntity(
@@ -593,6 +598,10 @@ class AnalyticsProjector @Inject constructor(
         storeKey = null,
         payoutStoreForms = StoreResolutionRunner.encodeForms(payoutStoreForms),
         storeKeyPinned = 0,
+        // #688 phase B: the machine-computed per-leg mileage (provenance; a driver miles edit never
+        // rewrites these — see applyDeliveryAdjustment).
+        milesToStore = milesToStore,
+        milesToDropoff = milesToDropoff,
     )
 
     private fun PickupFold.toEntity() = PickupRecordEntity(
@@ -667,7 +676,15 @@ class AnalyticsProjector @Inject constructor(
          * `delivery_records.storeKey`/`payoutStoreForms` + `offer_records.storeKey`/`linkedJobId`
          * columns for ALL history (rebuild ≡ backfill — the backfill is the first drain). The F8 wipe
          * clears `stores`/`pickup_records` so the refold's first-observed store fields are correct.
+         * v6 (#688 phase B): the fold now reads the lifecycle leg-anchor events it previously ignored
+         * (PICKUP_ARRIVED/DELIVERY_ARRIVED/DELIVERY_CONFIRMED, and advances the anchor on
+         * PICKUP_CONFIRMED/DELIVERY_COMPLETED) and the from-zero refold populates per-drop
+         * `milesToStore`/`milesToDropoff` + redistributed `realizedMiles`/`netProfit` on stacked drops
+         * from the odometer stamps already in the immutable log — so per-drop net redistributes within a
+         * stack while the session total is ~conserved. Phase-A driver edits (`DELIVERY_ADJUSTMENT`)
+         * replay after their targets on the refold, so a driver's corrected total survives. Precedented
+         * side effect (as v2/v3/v4): `CURRENT_FALLBACK` rows re-stamp against today's economy.
          */
-        private const val PROJECTOR_VERSION = 5
+        private const val PROJECTOR_VERSION = 6
     }
 }

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/CsvExporter.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/CsvExporter.kt
@@ -49,7 +49,8 @@ object CsvExporter {
 
     private val DELIVERY_HEADER = listOf(
         "date", "time", "platform", "store", "gross_pay", "tip", "base_pay", "cash_tip",
-        "miles", "minutes", "frozen_cost_per_mile", "net_profit", "pay_basis", "cost_basis",
+        "miles", "miles_to_store", "miles_to_dropoff", "minutes", "frozen_cost_per_mile",
+        "net_profit", "pay_basis", "cost_basis",
     )
 
     private val SESSION_HEADER = listOf(
@@ -98,6 +99,8 @@ object CsvExporter {
                         Csv.money(r.basePay),
                         Csv.money(r.cashTip),
                         Csv.decimal(r.realizedMiles),
+                        Csv.decimal(r.milesToStore),
+                        Csv.decimal(r.milesToDropoff),
                         Csv.decimal(r.realizedMinutes),
                         Csv.money(r.frozenCostPerMile, digits = 3),
                         Csv.money(r.netProfit),

--- a/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjectorTest.kt
+++ b/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjectorTest.kt
@@ -23,6 +23,7 @@ import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.ManualDeliveryPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.OfferPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.PayAdjustmentPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.PickupPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionEndSource
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStartPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStartSource
@@ -39,6 +40,7 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -1102,5 +1104,153 @@ class AnalyticsProjectorTest {
 
         val projector = AnalyticsProjector(db, repo, eventDao, analyticsDao, cancellingPrefs)
         projector.catchUp() // must rethrow, not degrade to a null cpm and continue
+    }
+
+    // ── #688 phase B: per-leg mileage (batch-boundary determinism + correction precedence) ──
+
+    /**
+     * A leg session: start → offer → pickup-arrive → pickup-confirm → delivery-arrive → complete →
+     * stop, with odometers so the completion folds milesToStore 0.5 + milesToDropoff 2.4 (realizedMiles
+     * 2.9, NOT the legacy 3.2 delta). The DELIVERY_COMPLETED is [deliverySeq].
+     */
+    private suspend fun seedLegSession(sid: String = "S1"): Long {
+        insert(
+            AppEventType.DASH_START, sid, 1_000,
+            SessionStartPayload(sid, Platform.DoorDash.name, 1_000, SessionStartSource.INTERACTION, "x"),
+            odometer = 100.0,
+        )
+        insert(
+            AppEventType.OFFER_ACCEPTED, sid, 1_500,
+            OfferPayload(
+                offerHash = "h1",
+                parsedOffer = ParsedOffer(offerHash = "h1", payAmount = 12.0, distanceMiles = 3.0),
+                evaluation = eval(0.25), outcome = AppEventType.OFFER_ACCEPTED,
+                presentedAt = 1_470, decidedAt = 1_500, returnFlow = Flow.Idle,
+            ),
+        )
+        insert(
+            AppEventType.PICKUP_ARRIVED, sid, 2_000,
+            PickupPayload(jobId = "J1", taskId = "P1", storeName = "StoreX", phaseStartedAt = 1_800, arrivedAt = 2_000),
+            odometer = 100.5,
+        )
+        insert(
+            AppEventType.PICKUP_CONFIRMED, sid, 2_500,
+            PickupPayload(jobId = "J1", taskId = "P1", storeName = "StoreX", phaseStartedAt = 1_800, arrivedAt = 2_000, confirmedAt = 2_500),
+            odometer = 100.6,
+        )
+        insert(
+            AppEventType.DELIVERY_ARRIVED, sid, 3_000,
+            DeliveryPayload(jobId = "J1", taskId = "D1", storeName = "StoreX", phaseStartedAt = 2_600, arrivedAt = 3_000),
+            odometer = 103.0,
+        )
+        val deliverySeq = insert(
+            AppEventType.DELIVERY_COMPLETED, sid, 3_500,
+            DeliveryPayload(
+                jobId = "J1", taskId = "D1", storeName = "StoreX", customerHash = "c",
+                phaseStartedAt = 2_600, arrivedAt = 3_000, completedAt = 3_500, totalPay = 10.0,
+            ),
+            odometer = 103.2,
+        )
+        insert(
+            AppEventType.DASH_STOP, sid, 4_000,
+            SessionStopPayload(sid, endedAt = 4_000, source = SessionEndSource.SUMMARY_SCREEN, totalEarnings = 10.0),
+            odometer = 103.5,
+        )
+        return deliverySeq
+    }
+
+    @Test
+    fun `criterion 5 - leg state round-trips across a batch boundary — incremental == single-drain (#688)`() = runBlocking {
+        val seq = seedLegSession()
+
+        // Fold with a boundary that falls BETWEEN PICKUP_ARRIVED (seq 3) and DELIVERY_COMPLETED (seq 6):
+        // batch 1 drains through PICKUP_CONFIRMED (seq 4), persisting the pending store leg to
+        // session_records.legStateJson; a fresh projector resumes and folds the completion.
+        projector().processBatch(limit = 4)
+        assertEquals(4L, analyticsDao.getWatermark()!!.watermarkSequenceId)
+        val resumed = projector()
+        resumed.processBatch(limit = 100)
+        assertNull(resumed.processBatch(limit = 100))
+
+        val incremental = analyticsDao.deliveryRecord(seq)!!
+        assertEquals("store leg survived the batch boundary", 0.5, incremental.milesToStore!!, 1e-6)
+        assertEquals(2.4, incremental.milesToDropoff!!, 1e-6)
+        assertEquals(2.9, incremental.realizedMiles!!, 1e-6)
+
+        // Force a from-zero refold (single drain) and prove the row is byte-identical.
+        analyticsDao.setWatermark(AnalyticsProjectionStateEntity(watermarkSequenceId = 7, projectorVersion = 99))
+        projector().catchUp()
+        val refold = analyticsDao.deliveryRecord(seq)!!
+        assertEquals(incremental.milesToStore, refold.milesToStore)
+        assertEquals(incremental.milesToDropoff, refold.milesToDropoff)
+        assertEquals(incremental.realizedMiles, refold.realizedMiles)
+        assertEquals(incremental.netProfit, refold.netProfit)
+    }
+
+    @Test
+    fun `criterion 5 - a garbage legStateJson blob decodes fail-closed to legacy-delta rows, no crash (#688)`() = runBlocking {
+        val seq = seedLegSession()
+        // Fold through PICKUP_CONFIRMED, then CORRUPT the persisted leg state before the completion folds.
+        projector().processBatch(limit = 4)
+        db.openHelper.writableDatabase.execSQL(
+            "UPDATE session_records SET legStateJson = 'not valid json {{' WHERE sessionId = 'S1'",
+        )
+        // Resume: the fail-closed decode degrades to empty leg state → the completion falls back to the
+        // legacy partition delta (no store/dropoff legs), never a crash.
+        projector().catchUp()
+
+        val d = analyticsDao.deliveryRecord(seq)!!
+        assertNull("garbage blob → no store leg", d.milesToStore)
+        assertNull("garbage blob → no dropoff leg", d.milesToDropoff)
+        // Legacy delta: no prior drop in the session → anchor is startOdometer 100 → 103.2 − 100 = 3.2.
+        assertEquals(3.2, d.realizedMiles!!, 1e-6)
+    }
+
+    @Test
+    fun `criterion 6 - a newMiles correction wins realizedMiles for money but leaves the machine legs intact (#688)`() = runBlocking {
+        val seq = seedLegSession()
+        projector().catchUp()
+        val before = analyticsDao.deliveryRecord(seq)!!
+        assertEquals(0.5, before.milesToStore!!, 1e-6)
+        assertEquals(2.4, before.milesToDropoff!!, 1e-6)
+
+        insert(
+            AppEventType.DELIVERY_ADJUSTMENT, "S1", 6_000,
+            DeliveryAdjustmentPayload(targetEventSequenceId = seq, sessionId = "S1", newMiles = 8.0),
+        )
+        projector().catchUp()
+
+        val d = analyticsDao.deliveryRecord(seq)!!
+        assertEquals("driver total wins realizedMiles", 8.0, d.realizedMiles!!, 1e-9)
+        assertEquals("machine store leg is provenance — never rewritten", 0.5, d.milesToStore!!, 1e-6)
+        assertEquals("machine dropoff leg untouched", 2.4, d.milesToDropoff!!, 1e-6)
+        // Net recomputed against the row's OWN frozen cpm over the DRIVER miles; basis unchanged (miles-only).
+        assertEquals(10.0 - 8.0 * 0.25, d.netProfit!!, 1e-9)
+        assertEquals("a miles-only edit does not flip the basis", before.payBasis, d.payBasis)
+        // The edit trail: leg sum (2.9) now disagrees with the driver's realizedMiles (8.0).
+        assertEquals(2.9, d.milesToStore!! + d.milesToDropoff!!, 1e-6)
+    }
+
+    @Test
+    fun `criterion 7 - reconciliation - per-row leg invariant holds and session odometer reads are unaffected (#688)`() = runBlocking {
+        val seq = seedLegSession()
+        projector().catchUp()
+
+        val d = analyticsDao.deliveryRecord(seq)!!
+        // Per-row invariant: realizedMiles == (milesToStore ?: 0) + milesToDropoff iff milesToDropoff != null.
+        assertEquals((d.milesToStore ?: 0.0) + d.milesToDropoff!!, d.realizedMiles!!, 1e-9)
+
+        // Reconciliation bound: 0 ≤ sessionDelta − Σ(row realizedMiles) ≤ residual (store dwell +
+        // arrived→completed drift). sessionDelta = 103.5 − 100 = 3.5; Σ legs = 2.9.
+        val session = analyticsDao.sessionRecord("S1")!!
+        val sessionDelta = session.lastOdometer!! - session.startOdometer!!
+        val residual = sessionDelta - d.realizedMiles!!
+        assertEquals(3.5, sessionDelta, 1e-6)
+        assertTrue("Σ leg miles never exceed the session odometer span", residual >= -1e-9)
+        assertTrue("residual is bounded (dwell + drift), not unboundedly large", residual <= 1.0)
+
+        // A period read (pay) is unaffected by leg redistribution — leg columns never touch pay.
+        val totals = analyticsDao.deliveryTotals(0, Long.MAX_VALUE).first()
+        assertEquals(10.0, totals.pay, 1e-9)
     }
 }

--- a/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/CsvExporterTest.kt
+++ b/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/CsvExporterTest.kt
@@ -26,6 +26,8 @@ class CsvExporterTest {
         pay: Double? = 8.50,
         basis: String = "DROP_SHARE",
         cashTip: Double? = null,
+        milesToStore: Double? = null,
+        milesToDropoff: Double? = null,
     ) = DeliveryRecordEntity(
         eventSequenceId = seq,
         sessionId = "s1",
@@ -50,6 +52,8 @@ class CsvExporterTest {
         netProfit = 7.81,
         costBasis = "OFFER_FROZEN",
         cashTip = cashTip,
+        milesToStore = milesToStore,
+        milesToDropoff = milesToDropoff,
     )
 
     private fun session(
@@ -79,22 +83,30 @@ class CsvExporterTest {
     )
 
     @Test fun deliveries_headerAndRow_withPlatformDisplayName() {
-        val out = CsvExporter.export(listOf(delivery(1, "H-E-B", cashTip = 4.00)), emptyList(), utc, generatedAt)
+        val out = CsvExporter.export(
+            listOf(delivery(1, "H-E-B", cashTip = 4.00, milesToStore = 1.20, milesToDropoff = 3.00)),
+            emptyList(), utc, generatedAt,
+        )
         val lines = out.deliveriesCsv.trim().lines()
         assertEquals(
-            "date,time,platform,store,gross_pay,tip,base_pay,cash_tip,miles,minutes,frozen_cost_per_mile,net_profit,pay_basis,cost_basis",
+            "date,time,platform,store,gross_pay,tip,base_pay,cash_tip,miles,miles_to_store," +
+                "miles_to_dropoff,minutes,frozen_cost_per_mile,net_profit,pay_basis,cost_basis",
             lines[0],
         )
         assertEquals(
-            "2026-07-05,14:03:27,DoorDash,H-E-B,8.50,3.25,5.25,4.00,4.20,12.50,0.165,7.81,DROP_SHARE,OFFER_FROZEN",
+            "2026-07-05,14:03:27,DoorDash,H-E-B,8.50,3.25,5.25,4.00,4.20,1.20,3.00,12.50,0.165,7.81,DROP_SHARE,OFFER_FROZEN",
             lines[1],
         )
     }
 
-    @Test fun deliveries_nullCashTip_isEmptyField() {
+    @Test fun deliveries_nullPerLegMileage_isEmptyField() {
         val out = CsvExporter.export(listOf(delivery(1, "H-E-B")), emptyList(), utc, generatedAt)
-        // cash_tip is column index 7 (date,time,platform,store,gross_pay,tip,base_pay,cash_tip).
-        assertEquals("", out.deliveriesCsv.trim().lines()[1].split(",")[7])
+        val cells = out.deliveriesCsv.trim().lines()[1].split(",")
+        // cash_tip is column index 7 (date,time,platform,store,gross_pay,tip,base_pay,cash_tip); the
+        // per-leg columns are miles(8), miles_to_store(9), miles_to_dropoff(10) — null → empty.
+        assertEquals("", cells[7])
+        assertEquals("", cells[9])
+        assertEquals("", cells[10])
     }
 
     @Test fun summary_totalCashTips_line() {

--- a/core/database/schemas/cloud.trotter.dashbuddy.core.database.DashBuddyDatabase/13.json
+++ b/core/database/schemas/cloud.trotter.dashbuddy.core.database.DashBuddyDatabase/13.json
@@ -1,0 +1,1118 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 13,
+    "identityHash": "d83a1cfd196b6b8a008e6eddd6b00fcc",
+    "entities": [
+      {
+        "tableName": "app_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sequenceId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `aggregateId` TEXT, `eventType` TEXT NOT NULL, `eventPayload` TEXT NOT NULL, `occurredAt` INTEGER NOT NULL, `metadata` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "sequenceId",
+            "columnName": "sequenceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "aggregateId",
+            "columnName": "aggregateId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "eventType",
+            "columnName": "eventType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventPayload",
+            "columnName": "eventPayload",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "occurredAt",
+            "columnName": "occurredAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadata",
+            "columnName": "metadata",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "sequenceId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_app_events_aggregateId",
+            "unique": false,
+            "columnNames": [
+              "aggregateId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_app_events_aggregateId` ON `${TABLE_NAME}` (`aggregateId`)"
+          },
+          {
+            "name": "index_app_events_eventType",
+            "unique": false,
+            "columnNames": [
+              "eventType"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_app_events_eventType` ON `${TABLE_NAME}` (`eventType`)"
+          },
+          {
+            "name": "index_app_events_occurredAt",
+            "unique": false,
+            "columnNames": [
+              "occurredAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_app_events_occurredAt` ON `${TABLE_NAME}` (`occurredAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "app_state_snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`correlationVersion` INTEGER NOT NULL, `capturedAt` INTEGER NOT NULL, `sessionId` TEXT, `stateJson` TEXT NOT NULL, PRIMARY KEY(`correlationVersion`))",
+        "fields": [
+          {
+            "fieldPath": "correlationVersion",
+            "columnName": "correlationVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "capturedAt",
+            "columnName": "capturedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "stateJson",
+            "columnName": "stateJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "correlationVersion"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `dashId` TEXT, `text` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `personaType` TEXT NOT NULL, `personaName` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dashId",
+            "columnName": "dashId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personaType",
+            "columnName": "personaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personaName",
+            "columnName": "personaName",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_messages_dashId",
+            "unique": false,
+            "columnNames": [
+              "dashId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_messages_dashId` ON `${TABLE_NAME}` (`dashId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "effects_fired",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `effectKey` TEXT NOT NULL, `firedAt` INTEGER NOT NULL, `correlationVersion` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "effectKey",
+            "columnName": "effectKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firedAt",
+            "columnName": "firedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "correlationVersion",
+            "columnName": "correlationVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_effects_fired_effectKey",
+            "unique": true,
+            "columnNames": [
+              "effectKey"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_effects_fired_effectKey` ON `${TABLE_NAME}` (`effectKey`)"
+          }
+        ]
+      },
+      {
+        "tableName": "observations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sequenceId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `occurredAt` INTEGER NOT NULL, `sessionId` TEXT, `pipelineId` TEXT NOT NULL, `ruleId` TEXT, `platform` TEXT, `flow` TEXT, `modeHint` TEXT, `parsedJson` TEXT NOT NULL, `captureId` TEXT, `metadataJson` TEXT NOT NULL, `correlationVersion` INTEGER NOT NULL, `timeoutType` TEXT, `payloadJson` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "sequenceId",
+            "columnName": "sequenceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "occurredAt",
+            "columnName": "occurredAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pipelineId",
+            "columnName": "pipelineId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ruleId",
+            "columnName": "ruleId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "flow",
+            "columnName": "flow",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "modeHint",
+            "columnName": "modeHint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "parsedJson",
+            "columnName": "parsedJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "captureId",
+            "columnName": "captureId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "metadataJson",
+            "columnName": "metadataJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "correlationVersion",
+            "columnName": "correlationVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeoutType",
+            "columnName": "timeoutType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "payloadJson",
+            "columnName": "payloadJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "sequenceId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_observations_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_observations_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          },
+          {
+            "name": "index_observations_occurredAt",
+            "unique": false,
+            "columnNames": [
+              "occurredAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_observations_occurredAt` ON `${TABLE_NAME}` (`occurredAt`)"
+          },
+          {
+            "name": "index_observations_correlationVersion",
+            "unique": false,
+            "columnNames": [
+              "correlationVersion"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_observations_correlationVersion` ON `${TABLE_NAME}` (`correlationVersion`)"
+          }
+        ]
+      },
+      {
+        "tableName": "delivery_records",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`eventSequenceId` INTEGER NOT NULL, `sessionId` TEXT, `platform` TEXT NOT NULL, `jobId` TEXT NOT NULL, `taskId` TEXT NOT NULL, `storeName` TEXT, `customerHash` TEXT, `addressHash` TEXT, `phaseStartedAt` INTEGER NOT NULL, `arrivedAt` INTEGER, `completedAt` INTEGER NOT NULL, `deadlineMillis` INTEGER, `realizedPay` REAL, `payBasis` TEXT NOT NULL, `tip` REAL, `basePay` REAL, `odometerAtCompletion` REAL, `realizedMiles` REAL, `realizedMinutes` REAL, `frozenCostPerMile` REAL, `frozenFuelPerMile` REAL, `frozenNonFuelPerMile` REAL, `netProfit` REAL, `costBasis` TEXT NOT NULL, `cashTip` REAL, `originalPayBasis` TEXT, `storeKey` TEXT, `payoutStoreForms` TEXT, `storeKeyPinned` INTEGER NOT NULL DEFAULT 0, `milesToStore` REAL, `milesToDropoff` REAL, PRIMARY KEY(`eventSequenceId`))",
+        "fields": [
+          {
+            "fieldPath": "eventSequenceId",
+            "columnName": "eventSequenceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jobId",
+            "columnName": "jobId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "taskId",
+            "columnName": "taskId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storeName",
+            "columnName": "storeName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customerHash",
+            "columnName": "customerHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addressHash",
+            "columnName": "addressHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "phaseStartedAt",
+            "columnName": "phaseStartedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "arrivedAt",
+            "columnName": "arrivedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deadlineMillis",
+            "columnName": "deadlineMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "realizedPay",
+            "columnName": "realizedPay",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "payBasis",
+            "columnName": "payBasis",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tip",
+            "columnName": "tip",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "basePay",
+            "columnName": "basePay",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "odometerAtCompletion",
+            "columnName": "odometerAtCompletion",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "realizedMiles",
+            "columnName": "realizedMiles",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "realizedMinutes",
+            "columnName": "realizedMinutes",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "frozenCostPerMile",
+            "columnName": "frozenCostPerMile",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "frozenFuelPerMile",
+            "columnName": "frozenFuelPerMile",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "frozenNonFuelPerMile",
+            "columnName": "frozenNonFuelPerMile",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "netProfit",
+            "columnName": "netProfit",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "costBasis",
+            "columnName": "costBasis",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cashTip",
+            "columnName": "cashTip",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "originalPayBasis",
+            "columnName": "originalPayBasis",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "storeKey",
+            "columnName": "storeKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "payoutStoreForms",
+            "columnName": "payoutStoreForms",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "storeKeyPinned",
+            "columnName": "storeKeyPinned",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "milesToStore",
+            "columnName": "milesToStore",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "milesToDropoff",
+            "columnName": "milesToDropoff",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "eventSequenceId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_delivery_records_completedAt",
+            "unique": false,
+            "columnNames": [
+              "completedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_delivery_records_completedAt` ON `${TABLE_NAME}` (`completedAt`)"
+          },
+          {
+            "name": "index_delivery_records_platform_completedAt",
+            "unique": false,
+            "columnNames": [
+              "platform",
+              "completedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_delivery_records_platform_completedAt` ON `${TABLE_NAME}` (`platform`, `completedAt`)"
+          },
+          {
+            "name": "index_delivery_records_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_delivery_records_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          },
+          {
+            "name": "index_delivery_records_sessionId_jobId",
+            "unique": false,
+            "columnNames": [
+              "sessionId",
+              "jobId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_delivery_records_sessionId_jobId` ON `${TABLE_NAME}` (`sessionId`, `jobId`)"
+          },
+          {
+            "name": "index_delivery_records_jobId",
+            "unique": false,
+            "columnNames": [
+              "jobId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_delivery_records_jobId` ON `${TABLE_NAME}` (`jobId`)"
+          },
+          {
+            "name": "index_delivery_records_storeName",
+            "unique": false,
+            "columnNames": [
+              "storeName"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_delivery_records_storeName` ON `${TABLE_NAME}` (`storeName`)"
+          },
+          {
+            "name": "index_delivery_records_storeKey",
+            "unique": false,
+            "columnNames": [
+              "storeKey"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_delivery_records_storeKey` ON `${TABLE_NAME}` (`storeKey`)"
+          }
+        ]
+      },
+      {
+        "tableName": "session_records",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sessionId` TEXT NOT NULL, `platform` TEXT NOT NULL, `startedAt` INTEGER NOT NULL, `endedAt` INTEGER, `lastEventAt` INTEGER NOT NULL, `endSource` TEXT, `startSource` TEXT, `startOdometer` REAL, `lastOdometer` REAL, `reportedEarnings` REAL, `reportedDurationMillis` INTEGER, `offersReceived` INTEGER NOT NULL, `offersAccepted` INTEGER NOT NULL, `offersDeclined` INTEGER NOT NULL, `offersTimeout` INTEGER NOT NULL, `deliveries` INTEGER NOT NULL, `jobsCompleted` INTEGER NOT NULL, `legStateJson` TEXT, PRIMARY KEY(`sessionId`))",
+        "fields": [
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "startedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endedAt",
+            "columnName": "endedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastEventAt",
+            "columnName": "lastEventAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endSource",
+            "columnName": "endSource",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "startSource",
+            "columnName": "startSource",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "startOdometer",
+            "columnName": "startOdometer",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "lastOdometer",
+            "columnName": "lastOdometer",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "reportedEarnings",
+            "columnName": "reportedEarnings",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "reportedDurationMillis",
+            "columnName": "reportedDurationMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "offersReceived",
+            "columnName": "offersReceived",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "offersAccepted",
+            "columnName": "offersAccepted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "offersDeclined",
+            "columnName": "offersDeclined",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "offersTimeout",
+            "columnName": "offersTimeout",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deliveries",
+            "columnName": "deliveries",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jobsCompleted",
+            "columnName": "jobsCompleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "legStateJson",
+            "columnName": "legStateJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sessionId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_session_records_startedAt",
+            "unique": false,
+            "columnNames": [
+              "startedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_session_records_startedAt` ON `${TABLE_NAME}` (`startedAt`)"
+          },
+          {
+            "name": "index_session_records_platform_startedAt",
+            "unique": false,
+            "columnNames": [
+              "platform",
+              "startedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_session_records_platform_startedAt` ON `${TABLE_NAME}` (`platform`, `startedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "offer_records",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`eventSequenceId` INTEGER NOT NULL, `sessionId` TEXT, `platform` TEXT NOT NULL, `offerHash` TEXT NOT NULL, `outcome` TEXT NOT NULL, `presentedAt` INTEGER NOT NULL, `decidedAt` INTEGER NOT NULL, `payAmount` REAL, `distanceMiles` REAL, `itemCount` INTEGER NOT NULL, `merchantName` TEXT, `score` REAL, `action` TEXT, `quality` TEXT, `estNetPay` REAL, `estDollarsPerHour` REAL, `estDollarsPerMile` REAL, `estTimeMinutes` REAL, `estOperatingCostPerMile` REAL, `estFuelPerMile` REAL, `estNonFuelPerMile` REAL, `storeKey` TEXT, `linkedJobId` TEXT, PRIMARY KEY(`eventSequenceId`))",
+        "fields": [
+          {
+            "fieldPath": "eventSequenceId",
+            "columnName": "eventSequenceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "offerHash",
+            "columnName": "offerHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "outcome",
+            "columnName": "outcome",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "presentedAt",
+            "columnName": "presentedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "decidedAt",
+            "columnName": "decidedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payAmount",
+            "columnName": "payAmount",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "distanceMiles",
+            "columnName": "distanceMiles",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "itemCount",
+            "columnName": "itemCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchantName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "action",
+            "columnName": "action",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "quality",
+            "columnName": "quality",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "estNetPay",
+            "columnName": "estNetPay",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "estDollarsPerHour",
+            "columnName": "estDollarsPerHour",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "estDollarsPerMile",
+            "columnName": "estDollarsPerMile",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "estTimeMinutes",
+            "columnName": "estTimeMinutes",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "estOperatingCostPerMile",
+            "columnName": "estOperatingCostPerMile",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "estFuelPerMile",
+            "columnName": "estFuelPerMile",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "estNonFuelPerMile",
+            "columnName": "estNonFuelPerMile",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "storeKey",
+            "columnName": "storeKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "linkedJobId",
+            "columnName": "linkedJobId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "eventSequenceId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_offer_records_decidedAt",
+            "unique": false,
+            "columnNames": [
+              "decidedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offer_records_decidedAt` ON `${TABLE_NAME}` (`decidedAt`)"
+          },
+          {
+            "name": "index_offer_records_platform_decidedAt",
+            "unique": false,
+            "columnNames": [
+              "platform",
+              "decidedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offer_records_platform_decidedAt` ON `${TABLE_NAME}` (`platform`, `decidedAt`)"
+          },
+          {
+            "name": "index_offer_records_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offer_records_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          },
+          {
+            "name": "index_offer_records_offerHash",
+            "unique": false,
+            "columnNames": [
+              "offerHash"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offer_records_offerHash` ON `${TABLE_NAME}` (`offerHash`)"
+          },
+          {
+            "name": "index_offer_records_linkedJobId",
+            "unique": false,
+            "columnNames": [
+              "linkedJobId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offer_records_linkedJobId` ON `${TABLE_NAME}` (`linkedJobId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "analytics_projection_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `watermarkSequenceId` INTEGER NOT NULL, `projectorVersion` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "watermarkSequenceId",
+            "columnName": "watermarkSequenceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "projectorVersion",
+            "columnName": "projectorVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "stores",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storeKey` TEXT NOT NULL, `platform` TEXT NOT NULL, `normalizedChain` TEXT NOT NULL, `chainDisplay` TEXT NOT NULL, `runningKey` TEXT, `offerNameForm` TEXT, `pickupNameForm` TEXT, `payoutNameForm` TEXT, `address` TEXT, PRIMARY KEY(`storeKey`))",
+        "fields": [
+          {
+            "fieldPath": "storeKey",
+            "columnName": "storeKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "normalizedChain",
+            "columnName": "normalizedChain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chainDisplay",
+            "columnName": "chainDisplay",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "runningKey",
+            "columnName": "runningKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "offerNameForm",
+            "columnName": "offerNameForm",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pickupNameForm",
+            "columnName": "pickupNameForm",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "payoutNameForm",
+            "columnName": "payoutNameForm",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storeKey"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_stores_normalizedChain",
+            "unique": false,
+            "columnNames": [
+              "normalizedChain"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_stores_normalizedChain` ON `${TABLE_NAME}` (`normalizedChain`)"
+          }
+        ]
+      },
+      {
+        "tableName": "pickup_records",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`eventSequenceId` INTEGER NOT NULL, `sessionId` TEXT, `platform` TEXT NOT NULL, `jobId` TEXT NOT NULL, `taskId` TEXT NOT NULL, `storeName` TEXT NOT NULL, `storeKey` TEXT, `phaseStartedAt` INTEGER NOT NULL, `arrivedAt` INTEGER, `confirmedAt` INTEGER, `deadlineMillis` INTEGER, `activity` TEXT, `storeAddress` TEXT, PRIMARY KEY(`eventSequenceId`))",
+        "fields": [
+          {
+            "fieldPath": "eventSequenceId",
+            "columnName": "eventSequenceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jobId",
+            "columnName": "jobId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "taskId",
+            "columnName": "taskId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storeName",
+            "columnName": "storeName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storeKey",
+            "columnName": "storeKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "phaseStartedAt",
+            "columnName": "phaseStartedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "arrivedAt",
+            "columnName": "arrivedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "confirmedAt",
+            "columnName": "confirmedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "deadlineMillis",
+            "columnName": "deadlineMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "activity",
+            "columnName": "activity",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "storeAddress",
+            "columnName": "storeAddress",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "eventSequenceId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_pickup_records_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_pickup_records_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          },
+          {
+            "name": "index_pickup_records_jobId",
+            "unique": false,
+            "columnNames": [
+              "jobId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_pickup_records_jobId` ON `${TABLE_NAME}` (`jobId`)"
+          },
+          {
+            "name": "index_pickup_records_storeKey",
+            "unique": false,
+            "columnNames": [
+              "storeKey"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_pickup_records_storeKey` ON `${TABLE_NAME}` (`storeKey`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'd83a1cfd196b6b8a008e6eddd6b00fcc')"
+    ]
+  }
+}

--- a/core/database/src/androidTest/java/cloud/trotter/dashbuddy/core/database/AnalyticsMigration12to13Test.kt
+++ b/core/database/src/androidTest/java/cloud/trotter/dashbuddy/core/database/AnalyticsMigration12to13Test.kt
@@ -1,0 +1,84 @@
+package cloud.trotter.dashbuddy.core.database
+
+import androidx.room.testing.MigrationTestHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * #688 phase B — execute the REAL committed `AutoMigration(12→13)` against a **populated** v12 database
+ * and prove it is additive-only: the pre-existing analytics rows survive, and the three new
+ * nullable columns are present (delivery_records.{milesToStore, milesToDropoff},
+ * session_records.legStateJson) — left NULL by the ADD COLUMN (the `PROJECTOR_VERSION` 5→6 refold
+ * repopulates them from the immutable log).
+ *
+ * Instrumented (androidTest) because [MigrationTestHelper] opens an on-disk SQLite DB via the
+ * framework factory and replays the exported schema JSONs. Runs under
+ * `:core:database:connectedAndroidTest` — it does NOT gate unit-only PR CI (the unit-level
+ * [SchemaVersionGuardTest] is the CI-gating guard); needs one device/emulator run before merge.
+ */
+@RunWith(AndroidJUnit4::class)
+class AnalyticsMigration12to13Test {
+
+    private val dbName = "migration-12-to-13-test"
+
+    @get:Rule
+    val helper = MigrationTestHelper(
+        InstrumentationRegistry.getInstrumentation(),
+        DashBuddyDatabase::class.java,
+        emptyList(),
+        FrameworkSQLiteOpenHelperFactory(),
+    )
+
+    @Test
+    fun migrate12To13_preservesRows_addsPerLegMileageColumns() {
+        helper.createDatabase(dbName, 12).use { db ->
+            db.execSQL(
+                """INSERT INTO delivery_records
+                   (eventSequenceId, sessionId, platform, jobId, taskId, storeName, customerHash,
+                    addressHash, phaseStartedAt, arrivedAt, completedAt, deadlineMillis, realizedPay,
+                    payBasis, tip, basePay, odometerAtCompletion, realizedMiles, realizedMinutes,
+                    frozenCostPerMile, frozenFuelPerMile, frozenNonFuelPerMile, netProfit, costBasis,
+                    cashTip, originalPayBasis, storeKey, payoutStoreForms, storeKeyPinned)
+                   VALUES (1, 'S1', 'doordash', 'J1', 'T1', 'Target', 'ch', 'ah', 100, NULL, 3000,
+                           NULL, 10.0, 'RECEIPT_TOTAL', NULL, NULL, 105.0, 5.0, 1.0, 0.25, 0.10, 0.15,
+                           8.75, 'OFFER_FROZEN', NULL, 'RECEIPT_TOTAL', 'doordash|target|1', NULL, 0)""",
+            )
+            db.execSQL(
+                """INSERT INTO session_records
+                   (sessionId, platform, startedAt, endedAt, lastEventAt, endSource, startSource,
+                    startOdometer, lastOdometer, reportedEarnings, reportedDurationMillis, offersReceived,
+                    offersAccepted, offersDeclined, offersTimeout, deliveries, jobsCompleted)
+                   VALUES ('S1', 'doordash', 1000, 5000, 5000, 'summary_screen', 'interaction', 100.0,
+                           110.0, 25.0, 4000, 1, 1, 0, 0, 1, 1)""",
+            )
+        }
+
+        val db = helper.runMigrationsAndValidate(dbName, 13, true)
+
+        // Pre-existing rows survived (additive-only).
+        db.query("SELECT COUNT(*) FROM delivery_records").use { c ->
+            c.moveToFirst(); assertEquals(1, c.getInt(0))
+        }
+        db.query("SELECT COUNT(*) FROM session_records").use { c ->
+            c.moveToFirst(); assertEquals(1, c.getInt(0))
+        }
+        // New delivery leg columns exist and are NULL post-migration.
+        db.query("SELECT milesToStore, milesToDropoff FROM delivery_records WHERE eventSequenceId = 1").use { c ->
+            c.moveToFirst()
+            assertTrue("milesToStore NULL post-migration", c.isNull(0))
+            assertTrue("milesToDropoff NULL post-migration", c.isNull(1))
+        }
+        // New session leg-state column exists and is NULL post-migration.
+        db.query("SELECT legStateJson FROM session_records WHERE sessionId = 'S1'").use { c ->
+            c.moveToFirst()
+            assertTrue("legStateJson NULL post-migration", c.isNull(0))
+        }
+        db.close()
+    }
+}

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/DashBuddyDatabase.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/DashBuddyDatabase.kt
@@ -64,11 +64,19 @@ import cloud.trotter.dashbuddy.core.database.snapshot.AppStateSnapshotEntity
     // offer_records.linkedJobId). The `PROJECTOR_VERSION` 4→5 refold this bump triggers populates the
     // two new tables + the storeKey columns for ALL history (rebuild ≡ backfill; the backfill is just
     // the first drain). Additive ⇒ never wipes app_events or the existing analytics rows.
+    // v12→v13 (#688 phase B) is additive-only: two new nullable REAL columns on delivery_records
+    // (milesToStore, milesToDropoff — the per-leg driving mileage) + one new nullable TEXT column on
+    // session_records (legStateJson — the serialized per-leg accumulator persisted across batch
+    // boundaries). The `PROJECTOR_VERSION` 5→6 refold this bump triggers folds the lifecycle
+    // metadata.odometer stamps (already in the immutable log) into per-drop milesToStore/milesToDropoff
+    // + redistributed realizedMiles/netProfit on stacked drops. Additive ⇒ never wipes app_events or
+    // the existing analytics rows.
     autoMigrations = [
         AutoMigration(from = 8, to = 9),
         AutoMigration(from = 9, to = 10),
         AutoMigration(from = 10, to = 11),
         AutoMigration(from = 11, to = 12),
+        AutoMigration(from = 12, to = 13),
     ],
 )
 @TypeConverters(DataTypeConverters::class)
@@ -96,7 +104,7 @@ abstract class DashBuddyDatabase : RoomDatabase() {
          * this in lockstep with a new `schemas/**/<N>.json`, an `AutoMigration(N-1 → N)`, and its
          * `MigrationTestHelper` case — see the release checklist in CLAUDE.md.
          */
-        const val VERSION = 12
+        const val VERSION = 13
     }
 
 }

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/DeliveryRecordEntity.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/DeliveryRecordEntity.kt
@@ -155,10 +155,14 @@ data class DeliveryRecordEntity(
     // ── Per-leg mileage (#688 phase B, v13) ─────────────────────────────────
     /**
      * Machine-computed to-store driving leg (#688 phase B) — this drop's claimed store leg (exact
-     * store-form match within the job, else FIFO). Provenance ONLY: a driver `newMiles`
+     * NORMALIZED-chain store-form match within the job, else FIFO). Stamped ONLY on a leg-sum row
+     * ([milesToDropoff] non-null); a LEGACY row (missed arrival) stamps null and instead retires its
+     * job's already-closed store legs (#688 review Fix 1/Fix 4), so a lone store leg never rides an
+     * otherwise-untouched legacy row — keeping `milesToStore + milesToDropoff != realizedMiles`
+     * meaningful strictly as the driver-edit trail. Provenance ONLY: a driver `newMiles`
      * DELIVERY_ADJUSTMENT rewrites [realizedMiles] but NEVER this column, so `milesToStore +
      * milesToDropoff` may then disagree with `realizedMiles` — that inequality is the visible edit
-     * trail (DEV-DECISION 1). Null on an anchorless/unclaimed leg and all pre-v13 history.
+     * trail (DEV-DECISION 1). Null on an anchorless/unclaimed/legacy leg and all pre-v13 history.
      */
     val milesToStore: Double? = null,
     /**

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/DeliveryRecordEntity.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/DeliveryRecordEntity.kt
@@ -156,8 +156,9 @@ data class DeliveryRecordEntity(
     /**
      * Machine-computed to-store driving leg (#688 phase B) — this drop's claimed store leg (exact
      * NORMALIZED-chain store-form match within the job, else FIFO). Stamped ONLY on a leg-sum row
-     * ([milesToDropoff] non-null); a LEGACY row (missed arrival) stamps null and instead retires its
-     * job's already-closed store legs (#688 review Fix 1/Fix 4), so a lone store leg never rides an
+     * ([milesToDropoff] non-null); a LEGACY row (missed arrival) stamps null and instead retires the
+     * SESSION's already-closed store legs — any job, since the legacy span is a session-level partition
+     * delta (#688 review Fix 1/Fix 4 + re-verify widening) — so a lone store leg never rides an
      * otherwise-untouched legacy row — keeping `milesToStore + milesToDropoff != realizedMiles`
      * meaningful strictly as the driver-edit trail. Provenance ONLY: a driver `newMiles`
      * DELIVERY_ADJUSTMENT rewrites [realizedMiles] but NEVER this column, so `milesToStore +

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/DeliveryRecordEntity.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/DeliveryRecordEntity.kt
@@ -151,4 +151,21 @@ data class DeliveryRecordEntity(
      * the additive AutoMigration back-fills existing rows).
      */
     @ColumnInfo(defaultValue = "0") val storeKeyPinned: Int = 0,
+
+    // ── Per-leg mileage (#688 phase B, v13) ─────────────────────────────────
+    /**
+     * Machine-computed to-store driving leg (#688 phase B) — this drop's claimed store leg (exact
+     * store-form match within the job, else FIFO). Provenance ONLY: a driver `newMiles`
+     * DELIVERY_ADJUSTMENT rewrites [realizedMiles] but NEVER this column, so `milesToStore +
+     * milesToDropoff` may then disagree with `realizedMiles` — that inequality is the visible edit
+     * trail (DEV-DECISION 1). Null on an anchorless/unclaimed leg and all pre-v13 history.
+     */
+    val milesToStore: Double? = null,
+    /**
+     * Machine-computed to-dropoff driving leg (#688 phase B), keyed by this drop's own `taskId`. When
+     * non-null, `realizedMiles == (milesToStore ?: 0) + milesToDropoff` (the leg-sum rule); when null
+     * the row keeps the legacy partition delta. Null when no odometer-bearing `DELIVERY_ARRIVED`
+     * preceded the completion (missed arrival, phantom-class completion, all pre-v13 history).
+     */
+    val milesToDropoff: Double? = null,
 )

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/SessionRecordEntity.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/SessionRecordEntity.kt
@@ -69,4 +69,16 @@ data class SessionRecordEntity(
     val deliveries: Int,
     /** Folded count of distinct jobIds delivered. */
     val jobsCompleted: Int,
+
+    // ── Per-leg mileage accumulator (#688 phase B, v13) ─────────────────────
+    /**
+     * Serialized [cloud.trotter.dashbuddy.domain.analytics.LegState] (#688 phase B) — the leg anchor +
+     * the pending to-store/to-dropoff legs of drops that have NOT yet completed. Persisted here because
+     * pending legs cannot be re-derived from record rows on a batch-boundary rehydration (unlike
+     * `prevDropOdometer`/`deliveredJobIds`), so incremental folding would otherwise diverge from a
+     * from-zero refold across a page boundary. Decoded FAIL-CLOSED (garbage/null ⇒ empty leg state ⇒
+     * the session's drops fall back to the legacy partition delta — never a crash, never wrong money).
+     * Null on all pre-v13 rows (the `PROJECTOR_VERSION` refold repopulates it from the immutable log).
+     */
+    val legStateJson: String? = null,
 )

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -81,11 +81,16 @@ was found **broken-in-part** (raw PII in capture envelopes) and moved to that en
   launch after install; expect a one-time refold at startup).
   **How to tell it's working (desk-side, after a dash with a stacked/multi-store job):** in the
   per-dash drill-down (and `delivery_records`), each drop of a stack shows a plausible nonzero
-  `X mi` (not one lump + 0.0); Σ per-drop miles ≤ the session odometer miles; the CSV export's
-  `miles_to_store`/`miles_to_dropoff` columns are populated for drops whose arrival frames fired;
-  and a driver miles edit via the Adjust dialog still wins the row total (the leg columns keep the
-  machine estimate — a deliberate mismatch, not a bug). A drop with a missed `DELIVERY_ARRIVED`
-  (no arrival frame) legitimately falls back to the old partition delta with blank leg columns.
+  `X mi` (not one lump + 0.0); **Σ per-drop miles ≤ the session odometer miles** — this is a
+  ONE-SIDED invariant: an undershoot is EXPECTED (the arrival→completion dwell/drift, and any store
+  legs retired when a stack-mate missed its arrival, land in the deadhead remainder), but Σ must
+  NEVER EXCEED the session span (that would be the mixed-basis double-count the #688-review Fix 1
+  closes); the CSV export's `miles_to_store`/`miles_to_dropoff` columns are populated for drops whose
+  arrival frames fired; and a driver miles edit via the Adjust dialog still wins the row total (the
+  leg columns keep the machine estimate — a deliberate mismatch, not a bug). A drop with a missed
+  `DELIVERY_ARRIVED` (no arrival frame) legitimately falls back to the old partition delta with blank
+  leg columns (and its own store legs are retired so no sibling re-claims them). An order unassigned
+  mid-dash (#736) contributes NO per-drop leg miles — its distance stays session-level only.
   - Confirmed: 0/2
 
 - **🆕 NEW — unassign an order mid-dash produces NO paid/confirmed artifacts (#736).**

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -73,6 +73,21 @@ card's **mechanical** half, #577 (re-confirmed, 24/24, ~0.55 s — with a new po
 that entry's Bug #1), the #457 path, and #554 ShadowProjector (2/2). The #462/#460 dropoff item
 was found **broken-in-part** (raw PII in capture envelopes) and moved to that entry's Bug #7.)_
 
+- **🆕 NEW — per-leg mileage: stacked drops each carry their own miles (#688 phase B).**
+  Delivery rows now fold `milesToStore`/`milesToDropoff` from the lifecycle odometer stamps, and a
+  drop's miles become the leg sum (to-store + to-dropoff) instead of the old lump-on-one-row
+  partition delta — the 07-05 Bill Miller/Mama Margies shape (6.76 mi on drop A, 0.0 on drop B)
+  should be gone, retroactively too (the `PROJECTOR_VERSION` 5→6 refold reworks history on first
+  launch after install; expect a one-time refold at startup).
+  **How to tell it's working (desk-side, after a dash with a stacked/multi-store job):** in the
+  per-dash drill-down (and `delivery_records`), each drop of a stack shows a plausible nonzero
+  `X mi` (not one lump + 0.0); Σ per-drop miles ≤ the session odometer miles; the CSV export's
+  `miles_to_store`/`miles_to_dropoff` columns are populated for drops whose arrival frames fired;
+  and a driver miles edit via the Adjust dialog still wins the row total (the leg columns keep the
+  machine estimate — a deliberate mismatch, not a bug). A drop with a missed `DELIVERY_ARRIVED`
+  (no arrival frame) legitimately falls back to the old partition delta with blank leg columns.
+  - Confirmed: 0/2
+
 - **🆕 NEW — unassign an order mid-dash produces NO paid/confirmed artifacts (#736).**
   When you unassign an active order via the pickup help / resolution flow ("Unassign order" survey →
   "You've been unassigned from this order" confirmation), the app now recognizes the unassign and

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/AnalyticsRecords.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/AnalyticsRecords.kt
@@ -41,6 +41,14 @@ data class DeliveryRecord(
      * read sites only (never inside [realizedPay]/[netProfit]); null on a machine completion.
      */
     val cashTip: Double? = null,
+    /**
+     * Machine-computed to-store driving leg (#688 phase B) — fold provenance for the drill-down's
+     * per-leg line. NOT rewritten by a driver miles edit, so it may disagree with [realizedMiles]
+     * on a corrected row (the visible edit trail). Null on anchorless/pre-phase-B rows.
+     */
+    val milesToStore: Double? = null,
+    /** Machine-computed to-dropoff driving leg (#688 phase B); same provenance rules as [milesToStore]. */
+    val milesToDropoff: Double? = null,
 )
 
 /** One dash session. */

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/LegFolds.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/LegFolds.kt
@@ -1,0 +1,168 @@
+package cloud.trotter.dashbuddy.domain.analytics
+
+import cloud.trotter.dashbuddy.domain.model.event.SequencedAppEvent
+import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.PickupPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.TaskUnassignedPayload
+import cloud.trotter.dashbuddy.domain.state.TaskPhase
+
+/**
+ * The #688 phase-B per-leg mileage machinery, split out of [RecordFolds] (#688 review Fix 6, P3 file
+ * ceiling). Pure — no Android / DB / wall clock — driven only by the event's own `metadata.odometer`
+ * stamps and threaded [SessionFoldContext]. The leg-anchor-only lifecycle events (`PICKUP_ARRIVED` /
+ * `DELIVERY_ARRIVED` / `DELIVERY_CONFIRMED`) and the `TASK_UNASSIGNED` leg purge live here; the
+ * `DELIVERY_COMPLETED` **consumption** side (which store leg a drop claims, the legacy-basis retire)
+ * stays in [RecordFolds.foldDeliveryCompleted] with the rest of the record mint. Shared session
+ * helpers ([resolveContext] / [advance]) are the ONE top-level definition in `RecordFolds.kt`.
+ */
+internal object LegFolds {
+
+    /**
+     * `PICKUP_ARRIVED` (#688 phase B) — closes a **to-store** leg (previous anchor → this arrival) and
+     * queues it for the job's completion to claim as `milesToStore`. Keeps the pre-existing liveness
+     * advance. A malformed/payload-less event advances liveness only (leg anchor unchanged, miles roll
+     * forward — never lost, at worst lumped like today).
+     */
+    fun foldPickupArrived(event: SequencedAppEvent, context: SessionFoldContext?): FoldOutcome {
+        val e = event.event
+        val sid = e.sessionId ?: return FoldOutcome(context = context)
+        val ctx = resolveContext(context, sid, e.occurredAt)
+        val odo = event.metadata?.odometer
+        val p = e.payload as? PickupPayload
+        val withLeg = if (p != null) ctx.closeStoreLeg(p.taskId, p.jobId, p.storeName, odo) else ctx
+        return FoldOutcome(context = withLeg.advance(e.occurredAt, odo))
+    }
+
+    /**
+     * `DELIVERY_ARRIVED` (#688 phase B) — closes a **to-dropoff** leg (previous anchor → this arrival),
+     * accumulated onto the drop's own `taskId` (a grace-flap re-arrival adds to the same entry, never a
+     * second one). Keeps the pre-existing liveness advance; a malformed event advances liveness only.
+     */
+    fun foldDeliveryArrived(event: SequencedAppEvent, context: SessionFoldContext?): FoldOutcome {
+        val e = event.event
+        val sid = e.sessionId ?: return FoldOutcome(context = context)
+        val ctx = resolveContext(context, sid, e.occurredAt)
+        val odo = event.metadata?.odometer
+        val p = e.payload as? DeliveryPayload
+        val withLeg = if (p != null) ctx.addDropoffLeg(p.taskId, odo) else ctx
+        return FoldOutcome(context = withLeg.advance(e.occurredAt, odo))
+    }
+
+    /**
+     * `DELIVERY_CONFIRMED` (#688 phase B) — advances the leg anchor only (the handoff/POD point, before
+     * the completion receipt), alongside the pre-existing liveness advance. Produces no record.
+     */
+    fun foldDeliveryConfirmed(event: SequencedAppEvent, context: SessionFoldContext?): FoldOutcome {
+        val e = event.event
+        val sid = e.sessionId ?: return FoldOutcome(context = context)
+        val ctx = resolveContext(context, sid, e.occurredAt)
+        val odo = event.metadata?.odometer
+        val p = e.payload as? DeliveryPayload
+        val withAnchor = if (p != null) ctx.copy(legState = ctx.legState.advanceAnchor(odo)) else ctx
+        return FoldOutcome(context = withAnchor.advance(e.occurredAt, odo))
+    }
+
+    /**
+     * `TASK_UNASSIGNED` (#736 × #688 review Fix 2) — a **leg-state-only** arm. The dasher abandoned this
+     * task via the pickup help / resolution flow; an unassigned task's miles are session-level ONLY,
+     * never per-delivery (the #736 decision), so its pending leg must be PURGED before a surviving
+     * sibling's FIFO claim can inherit it. A pickup-phase abandon drops the queued to-store leg keyed to
+     * the pickup task (legs are `pickupTaskId`-keyed — set from `PickupPayload.taskId` at
+     * `PICKUP_ARRIVED`, the same id the help flow reports); a dropoff-phase abandon drops the to-dropoff
+     * leg keyed to this `taskId` (also the future #752 shape). It mints NO record and is read-model
+     * row-inert; liveness advances EXACTLY as the old catch-all `else` arm did (identical
+     * `lastEventAt`/`lastOdometer`), so session duration/odometer stay byte-identical to pre-fix folds.
+     * A malformed/payload-less event degrades to a liveness-only advance (the `else`-arm behaviour).
+     */
+    fun foldTaskUnassigned(event: SequencedAppEvent, context: SessionFoldContext?): FoldOutcome {
+        val e = event.event
+        val sid = e.sessionId ?: return FoldOutcome(context = context)
+        val ctx = resolveContext(context, sid, e.occurredAt)
+        val odo = event.metadata?.odometer
+        val p = e.payload as? TaskUnassignedPayload
+            ?: return FoldOutcome(context = ctx.advance(e.occurredAt, odo))
+        val ls = ctx.legState
+        val cleaned = when (p.phase) {
+            TaskPhase.PICKUP ->
+                ls.copy(pendingStoreLegs = ls.pendingStoreLegs.filterNot { it.pickupTaskId == p.taskId })
+            TaskPhase.DROPOFF ->
+                ls.copy(pendingDropoffLegs = ls.pendingDropoffLegs - p.taskId)
+        }
+        return FoldOutcome(context = ctx.copy(legState = cleaned).advance(e.occurredAt, odo))
+    }
+}
+
+// ── #688 phase B leg helpers (pure; all mirror the partition-anchor conventions in RecordFolds) ──
+// Top-level `internal` extensions so both [RecordFolds] (foldPickupConfirmed's anchor advance,
+// foldDeliveryCompleted's inline consume) and [LegFolds] share ONE definition (Fix 6 file split).
+
+/**
+ * Advance the leg anchor to [odo]. A null odo does NOT advance (same rule as `prevDropOdometer`):
+ * the leg anchor stays put and the miles roll forward into the next closed leg.
+ */
+internal fun LegState.advanceAnchor(odo: Double?): LegState =
+    if (odo == null) this else copy(prevLegOdometer = odo)
+
+/**
+ * Close the current leg at [odo]: returns the leg miles (floored at 0 — the mid-session
+ * odometer-reset defense) and the leg state with its anchor advanced. `null` miles ⇒ unmeasurable:
+ * either this event carries no odo (anchor unchanged, miles roll forward) or no anchor was ever
+ * seen (anchor takes this odo, this leg is unknown).
+ */
+internal fun LegState.closeLeg(odo: Double?): Pair<Double?, LegState> = when {
+    odo == null -> null to this
+    prevLegOdometer == null -> null to copy(prevLegOdometer = odo)
+    else -> (odo - prevLegOdometer).coerceAtLeast(0.0) to copy(prevLegOdometer = odo)
+}
+
+/** Cap a pending list at [LegState.MAX_PENDING] with deterministic drop-oldest (bounded ingestion). */
+private fun <T> List<T>.capPending(): List<T> =
+    if (size <= LegState.MAX_PENDING) this else takeLast(LegState.MAX_PENDING)
+
+/**
+ * Close a to-store leg and queue it (or accumulate into the same [pickupTaskId] entry on a
+ * re-arrival). Bounded at [LegState.MAX_PENDING]. Stamps `closedAtOdometer` = this arrival's [odo]
+ * (guaranteed non-null on the `miles != null` branch) so a legacy-basis completion can retire only the
+ * store legs that closed BEFORE it (#688 review Fix 1); a re-arrival updates it to the LATEST close.
+ */
+internal fun SessionFoldContext.closeStoreLeg(
+    pickupTaskId: String,
+    jobId: String,
+    storeName: String?,
+    odo: Double?,
+): SessionFoldContext {
+    val (miles, ls) = legState.closeLeg(odo)
+    if (miles == null) return copy(legState = ls)
+    val existingIdx = ls.pendingStoreLegs.indexOfFirst { it.pickupTaskId == pickupTaskId }
+    val legs = if (existingIdx >= 0) {
+        ls.pendingStoreLegs.mapIndexed { i, leg ->
+            if (i == existingIdx) leg.copy(miles = leg.miles + miles, closedAtOdometer = odo) else leg
+        }
+    } else {
+        (ls.pendingStoreLegs + PendingStoreLeg(pickupTaskId, jobId, storeName, miles, closedAtOdometer = odo))
+            .capPending()
+    }
+    return copy(legState = ls.copy(pendingStoreLegs = legs))
+}
+
+/**
+ * Close a to-dropoff leg, accumulating onto the drop's own [taskId] (a re-arrival adds to the same
+ * entry). Bounded at [LegState.MAX_PENDING] with drop-oldest by insertion order.
+ */
+internal fun SessionFoldContext.addDropoffLeg(taskId: String, odo: Double?): SessionFoldContext {
+    val (miles, ls) = legState.closeLeg(odo)
+    if (miles == null) return copy(legState = ls)
+    val existing = ls.pendingDropoffLegs[taskId]
+    val merged = if (existing != null) {
+        ls.pendingDropoffLegs + (taskId to (existing + miles))
+    } else {
+        val added = ls.pendingDropoffLegs + (taskId to miles)
+        if (added.size <= LegState.MAX_PENDING) {
+            added
+        } else {
+            // Drop-oldest by insertion order (LinkedHashMap preserves it); keep the newest cap.
+            added.entries.toList().takeLast(LegState.MAX_PENDING).associate { it.key to it.value }
+        }
+    }
+    return copy(legState = ls.copy(pendingDropoffLegs = merged))
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/LegState.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/LegState.kt
@@ -19,13 +19,15 @@ data class PendingStoreLeg(
     val miles: Double,
     /**
      * The odometer reading at which this to-store leg CLOSED (the `PICKUP_ARRIVED` odo; the LATEST on a
-     * re-arrival accumulation). The ordering marker a legacy-basis completion uses to retire ONLY the
-     * store legs whose closure preceded it (#688 review Fix 1): such legs' miles are already inside the
-     * legacy partition span (prevDrop→completion), so a sibling drop must not re-claim them per-leg —
-     * that was the mixed-basis double-count. Nullable-with-default: an old persisted `legStateJson`
-     * blob (a mid-upgrade in-flight session) decodes this as null, and a null / unknown closure order
-     * is treated conservatively as "preceded" (retire → per-row under-attribution, never a
-     * double-count). Never an INFO+ log surface (P7).
+     * re-arrival accumulation). The ordering marker a legacy-basis completion uses to retire the
+     * pending store legs — SESSION-WIDE, any job — whose closure is at/before it (#688 review Fix 1 +
+     * re-verify widening): the legacy span is a session-level partition delta (prevDrop→completion,
+     * regardless of job), so any leg closed inside it, including a cross-job add-on's, is already
+     * inside that span and a later drop must not re-claim it per-leg — that was the mixed-basis
+     * double-count. Nullable-with-default: an old persisted `legStateJson` blob (a mid-upgrade
+     * in-flight session) decodes this as null, and a null / unknown closure order is treated
+     * conservatively as "preceded" (retire → per-row under-attribution, never a double-count). Never
+     * an INFO+ log surface (P7).
      */
     val closedAtOdometer: Double? = null,
 )

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/LegState.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/LegState.kt
@@ -1,0 +1,78 @@
+package cloud.trotter.dashbuddy.domain.analytics
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * One not-yet-consumed **to-store** driving leg (#688 phase B) — the miles from the previous leg
+ * anchor to a `PICKUP_ARRIVED`, held until the job's `DELIVERY_COMPLETED` consumes it as that drop's
+ * `milesToStore`. Keyed by [pickupTaskId] (its own arrival) so a grace-flap re-arrival ACCUMULATES
+ * into the same entry rather than appending a phantom second one. [storeName] enables the exact
+ * store-form match at consumption; null when the pickup screen carried no store (FIFO still attributes
+ * within the job). MERCHANT data only — never customer PII, never an INFO+ log surface (P7).
+ */
+@Serializable
+data class PendingStoreLeg(
+    val pickupTaskId: String,
+    val jobId: String,
+    val storeName: String?,
+    val miles: Double,
+)
+
+/**
+ * The per-session per-leg mileage accumulator (#688 phase B) — folded from the lifecycle
+ * `metadata.odometer` stamps and consumed at `DELIVERY_COMPLETED` into `milesToStore`/`milesToDropoff`.
+ *
+ * [prevLegOdometer] is the current leg anchor (the odometer reading a new leg is measured from),
+ * advanced by the enumerated anchor-event set (DASH_START / PICKUP_ARRIVED / PICKUP_CONFIRMED /
+ * DELIVERY_ARRIVED / DELIVERY_CONFIRMED / DELIVERY_COMPLETED). [pendingStoreLegs] queues closed
+ * to-store legs awaiting their drop; [pendingDropoffLegs] maps a drop's own `taskId` to its
+ * to-dropoff leg miles (unambiguous — the drop consumes its own key).
+ *
+ * **Persisted with the session row** (`session_records.legStateJson`, [LegStateCodec]) because these
+ * pending legs describe drops that have NOT yet completed and so cannot be re-derived from record
+ * rows the way `prevDropOdometer`/`deliveredJobIds` are — a batch-boundary rehydration must restore
+ * them or incremental folding would diverge from a from-zero refold (the #703 determinism class).
+ *
+ * **Bounded ingestion (Principle 6):** both collections are capped at [MAX_PENDING] with deterministic
+ * drop-oldest, so a pathological event stream (many arrivals, no completions) cannot grow the
+ * persisted context unboundedly. In the fielded shape both drain on every completion, so the cap is
+ * never approached.
+ */
+@Serializable
+data class LegState(
+    val prevLegOdometer: Double? = null,
+    val pendingStoreLegs: List<PendingStoreLeg> = emptyList(),
+    val pendingDropoffLegs: Map<String, Double> = emptyMap(),
+) {
+    companion object {
+        /** Bounded-ingestion cap on each pending collection (drop-oldest on overflow). */
+        const val MAX_PENDING = 32
+    }
+}
+
+/**
+ * Serialization SSOT for [LegState] ↔ `session_records.legStateJson` (#688 phase B). Kept in `:domain`
+ * with the type (no Android/DB dep — kotlinx-serialization only) so the projector's `toEntity`/
+ * `toContext` mapping routes through ONE definition.
+ *
+ * **Fail-closed decode:** a null/blank/malformed blob degrades to an EMPTY [LegState] — the session's
+ * rows fall back to the legacy partition delta, never a crash and never wrong money. This is the
+ * spec-level guard that makes a garbage `legStateJson` column safe.
+ */
+object LegStateCodec {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    /** Encode for persistence. An empty leg state serializes to a compact object (never null). */
+    fun encode(state: LegState): String = json.encodeToString(LegState.serializer(), state)
+
+    /** Decode, fail-closed to an empty [LegState] on null/blank/garbage input. */
+    fun decode(blob: String?): LegState {
+        if (blob.isNullOrBlank()) return LegState()
+        return try {
+            json.decodeFromString(LegState.serializer(), blob)
+        } catch (_: Exception) {
+            LegState()
+        }
+    }
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/LegState.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/LegState.kt
@@ -17,6 +17,17 @@ data class PendingStoreLeg(
     val jobId: String,
     val storeName: String?,
     val miles: Double,
+    /**
+     * The odometer reading at which this to-store leg CLOSED (the `PICKUP_ARRIVED` odo; the LATEST on a
+     * re-arrival accumulation). The ordering marker a legacy-basis completion uses to retire ONLY the
+     * store legs whose closure preceded it (#688 review Fix 1): such legs' miles are already inside the
+     * legacy partition span (prevDrop→completion), so a sibling drop must not re-claim them per-leg —
+     * that was the mixed-basis double-count. Nullable-with-default: an old persisted `legStateJson`
+     * blob (a mid-upgrade in-flight session) decodes this as null, and a null / unknown closure order
+     * is treated conservatively as "preceded" (retire → per-row under-attribution, never a
+     * double-count). Never an INFO+ log surface (P7).
+     */
+    val closedAtOdometer: Double? = null,
 )
 
 /**

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/RecordFolds.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/RecordFolds.kt
@@ -12,6 +12,7 @@ import cloud.trotter.dashbuddy.domain.model.event.payload.PickupPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStartPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStopPayload
 import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.domain.state.StoreKeys
 
 /** Provenance of a delivery's realized pay (#314) — mirrors the DB column, owned here as SSOT. */
 object PayBasis {
@@ -145,10 +146,13 @@ data class DeliveryFold(
     val payoutStoreForms: List<String>? = null,
     /**
      * Machine-computed to-store driving leg (#688 phase B) — the claimed [PendingStoreLeg]'s miles for
-     * this drop's job (exact store-form match, else FIFO within the job, else null). Provenance only:
-     * a driver `newMiles` correction rewrites [realizedMiles] but NEVER these leg columns, so
-     * `milesToStore + milesToDropoff` may then ≠ `realizedMiles` — that inequality is the visible edit
-     * trail. Null on a receipt-less/anchorless leg and all pre-phase-B history.
+     * this drop's job (exact NORMALIZED-chain store-form match, else FIFO within the job, else null).
+     * Stamped ONLY on a leg-sum row (`milesToDropoff != null`); a LEGACY row (missed arrival) stamps
+     * null and instead retires its job's already-closed store legs (#688 review Fix 1/Fix 4), so a
+     * lone store leg never rides an otherwise-untouched legacy row. Provenance only: a driver `newMiles`
+     * correction rewrites [realizedMiles] but NEVER these leg columns, so `milesToStore + milesToDropoff`
+     * may then ≠ `realizedMiles` — that inequality is the visible edit trail. Null on a
+     * receipt-less/anchorless/legacy leg and all pre-phase-B history.
      */
     val milesToStore: Double? = null,
     /**
@@ -320,10 +324,15 @@ object RecordFolds {
             AppEventType.OFFER_DECLINED,
             AppEventType.OFFER_TIMEOUT -> foldOffer(event, context)
             AppEventType.DELIVERY_COMPLETED -> foldDeliveryCompleted(event, context, currentCostPerMile)
-            // #688 phase B leg-anchor events (each also keeps the pre-existing liveness advance).
-            AppEventType.PICKUP_ARRIVED -> foldPickupArrived(event, context)
-            AppEventType.DELIVERY_ARRIVED -> foldDeliveryArrived(event, context)
-            AppEventType.DELIVERY_CONFIRMED -> foldDeliveryConfirmed(event, context)
+            // #688 phase B leg-anchor events (each also keeps the pre-existing liveness advance) —
+            // the leg machinery lives in LegFolds (P3 file split, #688 review Fix 6).
+            AppEventType.PICKUP_ARRIVED -> LegFolds.foldPickupArrived(event, context)
+            AppEventType.DELIVERY_ARRIVED -> LegFolds.foldDeliveryArrived(event, context)
+            AppEventType.DELIVERY_CONFIRMED -> LegFolds.foldDeliveryConfirmed(event, context)
+            // #736 unassign-via-help (#688 review Fix 2): a leg-state-only arm — purge the abandoned
+            // task's pending legs so a surviving sibling can't inherit them, liveness advanced exactly
+            // as the old catch-all `else` arm did (read-model row-inert; no record minted).
+            AppEventType.TASK_UNASSIGNED -> LegFolds.foldTaskUnassigned(event, context)
             AppEventType.PICKUP_CONFIRMED -> foldPickupConfirmed(event, context)
             AppEventType.MANUAL_DELIVERY -> foldManualDelivery(event, context, currentCostPerMile)
             AppEventType.PAY_ADJUSTMENT -> foldPayAdjustment(event, context)
@@ -560,20 +569,30 @@ object RecordFolds {
 
         // #688 phase B: consume this drop's per-leg mileage from the session leg accumulator.
         //  - milesToDropoff = this drop's own taskId entry (unambiguous).
-        //  - milesToStore   = one store leg of THIS job — exact store-form match wins (a null payload
-        //    storeName can't match, the #526/#557 "Unknown store" family), else the oldest unclaimed
-        //    leg of the job (FIFO); claimed once (DEV-DECISION 2: no fabricated split — a shared-store
-        //    stack's first drop claims the whole store leg, the sibling gets milesToStore null).
+        //  - milesToStore   = one store leg of THIS job, stamped ONLY on a LEG-SUM row (milesToDropoff
+        //    != null). Exact NORMALIZED-chain store-form match wins (#688 review Fix 3 — the #159
+        //    StoreKeys SSOT, so a payout form-drift like "StoreX #55" still matches the pickup form;
+        //    a null payload storeName can't match, the #526/#557 "Unknown store" family), else the
+        //    oldest unclaimed leg of the job (FIFO); claimed once (DEV-DECISION 2: no fabricated split —
+        //    a shared-store stack's first drop claims the whole store leg, the sibling gets null).
+        //  - A LEGACY row (missed DELIVERY_ARRIVED ⇒ milesToDropoff null) stamps NO store leg (#688
+        //    review Fix 4 — leg-sum ≠ realizedMiles must stay the driver-edit trail, not a machine
+        //    lone-leg stamp on an untouched row) and RETIRES the job's already-closed store legs below.
         val legState = ctx?.legState ?: LegState()
         val milesToDropoff = legState.pendingDropoffLegs[p.taskId]
         val storeLegs = legState.pendingStoreLegs
-        val claimIdx = run {
+        val claimIdx = if (milesToDropoff != null) {
             val exact = if (p.storeName != null) {
-                storeLegs.indexOfFirst { it.jobId == p.jobId && it.storeName == p.storeName }
+                storeLegs.indexOfFirst {
+                    it.jobId == p.jobId && it.storeName != null &&
+                        StoreKeys.normalizedChain(it.storeName) == StoreKeys.normalizedChain(p.storeName)
+                }
             } else {
                 -1
             }
             if (exact >= 0) exact else storeLegs.indexOfFirst { it.jobId == p.jobId }
+        } else {
+            -1
         }
         val milesToStore = claimIdx.takeIf { it >= 0 }?.let { storeLegs[it].miles }
 
@@ -658,10 +677,22 @@ object RecordFolds {
             // anchor to the completion odometer (null ⇒ anchor unchanged, miles roll forward).
             legState = legState.copy(
                 prevLegOdometer = odo ?: legState.prevLegOdometer,
-                pendingStoreLegs = if (claimIdx >= 0) {
-                    storeLegs.filterIndexed { i, _ -> i != claimIdx }
-                } else {
-                    storeLegs
+                pendingStoreLegs = when {
+                    // Leg-sum row: consume the single claimed store leg.
+                    claimIdx >= 0 -> storeLegs.filterIndexed { i, _ -> i != claimIdx }
+                    // Legacy row (#688 review Fix 1, mixed-basis double-count): RETIRE this job's store
+                    // legs whose closure preceded this completion — their miles are already inside the
+                    // legacy partition span (prevDrop→completion), so a surviving sibling must not
+                    // re-claim them per-leg. Keep only legs of this job provably closed AFTER this
+                    // completion odo (a genuinely later sibling's) + all legs of other jobs. A null
+                    // completion odo OR null leg-closure marker ⇒ retire (fail-null under-attribution,
+                    // never a double-count — the sanctioned error direction).
+                    milesToDropoff == null -> storeLegs.filterNot { leg ->
+                        leg.jobId == p.jobId &&
+                            !(leg.closedAtOdometer != null && odo != null && leg.closedAtOdometer > odo)
+                    }
+                    // Leg-sum row that found no store leg to claim: leave the queue untouched.
+                    else -> storeLegs
                 },
                 pendingDropoffLegs = if (milesToDropoff != null) {
                     legState.pendingDropoffLegs - p.taskId
@@ -712,51 +743,6 @@ object RecordFolds {
         val odo = event.metadata?.odometer
         val newCtx = ctx?.let { it.advance(e.occurredAt, odo).copy(legState = it.legState.advanceAnchor(odo)) }
         return FoldOutcome(context = newCtx, pickup = pickup)
-    }
-
-    /**
-     * `PICKUP_ARRIVED` (#688 phase B) — closes a **to-store** leg (previous anchor → this arrival) and
-     * queues it for the job's completion to claim as `milesToStore`. Keeps the pre-existing liveness
-     * advance. A malformed/payload-less event advances liveness only (leg anchor unchanged, miles roll
-     * forward — never lost, at worst lumped like today).
-     */
-    private fun foldPickupArrived(event: SequencedAppEvent, context: SessionFoldContext?): FoldOutcome {
-        val e = event.event
-        val sid = e.sessionId ?: return FoldOutcome(context = context)
-        val ctx = resolveContext(context, sid, e.occurredAt)
-        val odo = event.metadata?.odometer
-        val p = e.payload as? PickupPayload
-        val withLeg = if (p != null) ctx.closeStoreLeg(p.taskId, p.jobId, p.storeName, odo) else ctx
-        return FoldOutcome(context = withLeg.advance(e.occurredAt, odo))
-    }
-
-    /**
-     * `DELIVERY_ARRIVED` (#688 phase B) — closes a **to-dropoff** leg (previous anchor → this arrival),
-     * accumulated onto the drop's own `taskId` (a grace-flap re-arrival adds to the same entry, never a
-     * second one). Keeps the pre-existing liveness advance; a malformed event advances liveness only.
-     */
-    private fun foldDeliveryArrived(event: SequencedAppEvent, context: SessionFoldContext?): FoldOutcome {
-        val e = event.event
-        val sid = e.sessionId ?: return FoldOutcome(context = context)
-        val ctx = resolveContext(context, sid, e.occurredAt)
-        val odo = event.metadata?.odometer
-        val p = e.payload as? DeliveryPayload
-        val withLeg = if (p != null) ctx.addDropoffLeg(p.taskId, odo) else ctx
-        return FoldOutcome(context = withLeg.advance(e.occurredAt, odo))
-    }
-
-    /**
-     * `DELIVERY_CONFIRMED` (#688 phase B) — advances the leg anchor only (the handoff/POD point, before
-     * the completion receipt), alongside the pre-existing liveness advance. Produces no record.
-     */
-    private fun foldDeliveryConfirmed(event: SequencedAppEvent, context: SessionFoldContext?): FoldOutcome {
-        val e = event.event
-        val sid = e.sessionId ?: return FoldOutcome(context = context)
-        val ctx = resolveContext(context, sid, e.occurredAt)
-        val odo = event.metadata?.odometer
-        val p = e.payload as? DeliveryPayload
-        val withAnchor = if (p != null) ctx.copy(legState = ctx.legState.advanceAnchor(odo)) else ctx
-        return FoldOutcome(context = withAnchor.advance(e.occurredAt, odo))
     }
 
     /**
@@ -916,119 +902,6 @@ object RecordFolds {
         return FoldOutcome(context = newCtx, resolution = resolution)
     }
 
-    /**
-     * The in-memory/hydrated context for [sid], or a synthesized `_unknown`-platform context when a
-     * session-scoped event has no known DASH_START (fold started mid-session past the watermark, or
-     * a lost start). A synthesized session degrades to a null-odometer / _unknown-platform row —
-     * never a wrong one. [platformName] refines an `_unknown` platform when the event itself carries
-     * one (DASH_STOP's #314 stamp) — whether that `_unknown` context is being synthesized here for
-     * the first time, or was already synthesized by an EARLIER event in the session and is only now
-     * being hydrated/matched by [sid] (a skipped/malformed DASH_START leaves the session `_unknown`
-     * until its DASH_STOP arrives with the real platform; without this, the upgrade path only fired
-     * for a brand-new context and an already-`_unknown` session stayed `_unknown` forever). Never
-     * clobbers a REAL platform — only an `Unknown` one is eligible — and a [platformName] that itself
-     * fails to resolve (or resolves back to [Platform.Unknown]) leaves the context untouched.
-     */
-    private fun resolveContext(
-        context: SessionFoldContext?,
-        sid: String,
-        occurredAt: Long,
-        platformName: String? = null,
-    ): SessionFoldContext {
-        val existing = context?.takeIf { it.sessionId == sid }
-        if (existing != null) {
-            if (existing.platform == Platform.Unknown && platformName != null) {
-                val resolved = Platform.fromName(platformName)
-                if (resolved != null && resolved != Platform.Unknown) {
-                    return existing.copy(platform = resolved)
-                }
-            }
-            return existing
-        }
-        return SessionFoldContext(
-            sessionId = sid,
-            platform = platformName?.let { Platform.fromName(it) } ?: Platform.Unknown,
-            startedAt = occurredAt,
-            lastEventAt = occurredAt,
-        )
-    }
-
-    private fun SessionFoldContext.advance(occurredAt: Long, odometer: Double?): SessionFoldContext =
-        copy(
-            lastEventAt = maxOf(lastEventAt, occurredAt),
-            lastOdometer = odometer ?: lastOdometer,
-        )
-
-    // ── #688 phase B leg helpers (pure; all mirror the partition-anchor conventions above) ──
-
-    /**
-     * Advance the leg anchor to [odo]. A null odo does NOT advance (same rule as `prevDropOdometer`):
-     * the leg anchor stays put and the miles roll forward into the next closed leg.
-     */
-    private fun LegState.advanceAnchor(odo: Double?): LegState =
-        if (odo == null) this else copy(prevLegOdometer = odo)
-
-    /**
-     * Close the current leg at [odo]: returns the leg miles (floored at 0 — the mid-session
-     * odometer-reset defense) and the leg state with its anchor advanced. `null` miles ⇒ unmeasurable:
-     * either this event carries no odo (anchor unchanged, miles roll forward) or no anchor was ever
-     * seen (anchor takes this odo, this leg is unknown).
-     */
-    private fun LegState.closeLeg(odo: Double?): Pair<Double?, LegState> = when {
-        odo == null -> null to this
-        prevLegOdometer == null -> null to copy(prevLegOdometer = odo)
-        else -> (odo - prevLegOdometer).coerceAtLeast(0.0) to copy(prevLegOdometer = odo)
-    }
-
-    /** Cap a pending list at [LegState.MAX_PENDING] with deterministic drop-oldest (bounded ingestion). */
-    private fun <T> List<T>.capPending(): List<T> =
-        if (size <= LegState.MAX_PENDING) this else takeLast(LegState.MAX_PENDING)
-
-    /**
-     * Close a to-store leg and queue it (or accumulate into the same [pickupTaskId] entry on a
-     * re-arrival). Bounded at [LegState.MAX_PENDING].
-     */
-    private fun SessionFoldContext.closeStoreLeg(
-        pickupTaskId: String,
-        jobId: String,
-        storeName: String?,
-        odo: Double?,
-    ): SessionFoldContext {
-        val (miles, ls) = legState.closeLeg(odo)
-        if (miles == null) return copy(legState = ls)
-        val existingIdx = ls.pendingStoreLegs.indexOfFirst { it.pickupTaskId == pickupTaskId }
-        val legs = if (existingIdx >= 0) {
-            ls.pendingStoreLegs.mapIndexed { i, leg ->
-                if (i == existingIdx) leg.copy(miles = leg.miles + miles) else leg
-            }
-        } else {
-            (ls.pendingStoreLegs + PendingStoreLeg(pickupTaskId, jobId, storeName, miles)).capPending()
-        }
-        return copy(legState = ls.copy(pendingStoreLegs = legs))
-    }
-
-    /**
-     * Close a to-dropoff leg, accumulating onto the drop's own [taskId] (a re-arrival adds to the same
-     * entry). Bounded at [LegState.MAX_PENDING] with drop-oldest by insertion order.
-     */
-    private fun SessionFoldContext.addDropoffLeg(taskId: String, odo: Double?): SessionFoldContext {
-        val (miles, ls) = legState.closeLeg(odo)
-        if (miles == null) return copy(legState = ls)
-        val existing = ls.pendingDropoffLegs[taskId]
-        val merged = if (existing != null) {
-            ls.pendingDropoffLegs + (taskId to (existing + miles))
-        } else {
-            val added = ls.pendingDropoffLegs + (taskId to miles)
-            if (added.size <= LegState.MAX_PENDING) {
-                added
-            } else {
-                // Drop-oldest by insertion order (LinkedHashMap preserves it); keep the newest cap.
-                added.entries.toList().takeLast(LegState.MAX_PENDING).associate { it.key to it.value }
-            }
-        }
-        return copy(legState = ls.copy(pendingDropoffLegs = merged))
-    }
-
     private fun SessionFoldContext.bumpOutcome(type: AppEventType): SessionFoldContext = when (type) {
         AppEventType.OFFER_ACCEPTED -> copy(offersAccepted = offersAccepted + 1)
         AppEventType.OFFER_DECLINED -> copy(offersDeclined = offersDeclined + 1)
@@ -1036,3 +909,53 @@ object RecordFolds {
         else -> this
     }
 }
+
+/**
+ * The in-memory/hydrated context for [sid], or a synthesized `_unknown`-platform context when a
+ * session-scoped event has no known DASH_START (fold started mid-session past the watermark, or
+ * a lost start). A synthesized session degrades to a null-odometer / _unknown-platform row —
+ * never a wrong one. [platformName] refines an `_unknown` platform when the event itself carries
+ * one (DASH_STOP's #314 stamp) — whether that `_unknown` context is being synthesized here for
+ * the first time, or was already synthesized by an EARLIER event in the session and is only now
+ * being hydrated/matched by [sid] (a skipped/malformed DASH_START leaves the session `_unknown`
+ * until its DASH_STOP arrives with the real platform; without this, the upgrade path only fired
+ * for a brand-new context and an already-`_unknown` session stayed `_unknown` forever). Never
+ * clobbers a REAL platform — only an `Unknown` one is eligible — and a [platformName] that itself
+ * fails to resolve (or resolves back to [Platform.Unknown]) leaves the context untouched.
+ *
+ * `internal` top-level (not a `RecordFolds` member) so [LegFolds]'s leg-anchor handlers share the ONE
+ * definition (#688 review Fix 6 file split) — a duplicate would be an SSOT divergence bug.
+ */
+internal fun resolveContext(
+    context: SessionFoldContext?,
+    sid: String,
+    occurredAt: Long,
+    platformName: String? = null,
+): SessionFoldContext {
+    val existing = context?.takeIf { it.sessionId == sid }
+    if (existing != null) {
+        if (existing.platform == Platform.Unknown && platformName != null) {
+            val resolved = Platform.fromName(platformName)
+            if (resolved != null && resolved != Platform.Unknown) {
+                return existing.copy(platform = resolved)
+            }
+        }
+        return existing
+    }
+    return SessionFoldContext(
+        sessionId = sid,
+        platform = platformName?.let { Platform.fromName(it) } ?: Platform.Unknown,
+        startedAt = occurredAt,
+        lastEventAt = occurredAt,
+    )
+}
+
+/**
+ * Advance liveness (open-session duration + inferred-close + odometer anchors). `internal` top-level so
+ * both [RecordFolds] and [LegFolds] route through one definition (#688 review Fix 6).
+ */
+internal fun SessionFoldContext.advance(occurredAt: Long, odometer: Double?): SessionFoldContext =
+    copy(
+        lastEventAt = maxOf(lastEventAt, occurredAt),
+        lastOdometer = odometer ?: lastOdometer,
+    )

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/RecordFolds.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/RecordFolds.kt
@@ -148,8 +148,9 @@ data class DeliveryFold(
      * Machine-computed to-store driving leg (#688 phase B) — the claimed [PendingStoreLeg]'s miles for
      * this drop's job (exact NORMALIZED-chain store-form match, else FIFO within the job, else null).
      * Stamped ONLY on a leg-sum row (`milesToDropoff != null`); a LEGACY row (missed arrival) stamps
-     * null and instead retires its job's already-closed store legs (#688 review Fix 1/Fix 4), so a
-     * lone store leg never rides an otherwise-untouched legacy row. Provenance only: a driver `newMiles`
+     * null and instead retires the SESSION's already-closed store legs — any job, since the legacy span
+     * is a session-level partition delta (#688 review Fix 1/Fix 4 + re-verify widening) — so a lone
+     * store leg never rides an otherwise-untouched legacy row. Provenance only: a driver `newMiles`
      * correction rewrites [realizedMiles] but NEVER these leg columns, so `milesToStore + milesToDropoff`
      * may then ≠ `realizedMiles` — that inequality is the visible edit trail. Null on a
      * receipt-less/anchorless/legacy leg and all pre-phase-B history.
@@ -577,7 +578,8 @@ object RecordFolds {
         //    a shared-store stack's first drop claims the whole store leg, the sibling gets null).
         //  - A LEGACY row (missed DELIVERY_ARRIVED ⇒ milesToDropoff null) stamps NO store leg (#688
         //    review Fix 4 — leg-sum ≠ realizedMiles must stay the driver-edit trail, not a machine
-        //    lone-leg stamp on an untouched row) and RETIRES the job's already-closed store legs below.
+        //    lone-leg stamp on an untouched row) and RETIRES the session's already-closed store legs
+        //    below (session-wide — the legacy span is a session-level delta, re-verify widening).
         val legState = ctx?.legState ?: LegState()
         val milesToDropoff = legState.pendingDropoffLegs[p.taskId]
         val storeLegs = legState.pendingStoreLegs
@@ -680,16 +682,18 @@ object RecordFolds {
                 pendingStoreLegs = when {
                     // Leg-sum row: consume the single claimed store leg.
                     claimIdx >= 0 -> storeLegs.filterIndexed { i, _ -> i != claimIdx }
-                    // Legacy row (#688 review Fix 1, mixed-basis double-count): RETIRE this job's store
-                    // legs whose closure preceded this completion — their miles are already inside the
-                    // legacy partition span (prevDrop→completion), so a surviving sibling must not
-                    // re-claim them per-leg. Keep only legs of this job provably closed AFTER this
-                    // completion odo (a genuinely later sibling's) + all legs of other jobs. A null
-                    // completion odo OR null leg-closure marker ⇒ retire (fail-null under-attribution,
-                    // never a double-count — the sanctioned error direction).
-                    milesToDropoff == null -> storeLegs.filterNot { leg ->
-                        leg.jobId == p.jobId &&
-                            !(leg.closedAtOdometer != null && odo != null && leg.closedAtOdometer > odo)
+                    // Legacy row (#688 review Fix 1 + re-verify widening): RETIRE pending store legs
+                    // SESSION-WIDE whose closure is at/before this completion odometer (or unknown).
+                    // The legacy span is a SESSION-level partition delta (prevDrop→completion,
+                    // regardless of job), so a CROSS-JOB leg closed inside it — the add-on shape: J2's
+                    // pickup arrival en route while J1's order is out, then J1 completes legacy — is
+                    // equally double-countable; the original job-scoped retire left that real
+                    // double-count open. Keep only legs provably closed AFTER this completion odo (a
+                    // genuinely later arrival's). A null completion odo OR null leg-closure marker ⇒
+                    // retire (fail-null under-attribution, never a double-count — the sanctioned error
+                    // direction).
+                    milesToDropoff == null -> storeLegs.filter { leg ->
+                        leg.closedAtOdometer != null && odo != null && leg.closedAtOdometer > odo
                     }
                     // Leg-sum row that found no store leg to claim: leave the queue untouched.
                     else -> storeLegs

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/RecordFolds.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/RecordFolds.kt
@@ -143,6 +143,22 @@ data class DeliveryFold(
      * ROWS (never a trigger event), keeping every store of a multi-store stack keyed and monotonic.
      */
     val payoutStoreForms: List<String>? = null,
+    /**
+     * Machine-computed to-store driving leg (#688 phase B) — the claimed [PendingStoreLeg]'s miles for
+     * this drop's job (exact store-form match, else FIFO within the job, else null). Provenance only:
+     * a driver `newMiles` correction rewrites [realizedMiles] but NEVER these leg columns, so
+     * `milesToStore + milesToDropoff` may then ≠ `realizedMiles` — that inequality is the visible edit
+     * trail. Null on a receipt-less/anchorless leg and all pre-phase-B history.
+     */
+    val milesToStore: Double? = null,
+    /**
+     * Machine-computed to-dropoff driving leg (#688 phase B) — this drop's own `taskId` entry in the
+     * pending dropoff legs (unambiguous). Null when no odometer-bearing `DELIVERY_ARRIVED` preceded the
+     * completion (missed arrival, phantom-class completion, all pre-phase-B history). When non-null,
+     * `realizedMiles == (milesToStore ?: 0) + milesToDropoff` (the leg-sum rule, §2); when null the row
+     * keeps the legacy partition delta.
+     */
+    val milesToDropoff: Double? = null,
 )
 
 /**
@@ -304,6 +320,10 @@ object RecordFolds {
             AppEventType.OFFER_DECLINED,
             AppEventType.OFFER_TIMEOUT -> foldOffer(event, context)
             AppEventType.DELIVERY_COMPLETED -> foldDeliveryCompleted(event, context, currentCostPerMile)
+            // #688 phase B leg-anchor events (each also keeps the pre-existing liveness advance).
+            AppEventType.PICKUP_ARRIVED -> foldPickupArrived(event, context)
+            AppEventType.DELIVERY_ARRIVED -> foldDeliveryArrived(event, context)
+            AppEventType.DELIVERY_CONFIRMED -> foldDeliveryConfirmed(event, context)
             AppEventType.PICKUP_CONFIRMED -> foldPickupConfirmed(event, context)
             AppEventType.MANUAL_DELIVERY -> foldManualDelivery(event, context, currentCostPerMile)
             AppEventType.PAY_ADJUSTMENT -> foldPayAdjustment(event, context)
@@ -343,6 +363,8 @@ object RecordFolds {
                     lastOdometer = odo ?: context.lastOdometer,
                     // Already a real start — keep its original startSource; only fill if somehow null.
                     startSource = context.startSource ?: p.source,
+                    // #688: keep the running leg anchor; only fill it if the placeholder had none.
+                    legState = context.legState.copy(prevLegOdometer = context.legState.prevLegOdometer ?: odo),
                 ),
             )
         }
@@ -360,6 +382,8 @@ object RecordFolds {
                     lastOdometer = odo ?: context.lastOdometer,
                     started = true,
                     startSource = p.source,
+                    // #688: the placeholder's counters/liveness carry over; seed the leg anchor if unset.
+                    legState = context.legState.copy(prevLegOdometer = context.legState.prevLegOdometer ?: odo),
                 ),
                 freshSession = true,
             )
@@ -374,6 +398,8 @@ object RecordFolds {
                 lastOdometer = odo,
                 started = true,
                 startSource = p.source,
+                // #688: initialize the leg anchor to the start odometer (null ⇒ first leg unknown).
+                legState = LegState(prevLegOdometer = odo),
             ),
             freshSession = true,
         )
@@ -528,9 +554,34 @@ object RecordFolds {
         // reset yields a NEGATIVE delta, which would otherwise INFLATE this row's netProfit
         // (pay − negativeMiles × cpm). The next drop re-anchors off this (lower) reading naturally.
         val prevOdo = ctx?.prevDropOdometer ?: ctx?.startOdometer
-        val realizedMiles = if (odo != null && prevOdo != null) (odo - prevOdo).coerceAtLeast(0.0) else null
+        val legacyRealizedMiles = if (odo != null && prevOdo != null) (odo - prevOdo).coerceAtLeast(0.0) else null
         val prevAt = ctx?.prevDropAt ?: ctx?.startedAt
         val realizedMinutes = if (prevAt != null) (completedAt - prevAt) / 60_000.0 else null
+
+        // #688 phase B: consume this drop's per-leg mileage from the session leg accumulator.
+        //  - milesToDropoff = this drop's own taskId entry (unambiguous).
+        //  - milesToStore   = one store leg of THIS job — exact store-form match wins (a null payload
+        //    storeName can't match, the #526/#557 "Unknown store" family), else the oldest unclaimed
+        //    leg of the job (FIFO); claimed once (DEV-DECISION 2: no fabricated split — a shared-store
+        //    stack's first drop claims the whole store leg, the sibling gets milesToStore null).
+        val legState = ctx?.legState ?: LegState()
+        val milesToDropoff = legState.pendingDropoffLegs[p.taskId]
+        val storeLegs = legState.pendingStoreLegs
+        val claimIdx = run {
+            val exact = if (p.storeName != null) {
+                storeLegs.indexOfFirst { it.jobId == p.jobId && it.storeName == p.storeName }
+            } else {
+                -1
+            }
+            if (exact >= 0) exact else storeLegs.indexOfFirst { it.jobId == p.jobId }
+        }
+        val milesToStore = claimIdx.takeIf { it >= 0 }?.let { storeLegs[it].miles }
+
+        // realizedMiles becomes the leg SUM only when the final (to-dropoff) leg is known; a lone store
+        // leg understates (the legacy delta already contains it), so partial leg data never replaces the
+        // total — the `milesToDropoff != null` gate (§2). Invariant: realizedMiles == (milesToStore ?: 0)
+        // + milesToDropoff iff milesToDropoff != null.
+        val realizedMiles = if (milesToDropoff != null) (milesToStore ?: 0.0) + milesToDropoff else legacyRealizedMiles
 
         // Frozen economy — immutable historical fact.
         val (frozenCpm, costBasis) = when {
@@ -583,6 +634,8 @@ object RecordFolds {
             payoutStoreForms = p.parsedPay?.customerTips
                 ?.mapNotNull { it.type.takeIf { t -> t.isNotBlank() } }
                 ?.takeIf { it.isNotEmpty() },
+            milesToStore = milesToStore,
+            milesToDropoff = milesToDropoff,
         )
 
         // #691: mark the job receipted once any drop folds RECEIPT EVIDENCE, so a later receipt-less
@@ -601,6 +654,21 @@ object RecordFolds {
             prevDropAt = completedAt,
             lastEventAt = maxOf(ctx.lastEventAt, e.occurredAt),
             lastOdometer = odo ?: ctx.lastOdometer,
+            // #688: consume the claimed store leg + this drop's dropoff leg, then advance the leg
+            // anchor to the completion odometer (null ⇒ anchor unchanged, miles roll forward).
+            legState = legState.copy(
+                prevLegOdometer = odo ?: legState.prevLegOdometer,
+                pendingStoreLegs = if (claimIdx >= 0) {
+                    storeLegs.filterIndexed { i, _ -> i != claimIdx }
+                } else {
+                    storeLegs
+                },
+                pendingDropoffLegs = if (milesToDropoff != null) {
+                    legState.pendingDropoffLegs - p.taskId
+                } else {
+                    legState.pendingDropoffLegs
+                },
+            ),
         )
         // #159: every DELIVERY_COMPLETED re-triggers store resolution for its job (job-scoped). The
         // payout is NOT threaded — resolution reads payoutStoreForms from the committed rows (B1).
@@ -639,8 +707,56 @@ object RecordFolds {
             activity = p.activity,
             storeAddress = p.storeAddress,
         )
-        val newCtx = ctx?.advance(e.occurredAt, event.metadata?.odometer)
+        // #688: PICKUP_CONFIRMED advances the leg anchor only (parked — keeps the departure point
+        // fresh for the to-dropoff leg), alongside the existing liveness advance.
+        val odo = event.metadata?.odometer
+        val newCtx = ctx?.let { it.advance(e.occurredAt, odo).copy(legState = it.legState.advanceAnchor(odo)) }
         return FoldOutcome(context = newCtx, pickup = pickup)
+    }
+
+    /**
+     * `PICKUP_ARRIVED` (#688 phase B) — closes a **to-store** leg (previous anchor → this arrival) and
+     * queues it for the job's completion to claim as `milesToStore`. Keeps the pre-existing liveness
+     * advance. A malformed/payload-less event advances liveness only (leg anchor unchanged, miles roll
+     * forward — never lost, at worst lumped like today).
+     */
+    private fun foldPickupArrived(event: SequencedAppEvent, context: SessionFoldContext?): FoldOutcome {
+        val e = event.event
+        val sid = e.sessionId ?: return FoldOutcome(context = context)
+        val ctx = resolveContext(context, sid, e.occurredAt)
+        val odo = event.metadata?.odometer
+        val p = e.payload as? PickupPayload
+        val withLeg = if (p != null) ctx.closeStoreLeg(p.taskId, p.jobId, p.storeName, odo) else ctx
+        return FoldOutcome(context = withLeg.advance(e.occurredAt, odo))
+    }
+
+    /**
+     * `DELIVERY_ARRIVED` (#688 phase B) — closes a **to-dropoff** leg (previous anchor → this arrival),
+     * accumulated onto the drop's own `taskId` (a grace-flap re-arrival adds to the same entry, never a
+     * second one). Keeps the pre-existing liveness advance; a malformed event advances liveness only.
+     */
+    private fun foldDeliveryArrived(event: SequencedAppEvent, context: SessionFoldContext?): FoldOutcome {
+        val e = event.event
+        val sid = e.sessionId ?: return FoldOutcome(context = context)
+        val ctx = resolveContext(context, sid, e.occurredAt)
+        val odo = event.metadata?.odometer
+        val p = e.payload as? DeliveryPayload
+        val withLeg = if (p != null) ctx.addDropoffLeg(p.taskId, odo) else ctx
+        return FoldOutcome(context = withLeg.advance(e.occurredAt, odo))
+    }
+
+    /**
+     * `DELIVERY_CONFIRMED` (#688 phase B) — advances the leg anchor only (the handoff/POD point, before
+     * the completion receipt), alongside the pre-existing liveness advance. Produces no record.
+     */
+    private fun foldDeliveryConfirmed(event: SequencedAppEvent, context: SessionFoldContext?): FoldOutcome {
+        val e = event.event
+        val sid = e.sessionId ?: return FoldOutcome(context = context)
+        val ctx = resolveContext(context, sid, e.occurredAt)
+        val odo = event.metadata?.odometer
+        val p = e.payload as? DeliveryPayload
+        val withAnchor = if (p != null) ctx.copy(legState = ctx.legState.advanceAnchor(odo)) else ctx
+        return FoldOutcome(context = withAnchor.advance(e.occurredAt, odo))
     }
 
     /**
@@ -842,6 +958,76 @@ object RecordFolds {
             lastEventAt = maxOf(lastEventAt, occurredAt),
             lastOdometer = odometer ?: lastOdometer,
         )
+
+    // ── #688 phase B leg helpers (pure; all mirror the partition-anchor conventions above) ──
+
+    /**
+     * Advance the leg anchor to [odo]. A null odo does NOT advance (same rule as `prevDropOdometer`):
+     * the leg anchor stays put and the miles roll forward into the next closed leg.
+     */
+    private fun LegState.advanceAnchor(odo: Double?): LegState =
+        if (odo == null) this else copy(prevLegOdometer = odo)
+
+    /**
+     * Close the current leg at [odo]: returns the leg miles (floored at 0 — the mid-session
+     * odometer-reset defense) and the leg state with its anchor advanced. `null` miles ⇒ unmeasurable:
+     * either this event carries no odo (anchor unchanged, miles roll forward) or no anchor was ever
+     * seen (anchor takes this odo, this leg is unknown).
+     */
+    private fun LegState.closeLeg(odo: Double?): Pair<Double?, LegState> = when {
+        odo == null -> null to this
+        prevLegOdometer == null -> null to copy(prevLegOdometer = odo)
+        else -> (odo - prevLegOdometer).coerceAtLeast(0.0) to copy(prevLegOdometer = odo)
+    }
+
+    /** Cap a pending list at [LegState.MAX_PENDING] with deterministic drop-oldest (bounded ingestion). */
+    private fun <T> List<T>.capPending(): List<T> =
+        if (size <= LegState.MAX_PENDING) this else takeLast(LegState.MAX_PENDING)
+
+    /**
+     * Close a to-store leg and queue it (or accumulate into the same [pickupTaskId] entry on a
+     * re-arrival). Bounded at [LegState.MAX_PENDING].
+     */
+    private fun SessionFoldContext.closeStoreLeg(
+        pickupTaskId: String,
+        jobId: String,
+        storeName: String?,
+        odo: Double?,
+    ): SessionFoldContext {
+        val (miles, ls) = legState.closeLeg(odo)
+        if (miles == null) return copy(legState = ls)
+        val existingIdx = ls.pendingStoreLegs.indexOfFirst { it.pickupTaskId == pickupTaskId }
+        val legs = if (existingIdx >= 0) {
+            ls.pendingStoreLegs.mapIndexed { i, leg ->
+                if (i == existingIdx) leg.copy(miles = leg.miles + miles) else leg
+            }
+        } else {
+            (ls.pendingStoreLegs + PendingStoreLeg(pickupTaskId, jobId, storeName, miles)).capPending()
+        }
+        return copy(legState = ls.copy(pendingStoreLegs = legs))
+    }
+
+    /**
+     * Close a to-dropoff leg, accumulating onto the drop's own [taskId] (a re-arrival adds to the same
+     * entry). Bounded at [LegState.MAX_PENDING] with drop-oldest by insertion order.
+     */
+    private fun SessionFoldContext.addDropoffLeg(taskId: String, odo: Double?): SessionFoldContext {
+        val (miles, ls) = legState.closeLeg(odo)
+        if (miles == null) return copy(legState = ls)
+        val existing = ls.pendingDropoffLegs[taskId]
+        val merged = if (existing != null) {
+            ls.pendingDropoffLegs + (taskId to (existing + miles))
+        } else {
+            val added = ls.pendingDropoffLegs + (taskId to miles)
+            if (added.size <= LegState.MAX_PENDING) {
+                added
+            } else {
+                // Drop-oldest by insertion order (LinkedHashMap preserves it); keep the newest cap.
+                added.entries.toList().takeLast(LegState.MAX_PENDING).associate { it.key to it.value }
+            }
+        }
+        return copy(legState = ls.copy(pendingDropoffLegs = merged))
+    }
 
     private fun SessionFoldContext.bumpOutcome(type: AppEventType): SessionFoldContext = when (type) {
         AppEventType.OFFER_ACCEPTED -> copy(offersAccepted = offersAccepted + 1)

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/SessionFoldContext.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/SessionFoldContext.kt
@@ -78,6 +78,15 @@ data class SessionFoldContext(
      */
     val started: Boolean = false,
     /**
+     * Per-leg mileage accumulator (#688 phase B) — the leg anchor + the pending to-store / to-dropoff
+     * legs awaiting consumption at `DELIVERY_COMPLETED`. Persisted with the session row
+     * (`legStateJson`, [LegStateCodec]) because pending legs describe not-yet-completed drops and so
+     * cannot be re-derived from record rows on a batch-boundary rehydration. Default empty ⇒ a
+     * synthesized/mid-session-start context (or all pre-odometer history) folds legs unknown and each
+     * drop falls back to the legacy partition delta — byte-identical to today.
+     */
+    val legState: LegState = LegState(),
+    /**
      * Provenance of this session's start: the DASH_START payload's `source` (e.g. "interaction",
      * "recovery") once a real start has been seen; null for a synthesized `_unknown` placeholder that
      * has not (#659, retro finding 2). The persisted marker the projector rehydrates `started` from —

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/TimeEconomics.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/TimeEconomics.kt
@@ -10,12 +10,16 @@ import kotlin.math.roundToLong
  * sessions (joined via `sessionId`, with a null-session `completedAt` fallback).
  *
  * **Everything here is MEASURED, not estimated.** [onlineMillis] is Σ session durations,
- * [deliveryMinutes]/[deliveryMiles] are Σ per-delivery **partition deltas** (the odometer/time gap
- * since the previous drop, or `DASH_START` for the first), and [miles] is the session odometer
- * delta. Because delivery miles/minutes are anchored on drop completions, they **include the
- * approach legs between drops** — so the unattributed remainder ([unattributedMillis] /
- * [unattributedMiles]) is honestly "not attributed to any delivery": the tail after the last drop
- * and zero-delivery dashes, never a re-estimate.
+ * [deliveryMinutes] is Σ per-delivery **partition deltas** (the time gap since the previous drop, or
+ * `DASH_START` for the first), and [miles] is the session odometer delta. [deliveryMiles] is Σ
+ * per-delivery `realizedMiles`, which since #688 phase B is the per-**leg** sum (to-store + to-dropoff)
+ * on a leg-measured row and the legacy partition delta otherwise — so the mileage a delivery claims is
+ * bounded by its own driving legs, not the full inter-drop span. The remainder [unattributedMiles]
+ * (deadhead) therefore grows on leg-measured rows by the arrival→completion dwell/drift AND by any
+ * legs retired at a legacy-basis completion (the #688 review Fix 1 one-sided guard: Σ per-drop miles ≤
+ * the session span, undershoot expected, never over). [deliveryMinutes] is unchanged (still the full
+ * inter-drop time delta). Both remainders ([unattributedMillis] / [unattributedMiles]) stay honestly
+ * "not attributed to any delivery" — never a re-estimate.
  *
  * **Deadline coverage is explicit** (Principle 5/6 honesty): [deliveriesWithDeadline] is only the
  * deliveries that carried a captured deadline; [onTimeDeliveries] and [onTimeRate] cover ONLY that

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/LegStateCodecTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/LegStateCodecTest.kt
@@ -1,0 +1,35 @@
+package cloud.trotter.dashbuddy.domain.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/** #688 phase B — the [LegStateCodec] round-trip + fail-closed decode SSOT for `legStateJson`. */
+class LegStateCodecTest {
+
+    @Test
+    fun `round-trips a populated leg state`() {
+        val state = LegState(
+            prevLegOdometer = 712.45,
+            pendingStoreLegs = listOf(
+                PendingStoreLeg("PA", "J1", "Bill Miller BBQ", 0.22),
+                PendingStoreLeg("PB", "J1", null, 0.16),
+            ),
+            pendingDropoffLegs = mapOf("DA" to 2.98, "DB" to 3.39),
+        )
+        assertEquals(state, LegStateCodec.decode(LegStateCodec.encode(state)))
+    }
+
+    @Test
+    fun `an empty leg state round-trips`() {
+        assertEquals(LegState(), LegStateCodec.decode(LegStateCodec.encode(LegState())))
+    }
+
+    @Test
+    fun `decode fails closed to empty on null, blank, and garbage`() {
+        assertEquals(LegState(), LegStateCodec.decode(null))
+        assertEquals(LegState(), LegStateCodec.decode(""))
+        assertEquals(LegState(), LegStateCodec.decode("   "))
+        assertEquals(LegState(), LegStateCodec.decode("not valid json {{"))
+        assertEquals(LegState(), LegStateCodec.decode("""{"prevLegOdometer":"oops"}"""))
+    }
+}

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/RecordFoldsTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/RecordFoldsTest.kt
@@ -13,6 +13,7 @@ import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.ManualDeliveryPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.OfferPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.PayAdjustmentPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.PickupPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionEndSource
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStartPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.SessionStartSource
@@ -109,13 +110,14 @@ class RecordFoldsTest {
         offerPayShare: Double? = null,
         odo: Double? = null,
         phaseStartedAt: Long = at - 600_000,
+        storeName: String? = "StoreX",
         // Identity-bearing by default (a real delivered drop). A #498/#653 phantom payload has
         // BOTH hashes null (the payload copies the task's null hashes) — pass true to model it.
         identityLess: Boolean = false,
     ) = ev(
         AppEventType.DELIVERY_COMPLETED, sid, at,
         DeliveryPayload(
-            jobId = jobId, taskId = taskId, storeName = "StoreX",
+            jobId = jobId, taskId = taskId, storeName = storeName,
             customerHash = if (identityLess) null else "cust-$taskId",
             addressHash = if (identityLess) null else "addr-$taskId",
             phaseStartedAt = phaseStartedAt, arrivedAt = at - 120_000, completedAt = at,
@@ -131,6 +133,25 @@ class RecordFoldsTest {
             sid, endedAt = at, source = SessionEndSource.SUMMARY_SCREEN, totalEarnings = earnings,
             platform = platform,
         ),
+        odometer = odo,
+    )
+
+    // ── #688 phase B leg-anchor event helpers ──
+    private fun pickupArrived(sid: String, at: Long, jobId: String, taskId: String, storeName: String, odo: Double?) = ev(
+        AppEventType.PICKUP_ARRIVED, sid, at,
+        PickupPayload(jobId = jobId, taskId = taskId, storeName = storeName, phaseStartedAt = at - 300_000, arrivedAt = at),
+        odometer = odo,
+    )
+
+    private fun pickupConfirmed(sid: String, at: Long, jobId: String, taskId: String, storeName: String, odo: Double?) = ev(
+        AppEventType.PICKUP_CONFIRMED, sid, at,
+        PickupPayload(jobId = jobId, taskId = taskId, storeName = storeName, phaseStartedAt = at - 300_000, arrivedAt = at - 60_000, confirmedAt = at),
+        odometer = odo,
+    )
+
+    private fun deliveryArrived(sid: String, at: Long, jobId: String, taskId: String, storeName: String? = "StoreX", odo: Double?) = ev(
+        AppEventType.DELIVERY_ARRIVED, sid, at,
+        DeliveryPayload(jobId = jobId, taskId = taskId, storeName = storeName, phaseStartedAt = at - 300_000, arrivedAt = at),
         odometer = odo,
     )
 
@@ -1068,5 +1089,231 @@ class RecordFoldsTest {
         val adjustOut = RecordFolds.foldEvent(badAdjust, null, null)
         assertNull(adjustOut.payAdjustment)
         assertNotNull(adjustOut.skip)
+    }
+
+    // ── #688 phase B: per-leg mileage ──────────────────────────────────────
+
+    @Test
+    fun `criterion 1 - simple job splits realizedMiles into store and dropoff legs`() {
+        val s = "L1"
+        // 100 → arrive store 100.5 (to-store 0.5) → confirm 100.6 → arrive door 103.0 (to-dropoff 2.4)
+        // → complete 103.2. realizedMiles = 0.5 + 2.4 = 2.9 (NOT the 3.2 legacy delta 100→103.2).
+        val (outcomes, _) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 100.0),
+                offerAccepted(s, 1_500, "h1", eval(net = 9.0, dist = 3.0, opCpm = 0.25)),
+                pickupArrived(s, 2_000, "J1", "P1", "StoreX", odo = 100.5),
+                pickupConfirmed(s, 2_500, "J1", "P1", "StoreX", odo = 100.6),
+                deliveryArrived(s, 3_000, "J1", "D1", odo = 103.0),
+                delivery(s, 3_500, "J1", "D1", totalPay = 10.0, odo = 103.2),
+            ),
+        )
+        val d = outcomes[5].delivery!!
+        assertEquals(0.5, d.milesToStore!!, 1e-9)
+        assertEquals(2.4, d.milesToDropoff!!, 1e-9)
+        assertEquals(2.9, d.realizedMiles!!, 1e-9)
+        // Invariant: realizedMiles == milesToStore + milesToDropoff when milesToDropoff != null.
+        assertEquals(d.milesToStore!! + d.milesToDropoff!!, d.realizedMiles!!, 1e-9)
+        // Net computed against the leg-sum miles, not the legacy delta.
+        assertEquals(10.0 - 2.9 * 0.25, d.netProfit!!, 1e-9)
+    }
+
+    @Test
+    fun `criterion 2 - Bill Miller Mama Margies interleaved stack gets per-drop legs`() {
+        val s = "L2"
+        // The 07-05 field stack, straight from the log (Σ legs ≈ the collapsed 6.75):
+        //   prior anchor 705.70
+        //   → Bill Miller arrive 705.92   (to-store A 0.22)
+        //   → Mama Margies arrive 706.08  (to-store B 0.16)
+        //   → drop A arrive 709.06        (to-dropoff A 2.98)
+        //   → drop B arrive 712.45        (to-dropoff B 3.39)
+        //   → both complete at the SAME odometer 712.45 (the collapse the legacy fold produced)
+        val (outcomes, _) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 705.70),
+                offerAccepted(s, 1_500, "h1", eval(net = 9.0, dist = 6.0, opCpm = 0.30)),
+                pickupArrived(s, 2_000, "J1", "PA", "Bill Miller BBQ", odo = 705.92),
+                pickupConfirmed(s, 2_100, "J1", "PA", "Bill Miller BBQ", odo = 705.92),
+                pickupArrived(s, 2_200, "J1", "PB", "Mama Margies", odo = 706.08),
+                pickupConfirmed(s, 2_300, "J1", "PB", "Mama Margies", odo = 706.08),
+                deliveryArrived(s, 3_000, "J1", "DA", storeName = "Bill Miller BBQ", odo = 709.06),
+                deliveryArrived(s, 3_500, "J1", "DB", storeName = "Mama Margies", odo = 712.45),
+                delivery(s, 3_600, "J1", "DA", storeName = "Bill Miller BBQ", totalPay = 6.48, odo = 712.45),
+                delivery(s, 3_700, "J1", "DB", storeName = "Mama Margies", totalPay = 6.47, odo = 712.45),
+            ),
+        )
+        val dA = outcomes[8].delivery!!
+        val dB = outcomes[9].delivery!!
+        // Drop A: exact store-form match claims Bill Miller's store leg (0.22) + its own dropoff (2.98).
+        assertEquals(0.22, dA.milesToStore!!, 1e-6)
+        assertEquals(2.98, dA.milesToDropoff!!, 1e-6)
+        assertEquals(0.22 + 2.98, dA.realizedMiles!!, 1e-6)
+        // Drop B: exact store-form match claims Mama Margies' store leg (0.16) + its own dropoff (3.39).
+        assertEquals(0.16, dB.milesToStore!!, 1e-6)
+        assertEquals(3.39, dB.milesToDropoff!!, 1e-6)
+        assertEquals(0.16 + 3.39, dB.realizedMiles!!, 1e-6)
+        // The collapsed 6.75/0.0 shape is gone; Σ ≈ the old single lump.
+        assertEquals(6.75, dA.realizedMiles!! + dB.realizedMiles!!, 1e-6)
+    }
+
+    @Test
+    fun `criterion 3 - anchorless history is byte-identical - no lifecycle odometers`() {
+        val s = "L3"
+        // No PICKUP_ARRIVED/DELIVERY_ARRIVED events at all → legs unknown → legacy partition delta.
+        val (outcomes, _) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 100.0),
+                delivery(s, 3_000, "J1", "T1", totalPay = 10.0, odo = 105.0),
+            ),
+            currentCpm = 0.20,
+        )
+        val d = outcomes[1].delivery!!
+        assertNull(d.milesToStore)
+        assertNull(d.milesToDropoff)
+        assertEquals(5.0, d.realizedMiles!!, 1e-9) // legacy delta 100→105, unchanged
+        assertEquals(10.0 - 5.0 * 0.20, d.netProfit!!, 1e-9)
+    }
+
+    @Test
+    fun `criterion 3b - lifecycle events with null odometers produce null legs and legacy delta`() {
+        val s = "L3b"
+        val (outcomes, _) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 100.0),
+                pickupArrived(s, 2_000, "J1", "P1", "StoreX", odo = null),
+                deliveryArrived(s, 3_000, "J1", "D1", odo = null),
+                delivery(s, 3_500, "J1", "D1", totalPay = 10.0, odo = 105.0),
+            ),
+        )
+        val d = outcomes[3].delivery!!
+        assertNull(d.milesToStore)
+        assertNull(d.milesToDropoff)
+        assertEquals(5.0, d.realizedMiles!!, 1e-9)
+    }
+
+    @Test
+    fun `criterion 4 - repeat arrival accumulates into the same dropoff leg`() {
+        val s = "L4"
+        val (outcomes, _) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 100.0),
+                pickupArrived(s, 1_500, "J1", "P1", "StoreX", odo = 100.0),
+                pickupConfirmed(s, 1_600, "J1", "P1", "StoreX", odo = 100.0),
+                deliveryArrived(s, 2_000, "J1", "D1", odo = 102.0), // 2.0 from confirm anchor
+                deliveryArrived(s, 2_500, "J1", "D1", odo = 102.5), // grace re-arrival: +0.5, same taskId
+                delivery(s, 3_000, "J1", "D1", totalPay = 10.0, odo = 102.6),
+            ),
+        )
+        val d = outcomes[5].delivery!!
+        assertEquals(2.5, d.milesToDropoff!!, 1e-9) // 2.0 + 0.5 accumulated, not two entries
+    }
+
+    @Test
+    fun `criterion 4 - negative per-leg delta floors at zero`() {
+        val s = "L5"
+        val (outcomes, _) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 100.0),
+                pickupArrived(s, 1_500, "J1", "P1", "StoreX", odo = 100.0),
+                pickupConfirmed(s, 1_600, "J1", "P1", "StoreX", odo = 100.0),
+                deliveryArrived(s, 2_000, "J1", "D1", odo = 98.0), // odometer RESET → negative → floor 0
+                delivery(s, 3_000, "J1", "D1", totalPay = 10.0, odo = 98.5),
+            ),
+        )
+        val d = outcomes[4].delivery!!
+        assertEquals(0.0, d.milesToDropoff!!, 1e-9)
+    }
+
+    @Test
+    fun `criterion 4 - shared-store stack claims the store leg once`() {
+        val s = "L6"
+        // Two drops from ONE store visit (one pickup arrival). First drop claims the store leg; the
+        // sibling gets milesToStore null (DEV-DECISION 2: claim-once, no fabricated split).
+        val (outcomes, _) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 100.0),
+                pickupArrived(s, 1_500, "J1", "P1", "StoreX", odo = 101.0), // to-store 1.0
+                pickupConfirmed(s, 1_600, "J1", "P1", "StoreX", odo = 101.0),
+                deliveryArrived(s, 2_000, "J1", "DA", odo = 103.0), // to-dropoff A 2.0
+                deliveryArrived(s, 2_500, "J1", "DB", odo = 104.0), // to-dropoff B 1.0
+                delivery(s, 2_600, "J1", "DA", storeName = "StoreX", totalPay = 5.0, odo = 104.0),
+                delivery(s, 2_700, "J1", "DB", storeName = "StoreX", totalPay = 5.0, odo = 104.0),
+            ),
+        )
+        val dA = outcomes[5].delivery!!
+        val dB = outcomes[6].delivery!!
+        assertEquals(1.0, dA.milesToStore!!, 1e-9)
+        assertEquals(2.0, dA.milesToDropoff!!, 1e-9)
+        assertNull(dB.milesToStore) // store leg already claimed by the sibling
+        assertEquals(1.0, dB.milesToDropoff!!, 1e-9)
+        assertEquals(1.0, dB.realizedMiles!!, 1e-9) // dropoff leg only
+    }
+
+    @Test
+    fun `criterion 4 - storeName-less drop falls back to FIFO within the job`() {
+        val s = "L7"
+        // Two store visits, both drops complete with NULL storeName (the Unknown-store family). Exact
+        // match can't fire, so each drop claims the oldest unclaimed store leg of its job (FIFO).
+        val (outcomes, _) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 100.0),
+                pickupArrived(s, 1_500, "J1", "PA", "StoreA", odo = 100.5), // store leg A 0.5
+                pickupConfirmed(s, 1_600, "J1", "PA", "StoreA", odo = 100.5),
+                pickupArrived(s, 1_700, "J1", "PB", "StoreB", odo = 100.8), // store leg B 0.3
+                pickupConfirmed(s, 1_800, "J1", "PB", "StoreB", odo = 100.8),
+                deliveryArrived(s, 2_000, "J1", "DA", storeName = null, odo = 102.0),
+                deliveryArrived(s, 2_500, "J1", "DB", storeName = null, odo = 103.0),
+                delivery(s, 2_600, "J1", "DA", storeName = null, totalPay = 5.0, odo = 103.0),
+                delivery(s, 2_700, "J1", "DB", storeName = null, totalPay = 5.0, odo = 103.0),
+            ),
+        )
+        val dA = outcomes[7].delivery!!
+        val dB = outcomes[8].delivery!!
+        assertEquals(0.5, dA.milesToStore!!, 1e-9) // FIFO → oldest (store A) first
+        assertEquals(0.3, dB.milesToStore!!, 1e-9) // FIFO → store B
+    }
+
+    @Test
+    fun `criterion 4 - lone store leg does NOT replace realizedMiles`() {
+        val s = "L8"
+        // Store leg is known but NO DELIVERY_ARRIVED (missed arrival) → milesToDropoff null → the
+        // milesToDropoff != null gate keeps the legacy partition delta, not the lone store leg.
+        val (outcomes, _) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 100.0),
+                pickupArrived(s, 1_500, "J1", "P1", "StoreX", odo = 101.0),
+                pickupConfirmed(s, 1_600, "J1", "P1", "StoreX", odo = 101.0),
+                delivery(s, 3_000, "J1", "D1", totalPay = 10.0, odo = 105.0),
+            ),
+        )
+        val d = outcomes[3].delivery!!
+        assertNull(d.milesToDropoff)
+        // milesToStore is a claimed store leg (1.0) but does NOT drive realizedMiles here.
+        assertEquals(1.0, d.milesToStore!!, 1e-9)
+        assertEquals(5.0, d.realizedMiles!!, 1e-9) // legacy delta 100→105, unchanged
+    }
+
+    @Test
+    fun `criterion 4 - MANUAL delivery does not perturb leg state`() {
+        val s = "L9"
+        // A store leg is queued; a MANUAL_DELIVERY between arrival and the real completion must NOT
+        // touch the leg accumulator — the real drop still claims its full legs.
+        val manual = ev(
+            AppEventType.MANUAL_DELIVERY, s, 2_200,
+            ManualDeliveryPayload(sessionId = s, pay = 4.0, completedAt = 2_200),
+        )
+        val (outcomes, _) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 100.0),
+                pickupArrived(s, 1_500, "J1", "P1", "StoreX", odo = 100.5),
+                pickupConfirmed(s, 1_600, "J1", "P1", "StoreX", odo = 100.5),
+                deliveryArrived(s, 2_000, "J1", "D1", odo = 102.5),
+                manual,
+                delivery(s, 3_000, "J1", "D1", totalPay = 10.0, odo = 102.6),
+            ),
+        )
+        val d = outcomes[5].delivery!!
+        assertEquals(0.5, d.milesToStore!!, 1e-9)  // store leg intact through the MANUAL
+        assertEquals(2.0, d.milesToDropoff!!, 1e-9)
     }
 }

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/RecordFoldsTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/RecordFoldsTest.kt
@@ -23,9 +23,12 @@ import cloud.trotter.dashbuddy.domain.model.pay.ParsedPay
 import cloud.trotter.dashbuddy.domain.model.pay.ParsedPayItem
 import cloud.trotter.dashbuddy.domain.state.Flow
 import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.domain.model.event.payload.TaskUnassignedPayload
+import cloud.trotter.dashbuddy.domain.state.TaskPhase
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -152,6 +155,23 @@ class RecordFoldsTest {
     private fun deliveryArrived(sid: String, at: Long, jobId: String, taskId: String, storeName: String? = "StoreX", odo: Double?) = ev(
         AppEventType.DELIVERY_ARRIVED, sid, at,
         DeliveryPayload(jobId = jobId, taskId = taskId, storeName = storeName, phaseStartedAt = at - 300_000, arrivedAt = at),
+        odometer = odo,
+    )
+
+    private fun taskUnassigned(
+        sid: String,
+        at: Long,
+        jobId: String,
+        taskId: String,
+        phase: TaskPhase,
+        storeName: String? = null,
+        odo: Double? = null,
+    ) = ev(
+        AppEventType.TASK_UNASSIGNED, sid, at,
+        TaskUnassignedPayload(
+            jobId = jobId, taskId = taskId, phase = phase, storeName = storeName,
+            startedAt = at - 300_000, unassignedAt = at,
+        ),
         odometer = odo,
     )
 
@@ -1274,10 +1294,12 @@ class RecordFoldsTest {
     }
 
     @Test
-    fun `criterion 4 - lone store leg does NOT replace realizedMiles`() {
+    fun `criterion 4 - lone store leg does NOT replace realizedMiles and legacy row stamps no leg`() {
         val s = "L8"
         // Store leg is known but NO DELIVERY_ARRIVED (missed arrival) → milesToDropoff null → the
-        // milesToDropoff != null gate keeps the legacy partition delta, not the lone store leg.
+        // milesToDropoff != null gate keeps the legacy partition delta, not the lone store leg. Fix 4
+        // (#688 review): a legacy row stamps NO milesToStore either — leg-sum ≠ realizedMiles must stay
+        // the driver-edit trail, not a machine lone-leg stamp on an otherwise-untouched legacy row.
         val (outcomes, _) = foldSession(
             listOf(
                 dashStart(s, 1_000, odo = 100.0),
@@ -1288,8 +1310,7 @@ class RecordFoldsTest {
         )
         val d = outcomes[3].delivery!!
         assertNull(d.milesToDropoff)
-        // milesToStore is a claimed store leg (1.0) but does NOT drive realizedMiles here.
-        assertEquals(1.0, d.milesToStore!!, 1e-9)
+        assertNull(d.milesToStore) // Fix 4: legacy-basis row does NOT stamp a lone store leg
         assertEquals(5.0, d.realizedMiles!!, 1e-9) // legacy delta 100→105, unchanged
     }
 
@@ -1315,5 +1336,95 @@ class RecordFoldsTest {
         val d = outcomes[5].delivery!!
         assertEquals(0.5, d.milesToStore!!, 1e-9)  // store leg intact through the MANUAL
         assertEquals(2.0, d.milesToDropoff!!, 1e-9)
+    }
+
+    @Test
+    fun `Fix 1 - mixed-basis stack, legacy drop retires store legs so a sibling cannot double-count`() {
+        val s = "L10"
+        // Multi-store stack where drop A MISSES its DELIVERY_ARRIVED → folds on the LEGACY partition
+        // delta, whose span (start→A-completion) already CONTAINS both store legs. On 07315d7a drop A
+        // still claimed store leg A (0.5) AND left store leg B (0.3) queued, which sibling B then
+        // re-claimed per-leg → Σ per-drop miles (4.2) EXCEEDED the 3.9 session odometer span (the
+        // reviewer's double-count). The fix: drop A stamps no store leg (Fix 4) and RETIRES the job's
+        // store legs closed before its completion (Fix 1), so B claims none of them.
+        val (outcomes, ctx) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 100.0),
+                offerAccepted(s, 1_200, "h1", eval(net = 9.0, dist = 6.0, opCpm = 0.30)),
+                pickupArrived(s, 1_500, "J1", "PA", "StoreA", odo = 100.5), // store leg A 0.5, closes 100.5
+                pickupConfirmed(s, 1_600, "J1", "PA", "StoreA", odo = 100.5),
+                pickupArrived(s, 1_700, "J1", "PB", "StoreB", odo = 100.8), // store leg B 0.3, closes 100.8
+                pickupConfirmed(s, 1_800, "J1", "PB", "StoreB", odo = 100.8),
+                // Drop A: NO deliveryArrived → milesToDropoff null → LEGACY basis (span 100.0→103.0 = 3.0).
+                delivery(s, 3_000, "J1", "DA", storeName = "StoreA", totalPay = 5.0, odo = 103.0),
+                // Drop B: arrives + completes with no dwell.
+                deliveryArrived(s, 3_500, "J1", "DB", storeName = "StoreB", odo = 103.9), // dropoff B 0.9
+                delivery(s, 3_600, "J1", "DB", storeName = "StoreB", totalPay = 5.0, odo = 103.9),
+            ),
+        )
+        val dA = outcomes[6].delivery!!
+        val dB = outcomes[8].delivery!!
+        // Drop A is legacy: no leg stamped, realizedMiles is the partition delta.
+        assertNull(dA.milesToStore)
+        assertNull(dA.milesToDropoff)
+        assertEquals(3.0, dA.realizedMiles!!, 1e-9)
+        // Drop B did NOT re-claim store leg B (retired at A's legacy completion) — dropoff leg only.
+        assertNull(dB.milesToStore)
+        assertEquals(0.9, dB.milesToDropoff!!, 1e-9)
+        assertEquals(0.9, dB.realizedMiles!!, 1e-9)
+        // The load-bearing invariant: Σ per-drop realizedMiles ≤ the session odometer span (one-sided).
+        val span = ctx!!.lastOdometer!! - ctx.startOdometer!! // 103.9 − 100.0 = 3.9
+        assertEquals(3.9, span, 1e-9)
+        assertTrue(
+            "Σ per-drop miles (${dA.realizedMiles!! + dB.realizedMiles!!}) must not exceed span ($span)",
+            dA.realizedMiles!! + dB.realizedMiles!! <= span + 1e-9,
+        )
+    }
+
+    @Test
+    fun `Fix 2 - a pickup-phase unassign purges its store leg so a surviving sibling cannot inherit it`() {
+        val s = "L11"
+        // A stacked job: store A is abandoned via unassign-in-help during pickup; store B survives. The
+        // surviving drop completes with a NULL storeName (the Unknown-store family) so it must fall to
+        // FIFO. On 07315d7a TASK_UNASSIGNED was fold-inert → store leg A stayed queued → FIFO handed the
+        // surviving drop the ABANDONED store's 0.5 miles (contrary to #736: an unassigned task's miles
+        // are session-level only). The fix purges leg A, so FIFO correctly claims store B's 0.3.
+        val (outcomes, _) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 100.0),
+                offerAccepted(s, 1_100, "h1", eval(net = 9.0, dist = 6.0, opCpm = 0.30)),
+                pickupArrived(s, 1_500, "J1", "PA", "StoreA", odo = 100.5), // store leg A 0.5 (abandoned)
+                pickupArrived(s, 1_700, "J1", "PB", "StoreB", odo = 100.8), // store leg B 0.3 (survives)
+                taskUnassigned(s, 1_900, "J1", "PA", TaskPhase.PICKUP, storeName = "StoreA"),
+                deliveryArrived(s, 2_500, "J1", "DB", storeName = null, odo = 103.0), // dropoff B 2.2
+                delivery(s, 2_600, "J1", "DB", storeName = null, totalPay = 5.0, odo = 103.0),
+            ),
+        )
+        val dB = outcomes[6].delivery!!
+        // FIFO now sees only store leg B (A purged) → 0.3, NOT the abandoned store A's 0.5.
+        assertEquals(0.3, dB.milesToStore!!, 1e-9)
+        assertEquals(2.2, dB.milesToDropoff!!, 1e-9)
+    }
+
+    @Test
+    fun `Fix 3 - store-leg match runs through the normalizedChain SSOT, not raw equality`() {
+        val s = "L12"
+        // Two store legs; the surviving drop completes with a payout FORM-DRIFTED store name
+        // ("Mama Margies #55") that raw `==` would miss → FIFO would wrongly hand it the OLDEST leg
+        // (Bill Miller, 0.5). normalizedChain strips the "#55" franchise qualifier, so the exact match
+        // correctly claims Mama Margies' own 0.3 leg (the #159 StoreKeys SSOT, F9 read-side precedent).
+        val (outcomes, _) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 100.0),
+                offerAccepted(s, 1_100, "h1", eval(net = 9.0, dist = 6.0, opCpm = 0.30)),
+                pickupArrived(s, 1_500, "J1", "PA", "Bill Miller BBQ", odo = 100.5), // leg A 0.5 (oldest)
+                pickupArrived(s, 1_700, "J1", "PB", "Mama Margies", odo = 100.8),     // leg B 0.3
+                deliveryArrived(s, 2_500, "J1", "DB", storeName = "Mama Margies", odo = 103.0), // dropoff 2.2
+                delivery(s, 2_600, "J1", "DB", storeName = "Mama Margies #55", totalPay = 5.0, odo = 103.0),
+            ),
+        )
+        val dB = outcomes[5].delivery!!
+        // Normalized match claims Mama Margies' own leg (0.3), NOT Bill Miller's FIFO-oldest 0.5.
+        assertEquals(0.3, dB.milesToStore!!, 1e-9)
     }
 }

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/RecordFoldsTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/RecordFoldsTest.kt
@@ -1345,8 +1345,9 @@ class RecordFoldsTest {
         // delta, whose span (start→A-completion) already CONTAINS both store legs. On 07315d7a drop A
         // still claimed store leg A (0.5) AND left store leg B (0.3) queued, which sibling B then
         // re-claimed per-leg → Σ per-drop miles (4.2) EXCEEDED the 3.9 session odometer span (the
-        // reviewer's double-count). The fix: drop A stamps no store leg (Fix 4) and RETIRES the job's
-        // store legs closed before its completion (Fix 1), so B claims none of them.
+        // reviewer's double-count). The fix: drop A stamps no store leg (Fix 4) and RETIRES the
+        // session's store legs closed at/before its completion (Fix 1, session-wide per the re-verify
+        // widening — see the cross-job discriminator below), so B claims none of them.
         val (outcomes, ctx) = foldSession(
             listOf(
                 dashStart(s, 1_000, odo = 100.0),
@@ -1426,5 +1427,51 @@ class RecordFoldsTest {
         val dB = outcomes[5].delivery!!
         // Normalized match claims Mama Margies' own leg (0.3), NOT Bill Miller's FIFO-oldest 0.5.
         assertEquals(0.3, dB.milesToStore!!, 1e-9)
+    }
+
+    @Test
+    fun `Fix 1 widening - cross-job add-on leg closed inside a legacy span is retired session-wide`() {
+        val s = "L13"
+        // The re-verifier's cross-job shape: J1's order is out for delivery; a J2 ADD-ON is accepted
+        // and its PICKUP_ARRIVED closes a store leg (0.5) EN ROUTE; then J1's drop completes LEGACY
+        // (missed DELIVERY_ARRIVED). J1's legacy span is a SESSION-level partition delta
+        // (start→completion regardless of job) and already contains J2's store leg — under the
+        // jobId-SCOPED retire that leg stayed pending (different jobId), J2's leg-based drop then
+        // re-claimed it → Σ per-drop miles (3.0 + 1.5 = 4.5) EXCEEDED the 4.0 session span. The
+        // session-wide retire drops it (closed 100.9 ≤ J1's completion 103.0), so J2's drop carries
+        // its dropoff leg only.
+        val (outcomes, ctx) = foldSession(
+            listOf(
+                dashStart(s, 1_000, odo = 100.0),
+                offerAccepted(s, 1_100, "h1", eval(net = 9.0, dist = 6.0, opCpm = 0.30)),
+                pickupArrived(s, 1_500, "J1", "P1", "StoreOne", odo = 100.4), // J1 store leg 0.4, closes 100.4
+                pickupConfirmed(s, 1_600, "J1", "P1", "StoreOne", odo = 100.4),
+                // J2 add-on accepted mid-route; its pickup arrival closes a leg inside J1's span.
+                pickupArrived(s, 2_000, "J2", "P2", "StoreTwo", odo = 100.9), // J2 store leg 0.5, closes 100.9
+                pickupConfirmed(s, 2_100, "J2", "P2", "StoreTwo", odo = 100.9),
+                // J1's drop: NO deliveryArrived → LEGACY basis, span 100.0→103.0 = 3.0 (contains BOTH legs).
+                delivery(s, 3_000, "J1", "D1", storeName = "StoreOne", totalPay = 6.0, odo = 103.0),
+                // J2's drop: leg-based (arrival fired).
+                deliveryArrived(s, 3_500, "J2", "D2", storeName = "StoreTwo", odo = 104.0), // dropoff 1.0
+                delivery(s, 3_600, "J2", "D2", storeName = "StoreTwo", totalPay = 5.0, odo = 104.0),
+            ),
+        )
+        val d1 = outcomes[6].delivery!!
+        val d2 = outcomes[8].delivery!!
+        // J1 legacy: no legs stamped, partition delta.
+        assertNull(d1.milesToStore)
+        assertNull(d1.milesToDropoff)
+        assertEquals(3.0, d1.realizedMiles!!, 1e-9)
+        // J2's drop does NOT claim the store leg closed inside J1's legacy span — dropoff leg only.
+        assertNull(d2.milesToStore)
+        assertEquals(1.0, d2.milesToDropoff!!, 1e-9)
+        assertEquals(1.0, d2.realizedMiles!!, 1e-9)
+        // The one-sided invariant, now strictly guaranteed (minus odometer-reset sessions).
+        val span = ctx!!.lastOdometer!! - ctx.startOdometer!! // 104.0 − 100.0 = 4.0
+        assertEquals(4.0, span, 1e-9)
+        assertTrue(
+            "Σ per-drop miles (${d1.realizedMiles!! + d2.realizedMiles!!}) must not exceed span ($span)",
+            d1.realizedMiles!! + d2.realizedMiles!! <= span + 1e-9,
+        )
     }
 }


### PR DESCRIPTION
## Summary

**#688 phase B — per-leg mileage.** Folds the lifecycle `metadata.odometer` stamps (already in the immutable `app_events` log) into per-drop driving legs, fixing the stacked-job mileage collapse the issue documented (the 07-05 Bill Miller/Mama Margies stack: 6.76 mi lumped on one drop, 0.0 on the sibling — now ~3.20 / ~3.55 per the log's own leg readings).

Spec: the "Phase B design pass (top-tier, 2026-07-07) — build spec" comment on #688 (https://github.com/sjtrotter/DashBuddy/issues/688). **Version note:** the spec's schema numbers (v11→v12, projector 4→5) were written before #159 consumed those edges — this PR builds the next edges: **Room v12→v13, `PROJECTOR_VERSION` 5→6.**

### What changed

- **`:domain`** — `LegState`/`PendingStoreLeg`/`LegStateCodec` (new file, kotlinx-serialization; fail-closed decode → empty state → legacy delta; `MAX_PENDING = 32` bounded, drop-oldest); `SessionFoldContext.legState`; `RecordFolds`: new arms for `PICKUP_ARRIVED` (closes a to-store leg) / `DELIVERY_ARRIVED` (closes a to-dropoff leg keyed by the drop's own taskId; re-arrival **accumulates**) / `DELIVERY_CONFIRMED` (anchor only), anchor advances on `PICKUP_CONFIRMED`/`DELIVERY_COMPLETED`/`DASH_START` init; null-odometer anchor events do NOT advance (miles roll forward); per-leg floor at 0; `MANUAL_DELIVERY`/adjustments never perturb leg state. Consumption at `DELIVERY_COMPLETED`: `milesToDropoff` = own-taskId entry; `milesToStore` = one claimed store leg of the job (exact store-form match → FIFO → null; **claim-once**, no fabricated split — spec DEV-DECISION 2 default); `realizedMiles` = leg sum **iff `milesToDropoff != null`** (a lone store leg never replaces the legacy partition delta).
- **Room v12→v13 (additive-only)** — `delivery_records` +`milesToStore`/`milesToDropoff` (REAL, nullable); `session_records` +`legStateJson` (TEXT, nullable — pending legs describe not-yet-completed drops and can't be re-derived from record rows, so persistence is what keeps incremental ≡ from-zero refold across the projector's 500-event page boundaries). Full #690 checklist: `VERSION` 12→13, exported `13.json` committed, `AutoMigration(12,13)`, instrumented `AnalyticsMigration12to13Test` (**needs one device/emulator run — instrumented tests do not gate unit-only PR CI**), `SchemaVersionGuardTest` chain v8→13 green.
- **`PROJECTOR_VERSION` 5→6** — retroactive refold populates legs + redistributed `realizedMiles`/`netProfit` for ALL history from the odometer stamps already in the log. Phase-A driver edits replay after their targets (log order), so a `DELIVERY_ADJUSTMENT.newMiles` still wins `realizedMiles`/net; the machine leg columns are provenance and are **never rewritten** (spec DEV-DECISION 1 default) — leg-sum ≠ realizedMiles on a corrected row IS the visible edit trail. Precedented side effect: `CURRENT_FALLBACK` rows re-stamp against today's economy (same as v2/v3/v4). `applyDeliveryAdjustment` needed zero changes (`row.copy` preserves the new columns).
- **Read surfaces** — CSV deliveries +`miles_to_store`/`miles_to_dropoff`; drill-down travel line gains a glance-only `(→ store a.b · → door c.d)` parenthetical; `DeliveryRecord` domain read-model + mapper carry the two fields.
- **Out of scope (per spec §9)** — no per-leg editing, no per-drop tip/pay split, no change to session/period/IRS mileage reads (still odometer-span-anchored — asserted in tests), `realizedMinutes` unchanged, `newCompletedAt` stays banned, no `:core:state`/capture/rules changes (`Task.odometerAtEntry/Arrival` stay dead).

### Tests (all green — full gate `testDebugUnitTest :domain:test`)

- `RecordFoldsTest` (spec §8 criteria 1–4): simple-job leg split + leg-sum invariant + net vs leg miles; the Bill Miller/Mama Margies interleaved 2-store fixture (Σ legs ≈ the old 6.75 lump, collapse gone); anchorless byte-identity (no lifecycle events AND null-odometer lifecycle events → null legs, legacy delta — all existing fixtures pass **unchanged**); re-arrival accumulation; negative-delta floor; shared-store claim-once; FIFO on storeName-less drops; lone-store-leg gate; MANUAL non-perturbation.
- `LegStateCodecTest`: round-trip + fail-closed decode (null/blank/garbage/type-mismatch → empty).
- `AnalyticsProjectorTest` (criteria 5–7): batch-boundary determinism (page boundary between arrival and completion → row identical to a from-zero refold — proves the `legStateJson` round-trip); garbage-blob fail-closed (→ legacy-delta rows, no crash); correction precedence (driver total wins money, machine legs intact, basis untouched); reconciliation invariant (per-row leg-sum rule; 0 ≤ session span − Σ realizedMiles ≤ bound; period pay read unaffected).
- `CsvExporterTest` goldens updated deliberately (new header/row + null-legs-blank case).
- `AnalyticsMigration12to13Test` (instrumented): populated v12 → 13, rows survive, new columns NULL. **Not run on a device yet** — flagged for a device pass before merge (per repo posture, migration-correctness tests don't gate unit CI).

### Security / privacy posture

No new capture, no network, no new PII surface. The fold re-reads a log that already passed the edge hash; the new columns are odometer-derived miles keyed by ids; `PendingStoreLeg.storeName` is merchant data at rest (never in INFO+ lines — the only new log sites are the projector's existing count-only WARN/DEBUG paths). Untrusted-input hygiene: `legStateJson` decodes fail-closed with bounded pending collections (`MAX_PENDING` 32, deterministic drop-oldest).

### Design-goal review

- **P1 (UDF):** all new fold logic is pure `:domain` (no Android, no wall clock — `metadata.odometer`/event timestamps only); the impure edges (persist/hydrate `legStateJson`) live in the orchestrator's existing entity mapping.
- **P3 (SRP):** the leg vocabulary is its own file (`LegState.kt`); `RecordFolds` gains focused private helpers rather than inlining into `foldDeliveryCompleted`.
- **P4:** immutable value types, data classes, no stringly-typed state beyond the persisted JSON blob (owned by one codec).
- **P5 (SSOT):** `LegStateCodec` is the one owner of the `legStateJson` encoding (both `toEntity` and `toContext` route through it); net math stays on `NetProfit.net` (only the miles *input* changes); CSV decimals via the existing `Csv` primitives; drill-down formatting via `Formats.decimal`. Session/period miles remain derived from the odometer span — the leg columns are per-drop provenance, not a second session-miles owner (the locked #528/#438-B5 anchor rule untouched, asserted in criterion 7).
- **P6 (security/privacy):** stated above — fail-closed decode, bounded ingestion, no new PII surface, frozen economics preserved (the refold is the sanctioned mechanism, `PROJECTOR_VERSION` bump documented in the version-history KDoc).
- **P7 (logging):** no new log sites beyond the existing count-only projector lines; nothing merchant/customer-shaped at INFO+.
- **P8 (platform-agnostic):** leg anchoring keys on enumerated `AppEventType`s + `jobId`/`taskId`/`storeName` payload fields — no platform literals, no wire-string logic; nothing DoorDash-specific (the Bill Miller fixture is test data).
- **Reactive UI:** the drill-down line renders static historical facts (no time-derived value) — no ticker needed.

### Adversarial review

_The `### Adversarial review` block will be appended before merge (fable-tier `/code-review`; §4 batch-boundary determinism and criterion-3 anchorless byte-identity flagged as the reviewer focus per the spec's build-shape note)._

Closes nothing by keyword (phase B completes #688's remaining scope, but leaving the close to the dev per the phase-A mis-close precedent — the PR body deliberately avoids `closes #688`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


#### Post-review fixes

Two fable adversarial reviews produced findings, all applied in `387e90cf` (inside this same pending v6 refold — NO second `PROJECTOR_VERSION` bump):

- **Fix 1 (MED, both reviewers) — mixed-basis mileage double-count.** A legacy-basis completion (missed `DELIVERY_ARRIVED` ⇒ `milesToDropoff` null) now RETIRES its job'''s pending store legs whose closure preceded it — those miles are already inside the legacy partition span, so a sibling can'''t re-claim them per-leg. `PendingStoreLeg` gains a nullable `closedAtOdometer` ordering marker (old blobs decode null → conservative retire → per-row under-attribution, never double-count). New test asserts Σ per-drop `realizedMiles` ≤ session span and the sibling'''s leg is not double-claimed.
- **Fix 2 (MED) — #736 unassign interaction.** `TASK_UNASSIGNED` gets a leg-state-only fold arm that purges the abandoned task'''s pending legs (pickup→its store leg, dropoff→its dropoff leg / future #752); liveness advances identically to the old `else` arm, no record minted, read-model row-inert.
- **Fix 3 (MED-LOW) — store-leg match through `StoreKeys.normalizedChain` (the #159 SSOT), FIFO fallback unchanged.**
- **Fix 4 (LOW) — a legacy-basis row no longer stamps `milesToStore` either** (lone store leg never rides an untouched row; leg-sum ≠ realizedMiles stays the driver-edit trail).
- **Fix 5 (docs) — `TimeEconomics` KDoc corrected for leg-measured `deliveryMiles`; field-checklist item states the one-sided Σ ≤ span invariant + the #736 no-per-drop-miles note.**
- **Fix 6 (P3) — leg machinery extracted to `LegFolds.kt`** (pure mechanical move; `RecordFolds` 1038→961, residual is Fold-DTO/SSOT declarations).

Note: the CSV column insertion (`miles_to_store`/`miles_to_dropoff`) shifts positional indexes — the export is header-named (alpha-sanctioned), so consumers key on the header, not position.

Each of the 4 new/updated discriminator tests was verified to FAIL on `07315d7a` via a baseline revert; full gate (`testDebugUnitTest :domain:test`) green.

### Adversarial review

Loop: 2 independent fable finders (money/fold-determinism; schema/migration/SSOT) → opus fixer (07315d7a → 387e90cf) → fable re-verification → one pre-sanctioned amendment (→ 2a1b8187). **Final verdict: APPROVE.**

**Fixed in-PR:**
1. **MED (both finders, converged):** mixed-basis mileage double-count — a legacy-basis drop (missed arrival → whole-span partition delta) contained store legs its siblings also claimed per-leg, so Σ per-drop miles could exceed the session span (violating the PR's own field invariant). Fixed: a legacy completion retires pending store legs closed at/before its completion odometer (`PendingStoreLeg.closedAtOdometer`, persisted, null ⇒ conservative retire); re-verification then traced the cross-job add-on variant under the job-scoped retire, and the sanctioned amendment widened it **session-wide** (the legacy span is a session-level partition delta) — discriminators L10 (same-job) + L13 (cross-job), each proven failing under the prior code.
2. **MED:** `TASK_UNASSIGNED` was fold-inert, so an abandoned pickup's pending leg stayed FIFO-claimable by a surviving drop — contrary to #736's miles-stay-session-level decision. Fixed: a leg-state-only fold arm purges the abandoned task's pending legs (pickup + dropoff phases; the dropoff arm pre-covers #752), with liveness byte-identical to the old else arm (no refold divergence) and zero record minting. Discriminator L11.
3. **MED-LOW:** store-leg claim matched on raw string equality — now `StoreKeys.normalizedChain` (the #159 SSOT), FIFO fallback unchanged. Discriminator L12.
4. **LOW:** legacy rows no longer stamp `milesToStore` (preserves the "leg-sum ≠ realizedMiles ⇒ driver edit" trail); `TimeEconomics` KDoc corrected; checklist wording aligned to the (now strictly guaranteed) Σ ≤ span invariant; CSV positional-shift noted.
5. **P3:** leg machinery extracted to `LegFolds.kt` (verified textually mechanical; RecordFolds 1038→961; the residual overage is scoped-out DTO declarations — a pure `FoldTypes.kt` move is available if wanted).

**Verified-safe:** migration edge textbook (strictly additive v12→v13 proven from the schema JSONs; full release checklist; `SchemaVersionGuardTest` chains gapless; no destructive fallback); PROJECTOR_VERSION 5→6 wipe complete incl. stores/pickup_records (#159 F8); frozen economics intact (leg columns never rewritten by corrections; net recomputes against the row's OWN frozen cpm); batch-boundary/refold determinism proven incl. the persisted `LegState` and old-blob decode; no platform literals; zero new log sites; nothing blocks #660p2's later v13→v14.

**Residuals (documented, non-blocking):** Σ per-drop miles systematically ≤ session span (arrival→completion dwell/drift belongs to no drop — the deliberate flip side); odometer-reset sessions void all mileage invariants (legacy delta floors to 0); same-chain-different-franchise store forms can cross-match within a job (consistent with #159 F9 chain buckets); the v12→v13 instrumented migration test needs its device run — **pair with the still-pending v11→v12 run at the phone reinstall**.
