### PR TITLE
test(#764): Principle-7 Timber tag guard — ratchet out untagged INFO+ sites

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/log/TimberTagGuardTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/log/TimberTagGuardTest.kt
@@ -1,0 +1,183 @@
+package cloud.trotter.dashbuddy.log
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Source-scan guard for CLAUDE.md Principle 7 (semantic, PII-safe logging): every
+ * `Timber.i(`/`Timber.w(`/`Timber.e(` call site in MAIN source must be **tagged** —
+ * `Timber.tag("...")` immediately ahead of the call, on the same expression — never the
+ * catch-all default tag (`App`). Three manual cleanup passes (#679/#692/#763) already chased
+ * this drift down by hand; this test is the permanent backstop (#764) so it can't creep back.
+ * `Timber.d(`/`Timber.v(` (DEBUG/VERBOSE) are out of scope — Principle 7 only requires a stable
+ * tag from INFO up, since that's the exported "shareable" stream a user can send as a bug
+ * report.
+ *
+ * Follows the same repo-root **source scan** shape as `SchemaVersionGuardTest`
+ * (`:core:database`) — read `.kt` files off disk rather than reflecting over compiled code,
+ * because this is a textual/style property (which token sits immediately before the call),
+ * not something the Kotlin type system encodes.
+ *
+ * **Detection is a plain regex, not a real Kotlin parse — by design** (the spec for #764 is
+ * explicit: keep the scanner simple and predictable, don't build clever heuristics). A call
+ * site is "bare" when `Timber` is followed by nothing but whitespace before the `.i(`/`.w(`/
+ * `.e(`:
+ * ```
+ * Timber.i("...")            // bare — FLAGGED
+ * Timber
+ *     .w("...")               // bare — FLAGGED (whitespace-only gap, still multiline)
+ * Timber.tag("X").i("...")   // tagged — not flagged (`.tag(...)` sits in the gap)
+ * Timber.tag("X")
+ *     .e(e, "...")            // tagged — not flagged, multiline chain
+ * ```
+ * A receiver that legitimately re-tags — e.g. `private val log = Timber.tag(TAG)` then
+ * `log.i(...)` elsewhere — is not textually `Timber.i(` at all, so it's invisible to this
+ * scanner by construction. That is an accepted blind spot per the #764 spec ("wrappers/
+ * receivers that legitimately re-tag are handled or allowlisted explicitly — do not build
+ * clever heuristics"), not a gap this test claims to close; today's tree has no such receiver
+ * pattern in main source (verified by hand at the time this guard was written).
+ *
+ * **Ratchet**: current offenders are frozen in [allowlistFile] as `<path> <count>` lines — one
+ * per offending file, repo-relative, count = bare-site count at freeze time. This is a
+ * **strict** ratchet in both directions (SSOT for "how much debt is left", never allowed to go
+ * stale):
+ * - [everyUntaggedInfoPlusSiteIsAccountedFor] — a file not on the list may have zero untagged
+ *   sites; a listed file's actual count may not exceed its allowlisted number (a new bare call
+ *   added to an already-listed file is a regression, not free debt).
+ * - [allowlistHasNoStaleEntries] — a listed file's actual count may not fall *below* its
+ *   allowlisted number either: tagging a call means lowering (or deleting, at 0) that file's
+ *   line in the same change, so the list is always an exact mirror of live debt, not a ceiling
+ *   nobody revisits.
+ */
+class TimberTagGuardTest {
+
+    /** Module `src/main` roots to scan — every module that can carry `Timber` calls. */
+    private val roots = listOf(
+        "app/src/main",
+        "core/database/src/main",
+        "core/data/src/main",
+        "core/datastore/src/main",
+        "core/designsystem/src/main",
+        "core/location/src/main",
+        "core/network/src/main",
+        "core/pipeline/src/main",
+        "core/state/src/main",
+        "domain/src/main",
+    )
+
+    /**
+     * Matches `Timber` immediately followed by (only whitespace, then) `.i(`/`.w(`/`.e(` — i.e.
+     * a bare, untagged call. `Timber.tag("X").i(` does NOT match: the `.tag("X").` text between
+     * `Timber` and `.i(` is not whitespace, so the whitespace-only gap this pattern requires is
+     * broken. See the class doc for the multiline case.
+     */
+    private val bareCallRegex = Regex("""Timber\s*\.\s*(?:i|w|e)\s*\(""")
+
+    private val repoRoot: File by lazy { locateRepoRoot() }
+
+    private val allowlistFile: File by lazy {
+        File(repoRoot, "app/src/test/resources/timber-tag-guard-allowlist.txt")
+    }
+
+    private val allowlistRelPath: String by lazy {
+        allowlistFile.relativeTo(repoRoot).path.replace(File.separatorChar, '/')
+    }
+
+    /** repo-relative path -> allowlisted (frozen) bare-call count. */
+    private val allowlist: Map<String, Int> by lazy {
+        allowlistFile.readLines()
+            .map { it.trim() }
+            .filter { it.isNotEmpty() && !it.startsWith("#") }
+            .associate { line ->
+                val parts = line.split(Regex("\\s+"))
+                require(parts.size == 2) {
+                    "Malformed $allowlistRelPath line: '$line' (expected '<path> <count>')"
+                }
+                val count = parts[1].toIntOrNull()
+                    ?: error("Malformed count in $allowlistRelPath line: '$line'")
+                parts[0] to count
+            }
+    }
+
+    /** repo-relative path -> live count of bare (untagged) Timber.i/w/e( sites found today. */
+    private val liveOffendersByFile: Map<String, Int> by lazy {
+        val result = mutableMapOf<String, Int>()
+        for (root in roots) {
+            val rootDir = File(repoRoot, root)
+            if (!rootDir.isDirectory) continue
+            rootDir.walkTopDown()
+                .filter { it.isFile && it.extension == "kt" }
+                .forEach { file ->
+                    val count = bareCallRegex.findAll(file.readText()).count()
+                    if (count > 0) {
+                        val relPath = file.relativeTo(repoRoot).path.replace(File.separatorChar, '/')
+                        result[relPath] = count
+                    }
+                }
+        }
+        result
+    }
+
+    @Test
+    fun everyUntaggedInfoPlusSiteIsAccountedFor() {
+        val problems = mutableListOf<String>()
+        for ((path, liveCount) in liveOffendersByFile) {
+            val allowedCount = allowlist[path]
+            when {
+                allowedCount == null -> problems += "$path: $liveCount untagged " +
+                    "Timber.i/w/e( site(s), file is not on the allowlist at all"
+
+                liveCount > allowedCount -> problems += "$path: $liveCount untagged " +
+                    "Timber.i/w/e( site(s), exceeds the allowlisted $allowedCount " +
+                    "(a NEW bare call was added to an already-allowlisted file)"
+            }
+        }
+        assertTrue(
+            "Untagged Timber.i(/w(/e( call site(s) found beyond the frozen allowlist " +
+                "(CLAUDE.md Principle 7 — every INFO+ log call needs a stable " +
+                "Timber.tag(\"YourTag\") immediately ahead of it, never the catch-all default " +
+                "tag). Fix by adding Timber.tag(\"YourTag\") before the call " +
+                "(Timber.tag(\"X\").i(...) and the multiline Timber.tag(\"X\")\\n    .i(...) " +
+                "both satisfy the guard); if this is accepted new debt instead, add/raise the " +
+                "file's line in $allowlistRelPath. Problems:\n" +
+                problems.sorted().joinToString("\n"),
+            problems.isEmpty(),
+        )
+    }
+
+    @Test
+    fun allowlistHasNoStaleEntries() {
+        val problems = mutableListOf<String>()
+        for ((path, allowedCount) in allowlist) {
+            val liveCount = liveOffendersByFile[path] ?: 0
+            if (liveCount < allowedCount) {
+                problems += "$path: allowlisted for $allowedCount but only $liveCount " +
+                    "untagged site(s) remain — lower the count in $allowlistRelPath " +
+                    "(or delete the line once it reaches 0)"
+            }
+        }
+        assertTrue(
+            "Allowlist entries no longer match live debt — this is a STRICT ratchet, so the " +
+                "list must shrink as call sites get tagged, never sit stale. Problems:\n" +
+                problems.sorted().joinToString("\n"),
+            problems.isEmpty(),
+        )
+    }
+
+    /**
+     * JVM unit tests run with the working directory at the `:app` module root, but be robust to
+     * a repo-root (or any nested) cwd too — walk up until `settings.gradle.kts` is found.
+     */
+    private fun locateRepoRoot(): File {
+        var dir = File(".").absoluteFile.normalize()
+        while (true) {
+            if (File(dir, "settings.gradle.kts").isFile) return dir
+            dir = dir.parentFile
+                ?: error(
+                    "Could not locate repo root (settings.gradle.kts) walking up from " +
+                        File(".").absoluteFile.normalize().path,
+                )
+        }
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/log/TimberTagGuardTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/log/TimberTagGuardTest.kt
@@ -52,27 +52,53 @@ import java.io.File
  */
 class TimberTagGuardTest {
 
-    /** Module `src/main` roots to scan — every module that can carry `Timber` calls. */
-    private val roots = listOf(
-        "app/src/main",
-        "core/database/src/main",
-        "core/data/src/main",
-        "core/datastore/src/main",
-        "core/designsystem/src/main",
-        "core/location/src/main",
-        "core/network/src/main",
-        "core/pipeline/src/main",
-        "core/state/src/main",
-        "domain/src/main",
+    /** Modules that can carry `Timber` calls. */
+    private val modules = listOf(
+        "app",
+        "core/database",
+        "core/data",
+        "core/datastore",
+        "core/designsystem",
+        "core/location",
+        "core/network",
+        "core/pipeline",
+        "core/state",
+        "domain",
     )
 
+    /** Source-set directory-name prefixes to skip — test code is out of scope for this guard. */
+    private val excludedSourceSetPrefixes = listOf("test", "androidTest")
+
     /**
-     * Matches `Timber` immediately followed by (only whitespace, then) `.i(`/`.w(`/`.e(` — i.e.
-     * a bare, untagged call. `Timber.tag("X").i(` does NOT match: the `.tag("X").` text between
-     * `Timber` and `.i(` is not whitespace, so the whitespace-only gap this pattern requires is
-     * broken. See the class doc for the multiline case.
+     * `src/<sourceSet>` roots to scan, per module — every **main-type** source set (`main`,
+     * `debug`, `release`, …), not just `main`. A release/debug-only file (e.g. a build-variant
+     * Hilt module) can carry `Timber` calls just as easily as `main`'s, so scanning only `main`
+     * would leave a real blind spot. `test`/`androidTest` (and any variant sharing that prefix,
+     * e.g. `testDebug`) are excluded — test code is out of scope for this guard.
      */
-    private val bareCallRegex = Regex("""Timber\s*\.\s*(?:i|w|e)\s*\(""")
+    private val roots: List<String> by lazy {
+        modules.flatMap { module ->
+            val srcDir = File(repoRoot, "$module/src")
+            val sourceSets = srcDir.listFiles { f -> f.isDirectory }?.toList() ?: emptyList()
+            sourceSets
+                .filter { dir -> excludedSourceSetPrefixes.none { dir.name.startsWith(it) } }
+                .map { dir -> "$module/src/${dir.name}" }
+        }
+    }
+
+    /**
+     * Matches `Timber` immediately followed by (only whitespace, then) `.i(`/`.w(`/`.e(`/`.wtf(`
+     * — i.e. a bare, untagged call. `Timber.tag("X").i(` does NOT match: the `.tag("X").` text
+     * between `Timber` and `.i(` is not whitespace, so the whitespace-only gap this pattern
+     * requires is broken. See the class doc for the multiline case.
+     *
+     * An optional `.Forest` segment is folded in — `Timber` IS the `Forest` companion object, so
+     * `Timber.Forest.i(...)` is byte-identical semantics to `Timber.i(...)` and would otherwise
+     * escape this scanner (a real live pattern found in `core/data` repositories, #764 review
+     * fix). `Timber.Forest.tag("X").i(` still does NOT match: the `.tag("X").` text breaks the
+     * whitespace-only gap the same way it does for the non-`Forest` form.
+     */
+    private val bareCallRegex = Regex("""Timber\s*(?:\.\s*Forest\s*)?\.\s*(?:i|w|e|wtf)\s*\(""")
 
     private val repoRoot: File by lazy { locateRepoRoot() }
 
@@ -84,20 +110,33 @@ class TimberTagGuardTest {
         allowlistFile.relativeTo(repoRoot).path.replace(File.separatorChar, '/')
     }
 
-    /** repo-relative path -> allowlisted (frozen) bare-call count. */
+    /**
+     * repo-relative path -> allowlisted (frozen) bare-call count. Fails loud on a duplicated
+     * path line — silently letting the last one win (the old `.associate` behavior) would hide a
+     * copy-paste mistake behind whichever count happened to be listed last, corrupting the
+     * ratchet SSOT without any signal.
+     */
     private val allowlist: Map<String, Int> by lazy {
+        val result = mutableMapOf<String, Int>()
         allowlistFile.readLines()
             .map { it.trim() }
             .filter { it.isNotEmpty() && !it.startsWith("#") }
-            .associate { line ->
+            .forEach { line ->
                 val parts = line.split(Regex("\\s+"))
                 require(parts.size == 2) {
                     "Malformed $allowlistRelPath line: '$line' (expected '<path> <count>')"
                 }
+                val path = parts[0]
                 val count = parts[1].toIntOrNull()
                     ?: error("Malformed count in $allowlistRelPath line: '$line'")
-                parts[0] to count
+                require(!result.containsKey(path)) {
+                    "Duplicate $allowlistRelPath entry for '$path' — merge the lines into one " +
+                        "(the allowlist is a map, not a log; a duplicate key silently shadows " +
+                        "one of the counts)"
+                }
+                result[path] = count
             }
+        result
     }
 
     /** repo-relative path -> live count of bare (untagged) Timber.i/w/e( sites found today. */

--- a/app/src/test/resources/timber-tag-guard-allowlist.txt
+++ b/app/src/test/resources/timber-tag-guard-allowlist.txt
@@ -1,0 +1,47 @@
+# Frozen debt list for TimberTagGuardTest (#764, CLAUDE.md Principle 7).
+#
+# Each line is "<repo-relative .kt path> <count>" — count is the number of bare
+# (untagged) Timber.i(/w(/e( call sites TimberTagGuardTest currently finds in that file.
+# This is a STRICT ratchet in both directions:
+#   - a file NOT listed here may have ZERO untagged sites (any new one fails the build);
+#   - a listed file's actual count may not EXCEED its number here (a new untagged call in
+#     an already-listed file is a regression and fails the build);
+#   - a listed file's actual count may not fall BELOW its number here either — lower the
+#     number (or delete the line once it hits 0) as sites get tagged, so the list only
+#     shrinks and never goes stale.
+#
+# Frozen 2026-07-12 from the state left by the three manual cleanup passes #679/#692/#763.
+# To fix an entry: add Timber.tag("YourTag") immediately ahead of the call
+# (Timber.tag("X").i(...) or Timber.tag("X")\n    .i(...) both satisfy the guard), then lower
+# or remove the line below.
+
+app/src/main/java/cloud/trotter/dashbuddy/DashBuddyApplication.kt 3
+app/src/main/java/cloud/trotter/dashbuddy/di/DispatchersModule.kt 1
+app/src/main/java/cloud/trotter/dashbuddy/state/effects/OdometerEffectHandler.kt 8
+app/src/main/java/cloud/trotter/dashbuddy/state/effects/ScreenShotHandler.kt 8
+app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/WizardViewModel.kt 1
+app/src/main/java/cloud/trotter/dashbuddy/util/AccNodeUtils.kt 3
+core/data/src/main/java/cloud/trotter/dashbuddy/core/data/capability/RuleCapabilityRepository.kt 2
+core/data/src/main/java/cloud/trotter/dashbuddy/core/data/capture/DiskCaptureBus.kt 1
+core/data/src/main/java/cloud/trotter/dashbuddy/core/data/capture/NoOpCaptureBus.kt 1
+core/data/src/main/java/cloud/trotter/dashbuddy/core/data/event/AppEventRepo.kt 2
+core/data/src/main/java/cloud/trotter/dashbuddy/core/data/strategy/StrategyRepository.kt 1
+core/database/src/main/java/cloud/trotter/dashbuddy/core/database/DataTypeConverters.kt 1
+core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/strategy/StrategyDataSource.kt 1
+core/location/src/main/java/cloud/trotter/dashbuddy/core/location/FusedLocationDataSource.kt 6
+core/network/src/main/java/cloud/trotter/dashbuddy/core/network/vehicle/efficiency/epa/EpaVehicleDataSource.kt 5
+core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/CaptureWriter.kt 5
+core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/FrameGate.kt 1
+core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/PipelineStats.kt 1
+core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/PipelineSupervision.kt 1
+core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/AccessibilityPipeline.kt 2
+core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/input/AccessibilityListener.kt 1
+core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/accessibility/mapper/AccessibilityNodeMapper.kt 1
+core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/JsonRuleInterpreter.kt 14
+core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/ParsedFieldsFactory.kt 2
+core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/Ruleset.kt 2
+core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt 1
+core/state/src/main/java/cloud/trotter/dashbuddy/core/state/ObservationJournal.kt 3
+core/state/src/main/java/cloud/trotter/dashbuddy/core/state/OfferEffects.kt 4
+core/state/src/main/java/cloud/trotter/dashbuddy/core/state/SnapshotStore.kt 2
+core/state/src/main/java/cloud/trotter/dashbuddy/core/state/StateManagerV2.kt 8

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/fuel/FuelPriceRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/fuel/FuelPriceRepository.kt
@@ -36,7 +36,7 @@ class FuelPriceRepository @Inject constructor(
             try {
                 save(newPrice)
             } catch (e: Exception) {
-                Timber.Forest.e(e, "GasPriceRepository failed to persist fetched price")
+                Timber.tag(TAG).e(e, "GasPriceRepository failed to persist fetched price")
                 throw e
             }
             newPrice
@@ -47,7 +47,7 @@ class FuelPriceRepository @Inject constructor(
             val userLocation = locationDataSource.getUserLocation()
             gasDataSource.getFuelPrice(userLocation, fuelType)
         } catch (e: Exception) {
-            Timber.Forest.e(e, "GasPriceRepository failed to fetch price only")
+            Timber.tag(TAG).e(e, "GasPriceRepository failed to fetch price only")
             Result.failure(e)
         }
     }
@@ -61,8 +61,12 @@ class FuelPriceRepository @Inject constructor(
             )
             gasDataSource.getFuelPrice(userLocation, fuelType)
         } catch (e: Exception) {
-            Timber.Forest.e(e, "GasPriceRepository failed to update price")
+            Timber.tag(TAG).e(e, "GasPriceRepository failed to update price")
             Result.failure(e)
         }
+    }
+
+    private companion object {
+        private const val TAG = "FuelPrice"
     }
 }

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/location/OdometerRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/location/OdometerRepository.kt
@@ -99,7 +99,7 @@ class OdometerRepository @Inject constructor(
 
     fun startTracking() {
         if (trackingJob?.isActive == true) return
-        Timber.Forest.i("Starting GPS Tracking...")
+        Timber.tag(TAG).i("Starting GPS Tracking...")
         trackingJob = scope.launch {
             locationDataSource.locationUpdates.collect { processLocation(it) }
         }
@@ -107,7 +107,7 @@ class OdometerRepository @Inject constructor(
 
     fun stopTracking() {
         if (trackingJob?.isActive == true) {
-            Timber.Forest.i("Stopping GPS Tracking.")
+            Timber.tag(TAG).i("Stopping GPS Tracking.")
             trackingJob?.cancel()
             trackingJob = null
             lastCoords = null
@@ -141,4 +141,8 @@ class OdometerRepository @Inject constructor(
      * (#314). Unaffected by the #438 B5 per-session anchor change (it reads [_meters] only).
      */
     fun getCurrentMiles(): Double = _meters.value * metersToMiles
+
+    private companion object {
+        private const val TAG = "Odometer"
+    }
 }

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/settings/AppPreferencesRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/settings/AppPreferencesRepository.kt
@@ -313,7 +313,11 @@ class AppPreferencesRepository @Inject constructor(
     suspend fun resetEconomyDefaults() = dataSource.resetEconomyDefaults()
 
     suspend fun clearPreferences() {
-        Timber.Forest.w("Clearing App Preferences")
+        Timber.tag(TAG).w("Clearing App Preferences")
         dataSource.clear()
+    }
+
+    private companion object {
+        private const val TAG = "AppPrefs"
     }
 }

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/settings/DevSettingsRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/settings/DevSettingsRepository.kt
@@ -61,7 +61,11 @@ class DevSettingsRepository @Inject constructor(
     suspend fun setLogLevel(priority: Int) = dataSource.setLogLevel(priority)
 
     suspend fun clearPreferences() {
-        Timber.Forest.w("Clearing Developer Preferences")
+        Timber.tag(TAG).w("Clearing Developer Preferences")
         dataSource.clear()
+    }
+
+    private companion object {
+        private const val TAG = "DevSettings"
     }
 }

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/state/AppStateRepository.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/state/AppStateRepository.kt
@@ -17,7 +17,11 @@ class AppStateRepository @Inject constructor(
     }
 
     suspend fun clearPreferences() {
-        Timber.Forest.w("Clearing App State Preferences")
+        Timber.tag(TAG).w("Clearing App State Preferences")
         dataSource.clear()
+    }
+
+    private companion object {
+        private const val TAG = "AppState"
     }
 }


### PR DESCRIPTION
## Summary

Adds `TimberTagGuardTest` (`app/src/test/java/cloud/trotter/dashbuddy/log/TimberTagGuardTest.kt`), a unit-tier source-scan guard enforcing CLAUDE.md Principle 7: every `Timber.i(`/`Timber.w(`/`Timber.e(` call in **main** source must be tagged (`Timber.tag("...")` immediately ahead of it), never the catch-all default tag. `Timber.d`/`Timber.v` (DEBUG/VERBOSE) are out of scope. Three manual cleanup passes (#679/#692/#763) already chased this drift down by hand; this test is the permanent backstop.

### How the scanner works

- Walks all module `src/main/**/*.kt` files (app, core/*, domain) — no test/androidTest/build/generated dirs.
- Flags `Timber` immediately followed by (whitespace only, then) `.i(`/`.w(`/`.e(` as **bare**. `Timber.tag("X").i(...)` is not flagged — the `.tag("X").` text between `Timber` and `.i(` breaks the whitespace-only gap the bare regex requires. Multiline chains (`Timber.tag("X")\n    .i(...)`) also pass correctly, verified against the actual tree (89 tagged sites found alongside the 92 bare ones).
- Deliberately a plain regex over text, not a real parse — per the issue's own spec ("keep the scanner simple and predictable, don't build clever heuristics"). A receiver that legitimately re-tags (`val log = Timber.tag(TAG); log.i(...)`) isn't textually `Timber.i(` at all, so it's an accepted blind spot by construction — not present anywhere in today's main source (checked by hand).
- Compared against a frozen, committed allowlist (`app/src/test/resources/timber-tag-guard-allowlist.txt`), `<repo-relative path> <count>` per line — same repo-root source-scan approach as `SchemaVersionGuardTest` (`:core:database`).
- **Strict ratchet in both directions** (two tests):
  - `everyUntaggedInfoPlusSiteIsAccountedFor` — a file not listed may have zero bare sites; a listed file's live count may not *exceed* its allowlisted number (catches a new bare call sneaking into an already-debt-bearing file).
  - `allowlistHasNoStaleEntries` — a listed file's live count may not fall *below* its allowlisted number either — the list must be lowered (or the line deleted at 0) as sites get tagged, so it can't go stale.

### Allowlist size

**30 files / 92 bare sites**, frozen 2026-07-12 from the state left by #679/#692/#763. Example entries:

```
core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/JsonRuleInterpreter.kt 14
core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/PipelineStats.kt 1
core/state/src/main/java/cloud/trotter/dashbuddy/core/state/StateManagerV2.kt 8
app/src/main/java/cloud/trotter/dashbuddy/state/effects/OdometerEffectHandler.kt 8
```

`PipelineStats.logSummary`'s bare `Timber.i("PipelineStats[%s]: %s", ...)` — the exact case the issue named — is on the list (count 1).

### Red-probe proof

Temporarily added a bare `Timber.i("probe")` inside a fresh non-allowlisted file (`core/state/.../CrossPlatformRegionStepper.kt`), which has no prior Timber usage. Confirmed the guard **fails** with:

```
core/state/src/main/java/cloud/trotter/dashbuddy/core/state/CrossPlatformRegionStepper.kt:
1 untagged Timber.i/w/e( site(s), file is not on the allowlist at all
```

Reverted the probe before committing (`git status`/`git diff` clean on that file — not part of this PR's diff).

### Test results

- `:app:testDebugUnitTest --tests "*TimberTagGuardTest*"` — green (2/2).
- Full `:app:testDebugUnitTest` — green, 795 tests, 0 failures, 0 errors.

### Design-goal review (author draft)

1. **Testing infra only, no runtime change** — new test + a resource allowlist file; zero production code touched.
2. **Principle 7 (semantic, PII-safe logging)** — this PR *is* the Principle 7 enforcement: it makes the "every component logs under its own stable tag" rule a build-time gate instead of relying on call-site discipline / periodic manual audits.
3. **SSOT** — one allowlist file is the single source of truth for "how much Principle-7 debt remains"; the strict-ratchet tests keep it from silently drifting out of sync with the real tree (both directions — can't grow past what's declared, can't sit stale below it either).
4. **Clean code / single responsibility** — mirrors the existing `SchemaVersionGuardTest` precedent (`:core:database`) for shape/placement rather than inventing a new pattern.
5. Principles 1/2/4/6/8 and the Reactive UI rules — not touched by this diff (no state machine, no UDF/MAD surface, no recognition/effects/security boundary, no platform-specific logic, no UI).

## Review fixes applied

Adversarial review verdict was FIX FIRST. Four fixes applied in a follow-up commit:

1. **(HIGH) `Timber.Forest.i/w/e(` escaped the scanner.** `Timber` IS the `Forest` companion object, so `Timber.Forest.i(...)` is byte-identical to `Timber.i(...)` but was textually invisible to the old regex. Broadened `bareCallRegex` to `Timber\s*(?:\.\s*Forest\s*)?\.\s*(?:i|w|e|wtf)\s*\(` — an optional `.Forest` segment folded into the whitespace-only gap check. Verified `Timber.Forest.tag("X").i(` still does NOT match (the `.tag("X").` text still breaks the gap, same as the non-`Forest` form).
   This surfaced **8 live bare `Timber.Forest` sites** across 5 `core/data` files, which are now tagged in-PR (not allowlisted — this is exactly the debt class the guard exists to burn down):
   - `core/data/.../fuel/FuelPriceRepository.kt` — 3× `Forest.e` → `Timber.tag("FuelPrice").e(...)` (no existing sibling tag convention for this repo; picked a component-name tag per Principle 7).
   - `core/data/.../location/OdometerRepository.kt` — 2× `Forest.i` → `Timber.tag("Odometer").i(...)`.
   - `core/data/.../state/AppStateRepository.kt` — 1× `Forest.w` → `Timber.tag("AppState").w(...)`.
   - `core/data/.../settings/DevSettingsRepository.kt` — 1× `Forest.w` → `Timber.tag("DevSettings").w(...)`.
   - `core/data/.../settings/AppPreferencesRepository.kt` — 1× `Forest.w` → `Timber.tag("AppPrefs").w(...)`.
   Tag names mirror the existing `core/datastore` Hilt-qualifier naming convention (`AppPreferences`, `AppStatePreferences`, `DevSettingsPreferences`, `OdometerPreferences` in `DataStoreQualifiers.kt`) rather than inventing a new style. All 8 messages were checked for PII: counts/status strings only ("Starting GPS Tracking...", "Clearing App Preferences", "GasPriceRepository failed to fetch price only", etc.) — no raw store/customer/address text, so INFO/WARN/ERROR-safe as-is.
2. **(LOW) Added `wtf` to the level alternation** (ASSERT is exported-stream-relevant too). Verified zero live `Timber.wtf(`/`Timber.Forest.wtf(` sites exist — allowlist unaffected.
3. **(LOW) Scanner now covers all main-type source sets, not just `src/main`.** `roots` is now computed per-module by listing `src/<sourceSet>` directories and excluding any name starting with `test`/`androidTest` (so `debug`/`release`/etc are included). Only `core/data` actually has `src/debug`/`src/release` today (a `CaptureBusModule` Hilt binding in each) — verified neither file contains any `Timber` call, so the allowlist is unaffected.
4. **(NIT) Allowlist parsing now fails loud on a duplicated path line** — replaced the `.associate` (silent last-wins) with a manual fold that `require`s each path is seen only once, throwing a clear "Duplicate ... entry" message instead of silently corrupting the ratchet SSOT.

**Allowlist delta: none.** `app/src/test/resources/timber-tag-guard-allowlist.txt` is byte-identical after this commit — all 8 newly-tagged `Forest` sites were fresh conversions, not existing debt, and the broadened scan surfaced no other new offenders anywhere in the tree.

**Re-verification:**
- `:app:testDebugUnitTest --tests "*TimberTagGuardTest*"` — green (2/2), no regression, no new offenders beyond the 8 now-tagged sites.
- `:core:data:testDebugUnitTest` — green (5 files touched there).
- Fresh red-probe: temporarily added a bare `Timber.Forest.w("probe")` inside `TipEffectHandler.kt` (a non-allowlisted file) — `everyUntaggedInfoPlusSiteIsAccountedFor` correctly **FAILED** ("1 untagged Timber.i/w/e( site(s), file is not on the allowlist at all"), proving the broadened regex actually catches the `Forest` form live, not just in the 8 already-known sites. Probe reverted before commit (clean diff on that file).
- Full `:app:testDebugUnitTest` — green after revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
