### PR TITLE
docs: session-close context updates 2026-07-12 (#728 checklist, #732/#734 status, CLAUDE.md P7/app_events)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,7 +298,12 @@ clicks a third-party app, #425), `OfferActionReceiver` (notification Accept/Decl
 ### 5. Analytics Read-Model (`core/data/.../analytics/`, `core/database/.../analytics/`, #314)
 
 Analytics is a **CQRS read-model** projected from the durable `app_events` log — the event log is the
-source of truth; the read-model tables are a rebuildable cache. `AnalyticsProjector` (`:core:data`, started
+source of truth; the read-model tables are a rebuildable cache. **Ordering contract (#732, documented
++ pin-tested, dev-decided Option B — no re-stamp):** `sequenceId` is the authoritative fold/order key;
+`occurredAt` may lag it (sole carrier: `PICKUP_CONFIRMED`, whose `occurredAt` is the grace-armed
+`Task.completedAt`, appended at the close-out sweep — unbounded by the grace window). Consumers order
+by `sequenceId`; "when did it really happen" reads the payload's own domain timestamp. Authoritative
+KDoc at `AppEventEntity`; `GracedCommitOrderingInvariantTest` trips any silent re-stamp. `AnalyticsProjector` (`:core:data`, started
 from `DashBuddyApplication`, runs every launch off-main + supervised) folds `app_events` → three Room v10
 tables (`delivery_records`/`session_records`/`offer_records`) via the pure `RecordFolds`/`SessionFoldContext`
 (`:domain`). The fold is **exactly-once** — records + a watermark advance in one `db.withTransaction`, record
@@ -498,7 +503,12 @@ Every new feature or refactor holds to these — they are forefront design input
      failure, recovery failure). Always shipped/exported.
 
    Every component logs under its own **stable tag** (`Timber.tag("Pipeline")`, `"StateMachine"`,
-   `"Effects"`…), never the catch-all `App`. The INFO-must-be-PII-safe rule is **fail-closed and
+   `"Effects"`…), never the catch-all `App`. The tag rule is **enforced by a ratchet guard**
+   (#764, `TimberTagGuardTest` in `:app` unit tests): any new bare `Timber.i/w/e/wtf(` (incl. the
+   `Timber.Forest.*` form) in a main-type source set fails the build; the frozen allowlist
+   (`app/src/test/resources/timber-tag-guard-allowlist.txt`, 30 files) is the visible debt list —
+   tag a file's sites, shrink its entry (counts dropping below the frozen number also fail, so the
+   list only burns down). The INFO-must-be-PII-safe rule is **fail-closed and
    tested** (reuse `SensitiveTextMarkers`): a raw merchant/customer string in an INFO+ line is a
    privacy defect of the same class as leaking it to disk — gate the shareable-export sink behind that
    test, do not trust call-site discipline. When a change adds or moves a log site, state its level and

--- a/docs/field-testing/README.md
+++ b/docs/field-testing/README.md
@@ -78,6 +78,19 @@ card's **mechanical** half, #577 (re-confirmed, 24/24, ~0.55 s — with a new po
 that entry's Bug #1), the #457 path, and #554 ShadowProjector (2/2). The #462/#460 dropoff item
 was found **broken-in-part** (raw PII in capture envelopes) and moved to that entry's Bug #7.)_
 
