### PR TITLE
refactor(#762): D12 — de-DoorDash strategy vocab + resolve allowShopping

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/formatters/OfferFormatters.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/formatters/OfferFormatters.kt
@@ -127,6 +127,7 @@ fun OfferQuality.displayLabel(): String = when (this) {
     OfferQuality.BAD -> "BAD OFFER"
     OfferQuality.PROTECTED -> "Protected!"
     OfferQuality.BLOCKED -> "Blocked"
+    OfferQuality.SHOP_DECLINED -> "Shopping off"
     OfferQuality.UNKNOWN -> "No verdict"
 }
 

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/WizardScreen.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/WizardScreen.kt
@@ -188,14 +188,14 @@ fun WizardScreen(
                             option3Desc = stringResource(R.string.wizard_screen_goal_option3_desc),
                             selectedIndex = when (state.strategy) {
                                 OfferStrategy.CHERRY_PICKER -> 0
-                                OfferStrategy.PROTECT_PLATINUM -> 1
+                                OfferStrategy.PROTECT_STATUS -> 1
                                 OfferStrategy.MANUAL -> 2
                             },
                             onOptionSelected = { index ->
                                 viewModel.updateStrategy(
                                     when (index) {
                                         0 -> OfferStrategy.CHERRY_PICKER
-                                        1 -> OfferStrategy.PROTECT_PLATINUM
+                                        1 -> OfferStrategy.PROTECT_STATUS
                                         else -> OfferStrategy.MANUAL
                                     }
                                 )

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/WizardViewModel.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/setup/wizard/WizardViewModel.kt
@@ -81,7 +81,7 @@ class WizardViewModel @Inject constructor(
 
             val currentProtectMode = strategyRepository.protectStatsMode.first()
             val currentStrategy =
-                if (currentProtectMode) OfferStrategy.PROTECT_PLATINUM else OfferStrategy.MANUAL
+                if (currentProtectMode) OfferStrategy.PROTECT_STATUS else OfferStrategy.MANUAL
 
             val rules = strategyRepository.scoringRules.first()
             val minPayoutRule = rules.filterIsInstance<ScoringRule.MetricRule>()
@@ -508,14 +508,14 @@ class WizardViewModel @Inject constructor(
             }
 
             val isCherryPicker = finalState.strategy == OfferStrategy.CHERRY_PICKER
-            val isPlatinum = finalState.strategy == OfferStrategy.PROTECT_PLATINUM
+            val isProtectStatus = finalState.strategy == OfferStrategy.PROTECT_STATUS
 
             // Only write what the wizard actually collects (#347): the strategy-derived
             // toggles and the SHOPPING step's preference. The threshold values are NOT
             // wizard inputs — preserve their current values so a re-run + Finish
             // round-trips losslessly instead of resetting tuned automation config.
             val currentAutomation = strategyRepository.automationConfig.first()
-            strategyRepository.setProtectStatsMode(isPlatinum)
+            strategyRepository.setProtectStatsMode(isProtectStatus)
             strategyRepository.setMasterAutomation(isCherryPicker)
             strategyRepository.updateAutomation(
                 autoAccept = currentAutomation.autoAcceptEnabled,

--- a/app/src/main/res/values-es-rUS/strings.xml
+++ b/app/src/main/res/values-es-rUS/strings.xml
@@ -88,7 +88,7 @@
     <string name="wizard_desc_gas">¿Cuánto pagas actualmente por galón?</string>
 
     <string name="wizard_title_goal">Objetivo Principal</string>
-    <string name="wizard_desc_goal">¿Estás seleccionando ofertas detalladamente para obtener la máxima ganancia, o intentas proteger tu estado de Platinum/Top Dasher?</string>
+    <string name="wizard_desc_goal">¿Estás seleccionando ofertas detalladamente para obtener la máxima ganancia, o intentas proteger tu estado según tu tasa de aceptación?</string>
 
     <string name="wizard_title_shopping">Comprar y Entregar</string>
     <string name="wizard_desc_shopping">¿Actualmente aceptas pedidos de compras con la Tarjeta Roja (Red Card)?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -95,7 +95,7 @@
     <string name="wizard_desc_economy_costs">Tell us your real costs so we can show your true net pay. Tap any section to set your actual numbers — defaults are sensible estimates.</string>
 
     <string name="wizard_title_goal">Primary Goal</string>
-    <string name="wizard_desc_goal">Are you cherry-picking for maximum profit, or trying to protect your Platinum/Top Dasher status?</string>
+    <string name="wizard_desc_goal">Are you cherry-picking for maximum profit, or trying to protect your acceptance-rate status?</string>
 
     <string name="wizard_title_shopping">Shop &amp; Deliver</string>
     <string name="wizard_desc_shopping">Do you currently accept Red Card shopping orders?</string>
@@ -395,7 +395,7 @@
     <!-- setup/wizard/WizardScreen.kt -->
     <string name="wizard_screen_goal_option1_title">Cherry Picker</string>
     <string name="wizard_screen_goal_option1_desc">Maximize profit. Auto-decline unprofitable offers.</string>
-    <string name="wizard_screen_goal_option2_title">Protect Platinum</string>
+    <string name="wizard_screen_goal_option2_title">Protect Status</string>
     <string name="wizard_screen_goal_option2_desc">Maintain high acceptance rate. Do not auto-decline anything.</string>
     <string name="wizard_screen_goal_option3_title">Manual Mode</string>
     <string name="wizard_screen_goal_option3_desc">Just show me the math. I will make my own decisions.</string>

--- a/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/strategy/StrategyDataSource.kt
+++ b/core/datastore/src/main/java/cloud/trotter/dashbuddy/core/datastore/strategy/StrategyDataSource.kt
@@ -98,6 +98,14 @@ class StrategyDataSource @Inject constructor(
         }
     }
 
+    // #762 D12 — prefs-ownership decision record (NOT an oversight): `protectStatsMode`,
+    // `allowShopping`, and `quickDeclinesEnabled` are deliberately GLOBAL (one value across all
+    // platforms), not keyed by [Platform] like the shop-rate keys above. Rationale: the alpha fields
+    // exactly one platform (DoorDash), so a global is the correct single-user shape today, and these
+    // three are dasher-capability / preference facts ("I protect my acceptance rate", "I don't shop",
+    // "confirm my declines") that plausibly hold platform-wide anyway. Whether any of them should
+    // become per-[Platform] (e.g. a dasher who shops on one platform but not another) is a decision
+    // deferred until a 2nd platform actually ships — treat globality as intentional, not debt to fix.
     val protectStatsMode: Flow<Boolean> = ds.data.map { it[Keys.PROTECT_STATS_MODE] ?: false }
     val allowShopping: Flow<Boolean> = ds.data.map { it[Keys.ALLOW_SHOPPING] ?: true }
 

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/config/OfferStrategy.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/config/OfferStrategy.kt
@@ -1,4 +1,13 @@
 package cloud.trotter.dashbuddy.domain.config
 
-/** Defines the core behavior of the DashBuddy automation pipeline. */
-enum class OfferStrategy { CHERRY_PICKER, PROTECT_PLATINUM, MANUAL }
+/**
+ * Defines the core behavior of the DashBuddy automation pipeline.
+ *
+ * Platform-agnostic vocabulary (#762 D12): [PROTECT_STATUS] is the generic
+ * "keep my acceptance-rate-based standing high" goal — not any one platform's
+ * program name (DoorDash "Platinum", Uber "Pro", etc.). This enum is a
+ * wizard-UI selection only; it is never persisted — the wizard maps it to the
+ * Boolean `protectStatsMode` strategy pref on Finish and rebuilds it from that
+ * pref on load, so renaming a constant carries no migration hazard.
+ */
+enum class OfferStrategy { CHERRY_PICKER, PROTECT_STATUS, MANUAL }

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/EvaluationConfig.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/EvaluationConfig.kt
@@ -8,6 +8,12 @@ import cloud.trotter.dashbuddy.domain.state.Platform
 data class EvaluationConfig(
     val protectStatsMode: Boolean = false,
     val rules: List<ScoringRule> = emptyList(),
+    /**
+     * When `false`, the evaluator hard-declines any offer with a shop-for-items leg before scoring
+     * ([OfferEvaluator]; #762 D12) — the driver has opted out of shopping (no Red Card / won't shop),
+     * so the Settings "Allow Shopping Orders" toggle's promise is enforced at the verdict edge. Takes
+     * precedence over [protectStatsMode] (a capability constraint beats the acceptance-rate goal).
+     */
     val allowShopping: Boolean = true,
     /**
      * #588: **unresolved** shop-pace fields until [forPlatform] runs. [shopRates] is per-platform, so

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/OfferEvaluator.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/OfferEvaluator.kt
@@ -52,6 +52,33 @@ class OfferEvaluator() {
 
         val merchants = joinedStores.takeIf { it.isNotBlank() } ?: "Unknown Store"
 
+        // Shopping opt-out (#762 D12): if the dasher turned off shopping orders, a shop-for-items
+        // offer is a capability constraint (no Red Card / won't shop), so hard-decline it BEFORE any
+        // other verdict — including protect-stats. Placed first so the Settings toggle's promise ("If
+        // off, Red Card orders are auto-declined") is literally true in every mode. Only the DECLINE
+        // *verdict* is set here; the actual auto-decline is the app-owned automation gate consuming
+        // this action downstream (rules never actuate, #425). A non-shop offer is unaffected.
+        if (!config.allowShopping && isShop) {
+            return OfferEvaluation(
+                action = OfferAction.DECLINE,
+                score = 0.0,
+                qualityLevel = OfferQuality.SHOP_DECLINED,
+                payAmount = grossPay,
+                fuelCostEstimate = fuelCost,
+                nonFuelCostEstimate = nonFuelCost,
+                totalOperatingCost = operatingCost,
+                operatingCostPerMile = economy.operatingCostPerMile,
+                netPayAmount = netPay,
+                distanceMiles = dist,
+                dollarsPerMile = dpm,
+                dollarsPerHour = activeHourly,
+                estimatedTimeMinutes = estTimeMinutes,
+                itemCount = items,
+                merchantName = merchants,
+                isUsingDefaults = economy.isUsingDefaults,
+            )
+        }
+
         if (config.protectStatsMode) {
             return OfferEvaluation(
                 action = OfferAction.ACCEPT,

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/OfferQuality.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/evaluation/OfferQuality.kt
@@ -20,6 +20,13 @@ enum class OfferQuality {
     /** A merchant BLOCK rule hard-declined the offer before scoring. */
     BLOCKED,
 
+    /**
+     * The dasher turned off shopping orders ([EvaluationConfig.allowShopping] = false)
+     * and this offer contains a shop-for-items leg, so it was hard-declined before
+     * scoring (#762 D12).
+     */
+    SHOP_DECLINED,
+
     /** No verdict — e.g. no scoring rules are enabled. */
     UNKNOWN,
 }

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/evaluation/OfferEvaluatorTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/evaluation/OfferEvaluatorTest.kt
@@ -118,6 +118,71 @@ class OfferEvaluatorTest {
     }
 
     // -------------------------------------------------------------------------
+    // Allow Shopping toggle (#762 D12)
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `allowShopping off - shop offer hard-declines before scoring`() {
+        val cfg = EvaluationConfig(
+            allowShopping = false,
+            rules = listOf(metricRule(MetricType.PAYOUT, 7.0f)),
+            userEconomy = noCostEconomy,
+        )
+        // A generous shop offer that would otherwise ACCEPT.
+        val result = evaluator.evaluate(offer(pay = 30.0, orderType = OrderType.SHOP_FOR_ITEMS), cfg)
+        assertEquals(OfferAction.DECLINE, result.action)
+        assertEquals(0.0, result.score, 0.0001)
+        assertEquals(OfferQuality.SHOP_DECLINED, result.qualityLevel)
+    }
+
+    @Test
+    fun `allowShopping off - non-shop offer is unaffected`() {
+        val cfg = EvaluationConfig(
+            allowShopping = false,
+            rules = listOf(metricRule(MetricType.PAYOUT, 7.0f)),
+            userEconomy = noCostEconomy,
+        )
+        val result = evaluator.evaluate(offer(pay = 10.0, orderType = OrderType.PICKUP), cfg)
+        assertEquals(OfferAction.ACCEPT, result.action)
+    }
+
+    @Test
+    fun `allowShopping on (default) - shop offer scores normally`() {
+        // allowShopping defaults to true; a shop offer flows through metric scoring.
+        val cfg = config(metricRule(MetricType.PAYOUT, 7.0f))
+        val result = evaluator.evaluate(offer(pay = 10.0, orderType = OrderType.SHOP_FOR_ITEMS), cfg)
+        assertEquals(OfferAction.ACCEPT, result.action)
+    }
+
+    @Test
+    fun `allowShopping off - overrides protectStatsMode for a shop offer`() {
+        // Capability constraint beats the acceptance-rate goal: even in protect-stats mode, a shop
+        // offer is declined when shopping is off.
+        val cfg = EvaluationConfig(
+            protectStatsMode = true,
+            allowShopping = false,
+            rules = emptyList(),
+            userEconomy = noCostEconomy,
+        )
+        val result = evaluator.evaluate(offer(pay = 10.0, orderType = OrderType.SHOP_FOR_ITEMS), cfg)
+        assertEquals(OfferAction.DECLINE, result.action)
+        assertEquals(OfferQuality.SHOP_DECLINED, result.qualityLevel)
+    }
+
+    @Test
+    fun `allowShopping off - protectStatsMode still accepts a non-shop offer`() {
+        val cfg = EvaluationConfig(
+            protectStatsMode = true,
+            allowShopping = false,
+            rules = emptyList(),
+            userEconomy = noCostEconomy,
+        )
+        val result = evaluator.evaluate(offer(pay = 1.0, orderType = OrderType.PICKUP), cfg)
+        assertEquals(OfferAction.ACCEPT, result.action)
+        assertEquals(OfferQuality.PROTECTED, result.qualityLevel)
+    }
+
+    // -------------------------------------------------------------------------
     // Empty / Disabled Rules
     // -------------------------------------------------------------------------
 


### PR DESCRIPTION
Resolves #762 item **D12** (strategy-vocab de-DoorDashing + the dead `allowShopping` toggle).

## Summary

**1. Rename `OfferStrategy.PROTECT_PLATINUM` → `PROTECT_STATUS`.** "Platinum" is DoorDash program vocabulary; the generic goal is "keep my acceptance-rate standing high". Sites updated: the enum, `WizardScreen` (both `when`s), `WizardViewModel` (load-map + the `isPlatinum`→`isProtectStatus` local).

- **Persistence check (done first): the enum is NEVER persisted.** It is a wizard-UI selection only — `WizardViewModel` maps it to the Boolean `protectStatsMode` strategy pref on Finish (`setProtectStatsMode`) and rebuilds it from that pref on load. No DataStore key, serializer, or `.name` round-trip touches `OfferStrategy`. So the rename is a pure code-symbol change with zero migration hazard.
- **De-DoorDashed the adjacent user-visible copy:** `wizard_screen_goal_option2_title` "Protect Platinum" → "Protect Status"; `wizard_desc_goal` "Platinum/Top Dasher status" → "acceptance-rate status" (+ the es-rUS translation). Left `OfferBadge`'s KDoc mention of a "Platinum" badge — that describes the platform's own on-screen offer badge (recognition vocabulary), not our control. `strategy_settings_protect_stats_label` was already generic ("Protect Stats Mode").

**2. Resolve `allowShopping` — path taken: WIRE IT (not remove).** `EvaluationConfig.allowShopping` was stored in `StrategyDataSource`, surfaced as the Settings "🛒 Allow Shopping Orders" toggle, whose subtitle promises *"If off, Red Card orders are auto-declined"* — but `OfferEvaluator` never read it. The toggle's intent is unambiguous (a clear, labeled promise), so removal was not warranted; I made the label truthful.

- Wired at the **evaluator verdict edge** — the same config-consumption edge where `protectStatsMode` (→ ACCEPT) and merchant BLOCK (→ DECLINE) already short-circuit, and whose `OfferEvaluation.action` is exactly what the `EvaluateOffer` loopback feeds back to drive automation. Not scattered; one place.
- When `!config.allowShopping && isShop` (`isShop` was already computed for the time model), the evaluator returns `OfferAction.DECLINE` + new `OfferQuality.SHOP_DECLINED` **before** scoring. Placed **ahead of `protectStatsMode`** so the toggle's promise holds in every mode — a capability constraint (no Red Card / won't shop) beats the acceptance-rate goal.
- **No scoring math or frozen-economics change**: this is a pre-scoring verdict short-circuit; the full economics fields (net/cpm/dpm/etc.) are still populated on the returned evaluation, identical to the BLOCK path. Rules still never actuate (#425) — only the *verdict* is set here; the actual auto-decline is the downstream app-owned automation gate.
- Surfaces: added `OfferQuality.SHOP_DECLINED` (+ its `displayLabel` "Shopping off"); documented `EvaluationConfig.allowShopping` as now-consumed.

**3. Prefs-ownership decision record.** Added a KDoc block on `StrategyDataSource` stating `protectStatsMode` / `allowShopping` / `quickDeclinesEnabled` are deliberately GLOBAL for the single-platform alpha (correct single-user shape; all three are plausibly platform-wide capability/preference facts), and per-platform ownership is deferred until a 2nd platform ships (#762 D12) — so the next agent treats globality as intentional, not debt.

## Tests

Added 5 `OfferEvaluatorTest` cases (shop off → DECLINE+SHOP_DECLINED; non-shop off → unaffected; shop on → normal scoring; off overrides protect-stats for a shop; protect-stats still accepts a non-shop with shopping off). Full `./gradlew testDebugUnitTest :domain:test` **green** (244 tasks).

## Design-goal review

- **P4 (Kotlin/idioms):** typed verdict short-circuit reusing the existing `OfferEvaluation` shape; new `OfferQuality.SHOP_DECLINED` is a data value, not a stringly flag. The exhaustive `when` in `displayLabel` is updated (compiler-enforced).
- **P5 (SSOT):** removes a divergence — `allowShopping` had a UI owner + a DataStore key + a config field but no consumer, so the toggle and behavior had drifted apart. Now one consumer (the evaluator) makes the single stored value authoritative; `isShop` reuses the already-computed value rather than recomputing.
- **P8 (platform-agnostic core):** the rename removes a DoorDash-flavoured symbol from `:domain` (`PROTECT_PLATINUM`); the new logic keys on the platform-agnostic `orderType.isShoppingOrder`, no platform literal. `allowShopping` is a global pref by explicit, recorded decision (documented, not silent) — deferred to per-`Platform` when a 2nd platform ships, per the D12 note.
- **P6 (privacy):** no recognition/capture/network/effects surface touched; verdict is economics/flags only. No new log sites.

Not merging — leaving for the adversarial review loop.
