### PR TITLE
refactor(#762): enforce the rule→state intent/field contract (D6+D1)

### DIFF
--- a/app/src/test/java/cloud/trotter/dashbuddy/log/NotificationIntentSsotGuardTest.kt
+++ b/app/src/test/java/cloud/trotter/dashbuddy/log/NotificationIntentSsotGuardTest.kt
@@ -1,0 +1,93 @@
+package cloud.trotter.dashbuddy.log
+
+import cloud.trotter.dashbuddy.domain.pipeline.StateMachineContract
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Source-scan guard for the #762 D1 drift class: a raw effect-bearing notification-intent string
+ * literal (`"additional_tip"`, …) must never appear in production Kotlin in `:core:state`/`:app` —
+ * intents there must be compared against the
+ * [NotificationIntent][cloud.trotter.dashbuddy.domain.state.NotificationIntent] SSOT constants, not
+ * hand-typed literals. The exact bug this backstops: `NotificationEffects` used to branch on a
+ * literal `"additional_tip"`, so a rule/effect rename could silently desync the two sides and drop
+ * a recognized tip notification.
+ *
+ * The forbidden literal set is **derived from the SSOT itself** —
+ * [StateMachineContract.EFFECT_INTENTS]`.keys` — so adding a new effect-bearing intent automatically
+ * extends this guard with no test edit. The one legitimate home for each literal is the
+ * `NotificationIntent` `const val` definition, which lives in `:domain` (outside the scanned
+ * modules) and so is invisible to this scan by construction.
+ *
+ * Follows the repo-root source-scan shape of [TimberTagGuardTest] (read `.kt` off disk rather than
+ * reflecting over compiled code — this is a textual property, "does this literal appear in source",
+ * not something the type system encodes). Main-type source sets only; test code is out of scope.
+ */
+class NotificationIntentSsotGuardTest {
+
+    /** Modules where a `NotificationFields.intent` comparison could live. */
+    private val modules = listOf("core/state", "app")
+
+    /** Source-set directory-name prefixes to skip — test code is out of scope. */
+    private val excludedSourceSetPrefixes = listOf("test", "androidTest")
+
+    private val repoRoot: File by lazy { locateRepoRoot() }
+
+    private val roots: List<String> by lazy {
+        modules.flatMap { module ->
+            val srcDir = File(repoRoot, "$module/src")
+            (srcDir.listFiles { f -> f.isDirectory }?.toList() ?: emptyList())
+                .filter { dir -> excludedSourceSetPrefixes.none { dir.name.startsWith(it) } }
+                .map { dir -> "$module/src/${dir.name}" }
+        }
+    }
+
+    @Test
+    fun `no effect-bearing intent literal appears outside the NotificationIntent SSOT`() {
+        val forbidden = StateMachineContract.EFFECT_INTENTS.keys
+        assertTrue(
+            "EFFECT_INTENTS is empty — the guard has nothing to protect; if that's intended, " +
+                "remove this test, otherwise the contract lost its keys",
+            forbidden.isNotEmpty(),
+        )
+
+        val problems = mutableListOf<String>()
+        for (root in roots) {
+            val rootDir = File(repoRoot, root)
+            if (!rootDir.isDirectory) continue
+            rootDir.walkTopDown()
+                .filter { it.isFile && it.extension == "kt" }
+                .forEach { file ->
+                    val text = file.readText()
+                    for (intent in forbidden) {
+                        // The literal token exactly as it would appear in a comparison: a
+                        // double-quoted string equal to the intent wire value.
+                        if (text.contains("\"$intent\"")) {
+                            val relPath = file.relativeTo(repoRoot).path.replace(File.separatorChar, '/')
+                            problems += "$relPath: raw effect-intent literal \"$intent\" — compare " +
+                                "against NotificationIntent.${intent.uppercase()} (the SSOT), not a literal"
+                        }
+                    }
+                }
+        }
+        assertTrue(
+            "Effect-bearing notification-intent string literal(s) found in production Kotlin " +
+                "(#762 D1). Use the NotificationIntent SSOT constants instead. Problems:\n" +
+                problems.sorted().joinToString("\n"),
+            problems.isEmpty(),
+        )
+    }
+
+    private fun locateRepoRoot(): File {
+        var dir = File(".").absoluteFile.normalize()
+        while (true) {
+            if (File(dir, "settings.gradle.kts").isFile) return dir
+            dir = dir.parentFile
+                ?: error(
+                    "Could not locate repo root (settings.gradle.kts) walking up from " +
+                        File(".").absoluteFile.normalize().path,
+                )
+        }
+    }
+}

--- a/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompiler.kt
+++ b/core/pipeline/src/main/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompiler.kt
@@ -3,6 +3,7 @@ package cloud.trotter.dashbuddy.core.pipeline.rules
 import cloud.trotter.dashbuddy.domain.model.accessibility.UiNode
 import cloud.trotter.dashbuddy.domain.model.notification.NotifTextField
 import cloud.trotter.dashbuddy.domain.model.notification.RawNotificationData
+import cloud.trotter.dashbuddy.domain.pipeline.StateMachineContract
 import cloud.trotter.dashbuddy.domain.state.Flow
 import cloud.trotter.dashbuddy.domain.state.Mode
 import kotlinx.serialization.json.JsonArray
@@ -662,10 +663,31 @@ object RuleCompiler {
         val parseBlock = obj["parse"]?.jsonObject ?: ruleParseBlock
         val parseAs = parseBlock?.get("as")?.jsonPrimitive?.content ?: ruleParseAs
 
-        // --- Shape contract validation (M3) ---
+        // --- Parse-field contract validation (shape M3 + per-flow D6 + effect-intent D1) ---
+        // Declared field names, hoisted once: the SAME set feeds all three checks, and each must be
+        // able to see "no parse block ⇒ zero declared fields" (a missing required field for a flow
+        // or effect-intent is exactly the no-parse case the #762 guard must catch).
+        val declaredFields = parseBlock?.get("fields")?.jsonObject?.keys ?: emptySet()
         if (parseAs != null) {
-            val declaredFields = parseBlock?.get("fields")?.jsonObject?.keys ?: emptySet()
             ParsedFieldsFactory.validateShapeFields(parseAs, declaredFields, ruleId)
+        }
+        // #762 D6: a SCREEN rule/branch that drives a flow with declared required fields must parse
+        // them, even absent a parse block. Screen-scoped because flows are a screen-rule contribution.
+        if (context == RuleContext.SCREEN) {
+            val flowWire = (branchState.flow ?: ruleFlow)?.wire
+            if (flowWire != null) {
+                validateFlowFields(
+                    flowWire,
+                    StateMachineContract.REQUIRED_FIELDS_BY_FLOW[flowWire],
+                    declaredFields,
+                    ruleId,
+                )
+            }
+        }
+        // #762 D1: a NOTIFICATION rule/branch whose resolved intent is effect-bearing must declare
+        // the fields the effect consumer needs. Unknown intents stay legal (informational).
+        if (context == RuleContext.NOTIFICATION) {
+            validateEffectIntentFields(intent, declaredFields, ruleId)
         }
 
         val parser: (TInput, Bindings) -> Map<String, Any?> = when (context) {
@@ -796,6 +818,64 @@ object RuleCompiler {
         }
 
         return ParsedStateBlock(flow, modeHint)
+    }
+
+    // ==========================================================================
+    //  Rule→state contract validation (#762 D6/D1)
+    // ==========================================================================
+
+    /**
+     * D6 — per-flow required parse fields (#762). A SCREEN rule/branch that drives [flowWire] must
+     * declare every field in [required] in its parse block; enforced **even when the rule has no
+     * parse block** ([declaredFields] empty). [required] is passed in (rather than looked up here)
+     * so the check is unit-testable against a synthetic contract independent of the — currently
+     * empty — production [StateMachineContract.REQUIRED_FIELDS_BY_FLOW]. A `null`/empty [required]
+     * (the common case: flow not in the contract) is a no-op.
+     *
+     * Fail-closed and **isolable** (mirrors [ParsedFieldsFactory.validateShapeFields]): the worst
+     * case of skipping a malformed non-sensitive rule is one screen surface degrading to UNKNOWN →
+     * scrubbed — safe — while the sensitive belt in [compileRules] still rejects the whole file if
+     * the offending rule is sensitive-layer.
+     */
+    fun validateFlowFields(
+        flowWire: String?,
+        required: Set<String>?,
+        declaredFields: Set<String>,
+        ruleId: String?,
+    ) {
+        if (flowWire == null || required.isNullOrEmpty()) return
+        val missing = required - declaredFields
+        if (missing.isNotEmpty()) {
+            throw RuleCompileException(
+                "Rule '${ruleId ?: "?"}' drives flow '$flowWire' but its parse block is missing " +
+                    "required field(s): ${missing.joinToString(", ") { "'$it'" }} — the flow's " +
+                    "lifecycle handling consumes them, and a missing field silently misfolds rather " +
+                    "than failing loud. Declare them in parse.fields (or relax the contract).",
+                isolable = true,
+            )
+        }
+    }
+
+    /**
+     * D1 — effect-bearing notification intent field contract (#762). A NOTIFICATION rule/branch
+     * whose resolved [intent] is a key in [StateMachineContract.EFFECT_INTENTS] must declare every
+     * field the effect consumer reads. An intent NOT in the map is **informational by construction**
+     * and is always allowed with no fields — never reject an unknown intent (the OTA/data-driven
+     * recognition contract, [cloud.trotter.dashbuddy.domain.state.NotificationIntent]). Fail-closed
+     * and isolable, like [validateFlowFields].
+     */
+    fun validateEffectIntentFields(intent: String, declaredFields: Set<String>, ruleId: String?) {
+        val required = StateMachineContract.EFFECT_INTENTS[intent] ?: return
+        val missing = required - declaredFields
+        if (missing.isNotEmpty()) {
+            throw RuleCompileException(
+                "Notification rule '${ruleId ?: "?"}' declares effect-bearing intent '$intent' but " +
+                    "its parse block is missing field(s): ${missing.joinToString(", ") { "'$it'" }}. " +
+                    "The effect that consumes '$intent' requires them; an intent with no effect " +
+                    "consumer is informational and needs no fields.",
+                isolable = true,
+            )
+        }
     }
 
     // ==========================================================================

--- a/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompilerTest.kt
+++ b/core/pipeline/src/test/java/cloud/trotter/dashbuddy/core/pipeline/rules/RuleCompilerTest.kt
@@ -1158,6 +1158,168 @@ class RuleCompilerTest {
         RuleCompiler.compileRules<UiNode>(parseJson(rule).jsonArray, RuleContext.SCREEN)
     }
 
+    // =========================================================================
+    // Rule→state contract: per-flow required fields (#762 D6)
+    //
+    // The production StateMachineContract.REQUIRED_FIELDS_BY_FLOW is empirically
+    // EMPTY today (every task:* flow has a legitimately parse-less shipped rule,
+    // incl. the deliberately-PII-free GoPuff bin-scan branch), so the end-to-end
+    // compileRules path can't trip it. The check itself is unit-tested against a
+    // synthetic required set — validateFlowFields takes `required` as a parameter
+    // for exactly this reason.
+    // =========================================================================
+
+    @Test(expected = RuleCompileException::class)
+    fun `validateFlowFields rejects a flow missing a required parse field (#762 D6)`() {
+        RuleCompiler.validateFlowFields(
+            flowWire = "task:pickup:navigation",
+            required = setOf("storeName"),
+            declaredFields = setOf("phase", "subFlow"),
+            ruleId = "test.screen.pickup_nav",
+        )
+    }
+
+    @Test(expected = RuleCompileException::class)
+    fun `validateFlowFields rejects a NO-parse-block rule for a flow with required fields (#762 D6)`() {
+        // The pre-#762 gap: validateShapeFields only ran when parseAs != null, so a
+        // task-flow rule with no parse block got zero validation. Empty declaredFields
+        // IS the no-parse-block case at the call site.
+        RuleCompiler.validateFlowFields(
+            flowWire = "task:pickup:navigation",
+            required = setOf("storeName"),
+            declaredFields = emptySet(),
+            ruleId = "test.screen.parseless",
+        )
+    }
+
+    @Test
+    fun `validateFlowFields passes when required fields are declared`() {
+        RuleCompiler.validateFlowFields(
+            flowWire = "task:pickup:navigation",
+            required = setOf("storeName"),
+            declaredFields = setOf("storeName", "phase"),
+            ruleId = "test.screen.good",
+        )
+    }
+
+    @Test
+    fun `validateFlowFields is a no-op for a flow with no contract entry or no flow`() {
+        RuleCompiler.validateFlowFields("task:dropoff:arrived", null, emptySet(), "test.rule")
+        RuleCompiler.validateFlowFields("task:dropoff:arrived", emptySet(), emptySet(), "test.rule")
+        RuleCompiler.validateFlowFields(null, setOf("storeName"), emptySet(), "test.rule")
+    }
+
+    @Test
+    fun `a parse-less screen rule with a task flow compiles under the (empty) production contract`() {
+        // Backfill guarantee: the shipped shape — e.g. the GoPuff bin-scan branch, which
+        // deliberately has NO parse (no PII) and emits task:pickup:arrived — stays legal.
+        val ruleJson = """[{
+            "id": "test.screen.binscan_like",
+            "priority": 10,
+            "state": { "flow": "task:pickup:arrived" },
+            "require": { "exists": { "hasText": "Pickup steps" } }
+        }]"""
+        val rules = RuleCompiler.compileRules<UiNode>(
+            Json.parseToJsonElement(ruleJson).jsonArray, RuleContext.SCREEN,
+        )
+        assertEquals(1, rules.size)
+    }
+
+    // =========================================================================
+    // Rule→state contract: effect-bearing notification intents (#762 D1)
+    // =========================================================================
+
+    @Test
+    fun `notification rule with an effect-bearing intent but no parse fields is rejected (#762 D1)`() {
+        // The live drift shape: uber.notification.tip_received relabeled to additional_tip
+        // with `parse: { as: "notification" }` and no fields — recognized, then silently
+        // dropped by the effect guard. Must die at compile instead. The violation is
+        // isolable (non-sensitive) so compileRules SKIPS the rule rather than the file.
+        val ruleJson = """[{
+            "id": "test.notification.tip_no_fields",
+            "priority": 10,
+            "intent": "additional_tip",
+            "require": { "titleMatchesRegex": "received a \\$\\d" },
+            "parse": { "as": "notification" }
+        }]"""
+        val compiled = RuleCompiler.compileRules<RawNotificationData>(
+            Json.parseToJsonElement(ruleJson).jsonArray, RuleContext.NOTIFICATION,
+        )
+        assertTrue("the under-parsed effect-intent rule must be skipped, not compiled", compiled.isEmpty())
+    }
+
+    @Test(expected = RuleCompileException::class)
+    fun `effect-bearing intent missing a SUBSET of required fields throws (#762 D1)`() {
+        RuleCompiler.validateEffectIntentFields(
+            intent = "additional_tip",
+            declaredFields = setOf("amount", "storeName"), // deliveredAt missing
+            ruleId = "test.notification.partial",
+        )
+    }
+
+    @Test
+    fun `notification rule with an effect-bearing intent and all required fields compiles`() {
+        // Mirrors the working doordash.notification.additional_tip shape.
+        val ruleJson = """[{
+            "id": "test.notification.tip_full",
+            "priority": 10,
+            "intent": "additional_tip",
+            "require": { "anyFieldMatchesRegex": "added \\$(\\d+\\.\\d{2}) tip" },
+            "parse": {
+                "as": "notification",
+                "fields": {
+                    "amount": { "from": "fullString", "find": "\\$(\\d+\\.\\d{2})", "group": 1, "transform": "parseCurrency" },
+                    "storeName": { "from": "fullString", "find": "past (.+?) order delivered", "group": 1, "transform": "trim" },
+                    "deliveredAt": { "from": "fullString", "find": "delivered at (.+)", "group": 1, "transform": "trim" }
+                }
+            }
+        }]"""
+        val rules = RuleCompiler.compileRules<RawNotificationData>(
+            Json.parseToJsonElement(ruleJson).jsonArray, RuleContext.NOTIFICATION,
+        )
+        assertEquals(1, rules.size)
+    }
+
+    @Test
+    fun `notification rule with an UNKNOWN intent and no fields compiles - informational (#762 D1)`() {
+        // Unknown intents are informational by construction and must stay legal — rejecting
+        // them would break OTA/data-driven recognition (a future ruleset must be free to
+        // introduce new informational intents without an app change).
+        val ruleJson = """[{
+            "id": "test.notification.tip_received_informational",
+            "priority": 10,
+            "intent": "tip_received",
+            "require": { "titleMatchesRegex": "received a \\$\\d" },
+            "parse": { "as": "notification" }
+        }]"""
+        val rules = RuleCompiler.compileRules<RawNotificationData>(
+            Json.parseToJsonElement(ruleJson).jsonArray, RuleContext.NOTIFICATION,
+        )
+        assertEquals(1, rules.size)
+    }
+
+    @Test
+    fun `effect-intent contract applies per BRANCH - an under-parsed branch is caught (#762 D1)`() {
+        // Branch parse inheritance: a branch inherits the rule-level parse unless it overrides.
+        // A branch that overrides with a field-less parse while declaring the effect intent
+        // must be rejected (isolable → rule skipped).
+        val ruleJson = """[{
+            "id": "test.notification.branchy_tip",
+            "priority": 10,
+            "branches": [
+                {
+                    "intent": "additional_tip",
+                    "require": { "titleContains": "tip" },
+                    "parse": { "as": "notification" }
+                }
+            ]
+        }]"""
+        val compiled = RuleCompiler.compileRules<RawNotificationData>(
+            Json.parseToJsonElement(ruleJson).jsonArray, RuleContext.NOTIFICATION,
+        )
+        assertTrue("the under-parsed branch must skip the rule", compiled.isEmpty())
+    }
+
     @Test
     fun `a top-level redact on a branched rule still compiles (#624)`() {
         // The reject is scoped to branches[] entries; a whole-rule top-level redact

--- a/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/NotificationEffects.kt
+++ b/core/state/src/main/java/cloud/trotter/dashbuddy/core/state/NotificationEffects.kt
@@ -1,6 +1,7 @@
 package cloud.trotter.dashbuddy.core.state
 
 import cloud.trotter.dashbuddy.domain.pipeline.Observation
+import cloud.trotter.dashbuddy.domain.state.NotificationIntent
 import cloud.trotter.dashbuddy.domain.state.ParsedFields
 
 /**
@@ -21,7 +22,7 @@ internal fun EffectMap.diffNotification(obs: Observation): List<AppEffect> {
 
     return buildList {
         when (fields.intent) {
-            "additional_tip" -> {
+            NotificationIntent.ADDITIONAL_TIP -> {
                 val amount = fields.amount
                 val storeName = fields.storeName
                 val deliveredAt = fields.deliveredAt

--- a/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
+++ b/core/state/src/test/java/cloud/trotter/dashbuddy/core/state/EffectMapTest.kt
@@ -23,6 +23,7 @@ import cloud.trotter.dashbuddy.domain.state.Flow
 import cloud.trotter.dashbuddy.domain.state.FlowRegion
 import cloud.trotter.dashbuddy.domain.state.Job
 import cloud.trotter.dashbuddy.domain.state.Mode
+import cloud.trotter.dashbuddy.domain.state.NotificationIntent
 import cloud.trotter.dashbuddy.domain.state.OfferIntent
 import cloud.trotter.dashbuddy.domain.state.ParsedFields
 import cloud.trotter.dashbuddy.domain.state.PendingDestructive
@@ -1800,17 +1801,40 @@ class EffectMapTest {
 
     @Test
     fun `additional_tip notification emits ProcessTipNotification`() {
+        // Drives the SSOT const (#762 D1) so the test proves rule intent and effect branch
+        // resolve through the SAME definition — a drifted literal on either side goes red.
         val (platform, onlineRegion) = stateWithPlatform()
         val state = AppState(regions = Regions(platforms = mapOf(platform to onlineRegion)))
 
         val effects = effectMap.diff(state, state, notificationObs(
-            intent = "additional_tip",
+            intent = NotificationIntent.ADDITIONAL_TIP,
             amount = 5.0,
             storeName = "Chipotle",
             deliveredAt = "2024-01-01",
         ))
 
         assertTrue("Should emit ProcessTipNotification", effects.any { it is AppEffect.ProcessTipNotification })
+    }
+
+    @Test
+    fun `additional_tip notification with a missing required field fires nothing`() {
+        // The Kotlin effect guard is null-checked; the compile-time contract
+        // (StateMachineContract.EFFECT_INTENTS) exists so a shipped rule can't reach this state —
+        // but the runtime guard stays fail-closed for a field that parsed to null anyway.
+        val (platform, onlineRegion) = stateWithPlatform()
+        val state = AppState(regions = Regions(platforms = mapOf(platform to onlineRegion)))
+
+        val effects = effectMap.diff(state, state, notificationObs(
+            intent = NotificationIntent.ADDITIONAL_TIP,
+            amount = 5.0,
+            storeName = null, // parsed but missing → the effect must not fire half-formed
+            deliveredAt = "2024-01-01",
+        ))
+
+        assertTrue(
+            "No ProcessTipNotification on a null required field",
+            effects.none { it is AppEffect.ProcessTipNotification },
+        )
     }
 
     @Test

--- a/docs/adr/ADR-0002-cross-platform-state-taxonomy.md
+++ b/docs/adr/ADR-0002-cross-platform-state-taxonomy.md
@@ -425,3 +425,29 @@ configuration") rather than this ADR. It is a runtime / UX concern downstream
 of the multi-platform architecture, not part of the rule format itself, and
 the design (user opt-in per platform, never auto-derived from installed
 rulesets) belongs in its own decision record.
+
+---
+
+## Amendment 2026-07-14 — the "prerequisite parsed fields" guard now exists (#762 D6/D1)
+
+§"What stays in Kotlin" above lists *"Transition guards (valid from-states, prerequisite parsed
+fields)"* as a Kotlin responsibility. The prerequisite-parsed-fields half is now **enforced at rule
+compile time** rather than discovered at runtime:
+
+- **`StateMachineContract.REQUIRED_FIELDS_BY_FLOW`** (`:domain`) — per-flow required parse fields
+  for screen rules. A rule (or branch, post parse-inheritance) declaring a listed flow must parse
+  the listed fields, **even when it has no `parse` block at all** (previously the shape contract
+  only ran when `parse.as` was present, so a parse-less task-flow rule got zero validation). The
+  map is empirically empty at time of writing — every `task:*` flow has a legitimately parse-less
+  shipped rule (e.g. the deliberately PII-free GoPuff bin-scan branch) — so it encodes what is
+  true, not an aspiration; the mechanism is the deliverable.
+- **`StateMachineContract.EFFECT_INTENTS`** (`:domain`) — effect-bearing notification intents
+  (SSOT constants in `NotificationIntent`) mapped to the parse fields their Kotlin effect consumer
+  requires (`additional_tip` → `amount`/`storeName`/`deliveredAt`). A rule declaring such an
+  intent without the fields is rejected at compile — closing the recognized-then-silently-dropped
+  class. Intents *not* in the map remain informational by construction and are never rejected
+  (the OTA/data-driven recognition contract).
+
+Both checks live in `RuleCompiler` (fail-closed, isolable per #293 item 4) and keep the
+trust-boundary posture of this ADR: the DSL still cannot express transition logic; Kotlin now
+verifies at load that the DSL delivers the data its transitions and effects depend on.

--- a/docs/adr/ADR-0002-cross-platform-state-taxonomy.md
+++ b/docs/adr/ADR-0002-cross-platform-state-taxonomy.md
@@ -450,4 +450,6 @@ compile time** rather than discovered at runtime:
 
 Both checks live in `RuleCompiler` (fail-closed, isolable per #293 item 4) and keep the
 trust-boundary posture of this ADR: the DSL still cannot express transition logic; Kotlin now
-verifies at load that the DSL delivers the data its transitions and effects depend on.
+verifies at load that the DSL *declares* the fields its transitions and effects depend on
+(declaration, not extraction success — a declared field whose predicate never matches still
+nulls at runtime, where the effect guard's null-checks remain the second layer).

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/StateMachineContract.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/pipeline/StateMachineContract.kt
@@ -2,6 +2,7 @@ package cloud.trotter.dashbuddy.domain.pipeline
 
 import cloud.trotter.dashbuddy.domain.state.Flow
 import cloud.trotter.dashbuddy.domain.state.Mode
+import cloud.trotter.dashbuddy.domain.state.NotificationIntent
 
 /**
  * The contract the state machine advertises to the rule loader. Rules that
@@ -9,6 +10,11 @@ import cloud.trotter.dashbuddy.domain.state.Mode
  * rejected at load time. Rules that use effect verbs outside
  * [SUPPORTED_VERBS] or transition triggers outside [SUPPORTED_TRIGGERS]
  * are likewise rejected.
+ *
+ * [REQUIRED_FIELDS_BY_FLOW] and [EFFECT_INTENTS] extend this from "which vocabulary tokens are
+ * legal" to "which parse fields a rule that uses a token must actually produce" (#762 D6/D1) —
+ * the prerequisite-parsed-fields guard ADR-0002 §"What stays in Kotlin" always reserved for Kotlin.
+ * They are enforced at compile time by `RuleCompiler`; see each field's doc.
  */
 object StateMachineContract {
     const val API_VERSION_MAJOR = 1
@@ -18,4 +24,59 @@ object StateMachineContract {
     val SUPPORTED_MODES: Set<String> = Mode.entries.map { it.wire }.toSet()
     val SUPPORTED_VERBS: Set<String> = EffectVerb.entries.map { it.wire }.toSet()
     val SUPPORTED_TRIGGERS: Set<String> = TransitionTrigger.entries.map { it.wire }.toSet()
+
+    /**
+     * Per-flow **required parse fields** for `task:*` (and any other) flows (#762 D6). A SCREEN rule
+     * (or branch, post parse-inheritance) that drives a listed [Flow] wire value must declare every
+     * field named here in its `parse.fields` — the compiler enforces this even when the rule has NO
+     * `parse` block at all (a missing block ⇒ empty declared set ⇒ the required fields are missing).
+     * This is the field-level analog of `ParsedFieldsFactory.REQUIRED_FIELDS_BY_SHAPE`
+     * (`:core:pipeline`), but keyed on the state-machine flow rather than the parse shape,
+     * so a flow whose lifecycle handling depends on a field can't be driven by a rule that never
+     * parses it.
+     *
+     * **Deliberately empty today, and that is the empirically correct content — not a placeholder.**
+     * The map must "encode what's true, not aspirations": a field may be required for a flow ONLY if
+     * **every** shipped rule that declares that flow already parses it. An audit of the fielded
+     * rulesets (2026-07-14) found that **every** `task:*` flow has at least one legitimately
+     * parse-less rule that declares it, so no field can be mandated without either breaking a
+     * shipped rule or editing fielded rules to satisfy an aspiration (both forbidden by the #762
+     * spec — prefer relaxing the set):
+     *  - `task:pickup:navigation` — `doordash.screen.pickup_pre_arrival_multi` (a multi-order
+     *    confirm-at-store screen with no single store name to parse) declares it with no `parse`.
+     *  - `task:pickup:arrived` — many parse-less rules, incl. the GoPuff bin-scan branch of
+     *    `doordash.screen.pickup_steps`, which is **deliberately** parse-less (no PII) and emits this
+     *    flow; mandating a field here would break the #501 warehouse-batch anchor.
+     *  - `task:dropoff:navigation` — `doordash.screen.dropoff_alcohol_id_intro` declares it with no
+     *    `parse` (an instructional screen).
+     *  - `task:dropoff:arrived` — many parse-less handoff/photo/pin screens.
+     *  - `idle` — many parse-less "you're online" screens.
+     *  - `offer:presented` / `post:task` / `session:ended` are already covered by the parse-**shape**
+     *    contract (`REQUIRED_FIELDS_BY_SHAPE` for `offer`/`post_task`/`session_ended`), so a flow
+     *    entry would be redundant.
+     *
+     * The **mechanism** is the durable deliverable: the day a flow gains a field that every rule
+     * driving it parses, adding one line here makes the guard enforce it (with the no-parse-block
+     * case covered). An empty set for a flow is fine; an empty map means no flow currently supports
+     * a universally-satisfied requirement.
+     */
+    val REQUIRED_FIELDS_BY_FLOW: Map<String, Set<String>> = emptyMap()
+
+    /**
+     * **Effect-bearing** notification intents → the parse fields their effect consumer requires
+     * (#762 D1). A NOTIFICATION rule (or branch) whose resolved `intent` is a key here must declare
+     * every listed field in its `parse.fields`, or the compiler rejects it — closing the drift class
+     * where a rule is *recognized* but then silently dropped because the Kotlin effect guard finds a
+     * null field it needs (the live `uber.notification.tip_received` shape: recognized, parse block
+     * with no fields, so `amount`/`storeName`/`deliveredAt` are all null and
+     * `AppEffect.ProcessTipNotification` never fires).
+     *
+     * An intent **not** in this map is **informational by construction** and is always allowed with
+     * no fields — that asymmetry is the OTA/data-driven-recognition contract ([NotificationIntent]).
+     * The keys are the [NotificationIntent] SSOT constants; the field sets mirror exactly what
+     * `EffectMap.diffNotification` reads before firing the effect.
+     */
+    val EFFECT_INTENTS: Map<String, Set<String>> = mapOf(
+        NotificationIntent.ADDITIONAL_TIP to setOf("amount", "storeName", "deliveredAt"),
+    )
 }

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/NotificationIntent.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/NotificationIntent.kt
@@ -1,0 +1,31 @@
+package cloud.trotter.dashbuddy.domain.state
+
+/**
+ * Wire identifiers for **effect-bearing** notification intents (#762 D1). The single source of
+ * truth shared by: the ruleset notification classification (`NotificationFields.intent`), the
+ * effect diff that consumes them (`EffectMap.diffNotification`), and the rule→state contract that
+ * validates their prerequisite parse fields at compile time
+ * ([cloud.trotter.dashbuddy.domain.pipeline.StateMachineContract.EFFECT_INTENTS]).
+ *
+ * Only intents whose recognition drives an app effect live here. Every **other** notification
+ * intent is **informational by construction** — a rule may emit any intent string it likes and the
+ * effect layer simply ignores the ones it has no handler for. That asymmetry is deliberate and is
+ * the OTA/data-driven-recognition contract (a future CDN ruleset must be free to introduce new
+ * informational intents without an app change); the compiler therefore rejects a *known*
+ * effect-bearing intent that omits its required fields but **never** rejects an unknown one.
+ *
+ * Keep the literal here and nowhere else: a raw `"additional_tip"` string compared against
+ * `NotificationFields.intent` in `:core:state`/`:app` is the exact D1 drift this SSOT closes (the
+ * literal previously lived hard-coded in `NotificationEffects`), guarded by
+ * `NotificationIntentSsotGuardTest`.
+ */
+object NotificationIntent {
+    /**
+     * A tip added to an already-completed delivery (DoorDash: "added $X tip on a past STORE order
+     * delivered at TIME"). Canonical wire value — kept as DoorDash's fielded string so the working
+     * `doordash.notification.additional_tip` rule needs no rename. Consumed by
+     * `EffectMap.diffNotification` → `AppEffect.ProcessTipNotification`, which requires the
+     * `amount`/`storeName`/`deliveredAt` fields the contract mandates.
+     */
+    const val ADDITIONAL_TIP = "additional_tip"
+}

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/pipeline/StateMachineContractTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/pipeline/StateMachineContractTest.kt
@@ -24,4 +24,21 @@ class StateMachineContractTest {
             )
         }
     }
+
+    /**
+     * A typo'd flow key in [StateMachineContract.REQUIRED_FIELDS_BY_FLOW] would silently no-op
+     * (the compiler looks keys up by the rule's resolved flow, so an unknown key never matches
+     * anything) — exactly the fail-open drift class the contract exists to prevent (#762 D6,
+     * adversarial-review finding). Every key must be a real Flow wire value.
+     */
+    @Test
+    fun `REQUIRED_FIELDS_BY_FLOW keys are all valid Flow wire values`() {
+        for (key in StateMachineContract.REQUIRED_FIELDS_BY_FLOW.keys) {
+            assertTrue(
+                "'$key' in REQUIRED_FIELDS_BY_FLOW is not a SUPPORTED_FLOWS wire value — " +
+                    "a typo'd key silently no-ops instead of enforcing",
+                key in StateMachineContract.SUPPORTED_FLOWS,
+            )
+        }
+    }
 }

--- a/matchers/rules/uber.json5
+++ b/matchers/rules/uber.json5
@@ -816,6 +816,12 @@
       ]
     },
     {
+      // #762 D1: intent stays "tip_received" = INFORMATIONAL (not in StateMachineContract.EFFECT_INTENTS),
+      // so this compiles with no parse fields. Promotion to the effect-bearing "additional_tip" intent
+      // is CORPUS-GATED: the corpus has no real Uber tip-notification fixture, and the effect
+      // (AppEffect.ProcessTipNotification) requires amount+storeName+deliveredAt — the DoorDash push
+      // carries all three, but there's no evidence the Uber push does. Do NOT fabricate parse regexes;
+      // relabel + add the parse.fields only once a real Uber tip capture proves the fields are derivable.
       "id": "uber.notification.tip_received",
       "priority": 8,
       "require": {


### PR DESCRIPTION
Builds #762 Theme 1 (items **D6** per-flow required parse fields + **D1** effect-bearing notification-intent contract) from the vetted spec.

## Summary

**D1 — effect-bearing notification intents are now a compile-validated contract, not a free string matched by a Kotlin literal.**

- **`NotificationIntent`** (`:domain`, next to `OfferIntent`): SSOT for effect-bearing notification intent wire values. `ADDITIONAL_TIP = "additional_tip"` — DoorDash's fielded value kept canonical, no rule rename. Unknown intents are informational by construction (KDoc'd).
- **`StateMachineContract.EFFECT_INTENTS`**: `additional_tip → {amount, storeName, deliveredAt}` — exactly the fields `EffectMap.diffNotification`'s guard reads before firing `AppEffect.ProcessTipNotification`. `RuleCompiler` rejects a notification rule/branch (post parse-inheritance) declaring an effect-bearing intent without its required fields — **including when there is no parse `fields` block at all** (the exact live drift shape). Unknown intents are **never** rejected — rejecting them would break OTA/data-driven recognition.
- **`NotificationEffects`** branches on `NotificationIntent.ADDITIONAL_TIP`, no literal.
- **`NotificationIntentSsotGuardTest`** (`:app` tests, `TimberTagGuardTest` source-scan pattern): no production Kotlin in `:core:state`/`:app` may contain a raw effect-bearing intent literal; the forbidden set is derived from `EFFECT_INTENTS.keys`, so a new effect-bearing intent extends the guard automatically.

**D6 — per-flow required parse fields.**

- **`StateMachineContract.REQUIRED_FIELDS_BY_FLOW`** + **`RuleCompiler.validateFlowFields`**: a screen rule/branch driving a listed flow must declare the listed parse fields, enforced even with **no parse block** (the pre-existing gap: `validateShapeFields` only ran when `parse.as` was present, so a task-flow rule with no parse got zero validation).
- **The production map ships EMPTY — deliberately and empirically.** Per the spec's grounding rule ("only add a required field where its absence demonstrably breaks lifecycle AND all shipped rules already satisfy it"), the audit found every `task:*` flow has at least one legitimately parse-less shipped rule: `pickup_pre_arrival_multi` (`task:pickup:navigation`), the deliberately PII-free GoPuff bin-scan branch of `pickup_steps` (`task:pickup:arrived` — the spec's CRITICAL constraint, kept legal by construction), `dropoff_alcohol_id_intro` (`task:dropoff:navigation`), and multiple handoff/photo/pin screens (`task:dropoff:arrived`). So no field can be required without breaking a fielded rule; the contract encodes what's true, not aspirations. The **mechanism** (incl. the no-parse-block case) is the durable deliverable and is fully unit-tested against a synthetic required set (`validateFlowFields` takes `required` as a parameter for exactly this testability).

