### PR TITLE
fix(#734): actuation — tighten confirm_decline/expand_earnings bindings, abort-to-manual on candidate tie

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/ClickCandidateRanker.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/ClickCandidateRanker.kt
@@ -35,10 +35,11 @@ import cloud.trotter.dashbuddy.domain.pipeline.NodeRef
  *   is greater than zero. An exact bounds match is just the IoU == 1.0 case,
  *   so this tier subsumes the old exact-match fast path without a separate
  *   branch — a small amount of drift still resolves correctly.
- * - **[Tier.UNRESOLVED]** — nothing above was decisive. Falls back to the
- *   first candidate (same behavior as before the fix), but the caller logs
- *   this at WARN — it is now the genuinely exceptional case, not the common
- *   one Principle 7 warns will drown the WARN channel.
+ * - **[Tier.UNRESOLVED]** — nothing above was decisive. When more than one
+ *   verified candidate remains, the caller ABORTS to manual (no click) and
+ *   logs at WARN (#734 — fail-closed, matching the other fail arms); a single
+ *   surviving candidate still clicks. Ties are the genuinely exceptional case
+ *   by construction, so the WARN channel is not drowned (Principle 7).
  *
  * `pathFingerprint` (T3 in the #600 build plan) is intentionally NOT
  * implemented here. `Ruleset.buildNodeRef` computes it by walking the

--- a/app/src/main/java/cloud/trotter/dashbuddy/state/effects/UiInteractionHandler.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/effects/UiInteractionHandler.kt
@@ -30,7 +30,11 @@ import javax.inject.Singleton
  *    survives label verification, [ClickCandidateRanker] picks the strongest
  *    match (exact stored text, then max bounds overlap) instead of a
  *    since-abandoned exact-bounds `==` comparison that broke under an
- *    animating sheet's temporal drift.
+ *    animating sheet's temporal drift. If the ranker cannot decide
+ *    ([ClickCandidateRanker.Tier.UNRESOLVED]) among >1 survivor, the tap is
+ *    **aborted to manual** (#734) — clicking the first-in-tree candidate is
+ *    luck, not verification. The paired ruleset fix keeps the bound target
+ *    predicates tight enough that this decisive path resolves a single node.
  * 4. **Strict click** — self-or-ancestor only. The old clickable-*sibling*
  *    fallback is deliberately absent here: the verified node's sibling can be
  *    the opposite button (Accept sits beside Decline in the offer footer).
@@ -144,13 +148,21 @@ class UiInteractionHandler @Inject constructor(
         val target = verified[ranked.index]
         when {
             ranked.tier == ClickCandidateRanker.Tier.UNRESOLVED && verified.size > 1 -> {
+                // #734: an ambiguous target must NOT be clicked. Picking the
+                // first-in-tree candidate is luck, not verification, and breaks
+                // #425's fail-closed promise (a wrong click on a decline/accept
+                // surface acts against the dasher's intent). Abort to manual,
+                // matching the empty-candidate and label-fail arms above — the
+                // under-constrained predicate is tightened at the ruleset so the
+                // decisive single-candidate path is normally reached first.
                 // WARN carries counts only — raw third-party UI text is DEBUG-tier
                 // by Principle 7 (the WARN slice is user-exportable), #618 review F1.
                 Timber.tag("Effects").w(
-                    "No decisive match among %d verified candidates for: %s — clicking first",
+                    "No decisive match among %d verified candidates for: %s — refusing to click (fail closed)",
                     verified.size, description,
                 )
                 Timber.tag("Effects").d("Unresolved-tie candidate labels for %s: %s", description, facts.map { it.labels })
+                return false
             }
             verified.size == 1 -> Timber.tag("Effects").d("Single verified candidate for %s — clicking it", description)
             else -> Timber.tag("Effects").d(

--- a/app/src/test/java/cloud/trotter/dashbuddy/state/effects/ActuationBindingResolutionTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/state/effects/ActuationBindingResolutionTest.kt
@@ -212,9 +212,13 @@ class ActuationBindingResolutionTest {
             // EXPAND_EARNINGS is label-free, so both expandable_view nodes survive label
             // verification (the shared id can't be narrowed). The ranker must therefore
             // EITHER resolve the correct (pay) node via bounds, OR — on a degenerate frame
-            // whose pay rect is collapsed/zero-area — return an UNRESOLVED tie, which the
-            // handler now ABORTS to manual (#734). It must NEVER decisively resolve the
-            // stats node (a wrong click).
+            // whose pay rect is inverted/zero-area (3 of the 11 bound corpus frames:
+            // 165530_687 inverted, 180901_024 + 201237_957 zero-height) — return an
+            // UNRESOLVED tie, which the handler now ABORTS to manual (#734): a per-frame
+            // availability cost (~27% of bound corpus frames), mitigated per capture burst
+            // (most bursts contain a decisive sibling frame) and always preferable to the
+            // old behavior, which decisively clicked the WRONG (stats) node on exactly
+            // these frames. It must NEVER decisively resolve the stats node (a wrong click).
             val r = resolve(node, ref, action.verification)
             if (r.decisive) {
                 decisiveFrames++

--- a/app/src/test/java/cloud/trotter/dashbuddy/state/effects/ActuationBindingResolutionTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/state/effects/ActuationBindingResolutionTest.kt
@@ -1,0 +1,231 @@
+package cloud.trotter.dashbuddy.state.effects
+
+import cloud.trotter.dashbuddy.domain.action.RuleAction
+import cloud.trotter.dashbuddy.domain.action.TargetExpectation
+import cloud.trotter.dashbuddy.domain.model.accessibility.BoundingBox
+import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
+import cloud.trotter.dashbuddy.domain.pipeline.NodeRef
+import cloud.trotter.dashbuddy.test.util.TestResourceLoader
+import cloud.trotter.dashbuddy.test.util.TestRulesetFactory
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #734 — actuation target-binding disambiguation.
+ *
+ * Field logs (07-07/07-08) showed [UiInteractionHandler] resolving **2 verified
+ * candidates** and falling back to "clicking first" for two RuleActions:
+ * `CONFIRM_DECLINE` on the offer confirm-decline sheet and `EXPAND_EARNINGS` on
+ * the collapsed delivery summary. "First in tree order" is luck, not
+ * verification, and violates #425's fail-closed posture.
+ *
+ * This test drives the **real compiled ruleset** (matchers JSON5 → generated
+ * assets → `TestRulesetFactory`) over the **committed corpus** and replays the
+ * handler's own candidate-resolution pipeline (find-by-viewId candidate set →
+ * label verification via the RuleAction's [TargetExpectation] → the real
+ * [ClickCandidateRanker]) over the same node tree. It asserts the tightened
+ * bindings resolve a single, decisive, *correct* target — never an
+ * [ClickCandidateRanker.Tier.UNRESOLVED] tie among >1 survivor (the case the
+ * paired handler change now aborts to manual).
+ *
+ * The replay mirrors the handler exactly:
+ *  - candidate set = every node whose `viewIdResourceName` equals the pinned
+ *    ref's `viewIdSuffix` (the handler's find-by-viewId strategy; corpus ids are
+ *    already suffix-form). Falls back to by-text like the handler when the ref
+ *    has no id.
+ *  - labels = the node's own text/contentDescription + its bounded subtree's
+ *    (depth 3, 24 nodes) — the same walk as `collectLabels`.
+ *  - decision = `ClickCandidateRanker.rank`, then the handler's tie rule.
+ */
+class ActuationBindingResolutionTest {
+
+    private data class Resolution(
+        val verifiedCount: Int,
+        val tier: ClickCandidateRanker.Tier,
+        val resolved: UiNode?,
+        val decisive: Boolean,
+    )
+
+    /** Mirror of `UiInteractionHandler.collectLabels` over a UiNode subtree. */
+    private fun collectLabels(node: UiNode): List<String> {
+        val labels = mutableListOf<String>()
+        var visited = 0
+        fun visit(n: UiNode, depth: Int) {
+            if (depth > 3 || visited >= 24) return
+            visited++
+            n.text?.takeIf { it.isNotBlank() }?.let { labels.add(it) }
+            n.contentDescription?.takeIf { it.isNotBlank() }?.let { labels.add(it) }
+            for (c in n.children) visit(c, depth + 1)
+        }
+        visit(node, 0)
+        return labels
+    }
+
+    /** Mirror of `UiInteractionHandler.findCandidates` (viewId → text) over a UiNode tree. */
+    private fun findCandidates(tree: UiNode, ref: NodeRef): List<UiNode> {
+        ref.viewIdSuffix?.takeIf { it.isNotEmpty() }?.let { id ->
+            val byId = tree.findNodes { it.viewIdResourceName == id }
+            if (byId.isNotEmpty()) return byId
+        }
+        ref.text?.takeIf { it.isNotEmpty() }?.let { txt ->
+            val byText = tree.findNodes { (it.text?.contains(txt, ignoreCase = true) == true) }
+            if (byText.isNotEmpty()) return byText
+        }
+        return emptyList()
+    }
+
+    /**
+     * Replay the full handler resolution: candidate set → label verification →
+     * [ClickCandidateRanker] → the handler's tie rule.
+     */
+    private fun resolve(tree: UiNode, ref: NodeRef, expectation: TargetExpectation): Resolution {
+        val candidates = findCandidates(tree, ref)
+        val verified = candidates.filter { expectation.matchesLabels(collectLabels(it)) }
+        if (verified.isEmpty()) return Resolution(0, ClickCandidateRanker.Tier.UNRESOLVED, null, decisive = false)
+
+        val facts = verified.map { node ->
+            ClickCandidateRanker.CandidateFacts(
+                text = node.text,
+                labels = collectLabels(node),
+                bounds = node.boundsInScreen,
+            )
+        }
+        val ranked = ClickCandidateRanker.rank(ref, facts)
+        // The handler's tie rule: an UNRESOLVED ranking among >1 survivor is the
+        // ambiguous (now aborted) case; a single survivor, or a decisive tier, is fine.
+        val decisive = !(ranked.tier == ClickCandidateRanker.Tier.UNRESOLVED && verified.size > 1)
+        return Resolution(verified.size, ranked.tier, verified[ranked.index], decisive)
+    }
+
+    private fun matchTargets(tree: UiNode): Map<String, NodeRef> =
+        TestRulesetFactory.screenRuleset.matchFirst(tree)?.targets ?: emptyMap()
+
+    private fun subtreeHasText(node: UiNode, needle: String): Boolean {
+        if (node.text?.equals(needle, ignoreCase = true) == true) return true
+        return node.children.any { subtreeHasText(it, needle) }
+    }
+
+    // =========================================================================
+    // CONFIRM_DECLINE — offer_popup_confirm_decline
+    // =========================================================================
+
+    @Test
+    fun `confirm decline resolves exactly one verified button per corpus snapshot`() {
+        val action = RuleAction.CONFIRM_DECLINE
+        var withTarget = 0
+        for ((filename, node, _) in TestResourceLoader.loadSnapshots("snapshots/offer_popup_confirm_decline")) {
+            val ref = matchTargets(node)[action.targetBindName] ?: continue // optional bind
+            withTarget++
+            val r = resolve(node, ref, action.verification)
+            // Exactly ONE node verifies (the confirm sheet's 'Decline offer' button); the
+            // dialog-body 'Are you sure you want to decline...' copy has no id so it is
+            // never in the find-by-viewId candidate set.
+            assertEquals("$filename: exactly one candidate must verify for CONFIRM_DECLINE", 1, r.verifiedCount)
+            assertTrue("$filename: resolution must be decisive (no UNRESOLVED tie)", r.decisive)
+            assertEquals("$filename: resolved target must be the 'Decline offer' button", "Decline offer", r.resolved?.text)
+        }
+        assertTrue("expected the confirm-decline corpus to bind confirmDeclineButton on some frames", withTarget >= 4)
+    }
+
+    /**
+     * The field scenario the corpus alone can't show (the corpus captured only the
+     * sheet's own button): the offer popup BEHIND the confirm sheet carries its own
+     * bare "Decline" title under the SAME `textView_prism_button_title` id. Under the
+     * old `hasTextContaining: "decline"` bind, `findNode`'s pre-order walk could pin the
+     * *first* such node (the offer-popup "Decline"), and both survive the `\bdecline\b`
+     * label check — a genuine 2-candidate ambiguity. The exact-text anchor pins the
+     * confirm sheet's "Decline offer", and the ranker's EXACT_TEXT tier then resolves
+     * the single correct node decisively.
+     */
+    @Test
+    fun `confirm decline binds the sheet button, not the offer-popup decline behind it`() {
+        val action = RuleAction.CONFIRM_DECLINE
+        // offer-popup "Decline" appears FIRST in pre-order; confirm sheet "Decline offer" second.
+        val tree = UiNode(
+            children = listOf(
+                UiNode(text = "Are you sure you want to decline this offer?"),
+                UiNode( // offer popup (behind the sheet)
+                    viewIdResourceName = "secondary_action_button_dash_plus",
+                    boundsInScreen = BoundingBox(40, 1600, 1000, 1720),
+                    children = listOf(
+                        UiNode(
+                            viewIdResourceName = "textView_prism_button_title",
+                            text = "Decline",
+                            boundsInScreen = BoundingBox(40, 1600, 1000, 1720),
+                        ),
+                    ),
+                ),
+                UiNode( // confirm sheet button
+                    boundsInScreen = BoundingBox(40, 2000, 1000, 2120),
+                    children = listOf(
+                        UiNode(
+                            viewIdResourceName = "textView_prism_button_title",
+                            text = "Decline offer",
+                            boundsInScreen = BoundingBox(40, 2000, 1000, 2120),
+                        ),
+                    ),
+                ),
+            ),
+        ).restoreParents()
+
+        val ref = matchTargets(tree)[action.targetBindName]
+        assertNotNull("confirm rule must bind confirmDeclineButton on the synthetic sheet", ref)
+        assertEquals("bound target must be the sheet's 'Decline offer' node", "Decline offer", ref!!.text)
+
+        val r = resolve(tree, ref, action.verification)
+        assertEquals("both prism titles match \\bdecline\\b, so 2 nodes verify", 2, r.verifiedCount)
+        assertEquals("EXACT_TEXT must break the tie decisively", ClickCandidateRanker.Tier.EXACT_TEXT, r.tier)
+        assertTrue("resolution must be decisive", r.decisive)
+        assertEquals("must resolve the confirm sheet's button", "Decline offer", r.resolved?.text)
+        assertNotEquals("must NOT resolve the offer-popup bare 'Decline'", "Decline", r.resolved?.text)
+    }
+
+    // =========================================================================
+    // EXPAND_EARNINGS — delivery_summary_collapsed
+    // =========================================================================
+
+    @Test
+    fun `expand earnings binds the pay-breakdown expandable, never the stats one`() {
+        val action = RuleAction.EXPAND_EARNINGS
+        var withTarget = 0
+        var decisiveFrames = 0
+        for ((filename, node, _) in TestResourceLoader.loadSnapshots("snapshots/delivery_summary_collapsed")) {
+            val ref = matchTargets(node)[action.targetBindName] ?: continue // optional bind
+            withTarget++
+
+            // The independently-computed expected target: the sole expandable_view whose
+            // subtree does NOT carry the stats section's stable 'Total online time' row.
+            val payNode = node.findNodes {
+                it.viewIdResourceName == "expandable_view" && !subtreeHasText(it, "Total online time")
+            }.singleOrNull()
+            assertNotNull("$filename: exactly one pay-section expandable_view must exist", payNode)
+
+            // The tightened bind must select that pay node (was: first-in-tree stats node).
+            assertEquals(
+                "$filename: bound expandButton must be the pay ('This offer') expandable, not the stats one",
+                payNode!!.boundsInScreen, ref.boundsInScreen,
+            )
+
+            // EXPAND_EARNINGS is label-free, so both expandable_view nodes survive label
+            // verification (the shared id can't be narrowed). The ranker must therefore
+            // EITHER resolve the correct (pay) node via bounds, OR — on a degenerate frame
+            // whose pay rect is collapsed/zero-area — return an UNRESOLVED tie, which the
+            // handler now ABORTS to manual (#734). It must NEVER decisively resolve the
+            // stats node (a wrong click).
+            val r = resolve(node, ref, action.verification)
+            if (r.decisive) {
+                decisiveFrames++
+                val resolved = r.resolved
+                assertTrue(
+                    "$filename: a decisive resolution must be the pay section (no 'Total online time')",
+                    resolved != null && !subtreeHasText(resolved, "Total online time"),
+                )
+            }
+        }
+        assertTrue("expected the collapsed-summary corpus to bind expandButton on some frames", withTarget >= 5)
+        assertTrue("expected the pay expandable to resolve decisively on non-degenerate frames", decisiveFrames >= 4)
+    }
+}

--- a/app/src/test/java/cloud/trotter/dashbuddy/state/effects/UiInteractionHandlerTieTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/state/effects/UiInteractionHandlerTieTest.kt
@@ -1,0 +1,121 @@
+package cloud.trotter.dashbuddy.state.effects
+
+import android.graphics.Rect
+import android.view.accessibility.AccessibilityNodeInfo
+import cloud.trotter.dashbuddy.core.pipeline.accessibility.input.AccessibilitySource
+import cloud.trotter.dashbuddy.domain.action.RuleAction
+import cloud.trotter.dashbuddy.domain.model.accessibility.BoundingBox
+import cloud.trotter.dashbuddy.domain.pipeline.NodeRef
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+/**
+ * #734 — the actuation tie must ABORT, not "click first".
+ *
+ * When more than one live node survives label verification and the
+ * [ClickCandidateRanker] cannot decide ([ClickCandidateRanker.Tier.UNRESOLVED]),
+ * [UiInteractionHandler.performVerifiedClick] now refuses to click — matching the
+ * empty-candidate and label-fail arms, consistent with #425's fail-closed
+ * posture. The single-candidate path must still click (the ordering constraint:
+ * tightening the predicate first is what keeps the decisive path reachable).
+ *
+ * Robolectric provides real `Rect`/`AccessibilityNodeInfo` support so the
+ * handler's bounds bookkeeping (`Rect().toBoundingBox()`) runs; the candidate
+ * nodes are Mockito mocks with stubbed labels/bounds/click results.
+ */
+@RunWith(RobolectricTestRunner::class)
+class UiInteractionHandlerTieTest {
+
+    private val pkg = "com.doordash.driverapp"
+
+    /** A mocked live button whose label subtree is just its own [label]. */
+    private fun button(label: String, id: String, bounds: Rect, clickResult: Boolean = true): AccessibilityNodeInfo {
+        val node = mock<AccessibilityNodeInfo>()
+        whenever(node.text).thenReturn(label)
+        whenever(node.contentDescription).thenReturn(null)
+        whenever(node.childCount).thenReturn(0)
+        whenever(node.isClickable).thenReturn(true)
+        whenever(node.parent).thenReturn(null)
+        whenever(node.getBoundsInScreen(any())).thenAnswer { (it.arguments[0] as Rect).set(bounds) }
+        whenever(node.performAction(eq(AccessibilityNodeInfo.ACTION_CLICK))).thenReturn(clickResult)
+        return node
+    }
+
+    private fun root(viewId: String, matches: List<AccessibilityNodeInfo>): AccessibilityNodeInfo {
+        val root = mock<AccessibilityNodeInfo>()
+        whenever(root.packageName).thenReturn(pkg)
+        whenever(root.findAccessibilityNodeInfosByViewId(eq(viewId))).thenReturn(matches)
+        return root
+    }
+
+    private fun handler(root: AccessibilityNodeInfo): UiInteractionHandler {
+        val source = mock<AccessibilitySource> { on { getLiveWindowRoots() } doReturn listOf(root) }
+        return UiInteractionHandler(source)
+    }
+
+    @Test
+    fun `two verified candidates with no decisive match abort to manual (no click)`() = runTest {
+        val viewId = "com.doordash.driverapp:id/textView_prism_button_title"
+        // Both pass CONFIRM_DECLINE's \bdecline\b label check; neither overlaps the
+        // pinned ref bounds and the ref has no text, so the ranker is UNRESOLVED.
+        val a = button("Decline offer", viewId, Rect(40, 1600, 1000, 1720))
+        val b = button("Decline offer", viewId, Rect(40, 2000, 1000, 2120))
+        val handler = handler(root(viewId, listOf(a, b)))
+
+        val ref = NodeRef(
+            viewIdSuffix = viewId,
+            text = null,
+            classNameHint = null,
+            boundsInScreen = BoundingBox(0, 0, 10, 10),
+            pathFingerprint = "",
+        )
+
+        val clicked = handler.performVerifiedClick(
+            ref = ref,
+            expectedPackage = pkg,
+            expectation = RuleAction.CONFIRM_DECLINE.verification,
+            description = "confirm decline (tie)",
+        )
+
+        assertFalse("an ambiguous 2-candidate tie must NOT click", clicked)
+        verify(a, never()).performAction(eq(AccessibilityNodeInfo.ACTION_CLICK))
+        verify(b, never()).performAction(eq(AccessibilityNodeInfo.ACTION_CLICK))
+    }
+
+    @Test
+    fun `a single verified candidate still clicks`() = runTest {
+        val viewId = "com.doordash.driverapp:id/textView_prism_button_title"
+        val only = button("Decline offer", viewId, Rect(40, 2000, 1000, 2120))
+        val handler = handler(root(viewId, listOf(only)))
+
+        val ref = NodeRef(
+            viewIdSuffix = viewId,
+            text = "Decline offer",
+            classNameHint = null,
+            boundsInScreen = BoundingBox(40, 2000, 1000, 2120),
+            pathFingerprint = "",
+        )
+
+        val clicked = handler.performVerifiedClick(
+            ref = ref,
+            expectedPackage = pkg,
+            expectation = RuleAction.CONFIRM_DECLINE.verification,
+            description = "confirm decline (single)",
+        )
+
+        assertTrue("the decisive single-candidate path must still click", clicked)
+        verify(only, times(1)).performAction(eq(AccessibilityNodeInfo.ACTION_CLICK))
+    }
+}

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -78,6 +78,20 @@ card's **mechanical** half, #577 (re-confirmed, 24/24, ~0.55 s — with a new po
 that entry's Bug #1), the #457 path, and #554 ShadowProjector (2/2). The #462/#460 dropoff item
 was found **broken-in-part** (raw PII in capture envelopes) and moved to that entry's Bug #7.)_
 
+- **🆕 NEW — quick-decline auto-confirm + earnings auto-expand no longer "click first" on an ambiguous target (#734 / PR).**
+  Two actuation surfaces used to resolve **2 verified candidates** and tap the first-in-tree one (luck, not
+  verification): the offer confirm-decline sheet (`CONFIRM_DECLINE`) and the collapsed delivery-summary chevron
+  (`EXPAND_EARNINGS`). The rule bindings are now tightened (confirm sheet anchors the exact "Decline offer"
+  label; the summary binds the pay/"This offer" expandable, never the "Total online time" stats one), and an
+  ambiguous target now **aborts to manual** instead of clicking.
+  **How to tell it's working (needs quick-declines enabled; watch a few declines + a couple completions):** the
+  quick-decline still auto-confirms the "Are you sure?" sheet (declines take effect), and the post-delivery
+  earnings breakdown still auto-expands to the **pay** section (not the online-time stats). **Desk-side:**
+  `grep -iE 'refusing to click \(fail closed\)|No decisive match' shareable.log` — a WARN there means the tie
+  path fired and correctly aborted (the dev then finishes it by hand); the *count* dropping toward zero vs the
+  07-07/07-08 dashes (which saw 4× confirm + 3× expand ties) is the win. No wrong-button taps in the event log.
+  - Confirmed: 0/2
+
 - **🆕 NEW — notification-listener rebind rate is now quantified (#731 instrumentation / PR).**
   The NLS connect/disconnect lifecycle now rides `PipelineStats` counters and leveled log lines
   (tag `Pipeline`): the FIRST disconnect per process announces the degradation at WARN, every

--- a/matchers/rules/doordash/dropoff.json5
+++ b/matchers/rules/doordash/dropoff.json5
@@ -1185,14 +1185,27 @@
         }
       },
       "bind": {
+        // #734: bind ONLY the per-delivery pay-breakdown expandable ('This offer' /
+        // 'DoorDash pay'), never the dash-stats expandable. The collapsed summary renders
+        // TWO nodes sharing the expandable_view id — the online-time/stats section AND the
+        // pay section — so the old `any:[expandable_view, expandable_layout]` bound the
+        // first-in-tree (stats) node, and at fire time the app-owned actuation ranker saw a
+        // 2-candidate tie (both share the id, EXPAND_EARNINGS is label-free) and clicked the
+        // first. Anchor on the stats section's stable 'Total online time' row (present in
+        // every frame) and NEGATE it: the pay expandable never carries that text, so this
+        // selects exactly the pay node. Only the pay expandable_view is clickable in the
+        // field; clickNodeStrict taps it directly. A residual fire-time tie (shared id) now
+        // aborts to manual (#425 fail-closed).
         "expandButton": {
           "find": {
-            "any": [
+            "all": [
               {
                 "hasIdSuffix": "expandable_view"
               },
               {
-                "hasIdSuffix": "expandable_layout"
+                "not": {
+                  "hasAnyText": "Total online time"
+                }
               }
             ]
           },

--- a/matchers/rules/doordash/offer.json5
+++ b/matchers/rules/doordash/offer.json5
@@ -5,7 +5,7 @@
     {
       "id": "doordash.screen.offer_popup_confirm_decline",
       "priority": 19,
-      "comment": "#577 quick-decline: bind the confirm dialog's 'Decline offer' button. Its label is on a child text node (textView_prism_button_title, not itself clickable) — bind the labelled node + 'decline' text so we never grab a sibling Cancel/Go-back; clickNodeStrict walks up to the clickable ancestor. The app-owned CONFIRM_DECLINE tap fires (AUTOMATION) only when the dasher enabled quick-declines.",
+      "comment": "#577 quick-decline: bind the confirm dialog's 'Decline offer' button. Its label is on a child text node (textView_prism_button_title, not itself clickable) — clickNodeStrict walks up to the clickable ancestor. #734: anchor the EXACT label 'Decline offer' (was 'decline' substring). The offer popup behind the confirm sheet carries its own bare 'Decline' button under the SAME textView_prism_button_title id; a substring match let both survive the app-owned label check, so the actuation ranker saw a 2-candidate tie and clicked the first-in-tree node (luck, not verification). The exact 'Decline offer' anchor is unique to the confirm sheet's button (every corpus frame renders it verbatim), so the bound target — and thus the ranker's EXACT_TEXT tier — resolves the single correct node; a genuine tie now aborts to manual (#425 fail-closed). The app-owned CONFIRM_DECLINE tap fires (AUTOMATION) only when the dasher enabled quick-declines.",
       "state": {
         "flow": "offer:presented",
         "modeHint": "online"
@@ -18,7 +18,7 @@
                 "hasIdSuffix": "textView_prism_button_title"
               },
               {
-                "hasTextContaining": "decline"
+                "hasText": "Decline offer"
               }
             ]
           },


### PR DESCRIPTION
Closes #734.

`UiInteractionHandler` — the only path that ever clicks a third-party app (#425) — resolved **2 verified candidates** and fell back to "clicking first" (tree order = luck, not verification) on two surfaces across the 07-07/07-08 dashes: `confirm_decline` on `offer_popup_confirm_decline` (4×) and `expand_earnings` on `delivery_summary_collapsed` (3×). This is a fail-closed-posture violation: a wrong click on a decline/accept surface acts against the dasher's intent.

Two coupled parts, ordered (predicate-tightening first so the decisive single-target path is reachable before the tie branch flips):

## Part 1 — tighten the target bindings (ruleset JSON5, zero Kotlin matcher code)

**`confirmDeclineButton`** (`matchers/rules/doordash/offer.json5`): `hasTextContaining: "decline"` → `hasText: "Decline offer"` (exact).
- Snapshot evidence: every `offer_popup_confirm_decline/` frame renders the confirm sheet's button verbatim as `textView_prism_button_title` = **"Decline offer"**. The offer popup *behind* the sheet carries its own bare **"Decline"** title under the **same** `textView_prism_button_title` id (per `ClickCandidateRanker`'s own KDoc), so a `decline` substring let `findNode`'s pre-order walk pin the wrong node and let both survive the `\bdecline\b` label check. The exact "Decline offer" anchor is unique to the sheet button, so the bound ref — and the ranker's EXACT_TEXT tier — resolves the single correct node.

**`expandButton`** (`matchers/rules/doordash/dropoff.json5`): `any:[expandable_view, expandable_layout]` → `all:[ hasIdSuffix expandable_view, not hasAnyText "Total online time" ]`.
- Snapshot evidence: the collapsed summary renders **two** `expandable_view` nodes sharing that id — the dash-stats section ("Total online time" / "Offers accepted") and the per-delivery pay section ("This offer" / "DoorDash pay"). The old `any` bound the **first-in-tree (stats)** node. Anchoring on the stats section's stable "Total online time" row (present in every corpus frame) and negating it selects exactly the pay node — the one `EXPAND_EARNINGS` actually needs to read the pay line items, and the only one that is clickable in the field (verified in `delivery_summary_expanded/`).

## Part 2 — abort the tie to manual (`UiInteractionHandler.kt`)

The `ranked.tier == UNRESOLVED && verified.size > 1` branch flips from "clicking first" to **WARN + return false (no click)**, matching the empty-candidate and label-fail arms. WARN carries counts/ids only (Principle 7; the shareable slice stays PII-safe). The class KDoc is updated.

## Test coverage
- **`ActuationBindingResolutionTest`** — drives the real compiled ruleset + the real verification/ranking (`matchesLabels` + `ClickCandidateRanker`) over the committed corpus: exactly one verified candidate resolves for `confirm_decline` per snapshot; `expand_earnings` binds the pay node (never the stats one) and resolves decisively to it, or aborts on a degenerate (collapsed-rect) frame — never a wrong click. A synthetic 2-`textView_prism_button_title` sheet (offer-popup "Decline" first in tree, confirm "Decline offer" second) proves the exact-text anchor resolves the sheet button via EXACT_TEXT.
- **`UiInteractionHandlerTieTest`** — a 2-candidate UNRESOLVED tie aborts (no `performAction`); the single-candidate path still clicks.
- `ParseOutputGoldenTest` **unchanged** (bindings are not parse output). `AllMatchersSuite` + full `:app:testDebugUnitTest` green.

## Security / privacy posture
This PR **strengthens** the #425 fail-closed actuation property: an ambiguous target ⇒ **no click**. Rules still cannot declare actuation (bindings only *name* targets; the app decides and verifies). No new capture or network surface. The added WARN line carries no raw third-party UI text (counts/ids only).

### Design-goal review (author draft)
- **#6 Security & privacy (fail-closed):** the tie now aborts instead of clicking an unverified node — a strict tightening of the actuation trust boundary; the two under-constrained predicates are narrowed to a single decisive target. WARN is PII-safe.
- **#7 Semantic, PII-safe logging:** the ambiguous case stays WARN (a defended invariant fired — fail-closed denial), tag `Effects`, counts/ids only; candidate labels stay at DEBUG.
- **#8 Platform-agnostic core:** the tie-abort is generic handler logic — no platform literals; recognition stayed **data** (anchors changed in ruleset JSON5, zero Kotlin matcher classes). The `hasAnyText`/`not`/`hasText` predicates are the existing enumerated, load-validated vocabulary.
- **#5 SSOT:** the test replays the handler's own `collectLabels`/candidate logic and reuses the production `ClickCandidateRanker` + `RuleAction.verification` rather than re-deriving them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
