### PR TITLE
chore(#732): document sequenceId-authoritative ordering invariant + consumer audit + pin test

### DIFF
--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/event/AppEventRepo.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/event/AppEventRepo.kt
@@ -93,6 +93,11 @@ class AppEventRepo @Inject constructor(
 
     // ── Entity ↔ domain mapping ─────────────────────────────────────────
 
+    // #732: this is the event-append path — `occurredAt` below is carried through verbatim
+    // from the domain [AppEvent] (which for a graced destructive commit is `pend.since`, the
+    // grace-ARM time, not "now"), while `sequenceId` is minted by Room on THIS insert. See
+    // AppEventEntity's class KDoc ("sequenceId vs occurredAt") for the resulting ordering
+    // invariant and which column each consumer must key on.
     private fun AppEvent.toEntity(metadataJson: String?) = AppEventEntity(
         aggregateId = sessionId,
         eventType = type,

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/event/AppEventEntity.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/event/AppEventEntity.kt
@@ -5,6 +5,42 @@ import androidx.room.Index
 import androidx.room.PrimaryKey
 import cloud.trotter.dashbuddy.domain.model.event.AppEventType
 
+/**
+ * The durable, append-only event log entity (#354) — the analytics/state-recovery source of
+ * truth. `app_events` rows are never mutated or deleted; every read-model table is a
+ * rebuildable projection of this log.
+ *
+ * ## `sequenceId` vs `occurredAt` — the ordering invariant (#732)
+ *
+ * **[sequenceId] is the authoritative fold/order key. [occurredAt] is NOT guaranteed to be
+ * monotonic with it.**
+ *
+ * A graced destructive commit (`PlatformRegion.pendingDestructive` / the `GRACE_COMMIT` timer,
+ * #431 — a dash-end or task-retire that debounces behind a short grace window before it's
+ * believed) stamps its eventual event's [occurredAt] at grace-ARM time (`pend.since` — the
+ * timestamp of the observation that first signaled the destructive transition; see
+ * `PlatformRegionStepper.stepCore`'s lazy-expiry commit, ~L338-342). But the row is not
+ * INSERTED — and so does not receive its [sequenceId] — until the grace actually COMMITS,
+ * which happens later, after zero or more intervening, non-graced events have already been
+ * appended with their own (later, but lower-`sequenceId`) `occurredAt`. Net effect: a
+ * higher-`sequenceId` row can carry an EARLIER `occurredAt` than a lower-`sequenceId` row
+ * already ahead of it in the log. Two field receipts: 2026-07-07 sequenceId 70/71 and
+ * 2026-07-08 sequenceId 116/117 (an 11-minute inversion).
+ *
+ * This is a **documented, accepted invariant** (#732 Option B — the dev decided NOT to
+ * re-stamp): `occurredAt` stays honest about WHEN the destructive signal really appeared
+ * (`pend.since`) rather than lying with the append-time wall clock. Consequences for any code
+ * reading this table:
+ *   - **Fold/replay/windowing order** — the analytics projector's drain, crash recovery, "most
+ *     recent event", or anything reconstructing history — MUST order by [sequenceId], never by
+ *     [occurredAt]. (#732's PR description carries the full audit of existing consumers.)
+ *   - **Display/grouping by real-world time** — a delivery's completion time, a session's
+ *     start/end, a chronological CSV export — SHOULD use [occurredAt] (or a payload's own
+ *     domain timestamp, which is what most `RecordFolds` sites actually read): that IS the
+ *     honest real-world moment, append-order artifacts aside.
+ *   - [sequenceId] order is real commit/causal order (everything already durable when the
+ *     grace fired sorts before it); [occurredAt] order is not.
+ */
 @Entity(
     tableName = "app_events",
     indices = [
@@ -14,7 +50,12 @@ import cloud.trotter.dashbuddy.domain.model.event.AppEventType
     ]
 )
 data class AppEventEntity(
-    /** Auto-incrementing primary key. Defines the absolute order of events. */
+    /**
+     * Auto-incrementing primary key. Defines the absolute append/commit order of events — the
+     * **authoritative fold/order key**. See the class KDoc's "sequenceId vs occurredAt"
+     * section (#732): a graced destructive commit can append at a `sequenceId` higher than an
+     * intervening event's while carrying an EARLIER [occurredAt].
+     */
     @PrimaryKey(autoGenerate = true)
     val sequenceId: Long = 0,
 
@@ -30,7 +71,13 @@ data class AppEventEntity(
     /** The JSON serialization of the specific event data class. */
     val eventPayload: String,
 
-    /** The Unix timestamp of when the event happened. */
+    /**
+     * The Unix timestamp of when the event happened — the DOMAIN time, not necessarily the
+     * append order. **Not guaranteed monotonic with [sequenceId]**: a graced destructive
+     * commit (#431) stamps this at grace-ARM time (`pend.since`), not append/commit time. See
+     * the class KDoc's "sequenceId vs occurredAt" section (#732) for the full invariant and
+     * which consumers must order by which column.
+     */
     val occurredAt: Long = System.currentTimeMillis(),
 
     /** Optional JSON for device state (battery, GPS, etc.) at the time of event. */

--- a/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/event/AppEventEntity.kt
+++ b/core/database/src/main/java/cloud/trotter/dashbuddy/core/database/event/AppEventEntity.kt
@@ -15,31 +15,47 @@ import cloud.trotter.dashbuddy.domain.model.event.AppEventType
  * **[sequenceId] is the authoritative fold/order key. [occurredAt] is NOT guaranteed to be
  * monotonic with it.**
  *
- * A graced destructive commit (`PlatformRegion.pendingDestructive` / the `GRACE_COMMIT` timer,
- * #431 — a dash-end or task-retire that debounces behind a short grace window before it's
- * believed) stamps its eventual event's [occurredAt] at grace-ARM time (`pend.since` — the
- * timestamp of the observation that first signaled the destructive transition; see
- * `PlatformRegionStepper.stepCore`'s lazy-expiry commit, ~L338-342). But the row is not
- * INSERTED — and so does not receive its [sequenceId] — until the grace actually COMMITS,
- * which happens later, after zero or more intervening, non-graced events have already been
- * appended with their own (later, but lower-`sequenceId`) `occurredAt`. Net effect: a
- * higher-`sequenceId` row can carry an EARLIER `occurredAt` than a lower-`sequenceId` row
- * already ahead of it in the log. Two field receipts: 2026-07-07 sequenceId 70/71 and
- * 2026-07-08 sequenceId 116/117 (an 11-minute inversion).
+ * The lag has ONE concrete carrier, not a blanket "every graced commit lags" rule:
+ * **`PICKUP_CONFIRMED`** mints its [occurredAt] from `Task.completedAt`
+ * (`TaskEffects.kt` — `confirmedAt = task.completedAt ?: obs.timestamp`), and `completedAt` is
+ * itself stamped at grace-**ARM** time (`pend.since` — the timestamp of the observation that
+ * first signaled the destructive transition) by either `endSession` or the `TASK_RETIRE`
+ * displacement path (`retireSince ?: obs.timestamp`) in `PlatformRegionStepper.kt`. The
+ * `PICKUP_CONFIRMED` row itself is not appended — and so does not receive its [sequenceId] —
+ * until the close-out sweep runs, which can happen LONG after the grace committed (the
+ * inversion is NOT bounded by the grace window). Two field receipts: 2026-07-07 sequenceId
+ * 70/71 and 2026-07-08 sequenceId 116/117 — an 11-minute inversion traced to that sweep lag.
+ *
+ * **Other graced-commit event types do NOT carry this lag on [occurredAt].** `DASH_STOP`
+ * (`ModeEffects.kt`) and `DELIVERY_COMPLETED` (`DeliveryCompletionEffects.kt`) stamp
+ * [occurredAt] at the COMMITTING observation's own timestamp (`obs.timestamp`) — the honest
+ * domain time (grace-arm time when applicable) rides in the event's PAYLOAD instead
+ * (`SessionStopPayload.endedAt`; the delivery payload's `completedAt`), and the analytics fold
+ * reads that payload field, never the row's [occurredAt] (`RecordFolds.foldDashStop` reads
+ * `p.endedAt`, never `e.occurredAt`, for the session end time). Consumers wanting "when did
+ * the dash really end / the drop really complete" must read the PAYLOAD's domain timestamp,
+ * not [occurredAt].
+ *
+ * `PlatformRegion.pendingModeResume` commits (#605) log nothing off a lagging stamp at all —
+ * that grace never mints an event off its own armed time, so it's outside this invariant.
  *
  * This is a **documented, accepted invariant** (#732 Option B — the dev decided NOT to
- * re-stamp): `occurredAt` stays honest about WHEN the destructive signal really appeared
- * (`pend.since`) rather than lying with the append-time wall clock. Consequences for any code
- * reading this table:
+ * re-stamp `PICKUP_CONFIRMED`'s `occurredAt` to append time, because `Task.completedAt` is the
+ * honest domain moment the destructive signal appeared). Consequences for any code reading
+ * this table:
  *   - **Fold/replay/windowing order** — the analytics projector's drain, crash recovery, "most
  *     recent event", or anything reconstructing history — MUST order by [sequenceId], never by
- *     [occurredAt]. (#732's PR description carries the full audit of existing consumers.)
+ *     [occurredAt], across graced-commit boundaries. (#732's PR description carries the full
+ *     audit of existing consumers.)
  *   - **Display/grouping by real-world time** — a delivery's completion time, a session's
- *     start/end, a chronological CSV export — SHOULD use [occurredAt] (or a payload's own
- *     domain timestamp, which is what most `RecordFolds` sites actually read): that IS the
- *     honest real-world moment, append-order artifacts aside.
+ *     start/end, a chronological CSV export — SHOULD read the PAYLOAD's own domain timestamp
+ *     where the event type carries one (that's what `RecordFolds` actually reads, e.g.
+ *     `SessionStopPayload.endedAt`), NOT [occurredAt] — except for event types with no separate
+ *     payload timestamp (e.g. `PICKUP_CONFIRMED`, where [occurredAt] itself IS
+ *     `Task.completedAt`, so there is nothing else to read).
  *   - [sequenceId] order is real commit/causal order (everything already durable when the
- *     grace fired sorts before it); [occurredAt] order is not.
+ *     grace fired sorts before it); [occurredAt] order is not, for `PICKUP_CONFIRMED`
+ *     specifically.
  */
 @Entity(
     tableName = "app_events",
@@ -53,8 +69,10 @@ data class AppEventEntity(
     /**
      * Auto-incrementing primary key. Defines the absolute append/commit order of events — the
      * **authoritative fold/order key**. See the class KDoc's "sequenceId vs occurredAt"
-     * section (#732): a graced destructive commit can append at a `sequenceId` higher than an
-     * intervening event's while carrying an EARLIER [occurredAt].
+     * section (#732): `PICKUP_CONFIRMED` — whose [occurredAt] carries the grace-armed
+     * `Task.completedAt`, not append time — can append at a `sequenceId` higher than an
+     * intervening event's while carrying an EARLIER [occurredAt]. Other event types'
+     * [occurredAt] tracks commit-observation time and does not invert against [sequenceId].
      */
     @PrimaryKey(autoGenerate = true)
     val sequenceId: Long = 0,
@@ -72,11 +90,16 @@ data class AppEventEntity(
     val eventPayload: String,
 
     /**
-     * The Unix timestamp of when the event happened — the DOMAIN time, not necessarily the
-     * append order. **Not guaranteed monotonic with [sequenceId]**: a graced destructive
-     * commit (#431) stamps this at grace-ARM time (`pend.since`), not append/commit time. See
-     * the class KDoc's "sequenceId vs occurredAt" section (#732) for the full invariant and
-     * which consumers must order by which column.
+     * The Unix timestamp of when the event happened — the DOMAIN time for most event types,
+     * but NOT the append order. **Not guaranteed monotonic with [sequenceId]**:
+     * `PICKUP_CONFIRMED` stamps this from `Task.completedAt`, which can itself be a grace-ARM
+     * timestamp (`pend.since`, #431) rather than append/commit time — the row can be appended
+     * much later, at the close-out sweep. Other graced-commit event types (`DASH_STOP`,
+     * `DELIVERY_COMPLETED`) stamp this at commit-OBSERVATION time instead and carry the
+     * honest domain time in their PAYLOAD (`SessionStopPayload.endedAt`; the delivery
+     * payload's `completedAt`) — read the payload for those, not this column. See the class
+     * KDoc's "sequenceId vs occurredAt" section (#732) for the full invariant and which
+     * consumers must order/read by which column.
      */
     val occurredAt: Long = System.currentTimeMillis(),
 

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/EffectMap.kt
@@ -423,8 +423,12 @@ class EffectMap @Inject constructor(
     }
 
     // Pure domain emission (#354): payload encoding + device metadata happen at the
-    // executor edge. occurredAt is the OBSERVATION timestamp, so the LogEvent's
-    // idempotency key is identical between live execution and recovery replay (#300).
+    // executor edge. occurredAt is normally the OBSERVATION timestamp, so the LogEvent's
+    // default idempotency key ("log:<type>:<occurredAt>") is identical between live
+    // execution and recovery replay (#300). Exception: PICKUP_CONFIRMED passes
+    // Task.completedAt (which can be grace-armed, #732) instead of obs.timestamp — it
+    // stays idempotent because it always supplies its own effectKeyOverride (taskId-scoped,
+    // see AppEffect.kt ~L44) rather than relying on the default occurredAt-derived key.
     internal fun logEffect(
         sessionId: String?,
         type: AppEventType,

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
@@ -339,6 +339,14 @@ class PlatformRegionStepper @Inject constructor() {
                     // that armed the grace — not the deadline: the dash/task really
                     // ended when the destructive signal appeared, the grace only
                     // delayed our belief in it (#431).
+                    //
+                    // #732: this pend.since stamp (not "now") is the SOURCE of the
+                    // sequenceId/occurredAt ordering invariant — the committed event
+                    // appends to the log AFTER any intervening non-graced events but
+                    // carries an EARLIER domain timestamp than they do. See
+                    // AppEventEntity's class KDoc ("sequenceId vs occurredAt") for the
+                    // full invariant; this is a documented, accepted tradeoff (Option
+                    // B), not a bug to silently "fix" by re-stamping here.
                     commitDestructive(current, pend.kind, pend.since)
                 }
             }

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/PlatformRegionStepper.kt
@@ -340,13 +340,18 @@ class PlatformRegionStepper @Inject constructor() {
                     // ended when the destructive signal appeared, the grace only
                     // delayed our belief in it (#431).
                     //
-                    // #732: this pend.since stamp (not "now") is the SOURCE of the
-                    // sequenceId/occurredAt ordering invariant — the committed event
-                    // appends to the log AFTER any intervening non-graced events but
-                    // carries an EARLIER domain timestamp than they do. See
-                    // AppEventEntity's class KDoc ("sequenceId vs occurredAt") for the
-                    // full invariant; this is a documented, accepted tradeoff (Option
-                    // B), not a bug to silently "fix" by re-stamping here.
+                    // #732: this pend.since stamp is what makes Task.completedAt (set below,
+                    // in endSession/retireActiveTask) carry the grace-ARM time rather than
+                    // commit time — the TRUE source of the sequenceId/occurredAt ordering
+                    // invariant: a later PICKUP_CONFIRMED close-out sweep reads that
+                    // completedAt as its OWN occurredAt (TaskEffects.kt), so THAT event can
+                    // append to the log well AFTER intervening non-graced events while
+                    // carrying an EARLIER domain timestamp than they do. Other event types
+                    // (DASH_STOP, DELIVERY_COMPLETED) stamp their own occurredAt at
+                    // commit-observation time and do NOT inherit this lag. See
+                    // AppEventEntity's class KDoc ("sequenceId vs occurredAt") for the full
+                    // invariant; this is a documented, accepted tradeoff (Option B), not a
+                    // bug to silently "fix" by re-stamping here.
                     commitDestructive(current, pend.kind, pend.since)
                 }
             }

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/GracedCommitOrderingInvariantTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/GracedCommitOrderingInvariantTest.kt
@@ -1,0 +1,178 @@
+package cloud.trotter.dashbuddy.core.state
+
+import cloud.trotter.dashbuddy.domain.model.event.AppEventType
+import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.pipeline.TimeoutType
+import cloud.trotter.dashbuddy.domain.state.AppState
+import cloud.trotter.dashbuddy.domain.state.DestructiveKind
+import cloud.trotter.dashbuddy.domain.state.Flow
+import cloud.trotter.dashbuddy.domain.state.FlowRegion
+import cloud.trotter.dashbuddy.domain.state.Job
+import cloud.trotter.dashbuddy.domain.state.Mode
+import cloud.trotter.dashbuddy.domain.state.PendingDestructive
+import cloud.trotter.dashbuddy.domain.state.Platform
+import cloud.trotter.dashbuddy.domain.state.PlatformRegion
+import cloud.trotter.dashbuddy.domain.state.Regions
+import cloud.trotter.dashbuddy.domain.state.Session
+import cloud.trotter.dashbuddy.domain.state.Task
+import cloud.trotter.dashbuddy.domain.state.TaskPhase
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #732 characterization test — **pins the DOCUMENTED `sequenceId`/`occurredAt` ordering
+ * invariant** (see `AppEventEntity`'s class KDoc, `core/database/.../event/AppEventEntity.kt`):
+ * a graced destructive commit (`PlatformRegion.pendingDestructive` / the `GRACE_COMMIT` timer,
+ * #431) stamps its eventually-logged event's timestamp at grace-**ARM** time (`pend.since`),
+ * not commit/append time — so the event's `occurredAt` can be EARLIER than an intervening,
+ * non-graced event's `occurredAt`, even though the graced event's row is not appended to (and
+ * does not receive its `sequenceId` in) the `app_events` log until later — after the
+ * intervening event.
+ *
+ * The scenario below drives that through the REAL [PlatformRegionStepper] + [EffectMap]
+ * machinery (no hand-waved shortcuts): a `SESSION_END` grace is armed while a pickup task is
+ * active, an intervening non-flow observation is processed WHILE the grace is still open
+ * (proving real processing has moved past the arm time before the grace ever commits), and
+ * then a `GRACE_COMMIT` timeout past the deadline lazily commits the session end. The
+ * resulting `PICKUP_CONFIRMED` — minted by the #596/#526 close-out sweep off the
+ * grace-stamped `Task.completedAt` — carries `occurredAt == pend.since`, which is EARLIER than
+ * the intervening observation's own timestamp.
+ *
+ * This is a **documented, ACCEPTED tradeoff** (#732 Option B — the dev decided NOT to
+ * re-stamp `occurredAt` to append time, because `pend.since` is the honest domain moment the
+ * destructive signal appeared). If this test starts failing because a future change makes the
+ * graced commit re-stamp to "now" instead of `pend.since`, that is a deliberate behavior
+ * change requiring its own decision — re-read #732 before touching this test to match.
+ */
+class GracedCommitOrderingInvariantTest {
+
+    private val stepper = PlatformRegionStepper()
+    private val policy = TransitionPolicy()
+    private val effectMap = EffectMap()
+    private val platform = Platform.DoorDash
+    private val session = Session("sess-1", startedAt = 100L)
+
+    // The destructive signal (e.g. the offline/idle screen that implies "the dash really
+    // ended") appeared at armedAt — this is `pend.since`.
+    private val armedAt = 2_000L
+
+    // The grace window's deadline — nothing commits before this.
+    private val deadline = 2_500L
+
+    // A real, unrelated frame the state machine processes WHILE the grace is still open —
+    // later than armedAt, but well before the eventual commit.
+    private val interveningAt = 2_200L
+
+    // The GRACE_COMMIT timer's own fire time — past the deadline, this is when the lazy
+    // expiry actually commits (and the resulting event is finally appended to the log).
+    private val commitAt = 3_000L
+
+    private val pickupTaskFlow = FlowRegion(flow = Flow.TaskPickupArrived, activePlatform = platform)
+
+    private fun pickupTask(completedAt: Long? = null) = Task(
+        taskId = "pk", jobId = "job-1", phase = TaskPhase.PICKUP,
+        storeName = "H-E-B", arrivedAt = 400L, startedAt = 300L, completedAt = completedAt,
+    )
+
+    private fun job() = Job(
+        jobId = "job-1", offerStoreHint = listOf("H-E-B"), parentOfferHash = null,
+        startedAt = 200L, tasks = emptyList(),
+    )
+
+    private fun armedRegion() = PlatformRegion(
+        platform = platform, mode = Mode.Online, session = session,
+        activeJob = job(), activeTask = pickupTask(),
+        pendingDestructive = PendingDestructive(DestructiveKind.SESSION_END, since = armedAt, deadline = deadline),
+        lastActedFlow = Flow.TaskPickupArrived,
+    )
+
+    private fun uiInput(t: Long) = Observation.UiInput(timestamp = t, action = "noop", targetPlatform = platform)
+
+    private fun graceCommitTimeout(t: Long) =
+        Observation.Timeout(timestamp = t, type = TimeoutType.GRACE_COMMIT, targetPlatform = platform)
+
+    private fun state(region: PlatformRegion, flow: Flow) = AppState(
+        regions = Regions(
+            flow = FlowRegion(flow = flow, activePlatform = platform),
+            platforms = mapOf(platform to region),
+        ),
+    )
+
+    @Test
+    fun `an intervening observation while the grace is open does not commit it`() {
+        val armed = armedRegion()
+        val afterIntervening =
+            stepper.step(armed, pickupTaskFlow, pickupTaskFlow, uiInput(interveningAt), policy)
+
+        assertNotNull("the SESSION_END grace is still pending — deadline not reached", afterIntervening.pendingDestructive)
+        assertEquals("session untouched by the non-committing intervening frame", "sess-1", afterIntervening.session?.sessionId)
+        assertEquals("active task untouched", "pk", afterIntervening.activeTask?.taskId)
+    }
+
+    @Test
+    fun `the lazy-expiry commit stamps completedAt at pend-since, not at commit time`() {
+        val armed = armedRegion()
+        val afterIntervening =
+            stepper.step(armed, pickupTaskFlow, pickupTaskFlow, uiInput(interveningAt), policy)
+        val afterCommit =
+            stepper.step(afterIntervening, pickupTaskFlow, pickupTaskFlow, graceCommitTimeout(commitAt), policy)
+
+        assertNull("SESSION_END committed — session cleared", afterCommit.session)
+        assertNull("activeJob cleared by the session end", afterCommit.activeJob)
+        assertNull("grace cleared on commit", afterCommit.pendingDestructive)
+        val retiredTask = afterCommit.recentTasks.single { it.taskId == "pk" }
+        assertEquals(
+            "the retired task's completedAt is stamped at pend.since (armedAt), not obs.timestamp (commitAt)",
+            armedAt,
+            retiredTask.completedAt,
+        )
+        assertTrue(
+            "the INVERSION: the committed domain timestamp (armedAt) is EARLIER than the " +
+                "intervening frame's own timestamp, even though the intervening frame was " +
+                "processed — and would append to app_events — BEFORE this commit did",
+            retiredTask.completedAt!! < interveningAt,
+        )
+    }
+
+    @Test
+    fun `the resulting PICKUP_CONFIRMED event carries occurredAt equal to pend-since (armedAt), earlier than the intervening frame`() {
+        val armed = armedRegion()
+        val afterIntervening =
+            stepper.step(armed, pickupTaskFlow, pickupTaskFlow, uiInput(interveningAt), policy)
+        val commitObs = graceCommitTimeout(commitAt)
+        val afterCommit =
+            stepper.step(afterIntervening, pickupTaskFlow, pickupTaskFlow, commitObs, policy)
+
+        // Diff the SAME prev/next pair the real StateManagerV2 would diff around this exact
+        // commit step, with the SAME observation that drove it — this is the #596/#526
+        // close-out sweep: `endSession` unconditionally clears `activeJob`, so a job that was
+        // never a "physically complete" dropoff job (there ARE no dropoffs here) still gets
+        // its arrived pickup swept into a PICKUP_CONFIRMED.
+        val effects = effectMap.diff(
+            state(afterIntervening, Flow.TaskPickupArrived),
+            state(afterCommit, Flow.Idle),
+            commitObs,
+        )
+
+        val confirmed = effects.filterIsInstance<AppEffect.LogEvent>()
+            .single { it.event.type == AppEventType.PICKUP_CONFIRMED }
+
+        assertEquals(
+            "PICKUP_CONFIRMED's occurredAt is the ARMED time (pend.since), not the commit " +
+                "observation's timestamp — this is the value that lands in AppEventEntity.occurredAt " +
+                "(#732, see AppEventEntity's class KDoc)",
+            armedAt,
+            confirmed.event.occurredAt,
+        )
+        assertTrue(
+            "the pinned inversion: this event's occurredAt is EARLIER than an intervening " +
+                "frame's timestamp, despite this event not appending to the log until the " +
+                "GRACE_COMMIT fires at commitAt (well after the intervening frame was processed)",
+            confirmed.event.occurredAt < interveningAt,
+        )
+        assertTrue("commitAt is indeed after the intervening frame in real/processing time", commitAt > interveningAt)
+    }
+}

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/GracedCommitOrderingInvariantTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/GracedCommitOrderingInvariantTest.kt
@@ -131,8 +131,9 @@ class GracedCommitOrderingInvariantTest {
         )
         assertTrue(
             "the INVERSION: the committed domain timestamp (armedAt) is EARLIER than the " +
-                "intervening frame's own timestamp, even though the intervening frame was " +
-                "processed — and would append to app_events — BEFORE this commit did",
+                "intervening frame's own timestamp — a later-timestamped observation was " +
+                "processed before this commit appended (the intervening UiInput logs no " +
+                "app_events row of its own)",
             retiredTask.completedAt!! < interveningAt,
         )
     }

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/AppEvent.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/model/event/AppEvent.kt
@@ -10,10 +10,12 @@ import cloud.trotter.dashbuddy.domain.model.event.payload.AppEventPayload
  * auto-increment sequence, JSON payload column, device metadata — live on the
  * Room entity in :core:database and are mapped at the repository boundary.
  *
- * [occurredAt] is the OBSERVATION timestamp of the transition that emitted the
- * event, not the wall clock at execution time. That makes the event (and the
- * idempotency key derived from it) identical between live execution and
- * crash-recovery replay (#300).
+ * [occurredAt] is generally the OBSERVATION timestamp of the transition that emitted the
+ * event, not the wall clock at execution time — making the event (and the default
+ * idempotency key derived from it) identical between live execution and crash-recovery
+ * replay (#300). Exception: `PICKUP_CONFIRMED` carries `Task.completedAt` instead, which
+ * can be a grace-armed timestamp rather than the triggering observation's own — see
+ * `AppEventEntity`'s "sequenceId vs occurredAt" class KDoc (#732) for the full invariant.
  */
 data class AppEvent(
     val type: AppEventType,


### PR DESCRIPTION
## Summary

Documents (does **not** fix) the `sequenceId`/`occurredAt` ordering invariant on `app_events`,
per the dev's Option B decision: **do not re-stamp `occurredAt`; document the invariant and
audit consumers.**

**The invariant:** `sequenceId` is the authoritative fold/order key. `occurredAt` may lag it for
a graced destructive commit (`PlatformRegion.pendingDestructive` / the `GRACE_COMMIT` timer,
#431) — the eventually-logged event's `occurredAt` is stamped at grace-**ARM** time (`pend.since`
— the observation that first signaled the destructive transition, stamped in
`PlatformRegionStepper.stepCore`'s lazy-expiry commit, ~L338-342), not at append/commit time. The
row isn't inserted (and doesn't receive its `sequenceId`) until the grace actually commits, by
which point zero or more intervening, non-graced events have already appended with their own
later — but lower-`sequenceId` — `occurredAt`. Net effect: a higher-`sequenceId` row can carry an
EARLIER `occurredAt` than a lower-`sequenceId` row already ahead of it in the log. Two field
receipts: 2026-07-07 sequenceId 70/71; 2026-07-08 sequenceId 116/117 (an 11-minute inversion).

This is a **documented, accepted invariant**, not a bug: `occurredAt` stays honest about WHEN
the destructive signal really appeared rather than lying with the append-time wall clock.

## Changes (3 parts, no behavior change)

1. **Documentation at the contract site** — one authoritative KDoc on `AppEventEntity`
   (`core/database/.../event/AppEventEntity.kt`), class-level + on the `sequenceId`/`occurredAt`
   fields, stating the invariant, the mechanism, the two field receipts, and which consumers must
   order by which column. Short pointer comments (no duplicated explanation, SSOT) at:
   - the event-append path — `AppEventRepo.toEntity` (`core/data/.../event/AppEventRepo.kt`)
   - the grace-commit stamp site — `PlatformRegionStepper.stepCore`'s lazy-expiry commit
     (~L338-342)
2. **Consumer audit** — see table below. No sensitive (behavior-affecting) consumer found live in
   production code; one latent/dead-code finding flagged (not fixed — no live callers to break).
3. **Characterization test** — `GracedCommitOrderingInvariantTest`
   (`core/state/src/test/.../GracedCommitOrderingInvariantTest.kt`) drives a REAL `SESSION_END`
   grace through `PlatformRegionStepper` + `EffectMap` (arm → intervening non-committing frame →
   `GRACE_COMMIT` timeout past the deadline) and pins that the resulting `PICKUP_CONFIRMED`
   event's `occurredAt` equals `pend.since` — provably earlier than the intervening frame's own
   timestamp, despite appending to the log later. Its KDoc states explicitly that this pins the
   DOCUMENTED invariant; a future change that silently re-stamps to append time should trip it and
   force a deliberate decision, not a silent "fix."

No projector version bump, no migration, no payload change — comments/KDoc + one new test file
only.

## Consumer audit

| Consumer | File:line | Verdict |
|---|---|---|
| Analytics projector fold/drain (paged batch input) | `core/database/.../event/AppEventDao.kt:58` (`getEventsAfter`, `ORDER BY sequenceId ASC`); driven by `core/data/.../analytics/AnalyticsProjector.kt:168-171` | **Ordered by `sequenceId`** — authoritative, insensitive |
| Projector restart-correct context hydration (mid-session restart anchors) | `core/database/.../analytics/AnalyticsDao.kt:679` (`lastDeliveryInSession`, `ORDER BY eventSequenceId DESC LIMIT 1`), `:752,:765,:771` (`lastOfferCostPerMileInSession`/Fuel/NonFuel, same pattern); read by `AnalyticsProjector.kt:539-551` (`hydrate`) | **Ordered by `eventSequenceId`** — insensitive |
| Driver-correction adjustments apply order (PAY_ADJUSTMENT/DELIVERY_ADJUSTMENT/SessionAssign, "FIX 1") | `core/data/.../analytics/AnalyticsProjector.kt:227` (`adjustments.sortedBy { it.sequenceId }`) | **Ordered by `sequenceId`** — explicitly designed for log-order composition; insensitive |
| Store resolution trigger order (#159) | `core/data/.../analytics/AnalyticsProjector.kt:238` (`resolutions.sortedBy { it.sequenceId }`) | **Ordered by `sequenceId`** — insensitive |
| `StoreResolutionRunner` — job pickup/delivery rows read for anchor resolution | `core/data/.../analytics/StoreResolutionRunner.kt:49-68` reads `AnalyticsDao.pickupRecordsForJob`/`deliveryRecordsForJob` — `core/database/.../analytics/AnalyticsDao.kt:93,98` (`ORDER BY eventSequenceId ASC`) | **Ordered by `eventSequenceId`** — insensitive |
| `SessionFoldContext.lastEventAt` / session-duration liveness anchors | `domain/analytics/RecordFolds.kt:395,414,699,937` (`maxOf(context.lastEventAt, e.occurredAt)`); `RecordFolds.kt:976-1010` (`resolveContext`/`advance`) | **Insensitive by construction** — a monotonic clamp (`maxOf`); an inverted `occurredAt` on a later-sequenced event simply fails to advance `lastEventAt` further, it never regresses it |
| Per-record domain timestamps (`delivery_records.completedAt`/`pickup_records.confirmedAt`) | `domain/analytics/RecordFolds.kt:509` (`p.completedAt ?: e.occurredAt`), `:763` (`p.confirmedAt ?: e.occurredAt`) | **Not a fold-order dependency** — reads the PAYLOAD's own domain timestamp (task-completion-derived, i.e. `pend.since` when graced) in preference to the entity's `occurredAt`. This is the CORRECT/desired behavior per the invariant (`occurredAt` IS meant to be domain time) — not a finding |
| Candidate-session picker for an orphan delivery (#660, ±48h) | `core/data/.../analytics/AnalyticsRepository.kt:372-392` (`candidateSessionsForOrphan`, `sortedWith(compareBy({spanDistance}, {startedAt}))`) | **Insensitive** — ranks by domain-time proximity for a manual UI picker, not log order; this IS the correct semantics per the invariant |
| CSV export row ordering | `core/data/.../analytics/CsvExporter.kt:73-74` (`sortedBy { completedAt }` / `{ startedAt }`) | **Insensitive** — chronological export-by-domain-time is the desired UX, not a correctness-critical fold order |
| `AppEventDao.getEventsByType` / `getEventsInTimeRange` | `core/database/.../event/AppEventDao.kt:43,50` (`ORDER BY occurredAt`) | **FINDING (latent, not fixed here)** — these DO order by `occurredAt`, which would be inversion-sensitive for windowing/pagination. Zero production callers found (`AppEventRepo.getEventsByType`/`getEventsInTimeRange` are unused outside the DAO/repo definitions) — not live-sensitive today, but flagged so a future caller doesn't silently inherit the gap. No code change made (nothing to fix without a real consumer to define correct semantics for) |
| Offer-nomination temporal fallback (#159 F4) | `core/database/.../analytics/AnalyticsDao.kt:181-192` (`nominateOfferForJob`, windows/orders `offer_records` by `decidedAt` with `eventSequenceId DESC` tiebreak) | **Insensitive** — offer outcomes (`OFFER_RECEIVED`/`OFFER_ACCEPTED`/`OFFER_DECLINED`/`OFFER_TIMEOUT`) always mint with `obs.timestamp` as `occurredAt` (`OfferEffects.kt:54,64,114`) — offer resolution is never a graced destructive commit, so it never carries the `PICKUP_CONFIRMED`-class lag. Domain-time proximity is the intended semantics here, not an inversion risk |
| Leg-mileage fold anchors (#688 phase B) | `domain/analytics/LegFolds.kt` — nine `e.occurredAt` uses across `foldPickupArrived`/`foldDeliveryArrived`/`foldDeliveryConfirmed`/`foldTaskUnassigned` | **Insensitive** — every use routes through the same audited `resolveContext`/`advance` helpers as `RecordFolds`'s `lastEventAt` clamp (row above); the verdict transfers: a monotonic `maxOf` clamp can't regress from an inverted `occurredAt`, only fail to advance further |
| Session/delivery display & list queries | `core/database/.../analytics/AnalyticsDao.kt` — `deliveriesForSession`/`recentSessions`/`deliveriesBetween`/`sessionsBetween` (`ORDER BY completedAt`/`startedAt`, the read-model's OWN columns, not `app_events.occurredAt` directly) | **Insensitive** — domain-time display ordering for UI lists/exports; harmless even where the read-model column falls back to `e.occurredAt` (only when a payload is missing its own completion timestamp) |

## Design-goal review (author draft)

1. **UDF** — n/a, no reducer/effect logic changed; comments and one new pure characterization test only.
2. **MAD** — n/a.
3. **Single responsibility** — the invariant now has exactly one documented owner (`AppEventEntity`'s class KDoc); the two other touch sites are one-line pointers, not re-explanations (avoids the drift class principle 5 warns about).
4. **Kotlin/Android practices** — n/a, no code behavior changed.
5. **SSOT** — this PR's entire point: the invariant previously existed only as tribal knowledge (the dev's field receipts); it now has one authoritative KDoc (`AppEventEntity`) with pointers from the two mechanism sites (`AppEventRepo.toEntity`, `PlatformRegionStepper`'s grace-commit stamp), not three independent explanations.
6. **Security & privacy** — n/a, no capture/PII/network surface touched.
7. **Semantic, PII-safe logging** — n/a, no new log lines.
8. **Platform-agnostic core** — the invariant and its mechanism (`pendingDestructive`/`GRACE_COMMIT`) are already platform-agnostic (per-`PlatformRegion`, not a global); this PR adds no platform literals.

No violations found; nothing to file.

## Adversarial review

Pending — CI + the fable adversarial loop (`/code-review`) to run before merge per the standing
workflow. Not merged by this agent (dev-approved-merge policy applies at review time, not
build time).

## Test plan

- [x] `JAVA_HOME=/usr/lib/jvm/java-25 ./gradlew :core:state:testDebugUnitTest :core:database:testDebugUnitTest :domain:test` — all green, including the 3 new `GracedCommitOrderingInvariantTest` cases
- [x] No projector version bump, no migration, no payload/schema change (grep-verified: only comments/KDoc + one new test file in the diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review fixes applied

The initial adversarial review found the KDoc's blanket "graced destructive commits stamp
their eventual event's `occurredAt` at grace-ARM time" framing overclaimed — it's true for
exactly ONE event type, not graced commits in general. Fixed:

1. **True carrier mechanism, HIGH.** Rewrote `AppEventEntity`'s class KDoc + the
   `sequenceId`/`occurredAt` field KDocs, and the `PlatformRegionStepper.kt` pointer comment, to
   state the invariant accurately: `PICKUP_CONFIRMED` mints `occurredAt` from `Task.completedAt`
   (`TaskEffects.kt`), and `completedAt` is what gets grace-armed (`pend.since`) by
   `endSession`/`retireActiveTask`. The row appends at the close-out sweep — possibly much
   later, cf. the 07-08 11-minute receipt — so the lag is NOT bounded by the grace window.
   `DASH_STOP` (`ModeEffects.kt`) and `DELIVERY_COMPLETED` (`DeliveryCompletionEffects.kt`) do
   **not** carry this lag on `occurredAt` — both stamp it at the committing observation's own
   timestamp and carry the honest domain time in their PAYLOAD instead
   (`SessionStopPayload.endedAt`; the delivery payload's `completedAt`), which is what
   `RecordFolds.foldDashStop` actually reads (`p.endedAt`, never `e.occurredAt`). Consumers
   wanting the real end/completion time must read the payload field for those two event types.
   `pendingModeResume` commits log nothing off a lagging stamp at all.
2. **Contradicting comments, MED.** `AppEvent.kt`'s class KDoc and `EffectMap.kt`'s `logEffect`
   helper comment both previously implied `occurredAt` is unconditionally the observation
   timestamp / unconditionally identical live-vs-replay. Both now note the `PICKUP_CONFIRMED`
   exception and point at `AppEventEntity`'s authoritative KDoc; the `EffectMap.kt` comment also
   notes `PICKUP_CONFIRMED` stays idempotent via its own `effectKeyOverride`
   (`taskId`-scoped, `AppEffect.kt` ~L44), not the default `occurredAt`-derived key.
3. **Missed audit row, MED.** Added `AnalyticsDao.nominateOfferForJob` to the consumer audit
   table — **insensitive**: offer resolution always mints with `obs.timestamp`
   (`OfferEffects.kt:54,64,114`), never a graced destructive commit.
4. **Audit-table completeness, LOW.** Added `LegFolds.kt` (nine `e.occurredAt` uses, all through
   the already-audited `resolveContext`/`advance` helpers — verdict transfers) and the
   session/delivery display & list queries family (`deliveriesForSession`/`recentSessions`/
   `deliveriesBetween`/`sessionsBetween`) as their own audit row.
5. **Test narrative, LOW.** Reworded `GracedCommitOrderingInvariantTest`'s misleading assertion
   message ("would append to app_events BEFORE this commit did", which mischaracterized the
   intervening `UiInput` as logging its own row) to "a later-timestamped observation was
   processed before this commit appended (the intervening UiInput logs no app_events row of its
   own)". Assertions themselves are unchanged.

All five fixes are comments/KDoc/test-message/PR-body text only — verified `git diff` shows no
executable-statement changes.