**Corpus-gated decision on `uber.notification.tip_received` (explicit, per spec §6).** The corpus contains **no** Uber tip-notification fixture (searched `app/src/test/resources/snapshots/` and all test resources), so `amount`/`storeName`/`deliveredAt` are not derivable from evidence. Per spec, the rule's intent **stays `tip_received`** — informational and legal under the contract — with an in-rule comment citing #762 D1; promotion to `additional_tip` (+ real parse regexes) is gated on capturing a real Uber tip push. No fabricated regexes were added. The contract work stands either way: the moment someone relabels the rule to `additional_tip` without the fields, the build fails.

**Docs:** ADR-0002 gains a dated amendment recording that §"What stays in Kotlin"'s "prerequisite parsed fields" guard now exists at compile time. `docs/rules.schema.json` checked — it does **not** enumerate intents, so no schema change.

## Security / privacy posture

This touches rule compile — the **untrusted-input boundary** (third-party-authored / future-CDN rule JSON). Both new checks are **fail-closed**: a violating rule throws a typed `RuleCompileException` at compile, tagged `isolable` per the #293 item 4 discipline (worst case of skipping a malformed non-sensitive rule is one surface degrading to UNKNOWN → scrubbed; the sensitive-layer belt in `compileRules` still rejects the whole file for sensitive rules). No new parsing of untrusted content is introduced — the checks read already-parsed field-name sets; no bounded-ingestion caps change; no PII pathway changes. The unknown-intent allowance is a deliberate non-reject (informational intents carry no effects), documented in KDoc — it cannot be used to smuggle effects, since effects are validated separately (#425 actuation rejects, verb allowlist).

