### PR TITLE
chore(#731): desk-observability hooks — offer-hash tap join, learned shop-pace INFO, Effects-tagged actuation WARNs, NLS rebind counters + desk-validation playbook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,8 +50,10 @@ The DoorDash ICA §15.4 prohibits reverse-engineering of the platform; DashBuddy
 do that and our written material must not suggest otherwise. See `LEGAL.md` for the
 good-faith ICA interpretation that governs scope decisions.
 
-Cross-references: monetization plan #141; matchers infra RFC #192; aggregation RFC #193;
-academic federation RFC #194.
+Cross-references: matchers infra RFC #192; aggregation RFC #193; academic federation RFC #194.
+(Monetization pricing is recorded in pillar 1 above — its former pointer #141 was actually the
+cloud-data-platform RFC, closed 2026-07-12 with its un-built cloud half folded into the pillar
+epics.)
 
 ## Build Commands
 
@@ -520,7 +522,8 @@ Every new feature or refactor holds to these — they are forefront design input
    `:core:state` / `:core:pipeline` / `:domain` edits. DoorDash-heavy field testing *masks*
    violations (a global slot never collides while only one platform runs), so this is enforced at
    PR-review time — see *Every PR gets a design-goal review* under Git Workflow, and the drift
-   catalog in #585 (+ the per-platform ownership pack #438) for the known seams and receipts.
+   catalog in #585 (closed 2026-07-12; the six unshipped items now live in #762) plus the
+   per-platform ownership pack #438 for the known seams and receipts.
 
 If a change genuinely can't satisfy one of these, say so explicitly in the PR description instead
 of silently violating it. The design-goal review below exists to catch exactly that before merge.

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/OfferActionReceiver.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/OfferActionReceiver.kt
@@ -34,11 +34,13 @@ class OfferActionReceiver : BroadcastReceiver() {
 
     override fun onReceive(context: Context, intent: Intent) {
         val uiInput = uiInputFrom(intent) ?: return
-        // #731 desk-observability: the offer-hash prefix (PII-safe, #598) lets a desk pull join
-        // this tap to the resolved OFFER_ACCEPTED/OFFER_DECLINED event's hash (#438 B4).
+        // #731 desk-observability: the offer hash (PII-safe by construction) lets a desk pull join
+        // this tap to the resolved OFFER_ACCEPTED/OFFER_DECLINED event's hash (#438 B4). Logged in
+        // FULL — the same rendering as OfferEffects' offerHash= lines — so the join is an exact
+        // grep, not a prefix special case.
         Timber.tag("Effects").i(
             "OfferActionReceiver: %s on %s (offer=%s)",
-            uiInput.action, uiInput.targetPlatform?.wire ?: "?", uiInput.offerHash?.take(8) ?: "?",
+            uiInput.action, uiInput.targetPlatform?.wire ?: "?", uiInput.offerHash ?: "?",
         )
         // #457: dismiss the heads-up immediately — the dasher acted. (Offer resolution also fires
         // CancelOfferNotification, but cancel now so the banner/shade entry doesn't linger.)

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/OfferActionReceiver.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/OfferActionReceiver.kt
@@ -34,7 +34,12 @@ class OfferActionReceiver : BroadcastReceiver() {
 
     override fun onReceive(context: Context, intent: Intent) {
         val uiInput = uiInputFrom(intent) ?: return
-        Timber.tag("Effects").i("OfferActionReceiver: %s on %s", uiInput.action, uiInput.targetPlatform?.wire ?: "?")
+        // #731 desk-observability: the offer-hash prefix (PII-safe, #598) lets a desk pull join
+        // this tap to the resolved OFFER_ACCEPTED/OFFER_DECLINED event's hash (#438 B4).
+        Timber.tag("Effects").i(
+            "OfferActionReceiver: %s on %s (offer=%s)",
+            uiInput.action, uiInput.targetPlatform?.wire ?: "?", uiInput.offerHash?.take(8) ?: "?",
+        )
         // #457: dismiss the heads-up immediately — the dasher acted. (Offer resolution also fires
         // CancelOfferNotification, but cancel now so the banner/shade entry doesn't linger.)
         // #438 B4: dismiss ONLY this offer's banner (per-offer id from the tap's own carried hash),

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
@@ -38,6 +38,7 @@ import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import timber.log.Timber
+import java.util.Locale
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -329,15 +330,18 @@ class SideEffectEngine @Inject constructor(
                 // registry token, not PII); the merchant name (raw third-party UI text) stays DEBUG-only.
                 // #731: the learned running mean lives only in the strategy DataStore, invisible to a
                 // post-dash data pull — surface it here so the relearn trajectory is desk-visible.
+                // A never-learned mean renders "?" (an out-of-band sample folds nothing) — never a
+                // fake 0.00; Locale.ROOT keeps the desk grep stable on comma-decimal locales.
+                val learnedStr =
+                    learned.itemsPerMin?.let { String.format(Locale.ROOT, "%.2f", it) } ?: "?"
                 Timber.tag("ShopRate").i(
-                    "recorded %d items / %.1f min = %.2f/min [%s] → learned %.2f/min (n=%d)",
+                    "recorded %d items / %.1f min = %.2f/min [%s] → learned %s/min (n=%d)",
                     effect.itemsShopped, minutes, perMin, effect.platform.wire,
-                    learned.itemsPerMin ?: 0.0, learned.sampleCount,
+                    learnedStr, learned.sampleCount,
                 )
-                Timber.tag("ShopRate").d(
-                    "recorded %d items / %.1f min = %.2f/min (store=%s)",
-                    effect.itemsShopped, minutes, perMin, effect.storeName ?: "?",
-                )
+                // The INFO line above owns the rate math (one format string, not a drifting twin);
+                // DEBUG adds only the merchant name, which is PII-tier.
+                Timber.tag("ShopRate").d("recorded shop store=%s", effect.storeName ?: "?")
             }
 
             is AppEffect.ProcessTipNotification -> tipEffectHandler.process(engineScope, effect)

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngine.kt
@@ -323,13 +323,16 @@ class SideEffectEngine @Inject constructor(
             is AppEffect.RecordShopRate -> {
                 // #556/#588: learn the dasher's shopping pace for THIS platform.
                 val minutes = effect.shopDurationMs / 60_000.0
-                strategyRepository.recordShopRate(effect.platform, effect.itemsShopped, minutes)
+                val learned = strategyRepository.recordShopRate(effect.platform, effect.itemsShopped, minutes)
                 val perMin = if (minutes > 0) effect.itemsShopped / minutes else 0.0
                 // #551 P7: rate math + the platform wire are shareable INFO milestones (the wire is a
                 // registry token, not PII); the merchant name (raw third-party UI text) stays DEBUG-only.
+                // #731: the learned running mean lives only in the strategy DataStore, invisible to a
+                // post-dash data pull — surface it here so the relearn trajectory is desk-visible.
                 Timber.tag("ShopRate").i(
-                    "recorded %d items / %.1f min = %.2f/min [%s]",
+                    "recorded %d items / %.1f min = %.2f/min [%s] → learned %.2f/min (n=%d)",
                     effect.itemsShopped, minutes, perMin, effect.platform.wire,
+                    learned.itemsPerMin ?: 0.0, learned.sampleCount,
                 )
                 Timber.tag("ShopRate").d(
                     "recorded %d items / %.1f min = %.2f/min (store=%s)",

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/UiInteractionHandler.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/UiInteractionHandler.kt
@@ -75,7 +75,7 @@ class UiInteractionHandler @Inject constructor(
         Timber.i("UiInteractionHandler: attempting verified click (%s)", description)
 
         if (expectedPackage.isNullOrEmpty()) {
-            Timber.w("No package scope for %s — refusing to click (fail closed)", description)
+            Timber.tag("Effects").w("No package scope for %s — refusing to click (fail closed)", description)
             return false
         }
         // #602: a notification-action tap can land here ~tens of ms after the
@@ -94,7 +94,7 @@ class UiInteractionHandler @Inject constructor(
         }
         val roots = if (allowRetry) awaitLiveRoots(expectedPackage, source = rootsSource) else rootsSource()
         if (roots.isEmpty()) {
-            Timber.w(
+            Timber.tag("Effects").w(
                 "No live windows for package %s after %d retries over %dms — cannot click (%s)",
                 expectedPackage, RETRY_DELAYS_MS.size, RETRY_DELAYS_MS.sum(), description,
             )
@@ -103,7 +103,7 @@ class UiInteractionHandler @Inject constructor(
 
         val candidates = findCandidates(roots, ref)
         if (candidates.isEmpty()) {
-            Timber.w(
+            Timber.tag("Effects").w(
                 "Could not find any live node for: %s (id=%s, text=%s, bounds=%s)",
                 description, ref.viewIdSuffix, ref.text, ref.boundsInScreen,
             )
@@ -119,7 +119,7 @@ class UiInteractionHandler @Inject constructor(
             if (expectation.matchesLabels(labels)) node to labels else null
         }
         if (labeledCandidates.isEmpty()) {
-            Timber.w(
+            Timber.tag("Effects").w(
                 "%d candidate(s) for %s but NONE passed label verification (%s) — refusing to click",
                 candidates.size, description, expectation.labelPattern,
             )
@@ -146,7 +146,7 @@ class UiInteractionHandler @Inject constructor(
             ranked.tier == ClickCandidateRanker.Tier.UNRESOLVED && verified.size > 1 -> {
                 // WARN carries counts only — raw third-party UI text is DEBUG-tier
                 // by Principle 7 (the WARN slice is user-exportable), #618 review F1.
-                Timber.w(
+                Timber.tag("Effects").w(
                     "No decisive match among %d verified candidates for: %s — clicking first",
                     verified.size, description,
                 )

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/UiInteractionHandler.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/UiInteractionHandler.kt
@@ -72,7 +72,7 @@ class UiInteractionHandler @Inject constructor(
         description: String,
         allowRetry: Boolean = false,
     ): Boolean {
-        Timber.i("UiInteractionHandler: attempting verified click (%s)", description)
+        Timber.tag("Effects").i("UiInteractionHandler: attempting verified click (%s)", description)
 
         if (expectedPackage.isNullOrEmpty()) {
             Timber.tag("Effects").w("No package scope for %s — refusing to click (fail closed)", description)
@@ -150,10 +150,10 @@ class UiInteractionHandler @Inject constructor(
                     "No decisive match among %d verified candidates for: %s — clicking first",
                     verified.size, description,
                 )
-                Timber.d("Unresolved-tie candidate labels for %s: %s", description, facts.map { it.labels })
+                Timber.tag("Effects").d("Unresolved-tie candidate labels for %s: %s", description, facts.map { it.labels })
             }
-            verified.size == 1 -> Timber.d("Single verified candidate for %s — clicking it", description)
-            else -> Timber.d(
+            verified.size == 1 -> Timber.tag("Effects").d("Single verified candidate for %s — clicking it", description)
+            else -> Timber.tag("Effects").d(
                 "Resolved click target for %s via %s tier (%d candidate(s))",
                 description, ranked.tier, verified.size,
             )
@@ -275,7 +275,7 @@ internal suspend fun awaitLiveRoots(
         delay(delayMs)
         val roots = source()
         if (roots.isNotEmpty()) {
-            Timber.d("Live window for %s reappeared after a %dms retry", expectedPackage, delayMs)
+            Timber.tag("Effects").d("Live window for %s reappeared after a %dms retry", expectedPackage, delayMs)
             return roots
         }
     }

--- a/app/src/test/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngineTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/state/effects/SideEffectEngineTest.kt
@@ -14,6 +14,7 @@ import cloud.trotter.dashbuddy.domain.config.EvidenceCategory
 import cloud.trotter.dashbuddy.domain.config.EvidenceConfig
 import cloud.trotter.dashbuddy.domain.config.OfferAutomationConfig
 import cloud.trotter.dashbuddy.domain.evaluation.EvaluationConfig
+import cloud.trotter.dashbuddy.domain.evaluation.LearnedShopRate
 import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluation
 import cloud.trotter.dashbuddy.domain.evaluation.OfferEvaluator
 import cloud.trotter.dashbuddy.domain.model.cards.FlowCardSnapshot
@@ -93,6 +94,9 @@ class SideEffectEngineTest {
     private val strategyRepository: StrategyRepository = mock {
         on { this.evidenceConfig } doReturn this@SideEffectEngineTest.evidenceConfig
         on { this.evaluationConfig } doReturn this@SideEffectEngineTest.evaluationConfig
+        // #731: recordShopRate now returns the post-fold learned pace — stub it so RecordShopRate
+        // effects don't NPE on the (non-nullable) LearnedShopRate result.
+        on { recordShopRate(any(), any(), any()) } doReturn LearnedShopRate(0.8, 5)
     }
     private val screenShotHandler: ScreenShotHandler = mock()
     private val uiInteractionHandler: UiInteractionHandler = mock()
@@ -796,6 +800,9 @@ class SideEffectEngineTest {
             tree.assertLevelContains(Log.INFO, "24 items")
             // #588: the platform wire is a registry token (PII-safe) and rides the INFO milestone.
             tree.assertLevelContains(Log.INFO, "doordash")
+            // #731: the post-fold learned pace (stubbed above) rides the same INFO line — counts/
+            // rates only, PII-safe by construction.
+            tree.assertLevelContains(Log.INFO, "learned 0.80/min (n=5)")
             // The DEBUG firehose still names the store.
             tree.assertLevelContains(Log.DEBUG, "H-E-B")
         } finally {

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/strategy/StrategyRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/strategy/StrategyRepository.kt
@@ -191,7 +191,10 @@ class StrategyRepository @Inject constructor(
     }.stateIn(scope, SharingStarted.Eagerly, null)
 
 
-    /** #556/#588: fold a completed shop's measured pace into [platform]'s learned items/min (atomic). */
+    /**
+     * #556/#588: fold a completed shop's measured pace into [platform]'s learned items/min (atomic).
+     * Returns the post-fold [LearnedShopRate] (#731) so the caller can log the relearn trajectory.
+     */
     suspend fun recordShopRate(platform: Platform, items: Int, minutes: Double) =
         dataSource.recordShopRate(platform, items, minutes)
 

--- a/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/strategy/StrategyDataSource.kt
+++ b/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/strategy/StrategyDataSource.kt
@@ -119,20 +119,27 @@ class StrategyDataSource @Inject constructor(
      * #556/#588: fold one measured shop ([items] over [minutes] in-store) into [platform]'s running
      * mean, atomically (read-modify-write inside one edit, so back-to-back stacked shops can't race).
      * Out-of-band samples (below the [ShopRate] floors) are no-ops. Only [platform]'s key pair moves.
+     *
+     * Returns the post-fold [LearnedShopRate] (#731 desk-observability) — the running mean lives
+     * ONLY in this datastore, which a post-dash data pull never includes, so surfacing it lets the
+     * caller log the relearn trajectory instead of it being invisible to desk analysis.
      */
-    suspend fun recordShopRate(platform: Platform, items: Int, minutes: Double) {
+    suspend fun recordShopRate(platform: Platform, items: Int, minutes: Double): LearnedShopRate {
+        lateinit var result: LearnedShopRate
         ds.edit { p ->
             val (avg, n) = ShopRate.fold(p[shopRateKey(platform)], p[shopSamplesKey(platform)] ?: 0, items, minutes)
             if (avg != null) {
                 p[shopRateKey(platform)] = avg
                 p[shopSamplesKey(platform)] = n
             }
+            result = LearnedShopRate(avg, n)
             // #588 FIX 3b: one-time tidy — drop the old un-suffixed global keys now that shop-rate
             // learning is per-platform. Idempotent (a no-op once they're gone); rides the next fold
             // rather than a dedicated migration step since a fold happens on every real shop anyway.
             p.remove(legacyGlobalShopRateKey)
             p.remove(legacyGlobalShopSamplesKey)
         }
+        return result
     }
 
     suspend fun setEvidenceMaster(enabled: Boolean) {

--- a/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/strategy/StrategyDataSource.kt
+++ b/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/strategy/StrategyDataSource.kt
@@ -125,21 +125,22 @@ class StrategyDataSource @Inject constructor(
      * caller log the relearn trajectory instead of it being invisible to desk analysis.
      */
     suspend fun recordShopRate(platform: Platform, items: Int, minutes: Double): LearnedShopRate {
-        lateinit var result: LearnedShopRate
-        ds.edit { p ->
+        val prefs = ds.edit { p ->
             val (avg, n) = ShopRate.fold(p[shopRateKey(platform)], p[shopSamplesKey(platform)] ?: 0, items, minutes)
             if (avg != null) {
                 p[shopRateKey(platform)] = avg
                 p[shopSamplesKey(platform)] = n
             }
-            result = LearnedShopRate(avg, n)
             // #588 FIX 3b: one-time tidy — drop the old un-suffixed global keys now that shop-rate
             // learning is per-platform. Idempotent (a no-op once they're gone); rides the next fold
             // rather than a dedicated migration step since a fold happens on every real shop anyway.
             p.remove(legacyGlobalShopRateKey)
             p.remove(legacyGlobalShopSamplesKey)
         }
-        return result
+        // edit() returns the post-transform snapshot, so this read-back cannot desync from what was
+        // persisted: an in-band fold just wrote these keys; an out-of-band fold is a no-op and the
+        // untouched keys ARE the prior pair ShopRate.fold would have returned.
+        return LearnedShopRate(prefs[shopRateKey(platform)], prefs[shopSamplesKey(platform)] ?: 0)
     }
 
     suspend fun setEvidenceMaster(enabled: Boolean) {

--- a/core/datastore/src/test/java/cloud/trotter/dashbuddy/core/datastore/strategy/StrategyDataSourceShopRateTest.kt
+++ b/core/datastore/src/test/java/cloud/trotter/dashbuddy/core/datastore/strategy/StrategyDataSourceShopRateTest.kt
@@ -4,6 +4,7 @@ import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.doublePreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
+import cloud.trotter.dashbuddy.domain.evaluation.LearnedShopRate
 import cloud.trotter.dashbuddy.domain.evaluation.ShopRate
 import cloud.trotter.dashbuddy.domain.state.Platform
 import kotlinx.coroutines.CoroutineScope
@@ -58,8 +59,14 @@ class StrategyDataSourceShopRateTest {
         assertNull(rates[Platform.WalmartSpark])
 
         // Recording MORE DoorDash shops must not perturb Instacart's mean or count.
-        repeat(3) { src.recordShopRate(Platform.DoorDash, items = 12, minutes = 30.0) } // 0.4/min, drags DD down
+        // #731: recordShopRate now RETURNS the post-fold LearnedShopRate — assert the last call's
+        // return value reflects the fold, not just what a subsequent read of the flow shows.
+        var lastReturned: LearnedShopRate? = null
+        repeat(3) {
+            lastReturned = src.recordShopRate(Platform.DoorDash, items = 12, minutes = 30.0) // 0.4/min, drags DD down
+        }
         advanceUntilIdle()
+        assertEquals(8, lastReturned!!.sampleCount)
         val after = src.learnedShopRates.first()
         assertEquals("Instacart untouched", 1.5, after.getValue(Platform.Instacart).itemsPerMin!!, 1e-9)
         assertEquals("Instacart untouched", 5, after.getValue(Platform.Instacart).sampleCount)

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/PipelineStats.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/PipelineStats.kt
@@ -36,6 +36,8 @@ class PipelineStats @Inject constructor() {
     private val scrubbedUnknownCaptures = AtomicLong()
     private val redactBackstopScrubs = AtomicLong()
     private val notifRedactBackstopScrubs = AtomicLong()
+    private val notifListenerConnects = AtomicLong()
+    private val notifListenerDisconnects = AtomicLong()
 
     val droppedSensitiveCount: Long get() = droppedSensitive.get()
     val droppedNoiseCount: Long get() = droppedNoise.get()
@@ -49,6 +51,8 @@ class PipelineStats @Inject constructor() {
     val scrubbedUnknownCaptureCount: Long get() = scrubbedUnknownCaptures.get()
     val redactBackstopScrubCount: Long get() = redactBackstopScrubs.get()
     val notifRedactBackstopScrubCount: Long get() = notifRedactBackstopScrubs.get()
+    val notifListenerConnectCount: Long get() = notifListenerConnects.get()
+    val notifListenerDisconnectCount: Long get() = notifListenerDisconnects.get()
 
     /** A frame the shared content gate dropped (sensitive or noise, #399). */
     fun onContentGateDrop(parsed: ParsedFields) {
@@ -105,6 +109,14 @@ class PipelineStats @Inject constructor() {
     /** The supervised upstream crashed and is resubscribing. Returns the restart ordinal. */
     fun onPipelineRestart(): Long = restarts.incrementAndGet()
 
+    /** The system (re)bound the notification listener service (#731). Returns the running
+     *  connect count for this process. */
+    fun onNotifListenerConnected(): Long = notifListenerConnects.incrementAndGet()
+
+    /** The system tore down the notification listener (#731) — opens an offer-miss window until
+     *  reconnect, so this is a degradation, not a milestone. Returns the running disconnect count. */
+    fun onNotifListenerDisconnected(): Long = notifListenerDisconnects.incrementAndGet()
+
     /** An observation was forwarded to the state machine. */
     fun onForwarded() {
         val n = forwarded.incrementAndGet()
@@ -127,6 +139,8 @@ class PipelineStats @Inject constructor() {
             " unknownScrubbed=${scrubbedUnknownCaptures.get()}" +
             " redactBackstopScrubs=${redactBackstopScrubs.get()}" +
             " notifRedactBackstopScrubs=${notifRedactBackstopScrubs.get()}" +
+            " notifListenerConnects=${notifListenerConnects.get()}" +
+            " notifListenerDisconnects=${notifListenerDisconnects.get()}" +
             " restarts=${restarts.get()}"
 
     companion object {

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/notification/input/NotificationListener.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/notification/input/NotificationListener.kt
@@ -21,11 +21,11 @@ class NotificationListener : NotificationListenerService() {
     lateinit var pipelineStats: PipelineStats
 
     override fun onListenerConnected() {
-        // #731: the system rebinds this listener 129-240x/day per field observation — WARN (not
-        // INFO) because a rebind opens an offer-miss window until reconnect, per the connect side
-        // pairing with onListenerDisconnected below.
+        // #731: the connect is the RECOVERY half of a rebind cycle (and fires once at every normal
+        // startup), so it stays INFO; the degradation signal is the disconnect WARN below. The
+        // count still rides the exportable INFO+ slice for desk analysis of the flap rate.
         val count = pipelineStats.onNotifListenerConnected()
-        Timber.tag("Pipeline").w("Notification listener connected (count=%d this process)", count)
+        Timber.tag("Pipeline").i("Notification listener connected (count=%d this process)", count)
     }
 
     override fun onNotificationPosted(sbn: StatusBarNotification?) {

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/notification/input/NotificationListener.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/notification/input/NotificationListener.kt
@@ -2,6 +2,7 @@ package cloud.trotter.dashbuddy.core.pipeline.notification.input
 
 import android.service.notification.NotificationListenerService
 import android.service.notification.StatusBarNotification
+import cloud.trotter.dashbuddy.core.pipeline.PipelineStats
 import cloud.trotter.dashbuddy.domain.settings.PlatformPreferences
 import dagger.hilt.android.AndroidEntryPoint
 import timber.log.Timber
@@ -16,8 +17,15 @@ class NotificationListener : NotificationListenerService() {
     @Inject
     lateinit var platformPreferences: PlatformPreferences
 
+    @Inject
+    lateinit var pipelineStats: PipelineStats
+
     override fun onListenerConnected() {
-        Timber.i("Notification Listener Connected!")
+        // #731: the system rebinds this listener 129-240x/day per field observation — WARN (not
+        // INFO) because a rebind opens an offer-miss window until reconnect, per the connect side
+        // pairing with onListenerDisconnected below.
+        val count = pipelineStats.onNotifListenerConnected()
+        Timber.tag("Pipeline").w("Notification listener connected (count=%d this process)", count)
     }
 
     override fun onNotificationPosted(sbn: StatusBarNotification?) {
@@ -41,6 +49,9 @@ class NotificationListener : NotificationListenerService() {
 
     override fun onListenerDisconnected() {
         super.onListenerDisconnected()
-        Timber.i("Notification Listener Disconnected.")
+        // #731: WARN — a disconnect opens an offer-miss window until the system rebinds; the
+        // running count quantifies the field-observed 129-240x/day flap.
+        val count = pipelineStats.onNotifListenerDisconnected()
+        Timber.tag("Pipeline").w("Notification listener disconnected (count=%d this process)", count)
     }
 }

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/notification/input/NotificationListener.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/notification/input/NotificationListener.kt
@@ -36,7 +36,7 @@ class NotificationListener : NotificationListenerService() {
         // froze at the last value for the process lifetime.
         if (sbn.packageName !in platformPreferences.enabledPackages.value) return
 
-        Timber.d(
+        Timber.tag("Pipeline").d(
             "\uD83D\uDCEC Notification from %s: clearable=%s ongoing=%s channel=%s",
             sbn.packageName, sbn.isClearable, sbn.isOngoing, sbn.notification.channelId,
         )
@@ -49,9 +49,17 @@ class NotificationListener : NotificationListenerService() {
 
     override fun onListenerDisconnected() {
         super.onListenerDisconnected()
-        // #731: WARN — a disconnect opens an offer-miss window until the system rebinds; the
-        // running count quantifies the field-observed 129-240x/day flap.
+        // #731: a disconnect opens an offer-miss window until the system rebinds — a genuine
+        // degradation, but field-observed at 129-240x/day, which would drown the exportable WARN
+        // slice (Principle 7's "must not be drowned" clause; ~1.3k WARNs on the whole 06-19 dash).
+        // Edge-gate like the D6 join-miss WARN: the FIRST disconnect per process announces the
+        // degradation class at WARN; the rest ride INFO (still exported) with the running count,
+        // which is what the desk flap analysis actually consumes.
         val count = pipelineStats.onNotifListenerDisconnected()
-        Timber.tag("Pipeline").w("Notification listener disconnected (count=%d this process)", count)
+        if (count == 1L) {
+            Timber.tag("Pipeline").w("Notification listener disconnected (count=%d this process)", count)
+        } else {
+            Timber.tag("Pipeline").i("Notification listener disconnected (count=%d this process)", count)
+        }
     }
 }

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/PipelineStatsTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/PipelineStatsTest.kt
@@ -44,4 +44,21 @@ class PipelineStatsTest {
         assertTrue(summary.contains("restarts=2"))
         assertTrue(summary.contains("mappingFailures=1"))
     }
+
+    /** #731 — quantify the field-observed notification-listener rebind (129-240x/day). */
+    @Test
+    fun `notif listener connect and disconnect counters track independently and appear in the summary`() {
+        val stats = PipelineStats()
+
+        assertEquals(1L, stats.onNotifListenerConnected())
+        assertEquals(2L, stats.onNotifListenerConnected())
+        assertEquals(1L, stats.onNotifListenerDisconnected())
+
+        assertEquals(2L, stats.notifListenerConnectCount)
+        assertEquals(1L, stats.notifListenerDisconnectCount)
+
+        val summary = stats.summary()
+        assertTrue(summary.contains("notifListenerConnects=2"))
+        assertTrue(summary.contains("notifListenerDisconnects=1"))
+    }
 }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -28,8 +28,9 @@ Companion: `docs/design/analytics-roadmap.md` (the analytics-specific phases).
 
 ## Needs design / field data first (actionable-soon)
 
-- **#245** ADR-0007 canonical domain schema — high-leverage; unblocks #141 (cloud RFC) + #251
-  (Uber multi-offer) → which unblocks #110 (expanded offer overlay).
+- **#245** ADR-0007 canonical domain schema — high-leverage; unblocks #251
+  (Uber multi-offer) → which unblocks #110 (expanded offer overlay). (Formerly also gated #141,
+  closed 2026-07-12 — its un-built cloud half folded into the #192/#193/#194 pillar epics.)
 - **#526** pickup placeholders + swap (PR #546 is the dev-gated partial; reshaped scope; wait for
   multi-pickup field data). **#630** mid-stack under-attribution (same family). **#527** job
   lifetime. **#528** GPS $/mi slices B/C.
@@ -50,7 +51,7 @@ Companion: `docs/design/analytics-roadmap.md` (the analytics-specific phases).
 - **#246 LEGAL counsel** ← the pacing gate for: #170 (disclosure flow), #637→#636→#638 (matchers
   repo creation — PARKED by the 2026-07-03 keep-in-tree decision), and transitively #641.
 - **#416 signature verification** ← gates #640 (OTA fetch). **#419** is buildable now (above).
-- **#251** ← #245. **#110** ← #251 + #96. **#99** ← #56. **#588** ← #438. **#141** ← #245.
+- **#251** ← #245. **#110** ← #251 + #96. **#99** ← #56.
 - **#192 epic** (matchers distribution) — in-tree M1 done (#635/#639); repo-era work parked.
 - **#193/#194** academic pillar RFCs — future.
 

--- a/docs/adr/ADR-0007-canonical-domain-schema.md
+++ b/docs/adr/ADR-0007-canonical-domain-schema.md
@@ -578,7 +578,9 @@ unchanged (no code touched yet). Implementation PRs that follow will run
   `presentedZoneId` for the matcher OTA story.
 - RFC #194 (academic federation) — consumes the privacy-class taxonomy and
   the Aggregation Catalog as its query surface.
-- Issue #141 monetization plan — the managed-cloud sync tier ingests the
-  same canonical schema.
+- The managed-cloud sync tier (CLAUDE.md pillar 1) ingests the same canonical
+  schema. *(Its former tracker #141 — actually the cloud-data-platform RFC, not
+  the pricing plan — closed 2026-07-12; the cloud work is folded into the
+  #192/#193/#194 pillar epics.)*
 - `LEGAL.md` — framing pledge enforced field-by-field in the federation
   lens.

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -80,11 +80,14 @@ was found **broken-in-part** (raw PII in capture envelopes) and moved to that en
 
 - **🆕 NEW — notification-listener rebind rate is now quantified (#731 instrumentation / PR).**
   The NLS connect/disconnect lifecycle now rides `PipelineStats` counters and leveled log lines
-  (disconnect = WARN "Notification listener disconnected (count=N this process)", connect = INFO,
-  tag `Pipeline`), so the field-observed 129–240 cycles/day flap is measurable from a pull.
+  (tag `Pipeline`): the FIRST disconnect per process announces the degradation at WARN, every
+  subsequent disconnect and all connects ride INFO — all with running counts — so the
+  field-observed 129–240 cycles/day flap is measurable from a pull without drowning the WARN slice.
   **How to tell it's working (desk-side only):** after a dash,
-  `grep -i 'notification listener' shareable.log` shows the paired lines with running counts, and
-  the periodic `PipelineStats` summary carries `notifListenerConnects=`/`notifListenerDisconnects=`.
+  `grep -i 'notification listener' shareable.log` shows the paired lines with running counts
+  (`connects − disconnects ≈ process deaths` per process — a kill never logs its disconnect), and
+  the periodic `PipelineStats` summary carries `notifListenerConnects=`/`notifListenerDisconnects=`
+  (corroboration only — it emits per 50 forwarded observations, so it's quiet while idle).
   The counts themselves feed the #731 root-cause call (battery-optimization kills vs other) — high
   counts are the *expected* finding, not a failure of this item.
   - Confirmed: 0/2
@@ -228,7 +231,8 @@ was found **broken-in-part** (raw PII in capture envelopes) and moved to that en
   second platform (Uber/Instacart) is ever shopped. Watch for any shop offer suddenly reading an absurd
   $/hr (would mean the seed/reset went wrong). The same INFO line now also carries the post-fold
   `→ learned X.XX/min (n=N)` suffix (the desk window into the DataStore-only learned mean — watch `n`
-  climb from the reset and the mean converge off the 0.8 seed).
+  climb from the reset and the mean converge off the 0.8 seed; `learned ?/min (n=0)` means nothing
+  learned yet, not a zeroed mean).
   - Confirmed: 0/2
 - **🆕 NEW — store entity resolution keys real stores from live dashes (#159 / PR).**
   The read-model now resolves each job's stores (`stores` + `pickup_records` tables) from captured
@@ -343,9 +347,9 @@ was found **broken-in-part** (raw PII in capture envelopes) and moved to that en
   leaves the other's banner untouched — a tap must never act on a **replaced/older** offer (that path
   now WARN-aborts to manual rather than acting on the wrong one). A banner that acts on the wrong
   offer, or a stale banner that survives its offer, is a B4 regression — capture it. **Desk-side:**
-  each tap's `OfferActionReceiver:` INFO line now carries `(offer=<8-hex>)` — join it to the resolved
-  `OFFER_ACCEPTED`/`OFFER_DECLINED` event's hash; a mismatch is the wrong-offer regression, no eyes
-  needed.
+  each tap's `OfferActionReceiver:` INFO line now carries `(offer=<hash>)` (the full hash, same
+  rendering as OfferEffects) — exact-match it to the resolved `OFFER_ACCEPTED`/`OFFER_DECLINED`
+  event's hash; a mismatch is the wrong-offer regression, no eyes needed.
   - Confirmed: 0/2
 - **🆕 NEW — odometer arbitration holds single-platform (#438 B5 / PR).** The GPS odometer moved off
   each platform's own diff onto one cross-platform decision (starts once when a dash opens, pauses
@@ -2506,7 +2510,9 @@ replay test). Lower: #565 Walgreens, then the design calls (#6 decline fallback,
      "every screen to value is a place to lose someone" becomes literally true with money attached.
    - **Status:** Open — **strategic/design note only**, no work item filed, no code changes. Bookmark
      for the #141 monetization launch; near-term, only ensure economy config is deferred behind
-     defaults rather than gating the first dash.
+     defaults rather than gating the first dash. *[Editor's note 2026-07-12: #141 has since closed —
+     it was the cloud-data-platform RFC, not the pricing plan; the paid-tier launch plan lives in
+     CLAUDE.md pillar 1. The "funnel teardown at paid-tier launch" bookmark itself still stands.]*
 
 10. **Voice accept/decline of offers — hands-free, on-device. Feasibility / overhead note (dasher
     asked "what would the overhead be").** Let the driver say "accept" / "decline" instead of

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -53,6 +53,11 @@ PRs / closed issues) that were validated only against captured data and need
 eyes on a live dash. A field-testing agent reads this section at the start of a
 session and reports it to the developer.
 
+**Desk-first:** most items below are resolvable (fully or half) from a post-dash
+data pull alone — the per-item SQL/grep/capture checks live in
+[`desk-validation-playbook.md`](desk-validation-playbook.md) (audit 2026-07-12).
+Run the playbook against the pull before burning dev-eyes on anything.
+
 **Each item needs two independent field confirmations before it's considered
 validated** — one dash can pass by luck or miss the edge case. Track progress
 with a `- Confirmed: N/2` sub-line (note the date/conditions of each sighting).
@@ -72,6 +77,17 @@ heads-up **buttons** (≥16 clean fires from the floating banner — the field g
 card's **mechanical** half, #577 (re-confirmed, 24/24, ~0.55 s — with a new posture caution, see
 that entry's Bug #1), the #457 path, and #554 ShadowProjector (2/2). The #462/#460 dropoff item
 was found **broken-in-part** (raw PII in capture envelopes) and moved to that entry's Bug #7.)_
+
+- **🆕 NEW — notification-listener rebind rate is now quantified (#731 instrumentation / PR).**
+  The NLS connect/disconnect lifecycle now rides `PipelineStats` counters and leveled log lines
+  (disconnect = WARN "Notification listener disconnected (count=N this process)", connect = INFO,
+  tag `Pipeline`), so the field-observed 129–240 cycles/day flap is measurable from a pull.
+  **How to tell it's working (desk-side only):** after a dash,
+  `grep -i 'notification listener' shareable.log` shows the paired lines with running counts, and
+  the periodic `PipelineStats` summary carries `notifListenerConnects=`/`notifListenerDisconnects=`.
+  The counts themselves feed the #731 root-cause call (battery-optimization kills vs other) — high
+  counts are the *expected* finding, not a failure of this item.
+  - Confirmed: 0/2
 
 - **🆕 NEW — a same-customer double-order job closes at its receipt; the next offer is its OWN job (#749).**
   A job where **both orders go to the same customer** (the offer card literally says so — e.g. Willie's +
@@ -210,7 +226,9 @@ was found **broken-in-part** (raw PII in capture envelopes) and moved to that en
   the dash:** the shareable INFO log's
   `ShopRate` lines now carry a `[doordash]` platform tag; there should be no cross-platform bleed if a
   second platform (Uber/Instacart) is ever shopped. Watch for any shop offer suddenly reading an absurd
-  $/hr (would mean the seed/reset went wrong).
+  $/hr (would mean the seed/reset went wrong). The same INFO line now also carries the post-fold
+  `→ learned X.XX/min (n=N)` suffix (the desk window into the DataStore-only learned mean — watch `n`
+  climb from the reset and the mean converge off the 0.8 seed).
   - Confirmed: 0/2
 - **🆕 NEW — store entity resolution keys real stores from live dashes (#159 / PR).**
   The read-model now resolves each job's stores (`stores` + `pickup_records` tables) from captured
@@ -324,7 +342,10 @@ was found **broken-in-part** (raw PII in capture envelopes) and moved to that en
   same-platform): tapping the current banner acts on the **current** offer, and resolving one offer
   leaves the other's banner untouched — a tap must never act on a **replaced/older** offer (that path
   now WARN-aborts to manual rather than acting on the wrong one). A banner that acts on the wrong
-  offer, or a stale banner that survives its offer, is a B4 regression — capture it.
+  offer, or a stale banner that survives its offer, is a B4 regression — capture it. **Desk-side:**
+  each tap's `OfferActionReceiver:` INFO line now carries `(offer=<8-hex>)` — join it to the resolved
+  `OFFER_ACCEPTED`/`OFFER_DECLINED` event's hash; a mismatch is the wrong-offer regression, no eyes
+  needed.
   - Confirmed: 0/2
 - **🆕 NEW — odometer arbitration holds single-platform (#438 B5 / PR).** The GPS odometer moved off
   each platform's own diff onto one cross-platform decision (starts once when a dash opens, pauses

--- a/docs/field-testing/desk-validation-playbook.md
+++ b/docs/field-testing/desk-validation-playbook.md
@@ -1,0 +1,121 @@
+# Desk-validation playbook
+
+**Purpose.** Resolve as many `## Next field test` checklist items as possible from a
+post-dash data pull alone — no dev eyes needed while driving. Run these checks against
+the pull under `~/dashbuddy/logs/YYYY/MM/DD/`: the Room DB (`sqlite3` on the pulled db —
+remember the WAL sidecar), `app.log` (DEBUG firehose), `shareable.log` (INFO+ only), and
+the capture envelope tree.
+
+Classification of the current 0/2–1/2 items (audit 2026-07-12):
+**fully desk-resolvable:** #749, #660p2, #688B, #630, #736, #752, #733, #501 (items 1-2
+and 3), #159, #691-mechanism. **desk-partial** (data half here; UI half needs dev eyes):
+#588, #315 H5, #438 B3/B4/B5, #688A, #693, #701-positive. **dev-eyes only:** #722
+(bubble gas control has no durable trace — pure UI/DataStore surface).
+
+> `app.log` matters: some decision logs are DEBUG by design (reducer steps). Pull it,
+> not just the exported bug report.
+
+## SQL checks
+
+```sql
+-- #749  same-customer double-order job closes; next offer is its OWN job
+SELECT eventSequenceId, jobId, taskId, storeName, payBasis, realizedPay
+FROM delivery_records ORDER BY eventSequenceId;
+-- expect: one drop per customer for the double job; the NEXT offer's rows carry a DIFFERENT jobId;
+-- no unattributed spike for that stretch (see the #701 query).
+-- also: grep '#749 coverage arm closed' app.log   (DEBUG, tag StateMachine — jobId + counts)
+
+-- #660p2  orphan delivery categorized into its real dash
+SELECT eventSequenceId, sessionId, sessionAssigned, netProfit, realizedPay, payBasis
+FROM delivery_records WHERE sessionAssigned = 1;
+-- expect: sessionId now non-null = the picked dash; frozen economics unchanged vs pre-assign.
+-- guard rejections: grep 'DELIVERY_SESSION_ASSIGN' shareable.log  (WARN = a skip; INFO = the append)
+
+-- #688B  per-leg mileage + the ONE-SIDED Σ invariant
+SELECT jobId, taskId, milesToStore, milesToDropoff, realizedMiles
+FROM delivery_records WHERE sessionId = :sid;
+SELECT (SELECT SUM(realizedMiles) FROM delivery_records WHERE sessionId = s.sessionId) AS drop_miles,
+       (s.lastOdometer - s.startOdometer) AS span
+FROM session_records s WHERE sessionId = :sid;
+-- expect: stacked drops each nonzero (not one lump + 0.0); drop_miles <= span ALWAYS
+-- (undershoot expected; exceed = the mixed-basis double-count, a #688 Fix-1 regression).
+-- one-time refold on first post-install launch: grep 'projector version' shareable.log
+
+-- #630  stacked receipts split exactly
+SELECT jobId, SUM(realizedPay) FROM delivery_records
+WHERE payBasis IN ('DROP_SHARE','RECEIPT_TOTAL') GROUP BY jobId;
+-- expect: = the receipt total per job; no $0/NONE row where a receipt existed.
+-- tripwire (also the #756 promotion trigger):
+--   grep '#630 mid-stack non-final receipt exit' shareable.log   → a hit = grab that capture session
+
+-- #736 / #752  unassign produces NO paid/confirmed artifacts (either phase)
+SELECT eventType, json_extract(eventPayload,'$.phase') AS phase,
+       json_extract(eventPayload,'$.taskId') AS tid
+FROM app_events WHERE eventType = 'TASK_UNASSIGNED';
+-- expect: exactly one per abandon; phase PICKUP (#736) or DROPOFF (#752); then verify NO
+-- PICKUP_CONFIRMED / DELIVERY_CONFIRMED / DELIVERY_COMPLETED shares that taskId, and no
+-- delivery_records row for it. (A prior-frame DELIVERY_CONFIRMED before a dropoff-phase
+-- unassign may exist — expected, row-inert.)
+
+-- #733  multi-pickup job lands under a REAL store
+SELECT jobId, storeName, storeKey FROM delivery_records;
+-- expect: the multi-pickup drop carries a real storeName/storeKey, not NULL/Unknown.
+-- grep -c 'D6 join miss' shareable.log   → <= 1 per drop (ideally 0), never the old x23 storm
+
+-- #159  store entity resolution
+SELECT storeKey, runningKey, chainDisplay FROM stores;
+-- expect: runningKey non-empty (…|target|02426, not …|target|); BOTH stores of a stack keyed.
+-- guard held on a payout-less close: grep 'downgrade averted' shareable.log
+
+-- #691  receipt-less shop folds est. offer pay (mechanism half)
+SELECT jobId, taskId, payBasis, realizedPay FROM delivery_records WHERE payBasis = 'OFFER_PAY';
+-- expect: real $ (not 0); a stack shows ~equal halves summing to the offer total.
+
+-- #701  over-attribution (negative path) — also the #749 unattributed check
+SELECT s.sessionId, s.reportedEarnings,
+       (SELECT SUM(realizedPay + COALESCE(cashTip,0)) FROM delivery_records d
+        WHERE d.sessionId = s.sessionId) AS delivered
+FROM session_records s;
+-- expect: delivered <= reported on every session → no over-attribution callout.
+
+-- #315 H5  Patterns data sanity (render half is dev-eyes)
+SELECT taskId, (confirmedAt - arrivedAt)/60000.0 AS dwell_min FROM pickup_records;
+-- expect: minutes-scale dwell values, not seconds/hours artifacts.
+
+-- #438 B3 / B5  offer lifecycle + odometer arbitration (data halves)
+SELECT eventType, COUNT(*) FROM app_events WHERE eventType LIKE 'OFFER_%' GROUP BY eventType;
+SELECT taskId, realizedMiles FROM delivery_records;
+-- expect: outcomes incl. OFFER_TIMEOUT coherent; accepts minted jobs WITH economics; mileage
+-- deltas sane (no stuck-0 runs, no mid-dash reset shape).
+```
+
+## Log greps (shareable.log unless noted)
+
+| Item | Grep | Expect |
+|---|---|---|
+| #749 | `grep '#749 coverage arm closed' app.log` | the coverage-arm close (DEBUG, jobId+counts) |
+| #630/#756 | `grep '#630 mid-stack non-final receipt exit'` | ideally none; a hit = pull that capture session (and it's the #756 promotion trigger) |
+| #733 | `grep -c 'D6 join miss'` | ≤1 per drop, ideally 0 |
+| #688B | `grep 'projector version'` | the one-time 5→6 refold line on first post-install launch |
+| #588 | `grep 'ShopRate'` | every line tagged `[<platform.wire>]`; the trailing `→ learned …/min (n=…)` shows the relearn trajectory (seed-reset visible as n resetting) |
+| #438 B4 | `grep 'OfferActionReceiver:'` | each tap line carries `(offer=<8-hex>)`; join it to the resolved `OFFER_*` event's hash — a mismatch = acted on the wrong offer |
+| #731 | `grep -i 'notification listener'` + the `PipelineStats` summary | disconnects at WARN + connects at INFO, each with a running count; the `PipelineStats` summary line quantifies rebinds/day |
+| #159 | `grep 'downgrade averted'` / `grep 'store-chain resolved'` | monotonic backstop held / shadow resolution milestones |
+
+## Capture-tree checks
+
+- **#501 items 1-2:** multi-order dropoff confirm frames sort into
+  `captures/**/dropoff_multi_order_confirm/`, none in `**/UNKNOWN/`; envelope JSON shows the
+  customer line masked `[redacted:xxxx]`, store + item count kept.
+- **#501 item 3:** zone-arrival frames in `captures/**/pickup_zone_arrival/`, not UNKNOWN;
+  spot-check labeled frames are REAL zone screens (over-match check); exactly ONE
+  `PICKUP_ARRIVED` per warehouse visit in `app_events` (the rule is recognize-only and must
+  not steal the bin-scan anchor).
+
+## Known non-desk residuals
+
+- **#722** (bubble gas control): no durable trace — dev-eyes only.
+- Render halves of #315 H5 / #693 / #691-qualifier / #688A dialog / #438 B3 card visuals:
+  inherently dev-eyes.
+- **#588**: the persisted learned mean lives in the strategy DataStore (not pulled); the
+  `→ learned` INFO suffix is the desk window into it.

--- a/docs/field-testing/desk-validation-playbook.md
+++ b/docs/field-testing/desk-validation-playbook.md
@@ -15,6 +15,12 @@ and 3), #159, #691-mechanism. **desk-partial** (data half here; UI half needs de
 > `app.log` matters: some decision logs are DEBUG by design (reducer steps). Pull it,
 > not just the exported bug report.
 
+> **SSOT caution:** the item list above is a dated snapshot (the README checklist is the
+> live SSOT), and the grep strings below are literal copies of log messages verified
+> against the code on 2026-07-12. A later rename of a log string breaks its grep
+> *silently* — if a grep returns nothing where a hit was plausible, verify the string
+> against the code before reading "no hits" as "invariant held".
+
 ## SQL checks
 
 ```sql
@@ -97,9 +103,9 @@ SELECT taskId, realizedMiles FROM delivery_records;
 | #630/#756 | `grep '#630 mid-stack non-final receipt exit'` | ideally none; a hit = pull that capture session (and it's the #756 promotion trigger) |
 | #733 | `grep -c 'D6 join miss'` | ≤1 per drop, ideally 0 |
 | #688B | `grep 'projector version'` | the one-time 5→6 refold line on first post-install launch |
-| #588 | `grep 'ShopRate'` | every line tagged `[<platform.wire>]`; the trailing `→ learned …/min (n=…)` shows the relearn trajectory (seed-reset visible as n resetting) |
-| #438 B4 | `grep 'OfferActionReceiver:'` | each tap line carries `(offer=<8-hex>)`; join it to the resolved `OFFER_*` event's hash — a mismatch = acted on the wrong offer |
-| #731 | `grep -i 'notification listener'` + the `PipelineStats` summary | disconnects at WARN + connects at INFO, each with a running count; the `PipelineStats` summary line quantifies rebinds/day |
+| #588 | `grep 'ShopRate'` | every line tagged `[<platform.wire>]`; the trailing `→ learned …/min (n=…)` shows the relearn trajectory (seed-reset visible as n resetting). `learned ?/min (n=0)` = nothing learned yet (an out-of-band sample folds nothing) — NOT a zeroed mean |
+| #438 B4 | `grep 'OfferActionReceiver:'` | each tap line carries `(offer=<hash>)` (full hash, same rendering as OfferEffects) — exact-match it to the resolved `OFFER_*` event's hash; a mismatch = acted on the wrong offer |
+| #731 | `grep -i 'notification listener'` | the per-event lines are the PRIMARY record: first disconnect per process at WARN, the rest (and all connects) at INFO, each with a running count. `grep -c` them for the flap rate; per process, `connects − disconnects ≈ process deaths` (itself a diagnostic — a kill never logs its disconnect). The `PipelineStats` summary fields (`notifListenerConnects=`/`Disconnects=`) are corroboration ONLY — the summary emits per 50 forwarded observations, i.e. only while actively sensing, so it is blind exactly when the idle-time flap is worst |
 | #159 | `grep 'downgrade averted'` / `grep 'store-chain resolved'` | monotonic backstop held / shadow resolution milestones |
 
 ## Capture-tree checks


### PR DESCRIPTION
Part of #731 (instrumentation slice) + the 2026-07-12 desk-observability audit of the field-test checklist.

## Summary

The developer wants checklist items resolvable from a post-dash data pull without dev-eyes. The audit found only three avoidable observability gaps plus #731's unquantified NLS flap; this PR closes all four and ships the desk-validation playbook:

- **#438 B4 desk join** — `OfferActionReceiver`'s INFO line now carries `(offer=<8-hex>)` (hash prefix of the tapped offer), so a pull can join the tap to the resolved `OFFER_ACCEPTED`/`OFFER_DECLINED` event's hash; a mismatch = acted-on-wrong-offer, detectable without eyes.
- **#588 relearn trajectory** — the learned shop pace lives ONLY in the strategy DataStore (never in a pull). `recordShopRate` now returns the post-fold `LearnedShopRate` (existing domain class — SSOT, no new type) and the `ShopRate` INFO line appends `→ learned %.2f/min (n=%d)`.
- **Actuation WARNs greppable** — `UiInteractionHandler`'s 5 fail-closed WARN sites gain the package's stable `Effects` tag (they were default-tagged, invisible to component greps of `shareable.log`).
- **#731 instrumentation** — `PipelineStats` gains `notifListenerConnects/Disconnects` counters (in `summary()`); `NotificationListener` injects it and logs *disconnect at WARN* (opens an offer-miss window = degradation) / *connect at INFO* (recovery half; fires at every normal startup — WARN would be noise) with running counts. This is the data the #731 root-cause decision is gated on.
- **Docs** — NEW `docs/field-testing/desk-validation-playbook.md` (exact SQL/grep/capture checks for every 0/2-1/2 checklist item, from the audit); checklist updates (new #731 item at 0/2, desk notes on the #588/B4 items, playbook pointer); stale-reference fixes from today's umbrella closes (#141/#585/#588 in ROADMAP.md + CLAUDE.md).

No behavior changes beyond logging/counters and the `recordShopRate` return-value plumbing.

## Tests

Full gate green: `./gradlew testDebugUnitTest :domain:test` (2211 tests, 0 failures). Extended: `PipelineStatsTest` (new counters + summary), `StrategyDataSourceShopRateTest` (returned fold value), `SideEffectEngineTest` (the `learned 0.80/min (n=5)` INFO assertion + non-null stub).

## Security / privacy posture

Logging-only surface. All new/changed INFO+ content is PII-safe by construction: an offer-hash 8-char prefix (a hash of a hash-carrying identity, #598 precedent), platform wire tokens, counts, and rates — no raw store/customer text anywhere. No recognition, capture, network, or persistence changes.

### Design-goal review

- **P1 (UDF):** untouched — all changes at the effect/logging edge; no reducer/stepper logic.
- **P4 (idiomatic Kotlin):** `lateinit var` capture inside the single-run DataStore `edit` lambda is the minimal way to surface the fold result; mockito-kotlin's deprecated `onBlocking` replaced with `on { }`.
- **P5 (SSOT):** reused the existing `LearnedShopRate` domain class rather than a new Pair/wrapper; counters live in the one `PipelineStats` singleton beside their siblings.
- **P7 (semantic logging):** the headline principle here. New WARN = the NLS disconnect (a real degradation, field-observed 129–240×/day — the signal we're quantifying, not noise); connect deliberately kept INFO (recovery half + startup fires). All INFO+ additions are hashes/tokens/counts. The five re-tagged WARNs change tag only, not text/level.
- **P8 (platform-agnostic):** no platform literals; the ShopRate line keys on `platform.wire` from the registry.

### Adversarial review

Loop: 6 independent session-tier finders (line-by-line, removed-behavior, cross-file tracer, reuse/simplification, efficiency/altitude, CLAUDE.md conventions) → fixes applied in `03417046` → full gate re-run green. **Verdict: APPROVE (all findings fixed in-PR or filed).**

**Fixed in-PR (converged findings first):**
1. **Half-applied `Effects` retag (5 finders):** the INFO "attempting verified click" anchor (+4 DEBUG sites) stayed on the catch-all tag, breaking the tag-filtered attempt→refusal join this PR exists to enable. Every Timber site in `UiInteractionHandler` now carries `Effects` (0 untagged remain).
2. **Disconnect-WARN flood (4 finders):** a per-event WARN at the field-observed 129–240×/day would drown the exportable WARN slice the playbook triages (~1.3k WARNs on the whole 06-19 receipt dash). Edge-gated per the D6 precedent: FIRST disconnect per process at WARN (announces the degradation class), the rest at INFO with the running count — which is what the desk flap analysis actually consumes. Playbook + checklist updated to match, including the summary-emission blind spot (the `PipelineStats` summary only fires while actively sensing → per-event lines are the primary record; `connects − disconnects ≈ process deaths` is itself a diagnostic).
3. **Fake `learned 0.00/min` sentinel (3 finders):** a never-learned mean rendered as a literal zero on the desk-facing line. Now renders `?`; playbook/checklist explain the sentinel.
4. **Locale-fragile formatting (1 finder, verified):** Timber formats under the default locale, so the new test assertion `"0.80"` would fail on a comma-decimal JVM. The learned-rate substring is now formatted with `Locale.ROOT` (machine-string rule, principle 4), making both the log and the assertion locale-stable.
5. **`lateinit` lambda-capture (2 finders):** replaced with `ds.edit`'s returned post-transform snapshot — provably equivalent in both fold arms (in-band writes the keys; out-of-band no-op leaves the prior pair, which is exactly what `ShopRate.fold` returns), and the only lambda-capture among the module's 43 edit sites is gone.
6. **Third hash rendering (1 finder):** the 8-char prefix made the tap↔event join a prefix special case; now the FULL hash (OfferEffects rendering) → exact grep.
7. **Twin ShopRate format strings (1 finder):** DEBUG collapsed to a store-name supplement; the INFO line owns the rate math (the #358 twin-formatter drift class).
8. **#141 self-contradiction (1 finder):** the CLAUDE.md correction left ADR-0007 + the 07-07 field-log entry still calling #141 "the monetization plan" — both corrected (ADR cross-ref rewritten; field-log gets a dated editor's note, entry otherwise untouched).
9. Per-notification DEBUG in `NotificationListener` tagged `Pipeline` (same half-fix pattern as 1).

**Filed (not fixable in-PR):** the systemic gap — ~20 main-source files still carry untagged Timber sites and nothing enforces the Principle-7 tag rule (this was at least the third per-file manual pass). Follow-up issue filed for a source-scan guard test (the `SchemaVersionGuardTest` precedent): see the linked issue below.

**Verified-safe (finder-cleared):** `recordShopRate` Unit→`LearnedShopRate` breaks no caller (the only other `StrategyRepository` mock never calls it); DataStore `edit` runs its transform exactly once, so no uninitialized path existed in practice; Hilt injection precedes any NLS bind callback; all format strings balance specifiers/args; every playbook grep string, SQL column, and `PayBasis` literal verified against live code; new INFO+ content is PII-safe by construction (hash/wire/counts); the checklist-workflow obligation is satisfied (new 0/2 item + two augmented items); the #141/#585 doc-edit claims verified against GitHub state.

Full gate green post-fixes: `./gradlew testDebugUnitTest :domain:test`.
