### PR TITLE
test(#758): fix v13 seed INSERT — 30 values for 31 columns in AnalyticsMigration13to14Test

### DIFF
--- a/core/database/src/androidTest/java/cloud/trotter/dashbuddy/core/database/AnalyticsMigration13to14Test.kt
+++ b/core/database/src/androidTest/java/cloud/trotter/dashbuddy/core/database/AnalyticsMigration13to14Test.kt
@@ -48,7 +48,7 @@ class AnalyticsMigration13to14Test {
                     milesToStore, milesToDropoff)
                    VALUES (1, NULL, 'doordash', 'J1', 'T1', 'Target', 'ch', 'ah', 100, NULL, 3000,
                            NULL, 10.0, 'RECEIPT_TOTAL', NULL, NULL, 105.0, 5.0, 1.0, 0.25, 0.10, 0.15,
-                           8.75, 'OFFER_FROZEN', NULL, 'RECEIPT_TOTAL', 'doordash|target|1', 0,
+                           8.75, 'OFFER_FROZEN', NULL, 'RECEIPT_TOTAL', 'doordash|target|1', NULL, 0,
                            NULL, NULL)""",
             )
             db.execSQL(


### PR DESCRIPTION
One-line fix to `AnalyticsMigration13to14Test` (from PR #758): the v13 seed INSERT supplied 30 values for 31 columns — the `payoutStoreForms` value was omitted, sliding `storeKeyPinned`'s `0` into its slot and starving `milesToDropoff` → `SQLiteException` on-device before the migration under test ever ran. The test was authored without a device attached, and instrumented tests don't gate unit CI — the first real device run (2026-07-12, Pixel 7) caught it.

**Device evidence:** the full `:core:database:connectedAndroidTest` run executed all 8 instrumented tests on the Pixel 7 — v8→9 through v12→13 all PASSED (clearing the long-pending v11→12 and v12→13 device validations), only this test failed on its seed. After the fix, `AnalyticsMigration13to14Test` PASSES on the same device — **all six migration edges are now device-validated.**

### Design-goal review
Test-only, one token; no runtime surface, no schema/economics/pledge implications. The fix restores the test's power rather than weakening it (pre-fix it could never reach the migration).

### Adversarial review
Independent fable micro-review (same-tier rule): mapped all 31 VALUES to columns against the authoritative `13.json` — every value type- and nullability-coherent (`payoutStoreForms` = nullable TEXT, NULL legal; all nine NOT NULL columns non-NULL); audited the sibling `session_records` seed (18/18, correct); confirmed the fix cannot mask a real migration defect (`runMigrationsAndValidate` still schema-validates v14, row-survival counts + the `sessionAssigned` DEFAULT-0 assertion intact — v14 = exactly +1 column over v13); diff sweep = this one line only. **Verdict: merge-clean.** Plus the objective check: fail→pass on a physical Pixel 7.