## Test evidence

- `:domain:test`, `:core:state:testDebugUnitTest`, `:core:pipeline:testDebugUnitTest` — green
- `:app:testDebugUnitTest --tests "*AllMatchersSuite*"` — green (**backfill check: both production rulesets compile unchanged under the new contract; zero rule edits needed**)
- Full `./gradlew testDebugUnitTest :domain:test` — green; `ParseOutputGoldenTest` untouched (no parse-output change, no golden regen)
- New tests: `validateFlowFields` reject/pass/no-op incl. the **no-parse-block** case; parse-less task-flow rule compiles under the (empty) production contract (the GoPuff bin-scan shape); effect-intent missing-fields reject (whole-rule + per-branch + subset), all-fields compile, unknown-intent compile; `EffectMapTest` tip tests route through the SSOT const + new null-field negative; `NotificationIntentSsotGuardTest` ran and passed (1 test, 0 failures)

### Design-goal review

1. **UDF (P1)** — untouched behaviorally: reducers/effects unchanged except `NotificationEffects` swapping a literal for a const (byte-identical value). Validation added at the compile edge, not inside reducers.
2. **SSOT (P5)** — the point of the PR: the `additional_tip` wire value now has exactly one owner (`NotificationIntent`), consumed by rules, the effect branch, the contract map, and the guard test; the required-field sets have one owner (`StateMachineContract`), consumed by the compiler. The guard test derives its forbidden set from the contract rather than hand-listing it.
3. **Security & privacy (P6)** — see posture above: fail-closed compile validation at the untrusted-input boundary; isolable per #293; no PII changes.
4. **Platform-agnostic core (P8)** — no platform literals in logic: `REQUIRED_FIELDS_BY_FLOW` keys are `Flow` wire values (the enumerated contract), `EFFECT_INTENTS` keys are intent vocabulary — neither names a platform; the new vocabulary went through the enumerated, load-validated `StateMachineContract` exactly as the principle demands (this PR is itself a #762 platform-agnosticism remediation). The Uber rule edit is a comment only.
5. **Clean code (P3)** — additions are small focused units (a 2-const object, 2 contract maps, 2 ~20-line validators, 1 guard test); no oversized file grew materially.

Closes nothing (parent #762 stays open — Theme 1 of several).
