### PR TITLE
feature(#773): address-derived running-key fallback for chain-bare receipts

### DIFF
--- a/app/src/main/java/cloud/trotter/dashbuddy/state/shadow/ShadowStoreChainLogger.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/state/shadow/ShadowStoreChainLogger.kt
@@ -64,7 +64,11 @@ class ShadowStoreChainLogger @Inject constructor(
                 append(" offer=").append(l.offerName ?: "—")
                 append(" dropoff=").append(l.dropoffName ?: "—")
                 append(" payout=").append(l.payoutName ?: "—")
-                append(" key=").append(l.runningKey ?: "—")
+                // Resolved (ladder) key = what the projector persists — the shadow's whole job is
+                // parity with persisted keys, and on the chain-bare #773 shape the raw receipt
+                // token is null while the persisted key is the @-address fragment. (The raw
+                // payout form is already on the line via payout=.)
+                append(" key=").append(l.resolvedRunningKey ?: "—")
                 l.realizedTip?.let { append(" tip=").append(it) }
                 append(" custs=").append(l.customerHashes.map { it.take(6) })
             }

--- a/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/PatternsTab.kt
+++ b/app/src/main/java/cloud/trotter/dashbuddy/ui/main/analytics/PatternsTab.kt
@@ -288,7 +288,15 @@ private fun StoreRow(card: StoreReportCard) {
                 modifier = Modifier.weight(1f),
             )
             if (card.locationKnown && card.runningKey != null) {
-                AppChip(text = card.runningKey!!, uppercase = false)
+                // #773: an address-derived key (`@12125`) is a provenance marker, not a label — show the
+                // street line of the store address instead of the raw `@number`. (#765 redesigns this card.)
+                val runningKey = card.runningKey!!
+                val chipText = if (runningKey.startsWith("@")) {
+                    card.address?.substringBefore(",")?.trim()?.takeIf { it.isNotEmpty() } ?: runningKey
+                } else {
+                    runningKey
+                }
+                AppChip(text = chipText, uppercase = false)
             } else {
                 AppChip(
                     text = stringResource(R.string.patterns_tab_location_unknown),

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjector.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/AnalyticsProjector.kt
@@ -787,7 +787,15 @@ class AnalyticsProjector @Inject constructor(
          * stack while the session total is ~conserved. Phase-A driver edits (`DELIVERY_ADJUSTMENT`)
          * replay after their targets on the refold, so a driver's corrected total survives. Precedented
          * side effect (as v2/v3/v4): `CURRENT_FALLBACK` rows re-stamp against today's economy.
+         * v7 (#773): store resolution gains the address-derived running-key FALLBACK — when a receipt is
+         * chain-bare (no `(code)`/` - Area` key) the from-zero refold now keys the store off its pickup
+         * address's leading street number (`@12125`), so a chain's per-location visits split into distinct
+         * `stores`/`storeKey` rows instead of collapsing into one chain-only "location unknown" bucket. The
+         * refold re-keys the address-bearing subset of history (pre-#159 folds carry no pickup address, so
+         * those stay chain-only — a partial, honest backfill). Purely a projection re-key: `app_events`,
+         * every frozen economy column, and pay/net/miles are untouched. Precedented side effect (as
+         * v2/v3/v4/v6): the refold also re-stamps `CURRENT_FALLBACK` rows against today's economy.
          */
-        private const val PROJECTOR_VERSION = 6
+        private const val PROJECTOR_VERSION = 7
     }
 }

--- a/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/StoreResolutionRunner.kt
+++ b/core/data/src/main/java/cloud/trotter/dashbuddy/core/data/analytics/StoreResolutionRunner.kt
@@ -2,7 +2,6 @@ package cloud.trotter.dashbuddy.core.data.analytics
 
 import cloud.trotter.dashbuddy.core.database.analytics.AnalyticsDao
 import cloud.trotter.dashbuddy.core.database.analytics.OfferRecordEntity
-import cloud.trotter.dashbuddy.core.database.analytics.PickupRecordEntity
 import cloud.trotter.dashbuddy.core.database.analytics.StoreEntity
 import cloud.trotter.dashbuddy.domain.analytics.StoreResolution
 import cloud.trotter.dashbuddy.domain.model.event.AppEventType
@@ -73,7 +72,16 @@ internal class StoreResolutionRunner(private val dao: AnalyticsDao) {
         val offerRows = candidateOffers(task, jobId, jobFirstAt)
         val offerForms = offerRows.mapNotNull { it.merchantName }
 
-        val resolved = StoreResolver.resolveAnchors(anchors, offerForms, dropoffForms, payoutForms)
+        // Per-anchor address (#773): FIRST-NON-NULL storeAddress by eventSequenceId (pickups are
+        // ORDER BY eventSequenceId ASC), THEN fail — the address fallback key comes from that ONE row,
+        // never from a later row whose extraction would succeed (first-non-null-then-fail, F-3). The
+        // display-address seed (upsertStore) reads this SAME map, so an `@`-keyed card never shows a
+        // different location's address than the one that keyed it.
+        val anchorAddresses: Map<String, String?> = anchors.associateWith { anchor ->
+            pickups.firstOrNull { it.storeName == anchor && it.storeAddress != null }?.storeAddress
+        }
+
+        val resolved = StoreResolver.resolveAnchors(anchors, offerForms, dropoffForms, payoutForms, anchorAddresses)
         // FIX 7: key platform = the trigger's own platform when it is REAL, else the pickup row's
         // platform. This makes `StoreResolution.platform` load-bearing: a DASH_STOP re-resolution of an
         // `_unknown`-started session (its DASH_STOP carried the corrected platform) upgrades the key to
@@ -85,10 +93,11 @@ internal class StoreResolutionRunner(private val dao: AnalyticsDao) {
         val anchorKey = HashMap<String, String>()
         for (r in resolved) {
             val normChain = StoreKeys.normalizedChain(r.canonical)
-            val runKey = StoreKeys.normalizeRunningKey(r.runningKey)
+            // The #773 ladder SSOT: normalized receipt key ?: address `@`-key ?: null (chain-only).
+            val runKey = r.resolvedRunningKey
             val key = StoreKeys.storeKey(platform, normChain, runKey)
             anchorKey[r.canonical] = key
-            upsertStore(key, platform, normChain, runKey, r, pickups)
+            upsertStore(key, platform, normChain, runKey, r, anchorAddresses[r.canonical])
         }
 
         // Stamp pickup rows by their own anchor (storeName == the anchor). FIX 6 monotonic backstop:
@@ -120,20 +129,42 @@ internal class StoreResolutionRunner(private val dao: AnalyticsDao) {
     }
 
     /**
-     * FIX 6 monotonic-key backstop: true iff [newKey] is CHAIN-ONLY (empty running-key segment) and the
-     * row's [current] key is a KEYED variant of the same platform+chain — i.e. this would downgrade an
-     * already-keyed row. Resolution is row-sourced and monotonic by design, so this only fires on a rare
-     * evidence loss; keeping the keyed value guards against a silent regression. The storeKey strings
-     * are merchant-derived, so the observability note is DEBUG (keys) + a merchant-free WARN counter (P7).
+     * FIX 6 monotonic-key backstop, ladder-aware (#773): true iff [newKey] would lower the row's key
+     * TIER **within the same platform+chain** — receipt (`platform|chain|02426`) > address
+     * (`platform|chain|@12125`) > chain-only (`platform|chain|`). Resolution is row-sourced and monotonic
+     * by design, so this only fires on a rare evidence loss (a payout-less re-run losing a receipt line, or
+     * a receipt-keyed row seeing only address evidence on a later pass); keeping the higher-tier value
+     * guards against a silent regression.
+     *
+     * The **same platform+chain guard is load-bearing** (FIX 7): the platform upgrade
+     * `_unknown|heb|` → `doordash|heb|` crosses platforms (different prefix), so it is NOT a downgrade and
+     * stays allowed. The genuinely new #773 edge blocked here is receipt→address; `@`→chain-only and
+     * receipt→chain-only were already blocked. The storeKey strings are merchant-derived, so the
+     * observability note is DEBUG (keys) + a merchant-free WARN counter (P7).
      */
-    private fun isMonotonicDowngrade(current: String?, newKey: String): Boolean {
-        if (current == null || !newKey.endsWith("|")) return false
-        val downgrade = current != newKey && current.startsWith(newKey)
+    // `internal` (not private) so the ladder can be unit-tested directly — the 5 tier transitions
+    // (chain-only→@ upgrade, receipt→@ blocked, @→receipt allowed, platform-upgrade allowed, no-churn)
+    // are pure key-string logic that would be awkward to reconstruct end-to-end through the fold.
+    internal fun isMonotonicDowngrade(current: String?, newKey: String): Boolean {
+        if (current == null) return false
+        // Only compare within the same platform+chain prefix (everything up to the last '|').
+        if (current.substringBeforeLast('|') != newKey.substringBeforeLast('|')) return false
+        val downgrade = keyTier(newKey) < keyTier(current)
         if (downgrade) {
-            Timber.tag(TAG).d("store-key: kept keyed %s over chain-only recompute %s", current, newKey)
+            Timber.tag(TAG).d("store-key: kept tier-%d %s over lower-tier recompute %s", keyTier(current), current, newKey)
             Timber.tag(TAG).w("store-key downgrade averted (monotonic backstop)")
         }
         return downgrade
+    }
+
+    /** The #773 running-key tier of a storeKey: chain-only (0) < address `@` (1) < receipt (2). */
+    internal fun keyTier(key: String): Int {
+        val seg = key.substringAfterLast('|')
+        return when {
+            seg.isEmpty() -> 0
+            seg.startsWith("@") -> 1
+            else -> 2
+        }
     }
 
     private suspend fun candidateOffers(
@@ -159,11 +190,13 @@ internal class StoreResolutionRunner(private val dao: AnalyticsDao) {
         normalizedChain: String,
         runningKey: String?,
         r: StoreResolver.AnchorResolution,
-        pickups: List<PickupRecordEntity>,
+        selectedAddress: String?,
     ) {
         val prior = dao.store(storeKey)
-        val address = prior?.address
-            ?: pickups.firstOrNull { it.storeName == r.canonical && it.storeAddress != null }?.storeAddress
+        // The display-address seed uses the SAME row selection as the address key source (#773) — the
+        // caller's first-non-null-by-eventSequenceId anchorAddresses entry — so an `@`-keyed store's
+        // card can never display a different location's address than the one that keyed it.
+        val address = prior?.address ?: selectedAddress
         val store = StoreEntity(
             storeKey = storeKey,
             platform = platform,

--- a/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/StoreResolutionProjectorTest.kt
+++ b/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/StoreResolutionProjectorTest.kt
@@ -328,6 +328,100 @@ class StoreResolutionProjectorTest {
         assertEquals("poisoned pickup row gone after rebuild (F8)", 0, dao.pickupRecordsForJob("JGHOST").size)
     }
 
+    // ── #773: address-derived running-key fallback for chain-bare receipts ──
+
+    private val hebAddress = "12125 Alamo Rnch Pkwy, San Antonio, TX 78240, USA"
+    private val hebAddressKey = "doordash|h-e-b|@12125"
+
+    @Test
+    fun `#773 — a chain-bare grocery receipt keys the store off its pickup address`() = runBlocking {
+        insert(AppEventType.DASH_START, "S1", 1000, start("S1", 1000))
+        val pu = insert(AppEventType.PICKUP_CONFIRMED, "S1", 1100, pickup("J1", "pH", "H-E-B", 1100, hebAddress))
+        val d = insert(
+            AppEventType.DELIVERY_COMPLETED, "S1", 1200,
+            // chain-bare receipt: the payout store form carries no (code)/ - Area running key.
+            delivery("J1", "dH", "H-E-B", 1200, receipt("H-E-B" to 3.0), totalPay = 8.0),
+        )
+        insert(AppEventType.DASH_STOP, "S1", 1300, stop("S1", 1300))
+        projector().catchUp()
+
+        val store = dao.store(hebAddressKey)
+        assertNotNull("H-E-B keyed by its street number (@12125)", store)
+        assertEquals("h-e-b", store!!.normalizedChain)
+        assertEquals("@12125", store.runningKey)
+        assertEquals("the display address is seeded from the SAME row that keyed the store", hebAddress, store.address)
+        assertEquals(hebAddressKey, dao.deliveryRecord(d)!!.storeKey)
+        assertEquals(hebAddressKey, dao.pickupRecordsForJob("J1").single { it.eventSequenceId == pu }.storeKey)
+        // pay/net untouched by resolution.
+        assertEquals(8.0, dao.deliveryRecord(d)!!.realizedPay!!, 0.001)
+    }
+
+    @Test
+    fun `#773 F1 — a chain-bare address job folds identically incremental vs from-zero refold across a batch boundary`() = runBlocking {
+        // Batch boundary BETWEEN the pickups and the close (the F1 divergence-prone shape): the pickup
+        // resolves in one batch, the DELIVERY_COMPLETED/DASH_STOP close in the next.
+        insert(AppEventType.DASH_START, "S1", 1000, start("S1", 1000))
+        insert(AppEventType.PICKUP_CONFIRMED, "S1", 1100, pickup("J1", "pH", "H-E-B", 1100, hebAddress))
+        insert(AppEventType.DELIVERY_COMPLETED, "S1", 1200, delivery("J1", "dH", "H-E-B", 1200, receipt("H-E-B" to 3.0), totalPay = 8.0))
+        insert(AppEventType.DASH_STOP, "S1", 1300, stop("S1", 1300))
+
+        // Incremental: limit 2 lands DASH_START+pH in b1, dH+DASH_STOP in b2 — pickup and close split.
+        val p = projector()
+        while (p.processBatch(limit = 2) != null) { /* drain */ }
+        val incDelivery = dao.deliveryRecordByTask("dH")?.storeKey
+        val incPickup = dao.pickupRecordsForJob("J1").single().storeKey
+        val incVisible = dao.storeReportRows().first().map { it.storeKey }.toSet()
+
+        wipeAndResetWatermark()
+        projector().catchUp()
+        val refDelivery = dao.deliveryRecordByTask("dH")?.storeKey
+        val refPickup = dao.pickupRecordsForJob("J1").single().storeKey
+        val refVisible = dao.storeReportRows().first().map { it.storeKey }.toSet()
+
+        assertEquals(hebAddressKey, incDelivery)
+        assertEquals("delivery storeKey identical incremental vs refold", refDelivery, incDelivery)
+        assertEquals("pickup storeKey identical incremental vs refold", refPickup, incPickup)
+        assertEquals("read-visible store set identical incremental vs refold", refVisible, incVisible)
+        assertEquals(setOf(hebAddressKey), incVisible)
+    }
+
+    @Test
+    fun `#773 acceptance — four same-chain jobs at distinct addresses key to four @-rows, an address-less job stays chain-only`() = runBlocking {
+        insert(AppEventType.DASH_START, "S1", 1000, start("S1", 1000))
+        val addrs = listOf(
+            "100 Bandera Rd, San Antonio, TX 78228, USA",
+            "200 Culebra Rd, San Antonio, TX 78228",
+            "300 Marbach Rd, San Antonio, TX 78227-1000, United States",
+            "400 SW Loop 410, San Antonio, TX 78227",
+        )
+        var t = 1100L
+        addrs.forEachIndexed { i, addr ->
+            insert(AppEventType.PICKUP_CONFIRMED, "S1", t, pickup("J$i", "pH$i", "H-E-B", t, addr)); t += 50
+            insert(AppEventType.DELIVERY_COMPLETED, "S1", t, delivery("J$i", "dH$i", "H-E-B", t, receipt("H-E-B" to 3.0), totalPay = 8.0)); t += 50
+        }
+        // A fifth H-E-B job with NO pickup address → stays the chain-only "location unknown" bucket.
+        insert(AppEventType.PICKUP_CONFIRMED, "S1", t, pickup("J4", "pH4", "H-E-B", t)); t += 50
+        insert(AppEventType.DELIVERY_COMPLETED, "S1", t, delivery("J4", "dH4", "H-E-B", t, receipt("H-E-B" to 3.0), totalPay = 8.0)); t += 50
+        insert(AppEventType.DASH_STOP, "S1", t, stop("S1", t))
+        projector().catchUp()
+
+        // Four distinct located rows, each seeded with its own address.
+        listOf("@100" to addrs[0], "@200" to addrs[1], "@300" to addrs[2], "@400" to addrs[3]).forEach { (frag, addr) ->
+            val s = dao.store("doordash|h-e-b|$frag")
+            assertNotNull("located H-E-B $frag exists", s)
+            assertEquals(addr, s!!.address)
+        }
+        // The address-less job keeps its own chain-only bucket (no phantom merge).
+        val chainOnly = dao.store("doordash|h-e-b|")
+        assertNotNull("address-less job keeps the chain-only 'location unknown' bucket", chainOnly)
+        assertNull(chainOnly!!.runningKey)
+
+        val hebRunningKeys = dao.allStores().filter { it.normalizedChain == "h-e-b" }.map { it.runningKey }.toSet()
+        assertEquals(setOf("@100", "@200", "@300", "@400", null), hebRunningKeys)
+        assertEquals("doordash|h-e-b|@100", dao.deliveryRecordByTask("dH0")?.storeKey)
+        assertEquals("doordash|h-e-b|", dao.deliveryRecordByTask("dH4")?.storeKey)
+    }
+
     // ── FIX 12d: F4 offer-link guards ──
 
     private fun offerAccepted(offerHash: String, merchant: String, at: Long) =

--- a/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/StoreResolutionRunnerLadderTest.kt
+++ b/core/data/src/test/java/cloud/trotter/dashbuddy/core/data/analytics/StoreResolutionRunnerLadderTest.kt
@@ -1,0 +1,87 @@
+package cloud.trotter.dashbuddy.core.data.analytics
+
+import cloud.trotter.dashbuddy.core.database.analytics.AnalyticsDao
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.mock
+
+/**
+ * #773 — the ladder-aware monotonic backstop ([StoreResolutionRunner.isMonotonicDowngrade]) in
+ * isolation: the running-key TIER order chain-only (0) < address `@` (1) < receipt (2), compared ONLY
+ * within the same platform+chain prefix. Pure key-string logic, so it is tested directly rather than
+ * reconstructed end-to-end through the fold.
+ */
+class StoreResolutionRunnerLadderTest {
+
+    private val runner = StoreResolutionRunner(mock<AnalyticsDao>())
+
+    // ── keyTier ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `keyTier orders chain-only below address below receipt`() {
+        assertTrue(runner.keyTier("doordash|heb|") == 0)
+        assertTrue(runner.keyTier("doordash|heb|@12125") == 1)
+        assertTrue(runner.keyTier("doordash|target|02426") == 2)
+    }
+
+    // ── upgrades (NOT downgrades) ───────────────────────────────────────
+
+    @Test
+    fun `chain-only to address is an upgrade — re-stamp allowed`() {
+        assertFalse(runner.isMonotonicDowngrade("doordash|heb|", "doordash|heb|@12125"))
+    }
+
+    @Test
+    fun `chain-only to receipt is an upgrade`() {
+        assertFalse(runner.isMonotonicDowngrade("doordash|target|", "doordash|target|02426"))
+    }
+
+    @Test
+    fun `address to receipt is an upgrade — re-stamp allowed`() {
+        assertFalse(runner.isMonotonicDowngrade("doordash|heb|@12125", "doordash|heb|799"))
+    }
+
+    // ── blocked downgrades ──────────────────────────────────────────────
+
+    @Test
+    fun `receipt to address is BLOCKED — the genuinely new #773 edge`() {
+        assertTrue(runner.isMonotonicDowngrade("doordash|target|02426", "doordash|target|@12125"))
+    }
+
+    @Test
+    fun `address to chain-only is BLOCKED`() {
+        assertTrue(runner.isMonotonicDowngrade("doordash|heb|@12125", "doordash|heb|"))
+    }
+
+    @Test
+    fun `receipt to chain-only is BLOCKED`() {
+        assertTrue(runner.isMonotonicDowngrade("doordash|target|02426", "doordash|target|"))
+    }
+
+    // ── no-churn + platform-upgrade + guards ────────────────────────────
+
+    @Test
+    fun `an identical key is not a downgrade (value-compare no-churn)`() {
+        assertFalse(runner.isMonotonicDowngrade("doordash|heb|@12125", "doordash|heb|@12125"))
+    }
+
+    @Test
+    fun `a platform upgrade across platforms is allowed at every tier (FIX 7 stays intact)`() {
+        // _unknown|heb|… → doordash|heb|… : different platform+chain prefix, so never a downgrade even
+        // though the tiers are equal. This is the FIX 7 re-stamp the ladder must not break.
+        assertFalse(runner.isMonotonicDowngrade("_unknown|heb|", "doordash|heb|"))
+        assertFalse(runner.isMonotonicDowngrade("_unknown|heb|@12125", "doordash|heb|@12125"))
+        assertFalse(runner.isMonotonicDowngrade("_unknown|target|02426", "doordash|target|02426"))
+    }
+
+    @Test
+    fun `a null current key is never a downgrade`() {
+        assertFalse(runner.isMonotonicDowngrade(null, "doordash|heb|@12125"))
+    }
+
+    @Test
+    fun `a different chain is never a downgrade (prefix guard)`() {
+        assertFalse(runner.isMonotonicDowngrade("doordash|target|02426", "doordash|heb|"))
+    }
+}

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/StoreChainProjection.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/StoreChainProjection.kt
@@ -18,8 +18,11 @@ data class StoreChainLink(
     val dropoffName: String?,
     /** The payout-line form — the running-key representation (`Target (02426)`), the #159 runningKey carrier. */
     val payoutName: String?,
-    /** The running key teased out of [payoutName]: the store number (`02426`) or area (`Alamo Ranch`). */
+    /** The RAW running key teased out of [payoutName]: the store number (`02426`) or area (`Alamo Ranch`). */
     val runningKey: String?,
+    /** The address-derived `@`-prefixed key (#773), the chain-bare fallback; null unless the receipt was
+     *  chain-bare AND the store's pickup address gave a leading street number. */
+    val addressKey: String? = null,
     /** Hashed customers delivered to this store on this job (dedup-safe; never raw PII). */
     val customerHashes: List<String>,
     /** Realized tip attributed to this store from the payout, when present. */
@@ -48,15 +51,28 @@ object StoreResolver {
     /** One payout store line — the store form ([type]) and its realized amount ([amount], shadow-only). */
     data class PayoutForm(val type: String, val amount: Double? = null)
 
-    /** One anchor's resolved cross-surface forms. Running key is the RAW extracted token ([StoreKeys]). */
+    /** One anchor's resolved cross-surface forms. [runningKey] is the RAW receipt token ([StoreKeys]);
+     *  [addressKey] is the `@`-prefixed address fallback (#773). [resolvedRunningKey] is the deterministic
+     *  ladder both adapters key on. */
     data class AnchorResolution(
         val canonical: String,
         val offerForm: String?,
         val dropoffForm: String?,
         val payoutForm: String?,
         val runningKey: String?,
+        val addressKey: String? = null,
         val realizedTip: Double?,
-    )
+    ) {
+        /**
+         * The #773 precedence ladder (the ONE ladder SSOT both adapters key on): the
+         * canonicalized **receipt** key ([StoreKeys.normalizeRunningKey], which strips any masquerading
+         * `@`) wins; else the **address**-derived `@`-key ([StoreKeys.addressRunningKey], already
+         * canonical, bypasses the receipt canonicalizer so its `@` survives); else null (chain-only).
+         * Address-derived keys are provenance-marked by their leading `@` (F-1) — no extra column.
+         */
+        val resolvedRunningKey: String?
+            get() = StoreKeys.normalizeRunningKey(runningKey) ?: addressKey
+    }
 
     /**
      * Resolve every distinct pickup anchor against the offer / dropoff / payout surfaces. Each payout
@@ -70,15 +86,18 @@ object StoreResolver {
      * per-anchor best-line semantics (the spec's D4 intent), so the pre-PR shadow logs are NOT
      * line-for-line comparable to this output.
      *
-     * TODO(#159 phase-2): the unimplemented D4 bullet — match a payout line to a store by address / running
-     *  key when brand tokens share ZERO overlap (grocery payout lines that are bare order numbers). Today
-     *  such a line matches no anchor and is dropped; phase-2 adds the address/key fallback join.
+     * **Address fallback (#773):** [anchorAddresses] maps an anchor to its (caller-selected) store
+     * address; when a receipt yields no running key the anchor's [AnchorResolution.addressKey] carries
+     * the address-derived `@`-fragment ([StoreKeys.addressRunningKey]), and [AnchorResolution.resolvedRunningKey]
+     * applies the `receiptKey ?: addressKey ?: null` ladder — so a chain-bare grocery payout keys per
+     * location instead of collapsing every visit into one chain-only bucket.
      */
     fun resolveAnchors(
         anchors: List<String>,
         offerForms: List<String>,
         dropoffForms: List<String>,
         payoutForms: List<PayoutForm>,
+        anchorAddresses: Map<String, String?> = emptyMap(),
     ): List<AnchorResolution> {
         val cleanAnchors = anchors.filter { it.isNotBlank() }.distinct()
         if (cleanAnchors.isEmpty()) return emptyList()
@@ -101,6 +120,7 @@ object StoreResolver {
                 dropoffForm = StoreNameMatch.bestMatch(cleanDropoffs, canonical),
                 payoutForm = keyForm?.type,
                 runningKey = keyForm?.type?.let { StoreKeys.extractRunningKey(it) },
+                addressKey = StoreKeys.addressRunningKey(anchorAddresses[canonical]),
                 realizedTip = matched.mapNotNull { it.amount }.takeIf { it.isNotEmpty() }?.sum(),
             )
         }
@@ -120,10 +140,13 @@ object StoreResolver {
 object StoreChainProjector {
 
     fun project(job: Job, payout: ParsedPay?): JobStoreChain {
-        val pickupStores = job.tasks
-            .filter { it.phase == TaskPhase.PICKUP && !it.storeName.isNullOrBlank() }
-            .map { it.storeName!! }
-            .distinct()
+        val pickupTasks = job.tasks.filter { it.phase == TaskPhase.PICKUP && !it.storeName.isNullOrBlank() }
+        val pickupStores = pickupTasks.map { it.storeName!! }.distinct()
+        // Per-anchor address (#773): the FIRST pickup of this store carrying a non-null address — the
+        // Job-side analog of the runner's first-non-null-by-eventSequenceId row selection.
+        val anchorAddresses: Map<String, String?> = pickupStores.associateWith { store ->
+            pickupTasks.firstOrNull { it.storeName == store && it.storeAddress != null }?.storeAddress
+        }
         val offerHints = job.offerStoreHint
         val dropoffStores = job.tasks
             .filter { it.phase == TaskPhase.DROPOFF && !it.storeName.isNullOrBlank() }
@@ -132,7 +155,7 @@ object StoreChainProjector {
             .filter { it.type.isNotBlank() }
             .map { StoreResolver.PayoutForm(it.type, it.amount) }
 
-        val links = StoreResolver.resolveAnchors(pickupStores, offerHints, dropoffStores, payoutForms)
+        val links = StoreResolver.resolveAnchors(pickupStores, offerHints, dropoffStores, payoutForms, anchorAddresses)
             .map { r ->
                 val customerHashes = job.tasks
                     .filter { it.phase == TaskPhase.DROPOFF && it.storeName == r.canonical && it.customerNameHash != null }
@@ -144,6 +167,7 @@ object StoreChainProjector {
                     dropoffName = r.dropoffForm,
                     payoutName = r.payoutForm,
                     runningKey = r.runningKey,
+                    addressKey = r.addressKey,
                     customerHashes = customerHashes,
                     realizedTip = r.realizedTip,
                 )

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/StoreChainProjection.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/StoreChainProjection.kt
@@ -27,7 +27,16 @@ data class StoreChainLink(
     val customerHashes: List<String>,
     /** Realized tip attributed to this store from the payout, when present. */
     val realizedTip: Double?,
-)
+) {
+    /**
+     * The `receiptKey ?: addressKey ?: null` ladder — the SAME derivation
+     * [AnchorResolution.resolvedRunningKey] applies, mirrored here so link consumers (and the
+     * shadow log, which field-verifies persisted-key parity) never re-derive it by hand
+     * (#773 adversarial-review finding 2).
+     */
+    val resolvedRunningKey: String?
+        get() = StoreKeys.normalizeRunningKey(runningKey) ?: addressKey
+}
 
 /** The full store chain for one job — every order/store linked across offer → pickup → dropoff → payout. */
 data class JobStoreChain(

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/StoreKeys.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/StoreKeys.kt
@@ -89,12 +89,46 @@ object StoreKeys {
     }
 
     /**
-     * Canonicalize a running key for the [storeKey]: `Locale.ROOT` lowercase + whitespace-collapse so
-     * "Alamo Ranch" and "alamo ranch" don't fork one store into two entities (F7). Null/blank → null
-     * (an empty key segment, the chain-only provisional form).
+     * Canonicalize a **receipt-derived** running key for the [storeKey]: `Locale.ROOT` lowercase +
+     * whitespace-collapse so "Alamo Ranch" and "alamo ranch" don't fork one store into two entities
+     * (F7). Null/blank → null (an empty key segment, the chain-only provisional form).
+     *
+     * **`@`-strip (#773 F-1, prefix soundness):** an `@` prefix is the provenance marker of an
+     * ADDRESS-derived key ([addressRunningKey]). [extractRunningKey]'s parenthetical / ` - `-tail
+     * captures pass arbitrary untrusted merchant text, so a payout form like `"Joe's (@joescafe)"`
+     * could otherwise mint a receipt-tier key that STARTS WITH `@` and masquerade as address-tier. This
+     * canonicalizer runs on the receipt path only and strips any leading `@`, so a legitimate
+     * address key (minted by [addressRunningKey], which bypasses this function) is the ONLY source of a
+     * `@`-prefixed running key — provenance-by-prefix is sound, with no extra column.
      */
     fun normalizeRunningKey(raw: String?): String? =
-        raw?.let { collapse(it) }?.ifEmpty { null }
+        raw?.let { collapse(it).trimStart('@').trim() }?.ifEmpty { null }
+
+    /**
+     * The **address-derived** running key (#773): the leading street-NUMBER token of [address],
+     * `@`-prefixed — the fallback location discriminator for a **chain-bare** payout (a receipt that
+     * carries no `(code)` / ` - Area` running key, e.g. grocery). Used ONLY when [extractRunningKey]
+     * yields nothing, so an address-keyed store's running key always carries the `@` provenance marker
+     * ([normalizeRunningKey] guarantees no receipt key can).
+     *
+     * Accept the FIRST whitespace token of the trimmed [address] iff it is a **pure ASCII digit-run**
+     * (`"12125 Alamo Rnch Pkwy, San Antonio, TX 78240, USA"` → `"@12125"`; `"7330 N Loop 1604 W…"` →
+     * `"@7330"`) — returning `"@" + token`. Anything else is **fail-null** (F-3, the conservative
+     * reading — fail toward conflation, never a truncated/garbage fragment): a hyphenated house number
+     * (`"12125-A"`), a range (`"2500-2504"`), a suffixed number (`"12125B"`), a non-numeric first line
+     * (a mall/plaza name), or a degenerate/blank input all → null.
+     *
+     * Street-number-only by design (F7 churn defense): render variance lives in the address TAIL
+     * (`ZIP+4`/`ZIP5`, `USA`/`United States`) and street names are abbreviation-prone, but the leading
+     * number is the fragment most invariant across renders of the SAME location. `Locale.ROOT` — the
+     * ASCII digit-run check is locale-independent by construction.
+     */
+    fun addressRunningKey(address: String?): String? {
+        val firstToken = address?.trim()?.takeIf { it.isNotEmpty() }
+            ?.split(WHITESPACE)?.firstOrNull()
+            ?: return null
+        return if (firstToken.isNotEmpty() && firstToken.all { it in '0'..'9' }) "@$firstToken" else null
+    }
 
     /**
      * The deterministic entity key: `platform + "|" + normalizedChain + "|" + runningKey`

--- a/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/StoreKeys.kt
+++ b/domain/src/main/java/cloud/trotter/dashbuddy/domain/state/StoreKeys.kt
@@ -127,8 +127,17 @@ object StoreKeys {
         val firstToken = address?.trim()?.takeIf { it.isNotEmpty() }
             ?.split(WHITESPACE)?.firstOrNull()
             ?: return null
-        return if (firstToken.isNotEmpty() && firstToken.all { it in '0'..'9' }) "@$firstToken" else null
+        // Length cap: a real US street number is 1–6 digits; an untrusted-UI degenerate like a
+        // 20-digit run is not a street number — fail-null, never a garbage key (#773
+        // adversarial-review finding 3, same fail-toward-conflation philosophy as F-3).
+        return if (firstToken.length in 1..MAX_STREET_NUMBER_DIGITS && firstToken.all { it in '0'..'9' }) {
+            "@$firstToken"
+        } else {
+            null
+        }
     }
+
+    private const val MAX_STREET_NUMBER_DIGITS = 6
 
     /**
      * The deterministic entity key: `platform + "|" + normalizedChain + "|" + runningKey`

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/state/StoreChainProjectorTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/state/StoreChainProjectorTest.kt
@@ -141,6 +141,37 @@ class StoreChainProjectorTest {
     }
 
     @Test
+    fun `M5 — the Job adapter feeds the address fallback into the same resolved key as the row adapter (#773)`() {
+        // A chain-bare grocery job: pickup carries an address, the payout has no running key. Both adapters
+        // must resolve the SAME address-derived `@`-key — the shadow log stays a valid oracle for the
+        // persisted path when the address fallback fires.
+        val pickupTask = Task(
+            taskId = "p1", jobId = "job-1", phase = TaskPhase.PICKUP, storeName = "H-E-B",
+            storeAddress = "12125 Alamo Rnch Pkwy, San Antonio, TX 78240, USA", startedAt = 100L, completedAt = 200L,
+        )
+        val j = job(tasks = listOf(pickupTask, dropoff("d1", "H-E-B", "cust-1")), offerHints = listOf("H-E-B"))
+
+        // Job adapter: address flows from task.storeAddress.
+        val jobLink = StoreChainProjector.project(j, payout = null).links.single()
+        assertEquals("@12125", jobLink.addressKey)
+        assertNull("chain-bare receipt → no raw receipt key", jobLink.runningKey)
+
+        // Row adapter: the SAME surfaces as neutral lists + the per-anchor address map.
+        val rowResolved = StoreResolver.resolveAnchors(
+            anchors = listOf("H-E-B"),
+            offerForms = listOf("H-E-B"),
+            dropoffForms = listOf("H-E-B"),
+            payoutForms = emptyList(),
+            anchorAddresses = mapOf("H-E-B" to "12125 Alamo Rnch Pkwy, San Antonio, TX 78240, USA"),
+        ).single()
+
+        // Both adapters key on the SAME ladder result.
+        val jobResolvedKey = StoreKeys.normalizeRunningKey(jobLink.runningKey) ?: jobLink.addressKey
+        assertEquals("row adapter ≡ Job adapter resolved key (address fallback)", rowResolved.resolvedRunningKey, jobResolvedKey)
+        assertEquals("@12125", jobResolvedKey)
+    }
+
+    @Test
     fun `null payout still yields the pickup-anchored links`() {
         val j = job(
             tasks = listOf(pickup("p1", "Chipotle"), dropoff("d1", "Chipotle", "cust-1")),

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/state/StoreKeysTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/state/StoreKeysTest.kt
@@ -121,6 +121,67 @@ class StoreKeysTest {
     }
 
     @Test
+    fun `normalizeRunningKey strips a leading at-sign so a receipt key cannot masquerade as address-tier (F-1)`() {
+        // A payout parenthetical like "Joe's (@joescafe)" would otherwise mint a receipt key starting
+        // with '@' and be misread as an address-derived key. The receipt canonicalizer strips it.
+        assertEquals("joescafe", StoreKeys.normalizeRunningKey("@joescafe"))
+        assertEquals("12125", StoreKeys.normalizeRunningKey("@12125"))
+        assertEquals("x", StoreKeys.normalizeRunningKey("@@x"))
+        assertNull("an at-only token collapses to null, not an empty @-key", StoreKeys.normalizeRunningKey("@"))
+    }
+
+    // ── addressRunningKey (#773 address fallback) ───────────────────────
+
+    @Test
+    fun `addressRunningKey pulls the leading street number, at-prefixed`() {
+        assertEquals("@12125", StoreKeys.addressRunningKey("12125 Alamo Rnch Pkwy, San Antonio, TX 78240, USA"))
+        assertEquals("@7330", StoreKeys.addressRunningKey("7330 N Loop 1604 W, San Antonio, TX 78249"))
+    }
+
+    @Test
+    fun `addressRunningKey yields the SAME fragment across both fielded render formats of one address`() {
+        // The 07-13 render variance lives in the address TAIL (ZIP5 vs ZIP+4, USA vs United States); the
+        // leading street number is invariant, so both renders of the SAME location key identically.
+        val zip5Usa = StoreKeys.addressRunningKey("1200 Bandera Rd, San Antonio, TX 78240, USA")
+        val zip4UnitedStates = StoreKeys.addressRunningKey("1200 Bandera Rd, San Antonio, TX 78249-2900, United States")
+        assertEquals("@1200", zip5Usa)
+        assertEquals(zip5Usa, zip4UnitedStates)
+    }
+
+    @Test
+    fun `addressRunningKey handles the short address form`() {
+        assertEquals("@1200", StoreKeys.addressRunningKey("1200 Bandera Rd"))
+    }
+
+    @Test
+    fun `addressRunningKey fails null on a hyphenated house number`() {
+        assertNull(StoreKeys.addressRunningKey("12125-A Alamo Ranch Pkwy"))
+    }
+
+    @Test
+    fun `addressRunningKey fails null on a range address`() {
+        assertNull(StoreKeys.addressRunningKey("2500-2504 Broadway"))
+    }
+
+    @Test
+    fun `addressRunningKey fails null on a suffixed house number`() {
+        assertNull(StoreKeys.addressRunningKey("12125B Alamo Ranch Pkwy"))
+    }
+
+    @Test
+    fun `addressRunningKey fails null on a non-numeric first line`() {
+        assertNull(StoreKeys.addressRunningKey("The Rim Shopping Center, San Antonio, TX"))
+        assertNull(StoreKeys.addressRunningKey("Alamo Ranch Pkwy"))
+    }
+
+    @Test
+    fun `addressRunningKey fails null on degenerate input`() {
+        assertNull(StoreKeys.addressRunningKey(null))
+        assertNull(StoreKeys.addressRunningKey(""))
+        assertNull(StoreKeys.addressRunningKey("   "))
+    }
+
+    @Test
     fun `storeKey composes platform, chain, and running key with empty segment while unknown`() {
         assertEquals("doordash|target|02426", StoreKeys.storeKey("doordash", "target", "02426"))
         assertEquals("doordash|heb|", StoreKeys.storeKey("doordash", "heb", null))

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/state/StoreKeysTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/state/StoreKeysTest.kt
@@ -159,6 +159,15 @@ class StoreKeysTest {
     }
 
     @Test
+    fun `addressRunningKey caps the digit-run length — a degenerate long run fails null`() {
+        // Real US street numbers are 1-6 digits; a 20-digit run from untrusted UI text is
+        // not a street number (#773 adversarial-review finding 3 — fail toward conflation).
+        assertNull(StoreKeys.addressRunningKey("00000000000000000000 Main St"))
+        assertNull(StoreKeys.addressRunningKey("1234567 Main St"))
+        assertEquals("@123456", StoreKeys.addressRunningKey("123456 Main St"))
+    }
+
+    @Test
     fun `addressRunningKey fails null on a range address`() {
         assertNull(StoreKeys.addressRunningKey("2500-2504 Broadway"))
     }

--- a/domain/src/test/java/cloud/trotter/dashbuddy/domain/state/StoreResolverTest.kt
+++ b/domain/src/test/java/cloud/trotter/dashbuddy/domain/state/StoreResolverTest.kt
@@ -72,4 +72,45 @@ class StoreResolverTest {
         val r = StoreResolver.resolveAnchors(emptyList(), emptyList(), emptyList(), emptyList())
         assertEquals(0, r.size)
     }
+
+    // ── #773 address fallback ladder (resolvedRunningKey) ───────────────
+
+    @Test
+    fun `a receipt running key WINS over an address key (ladder — receipt first)`() {
+        val r = StoreResolver.resolveAnchors(
+            anchors = listOf("Target"),
+            offerForms = emptyList(),
+            dropoffForms = emptyList(),
+            payoutForms = payout("Target (02426)" to 2.25),
+            anchorAddresses = mapOf("Target" to "12125 Alamo Rnch Pkwy, San Antonio, TX"),
+        ).single()
+        assertEquals("02426", r.runningKey) // raw receipt token unchanged
+        assertEquals("02426", r.resolvedRunningKey) // ladder picks the receipt tier
+    }
+
+    @Test
+    fun `a chain-bare receipt falls back to the address key`() {
+        val r = StoreResolver.resolveAnchors(
+            anchors = listOf("H-E-B"),
+            offerForms = emptyList(),
+            dropoffForms = emptyList(),
+            payoutForms = emptyList(), // grocery: chain-bare, no running key on the receipt
+            anchorAddresses = mapOf("H-E-B" to "12125 Alamo Rnch Pkwy, San Antonio, TX 78240, USA"),
+        ).single()
+        assertNull(r.runningKey)
+        assertEquals("@12125", r.addressKey)
+        assertEquals("@12125", r.resolvedRunningKey)
+    }
+
+    @Test
+    fun `neither a receipt key nor a usable address yields a null resolved key (chain-only)`() {
+        val r = StoreResolver.resolveAnchors(
+            anchors = listOf("H-E-B"),
+            offerForms = emptyList(),
+            dropoffForms = emptyList(),
+            payoutForms = emptyList(),
+            anchorAddresses = mapOf("H-E-B" to "The Rim Shopping Center"), // no leading street number
+        ).single()
+        assertNull(r.resolvedRunningKey)
+    }
 }


### PR DESCRIPTION
Implements the vetted [Fable design pass on #773](https://github.com/sjtrotter/DashBuddy/issues/773#issuecomment-4974986850) — the address-derived running-key fallback for chain-bare receipts (the explicitly-deferred #159 phase-2 TODO at `StoreChainProjection.kt`).

## Problem

A grocery chain (H-E-B) settles on a **chain-bare** receipt — the payout store form carries no `(code)`/` - Area` running key — so every location of that chain resolves to one chain-only `platform|heb|` "location unknown" bucket, blending distinct stores' dwell/economics. (The 07-13 desk pass field-quantified this: 4 physical H-E-Bs conflating to one chain-only key.)

## What this does

When (and only when) the receipt yields no running key, resolution now keys the store off the **leading street-number token** of its pickup address, `@`-prefixed (`@12125`). So a chain's per-location visits split into distinct `stores`/`storeKey` rows.

- **`StoreKeys.addressRunningKey(address)`** (pure `:domain`): first whitespace token of the trimmed address, accepted iff a pure ASCII digit-run → `"@" + token`; anything else fail-null. Street-number-only because the render variance lives in the tail (ZIP+4/ZIP5, `USA`/`United States`) and the leading number is the fragment most invariant across renders of the same location.
- **`StoreKeys.normalizeRunningKey` `@`-strip (F-1)**: the receipt canonicalizer strips a leading `@`, so a payout parenthetical like `"Joe's (@joescafe)"` can't masquerade as address-tier. `@`-prefix ⇒ address-derived by construction — provenance-by-prefix with **no new column**.
- **`StoreResolver.resolveAnchors`** gains per-anchor address input and the `receiptKey ?: addressKey ?: null` ladder (`AnchorResolution.resolvedRunningKey`, the one ladder SSOT both adapters key on). The row adapter (`StoreResolutionRunner`) selects the address by **first-non-null `storeAddress` by `eventSequenceId`, then fail** — the same row selection the display-address seed uses, so an `@`-keyed card never shows a different location's address than the one that keyed it. The shadow `StoreChainProjector` Job adapter feeds `task.storeAddress`, so it stays a valid field oracle.
- **`StoreResolutionRunner.isMonotonicDowngrade`** is now tier-aware — receipt > address(`@`) > chain-only — compared **only within the same platform+chain prefix**, so the FIX-7 `_unknown|…`→`doordash|…` platform upgrade stays allowed; the genuinely new blocked edge is receipt→address.
- **`PROJECTOR_VERSION` 6 → 7**: refolds history, re-keying the address-bearing subset (pre-#159 folds carry no pickup address → stay chain-only, a partial honest backfill). Precedented `CURRENT_FALLBACK` re-stamp side effect (v2/v3/v4/v6 pattern), documented in the KDoc.
- **UI**: `PatternsTab.StoreRow` shows the address street line instead of the raw `@12125` chip for an address-keyed store — the one substitution; #765 redesigns this card later.

**No** Room migration, payload change, new columns, network, or new INFO+ log lines (keys/fragments stay DEBUG-only).

## Security / privacy posture

Store names and addresses are **merchant data** — fine at rest, never customer PII, and never emitted at INFO+ (the address key + fragments are computed and logged at DEBUG only, P7). No network, no new capture surface. No change to the customer-hash or sensitive-block sides.

## Tests

- `:domain` `StoreKeysTest`: `addressRunningKey` — both fielded render formats of a same-number address (`…TX 78240, USA` vs `…TX 78249-2900, United States`) → same fragment; short form; the fail-null shapes (`12125-A`, `2500-2504`, `12125B`, non-numeric first line, null/empty/blank); Locale.ROOT. `normalizeRunningKey` `@`-strip (incl. `@@x`, at-only → null).
- `:domain` `StoreResolverTest`: ladder precedence (receipt wins; chain-bare + address → `@`key; neither → null).
- `:domain` `StoreChainProjectorTest`: shadow-parity — the Job adapter feeds the address fallback into the same resolved key as the row adapter.
- `:core:data` `StoreResolutionRunnerLadderTest` (new): the 5 tier transitions — chain-only→`@` upgrade, `@`→receipt allowed, receipt→`@` blocked, `@`/receipt→chain-only blocked, identical no-churn, platform-upgrade allowed at every tier, null/different-chain guards.
- `:core:data` `StoreResolutionProjectorTest`: chain-bare grocery keying (+ same-row display-address seed); F1 incremental ≡ from-zero refold with a batch boundary splitting the job's pickup from its close; the 4-same-chain-jobs acceptance fixture (4 distinct `@`-keys + 1 address-less job staying chain-only).

Full `./gradlew testDebugUnitTest :domain:test` green.

## Design-goal review

- **1 (UDF):** resolver + key logic are pure `:domain`; resolution reads committed rows and writes at the projector transaction edge — unchanged. UI observes `StoreReportCard` state and derives the chip text; no new state, no reducer/wall-clock coupling. The touched Patterns card is a static read surface (no time-derived value), so the Reactive UI rules are unaffected.
- **5 (SSOT):** the ladder lives in exactly one place (`AnchorResolution.resolvedRunningKey`); both adapters key on it. The address-key extraction is one `:domain` function. The display-address seed and the address-key source share one row selection (no second copy of "which address").
- **6 (security/privacy):** merchant data at rest only; address key/fragments DEBUG-only; no network, no capture, no PII-side change.
- **8 (platform-agnostic):** no platform literal added; the fallback is a surface-shape heuristic (leading digit-run) on address DATA, not a `when` on platform. The tier comparison is prefix-structural, and the platform segment is already `Platform.wire`.

`### Adversarial review` to follow (fable `/code-review` + `/security-review` per the merge loop).
