### PR TITLE
feat(#728): idle bubble — gas + vehicle as separate full-width cards

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/ModeCards.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/ModeCards.kt
@@ -2,13 +2,13 @@ package cloud.trotter.dashbuddy.ui.bubble
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -32,6 +32,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import cloud.trotter.dashbuddy.R
+import cloud.trotter.dashbuddy.core.designsystem.component.AppCard
 import cloud.trotter.dashbuddy.core.designsystem.time.rememberNow
 import cloud.trotter.dashbuddy.domain.analytics.SessionRecord
 import cloud.trotter.dashbuddy.domain.evaluation.UserEconomy
@@ -165,6 +166,13 @@ private fun LastSessionSummary(session: SessionRecord, focusedPlatform: Platform
     }
 }
 
+/**
+ * #728: the old single-Row layout crammed both just-in-time actions together at tiny (28dp)
+ * touch targets — "looks bad and is a nightmare to try to operate" per field feedback. This is
+ * the bubble idle card, a glance surface operated around driving (Reactive UI rule 5, the
+ * strictest operability bar in the app), so each action gets its own full-width [AppCard] with
+ * generous internal padding instead of sharing a cramped Row.
+ */
 @Composable
 private fun JustInTimeActions(
     gasPrice: Float?,
@@ -176,22 +184,29 @@ private fun JustInTimeActions(
     onResumeAutoGasPrice: () -> Unit,
     onOpenVehicleSettings: () -> Unit,
 ) {
-    Row(
+    Column(
         modifier = Modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        GasQuickEdit(
-            gasPrice = gasPrice,
-            isGasPriceAuto = isGasPriceAuto,
-            isRefreshing = isGasPriceRefreshing,
-            showRefreshError = showGasPriceRefreshError,
-            onSetGasPrice = onSetGasPrice,
-            onRefreshGasPrice = onRefreshGasPrice,
-            onResumeAutoGasPrice = onResumeAutoGasPrice,
-        )
-        Spacer(modifier = Modifier.width(4.dp))
-        VehicleAction(onClick = onOpenVehicleSettings)
+        AppCard(modifier = Modifier.fillMaxWidth()) {
+            GasQuickEdit(
+                gasPrice = gasPrice,
+                isGasPriceAuto = isGasPriceAuto,
+                isRefreshing = isGasPriceRefreshing,
+                showRefreshError = showGasPriceRefreshError,
+                onSetGasPrice = onSetGasPrice,
+                onRefreshGasPrice = onRefreshGasPrice,
+                onResumeAutoGasPrice = onResumeAutoGasPrice,
+            )
+        }
+        AppCard(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(min = 48.dp)
+                .clickable(onClick = onOpenVehicleSettings),
+        ) {
+            VehicleAction()
+        }
     }
 }
 
@@ -227,9 +242,10 @@ private fun GasQuickEdit(
             GasPriceAutoDisplay(price = current, onTakeManualControl = { onSetGasPrice(current) })
             GasRefreshButton(isRefreshing = isRefreshing, onClick = onRefreshGasPrice)
         } else {
+            // 48dp touch target (#728) — was 28dp, too small to reliably tap while driving.
             IconButton(
                 onClick = { onSetGasPrice((current - GAS_STEP).coerceAtLeast(0f)) },
-                modifier = Modifier.size(28.dp),
+                modifier = Modifier.size(48.dp),
             ) {
                 Icon(
                     imageVector = Icons.Filled.Remove,
@@ -252,7 +268,7 @@ private fun GasQuickEdit(
             }
             IconButton(
                 onClick = { onSetGasPrice(current + GAS_STEP) },
-                modifier = Modifier.size(28.dp),
+                modifier = Modifier.size(48.dp),
             ) {
                 Icon(
                     imageVector = Icons.Filled.Add,
@@ -278,9 +294,12 @@ private fun GasQuickEdit(
 private fun GasPriceAutoDisplay(price: Float, onTakeManualControl: () -> Unit) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+        // 48dp touch target (#728) — was a bare 6/2dp pad, too small to reliably tap.
         modifier = Modifier
             .clip(RoundedCornerShape(6.dp))
             .clickable(onClick = onTakeManualControl)
+            .heightIn(min = 48.dp)
             .padding(horizontal = 6.dp, vertical = 2.dp),
     ) {
         Row(
@@ -314,7 +333,7 @@ private fun GasRefreshButton(isRefreshing: Boolean, onClick: () -> Unit) {
     IconButton(
         onClick = onClick,
         enabled = !isRefreshing,
-        modifier = Modifier.size(28.dp),
+        modifier = Modifier.size(48.dp),
     ) {
         if (isRefreshing) {
             CircularProgressIndicator(
@@ -343,46 +362,56 @@ private fun ResumeAutoChip(isRefreshing: Boolean, onClick: () -> Unit) {
         shape = RoundedCornerShape(6.dp),
         color = MaterialTheme.colorScheme.secondaryContainer,
     ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(4.dp),
-            modifier = Modifier.padding(horizontal = 8.dp, vertical = 5.dp),
+        // 48dp touch target (#728) — was a bare 8/5dp pad, too small to reliably tap; the Box
+        // forces the surface to at least 48dp and centers the (shorter) content within it.
+        Box(
+            modifier = Modifier.heightIn(min = 48.dp),
+            contentAlignment = Alignment.Center,
         ) {
-            if (isRefreshing) {
-                CircularProgressIndicator(
-                    modifier = Modifier.size(12.dp),
-                    strokeWidth = 2.dp,
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 5.dp),
+            ) {
+                if (isRefreshing) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(12.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.onSecondaryContainer,
+                    )
+                } else {
+                    Icon(
+                        imageVector = Icons.Filled.Refresh,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                        modifier = Modifier.size(12.dp),
+                    )
+                }
+                Text(
+                    text = stringResource(R.string.bubble_mode_idle_gas_resume_auto),
+                    style = MaterialTheme.typography.labelSmall,
+                    fontWeight = FontWeight.Medium,
                     color = MaterialTheme.colorScheme.onSecondaryContainer,
                 )
-            } else {
-                Icon(
-                    imageVector = Icons.Filled.Refresh,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onSecondaryContainer,
-                    modifier = Modifier.size(12.dp),
-                )
             }
-            Text(
-                text = stringResource(R.string.bubble_mode_idle_gas_resume_auto),
-                style = MaterialTheme.typography.labelSmall,
-                fontWeight = FontWeight.Medium,
-                color = MaterialTheme.colorScheme.onSecondaryContainer,
-            )
         }
     }
 }
 
+/**
+ * Vehicle deep-link content (#728) — the tap target is now the whole [AppCard] the caller wraps
+ * this in (see [JustInTimeActions]), so this composable renders content only, no Surface/onClick
+ * of its own.
+ */
 @Composable
-private fun VehicleAction(onClick: () -> Unit) {
-    Surface(
-        onClick = onClick,
-        shape = RoundedCornerShape(6.dp),
-        color = MaterialTheme.colorScheme.surfaceVariant,
+private fun VehicleAction() {
+    Box(
+        modifier = Modifier.fillMaxWidth(),
+        contentAlignment = Alignment.CenterStart,
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(4.dp),
-            modifier = Modifier.padding(horizontal = 8.dp, vertical = 5.dp),
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
         ) {
             Icon(
                 imageVector = Icons.Filled.DirectionsCar,


### PR DESCRIPTION
## What changed

The bubble idle card's just-in-time actions (gas quick-edit + vehicle deep-link) were
crammed into a single tight `Row` with 8dp spacing and 28dp touch targets. Per the dev's
field complaint, this "looks bad and is a nightmare to try to operate." This PR replaces
that `Row` with a full-width `Column` (8dp `spacedBy`) of two `AppCard`s — one for gas,
one for vehicle — each with generous internal padding, and bumps every cramped internal
tap target inside them to at least 48dp:

- `JustInTimeActions` (`app/src/main/java/cloud/trotter/dashbuddy/ui/bubble/ModeCards.kt`)
  now lays out `GasQuickEdit` and `VehicleAction` as two stacked `AppCard`s instead of a
  shared `Row`.
- `GasQuickEdit`'s +/- stepper `IconButton`s and the auto-mode refresh `IconButton` grow
  from `size(28.dp)` to `size(48.dp)`.
- `GasPriceAutoDisplay`'s "take manual control" tap target gains `heightIn(min = 48.dp)`
  (was a bare 6/2dp pad).
- `ResumeAutoChip`'s tap target gains a centering `Box` with `heightIn(min = 48.dp)` (was
  a bare 8/5dp pad).
- `VehicleAction` drops its own `Surface`/`onClick` — the whole `AppCard` it now lives
  inside is the tap target (`Modifier.fillMaxWidth().heightIn(min = 48.dp).clickable(...)`,
  matching the existing `AppCard(...).clickable(...)` pattern already used in
  `DashboardScreen.kt`).

All hoisted params/callbacks are unchanged; `GasQuickEdit`/`VehicleAction` internals are
otherwise untouched. Pure layout change — no ViewModel, state, recognition, or economics
edits.

**Spec source:** issue #728's build-ready grooming note.

## Design-goal review (author draft)

Only the principles this diff touches:

- **Reactive UI rule 5 (bubble HUD operability bar).** This is the bubble idle card — a
  glance surface operated around driving, the strictest operability bar in the app. The
  prior 28dp targets and bare-padding tap zones were below Android's 48dp minimum
  recommended touch target; every interactive element in the two new cards now meets or
  exceeds 48dp, sized via `Modifier.size(48.dp)` on `IconButton`s and `Modifier.heightIn(min
  = 48.dp)` (with a centering `Box` where content is naturally smaller) on the
  Surface/clickable-Column targets.
- **Principle 3 (single responsibility / clean code).** Pure layout restructuring confined
  to one file, `ModeCards.kt`; no new responsibilities added to any composable —
  `VehicleAction` actually sheds a responsibility (its own click surface) since the tap
  target moved up to the wrapping `AppCard`.
- **Principle 1 (UDF).** No state changes. All existing hoisted params/callbacks
  (`onSetGasPrice`, `onRefreshGasPrice`, `onResumeAutoGasPrice`, `onOpenVehicleSettings`)
  pass through unchanged; state stays fully hoisted in the caller.
- **Principle 6 (security & privacy).** No new surface — no recognition, capture, network,
  or effect changes. Not applicable beyond that.

## Test plan

- [x] `JAVA_HOME=/usr/lib/jvm/java-25 ./gradlew :app:compileDebugKotlin` — BUILD SUCCESSFUL
- [x] `JAVA_HOME=/usr/lib/jvm/java-25 ./gradlew :app:testDebugUnitTest` — BUILD SUCCESSFUL
- [ ] Field-verify on-device that both cards render full-width and are comfortably tappable
      while the bubble is expanded in idle mode (no automated test covers Compose layout
      visually)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Adversarial review

Independent fable-tier reviewer (session model), full-diff attack on correctness / design principles / security. **Verdict: APPROVE — no HIGH or MED findings.** Verified clean: touch-target dp math on all four targets (modifier chains ordered correctly, clickable outside heightIn, clip-before-clickable ripple bounds); exactly one indication node per control (no double ripple — VehicleAction is content-only, the AppCard is the sole tap surface); no unbounded-constraint hazard (traced BubbleScreen → Card → Box constraint env); state hoisting byte-identical signatures; zero security surface.

Four LOW findings, none merge-blocking, recorded for posterity:
1. Vehicle-card ripple not clipped to rounded corners — matches the existing app-wide `AppCard(...).clickable` idiom (DashboardScreen.kt:197/307), pre-existing behavior, not a regression.
2. Vehicle-card content sits ~2–4dp above true center when the 48dp min wins — cosmetic, likely invisible.
3. Five hand-rolled `48.dp` literals (SSOT nit) — the literal is the platform guideline; a `MinTouchTarget` design-system token is optional future hygiene.
4. Manual-mode gas row can still clip on a very narrow window — strictly better than master's row (~336dp vs ~355dp needed); covered by the field-verification checklist item.

Merging on CI green + approve verdict per the standing merge authorization.