+- **🆕 NEW — idle bubble: gas + vehicle are now two separate full-width cards (#728 / PR #767).**
+  The cramped one-row `JustInTimeActions` (the layout the dev called "a nightmare to try to operate")
+  is now a stacked pair of full-width cards on the idle dashboard card: one for the #722 mode-adaptive
+  gas control, one for Vehicle — every touch target ≥48dp (stepper −/+, refresh, "Resume auto" chip,
+  and the whole vehicle card is the tap surface).
+  **How to tell it's working (on-device, no dash needed):** open the bubble while OFFLINE — two
+  visually distinct cards instead of one crowded row; every control comfortably tappable with a thumb;
+  gas behavior itself unchanged (AUTO refresh / take-manual / Resume auto per the #722 item above);
+  Vehicle tap still opens Personal Economy. Watch for: content clipping on the MANUAL gas row (known
+  residual on very narrow windows — strictly better than before, but capture it if seen), and any
+  visual double-ripple or dead tap zone on the vehicle card.
+  - Confirmed: 0/2
+
 - **🆕 NEW — quick-decline auto-confirm + earnings auto-expand no longer "click first" on an ambiguous target (#734 / PR).**
   Two actuation surfaces used to resolve **2 verified candidates** and tap the first-in-tree one (luck, not
   verification): the offer confirm-decline sheet (`CONFIRM_DECLINE`) and the collapsed delivery-summary chevron
@@ -1772,12 +1785,14 @@ Accept and Decline registered on DoorDash — and moved to that session's entry 
    anything to a dasher either. One possibility: fewer numbers per card with plain-language
    labels (e.g. "usual wait" / "worst waits" instead of avg/median/p95), progressive disclosure
    for the rest. Issue filed from this feedback (dasher-friendly store-card copy + density).
-   - **Status:** Open — issue filed 2026-07-12.
+   - **Status:** Open — filed #765 (2026-07-12).
 3. **#722 gas control validated (first confirmation).** Dev exercised the idle-card gas control:
    "works fine." Checklist item moved to 1/2.
 4. **#728 reconfirmed.** Dev restated the direction: gas control and vehicle control should be
    **separate cards**, and the idle-bubble layout overall "could use some polish." #728 (already
    build-ready) is promoted to the front of the build queue.
+   - **Status:** Shipped in #767 (2026-07-12, same day) — two full-width cards, ≥48dp targets;
+     checklist item added (0/2).
 
 ---
 
@@ -1800,7 +1815,11 @@ Accept and Decline registered on DoorDash — and moved to that session's entry 
    PICKUP_CONFIRMED occurredAt 19:24 appended after Sonic's 19:35 PICKUP_ARRIVED — an 11-min
    inversion from the pickup-confirm grace). Not corrupting today (folds are seq-ordered), a
    latent event-sourcing fidelity trap.
-   - **Status:** Open (filed #732).
+   - **Status:** Shipped in #769 (2026-07-12) — Option B (dev-decided): the invariant is documented
+     at the `AppEventEntity` contract (sequenceId authoritative; the sole inversion carrier is
+     PICKUP_CONFIRMED via the grace-armed `Task.completedAt`, appended at the close-out sweep),
+     consumers audited (all sequenceId-ordered or insensitive), and a characterization test pins the
+     shape so a silent re-stamp trips it. No behavior change.
 3. **#733 — D6 join miss → NULL-store delivery (TOP finding).** The Sonic Drive-In + Willie's
    Grill & Icehouse two-pickup single-customer job ($19.50): the dropoff's customer hash matched
    **0 of 2** pickup-lineage hashes ("possible pickup/dropoff hash-format drift" per the WARN,
@@ -1810,7 +1829,9 @@ Accept and Decline registered on DoorDash — and moved to that session's entry 
 4. **#734 — actuation 2-candidate label ties.** `confirm_decline` (×4) and `expand_earnings` (×3)
    across the two dashes resolved 2 verified candidates and clicked the first. No observed
    misfire, but a tie should abort to manual per the #425 posture.
-   - **Status:** Open (filed #734).
+   - **Status:** Shipped in #770 (2026-07-12) — bindings tightened from the corpus (the old
+     `expandButton` bind was decisively tapping the WRONG node — the stats section) and an
+     unresolved tie now aborts to manual per the #425 posture. Checklist item above.
 
 ### Validations (data-side)
 


### PR DESCRIPTION
[skip ci]

Session-close context updates for the 2026-07-12 autonomous build session (PRs #767/#768/#769/#770):

- **Field-test checklist:** new #728 item (two-card idle layout, 0/2 — on-device operability check). The #734 item shipped in-PR with #770.
- **Status lines:** 07-09 log entry items for #732 (→ Shipped #769, Option B summary) and #734 (→ Shipped #770); 07-12 entry item 2 names #765, item 4 → Shipped #767.
- **CLAUDE.md:** Principle 7 now records the #764 `TimberTagGuardTest` ratchet enforcement; the analytics read-model section records the #732 `sequenceId`-authoritative ordering contract (authoritative KDoc at `AppEventEntity`).

### Design-goal review
Docs-only (checklist/status bookkeeping + the CLAUDE.md context-update duty that ships with every PR). No code surface.

### Adversarial review
N/A — non-code context bookkeeping following the documented formats (precedent: #766 and prior docs PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
