### PR TITLE
docs(#761): fix fold-site references stale after the split

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -360,7 +360,7 @@ delivery's own `completedAt` day, since there's no session start to anchor on), 
 own `noSessionPay`/`noSessionDeliveries` review signal (Money tab callout, same pattern as
 unattributed/over-attributed). **Piece 2 (#660, shipped): categorize an orphan into its real dash.** A new
 correction event `DELIVERY_SESSION_ASSIGN` (`DeliverySessionAssignPayload{targetEventSequenceId, newSessionId
-(null⇒unassign/undo), note}`, folded by `RecordFolds.foldDeliverySessionAssign` — context untouched, F2
+(null⇒unassign/undo), note}`, folded by `CorrectionFolds.foldDeliverySessionAssign` (#761 split; `RecordFolds.foldEvent` stays the dispatcher) — context untouched, F2
 liveness discipline) is written by `CorrectionRepository.assignDeliverySession` from the tappable Money-tab
 callout (→ orphan list + ±48h/same-platform/ended-only session picker in `NoSessionAssignDialogs.kt`) and the
 drill-down undo ("assigned by you" caption + "Remove from this dash"). The projector's `applySessionAssign`

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/LegFolds.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/analytics/LegFolds.kt
@@ -12,7 +12,7 @@ import cloud.trotter.dashbuddy.domain.state.TaskPhase
  * stamps and threaded [SessionFoldContext]. The leg-anchor-only lifecycle events (`PICKUP_ARRIVED` /
  * `DELIVERY_ARRIVED` / `DELIVERY_CONFIRMED`) and the `TASK_UNASSIGNED` leg purge live here; the
  * `DELIVERY_COMPLETED` **consumption** side (which store leg a drop claims, the legacy-basis retire)
- * stays in [RecordFolds.foldDeliveryCompleted] with the rest of the record mint. Shared session
+ * stays in [DeliveryFolds.foldDeliveryCompleted] (#761 split) with the rest of the record mint. Shared session
  * helpers ([resolveContext] / [advance]) are the ONE top-level definition in `RecordFolds.kt`.
  */
 internal object LegFolds {
@@ -93,7 +93,7 @@ internal object LegFolds {
 }
 
 // ── #688 phase B leg helpers (pure; all mirror the partition-anchor conventions in RecordFolds) ──
-// Top-level `internal` extensions so both [RecordFolds] (foldPickupConfirmed's anchor advance,
+// Top-level `internal` extensions so both [DeliveryFolds] (foldPickupConfirmed's anchor advance,
 // foldDeliveryCompleted's inline consume) and [LegFolds] share ONE definition (Fix 6 file split).
 
 /**


### PR DESCRIPTION
Follow-up to PR #776: three comment/doc references still pointed at the pre-split fold sites.

- `LegFolds.kt` KDoc: `RecordFolds.foldDeliveryCompleted` → `DeliveryFolds.foldDeliveryCompleted`; helper-comment `[RecordFolds]` → `[DeliveryFolds]`.
- `CLAUDE.md` §Analytics: `RecordFolds.foldDeliverySessionAssign` → `CorrectionFolds.foldDeliverySessionAssign` (dispatcher note added).

Comment/markdown only — zero code-token changes (the `.kt` edit is inside a KDoc + a `//` line), but CI runs since a source file is touched.

### Design-goal review
- P5 (SSOT): pointers re-aimed at the actual single definitions post-#761; no content duplicated.
- No other principles touched (no logic, no log sites, no platform vocabulary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)