### PR TITLE
feature(#660): categorize orphan deliveries into sessions — DELIVERY_SESSION_ASSIGN

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -351,8 +351,20 @@ the same null-session population (`AnalyticsDao.noSessionTotals`/`noSessionTotal
 `noSessionDailyRows`) into `PeriodEconomics.grossEarnings` and the per-day chart (bucketed on the
 delivery's own `completedAt` day, since there's no session start to anchor on), and surfacing it as its
 own `noSessionPay`/`noSessionDeliveries` review signal (Money tab callout, same pattern as
-unattributed/over-attributed). Piece 2 (deferred, #660) lets the driver categorize an orphan delivery
-into a real session via a new correction event. Period totals are **read-side only** — they never re-enter the pure state machine (the dead
+unattributed/over-attributed). **Piece 2 (#660, shipped): categorize an orphan into its real dash.** A new
+correction event `DELIVERY_SESSION_ASSIGN` (`DeliverySessionAssignPayload{targetEventSequenceId, newSessionId
+(null⇒unassign/undo), note}`, folded by `RecordFolds.foldDeliverySessionAssign` — context untouched, F2
+liveness discipline) is written by `CorrectionRepository.assignDeliverySession` from the tappable Money-tab
+callout (→ orphan list + ±48h/same-platform/ended-only session picker in `NoSessionAssignDialogs.kt`) and the
+drill-down undo ("assigned by you" caption + "Remove from this dash"). The projector's `applySessionAssign`
+(a third `Adjustment.SessionAssign` in the FIX-1 log-ordered stream) re-attributes **attribution ONLY** —
+`sessionId` + the additive Room-v13→v14 marker `delivery_records.sessionAssigned` via `row.copy`, every frozen
+economy column byte-identical (never re-prices) — behind FIVE fail-closed guards (movable rows only = null-session
+OR already-assigned; real ENDED target session, load-bearing for hydration determinism; platform coherence;
+cash-bearing-unassign block; missing row), each a counted ids-only-WARN skip. The session `deliveries` counter
+rides a **relative** `bumpSessionDeliveries` ±1 (refold-stable). No `PROJECTOR_VERSION` bump (new event type
+can't exist in folded history; the DEFAULT-0 column is correct for all history). The categorized row re-enters
+its session's `GROUP BY sessionId` reconciliation, healing the piece-1 correlated-orphan double-count. Period totals are **read-side only** — they never re-enter the pure state machine (the dead
 `CrossPlatformRegion.PeriodTotals` fields were deleted). The free-tier **CSV export** (#319) is a second
 read-side consumer: `AnalyticsRepository.buildCsvExport` reads raw `deliveriesBetween`/`sessionsBetween`
 rows (row-level, bucketing-free — the driver's own records dumped, not session-anchored periods) and the

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsScreen.kt
@@ -19,12 +19,15 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.compose.runtime.getValue
 import cloud.trotter.dashbuddy.R
 import cloud.trotter.dashbuddy.core.designsystem.component.AppSegmented
 import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
@@ -47,6 +50,8 @@ fun AnalyticsScreen(
     viewModel: AnalyticsViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    // "(No session)" categorize flow (#660 piece 2) — opened from the Money-tab callout.
+    var showAssignSheet by remember { mutableStateOf(false) }
 
     Scaffold(
         topBar = {
@@ -106,6 +111,7 @@ fun AnalyticsScreen(
                         recentSessions = uiState.recentSessions,
                         dailyEarnings = uiState.dailyEarnings,
                         onOpenSession = onOpenSession,
+                        onOpenNoSession = { showAssignSheet = true },
                     )
                 }
 
@@ -134,6 +140,15 @@ fun AnalyticsScreen(
                 )
             }
         }
+    }
+
+    if (showAssignSheet) {
+        NoSessionAssignDialog(
+            orphans = uiState.noSessionDeliveries,
+            candidateSessionsFor = viewModel::candidateSessionsFor,
+            onAssign = viewModel::assignToSession,
+            onDismiss = { showAssignSheet = false },
+        )
     }
 }
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsUiState.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsUiState.kt
@@ -5,6 +5,7 @@ import cloud.trotter.dashbuddy.R
 import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
 import cloud.trotter.dashbuddy.domain.analytics.DailyEarnings
 import cloud.trotter.dashbuddy.domain.analytics.DecisionEconomics
+import cloud.trotter.dashbuddy.domain.analytics.DeliveryRecord
 import cloud.trotter.dashbuddy.domain.analytics.EarningsHeatmap
 import cloud.trotter.dashbuddy.domain.analytics.PeriodEconomics
 import cloud.trotter.dashbuddy.domain.analytics.SessionRecord
@@ -60,6 +61,11 @@ data class AnalyticsUiState(
     val dailyEarnings: List<DailyEarnings> = emptyList(),
     /** Most recent dash sessions, newest first — each row taps through to the per-dash drill-down (#650). */
     val recentSessions: List<SessionRecord> = emptyList(),
+    /**
+     * The period's orphan "(No session)" deliveries (#660 piece 2) — the categorize flow's list, opened
+     * from the Money-tab callout. Reactive: shrinks as the projector folds a `DELIVERY_SESSION_ASSIGN`.
+     */
+    val noSessionDeliveries: List<DeliveryRecord> = emptyList(),
     /** Offer-decision economics for [selectedPeriod] — the Decisions tab (#315 H3, frozen est.). */
     val decisions: DecisionEconomics = DecisionEconomics.EMPTY,
     /** Time / mileage economics for [selectedPeriod] — the Time tab (#315 H4, measured). */

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsViewModel.kt
@@ -3,13 +3,17 @@ package cloud.trotter.dashbuddy.ui.main.analytics
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import cloud.trotter.dashbuddy.core.data.analytics.AnalyticsRepository
+import cloud.trotter.dashbuddy.core.data.analytics.CorrectionRepository
 import cloud.trotter.dashbuddy.domain.analytics.AnalyticsPeriod
 import cloud.trotter.dashbuddy.domain.analytics.DailyEarnings
 import cloud.trotter.dashbuddy.domain.analytics.DecisionEconomics
+import cloud.trotter.dashbuddy.domain.analytics.DeliveryRecord
 import cloud.trotter.dashbuddy.domain.analytics.PeriodEconomics
+import cloud.trotter.dashbuddy.domain.analytics.SessionRecord
 import cloud.trotter.dashbuddy.domain.analytics.StoreEconomics
 import cloud.trotter.dashbuddy.domain.analytics.TimeEconomics
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -17,6 +21,8 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 /**
@@ -42,7 +48,8 @@ import javax.inject.Inject
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class AnalyticsViewModel @Inject constructor(
-    analyticsRepository: AnalyticsRepository,
+    private val analyticsRepository: AnalyticsRepository,
+    private val correctionRepository: CorrectionRepository,
 ) : ViewModel() {
 
     /** UDF intent targets — the selected review window and tab. */
@@ -62,9 +69,15 @@ class AnalyticsViewModel @Inject constructor(
                 analyticsRepository.perStoreEconomics(period),
                 analyticsRepository.decisionEconomics(period),
                 analyticsRepository.timeEconomics(period),
-                analyticsRepository.dailyEarnings(period),
-            ) { economics, stores, decisions, time, daily ->
-                PeriodData(period, economics, stores, decisions, time, daily)
+                // The typed `combine` tops out at 5 flows, so the per-day chart + the "(No session)"
+                // orphan list (#660 piece 2) ride ONE nested sub-combine into the 5th slot. Both are
+                // period-anchored, so they re-anchor atomically with everything else on a period switch.
+                combine(
+                    analyticsRepository.dailyEarnings(period),
+                    analyticsRepository.noSessionDeliveries(period),
+                ) { daily, orphans -> daily to orphans },
+            ) { economics, stores, decisions, time, (daily, orphans) ->
+                PeriodData(period, economics, stores, decisions, time, daily, orphans)
             }
         },
         analyticsRepository.recentSessions(RECENT_SESSIONS_LIMIT),
@@ -82,6 +95,7 @@ class AnalyticsViewModel @Inject constructor(
             decisions = data.decisions,
             time = data.time,
             dailyEarnings = data.dailyEarnings,
+            noSessionDeliveries = data.orphanDeliveries,
             storeReportCards = storeCards,
             earningsHeatmap = heatmap,
         )
@@ -97,6 +111,38 @@ class AnalyticsViewModel @Inject constructor(
         selectedTab.value = tab
     }
 
+    /**
+     * The candidate dashes an orphan could be categorized into (#660 piece 2) — a one-shot suspend read
+     * the picker runs in a `produceState` when the driver taps an orphan. Delegates to the repository's
+     * ±48 h / same-platform / ended-only policy (the pre-filter; the projector's ended-session guard is
+     * the authority).
+     */
+    suspend fun candidateSessionsFor(orphan: DeliveryRecord): List<SessionRecord> =
+        analyticsRepository.candidateSessionsForOrphan(orphan.completedAt, orphan.platform)
+
+    /**
+     * UDF intent (#660 piece 2) — categorize an orphan delivery into [newSessionId] by appending a
+     * `DELIVERY_SESSION_ASSIGN`. The projector applies it (with its fail-closed guards) and Room
+     * invalidation refreshes the callout + the orphan list — no optimistic local mutation.
+     */
+    fun assignToSession(targetEventSequenceId: Long, newSessionId: String) {
+        viewModelScope.launch {
+            // Fail-closed backstop — a rejected append (blank id) must not crash the launch (parity with
+            // the SessionDetail corrections). Alpha-acceptable silent reject; the projector is authoritative.
+            try {
+                correctionRepository.assignDeliverySession(
+                    targetEventSequenceId = targetEventSequenceId,
+                    newSessionId = newSessionId,
+                )
+            } catch (e: CancellationException) {
+                throw e // cooperative cancellation — never swallow it
+            } catch (e: Exception) {
+                // P7: counts/ids only.
+                Timber.tag(TAG).w(e, "assignToSession rejected for delivery seq %d", targetEventSequenceId)
+            }
+        }
+    }
+
     /** One period switch's worth of read-model, re-anchored atomically under [flatMapLatest]. */
     private data class PeriodData(
         val period: AnalyticsPeriod,
@@ -105,10 +151,12 @@ class AnalyticsViewModel @Inject constructor(
         val decisions: DecisionEconomics,
         val time: TimeEconomics,
         val dailyEarnings: List<DailyEarnings>,
+        val orphanDeliveries: List<DeliveryRecord>,
     )
 
     private companion object {
         const val TOP_STORES = 5
         const val RECENT_SESSIONS_LIMIT = 10
+        const val TAG = "AnalyticsVm"
     }
 }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/MoneyTab.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/MoneyTab.kt
@@ -58,6 +58,7 @@ fun MoneyTab(
     recentSessions: List<SessionRecord>,
     dailyEarnings: List<DailyEarnings>,
     onOpenSession: (String) -> Unit,
+    onOpenNoSession: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(16.dp)) {
@@ -83,10 +84,11 @@ fun MoneyTab(
                 modifier = Modifier.fillMaxWidth(),
             )
         }
-        // "(No session)" bucket (#660 piece 1): deliveries whose source event carried no sessionId at
-        // all. Already folded into [economics.grossEarnings]/[netProfit] above (so gross can't read
-        // below net from this seam) — this callout is the visible data-quality signal, same pattern as
-        // the unattributed/over-attributed flags. Categorizing the bucket into a session is #660 piece 2.
+        // "(No session)" bucket (#660): deliveries whose source event carried no sessionId at all.
+        // Already folded into [economics.grossEarnings]/[netProfit] above (so gross can't read below net
+        // from this seam) — this callout is the visible data-quality signal, same pattern as the
+        // unattributed/over-attributed flags. TAPPABLE (#660 piece 2): opens the categorize flow to
+        // assign an orphan into its real dash, which heals the double-count and empties this bucket.
         if (economics.noSessionPay > UNATTRIBUTED_EPSILON) {
             val deliveryWord = if (economics.noSessionDeliveries == 1) {
                 stringResource(R.string.time_tab_delivery_singular)
@@ -101,7 +103,9 @@ fun MoneyTab(
                     deliveryWord,
                 ),
                 container = AppTheme.colors.warnBg,
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { onOpenNoSession() },
             )
         }
         TopStoresCard(topStores)

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/MoneyTab.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/MoneyTab.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import cloud.trotter.dashbuddy.R
@@ -89,12 +90,15 @@ fun MoneyTab(
         // from this seam) — this callout is the visible data-quality signal, same pattern as the
         // unattributed/over-attributed flags. TAPPABLE (#660 piece 2): opens the categorize flow to
         // assign an orphan into its real dash, which heals the double-count and empties this bucket.
-        if (economics.noSessionPay > UNATTRIBUTED_EPSILON) {
+        // Gated on the COUNT, not the pay (#660 review): a pay-less orphan ($0.00 captured) is still a
+        // categorizable data-quality item — the count is the population, the pay is just its magnitude.
+        if (economics.noSessionDeliveries > 0) {
             val deliveryWord = if (economics.noSessionDeliveries == 1) {
                 stringResource(R.string.time_tab_delivery_singular)
             } else {
                 stringResource(R.string.time_tab_delivery_plural)
             }
+            val clickLabel = stringResource(R.string.money_tab_no_session_callout_click_label)
             AppCallout(
                 text = stringResource(
                     R.string.money_tab_no_session_callout_format,
@@ -105,7 +109,7 @@ fun MoneyTab(
                 container = AppTheme.colors.warnBg,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .clickable { onOpenNoSession() },
+                    .clickable(onClickLabel = clickLabel, role = Role.Button) { onOpenNoSession() },
             )
         }
         TopStoresCard(topStores)

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/NoSessionAssignDialogs.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/NoSessionAssignDialogs.kt
@@ -28,6 +28,7 @@ import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
 import cloud.trotter.dashbuddy.domain.analytics.DeliveryRecord
 import cloud.trotter.dashbuddy.domain.analytics.SessionRecord
 import cloud.trotter.dashbuddy.domain.format.Formats
+import cloud.trotter.dashbuddy.domain.format.formatClockTime
 import cloud.trotter.dashbuddy.domain.format.formatShortDate
 
 /**
@@ -117,7 +118,10 @@ private fun OrphanListDialog(
                                     color = c.text,
                                 )
                                 Text(
-                                    text = formatShortDate(o.completedAt),
+                                    // Date AND time-of-day (#660 review) — two same-store same-day
+                                    // orphans must be distinguishable; both route through the
+                                    // domain time-format SSOT.
+                                    text = "${formatShortDate(o.completedAt)} · ${formatClockTime(o.completedAt)}",
                                     style = MaterialTheme.typography.bodySmall,
                                     color = c.text3,
                                 )

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/NoSessionAssignDialogs.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/NoSessionAssignDialogs.kt
@@ -1,0 +1,226 @@
+package cloud.trotter.dashbuddy.ui.main.analytics
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import cloud.trotter.dashbuddy.R
+import cloud.trotter.dashbuddy.core.designsystem.theme.AppTheme
+import cloud.trotter.dashbuddy.domain.analytics.DeliveryRecord
+import cloud.trotter.dashbuddy.domain.analytics.SessionRecord
+import cloud.trotter.dashbuddy.domain.format.Formats
+import cloud.trotter.dashbuddy.domain.format.formatShortDate
+
+/**
+ * The "(No session)" categorize flow (#660 piece 2) — a two-step dialog opened from the Money-tab
+ * callout. Step 1 lists the period's orphan deliveries; tapping one opens step 2, the session picker
+ * (ENDED dashes within ±48 h of the orphan's completion, same platform, nearest first). Confirming
+ * writes a `DELIVERY_SESSION_ASSIGN` via the ViewModel; Room invalidation shrinks [orphans]
+ * reactively (the assigned row leaves the bucket), so the list updates without a manual refresh.
+ *
+ * Kept OUT of `MoneyTab.kt` (Principle 3 — file-size budget). Pure data in / lambdas out (Principle 1):
+ * [candidateSessionsFor] is a suspend fetch the picker runs in a [produceState]; [onAssign] appends the
+ * correction event. No PII surface — store/merchant names are driver-owned; no customer hashes.
+ */
+@Composable
+fun NoSessionAssignDialog(
+    orphans: List<DeliveryRecord>,
+    candidateSessionsFor: suspend (DeliveryRecord) -> List<SessionRecord>,
+    onAssign: (targetEventSequenceId: Long, newSessionId: String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var selectedOrphan by remember { mutableStateOf<DeliveryRecord?>(null) }
+    val orphan = selectedOrphan
+
+    if (orphan == null) {
+        OrphanListDialog(
+            orphans = orphans,
+            onSelect = { selectedOrphan = it },
+            onDismiss = onDismiss,
+        )
+    } else {
+        SessionPickerDialog(
+            orphan = orphan,
+            candidateSessionsFor = candidateSessionsFor,
+            onAssign = { sessionId ->
+                onAssign(orphan.eventSequenceId, sessionId)
+                // Return to the (reactively-shrinking) list so the driver can categorize more.
+                selectedOrphan = null
+            },
+            onBack = { selectedOrphan = null },
+            onDismiss = onDismiss,
+        )
+    }
+}
+
+@Composable
+private fun OrphanListDialog(
+    orphans: List<DeliveryRecord>,
+    onSelect: (DeliveryRecord) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val c = AppTheme.colors
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.no_session_assign_title)) },
+        text = {
+            Column(
+                modifier = Modifier
+                    .heightIn(max = 360.dp)
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                Text(
+                    text = stringResource(R.string.no_session_assign_subtitle),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = c.text3,
+                )
+                if (orphans.isEmpty()) {
+                    Text(
+                        text = stringResource(R.string.no_session_assign_empty),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = c.text3,
+                        modifier = Modifier.padding(vertical = 8.dp),
+                    )
+                } else {
+                    orphans.forEach { o ->
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable { onSelect(o) }
+                                .padding(vertical = 8.dp),
+                        ) {
+                            Column(Modifier.weight(1f)) {
+                                Text(
+                                    text = o.storeName ?: stringResource(R.string.no_session_assign_unknown_store),
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = c.text,
+                                )
+                                Text(
+                                    text = formatShortDate(o.completedAt),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = c.text3,
+                                )
+                            }
+                            Text(
+                                text = o.realizedPay?.let { Formats.money(it) } ?: EMPTY_VALUE,
+                                style = AppTheme.num.smNum,
+                                color = c.text,
+                            )
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.no_session_assign_close)) }
+        },
+    )
+}
+
+@Composable
+private fun SessionPickerDialog(
+    orphan: DeliveryRecord,
+    candidateSessionsFor: suspend (DeliveryRecord) -> List<SessionRecord>,
+    onAssign: (newSessionId: String) -> Unit,
+    onBack: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val c = AppTheme.colors
+    // Re-fetched whenever the target orphan changes; null while the suspend read is in flight.
+    val candidates by produceState<List<SessionRecord>?>(initialValue = null, orphan) {
+        value = candidateSessionsFor(orphan)
+    }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.no_session_assign_pick_dash_title)) },
+        text = {
+            Column(
+                modifier = Modifier
+                    .heightIn(max = 360.dp)
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                val list = candidates
+                when {
+                    list == null -> Text(
+                        text = stringResource(R.string.no_session_assign_loading),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = c.text3,
+                        modifier = Modifier.padding(vertical = 8.dp),
+                    )
+                    list.isEmpty() -> Text(
+                        text = stringResource(R.string.no_session_assign_no_candidates),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = c.text3,
+                        modifier = Modifier.padding(vertical = 8.dp),
+                    )
+                    else -> list.forEach { s ->
+                        val deliveryWord = if (s.deliveries == 1) {
+                            stringResource(R.string.time_tab_delivery_singular)
+                        } else {
+                            stringResource(R.string.time_tab_delivery_plural)
+                        }
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable { onAssign(s.sessionId) }
+                                .padding(vertical = 8.dp),
+                        ) {
+                            Column(Modifier.weight(1f)) {
+                                Text(
+                                    text = formatShortDate(s.startedAt),
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = c.text,
+                                )
+                                Text(
+                                    // Platform label is registry-resolved (never a literal) — Principle 8.
+                                    text = stringResource(
+                                        R.string.no_session_assign_session_deliveries_format,
+                                        s.platform.shortName.ifEmpty { s.platform.displayName },
+                                        Formats.commaInt(s.deliveries),
+                                        deliveryWord,
+                                    ),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = c.text3,
+                                )
+                            }
+                            Text(
+                                text = s.reportedEarnings?.let { Formats.money(it) } ?: EMPTY_VALUE,
+                                style = AppTheme.num.smNum,
+                                color = c.text,
+                            )
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onBack) { Text(stringResource(R.string.no_session_assign_back)) }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.session_detail_cancel_button)) }
+        },
+    )
+}

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/SessionDetailScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/SessionDetailScreen.kt
@@ -570,9 +570,22 @@ private fun AdjustDeliveryDialog(
                 MoneyField(note, { note = it }, stringResource(R.string.session_detail_field_note_optional), numeric = false)
                 // #660 piece 2 undo: only a driver-assigned row can be removed back to the bucket (a
                 // machine row is never movable by the projector guard). Attribution-only — never re-prices.
+                // A cash-bearing row's unassign is REFUSED by the projector's F3 sessionful-cash guard
+                // (a null-session cash row would reach net but not gross), so disable the action with a
+                // hint rather than showing a control whose tap silently no-ops (#660 review).
                 if (target.sessionAssigned) {
-                    TextButton(onClick = onUnassign, modifier = Modifier.align(Alignment.Start)) {
-                        Text(stringResource(R.string.session_detail_remove_from_dash))
+                    val cashLocked = target.cashTip != null
+                    Column(Modifier.align(Alignment.Start)) {
+                        TextButton(onClick = onUnassign, enabled = !cashLocked) {
+                            Text(stringResource(R.string.session_detail_remove_from_dash))
+                        }
+                        if (cashLocked) {
+                            Text(
+                                text = stringResource(R.string.session_detail_remove_cash_locked_supporting),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = AppTheme.colors.text3,
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/SessionDetailScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/SessionDetailScreen.kt
@@ -96,6 +96,7 @@ fun SessionDetailScreen(
                 detail = detail,
                 onAddManualDelivery = viewModel::addManualDelivery,
                 onAdjustDelivery = viewModel::adjustDelivery,
+                onUnassignDelivery = viewModel::unassignDelivery,
                 modifier = Modifier
                     .padding(padding)
                     .verticalScroll(rememberScrollState())
@@ -123,6 +124,7 @@ private fun DashDetailContent(
         newMiles: Double?,
         note: String?,
     ) -> Unit,
+    onUnassignDelivery: (targetEventSequenceId: Long) -> Unit,
     modifier: Modifier,
 ) {
     // Correction dialog state — hoisted here, stateless children below (Principle 1 / 3).
@@ -181,6 +183,10 @@ private fun DashDetailContent(
             onDismiss = { adjustTarget = null },
             onConfirm = { store, newPay, newTip, newCashTip, newMiles, note ->
                 onAdjustDelivery(target.eventSequenceId, store, newPay, newTip, newCashTip, newMiles, note)
+                adjustTarget = null
+            },
+            onUnassign = {
+                onUnassignDelivery(target.eventSequenceId)
                 adjustTarget = null
             },
         )
@@ -314,6 +320,15 @@ private fun DeliveryRow(delivery: DeliveryRecord, onAdjust: () -> Unit) {
             )
             travelLine(delivery)?.let {
                 Text(text = it, style = MaterialTheme.typography.bodySmall, color = c.text3)
+            }
+            // #660 piece 2 disclosure: a driver-categorized orphan (parity with the OFFER_PAY
+            // "est. offer pay" disclosure family) — this row was assigned here by the driver, not captured.
+            if (delivery.sessionAssigned) {
+                Text(
+                    text = stringResource(R.string.session_detail_assigned_by_you),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = c.accent,
+                )
             }
         }
         Column(horizontalAlignment = Alignment.End) {
@@ -495,6 +510,7 @@ private fun AdjustDeliveryDialog(
         newMiles: Double?,
         note: String?,
     ) -> Unit,
+    onUnassign: () -> Unit,
 ) {
     // All field state is keyed on [target] (F6): a mid-edit Room re-emission that produces a DIFFERENT
     // target snapshot re-initialises the fields from it, so the change-diff below never compares an
@@ -552,6 +568,13 @@ private fun AdjustDeliveryDialog(
                 MoneyField(cashTip, { cashTip = it }, stringResource(R.string.session_detail_field_cash_tip))
                 MoneyField(miles, { miles = it }, stringResource(R.string.session_detail_stat_miles))
                 MoneyField(note, { note = it }, stringResource(R.string.session_detail_field_note_optional), numeric = false)
+                // #660 piece 2 undo: only a driver-assigned row can be removed back to the bucket (a
+                // machine row is never movable by the projector guard). Attribution-only — never re-prices.
+                if (target.sessionAssigned) {
+                    TextButton(onClick = onUnassign, modifier = Modifier.align(Alignment.Start)) {
+                        Text(stringResource(R.string.session_detail_remove_from_dash))
+                    }
+                }
             }
         },
         confirmButton = {

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/SessionDetailViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/SessionDetailViewModel.kt
@@ -120,6 +120,31 @@ class SessionDetailViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Remove a driver-assigned delivery from this dash (#660 piece 2, the undo) — writes a
+     * `DELIVERY_SESSION_ASSIGN` with `newSessionId = null`, returning the row to the "(No session)"
+     * bucket where it can be re-assigned correctly. Only offered for a `sessionAssigned` row (a machine
+     * row is never movable by the projector's guard). The projector applies it and the read-model Flow
+     * refreshes the screen (the row leaves this dash) — no optimistic local mutation.
+     */
+    fun unassignDelivery(targetEventSequenceId: Long) {
+        viewModelScope.launch {
+            // F4c: fail-closed backstop — a rejected unassign (e.g. the cash-bearing block) must not
+            // crash the launch. Alpha-acceptable silent reject; the projector guard is the authority.
+            try {
+                correctionRepository.assignDeliverySession(
+                    targetEventSequenceId = targetEventSequenceId,
+                    newSessionId = null,
+                )
+            } catch (e: CancellationException) {
+                throw e // cooperative cancellation — never swallow it
+            } catch (e: Exception) {
+                // P7: counts/ids only.
+                Timber.tag(TAG).w(e, "unassignDelivery rejected for delivery seq %d", targetEventSequenceId)
+            }
+        }
+    }
+
     private companion object {
         private const val TAG = "SessionDetailVm"
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -494,6 +494,7 @@
     <string name="money_tab_unattributed_callout_format">%1$s not attributed to any delivery — bonuses/adjustments; review coming (#650)</string>
     <string name="money_tab_over_attributed_callout_format">attributed exceeds reported by %1$s — review estimates/corrections</string>
     <string name="money_tab_no_session_callout_format">(No session): %1$s across %2$s %3$s not tied to a dash — data-quality flag (#660)</string>
+    <string name="money_tab_no_session_callout_click_label">Assign to a dash</string>
     <string name="money_tab_recent_sessions_title">RECENT SESSIONS</string>
     <string name="money_tab_no_sessions_recorded_yet">No sessions recorded yet.</string>
     <string name="money_tab_cash_marker_format">+%1$s cash</string>
@@ -532,6 +533,7 @@
     <string name="session_detail_save_button">Save</string>
     <string name="session_detail_assigned_by_you">assigned by you</string>
     <string name="session_detail_remove_from_dash">Remove from this dash</string>
+    <string name="session_detail_remove_cash_locked_supporting">Clear the cash tip first, then remove</string>
 
     <!-- main/analytics/NoSessionAssignDialogs.kt (#660 piece 2) -->
     <string name="no_session_assign_title">(No session) deliveries</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -530,6 +530,20 @@
     <string name="session_detail_field_pay_locked_supporting">de-duplicated receipt — edit the real drop\'s row</string>
     <string name="session_detail_field_cash_tip">Cash tip</string>
     <string name="session_detail_save_button">Save</string>
+    <string name="session_detail_assigned_by_you">assigned by you</string>
+    <string name="session_detail_remove_from_dash">Remove from this dash</string>
+
+    <!-- main/analytics/NoSessionAssignDialogs.kt (#660 piece 2) -->
+    <string name="no_session_assign_title">(No session) deliveries</string>
+    <string name="no_session_assign_subtitle">Tap a delivery to assign it to a dash.</string>
+    <string name="no_session_assign_empty">No unassigned deliveries in this period.</string>
+    <string name="no_session_assign_pick_dash_title">Assign to a dash</string>
+    <string name="no_session_assign_loading">Finding nearby dashes…</string>
+    <string name="no_session_assign_no_candidates">No nearby ended dashes to assign this to.</string>
+    <string name="no_session_assign_unknown_store">Unknown store</string>
+    <string name="no_session_assign_session_deliveries_format">%1$s · %2$s %3$s</string>
+    <string name="no_session_assign_close">Close</string>
+    <string name="no_session_assign_back">Back</string>
 
     <!-- bubble/cards/FlowCardItem.kt -->
     <string name="flow_card_content_desc_collapse">Collapse</string>

--- a/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsViewModelTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/ui/main/analytics/AnalyticsViewModelTest.kt
@@ -41,6 +41,7 @@ import org.mockito.kotlin.whenever
 class AnalyticsViewModelTest {
 
     private val analyticsRepository: AnalyticsRepository = mock()
+    private val correctionRepository: cloud.trotter.dashbuddy.core.data.analytics.CorrectionRepository = mock()
 
     /**
      * The Patterns-tab sources (#315 H5) are LIFETIME-scoped and collected unconditionally in the
@@ -69,6 +70,9 @@ class AnalyticsViewModelTest {
         whenever(analyticsRepository.decisionEconomics(eq(period))).thenReturn(flowOf(decisions))
         whenever(analyticsRepository.timeEconomics(eq(period))).thenReturn(flowOf(time))
         whenever(analyticsRepository.dailyEarnings(eq(period), anyOrNull())).thenReturn(flowOf(dailyEarnings))
+        // The VM also collects the "(No session)" orphan list per period (#660 piece 2) in the same
+        // combine, so it must be stubbed or the combine folds a null Flow.
+        whenever(analyticsRepository.noSessionDeliveries(eq(period))).thenReturn(flowOf(emptyList()))
     }
 
     private fun decisions(accepted: Int, declined: Int, timedOut: Int, acceptanceRate: Double?) =
@@ -128,7 +132,7 @@ class AnalyticsViewModelTest {
         offersDeclined = 2, offersTimeout = 0,
     )
 
-    private fun buildViewModel() = AnalyticsViewModel(analyticsRepository)
+    private fun buildViewModel() = AnalyticsViewModel(analyticsRepository, correctionRepository)
 
     @After
     fun tearDown() = Dispatchers.resetMain()

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsMappers.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsMappers.kt
@@ -32,6 +32,7 @@ internal fun DeliveryRecordEntity.toDomain(): DeliveryRecord = DeliveryRecord(
     cashTip = cashTip,
     milesToStore = milesToStore,
     milesToDropoff = milesToDropoff,
+    sessionAssigned = sessionAssigned == 1,
 )
 
 internal fun SessionRecordEntity.toDomain(): SessionRecord = SessionRecord(

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjector.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjector.kt
@@ -411,9 +411,16 @@ class AnalyticsProjector @Inject constructor(
      *     `delivery_records` BY sessionId, so assigning into a LIVE session could make a later machine
      *     `DELIVERY_COMPLETED`'s fold differ between incremental (no orphan row in the in-memory context)
      *     and from-zero refold at a batch boundary (orphan row visible in the hydrated context). An ended
-     *     session folds no future machine completion, so that divergence class is inert. (Stated residual:
-     *     a pathological post-`DASH_STOP` `DELIVERY_COMPLETED` for the same session could still hydrate
-     *     differently — the same residual class the ended-session assumption already carries elsewhere.)
+     *     session folds no future machine completion, so that divergence class is inert. The stronger,
+     *     rules-independent backstop is at the DAO: the three hydration reads
+     *     ([AnalyticsDao.deliveredJobIdsInSession]/[AnalyticsDao.receiptedJobIdsInSession]/
+     *     [AnalyticsDao.lastDeliveryInSession], plus the #159 [AnalyticsDao.jobIdsForSession] resolution
+     *     enumerator) all filter `sessionAssigned = 0`, so a driver-assigned orphan is INVISIBLE to
+     *     machine-fold hydration and #159 resolution regardless of the session's ended state — a later-batch
+     *     correction on the same session (e.g. a note edit that re-hydrates + pass-through-upserts the
+     *     context) can no longer inflate `jobsCompleted` off the orphan's job, and incremental ≡ refold
+     *     holds even under the pathological post-`DASH_STOP` `DELIVERY_COMPLETED` shape the ended-session
+     *     assumption alone left as a residual.
      *  4. **Platform coherence:** both platforms known and differing ⇒ skip (a DoorDash drop in an Uber
      *     dash's reconciliation is never right). No platform re-stamp in v1.
      *  5. **Cash-bearing unassign block:** `newSessionId == null && row.cashTip != null` ⇒ skip — the

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjector.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjector.kt
@@ -19,6 +19,7 @@ import cloud.trotter.dashbuddy.domain.analytics.PayAdjustmentFold
 import cloud.trotter.dashbuddy.domain.analytics.PayBasis
 import cloud.trotter.dashbuddy.domain.analytics.PickupFold
 import cloud.trotter.dashbuddy.domain.analytics.RecordFolds
+import cloud.trotter.dashbuddy.domain.analytics.SessionAssignFold
 import cloud.trotter.dashbuddy.domain.analytics.SessionFoldContext
 import cloud.trotter.dashbuddy.domain.analytics.StoreResolution
 import cloud.trotter.dashbuddy.domain.evaluation.NetProfit
@@ -193,6 +194,7 @@ class AnalyticsProjector @Inject constructor(
             outcome.resolution?.let { resolutions += ResolutionTask(ev.sequenceId, it) }
             outcome.payAdjustment?.let { adjustments += Adjustment.Pay(ev.sequenceId, it) }
             outcome.deliveryAdjustment?.let { adjustments += Adjustment.Delivery(ev.sequenceId, it) }
+            outcome.sessionAssign?.let { adjustments += Adjustment.SessionAssign(ev.sequenceId, it) }
             outcome.context?.let { ctx ->
                 contexts[ctx.sessionId] = ctx
                 touched += ctx.sessionId
@@ -226,6 +228,7 @@ class AnalyticsProjector @Inject constructor(
                 val skipped = when (adj) {
                     is Adjustment.Pay -> applyPayAdjustment(adj.fold)
                     is Adjustment.Delivery -> applyDeliveryAdjustment(adj.fold)
+                    is Adjustment.SessionAssign -> applySessionAssign(adj.fold)
                 }
                 if (skipped) adjustmentSkips++
             }
@@ -257,6 +260,7 @@ class AnalyticsProjector @Inject constructor(
         val sequenceId: Long
         data class Pay(override val sequenceId: Long, val fold: PayAdjustmentFold) : Adjustment
         data class Delivery(override val sequenceId: Long, val fold: DeliveryAdjustmentFold) : Adjustment
+        data class SessionAssign(override val sequenceId: Long, val fold: SessionAssignFold) : Adjustment
     }
 
     /** A #159 store-resolution trigger carrying its source event's [sequenceId] for the seq-ordered
@@ -384,6 +388,98 @@ class AnalyticsProjector @Inject constructor(
                 storeKeyPinned = if (storeChanged) 1 else row.storeKeyPinned,
             ),
         )
+        return false
+    }
+
+    /**
+     * Apply one driver DELIVERY_SESSION_ASSIGN (#660 piece 2) — (re-)attribute an orphan
+     * "(No session)" delivery to its real ended dash, or UNASSIGN it back to the bucket (the undo).
+     * Returns true iff the apply was SKIPPED (a counted skip + PII-safe WARN, ids only — never a crash).
+     * Changes **attribution ONLY**: `sessionId` + the `sessionAssigned` marker via `row.copy`; every
+     * frozen economy column (pay, net, tip, `payBasis`, `originalPayBasis`, frozen cpm/fuel/nonfuel,
+     * `cashTip`, `storeKey`/pin, miles, `completedAt`) is byte-identical (categorizing never re-prices),
+     * and no `completedAt` edit keeps us out of the #688 VET-F2 anchor-determinism problem entirely.
+     *
+     * Five fail-closed guards (each a counted skip, never a crash):
+     *  1. **Target row exists** (same as the other applies).
+     *  2. **Movable rows only:** `row.sessionId == null || row.sessionAssigned == 1`. A machine- or
+     *     MANUAL-attributed sessionful row is NEVER moved — moving one would silently break its source
+     *     session's reported-vs-delivered reconciliation. (The UI only offers orphan/assigned rows; this
+     *     is the fail-closed backstop.)
+     *  3. **Assign target is a real, ENDED session** (`endedAt != null`). Load-bearing for determinism,
+     *     not hygiene: restart hydration derives `deliveredJobIds`/`receiptedJobIds`/prevDrop anchors from
+     *     `delivery_records` BY sessionId, so assigning into a LIVE session could make a later machine
+     *     `DELIVERY_COMPLETED`'s fold differ between incremental (no orphan row in the in-memory context)
+     *     and from-zero refold at a batch boundary (orphan row visible in the hydrated context). An ended
+     *     session folds no future machine completion, so that divergence class is inert. (Stated residual:
+     *     a pathological post-`DASH_STOP` `DELIVERY_COMPLETED` for the same session could still hydrate
+     *     differently — the same residual class the ended-session assumption already carries elsewhere.)
+     *  4. **Platform coherence:** both platforms known and differing ⇒ skip (a DoorDash drop in an Uber
+     *     dash's reconciliation is never right). No platform re-stamp in v1.
+     *  5. **Cash-bearing unassign block:** `newSessionId == null && row.cashTip != null` ⇒ skip — the
+     *     mirror of the projector's F3 "cash-bearing rows are always sessionful" invariant (a null-session
+     *     cash row would reach net but not gross).
+     *
+     * The session `deliveries` counter is maintained by a RELATIVE ±1 UPDATE ([bumpSessionDeliveries]),
+     * order-safe with the batch's earlier session-context upserts and identical under incremental fold vs
+     * refold. `jobsCompleted` + store resolution are deliberately untouched (job counts are
+     * `COUNT(DISTINCT jobId)` and pick the row up automatically; re-anchoring #159 resolution is a v1
+     * non-goal).
+     */
+    private suspend fun applySessionAssign(adj: SessionAssignFold): Boolean {
+        val row = analyticsDao.deliveryRecord(adj.targetEventSequenceId) ?: run {
+            // P7: counts only, no payload text.
+            Timber.tag(TAG).w("DELIVERY_SESSION_ASSIGN: target row %d not found", adj.targetEventSequenceId)
+            return true
+        }
+        // Guard 2: movable rows only (null-session OR previously driver-assigned).
+        if (row.sessionId != null && row.sessionAssigned != 1) {
+            Timber.tag(TAG).w(
+                "DELIVERY_SESSION_ASSIGN: row %d is machine-attributed (session-bound, not driver-assigned) — skipped",
+                adj.targetEventSequenceId,
+            )
+            return true
+        }
+        val newSessionId = adj.newSessionId
+        if (newSessionId != null) {
+            // Guard 3: real, ENDED target session.
+            val session = analyticsDao.sessionRecord(newSessionId)
+            if (session == null || session.endedAt == null) {
+                Timber.tag(TAG).w(
+                    "DELIVERY_SESSION_ASSIGN: target session for row %d is missing or still live — skipped",
+                    adj.targetEventSequenceId,
+                )
+                return true
+            }
+            // Guard 4: platform coherence (both known and differing).
+            val rowPlatform = Platform.fromWire(row.platform)
+            val sessionPlatform = Platform.fromWire(session.platform)
+            if (rowPlatform != null && rowPlatform != Platform.Unknown &&
+                sessionPlatform != null && sessionPlatform != Platform.Unknown &&
+                rowPlatform != sessionPlatform
+            ) {
+                Timber.tag(TAG).w(
+                    "DELIVERY_SESSION_ASSIGN: row %d platform ≠ target session platform — skipped",
+                    adj.targetEventSequenceId,
+                )
+                return true
+            }
+        } else if (row.cashTip != null) {
+            // Guard 5: cash-bearing unassign block (F3 sessionful-cash invariant).
+            Timber.tag(TAG).w(
+                "DELIVERY_SESSION_ASSIGN: cannot unassign cash-bearing row %d (F3 sessionful-cash invariant) — skipped",
+                adj.targetEventSequenceId,
+            )
+            return true
+        }
+
+        val oldSessionId = row.sessionId
+        // Attribution-only: sessionId + marker via row.copy; every frozen column preserved byte-identically.
+        analyticsDao.upsertDelivery(
+            row.copy(sessionId = newSessionId, sessionAssigned = if (newSessionId != null) 1 else 0),
+        )
+        if (oldSessionId != null) analyticsDao.bumpSessionDeliveries(oldSessionId, -1)
+        if (newSessionId != null) analyticsDao.bumpSessionDeliveries(newSessionId, +1)
         return false
     }
 

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
@@ -357,10 +357,17 @@ class AnalyticsRepository @Inject constructor(
     /**
      * The **candidate dashes** an orphan delivery could be categorized into (#660 piece 2): ENDED
      * sessions within ±48 h of [completedAt], same [platform] (ALL platforms when the orphan's platform
-     * is [Platform.Unknown]), nearest-in-time first. A one-shot snapshot fetched when the driver opens the
-     * picker (not a live surface — the picker is a transient dialog); the projector's ended-session guard
-     * is the authority, this is the UI-policy pre-filter over the existing [AnalyticsDao.sessionsBetween]
+     * is [Platform.Unknown]), nearest-in-**span** first. A one-shot snapshot fetched when the driver opens
+     * the picker (not a live surface — the picker is a transient dialog); the projector's ended-session
+     * guard is the authority, this is the UI-policy pre-filter over the existing [AnalyticsDao.sessionsBetween]
      * raw read (no new DAO query). No economy dependency, no new PII surface (session metadata only).
+     *
+     * **Ranked by distance to the session's [startedAt, endedAt] SPAN, not to its start instant** — a
+     * mid-dash-restart orphan completes hours INTO its real dash, so sorting on `abs(startedAt −
+     * completedAt)` would rank a short later dash above the long dash that actually contains the orphan.
+     * A completion inside the span scores 0 (the containing dash always wins); otherwise it scores the
+     * gap to the nearer endpoint. Tie-break by [startedAt] so the ordering is deterministic when two
+     * candidates are equidistant. `endedAt` is non-null here (the ENDED filter above ran first).
      */
     suspend fun candidateSessionsForOrphan(completedAt: Long, platform: Platform): List<SessionRecord> {
         val start = completedAt - CANDIDATE_WINDOW_MILLIS
@@ -369,7 +376,19 @@ class AnalyticsRepository @Inject constructor(
             .map { it.toDomain() }
             .filter { it.endedAt != null }
             .filter { platform == Platform.Unknown || it.platform == platform }
-            .sortedBy { kotlin.math.abs(it.startedAt - completedAt) }
+            .sortedWith(compareBy({ spanDistance(it, completedAt) }, { it.startedAt }))
+    }
+
+    /** Distance from [completedAt] to a session's `[startedAt, endedAt]` span: 0 when inside the span,
+     *  else the gap to the nearer endpoint. `endedAt` is non-null at every call site (ENDED-filtered). */
+    private fun spanDistance(session: SessionRecord, completedAt: Long): Long {
+        val startedAt = session.startedAt
+        val endedAt = session.endedAt ?: startedAt
+        return when {
+            completedAt < startedAt -> startedAt - completedAt
+            completedAt > endedAt -> completedAt - endedAt
+            else -> 0L
+        }
     }
 
     /**

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepository.kt
@@ -344,6 +344,35 @@ class AnalyticsRepository @Inject constructor(
         analyticsDao.deliveriesForSession(sessionId).map { rows -> rows.map { it.toDomain() } }
 
     /**
+     * The orphan "(No session)" deliveries for [period], newest first (#660 piece 2) — the categorize
+     * flow's list (the Money-tab callout opens it). Reactive: the list re-emits as the projector folds a
+     * `DELIVERY_SESSION_ASSIGN` (the tapped row leaves the bucket, no longer `sessionId IS NULL`). No new
+     * PII surface (store names are driver-owned; no customer hashes on [DeliveryRecord]).
+     */
+    fun noSessionDeliveries(period: AnalyticsPeriod): Flow<List<DeliveryRecord>> =
+        periodBoundariesFlow(period).flatMapLatest { (start, end) ->
+            analyticsDao.noSessionDeliveryRows(start, end).map { rows -> rows.map { it.toDomain() } }
+        }
+
+    /**
+     * The **candidate dashes** an orphan delivery could be categorized into (#660 piece 2): ENDED
+     * sessions within ±48 h of [completedAt], same [platform] (ALL platforms when the orphan's platform
+     * is [Platform.Unknown]), nearest-in-time first. A one-shot snapshot fetched when the driver opens the
+     * picker (not a live surface — the picker is a transient dialog); the projector's ended-session guard
+     * is the authority, this is the UI-policy pre-filter over the existing [AnalyticsDao.sessionsBetween]
+     * raw read (no new DAO query). No economy dependency, no new PII surface (session metadata only).
+     */
+    suspend fun candidateSessionsForOrphan(completedAt: Long, platform: Platform): List<SessionRecord> {
+        val start = completedAt - CANDIDATE_WINDOW_MILLIS
+        val end = completedAt + CANDIDATE_WINDOW_MILLIS
+        return analyticsDao.sessionsBetween(start, end)
+            .map { it.toDomain() }
+            .filter { it.endedAt != null }
+            .filter { platform == Platform.Unknown || it.platform == platform }
+            .sortedBy { kotlin.math.abs(it.startedAt - completedAt) }
+    }
+
+    /**
      * One dash fully expanded (#650 PR A drill-down): the session header + its deliveries in
      * completion order, as a [SessionDetail], or `null` when no session row exists for [sessionId]
      * (the dash was never recorded, or the projector wiped/rebuilt). Read-model only, reactive by
@@ -420,9 +449,12 @@ class AnalyticsRepository @Inject constructor(
         // callout on the Money tab. This mirrors the pre-existing net-side overlap (an orphan's frozen net
         // was always folded via [deliveryTotals], with the identical correlated-restart caveat) — it is
         // not a new class of bug, just newly visible on the gross side now that this bucket folds in. The
-        // real fix is #660 piece 2 (categorize an orphan delivery into its real session via a correction
-        // event), which removes the row from this bucket entirely rather than trying to detect the overlap
-        // here; until then this is a documented, desk-verifiable edge, not a defect to patch in piece 1.
+        // real fix SHIPPED as #660 piece 2 (`DELIVERY_SESSION_ASSIGN` — [CorrectionRepository.assignDeliverySession]
+        // → [AnalyticsProjector.applySessionAssign]): the driver categorizes the orphan into its real dash,
+        // which removes the row from this bucket entirely (its `sessionId` flips non-null) and heals the
+        // double-count via the existing session join, rather than trying to detect the overlap here. Until
+        // the driver categorizes a given orphan this fold remains a documented, desk-verifiable overstatement,
+        // not a defect to patch here (piece 1 kept it visible on purpose so the driver can act on it).
         val net = deliveryNet + unattributed + cash
         val hours = onlineMillis / 3_600_000.0
         return PeriodEconomics(
@@ -514,4 +546,9 @@ class AnalyticsRepository @Inject constructor(
         onTimeDeliveries = delivery.onTime,
         avgDeadlineMarginMillis = delivery.avgDeadlineMarginMillis,
     )
+
+    private companion object {
+        /** ±window around an orphan's `completedAt` for the #660 piece-2 categorize picker (48 h). */
+        private const val CANDIDATE_WINDOW_MILLIS = 48L * 60L * 60L * 1_000L
+    }
 }

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/CorrectionRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/CorrectionRepository.kt
@@ -4,6 +4,7 @@ import cloud.trotter.dashbuddy.core.data.event.AppEventRepo
 import cloud.trotter.dashbuddy.domain.model.event.AppEvent
 import cloud.trotter.dashbuddy.domain.model.event.AppEventType
 import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryAdjustmentPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.DeliverySessionAssignPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.ManualDeliveryPayload
 import timber.log.Timber
 import javax.inject.Inject
@@ -123,6 +124,44 @@ class CorrectionRepository @Inject constructor(
         )
         // P7: no note/store text — counts/ids only.
         Timber.tag(TAG).i("DELIVERY_ADJUSTMENT appended for delivery seq %d", targetEventSequenceId)
+    }
+
+    /**
+     * Append a driver session-(re)attribution of an orphan "(No session)" delivery (#660 piece 2).
+     * [targetEventSequenceId] is the PK of the target `delivery_record`; [newSessionId] is the dash to
+     * assign it to, or **null to UNASSIGN** it back to the "(No session)" bucket (the undo). The
+     * envelope `sessionId` = [newSessionId] (attribution/liveness only, the corrections convention). The
+     * projector applies the re-attribution — with its fail-closed guards (movable rows only, real ended
+     * target session, platform coherence, cash-bearing-unassign block) — on its next drain; the original
+     * event stays, and it re-prices NOTHING (attribution only).
+     *
+     * Validation is deliberately minimal (the projector guards are the authority, and the repository
+     * cannot see the read model, per the existing read/write split): a non-null [newSessionId] must be
+     * non-blank (a blank id would fold to a dangling attribution).
+     */
+    suspend fun assignDeliverySession(
+        targetEventSequenceId: Long,
+        newSessionId: String?,
+        note: String? = null,
+    ) {
+        require(newSessionId == null || newSessionId.isNotBlank()) { "newSessionId must be non-blank when assigning" }
+        appEventRepo.appendUserEvent(
+            AppEvent(
+                type = AppEventType.DELIVERY_SESSION_ASSIGN,
+                occurredAt = System.currentTimeMillis(),
+                sessionId = newSessionId,
+                payload = DeliverySessionAssignPayload(
+                    targetEventSequenceId = targetEventSequenceId,
+                    newSessionId = newSessionId,
+                    note = note,
+                ),
+            ),
+        )
+        // P7: no note text — counts/ids only.
+        Timber.tag(TAG).i(
+            "DELIVERY_SESSION_ASSIGN appended for delivery seq %d (assigned=%b)",
+            targetEventSequenceId, newSessionId != null,
+        )
     }
 
     private companion object {

--- a/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsDailyEarningsTest.kt
+++ b/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsDailyEarningsTest.kt
@@ -212,4 +212,28 @@ class AnalyticsDailyEarningsTest {
         assertEquals("Monday keeps its session gross", 20.0, days[0].gross, 1e-9)
         assertEquals("Wednesday gets the orphan delivery's own-day gross", 8.0, days[2].gross, 1e-9)
     }
+
+    /**
+     * #660 piece 2: once the driver categorizes the Wednesday orphan into the Monday dash
+     * (`DELIVERY_SESSION_ASSIGN` → the row carries `sessionId = "M"`), its gross moves OFF its own
+     * completion day and onto the session's start day — a midnight/day-spanning categorize lands the
+     * dollars with the rest of the dash (session-anchored, #655), no longer on the stray Wednesday bar.
+     */
+    @Test
+    fun `a categorized orphan's gross moves from its completion day to the session's start day (#660 piece 2)`() = runBlocking {
+        val base = weekStart()
+        // A real Monday dash whose delivered pay is captured session-tied (reported null → Σ delivered).
+        dao.upsertSession(session("M", base, reportedEarnings = null))
+        dao.upsertDelivery(delivery(1, "M", completedAt = base + hour, pay = 20.0))
+        // The former orphan, completing Wednesday, NOW categorized into the Monday dash (post-apply state).
+        val wednesday = Instant.ofEpochMilli(base).atZone(zone).toLocalDate().plusDays(2)
+        val wednesdayNoon = wednesday.atTime(12, 0).atZone(zone).toInstant().toEpochMilli()
+        dao.upsertDelivery(
+            delivery(99, sessionId = "M", completedAt = wednesdayNoon, pay = 8.0).copy(sessionAssigned = 1),
+        )
+
+        val days = repo.dailyEarnings(AnalyticsPeriod.THIS_WEEK, zone).first()
+        assertEquals("Monday now carries the whole dash: 20 + the categorized 8", 28.0, days[0].gross, 1e-9)
+        assertEquals("Wednesday no longer shows the orphan (it moved to the dash's start day)", 0.0, days[2].gross, 1e-9)
+    }
 }

--- a/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjectorTest.kt
+++ b/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjectorTest.kt
@@ -1114,7 +1114,12 @@ class AnalyticsProjectorTest {
         insert(AppEventType.DELIVERY_SESSION_ASSIGN, "S1", 6_000, DeliverySessionAssignPayload(orphanSeq, "S1"))
         insert(AppEventType.DELIVERY_SESSION_ASSIGN, null, 7_000, DeliverySessionAssignPayload(orphanSeq, null))
         insert(AppEventType.DELIVERY_SESSION_ASSIGN, "S2", 8_000, DeliverySessionAssignPayload(orphanSeq, "S2"))
-        projector().catchUp()
+        // Drain INCREMENTALLY (one event per batch, #660 review Fix 3) so each assign/unassign/re-assign
+        // hydrates from committed DB state — a real batch-boundary path. The prior single-drain
+        // "incremental" side was two identical from-zero folds and could not catch batch-boundary
+        // divergence at all.
+        val live = projector()
+        while (live.processBatch(limit = 1) != null) { /* one event at a time */ }
 
         val deliveriesBefore = analyticsDao.deliveriesBetween(Long.MIN_VALUE, Long.MAX_VALUE)
         val sessionsBefore = analyticsDao.sessionsBetween(Long.MIN_VALUE, Long.MAX_VALUE)
@@ -1128,6 +1133,58 @@ class AnalyticsProjectorTest {
             deliveriesBefore, analyticsDao.deliveriesBetween(Long.MIN_VALUE, Long.MAX_VALUE),
         )
         assertEquals(sessionsBefore, analyticsDao.sessionsBetween(Long.MIN_VALUE, Long.MAX_VALUE))
+    }
+
+    @Test
+    fun `an assigned orphan stays invisible to a later-batch correction's hydration (jobsCompleted determinism, #660)`() = runBlocking {
+        // #660 review Fix 1: after an orphan is categorized into ended S1, a LATER-batch correction that
+        // re-hydrates S1 must NOT count the assigned orphan's (distinct) job — jobsCompleted is
+        // deliveredJobIds.size, and hydrating it off the DB (which now shows the orphan session-bound)
+        // would inflate it and pass-through-upsert the inflated counter, diverging from a from-zero
+        // refold whose in-memory context (untouched by the assign fold) never sees the orphan. The
+        // sessionAssigned=0 filter on deliveredJobIdsInSession is the fix.
+        val machineSeq = seedCorrectableSession(sid = "S1", deliveryPay = 10.0, reportedEarnings = 20.0)
+        val orphanSeq = insertOrphanDelivery(pay = 8.0, jobId = "ORPHAN")
+        // Batch 1: fold the machine session + the orphan.
+        projector().catchUp()
+        assertEquals("S1 starts with exactly one machine job", 1, analyticsDao.sessionRecord("S1")!!.jobsCompleted)
+
+        // Batch 2 (separate drain): assign the orphan into ended S1 — commits sessionId + marker + the
+        // relative counter bump.
+        insert(
+            AppEventType.DELIVERY_SESSION_ASSIGN, "S1", 6_000,
+            DeliverySessionAssignPayload(targetEventSequenceId = orphanSeq, newSessionId = "S1"),
+        )
+        projector().catchUp()
+
+        // Batch 3 (separate drain): an innocuous note-only DELIVERY_ADJUSTMENT on an S1 MACHINE row
+        // re-hydrates the S1 context and pass-through-upserts it. The assigned orphan's job must stay
+        // out of the hydrated deliveredJobIds.
+        insert(
+            AppEventType.DELIVERY_ADJUSTMENT, "S1", 7_000,
+            DeliveryAdjustmentPayload(targetEventSequenceId = machineSeq, sessionId = "S1", note = "annotated"),
+        )
+        projector().catchUp()
+
+        assertEquals(
+            "a later-batch correction must not count the assigned orphan's job — jobsCompleted stays 1",
+            1, analyticsDao.sessionRecord("S1")!!.jobsCompleted,
+        )
+        // The delivery COUNTER still reflects the assigned orphan (the relative ±1 bump, not the
+        // distinct-job set) — the two are maintained independently.
+        assertEquals("the delivery counter still includes the assigned orphan", 2, analyticsDao.sessionRecord("S1")!!.deliveries)
+
+        // A from-zero refold (single drain; its in-memory context never sees the orphan) must reproduce
+        // byte-identical session + delivery rows — the equality that batch-boundary divergence breaks.
+        val sessionsBefore = analyticsDao.sessionsBetween(Long.MIN_VALUE, Long.MAX_VALUE)
+        val deliveriesBefore = analyticsDao.deliveriesBetween(Long.MIN_VALUE, Long.MAX_VALUE)
+        analyticsDao.setWatermark(AnalyticsProjectionStateEntity(watermarkSequenceId = 99, projectorVersion = 99))
+        projector().catchUp()
+        assertEquals(
+            "session rows rebuild byte-identically from the log (incremental ≡ refold)",
+            sessionsBefore, analyticsDao.sessionsBetween(Long.MIN_VALUE, Long.MAX_VALUE),
+        )
+        assertEquals(deliveriesBefore, analyticsDao.deliveriesBetween(Long.MIN_VALUE, Long.MAX_VALUE))
     }
 
     @Test

--- a/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjectorTest.kt
+++ b/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjectorTest.kt
@@ -20,6 +20,7 @@ import cloud.trotter.dashbuddy.domain.model.event.AppEventType
 import cloud.trotter.dashbuddy.domain.model.event.payload.AppEventPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryAdjustmentPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.DeliverySessionAssignPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.ManualDeliveryPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.OfferPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.PayAdjustmentPayload
@@ -903,6 +904,230 @@ class AnalyticsProjectorTest {
         analyticsDao.setWatermark(AnalyticsProjectionStateEntity(watermarkSequenceId = seq + 1, projectorVersion = 99))
         projector().catchUp()
         assertEquals("live == from-zero refold", liveRow, analyticsDao.deliveryRecord(seq))
+    }
+
+    // ── DELIVERY_SESSION_ASSIGN (#660 piece 2) ──────────────────────────
+
+    /** An orphan "(No session)" completion — a real DELIVERY_COMPLETED whose event carried no sessionId. */
+    private suspend fun insertOrphanDelivery(at: Long = 5_000, jobId: String = "ORPHAN", pay: Double = 8.0): Long =
+        insert(
+            AppEventType.DELIVERY_COMPLETED, sessionId = null, at = at,
+            DeliveryPayload(
+                jobId = jobId, taskId = "OT-$at", storeName = "Chipotle", customerHash = "co",
+                phaseStartedAt = at - 600, completedAt = at, totalPay = pay,
+            ),
+            odometer = null,
+        )
+
+    @Test
+    fun `a DELIVERY_SESSION_ASSIGN moves an orphan into its dash, bumps the counter, and touches no frozen column (#660)`() = runBlocking {
+        seedCorrectableSession(sid = "S1", deliveryPay = 10.0, reportedEarnings = 20.0) // S1 ends with 1 delivery
+        val orphanSeq = insertOrphanDelivery(pay = 8.0)
+        projector().catchUp()
+
+        val before = analyticsDao.deliveryRecord(orphanSeq)!!
+        assertNull("the orphan starts session-less", before.sessionId)
+        assertEquals(0, before.sessionAssigned)
+        assertEquals("S1 has its one machine delivery before the assign", 1, analyticsDao.sessionRecord("S1")!!.deliveries)
+
+        insert(
+            AppEventType.DELIVERY_SESSION_ASSIGN, "S1", 6_000,
+            DeliverySessionAssignPayload(targetEventSequenceId = orphanSeq, newSessionId = "S1", note = "was mine"),
+        )
+        projector().catchUp()
+
+        val after = analyticsDao.deliveryRecord(orphanSeq)!!
+        assertEquals("S1", after.sessionId)
+        assertEquals("the driver-assigned marker is set", 1, after.sessionAssigned)
+        assertEquals("session counter +1 (header/list agree)", 2, analyticsDao.sessionRecord("S1")!!.deliveries)
+        // Frozen economics byte-identical: ONLY sessionId + the marker changed.
+        assertEquals("attribution-only edit — every other column is byte-identical", before.copy(sessionId = "S1", sessionAssigned = 1), after)
+        assertEquals(before.realizedPay, after.realizedPay)
+        assertEquals(before.netProfit, after.netProfit)
+        assertEquals(before.payBasis, after.payBasis)
+        assertEquals(before.originalPayBasis, after.originalPayBasis)
+        assertEquals(before.frozenCostPerMile, after.frozenCostPerMile)
+        assertEquals(before.frozenFuelPerMile, after.frozenFuelPerMile)
+        assertEquals(before.frozenNonFuelPerMile, after.frozenNonFuelPerMile)
+        assertEquals(before.cashTip, after.cashTip)
+        assertEquals(before.storeKey, after.storeKey)
+    }
+
+    @Test
+    fun `assigning into a still-live session is skipped and the row is unchanged (ended-session guard, #660)`() = runBlocking {
+        // A LIVE session: DASH_START with no DASH_STOP.
+        insert(
+            AppEventType.DASH_START, "LIVE", 1_000,
+            SessionStartPayload("LIVE", Platform.DoorDash.name, 1_000, SessionStartSource.INTERACTION, "x"),
+            odometer = 100.0,
+        )
+        val orphanSeq = insertOrphanDelivery(at = 2_000)
+        projector().catchUp()
+        val before = analyticsDao.deliveryRecord(orphanSeq)!!
+
+        insert(
+            AppEventType.DELIVERY_SESSION_ASSIGN, "LIVE", 3_000,
+            DeliverySessionAssignPayload(targetEventSequenceId = orphanSeq, newSessionId = "LIVE"),
+        )
+        projector().catchUp() // must not throw
+
+        assertEquals("a live target session is refused — row untouched", before, analyticsDao.deliveryRecord(orphanSeq))
+        assertEquals("the watermark advanced past the skipped assign", 3L, analyticsDao.getWatermark()!!.watermarkSequenceId)
+    }
+
+    @Test
+    fun `assigning a missing target row is skipped without crashing (#660)`() = runBlocking {
+        seedCorrectableSession(sid = "S1")
+        projector().catchUp()
+
+        insert(
+            AppEventType.DELIVERY_SESSION_ASSIGN, "S1", 6_000,
+            DeliverySessionAssignPayload(targetEventSequenceId = 9_999, newSessionId = "S1"),
+        )
+        projector().catchUp() // must not throw
+        assertEquals("watermark advanced past the skipped assign", 5L, analyticsDao.getWatermark()!!.watermarkSequenceId)
+    }
+
+    @Test
+    fun `a machine-attributed sessionful row is never moved (movable-rows-only guard, #660)`() = runBlocking {
+        val machineSeq = seedCorrectableSession(sid = "S1", deliveryPay = 10.0) // its delivery is sessionful, sessionAssigned = 0
+        // A second ended dash to try to move it into.
+        seedCorrectableSession(sid = "S2", deliveryPay = 5.0)
+        projector().catchUp()
+        val before = analyticsDao.deliveryRecord(machineSeq)!!
+
+        insert(
+            AppEventType.DELIVERY_SESSION_ASSIGN, "S2", 7_000,
+            DeliverySessionAssignPayload(targetEventSequenceId = machineSeq, newSessionId = "S2"),
+        )
+        projector().catchUp() // must not throw
+
+        assertEquals("a machine-attributed row is never re-attributed", before, analyticsDao.deliveryRecord(machineSeq))
+        assertEquals("S1 still owns its one delivery", 1, analyticsDao.sessionRecord("S1")!!.deliveries)
+        assertEquals("S2's counter is unmoved", 1, analyticsDao.sessionRecord("S2")!!.deliveries)
+    }
+
+    @Test
+    fun `a platform-mismatched assign is skipped (platform-coherence guard, #660)`() = runBlocking {
+        // An Uber ended session.
+        insert(
+            AppEventType.DASH_START, "U1", 1_000,
+            SessionStartPayload("U1", Platform.Uber.name, 1_000, SessionStartSource.INTERACTION, "x"),
+        )
+        insert(
+            AppEventType.DASH_STOP, "U1", 2_000,
+            SessionStopPayload("U1", endedAt = 2_000, source = SessionEndSource.SUMMARY_SCREEN, totalEarnings = 10.0),
+        )
+        projector().catchUp()
+        // A movable (null-session) row that carries a KNOWN doordash platform — direct-seeded, since a
+        // genuine orphan folds Unknown; this exercises the defensive coherence backstop.
+        val row = DeliveryRecordEntity(
+            eventSequenceId = 500, sessionId = null, platform = "doordash", jobId = "J", taskId = "T",
+            storeName = "Wendys", customerHash = null, addressHash = null, phaseStartedAt = 1_500,
+            arrivedAt = null, completedAt = 1_800, deadlineMillis = null, realizedPay = 8.0,
+            payBasis = "RECEIPT_TOTAL", tip = null, basePay = null, odometerAtCompletion = null,
+            realizedMiles = null, realizedMinutes = null, frozenCostPerMile = null, netProfit = null,
+            costBasis = "NONE",
+        )
+        analyticsDao.upsertDelivery(row)
+
+        insert(
+            AppEventType.DELIVERY_SESSION_ASSIGN, "U1", 3_000,
+            DeliverySessionAssignPayload(targetEventSequenceId = 500, newSessionId = "U1"),
+        )
+        projector().catchUp() // must not throw
+
+        assertEquals("a doordash row is not moved into an uber dash", row, analyticsDao.deliveryRecord(500))
+    }
+
+    @Test
+    fun `a cash-bearing row cannot be unassigned (F3 sessionful-cash invariant, #660)`() = runBlocking {
+        seedCorrectableSession(sid = "S1")
+        projector().catchUp()
+        // An assigned, cash-bearing row (direct-seed: sessionAssigned = 1, cashTip set, session-bound).
+        val row = DeliveryRecordEntity(
+            eventSequenceId = 500, sessionId = "S1", platform = "doordash", jobId = "J", taskId = "T",
+            storeName = "Wendys", customerHash = null, addressHash = null, phaseStartedAt = 1_500,
+            arrivedAt = null, completedAt = 1_800, deadlineMillis = null, realizedPay = 8.0,
+            payBasis = "RECEIPT_TOTAL", tip = null, basePay = null, odometerAtCompletion = null,
+            realizedMiles = null, realizedMinutes = null, frozenCostPerMile = null, netProfit = null,
+            costBasis = "NONE", cashTip = 3.0, sessionAssigned = 1,
+        )
+        analyticsDao.upsertDelivery(row)
+
+        insert(
+            AppEventType.DELIVERY_SESSION_ASSIGN, null, 6_000,
+            DeliverySessionAssignPayload(targetEventSequenceId = 500, newSessionId = null),
+        )
+        projector().catchUp() // must not throw
+
+        assertEquals("a cash-bearing row is never unassigned back to the bucket", row, analyticsDao.deliveryRecord(500))
+    }
+
+    @Test
+    fun `assign then unassign returns the row to the bucket and restores the counter (undo, #660)`() = runBlocking {
+        seedCorrectableSession(sid = "S1", deliveryPay = 10.0)
+        val orphanSeq = insertOrphanDelivery(pay = 8.0)
+        insert(
+            AppEventType.DELIVERY_SESSION_ASSIGN, "S1", 6_000,
+            DeliverySessionAssignPayload(targetEventSequenceId = orphanSeq, newSessionId = "S1"),
+        )
+        insert(
+            AppEventType.DELIVERY_SESSION_ASSIGN, null, 7_000,
+            DeliverySessionAssignPayload(targetEventSequenceId = orphanSeq, newSessionId = null),
+        )
+        projector().catchUp()
+
+        val row = analyticsDao.deliveryRecord(orphanSeq)!!
+        assertNull("the row is back in the (No session) bucket", row.sessionId)
+        assertEquals("the marker is cleared", 0, row.sessionAssigned)
+        assertEquals("S1's counter is restored (+1 then −1)", 1, analyticsDao.sessionRecord("S1")!!.deliveries)
+    }
+
+    @Test
+    fun `an assign then a same-batch cash edit compose in log order (F3 sees the session, #660)`() = runBlocking {
+        seedCorrectableSession(sid = "S1")
+        projector().catchUp()
+        val orphanSeq = insertOrphanDelivery(pay = 8.0)
+        // Assign THEN a cash edit on the same row, both in ONE later batch.
+        insert(
+            AppEventType.DELIVERY_SESSION_ASSIGN, "S1", 6_000,
+            DeliverySessionAssignPayload(targetEventSequenceId = orphanSeq, newSessionId = "S1"),
+        )
+        insert(
+            AppEventType.DELIVERY_ADJUSTMENT, "S1", 6_100,
+            DeliveryAdjustmentPayload(targetEventSequenceId = orphanSeq, sessionId = "S1", newCashTip = 4.0),
+        )
+        projector().catchUp()
+
+        val row = analyticsDao.deliveryRecord(orphanSeq)!!
+        assertEquals("S1", row.sessionId)
+        assertEquals("the cash edit's F3 sessionful-check passes — assign committed first (log order)", 4.0, row.cashTip!!, 1e-9)
+    }
+
+    @Test
+    fun `wiping and refolding reproduces byte-identical rows across assign, unassign, and re-assign (#660 rebuild-faithful)`() = runBlocking {
+        seedCorrectableSession(sid = "S1", deliveryPay = 10.0, reportedEarnings = 20.0)
+        seedCorrectableSession(sid = "S2", deliveryPay = 5.0, reportedEarnings = 9.0)
+        val orphanSeq = insertOrphanDelivery(pay = 8.0)
+        // assign → unassign → re-assign to a DIFFERENT dash: the ±1 counters must telescope identically.
+        insert(AppEventType.DELIVERY_SESSION_ASSIGN, "S1", 6_000, DeliverySessionAssignPayload(orphanSeq, "S1"))
+        insert(AppEventType.DELIVERY_SESSION_ASSIGN, null, 7_000, DeliverySessionAssignPayload(orphanSeq, null))
+        insert(AppEventType.DELIVERY_SESSION_ASSIGN, "S2", 8_000, DeliverySessionAssignPayload(orphanSeq, "S2"))
+        projector().catchUp()
+
+        val deliveriesBefore = analyticsDao.deliveriesBetween(Long.MIN_VALUE, Long.MAX_VALUE)
+        val sessionsBefore = analyticsDao.sessionsBetween(Long.MIN_VALUE, Long.MAX_VALUE)
+
+        // Force a version-mismatch wipe + from-zero refold.
+        analyticsDao.setWatermark(AnalyticsProjectionStateEntity(watermarkSequenceId = 99, projectorVersion = 99))
+        projector().catchUp()
+
+        assertEquals(
+            "assign/unassign/re-assign rebuild byte-identically from the log",
+            deliveriesBefore, analyticsDao.deliveriesBetween(Long.MIN_VALUE, Long.MAX_VALUE),
+        )
+        assertEquals(sessionsBefore, analyticsDao.sessionsBetween(Long.MIN_VALUE, Long.MAX_VALUE))
     }
 
     @Test

--- a/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepositoryTest.kt
+++ b/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepositoryTest.kt
@@ -60,6 +60,7 @@ class AnalyticsRepositoryTest {
         completedAt: Long,
         platform: String = "doordash",
         cashTip: Double? = null,
+        sessionAssigned: Int = 0,
     ) = DeliveryRecordEntity(
         eventSequenceId = seq,
         sessionId = sessionId,
@@ -84,6 +85,7 @@ class AnalyticsRepositoryTest {
         netProfit = net,
         costBasis = "OFFER_FROZEN",
         cashTip = cashTip,
+        sessionAssigned = sessionAssigned,
     )
 
     private fun session(
@@ -459,34 +461,30 @@ class AnalyticsRepositoryTest {
     }
 
     /**
-     * #660 piece 1 CHARACTERIZATION (adjudicated, documented in [AnalyticsRepository.assemble]'s
-     * KDoc/comment): when the orphan's pay is semantically ALREADY INSIDE a surviving session's
-     * captured `reportedEarnings` — e.g. a mid-dash accessibility-service restart drops this one
-     * delivery's `sessionId`, but the dash's summary screen still gets captured afterward and its
-     * `reportedEarnings` already reflects that delivery's pay — piece 1 has no way to detect the
-     * overlap (the two source queries are structurally disjoint, by design, per the test above) and
-     * so it double-counts: those same 8 dollars land in BOTH the session's own gross-vs-delivered
-     * unattributed delta AND the "(No session)" bucket. This pins that CURRENT, KNOWN behavior
-     * on purpose — it is the seam #660 piece 2 (categorize an orphan into its real session) is
-     * scoped to close. When piece 2 lands, this exact test SHOULD go red (gross should drop to
-     * 100.0 once the orphan is categorized away rather than double-added) — that failure is the
-     * signal piece 2 shipped correctly, not a regression to chase.
+     * #660 piece 2 (the resolved state the piece-1 characterization pinned as red): when the orphan's
+     * pay was semantically ALREADY INSIDE a surviving session's captured `reportedEarnings` — a mid-dash
+     * accessibility-service restart drops this one delivery's `sessionId`, but the dash's summary screen
+     * still gets captured afterward and its `reportedEarnings` already reflects that delivery's pay — the
+     * driver categorizes the orphan into its real dash (`DELIVERY_SESSION_ASSIGN`). The projector's apply
+     * leaves the row with `sessionId = "S1"` + `sessionAssigned = 1` (this is that post-apply state at the
+     * repository level). The double-count HEALS: the row re-enters S1's `GROUP BY sessionId` reconciliation,
+     * gross drops from the piece-1 108.0 to 100.0 (reported-authoritative, no double-add), unattributed
+     * shrinks to 0 (92 + 8 delivered = 100 reported), and the "(No session)" bucket empties. Frozen
+     * economics are untouched — only attribution changed.
      */
     @Test
-    fun `CHARACTERIZATION - correlated orphan double-counts into gross until piece 2 lands (#660)`() = runBlocking {
-        // S1 reported 100, but only 92 of that is captured as session-tied delivered pay (unattributed
-        // = 8) — the missing 8 is semantically the SAME delivery re-appearing below as a null-session
-        // orphan (a restart mid-dash lost its sessionId after the summary screen already saw its pay).
-        dao.upsertSession(session("S1", base, reportedEarnings = 100.0, durationMillis = hour, startOdo = 0.0, lastOdo = 10.0, deliveries = 1, jobsCompleted = 1))
+    fun `correlated orphan reconciles into its session once categorized (#660 piece 2)`() = runBlocking {
+        // S1 reported 100; 92 captured session-tied, and the previously-orphan 8 now categorized into S1.
+        dao.upsertSession(session("S1", base, reportedEarnings = 100.0, durationMillis = hour, startOdo = 0.0, lastOdo = 10.0, deliveries = 2, jobsCompleted = 1))
         dao.upsertDelivery(delivery(1, "S1", "J1", "Wendys", pay = 92.0, net = 80.0, completedAt = base + hour))
-        // The correlated orphan: pay 8, no sessionId — its dollars are ALREADY inside S1's reported 100.
-        dao.upsertDelivery(delivery(2, sessionId = null, jobId = "J1", storeName = "Wendys", pay = 8.0, net = 6.0, completedAt = base + 90 * 60_000))
+        // The orphan AS THE APPLY LEAVES IT: assigned to S1, marker set — no longer sessionId IS NULL.
+        dao.upsertDelivery(delivery(2, sessionId = "S1", jobId = "J1", storeName = "Wendys", pay = 8.0, net = 6.0, completedAt = base + 90 * 60_000, sessionAssigned = 1))
 
         val eco = repo.periodEconomics(AnalyticsPeriod.LIFETIME).first()
-        // CURRENT (documented) behavior: gross = reported 100 + the orphan's own 8 = 108 (double-counted).
-        assertEquals("pins the documented double-count: 100 (reported, already incl. the 8) + 8 (orphan) = 108", 108.0, eco.grossEarnings, 1e-9)
-        assertEquals("unattributed = reported 100 minus session-tied delivered 92", 8.0, eco.unattributedPay, 1e-9)
-        assertEquals("the (No session) bucket still surfaces its own 8, as designed", 8.0, eco.noSessionPay, 1e-9)
+        assertEquals("gross = reported 100 (the 8 is now inside S1's reconciliation, no double-add)", 100.0, eco.grossEarnings, 1e-9)
+        assertEquals("unattributed = reported 100 minus session-tied delivered 100 = 0 (double-count healed)", 0.0, eco.unattributedPay, 1e-9)
+        assertEquals("the (No session) bucket is emptied", 0.0, eco.noSessionPay, 1e-9)
+        assertEquals("no orphan deliveries remain in the bucket", 0, eco.noSessionDeliveries)
     }
 
     /**

--- a/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepositoryTest.kt
+++ b/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsRepositoryTest.kt
@@ -535,4 +535,24 @@ class AnalyticsRepositoryTest {
         val eco = repo.periodEconomics(AnalyticsPeriod.LIFETIME).first()
         assertEquals("overAttributed compares cash-free delivered pay: 18 − 10 = 8, cash never counted", 8.0, eco.overAttributedPay, 1e-9)
     }
+
+    /**
+     * #660 review Fix 4: a mid-dash-restart orphan completes hours INTO the dash that contains it, so
+     * the candidate picker must rank by distance to the session SPAN — the containing dash first — not
+     * by distance to its start instant (which would rank a short LATER dash above the one it belongs to).
+     */
+    @Test
+    fun `candidateSessionsForOrphan ranks the containing dash first, not the nearest-start dash (span sort, #660)`() = runBlocking {
+        // Dash A: 9am → 3pm (a long dash). Dash B: starts 4pm (a short later dash).
+        dao.upsertSession(session("A", base, reportedEarnings = 60.0, durationMillis = 6 * hour, startOdo = 0.0, lastOdo = 40.0, deliveries = 5, jobsCompleted = 5))
+        dao.upsertSession(session("B", base + 7 * hour, reportedEarnings = 12.0, durationMillis = hour, startOdo = 0.0, lastOdo = 6.0, deliveries = 1, jobsCompleted = 1))
+
+        // The orphan completes at 2:50pm — INSIDE A's span, but closer to B's START instant.
+        val orphanCompletedAt = base + 5 * hour + 50 * 60_000L
+        val candidates = repo.candidateSessionsForOrphan(orphanCompletedAt, cloud.trotter.dashbuddy.domain.state.Platform.DoorDash)
+
+        assertEquals("both ended dashes are candidates", 2, candidates.size)
+        assertEquals("the dash whose span CONTAINS the orphan ranks first (span distance 0)", "A", candidates[0].sessionId)
+        assertEquals("B", candidates[1].sessionId)
+    }
 }

--- a/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/CorrectionRepositoryTest.kt
+++ b/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/CorrectionRepositoryTest.kt
@@ -2,12 +2,17 @@ package cloud.trotter.dashbuddy.core.data.analytics
 
 import cloud.trotter.dashbuddy.core.data.analytics.CorrectionRepository
 import cloud.trotter.dashbuddy.core.data.event.AppEventRepo
+import cloud.trotter.dashbuddy.domain.model.event.AppEventType
+import cloud.trotter.dashbuddy.domain.model.event.payload.DeliverySessionAssignPayload
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertThrows
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
@@ -67,6 +72,45 @@ class CorrectionRepositoryTest {
         repo.adjustDelivery(targetEventSequenceId = 1L, sessionId = "S1", note = "just a note")
         repo.adjust(newPay = 12.0, newTip = 0.0, newCashTip = 0.0, newMiles = 0.0)
         verify(appEventRepo, times(2)).appendUserEvent(any(), anyOrNull())
+    }
+
+    // ── assignDeliverySession (#660 piece 2) ────────────────────────────
+
+    @Test
+    fun `assignDeliverySession appends the assign event with envelope sessionId == newSessionId`() = runTest {
+        repo.assignDeliverySession(targetEventSequenceId = 42L, newSessionId = "S1", note = "was mine")
+
+        val captor = argumentCaptor<cloud.trotter.dashbuddy.domain.model.event.AppEvent>()
+        verify(appEventRepo).appendUserEvent(captor.capture(), anyOrNull())
+        val event = captor.firstValue
+        assertEquals(AppEventType.DELIVERY_SESSION_ASSIGN, event.type)
+        assertEquals("envelope sessionId == newSessionId (attribution/liveness convention)", "S1", event.sessionId)
+        val payload = event.payload as DeliverySessionAssignPayload
+        assertEquals(42L, payload.targetEventSequenceId)
+        assertEquals("S1", payload.newSessionId)
+        assertEquals("note passes through", "was mine", payload.note)
+    }
+
+    @Test
+    fun `assignDeliverySession with a null newSessionId is the unassign (undo) — envelope sessionId null`() = runTest {
+        repo.assignDeliverySession(targetEventSequenceId = 7L, newSessionId = null)
+
+        val captor = argumentCaptor<cloud.trotter.dashbuddy.domain.model.event.AppEvent>()
+        verify(appEventRepo).appendUserEvent(captor.capture(), anyOrNull())
+        val event = captor.firstValue
+        assertNull("unassign carries a null envelope sessionId", event.sessionId)
+        val payload = event.payload as DeliverySessionAssignPayload
+        assertEquals(7L, payload.targetEventSequenceId)
+        assertNull(payload.newSessionId)
+        assertNull(payload.note)
+    }
+
+    @Test
+    fun `assignDeliverySession rejects a blank (non-null) newSessionId and appends nothing`() = runTest {
+        assertThrows(IllegalArgumentException::class.java) {
+            runBlocking { repo.assignDeliverySession(targetEventSequenceId = 1L, newSessionId = "   ") }
+        }
+        verify(appEventRepo, never()).appendUserEvent(any(), anyOrNull())
     }
 
     @Test

--- a/core/database/schemas/cloud.trotter.dashbuddy.core.database.DashBuddyDatabase/14.json
+++ b/core/database/schemas/cloud.trotter.dashbuddy.core.database.DashBuddyDatabase/14.json
@@ -1,0 +1,1125 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 14,
+    "identityHash": "53e7fca9f89d98dedf0068d0905a23b9",
+    "entities": [
+      {
+        "tableName": "app_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sequenceId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `aggregateId` TEXT, `eventType` TEXT NOT NULL, `eventPayload` TEXT NOT NULL, `occurredAt` INTEGER NOT NULL, `metadata` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "sequenceId",
+            "columnName": "sequenceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "aggregateId",
+            "columnName": "aggregateId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "eventType",
+            "columnName": "eventType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventPayload",
+            "columnName": "eventPayload",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "occurredAt",
+            "columnName": "occurredAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadata",
+            "columnName": "metadata",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "sequenceId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_app_events_aggregateId",
+            "unique": false,
+            "columnNames": [
+              "aggregateId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_app_events_aggregateId` ON `${TABLE_NAME}` (`aggregateId`)"
+          },
+          {
+            "name": "index_app_events_eventType",
+            "unique": false,
+            "columnNames": [
+              "eventType"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_app_events_eventType` ON `${TABLE_NAME}` (`eventType`)"
+          },
+          {
+            "name": "index_app_events_occurredAt",
+            "unique": false,
+            "columnNames": [
+              "occurredAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_app_events_occurredAt` ON `${TABLE_NAME}` (`occurredAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "app_state_snapshots",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`correlationVersion` INTEGER NOT NULL, `capturedAt` INTEGER NOT NULL, `sessionId` TEXT, `stateJson` TEXT NOT NULL, PRIMARY KEY(`correlationVersion`))",
+        "fields": [
+          {
+            "fieldPath": "correlationVersion",
+            "columnName": "correlationVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "capturedAt",
+            "columnName": "capturedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "stateJson",
+            "columnName": "stateJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "correlationVersion"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `dashId` TEXT, `text` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `personaType` TEXT NOT NULL, `personaName` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dashId",
+            "columnName": "dashId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personaType",
+            "columnName": "personaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personaName",
+            "columnName": "personaName",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_messages_dashId",
+            "unique": false,
+            "columnNames": [
+              "dashId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_messages_dashId` ON `${TABLE_NAME}` (`dashId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "effects_fired",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `effectKey` TEXT NOT NULL, `firedAt` INTEGER NOT NULL, `correlationVersion` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "effectKey",
+            "columnName": "effectKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firedAt",
+            "columnName": "firedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "correlationVersion",
+            "columnName": "correlationVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_effects_fired_effectKey",
+            "unique": true,
+            "columnNames": [
+              "effectKey"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_effects_fired_effectKey` ON `${TABLE_NAME}` (`effectKey`)"
+          }
+        ]
+      },
+      {
+        "tableName": "observations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sequenceId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `occurredAt` INTEGER NOT NULL, `sessionId` TEXT, `pipelineId` TEXT NOT NULL, `ruleId` TEXT, `platform` TEXT, `flow` TEXT, `modeHint` TEXT, `parsedJson` TEXT NOT NULL, `captureId` TEXT, `metadataJson` TEXT NOT NULL, `correlationVersion` INTEGER NOT NULL, `timeoutType` TEXT, `payloadJson` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "sequenceId",
+            "columnName": "sequenceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "occurredAt",
+            "columnName": "occurredAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pipelineId",
+            "columnName": "pipelineId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ruleId",
+            "columnName": "ruleId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "flow",
+            "columnName": "flow",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "modeHint",
+            "columnName": "modeHint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "parsedJson",
+            "columnName": "parsedJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "captureId",
+            "columnName": "captureId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "metadataJson",
+            "columnName": "metadataJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "correlationVersion",
+            "columnName": "correlationVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeoutType",
+            "columnName": "timeoutType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "payloadJson",
+            "columnName": "payloadJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "sequenceId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_observations_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_observations_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          },
+          {
+            "name": "index_observations_occurredAt",
+            "unique": false,
+            "columnNames": [
+              "occurredAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_observations_occurredAt` ON `${TABLE_NAME}` (`occurredAt`)"
+          },
+          {
+            "name": "index_observations_correlationVersion",
+            "unique": false,
+            "columnNames": [
+              "correlationVersion"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_observations_correlationVersion` ON `${TABLE_NAME}` (`correlationVersion`)"
+          }
+        ]
+      },
+      {
+        "tableName": "delivery_records",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`eventSequenceId` INTEGER NOT NULL, `sessionId` TEXT, `platform` TEXT NOT NULL, `jobId` TEXT NOT NULL, `taskId` TEXT NOT NULL, `storeName` TEXT, `customerHash` TEXT, `addressHash` TEXT, `phaseStartedAt` INTEGER NOT NULL, `arrivedAt` INTEGER, `completedAt` INTEGER NOT NULL, `deadlineMillis` INTEGER, `realizedPay` REAL, `payBasis` TEXT NOT NULL, `tip` REAL, `basePay` REAL, `odometerAtCompletion` REAL, `realizedMiles` REAL, `realizedMinutes` REAL, `frozenCostPerMile` REAL, `frozenFuelPerMile` REAL, `frozenNonFuelPerMile` REAL, `netProfit` REAL, `costBasis` TEXT NOT NULL, `cashTip` REAL, `originalPayBasis` TEXT, `storeKey` TEXT, `payoutStoreForms` TEXT, `storeKeyPinned` INTEGER NOT NULL DEFAULT 0, `milesToStore` REAL, `milesToDropoff` REAL, `sessionAssigned` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`eventSequenceId`))",
+        "fields": [
+          {
+            "fieldPath": "eventSequenceId",
+            "columnName": "eventSequenceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jobId",
+            "columnName": "jobId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "taskId",
+            "columnName": "taskId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storeName",
+            "columnName": "storeName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customerHash",
+            "columnName": "customerHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addressHash",
+            "columnName": "addressHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "phaseStartedAt",
+            "columnName": "phaseStartedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "arrivedAt",
+            "columnName": "arrivedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deadlineMillis",
+            "columnName": "deadlineMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "realizedPay",
+            "columnName": "realizedPay",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "payBasis",
+            "columnName": "payBasis",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tip",
+            "columnName": "tip",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "basePay",
+            "columnName": "basePay",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "odometerAtCompletion",
+            "columnName": "odometerAtCompletion",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "realizedMiles",
+            "columnName": "realizedMiles",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "realizedMinutes",
+            "columnName": "realizedMinutes",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "frozenCostPerMile",
+            "columnName": "frozenCostPerMile",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "frozenFuelPerMile",
+            "columnName": "frozenFuelPerMile",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "frozenNonFuelPerMile",
+            "columnName": "frozenNonFuelPerMile",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "netProfit",
+            "columnName": "netProfit",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "costBasis",
+            "columnName": "costBasis",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cashTip",
+            "columnName": "cashTip",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "originalPayBasis",
+            "columnName": "originalPayBasis",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "storeKey",
+            "columnName": "storeKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "payoutStoreForms",
+            "columnName": "payoutStoreForms",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "storeKeyPinned",
+            "columnName": "storeKeyPinned",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "milesToStore",
+            "columnName": "milesToStore",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "milesToDropoff",
+            "columnName": "milesToDropoff",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "sessionAssigned",
+            "columnName": "sessionAssigned",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "eventSequenceId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_delivery_records_completedAt",
+            "unique": false,
+            "columnNames": [
+              "completedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_delivery_records_completedAt` ON `${TABLE_NAME}` (`completedAt`)"
+          },
+          {
+            "name": "index_delivery_records_platform_completedAt",
+            "unique": false,
+            "columnNames": [
+              "platform",
+              "completedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_delivery_records_platform_completedAt` ON `${TABLE_NAME}` (`platform`, `completedAt`)"
+          },
+          {
+            "name": "index_delivery_records_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_delivery_records_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          },
+          {
+            "name": "index_delivery_records_sessionId_jobId",
+            "unique": false,
+            "columnNames": [
+              "sessionId",
+              "jobId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_delivery_records_sessionId_jobId` ON `${TABLE_NAME}` (`sessionId`, `jobId`)"
+          },
+          {
+            "name": "index_delivery_records_jobId",
+            "unique": false,
+            "columnNames": [
+              "jobId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_delivery_records_jobId` ON `${TABLE_NAME}` (`jobId`)"
+          },
+          {
+            "name": "index_delivery_records_storeName",
+            "unique": false,
+            "columnNames": [
+              "storeName"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_delivery_records_storeName` ON `${TABLE_NAME}` (`storeName`)"
+          },
+          {
+            "name": "index_delivery_records_storeKey",
+            "unique": false,
+            "columnNames": [
+              "storeKey"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_delivery_records_storeKey` ON `${TABLE_NAME}` (`storeKey`)"
+          }
+        ]
+      },
+      {
+        "tableName": "session_records",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sessionId` TEXT NOT NULL, `platform` TEXT NOT NULL, `startedAt` INTEGER NOT NULL, `endedAt` INTEGER, `lastEventAt` INTEGER NOT NULL, `endSource` TEXT, `startSource` TEXT, `startOdometer` REAL, `lastOdometer` REAL, `reportedEarnings` REAL, `reportedDurationMillis` INTEGER, `offersReceived` INTEGER NOT NULL, `offersAccepted` INTEGER NOT NULL, `offersDeclined` INTEGER NOT NULL, `offersTimeout` INTEGER NOT NULL, `deliveries` INTEGER NOT NULL, `jobsCompleted` INTEGER NOT NULL, `legStateJson` TEXT, PRIMARY KEY(`sessionId`))",
+        "fields": [
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "startedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endedAt",
+            "columnName": "endedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastEventAt",
+            "columnName": "lastEventAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endSource",
+            "columnName": "endSource",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "startSource",
+            "columnName": "startSource",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "startOdometer",
+            "columnName": "startOdometer",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "lastOdometer",
+            "columnName": "lastOdometer",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "reportedEarnings",
+            "columnName": "reportedEarnings",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "reportedDurationMillis",
+            "columnName": "reportedDurationMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "offersReceived",
+            "columnName": "offersReceived",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "offersAccepted",
+            "columnName": "offersAccepted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "offersDeclined",
+            "columnName": "offersDeclined",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "offersTimeout",
+            "columnName": "offersTimeout",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deliveries",
+            "columnName": "deliveries",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jobsCompleted",
+            "columnName": "jobsCompleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "legStateJson",
+            "columnName": "legStateJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sessionId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_session_records_startedAt",
+            "unique": false,
+            "columnNames": [
+              "startedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_session_records_startedAt` ON `${TABLE_NAME}` (`startedAt`)"
+          },
+          {
+            "name": "index_session_records_platform_startedAt",
+            "unique": false,
+            "columnNames": [
+              "platform",
+              "startedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_session_records_platform_startedAt` ON `${TABLE_NAME}` (`platform`, `startedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "offer_records",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`eventSequenceId` INTEGER NOT NULL, `sessionId` TEXT, `platform` TEXT NOT NULL, `offerHash` TEXT NOT NULL, `outcome` TEXT NOT NULL, `presentedAt` INTEGER NOT NULL, `decidedAt` INTEGER NOT NULL, `payAmount` REAL, `distanceMiles` REAL, `itemCount` INTEGER NOT NULL, `merchantName` TEXT, `score` REAL, `action` TEXT, `quality` TEXT, `estNetPay` REAL, `estDollarsPerHour` REAL, `estDollarsPerMile` REAL, `estTimeMinutes` REAL, `estOperatingCostPerMile` REAL, `estFuelPerMile` REAL, `estNonFuelPerMile` REAL, `storeKey` TEXT, `linkedJobId` TEXT, PRIMARY KEY(`eventSequenceId`))",
+        "fields": [
+          {
+            "fieldPath": "eventSequenceId",
+            "columnName": "eventSequenceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "offerHash",
+            "columnName": "offerHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "outcome",
+            "columnName": "outcome",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "presentedAt",
+            "columnName": "presentedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "decidedAt",
+            "columnName": "decidedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payAmount",
+            "columnName": "payAmount",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "distanceMiles",
+            "columnName": "distanceMiles",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "itemCount",
+            "columnName": "itemCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchantName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "action",
+            "columnName": "action",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "quality",
+            "columnName": "quality",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "estNetPay",
+            "columnName": "estNetPay",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "estDollarsPerHour",
+            "columnName": "estDollarsPerHour",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "estDollarsPerMile",
+            "columnName": "estDollarsPerMile",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "estTimeMinutes",
+            "columnName": "estTimeMinutes",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "estOperatingCostPerMile",
+            "columnName": "estOperatingCostPerMile",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "estFuelPerMile",
+            "columnName": "estFuelPerMile",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "estNonFuelPerMile",
+            "columnName": "estNonFuelPerMile",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "storeKey",
+            "columnName": "storeKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "linkedJobId",
+            "columnName": "linkedJobId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "eventSequenceId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_offer_records_decidedAt",
+            "unique": false,
+            "columnNames": [
+              "decidedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offer_records_decidedAt` ON `${TABLE_NAME}` (`decidedAt`)"
+          },
+          {
+            "name": "index_offer_records_platform_decidedAt",
+            "unique": false,
+            "columnNames": [
+              "platform",
+              "decidedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offer_records_platform_decidedAt` ON `${TABLE_NAME}` (`platform`, `decidedAt`)"
+          },
+          {
+            "name": "index_offer_records_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offer_records_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          },
+          {
+            "name": "index_offer_records_offerHash",
+            "unique": false,
+            "columnNames": [
+              "offerHash"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offer_records_offerHash` ON `${TABLE_NAME}` (`offerHash`)"
+          },
+          {
+            "name": "index_offer_records_linkedJobId",
+            "unique": false,
+            "columnNames": [
+              "linkedJobId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offer_records_linkedJobId` ON `${TABLE_NAME}` (`linkedJobId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "analytics_projection_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `watermarkSequenceId` INTEGER NOT NULL, `projectorVersion` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "watermarkSequenceId",
+            "columnName": "watermarkSequenceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "projectorVersion",
+            "columnName": "projectorVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "stores",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storeKey` TEXT NOT NULL, `platform` TEXT NOT NULL, `normalizedChain` TEXT NOT NULL, `chainDisplay` TEXT NOT NULL, `runningKey` TEXT, `offerNameForm` TEXT, `pickupNameForm` TEXT, `payoutNameForm` TEXT, `address` TEXT, PRIMARY KEY(`storeKey`))",
+        "fields": [
+          {
+            "fieldPath": "storeKey",
+            "columnName": "storeKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "normalizedChain",
+            "columnName": "normalizedChain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chainDisplay",
+            "columnName": "chainDisplay",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "runningKey",
+            "columnName": "runningKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "offerNameForm",
+            "columnName": "offerNameForm",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pickupNameForm",
+            "columnName": "pickupNameForm",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "payoutNameForm",
+            "columnName": "payoutNameForm",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storeKey"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_stores_normalizedChain",
+            "unique": false,
+            "columnNames": [
+              "normalizedChain"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_stores_normalizedChain` ON `${TABLE_NAME}` (`normalizedChain`)"
+          }
+        ]
+      },
+      {
+        "tableName": "pickup_records",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`eventSequenceId` INTEGER NOT NULL, `sessionId` TEXT, `platform` TEXT NOT NULL, `jobId` TEXT NOT NULL, `taskId` TEXT NOT NULL, `storeName` TEXT NOT NULL, `storeKey` TEXT, `phaseStartedAt` INTEGER NOT NULL, `arrivedAt` INTEGER, `confirmedAt` INTEGER, `deadlineMillis` INTEGER, `activity` TEXT, `storeAddress` TEXT, PRIMARY KEY(`eventSequenceId`))",
+        "fields": [
+          {
+            "fieldPath": "eventSequenceId",
+            "columnName": "eventSequenceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jobId",
+            "columnName": "jobId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "taskId",
+            "columnName": "taskId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storeName",
+            "columnName": "storeName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storeKey",
+            "columnName": "storeKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "phaseStartedAt",
+            "columnName": "phaseStartedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "arrivedAt",
+            "columnName": "arrivedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "confirmedAt",
+            "columnName": "confirmedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "deadlineMillis",
+            "columnName": "deadlineMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "activity",
+            "columnName": "activity",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "storeAddress",
+            "columnName": "storeAddress",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "eventSequenceId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_pickup_records_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_pickup_records_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          },
+          {
+            "name": "index_pickup_records_jobId",
+            "unique": false,
+            "columnNames": [
+              "jobId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_pickup_records_jobId` ON `${TABLE_NAME}` (`jobId`)"
+          },
+          {
+            "name": "index_pickup_records_storeKey",
+            "unique": false,
+            "columnNames": [
+              "storeKey"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_pickup_records_storeKey` ON `${TABLE_NAME}` (`storeKey`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '53e7fca9f89d98dedf0068d0905a23b9')"
+    ]
+  }
+}

--- a/core/database/src/androidTest/java/cloud/trotter/dashbuddy/core/database/AnalyticsMigration13to14Test.kt
+++ b/core/database/src/androidTest/java/cloud/trotter/dashbuddy/core/database/AnalyticsMigration13to14Test.kt
@@ -1,0 +1,80 @@
+package cloud.trotter.dashbuddy.core.database
+
+import androidx.room.testing.MigrationTestHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * #660 piece 2 — execute the REAL committed `AutoMigration(13→14)` against a **populated** v13 database
+ * and prove it is additive-only: the pre-existing analytics rows survive, and the one new
+ * nullable-defaulted column (delivery_records.sessionAssigned) is present and DEFAULT 0 on existing
+ * rows (there is NO `PROJECTOR_VERSION` bump — a fresh drain folds new `DELIVERY_SESSION_ASSIGN`
+ * events; nothing needs refolding).
+ *
+ * Instrumented (androidTest) because [MigrationTestHelper] opens an on-disk SQLite DB via the
+ * framework factory and replays the exported schema JSONs. Runs under
+ * `:core:database:connectedAndroidTest` — it does NOT gate unit-only PR CI (the unit-level
+ * [SchemaVersionGuardTest] is the CI-gating guard); needs one device/emulator run before merge (three
+ * are now pending a device pass: v11→v12, v12→v13, v13→v14).
+ */
+@RunWith(AndroidJUnit4::class)
+class AnalyticsMigration13to14Test {
+
+    private val dbName = "migration-13-to-14-test"
+
+    @get:Rule
+    val helper = MigrationTestHelper(
+        InstrumentationRegistry.getInstrumentation(),
+        DashBuddyDatabase::class.java,
+        emptyList(),
+        FrameworkSQLiteOpenHelperFactory(),
+    )
+
+    @Test
+    fun migrate13To14_preservesRows_addsSessionAssignedColumnDefaultZero() {
+        helper.createDatabase(dbName, 13).use { db ->
+            db.execSQL(
+                """INSERT INTO delivery_records
+                   (eventSequenceId, sessionId, platform, jobId, taskId, storeName, customerHash,
+                    addressHash, phaseStartedAt, arrivedAt, completedAt, deadlineMillis, realizedPay,
+                    payBasis, tip, basePay, odometerAtCompletion, realizedMiles, realizedMinutes,
+                    frozenCostPerMile, frozenFuelPerMile, frozenNonFuelPerMile, netProfit, costBasis,
+                    cashTip, originalPayBasis, storeKey, payoutStoreForms, storeKeyPinned,
+                    milesToStore, milesToDropoff)
+                   VALUES (1, NULL, 'doordash', 'J1', 'T1', 'Target', 'ch', 'ah', 100, NULL, 3000,
+                           NULL, 10.0, 'RECEIPT_TOTAL', NULL, NULL, 105.0, 5.0, 1.0, 0.25, 0.10, 0.15,
+                           8.75, 'OFFER_FROZEN', NULL, 'RECEIPT_TOTAL', 'doordash|target|1', 0,
+                           NULL, NULL)""",
+            )
+            db.execSQL(
+                """INSERT INTO session_records
+                   (sessionId, platform, startedAt, endedAt, lastEventAt, endSource, startSource,
+                    startOdometer, lastOdometer, reportedEarnings, reportedDurationMillis, offersReceived,
+                    offersAccepted, offersDeclined, offersTimeout, deliveries, jobsCompleted, legStateJson)
+                   VALUES ('S1', 'doordash', 1000, 5000, 5000, 'summary_screen', 'interaction', 100.0,
+                           110.0, 25.0, 4000, 1, 1, 0, 0, 1, 1, NULL)""",
+            )
+        }
+
+        val db = helper.runMigrationsAndValidate(dbName, 14, true)
+
+        // Pre-existing rows survived (additive-only).
+        db.query("SELECT COUNT(*) FROM delivery_records").use { c ->
+            c.moveToFirst(); assertEquals(1, c.getInt(0))
+        }
+        db.query("SELECT COUNT(*) FROM session_records").use { c ->
+            c.moveToFirst(); assertEquals(1, c.getInt(0))
+        }
+        // New sessionAssigned column exists and is 0 (DEFAULT) on the pre-existing row.
+        db.query("SELECT sessionAssigned FROM delivery_records WHERE eventSequenceId = 1").use { c ->
+            c.moveToFirst()
+            assertEquals("sessionAssigned DEFAULT 0 post-migration", 0, c.getInt(0))
+        }
+        db.close()
+    }
+}

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/DashBuddyDatabase.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/DashBuddyDatabase.kt
@@ -71,12 +71,19 @@ import cloud.trotter.dashbuddy.core.database.snapshot.AppStateSnapshotEntity
     // metadata.odometer stamps (already in the immutable log) into per-drop milesToStore/milesToDropoff
     // + redistributed realizedMiles/netProfit on stacked drops. Additive ⇒ never wipes app_events or
     // the existing analytics rows.
+    // v13→v14 (#660 piece 2) is additive-only: one new nullable-defaulted INTEGER column on
+    // delivery_records (sessionAssigned — the driver-attribution marker set by DELIVERY_SESSION_ASSIGN,
+    // DEFAULT 0 back-fills existing rows). There is NO `PROJECTOR_VERSION` bump: DELIVERY_SESSION_ASSIGN
+    // is a new event type that cannot exist in already-folded history, and the DEFAULT 0 is correct for
+    // all history — a fresh drain folds new assigns; nothing needs refolding. Additive ⇒ never wipes
+    // app_events or the existing analytics rows.
     autoMigrations = [
         AutoMigration(from = 8, to = 9),
         AutoMigration(from = 9, to = 10),
         AutoMigration(from = 10, to = 11),
         AutoMigration(from = 11, to = 12),
         AutoMigration(from = 12, to = 13),
+        AutoMigration(from = 13, to = 14),
     ],
 )
 @TypeConverters(DataTypeConverters::class)
@@ -104,7 +111,7 @@ abstract class DashBuddyDatabase : RoomDatabase() {
          * this in lockstep with a new `schemas/**/<N>.json`, an `AutoMigration(N-1 → N)`, and its
          * `MigrationTestHelper` case — see the release checklist in CLAUDE.md.
          */
-        const val VERSION = 13
+        const val VERSION = 14
     }
 
 }

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
@@ -57,6 +57,17 @@ interface AnalyticsDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun setWatermark(state: AnalyticsProjectionStateEntity)
 
+    /**
+     * Adjust a session's delivery counter by a RELATIVE [delta] (#660 piece 2) — the
+     * `DELIVERY_SESSION_ASSIGN` apply's ±1 as the target row leaves/enters this session. **Relative,
+     * never absolute**, so it composes order-safely with the same transaction's earlier session-context
+     * upserts (the counter's absolute value is folded, not re-derived here) and is identical under an
+     * incremental fold vs a from-zero refold — the ±1 deltas telescope to the same final count either
+     * way. A missing sessionId matches zero rows (a no-op, never a crash).
+     */
+    @Query("UPDATE session_records SET deliveries = deliveries + :delta WHERE sessionId = :sessionId")
+    suspend fun bumpSessionDeliveries(sessionId: String, delta: Int)
+
     // ── Version rebuild (projectorVersion bump ⇒ wipe + refold from 0) ───
 
     @Query("DELETE FROM delivery_records")
@@ -612,6 +623,20 @@ interface AnalyticsDao {
     /** Every delivery in a session, in completion order — the per-dash breakdown. */
     @Query("SELECT * FROM delivery_records WHERE sessionId = :sessionId ORDER BY completedAt ASC")
     fun deliveriesForSession(sessionId: String): Flow<List<DeliveryRecordEntity>>
+
+    /**
+     * Every orphan "(No session)" delivery whose own `completedAt` is in `[start, end)`, newest first —
+     * the #660 piece 2 categorize flow's list (the Money-tab callout opens it). Full rows so the picker
+     * can read the row's `completedAt`/`platform`/`storeName`/`realizedPay`. A `Flow` so the list re-emits
+     * as the projector folds an assign (the tapped row leaves the bucket) — Room invalidation, no manual
+     * refresh. Matches the same null-session population [noSessionTotals] surfaces (`sessionId IS NULL`).
+     */
+    @Query(
+        """SELECT * FROM delivery_records
+           WHERE sessionId IS NULL AND completedAt >= :start AND completedAt < :end
+           ORDER BY completedAt DESC"""
+    )
+    fun noSessionDeliveryRows(start: Long, end: Long): Flow<List<DeliveryRecordEntity>>
 
     /** One session row as a Flow — the #650 drill-down header (re-emits on projector commits). */
     @Query("SELECT * FROM session_records WHERE sessionId = :id")

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/AnalyticsDao.kt
@@ -119,11 +119,17 @@ interface AnalyticsDao {
     suspend fun pickupRecordCount(): Int
 
     /** Distinct jobIds referenced by a session's pickup OR delivery rows — a session-level trigger
-     *  (DASH_STOP / inferred close) enumerates its jobs to re-resolve each (#159 L2). */
+     *  (DASH_STOP / inferred close) enumerates its jobs to re-resolve each (#159 L2).
+     *
+     *  The delivery-half is filtered `sessionAssigned = 0` (#660 piece 2 posture: a driver-assigned
+     *  orphan NEVER perturbs machine-fold hydration): the v1 decision is "no #159 store resolution
+     *  re-run on assign", so a refold's same-batch phase inversion must not enumerate the assigned
+     *  orphan's job here and run resolution over it. Pickup rows are never driver-assigned (only
+     *  `delivery_records` carries `sessionAssigned`), so only the delivery UNION arm needs the filter. */
     @Query(
         """SELECT DISTINCT jobId FROM (
               SELECT jobId FROM pickup_records WHERE sessionId = :sessionId
-              UNION SELECT jobId FROM delivery_records WHERE sessionId = :sessionId)
+              UNION SELECT jobId FROM delivery_records WHERE sessionId = :sessionId AND sessionAssigned = 0)
            ORDER BY jobId ASC"""
     )
     suspend fun jobIdsForSession(sessionId: String): List<String>
@@ -662,8 +668,15 @@ interface AnalyticsDao {
     @Query("SELECT * FROM session_records WHERE sessionId = :id")
     suspend fun sessionRecord(id: String): SessionRecordEntity?
 
-    /** The prevDropAnchor for a mid-session restart: (odometerAtCompletion, completedAt). */
-    @Query("SELECT * FROM delivery_records WHERE sessionId = :id ORDER BY eventSequenceId DESC LIMIT 1")
+    /** The prevDropAnchor for a mid-session restart: (odometerAtCompletion, completedAt).
+     *
+     *  Filtered `sessionAssigned = 0` (#660 piece 2 posture: a driver-assigned orphan is INVISIBLE to
+     *  machine-fold hydration). A categorized orphan must never become the prevDrop odometer/time anchor
+     *  a later machine `DELIVERY_COMPLETED` reads — its economics were frozen against a different session's
+     *  offer, so anchoring off it would desync incremental fold from a from-zero refold at a batch boundary
+     *  (the refold's in-memory context, whose assign leaves it untouched, never sees the orphan). Inert on
+     *  today's ended-session assigns (an ended session folds no future completion), correct by construction. */
+    @Query("SELECT * FROM delivery_records WHERE sessionId = :id AND sessionAssigned = 0 ORDER BY eventSequenceId DESC LIMIT 1")
     suspend fun lastDeliveryInSession(id: String): DeliveryRecordEntity?
 
     /**
@@ -687,8 +700,15 @@ interface AnalyticsDao {
      * The distinct delivered jobIds already recorded for a session — rehydrates the fold's
      * distinct-job set on a mid-session restart so `jobsCompleted` counts a stacked job once even
      * across a process death (PR2).
+     *
+     * Filtered `sessionAssigned = 0` (#660 piece 2 posture: a driver-assigned orphan is INVISIBLE to
+     * machine-fold hydration). `jobsCompleted` is `deliveredJobIds.size`, so a categorized orphan's job
+     * counted here would inflate the counter the moment a LATER-batch correction re-hydrates the session
+     * and pass-through-upserts it — a divergence from a from-zero refold (whose in-memory context, left
+     * untouched by the assign fold, never sees the orphan). The assign's own delivery-count ±1 rides the
+     * relative [bumpSessionDeliveries]; the distinct-job set must exclude the assigned row to match refold.
      */
-    @Query("SELECT DISTINCT jobId FROM delivery_records WHERE sessionId = :id")
+    @Query("SELECT DISTINCT jobId FROM delivery_records WHERE sessionId = :id AND sessionAssigned = 0")
     suspend fun deliveredJobIdsInSession(id: String): List<String>
 
     /**
@@ -704,9 +724,15 @@ interface AnalyticsDao {
      * `originalPayBasis`, closing the #691 VET F1 hydration wrinkle even for re-priced rows; the
      * COALESCE covers legacy rows whose `originalPayBasis` is still null (pre-`PROJECTOR_VERSION` 4
      * refold). Deliberately excludes `USER_CORRECTED` itself and the estimate/none bases.
+     *
+     * Filtered `sessionAssigned = 0` (#660 piece 2 posture: a driver-assigned orphan is INVISIBLE to
+     * machine-fold hydration). A categorized orphan's receipt evidence must not enter this session's
+     * #691 mixed-receipt guard set — it belonged to a different job/dash, and letting it deny a later
+     * sibling's offer-pay estimate would (like the distinct-job set above) split incremental fold from
+     * from-zero refold at a batch boundary.
      */
     @Query(
-        "SELECT DISTINCT jobId FROM delivery_records WHERE sessionId = :id " +
+        "SELECT DISTINCT jobId FROM delivery_records WHERE sessionId = :id AND sessionAssigned = 0 " +
             "AND COALESCE(originalPayBasis, payBasis) IN ('" + PayBasis.DROP_SHARE + "', '" +
             PayBasis.RECEIPT_TOTAL + "', '" + PayBasis.SUSPECT_FULL_RECEIPT + "')"
     )

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/DeliveryRecordEntity.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/analytics/DeliveryRecordEntity.kt
@@ -173,4 +173,17 @@ data class DeliveryRecordEntity(
      * preceded the completion (missed arrival, phantom-class completion, all pre-v13 history).
      */
     val milesToDropoff: Double? = null,
+
+    // ── Session-attribution marker (#660 piece 2, v14) ──────────────────────
+    /**
+     * Driver-attribution sticky bit (#660 piece 2). Set to 1 when a `DELIVERY_SESSION_ASSIGN` assigns
+     * this orphan ("(No session)") row into a real ended dash; 0 when machine-attributed, unassigned
+     * (back in the bucket), or MANUAL. The projector's apply guard only ever MOVES a row that is either
+     * null-session OR already `sessionAssigned = 1` — the fail-closed backstop that keeps a machine
+     * row's source-session reconciliation from being silently broken by one wrong tap (undo/re-assign
+     * are safe only because of this marker). Drives the drill-down's "assigned by you" caption + undo.
+     * Derived from the `DELIVERY_SESSION_ASSIGN` event ⇒ a from-zero refold re-derives it. Default 0
+     * (SQL column default so the additive AutoMigration back-fills existing rows).
+     */
+    @ColumnInfo(defaultValue = "0") val sessionAssigned: Int = 0,
 )

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -73,6 +73,24 @@ card's **mechanical** half, #577 (re-confirmed, 24/24, ~0.55 s — with a new po
 that entry's Bug #1), the #457 path, and #554 ShadowProjector (2/2). The #462/#460 dropoff item
 was found **broken-in-part** (raw PII in capture envelopes) and moved to that entry's Bug #7.)_
 
+- **🆕 NEW — categorize a "(No session)" orphan delivery into its real dash (#660 piece 2).**
+  The Money-tab "(No session): $X across N deliveries" callout is now **tappable** — it opens an
+  orphan list; tapping a delivery opens a session picker (ended dashes within ±48 h of the drop, same
+  platform, nearest first). Confirming assigns the orphan to that dash. A `DELIVERY_SESSION_ASSIGN`
+  correction is written; the projector re-attributes the row (attribution ONLY — pay/net are never
+  re-priced) and the read-model refreshes reactively.
+  **How to tell it's working (needs a real orphan on-device — a mid-dash service/app restart that
+  dropped a delivery's `sessionId` while the dash summary still captured its pay):** the callout shows
+  a nonzero "(No session)" amount; tapping it lists the orphan(s); picking the correct dash makes the
+  **callout shrink by that delivery's pay** (and empty entirely once all orphans are categorized) with
+  no manual refresh; the target dash's **drill-down gains a row tagged "assigned by you"** and its
+  **header delivery count goes up by one** (header and list agree — no mismatch); and if the orphan's
+  dollars were already inside that dash's reported summary, the Money-tab **gross drops** (the
+  double-count heals) rather than staying inflated. Undo path: open the assigned row's Adjust dialog →
+  **"Remove from this dash"** returns it to the bucket. Frozen economics must be untouched by all of
+  this (the row's net/pay/est-offer-pay disclosure are the same before and after). PR for #660 piece 2.
+  - Confirmed: 0/2
+
 - **🆕 NEW — per-leg mileage: stacked drops each carry their own miles (#688 phase B).**
   Delivery rows now fold `milesToStore`/`milesToDropoff` from the lifecycle odometer stamps, and a
   drop's miles become the leg sum (to-store + to-dropoff) instead of the old lump-on-one-row

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/AnalyticsRecords.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/AnalyticsRecords.kt
@@ -49,6 +49,13 @@ data class DeliveryRecord(
     val milesToStore: Double? = null,
     /** Machine-computed to-dropoff driving leg (#688 phase B); same provenance rules as [milesToStore]. */
     val milesToDropoff: Double? = null,
+    /**
+     * True when a driver DELIVERY_SESSION_ASSIGN (#660 piece 2) attributed this row to [sessionId] —
+     * an orphan the driver categorized into its real dash. Drives the drill-down's "assigned by you"
+     * caption + the "Remove from this dash" undo (only shown when set). A machine-attributed row is
+     * `false`; an unassigned (bucket) row is `false`. Event-derived, so a from-zero refold re-derives it.
+     */
+    val sessionAssigned: Boolean = false,
 )
 
 /** One dash session. */

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/RecordFolds.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/RecordFolds.kt
@@ -5,6 +5,7 @@ import cloud.trotter.dashbuddy.domain.model.event.AppEventType
 import cloud.trotter.dashbuddy.domain.model.event.SequencedAppEvent
 import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryAdjustmentPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.DeliverySessionAssignPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.ManualDeliveryPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.OfferPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.PayAdjustmentPayload
@@ -260,6 +261,12 @@ data class FoldOutcome(
     val pickup: PickupFold? = null,
     /** A store-resolution trigger (#159) the orchestrator runs against the job's committed rows. */
     val resolution: StoreResolution? = null,
+    /**
+     * A driver DELIVERY_SESSION_ASSIGN decision (#660 piece 2): the pure fold decides WHICH row and
+     * WHICH session (null ⇒ unassign), but cannot read/guard the target `delivery_record` here — the
+     * orchestrator applies the re-attribution (with its fail-closed guards) inside the batch transaction.
+     */
+    val sessionAssign: SessionAssignFold? = null,
 )
 
 /**
@@ -290,6 +297,21 @@ data class DeliveryAdjustmentFold(
     val newTip: Double? = null,
     val newCashTip: Double? = null,
     val newMiles: Double? = null,
+)
+
+/**
+ * A driver's session-(re)attribution decision (#660 piece 2) — the pure fold's output for a
+ * DELIVERY_SESSION_ASSIGN. The orchestrator looks up [targetEventSequenceId] in `delivery_records` and,
+ * subject to its fail-closed guards (movable-rows-only, real ENDED target session, platform coherence,
+ * cash-bearing-unassign block), rewrites ONLY the row's `sessionId` (→ [newSessionId]; null ⇒ unassign
+ * back to the "(No session)" bucket) and its `sessionAssigned` marker — never any frozen economy column.
+ * Because a DELIVERY_SESSION_ASSIGN always sequences after its target's completion AND after the target
+ * session's `DASH_STOP`, a from-zero refold replays them in order and reproduces identical rows/counters.
+ * `note` is intentionally absent — it lives only in the event payload and changes no column.
+ */
+data class SessionAssignFold(
+    val targetEventSequenceId: Long,
+    val newSessionId: String? = null,
 )
 
 /**
@@ -338,6 +360,7 @@ object RecordFolds {
             AppEventType.MANUAL_DELIVERY -> foldManualDelivery(event, context, currentCostPerMile)
             AppEventType.PAY_ADJUSTMENT -> foldPayAdjustment(event, context)
             AppEventType.DELIVERY_ADJUSTMENT -> foldDeliveryAdjustment(event, context)
+            AppEventType.DELIVERY_SESSION_ASSIGN -> foldDeliverySessionAssign(event, context)
             AppEventType.DASH_STOP -> foldDashStop(event, context)
             // Every other session-attributed event just advances the liveness/odometer anchors so
             // the open-session duration and lastOdometer stay honest; the watermark still moves past
@@ -875,6 +898,26 @@ object RecordFolds {
                 newCashTip = p.newCashTip,
                 newMiles = p.newMiles,
             ),
+        )
+    }
+
+    /**
+     * A driver DELIVERY_SESSION_ASSIGN (#660 piece 2) — the pure fold emits the [SessionAssignFold]
+     * decision (which row, which target session / unassign); it CANNOT read/guard the target
+     * `delivery_record` here, so the orchestrator applies the re-attribution (with its fail-closed
+     * guards) inside the batch transaction. The session context passes through UNTOUCHED (the #650
+     * review F2 liveness discipline, identical to [foldPayAdjustment]/[foldDeliveryAdjustment]): a
+     * categorize recorded days later must not stretch a crash-orphaned session's online span, and it
+     * must not synthesize a context (the target session row already exists — the UI can only offer an
+     * ENDED session that folded a DASH_STOP, and the orphan's own delivery row exists too).
+     */
+    private fun foldDeliverySessionAssign(event: SequencedAppEvent, context: SessionFoldContext?): FoldOutcome {
+        val e = event.event
+        val p = e.payload as? DeliverySessionAssignPayload
+            ?: return FoldOutcome(context = context, skip = "DELIVERY_SESSION_ASSIGN: missing/malformed payload")
+        return FoldOutcome(
+            context = context,
+            sessionAssign = SessionAssignFold(p.targetEventSequenceId, p.newSessionId),
         )
     }
 

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/AppEventCodec.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/AppEventCodec.kt
@@ -3,6 +3,7 @@ package cloud.trotter.dashbuddy.domain.model.event
 import cloud.trotter.dashbuddy.domain.model.event.payload.AppEventPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryAdjustmentPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.DeliverySessionAssignPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.ManualDeliveryPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.OfferPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.PayAdjustmentPayload
@@ -41,6 +42,7 @@ object AppEventCodec {
         is ManualDeliveryPayload -> json.encodeToString(payload)
         is PayAdjustmentPayload -> json.encodeToString(payload)
         is DeliveryAdjustmentPayload -> json.encodeToString(payload)
+        is DeliverySessionAssignPayload -> json.encodeToString(payload)
         is TaskUnassignedPayload -> json.encodeToString(payload)
     }
 
@@ -89,6 +91,9 @@ object AppEventCodec {
 
             AppEventType.DELIVERY_ADJUSTMENT ->
                 json.decodeFromString<DeliveryAdjustmentPayload>(payloadJson)
+
+            AppEventType.DELIVERY_SESSION_ASSIGN ->
+                json.decodeFromString<DeliverySessionAssignPayload>(payloadJson)
 
             AppEventType.TASK_UNASSIGNED ->
                 json.decodeFromString<TaskUnassignedPayload>(payloadJson)

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/AppEventType.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/AppEventType.kt
@@ -34,6 +34,8 @@ enum class AppEventType {
     PAY_ADJUSTMENT,  // A driver re-price of an already-recorded delivery (the original event stays)
     DELIVERY_ADJUSTMENT, // A driver multi-field edit of an already-recorded delivery (#688) — widens
                          // PAY_ADJUSTMENT (store/pay/tip/cash-tip/miles/note); the original event stays
+    DELIVERY_SESSION_ASSIGN, // A driver assigns/unassigns an orphan "(No session)" delivery's session
+                             // (#660 piece 2) — changes ATTRIBUTION only (never pay/net); the original event stays
 
     // --- System / Generic ---
     SCREEN_VIEWED, // For generic screen transitions like "Earnings Screen"

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/payload/AppEventPayloads.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/payload/AppEventPayloads.kt
@@ -292,6 +292,31 @@ data class PayAdjustmentPayload(
     val note: String? = null,
 ) : AppEventPayload
 
+/**
+ * Payload for `DELIVERY_SESSION_ASSIGN` (#660 piece 2) — a driver (re-)attribution of an orphan
+ * "(No session)" delivery to its real dash session, or an UNASSIGN back to the bucket (the undo). It
+ * is an **event, never a destructive edit**: the original `DELIVERY_COMPLETED`/`MANUAL_DELIVERY` event
+ * and its provenance stay in the log; the projector re-attributes the target `delivery_record` in place
+ * inside the batch transaction. Because a correction always sequences AFTER its target's completion (and
+ * after the target session's `DASH_STOP`), a from-zero refold replays them in order and reproduces
+ * identical rows/counters.
+ *
+ * It changes **attribution ONLY** — the projector never rewrites pay/net/tip/basis/miles/`originalPayBasis`
+ * or any frozen economy column (the frozen-economics rule; categorizing never re-prices). New in this
+ * correction family: an assign is guarded (movable rows only, real ENDED target session, platform
+ * coherence, cash-bearing-unassign block) so a machine-attributed row is never silently moved out of its
+ * source session's reconciliation.
+ */
+@Serializable
+data class DeliverySessionAssignPayload(
+    /** PK (source `sequenceId`) of the `delivery_record` being (re-)attributed. */
+    val targetEventSequenceId: Long,
+    /** The session to assign the row to; null ⇒ UNASSIGN back to the "(No session)" bucket (undo). */
+    val newSessionId: String? = null,
+    /** Driver-authored free text — driver-owned local data, never in INFO+ logs (P7). */
+    val note: String? = null,
+) : AppEventPayload
+
 /** Wire values for [SessionStartPayload.source] (#366) — mirrors [SessionEndSource]. */
 object SessionStartSource {
     /** Normal user-initiated start. */

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/RecordFoldsTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/analytics/RecordFoldsTest.kt
@@ -9,6 +9,7 @@ import cloud.trotter.dashbuddy.domain.model.event.EventMetadata
 import cloud.trotter.dashbuddy.domain.model.event.SequencedAppEvent
 import cloud.trotter.dashbuddy.domain.model.event.payload.AppEventPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryAdjustmentPayload
+import cloud.trotter.dashbuddy.domain.model.event.payload.DeliverySessionAssignPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.DeliveryPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.ManualDeliveryPayload
 import cloud.trotter.dashbuddy.domain.model.event.payload.OfferPayload
@@ -1064,6 +1065,57 @@ class RecordFoldsTest {
         // correction's wall-clock time.
         assertEquals(ctx, out.context)
         assertEquals(1_000L, out.context!!.lastEventAt)
+    }
+
+    @Test
+    fun `DELIVERY_SESSION_ASSIGN emits the assign decision, no record, and passes the context through untouched (#660 F2)`() {
+        val s = "M10"
+        val ctx = RecordFolds.foldEvent(dashStart(s, 1_000, odo = 0.0), null, null).context
+        val ev = ev(
+            AppEventType.DELIVERY_SESSION_ASSIGN, s, 5_000,
+            DeliverySessionAssignPayload(targetEventSequenceId = 42L, newSessionId = s, note = "was mine"),
+        )
+        val out = RecordFolds.foldEvent(ev, ctx, null)
+
+        assertNull("a session assign produces no delivery record in the pure fold", out.delivery)
+        assertNull(out.offer)
+        assertNull(out.payAdjustment)
+        assertNull(out.deliveryAdjustment)
+        val adj = out.sessionAssign!!
+        assertEquals(42L, adj.targetEventSequenceId)
+        assertEquals(s, adj.newSessionId)
+        // Bookkeeping about a past row, not session activity: liveness must NOT advance to the
+        // correction's wall-clock time (it would stretch an endedAt-null session's online span).
+        assertEquals(ctx, out.context)
+        assertEquals(1_000L, out.context!!.lastEventAt)
+    }
+
+    @Test
+    fun `a DELIVERY_SESSION_ASSIGN with a null newSessionId is the unassign (undo) decision (#660)`() {
+        val s = "M11"
+        val out = RecordFolds.foldEvent(
+            ev(
+                AppEventType.DELIVERY_SESSION_ASSIGN, sessionId = null, at = 6_000,
+                payload = DeliverySessionAssignPayload(targetEventSequenceId = 7L, newSessionId = null),
+            ),
+            null, null,
+        )
+        val adj = out.sessionAssign!!
+        assertEquals(7L, adj.targetEventSequenceId)
+        assertNull("null newSessionId ⇒ unassign back to the bucket", adj.newSessionId)
+        assertNull(out.delivery)
+    }
+
+    @Test
+    fun `a malformed DELIVERY_SESSION_ASSIGN payload is skipped, not folded (#660)`() {
+        val s = "M12"
+        val bad = SequencedAppEvent(
+            sequenceId = ++seq,
+            event = AppEvent(AppEventType.DELIVERY_SESSION_ASSIGN, occurredAt = 2_000, sessionId = s, payload = null),
+        )
+        val out = RecordFolds.foldEvent(bad, null, null)
+        assertNull(out.sessionAssign)
+        assertNotNull(out.skip)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Piece 2 of #660: the driver can now **categorize a "(No session)" orphan delivery into its real dash** via a new non-destructive correction event. Piece 1 (#748) made the `sessionId IS NULL` population visible and gross-consistent, but when an orphan's dollars were semantically already inside a surviving session's captured `reportedEarnings` (a mid-dash service restart, summary captured afterward), the same dollars double-counted into gross. This closes that seam: the driver assigns the orphan to its dash, the row re-enters that session's `GROUP BY sessionId` reconciliation, the bucket shrinks, and the double-count heals — **without re-pricing anything** (frozen economics untouched; only attribution changes).

Build-ready spec: [#660 "Build-ready spec — piece 2"](https://github.com/sjtrotter/DashBuddy/issues/660). All 8 proceed-unless-vetoed defaults taken. Two repo-drift corrections vs the spec's numbers: schema edge is **Room v13→v14** (not v12→v13 — #755 took v12→v13) and **PROJECTOR_VERSION stays 6** (no bump — the new event type can't exist in folded history, the DEFAULT-0 column is correct for all history).

### What landed
- **domain:** `AppEventType.DELIVERY_SESSION_ASSIGN` + `DeliverySessionAssignPayload{targetEventSequenceId, newSessionId (null⇒unassign), note}`; codec encode/decode arms; `RecordFolds.foldDeliverySessionAssign` → `SessionAssignFold` (context passed through untouched — the #650 F2 liveness discipline); `DeliveryRecord.sessionAssigned`.
- **database (Room v13→v14, additive-only):** `delivery_records.sessionAssigned INTEGER DEFAULT 0`; `AnalyticsDao.bumpSessionDeliveries` (relative ±1 UPDATE) + `noSessionDeliveryRows`; exported `14.json`; `AnalyticsMigration13to14Test` (instrumented — device run pending, alongside the standing v11→v12 / v12→v13 runs).
- **projector:** `applySessionAssign` as a third `Adjustment.SessionAssign` in the FIX-1 log-ordered stream — attribution-only (`row.copy(sessionId, sessionAssigned)`, every frozen column byte-identical) behind five fail-closed guards (movable rows only = null-session OR already-assigned; real ENDED target session; platform coherence; cash-bearing-unassign block; missing row), each a counted ids-only-WARN skip. Session counter via the relative `bumpSessionDeliveries`.
- **write side:** `CorrectionRepository.assignDeliverySession`.
- **UI:** tappable Money-tab "(No session)" callout → `NoSessionAssignDialogs` (orphan list → ±48 h / same-platform / ended-only session picker); drill-down "assigned by you" caption + "Remove from this dash" undo.
- **tests:** RecordFolds fold (emit/unassign/malformed); projector end-to-end + all 5 guards + undo + refold-equality (assign→unassign→re-assign) + same-batch assign+cash composition; the characterization flip (`108.0` → `100.0/0.0/0.0`, sibling 58/8 test untouched); `CorrectionRepository` append shape; daily-chart day-move.
- **context:** CLAUDE.md §5 + `docs/field-testing/README.md` checklist item.

Full unit gate green: `./gradlew testDebugUnitTest :domain:test` → BUILD SUCCESSFUL. Schema gates green (14.json committed; `SchemaVersionGuardTest` chains v8→14).

## Security / privacy posture

No new capture, network, or PII surface — it re-reads the already-hashed `app_events` log and edits one attribution column. The driver-authored `note` is driver-owned local data and is **never emitted in an INFO+ log line** (P7): every WARN/INFO here carries counts / sequence ids / a boolean only, never note or store text. The five apply guards fail **closed** (a machine-attributed row is never silently moved out of its source session's reconciliation; a cash-bearing row is never unassigned into a gross-invisible state). No untrusted-input boundary touched (no rule/regex/accessibility-tree changes).

### Design-goal review

- **1 (UDF):** steppers/projector stay pure; the fold context is untouched (F2) so a categorize recorded days later can't stretch a crash-orphaned session's span. UI observes immutable `AnalyticsUiState`/`SessionDetail` and dispatches intents (`assignToSession`/`unassignDelivery`); no repo writes from composables. The callout→dialog is reactive via Room invalidation only (no manual refresh).
- **3 (single responsibility):** new dialogs live in `NoSessionAssignDialogs.kt` (keeps `MoneyTab.kt` under budget); write-side stays on `CorrectionRepository`, read-side on `AnalyticsRepository`.
- **4 (idiomatic Kotlin):** relative counter UPDATE (order-safe/refold-stable); nested `combine` for the 6th flow (typed `combine` tops at 5).
- **5 (SSOT):** attribution edit is `row.copy` (frozen columns provably byte-identical, test-asserted); the counter is never re-derived absolutely; the ±48 h window + ended-only policy has one owner (`AnalyticsRepository.candidateSessionsForOrphan`).
- **6 (privacy):** see posture above.
- **7 (logging):** all new WARN/INFO are ids/booleans only.
- **8 (platform-agnostic):** new rule↔state vocabulary went through the enumerated `AppEventType` + typed payload (no magic strings); platform coherence resolves via `Platform.fromWire` (never a literal `== DoorDash`); the picker's platform label is registry-resolved.
- **Reactive UI:** the callout, orphan list, and drill-down all re-emit on projector commits (Room invalidation); no frozen-value defects (a historical period's figures are fixed, no ticker needed).

### Adversarial review

_To be appended pre-merge (fable `/code-review` + `/security-review`, per the #589/#591 loop)._

#### Post-review fixes

Two fable adversarial reviews returned findings; applied exactly (full unit gate re-run green: `./gradlew testDebugUnitTest :domain:test` → BUILD SUCCESSFUL).

- **Hydration-filter posture (MED + LOW) — a driver-assigned row is INVISIBLE to machine-fold hydration.** Added `AND sessionAssigned = 0` to the three restart-hydration reads `AnalyticsDao.deliveredJobIdsInSession` / `receiptedJobIdsInSession` / `lastDeliveryInSession`, and to the delivery-half UNION of the #159 `jobIdsForSession` resolution enumerator. Without it, a LATER-batch correction that re-hydrates a session (e.g. an innocuous note edit) pass-through-upserts a `jobsCompleted` (= `deliveredJobIds.size`) inflated by the assigned orphan's distinct job — diverging from a from-zero refold, whose in-memory context (untouched by the assign fold) never sees the orphan. The four filters also keep the assigned orphan out of the #691 receipt-evidence set, the prevDrop anchor, and #159 store re-resolution (matching the v1 "no #159 re-run on assign" decision). No schema / `PROJECTOR_VERSION` change — read-time filters, and the divergence they prevent never shipped. `applySessionAssign`'s guard-3 KDoc residual note extended accordingly.
- **Strengthened incremental-vs-refold tests.** The assign/unassign/re-assign refold test now drains **incrementally** (`processBatch(limit = 1)`, one event per batch) instead of a single from-zero drain that only compared two identical folds — so it exercises a real batch boundary. New discriminator test `an assigned orphan stays invisible to a later-batch correction's hydration` proves the hydration-filter fix (assign into ended S1, then a separate-batch note edit; asserts `jobsCompleted` stays 1 AND wipe-refold byte-equality; **fails on 7ef8df54** at the `jobsCompleted` assertion when the filter is reverted).
- **Span-sort for the candidate picker (MED).** `candidateSessionsForOrphan` now ranks by distance to the session `[startedAt, endedAt]` **span** (0 when the completion is inside the span, else the gap to the nearer endpoint; tie-break by `startedAt`), not `abs(startedAt − completedAt)`. A mid-dash-restart orphan completes hours into its real dash, so the old sort ranked a short later dash above the containing one. New unit test (dash A 9am–3pm + orphan 2:50pm + dash B 4pm → **A first**; **fails on 7ef8df54** under the abs-start sort).
- **Cash-gated undo (MED).** "Remove from this dash" is now **disabled** on a `cashTip != null` row with a locked-hint supporting line ("Clear the cash tip first, then remove", reusing the `session_detail_field_pay_locked_supporting` pattern) — the projector's F3 cash-bearing-unassign guard would otherwise make the tap a silent no-op.
- **Count-based callout entry point (LOW).** The Money-tab "(No session)" callout now renders on `noSessionDeliveries > 0` (was `noSessionPay > EPSILON`), so a pay-less orphan ($0.00 captured) stays categorizable — the count is the population, the pay just its magnitude (the callout copy reads fine at `$0.00`).
- **Accessibility NITs (LOW).** The callout's clickable now carries `Role.Button` + an `onClickLabel` ("Assign to a dash"); the orphan-row label now shows date **and** time-of-day (via the `formatClockTime` SSOT) so two same-store same-day orphans are distinguishable.
- **Guard 4 status.** The platform-coherence guard is **defensive / unreachable today**: a genuine orphan folds `Platform.Unknown` (so its `rowPlatform != Unknown` arm is never taken), and a known-platform sessionful row is already blocked by guard 2 (movable-rows-only) — it fires only for a direct-seeded movable known-platform row, exercised by the coherence test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



### Adversarial review

Loop: 2 independent fable finders (money/projector-apply; schema/UI/principles) → opus fixer (7ef8df54 → 6b32c762) → fable re-verification. **Final verdict: APPROVE.**

**Fixed in-PR:**
1. **MED (determinism):** after an assign, session-scoped hydration queries saw the assigned row the in-memory fold never saw — `jobsCompleted` flipped lazily on the next session-touching correction, making incremental ≠ from-zero refold (the exact class guard 3 exists to kill, via a side-channel the ended-session argument didn't cover). Fixed: `AND sessionAssigned = 0` on `deliveredJobIdsInSession` / `receiptedJobIdsInSession` / `lastDeliveryInSession` / `jobIdsForSession`-delivery-half — the posture: driver-assigned rows are invisible to machine-fold hydration (prevDrop anchors, #691 receipt evidence, job counts, #159 enumeration). Re-verify proved the filters are a structural no-op for never-assigned sessions and match refold semantics where they apply; discriminator proven on a real per-event batch boundary.
2. **MED (UX-correctness):** the session picker ranked by distance-to-start, putting the wrong dash first in the flagship mid-dash-restart scenario — now span-distance sort (0 inside the session span; else nearer-endpoint gap; startedAt tie-break), discriminator proven.
3. **MED (UX-correctness):** "Remove from this dash" silently no-op'd on cash-bearing rows (guard 5 skips with only a WARN) — now a semantically disabled action with a resource-string locked-hint; the projector guard stays the fail-closed backstop.
4. **LOWs:** refold-equality tests strengthened to genuine incremental draining (the prior shape compared two identical single-batch folds); callout entry gated on delivery count (pay-less orphans stay categorizable); Role.Button + onClickLabel; orphan rows show date · time via the TimeFormats SSOT.

**Verified-safe:** frozen economics untouchable (single `row.copy(sessionId, sessionAssigned)` write site; full-entity byte-identity assertion, mutation-killed twice); all five guards fail-closed with zero counter movement on skip; the relative deliveries counter telescopes under every constructed composition incl. MANUAL_DELIVERY same-batch; no reachable REPLACE-clobber of an assigned row (atomic watermark; refold replays in order); migration v13→v14 proven single-column additive from the schema JSONs, full checklist, chain v8→14; the characterization test flip preserves the exact correlated-orphan shape (108.0 → 100.0/0.0/0.0); driver-authored `note` never reaches any log; P8 platform comparisons via typed registry values.

**Residuals (documented, non-blocking):** the deliveries-vs-jobsCompleted asymmetry on assigned rows is the spec's stated posture, currently invisible (no surface renders jobsCompleted — KDoc'd at both sites for any future surface); guard 4 (platform coherence) is defensive/unreachable today (a genuine orphan folds Unknown; known-platform rows are blocked by guard 2); the session-picker candidate list is a one-shot snapshot (transient dialog, deliberate); two cosmetic a11y nits on the dialog list rows; **three instrumented migration tests (v11→v12, v12→v13, v13→v14) await one device run — pair with the phone reinstall before the next dash.**
